### PR TITLE
adding moa service quota guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -53,6 +53,8 @@ Distros: openshift-moa
 Topics:
 - Name: Creating your first cluster
   File: creating-first-moa-cluster
+- Name: Required AWS service quotas
+  File: required-aws-service-quotas
 ---
 Name: Cloud infrastructure access
 Dir: cloud_infrastructure_access

--- a/getting_started_moa/required-aws-service-quotas.adoc
+++ b/getting_started_moa/required-aws-service-quotas.adoc
@@ -1,0 +1,10 @@
+[id="required-aws-service-quotas"]
+= Required AWS service quotas
+include::modules/common-attributes.adoc[]
+:context: required-aws-service-quotas
+
+toc::[]
+
+This guide covers the required AWS service quotas to run an {product-title} cluster.
+
+include::modules/moa-required-aws-service-quotas.adoc[leveloffset=+1]

--- a/modules/moa-required-aws-service-quotas.adoc
+++ b/modules/moa-required-aws-service-quotas.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// getting_started_moa/required-aws-service-quotas.adoc
+
+
+[id="moa-required-aws-service-quotas"]
+= Required AWS service quotas
+
+The table below describes the AWS service quotas and levels required to create and run an {product-title} cluster.
+
+If you need to modify or increase a specific quota, please refer to Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota inscrease].
+
+[options="header"]
+|===
+|Quota name |Service code |Quota code| Required value
+
+|Number of EIPs - VPC EIPs
+|ec2
+|L-0263D0A3
+|5
+
+|Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances
+|ec2
+|L-1216C47A
+|100
+
+|VPCs per Region
+|vpc
+|L-F678F1CE
+|5
+
+|Internet gateways per Region
+|vpc
+|L-A4707A72
+|5
+
+|Network interfaces per Region
+|vpc
+|L-DF5E4CA3
+|5000
+
+|General Purpose SSD (gp2) volume storage
+|ebs
+|L-D18FCD1D
+|300
+
+|Number of EBS snapshots
+|ebs
+|L-309BACF6
+|300
+
+|Provisioned IOPS
+|ebs
+|L-B3A130E6
+|300000
+
+|Provisioned IOPS SSD (io1) volume storage
+|ebs
+|L-FD252861
+|300
+
+|Application Load Balancers per Region
+|elasticloadbalancing
+|L-53DA6B97
+|50
+
+|Classic Load Balancers per Region
+|elasticloadbalancing
+|L-E9E9831D
+|20
+|


### PR DESCRIPTION
Adding guide to describe aws service quotas.

Manual preview available here - http://file.bos.redhat.com/klamenzo/moa/openshift-moa/moa/getting_started_moa/required-aws-service-quotas.html