### PR TITLE
BZ1850510 - remove NFS from image reg docs

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -113,6 +113,8 @@ include::modules/registry-removed.adoc[leveloffset=+2]
 
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
+include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+2]
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -125,6 +125,8 @@ include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]
 
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+3]
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -131,6 +131,8 @@ include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]
 
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+3]
 
+include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+3]
+
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 == Next steps

--- a/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_baremetal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_baremetal/installing-restricted-networks-bare-metal.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+
+[id="installation-registry-storage-block-recreate-rollout-bare-metal_{context}"]
+= Configuring block registry storage for bare metal
+
+To allow the image registry to use block storage types during upgrades as a cluster administrator, you can use the `Recreate` rollout strategy.
+
+[IMPORTANT]
+====
+Block storage volumes are supported but not recommended for use with the image
+registry on production clusters. An installation where the registry is
+configured on block storage is not highly available because the registry cannot
+have more than one replica.
+====
+
+.Procedure
+
+. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only one (`1`) replica:
++
+[source,terminal]
+----
+$ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
+----
++
+. Provision the PV for the block storage device, and create a PVC for that volume. The requested block volume uses the ReadWriteOnce (RWO) access mode.
++
+. Edit the registry configuration so that it references the correct PVC.

--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
-// * registry/configuring_registry_storage-baremetal
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
 
@@ -16,9 +16,13 @@ registry to use storage.
 
 * Cluster administrator permissions.
 * A cluster on bare metal.
-* Provisioned persistent storage
-for your cluster, such as Red Hat OpenShift Container Storage. To deploy a private image registry, your storage must provide
-ReadWriteMany access mode.
+* Persistent storage provisioned for your cluster, such as Red Hat OpenShift Container Storage.
++
+[IMPORTANT]
+====
+{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
+====
+
 * Must have "100Gi" capacity.
 
 .Procedure
@@ -28,10 +32,10 @@ the `configs.imageregistry/cluster` resource.
 +
 [NOTE]
 ====
-When using shared storage such as NFS, it is strongly recommended to use the `supplementalGroups` strategy, which dictates the allowable supplemental groups for the Security Context, rather than the `fsGroup` ID. Refer to the NFS *Group IDs* documentation for details.
+When using shared storage, review your security settings to prevent outside access.
 ====
 
-. Verify you do not have a registry Pod:
+. Verify that you do not have a registry Pod:
 +
 [source,terminal]
 ----
@@ -40,30 +44,7 @@ $ oc get pod -n openshift-image-registry
 +
 [NOTE]
 =====
-* If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
-+
-[source,terminal]
-----
-# cat /etc/exports
-----
-+
-.Example output
-[source,terminal]
-----
-/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
-----
-+
-[source,terminal]
-----
-sh-4.2# exportfs -rv
-----
-+
-.Example output
-[source,terminal]
-----
-exporting *:/mnt/data
-----
+If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
 =====
 +
 . Check the registry configuration:
@@ -73,7 +54,7 @@ exporting *:/mnt/data
 $ oc edit configs.imageregistry.operator.openshift.io
 ----
 +
-.Example registry configuration
+.Example output
 [source,yaml]
 ----
 storage:

--- a/modules/registry-configuring-storage-vsphere.adoc
+++ b/modules/registry-configuring-storage-vsphere.adoc
@@ -10,20 +10,17 @@
 [id="registry-configuring-storage-vsphere_{context}"]
 = Configuring registry storage for VMware vSphere
 
-As a cluster administrator, following installation you must configure your
-registry to use storage.
+As a cluster administrator, following installation you must configure your registry to use storage.
 
 .Prerequisites
 
 * Cluster administrator permissions.
 * A cluster on VMware vSphere.
-* Provision persistent storage for your cluster. To deploy a private image registry, your storage must provide
-ReadWriteMany access mode.
+* Persistent storage provisioned for your cluster, such as Red Hat OpenShift Container Storage.
 +
 [IMPORTANT]
 ====
-vSphere volumes do not support the `ReadWriteMany` access mode. You must use
-a different storage backend, such as object storage, to configure the registry storage for high-availability.
+{product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
 ====
 +
 * Must have "100Gi" capacity.
@@ -43,15 +40,14 @@ components.
 
 .Procedure
 
-. To configure your registry to use storage, change the `spec.storage.pvc` in the
-`configs.imageregistry/cluster` resource.
+. To configure your registry to use storage, change the `spec.storage.pvc` in the `configs.imageregistry/cluster` resource.
 +
 [NOTE]
 ====
-When using shared storage such as NFS, it is strongly recommended to use the `supplementalGroups` strategy, which dictates the allowable supplemental groups for the Security Context, rather than the `fsGroup` ID. Refer to the NFS *Group IDs* documentation for details.
+When using shared storage, review your security settings to prevent outside access.
 ====
 
-. Verify you do not have a registry Pod:
+. Verify that you do not have a registry Pod:
 +
 [source,terminal]
 ----
@@ -60,30 +56,7 @@ $ oc get pod -n openshift-image-registry
 +
 [NOTE]
 =====
-* If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
-* If the storage type is `NFS`, you must enable the `no_wdelay` and `root_squash` mount options. For example:
-+
-[source,terminal]
-----
-# cat /etc/exports
-----
-+
-.Example output
-[source,terminal]
-----
-/mnt/data *(rw,sync,no_wdelay,root_squash,insecure,fsid=0)
-----
-+
-[source,terminal]
-----
-sh-4.2# exportfs -rv
-----
-+
-.Example output
-[source,terminal]
-----
-exporting *:/mnt/data
-----
+If the storage type is `emptyDIR`, the replica number cannot be greater than `1`.
 =====
 +
 . Check the registry configuration:
@@ -93,93 +66,16 @@ exporting *:/mnt/data
 $ oc edit configs.imageregistry.operator.openshift.io
 ----
 +
-.Example registry configuration
+.Example output
 [source,yaml]
 ----
 storage:
   pvc:
-    claim:
+    claim: <1>
 ----
 +
-Leave the `claim` field blank to allow the automatic creation of an
-`image-registry-storage` PVC.
+<1> Leave the `claim` field blank to allow the automatic creation of an `image-registry-storage` PVC.
 
-. Optional: Add a new storage class to a PV:
-.. Create the PV:
-+
-[source,terminal]
-----
-$ oc create -f -
-----
-+
-[source,yaml]
-----
-
-apiVersion: v1
-kind: PersistentVolume
-metadata:
-  name: image-registry-pv
-spec:
-  accessModes:
-    - ReadWriteMany
-  capacity:
-      storage: 100Gi
-  nfs:
-    path: /registry
-    server: 172.16.231.181
-  persistentVolumeReclaimPolicy: Retain
-  storageClassName: nfs01
-----
-+
-[source,terminal]
-----
-$ oc get pv
-----
-
-.. Create the PVC:
-+
-[source,terminal]
-----
-$ oc create -n openshift-image-registry -f -
-----
-+
-[source,yaml]
-----
-apiVersion: "v1"
-kind: "PersistentVolumeClaim"
-metadata:
-  name: "image-registry-pvc"
-spec:
-  accessModes:
-    - ReadWriteMany
-  resources:
-    requests:
-      storage: 100Gi
-  storageClassName: nfs01
-  volumeMode: Filesystem
-----
-+
-[source,terminal]
-----
-$ oc get pvc -n openshift-image-registry
-----
-+
-Finally, add the name of your PVC:
-+
-[source,terminal]
-----
-$ oc edit configs.imageregistry.operator.openshift.io -o yaml
-----
-+
-[source,yaml]
-----
-storage:
-  pvc:
-    claim: image-registry-pvc <1>
-----
-<1> Creating a custom PVC allows you to leave the `claim` field blank for default automatic creation of an `image-registry-storage` PVC.
-
-+
 . Check the `clusteroperator` status:
 +
 [source,terminal]

--- a/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
@@ -12,9 +12,9 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+1]
 
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+1]
 
