### PR TITLE
changed chrony modifications to make example working with copy and paste

### DIFF
--- a/modules/installation-special-config-crony.adoc
+++ b/modules/installation-special-config-crony.adoc
@@ -21,7 +21,7 @@ $ cat << EOF | base64
     makestep 1.0 3
     rtcsync
     logdir /var/log/chrony
-    EOF
+EOF
 ----
 +
 .Example output
@@ -44,7 +44,7 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: master
-  name: masters-chrony-configuration
+  name: 99-masters-chrony-configuration
 spec:
   config:
     ignition:
@@ -75,5 +75,5 @@ directory, then continue to create the cluster.
 +
 [source,terminal]
 ----
- $ oc apply -f ./masters-chrony-configuration.yaml
+ $ oc apply -f ./99-masters-chrony-configuration.yaml
 ----


### PR DESCRIPTION
- moved EOF in first block to beginning of line to make that working
- changed  MachineConfig name from `masters-chrony-configuration` to `99-masters-chrony-configuration` to comply with naming
- corrected oc apply to the correct file name as we create 99- .. but oc apply omitted that 