### PR TITLE
changed journald example to be full c&p ready

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -75,32 +75,46 @@ For more information on systemd settings, see link:https://www.freedesktop.org/s
 $ export jrnl_cnf=$( cat /journald.conf | base64 -w0 )
 ----
 
-. Create a new MachineConfig for master or worker and add the `journal.conf` parameters:
+. The following example creates a MachineConfig to change  `journald.conf` parameters for worker. You can change it to master or make an additional MachineConfig for the master role:
 +
-For example: 
-+
-[source,yaml]
+[source,terminal]
 ----
-
-...
-
-config:
-  storage:
-    files:
-    - contents:
-        source: data:text/plain;charset=utf-8;base64,${jrnl_cnf}
-      mode: 0644 <1>
-      overwrite: true
-      path: /etc/systemd/journald.conf <2>
+$ cat << EOF > ./99-worker-journald-configuration.yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-journald-configuration
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${jrnl_cnf} <1>
+          verification: {}
+        filesystem: root
+        mode: 0644 <2>
+        path: /etc/systemd/journald.conf
+  osImageURL: ""
+EOF
 ----
-<1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions. 
-<2> Specify the path to the base64-encoded `journal.conf` file.
+<1> If you want to copy and past just the content of the configuration you must replace `${jrnl_cnf}` with the output of `echo $jrnl_cnf`
+<2> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions. 
 
 . Create the MachineConfig:
 +
 [source,terminal]
 ----
-$ oc apply -f <filename>.yaml
+$ oc apply -f 99-worker-journald-configuration.yaml
 ----
 +
 The controller detects the new MachineConfig and generates a new `rendered-worker-<hash>` version. 

--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -142,3 +142,4 @@ Conditions:
   Message:               
   Reason:                All nodes are updating to rendered-worker-913514517bcea7c93bd446f4830bc64e
 ----
+

--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -107,7 +107,7 @@ spec:
   osImageURL: ""
 EOF
 ----
-<1> If you want to copy and past just the content of the configuration you must replace `${jrnl_cnf}` with the output of `echo $jrnl_cnf`
+<1> Optional: To include a static copy of the parameters in the `journald.conf` file, replace `${jrnl_cnf}` with the output of the `echo $jrnl_cnf` command.
 <2> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions. 
 
 . Create the MachineConfig:


### PR DESCRIPTION
- Following the current example is not working out of the box, as 
   - we use a variable in the example (${jrnl_cnf}) which is not filled when just copied over which leads to issues 
    - machineconfig example just shows an excerpt instead of a fully usable machineconfig. yaml as we do in other sections (e.g. chrony) 

improvement: 
  - use a full example of the machine.config that is ready to be copy and pasted
  - highlight, that in case we copy the example on needs to copy as well the created encoded file in, replacing the variable
  - use a proper naming as well, e.g. 99-....

I think this applies to all versions where we have this in the docs, so back to 4.2 

This worked in my tests but you may want to have eng check this before merging

@openshift/team-documentation.