### PR TITLE
BZ-1880750 Updated clipboard.js to remove sh-4.x# from copied code blocks

### DIFF
--- a/_javascripts/clipboard.js
+++ b/_javascripts/clipboard.js
@@ -17,6 +17,10 @@ var clipboard = new ClipboardJS('.clipboard-button', {
         return clipboardText.substr(2);
       }
 
+      if (clipboardText.slice(0,5) === "sh-4.") {
+        return clipboardText.substr(8)
+      }
+
       return clipboardText;
     }
 });

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -56,7 +56,7 @@
               <option value="4.4">4.4</option>
               <option value="4.3">4.3</option>
               <option value="4.2">4.2</option>
-              <option value="4.1">4.1</option>          
+              <option value="4.1">4.1</option>
               <option value="3.11">3.11</option>
               <option value="3.10">3.10</option>
               <option value="3.9">3.9</option>
@@ -65,9 +65,9 @@
               <option value="3.5">3.5</option>
               <option value="3.4">3.4</option>
               <option value="3.3">3.3</option>
-              <option value="3.2">3.2</option>            
-              <option value="3.1">3.1</option>            
-              <option value="3.0">3.0</option>                        
+              <option value="3.2">3.2</option>
+              <option value="3.1">3.1</option>
+              <option value="3.0">3.0</option>
           </select>
         <% else %>
           <%= breadcrumb_root %>


### PR DESCRIPTION
BZ-1880750 - https://bugzilla.redhat.com/show_bug.cgi?id=1880750

Removing `sh-4.2#` from the beginning of a command when copied with the click-to-copy button. I found `sh-4.2#` and `sh-4.4#` in the 4.5 docs, and `sh-4.2$` in 3.11. This update removes any instance of `sh-4.x` followed by `#` or `$` from the beginning of a command when copied.

A preview is available [here](http://file.bos.redhat.com/lbarbeev/09252020/BZ1880750-updates-to-clipboard-js/backup_and_restore/replacing-unhealthy-etcd-member.html#replacing-the-unhealthy-etcd-member).