### PR TITLE
OSDOCS-1209: Adding OpenShift control plane services including the OA…

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -58,26 +58,48 @@ master static Pods and etcd static Pods working on the same hosts.
 ====
 
 Services that fall under the Kubernetes category on the master include the
-API server, etcd, controller manager server, and HAProxy services.
+Kubernetes API server, etcd, Kubernetes controller manager, and HAProxy services.
 
 .Kubernetes services that run on the control plane
-
-[options="header"]
+[cols="1,2",options="header"]
 |===
 |Component |Description
-|API Server
+|Kubernetes API server
 |The Kubernetes API server validates and configures the data for Pods, Services,
-and replication controllers. It also provides a focal point for cluster’s shared
-state.
+and replication controllers. It also provides a focal point for the shared state of the cluster.
 |etcd
 |etcd stores the persistent master state while other components watch etcd for
 changes to bring themselves into the specified state.
 //etcd can be optionally configured for high availability, typically deployed with 2n+1 peer services.
-|Controller Manager Server
-|The Controller Manager Server watches etcd for changes to objects such as
-replication, namespace, and serviceaccount controller objects, and then uses the
+|Kubernetes controller manager
+|The Kubernetes controller manager watches etcd for changes to objects such as
+replication, namespace, and service account controller objects, and then uses the
 API to enforce the specified state. Several such processes create a cluster with
 one active leader at a time.
+|===
+
+There are also OpenShift services that run on the control plane, which include the OpenShift API server, OpenShift controller manager, and OAuth API server.
+
+.OpenShift services that run on the control plane
+[cols="1,2",options="header"]
+|===
+|Component |Description
+|OpenShift API server
+|The OpenShift API server validates and configures the data for OpenShift resources, such as projects, routes, and templates.
+
+The OpenShift API server is managed by the OpenShift API Server Operator.
+|OpenShift controller manager
+|The OpenShift controller manager watches etcd for changes to OpenShift objects, such as project, route, and template controller objects, and then uses the API to enforce the specified state.
+
+The OpenShift controller manager is managed by the OpenShift Controller Manager Operator.
+|OpenShift OAuth API server
+|The OpenShift OAuth API server validates and configures the data to authenticate to OpenShift Container Platform, such as users, groups, and OAuth tokens.
+
+The OpenShift OAuth API server is managed by the Cluster Authentication Operator.
+|OpenShift OAuth server
+|Users request tokens from the OpenShift OAuth server to authenticate themselves to the API.
+
+The OpenShift OAuth server is managed by the Cluster Authentication Operator.
 |===
 
 Some of these services on the master machines run as systemd services, while


### PR DESCRIPTION
…uth API server

https://issues.redhat.com/browse/OSDOCS-1209

Preview: https://osdocs-1209--ocpdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#defining-masters_control-plane