### PR TITLE
OSDOCS-1173: Adding release notes for audit log config

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -105,7 +105,7 @@ Ignition snippets, they should be created using Ignition spec v3. However, the
 Machine Config Operator (MCO) still supports Ignition spec v2.
 
 [id="ocp-4-6-extensions-supported-for-rhcos-mco"]
-==== Extensions now supported for {op-system} and MCO 
+==== Extensions now supported for {op-system} and MCO
 
 {op-system} and the MCO now support the following extensions to the default
 {op-system} installation.
@@ -376,6 +376,16 @@ has a new `expiration` field. If the `expiration` duration value is set on a Rep
 and no other Reports or ReportQueries depend on the expiring Report, the Metering Operator
 removes the Report from your cluster at the end of its retention period. For more information,
 see metering Reports xref:../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[expiration].
+
+[id="ocp-4-6-nodes"]
+=== Nodes
+
+[id="ocp-4-6-nodes-audit-log-policy"]
+==== Configure the node audit log policy
+
+You can now control the amount of information that is logged to the node audit logs by choosing the audit log policy profile to use.
+
+See xref:../nodes/nodes/nodes-nodes-audit-config.adoc#nodes-nodes-audit-config[Configuring the node audit log policy] for more information.
 
 [id="ocp-4-6-notable-technical-changes"]
 == Notable technical changes


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1173

Preview: https://osdocs-1173-rn--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-nodes-audit-log-policy