-See xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs[Group IDs] for additional details about using supplemental groups to handle NFS access.
-
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
+
+include::modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc[leveloffset=+1]
 
 
 [id="configuring-registry-storage-baremetal-addtl-resources"]

--- a/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
@@ -12,8 +12,6 @@ include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+1]
 
-See xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#storage-persistent-storage-nfs-group-ids_persistent-storage-nfs[Group IDs] for additional details about using supplemental groups to handle NFS access.
-
 include::modules/installation-registry-storage-non-production.adoc[leveloffset=+1]
 
 include::modules/installation-registry-storage-block-recreate-rollout.adoc[leveloffset=+1]


### PR DESCRIPTION
This work updates content that was added in https://github.com/openshift/openshift-docs/pull/24276/ and is a continuation of [BZ 1850510](https://bugzilla.redhat.com/show_bug.cgi?id=1850510). Based on consultation with @huffmanca, this PR:

- Removes NFS references throughout bare metal and vsphere registry storage docs.
- Updates the notes that begin with, "When using shared storage..." and reworded these to say, "When using shared storage review your security settings to prevent outside access".
- Updates the procedures that previously had references to NFS and RWX. For vSphere, I used the PV/PVC examples from https://docs.openshift.com/container-platform/4.4/storage/persistent_storage/persistent-storage-vsphere.html
- Removes xrefs to NFS Group IDs topic.
- Updates the prereqs note about provisioned storage in both vSphere and bare metal to indicate new functionality introduced in 4.4 that supports RWO if you have only one replica. Hence, this PR will be CP'ed only back to 4.4.

**Preview links:**
- [Configuring registry storage for VMware vSphere](https://bz1850510-update--ocpdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html#registry-configuring-storage-vsphere_configuring-registry-storage-vsphere)
- [Configuring registry storage for bare metal](https://bz1850510-update--ocpdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-baremetal.html#registry-configuring-storage-baremetal_configuring-registry-storage-baremetal)