### PR TITLE
cnv 2.5: VMware import supports Ceph block-format storage

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -37,16 +37,20 @@ ifdef::virt-features-for-storage[]
 |Yes
 |Yes
 endif::[]
-ifdef::virt-importing-rhv-vm[]
-ifeval::["{VirtVersion}" == "2.5"]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+ifeval::["{VirtVersion}" >= "2.5"]
 |Yes
 endif::[]
-ifeval::["{VirtVersion}" == "2.4"]
+ifeval::["{VirtVersion}" < "2.5"]
 |No
 endif::[]
 endif::[]
-ifdef::virt-importing-vmware-vm[]
-|No
+
+ifeval::["{VirtVersion}" >= "2.5"]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
+|OpenShift Container Storage: RBD filesystem volumes
+|Yes
+endif::[]
 endif::[]
 
 |{VirtProductName} hostpath provisioner
@@ -58,7 +62,12 @@ ifdef::virt-importing-rhv-vm[]
 |No
 endif::[]
 ifdef::virt-importing-vmware-vm[]
+ifeval::["{VirtVersion}" < "2.5"]
 |Yes ^[1]^
+endif::[]
+ifeval::["{VirtVersion}" >= "2.5"]
+|Yes
+endif::[]
 endif::[]
 
 |Other multi-node writable storage
@@ -70,7 +79,12 @@ ifdef::virt-importing-rhv-vm[]
 |Yes ^[1]^
 endif::[]
 ifdef::virt-importing-vmware-vm[]
+ifeval::["{VirtVersion}" < "2.5"]
 |Yes ^[2]^
+endif::[]
+ifeval::["{VirtVersion}" >= "2.5"]
+|Yes ^[1]^
+endif::[]
 endif::[]
 
 |Other single-node writable storage
@@ -82,15 +96,26 @@ ifdef::virt-importing-rhv-vm[]
 |Yes ^[2]^
 endif::[]
 ifdef::virt-importing-vmware-vm[]
+ifeval::["{VirtVersion}" < "2.5"]
 |Yes ^[3]^
+endif::[]
+ifeval::["{VirtVersion}" >= "2.5"]
+|Yes ^[2]^
+endif::[]
 endif::[]
 |===
 [.small]
 ifdef::virt-importing-vmware-vm[]
 --
+ifeval::["{VirtVersion}" < "2.5"]
 1. The `v2v-conversion-template` disk must use {VirtProductName} hostpath provisioner storage if the VM disks use NFS storage.
 2. PVCs must request a ReadWriteMany access mode.
 3. PVCs must request a ReadWriteOnce access mode.
+endif::[]
+ifeval::["{VirtVersion}" >= "2.5"]
+1. PVCs must request a ReadWriteMany access mode.
+2. PVCs must request a ReadWriteOnce access mode.
+endif::[]
 --
 endif::[]
 ifdef::virt-features-for-storage,virt-importing-rhv-vm[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1874786

CP 4.5, 4.6