### PR TITLE
Bug 1879902, added metrics for 3.11 route maximums + Fixed footnotes

### DIFF
--- a/scaling_performance/cluster_maximums.adoc
+++ b/scaling_performance/cluster_maximums.adoc
@@ -34,7 +34,7 @@ Services, and Microsoft Azure.
 | Number of Nodes
 | 2,000
 
-| Number of Pods footnoteref:[numberofpodsmajorrelease,The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
+| Number of Pods ^[1]^
 | 150,000
 
 | Number of xref:../admin_guide/manage_nodes.adoc#admin-guide-max-pods-per-node[Pods per Node]
@@ -49,16 +49,10 @@ Services, and Microsoft Azure.
 | Number of Builds: Pipeline Strategy
 | 10,000 (Default pod RAM 512Mi)
 
-| Number of Pods per Namespace footnoteref:[objectpernamespacemajorrelease,There are
-a number of control loops in the system that need to iterate over all objects
-in a given namespace as a reaction to some changes in state. Having a large
-number of objects of a given type in a single namespace can make those loops
-expensive and slow down processing given state changes. The maximum
-assumes that the system has enough CPU, memory, and disk to satisfy the
-application requirements.]
+| Number of Pods per Namespace ^[2]^
 | 25,000
 
-| Number of Services footnoteref:[servicesandendpointsmajorrelease,Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given Service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| Number of Services ^[3]^
 | 10,000
 
 | Number of Services per Namespace
@@ -67,10 +61,26 @@ application requirements.]
 | Number of Back-ends per Service
 | 5,000
 
-| Number of Deployments per Namespace footnoteref:[objectpernamespacemajorrelease]
+| Number of Deployments per Namespace ^[2]^
 | 2,000
 
 |===
+
+[.small]
+--
+1. The Pod count displayed here is the number of test Pods. The actual number of
+Pods depends on the application’s memory, CPU, and storage requirements.
+2. There are a number of control loops in the system that need to iterate over
+all objects in a given namespace as a reaction to some changes in state. Having
+a large number of objects of a given type in a single namespace can make those
+loops expensive and slow down processing given state changes. The maximum
+assumes that the system has enough CPU, memory, and disk to satisfy the
+application requirements.
+3. Each Service port and each Service back-end has a corresponding entry in
+iptables. The number of back-ends of a given Service impact the size of the
+endpoints objects, which impacts the size of data that is being sent all over
+the system.
+--
 
 [[scaling-performance-current-cluster-maximums]]
 == {product-title} Tested Cluster Maximums
@@ -85,7 +95,7 @@ application requirements.]
 | 2,000
 | 2,000
 
-| Number of Pods footnoteref:numberofpods[The Pod count displayed here is the number of test Pods. The actual number of Pods depends on the application’s memory, CPU, and storage requirements.]
+| Number of Pods ^[1]^
 | 120,000
 | 120,000
 | 150,000
@@ -109,26 +119,19 @@ application requirements.]
 | 10,000
 | 10,000
 
-
 | Number of Builds: Pipeline Strategy
 | N/A
 | 10,000 (Default pod RAM 512Mi)
 | 10,000 (Default pod RAM 512Mi)
 | 10,000 (Default pod RAM 512Mi)
 
-| Number of Pods per Namespace footnoteref:objectpernamespace[There are
-a number of control loops in the system that need to iterate over all objects
-in a given namespace as a reaction to some changes in state. Having a large
-number of objects of a given type in a single namespace can make those loops
-expensive and slow down processing given state changes. The maximum
-assumes that the system has enough CPU, memory, and disk to satisfy the
-application requirements.]
+| Number of Pods per Namespace ^[2]^
 | 3,000
 | 3,000
 | 3,000
 | 25,000
 
-| Number of Services footnoteref:servicesandendpoints[Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.]
+| Number of Services ^[3]^
 | 10,000
 | 10,000
 | 10,000
@@ -146,13 +149,39 @@ application requirements.]
 | 5,000
 | 5,000
 
-| Number of Deployments per Namespace footnoteref:objectpernamespace[]
+| Number of Deployments per Namespace ^[2]^
 | 2,000
 | 2,000
 | 2,000
 | 2,000
 
 |===
+
+[.small]
+--
+1. The Pod count displayed here is the number of test Pods. The actual number of
+Pods depends on the application’s memory, CPU, and storage requirements.
+2. There are a number of control loops in the system that need to iterate over all
+objects in a given namespace as a reaction to some changes in state. Having a
+large number of objects of a given type in a single namespace can make those
+loops expensive and slow down processing given state changes. The maximum
+assumes that the system has enough CPU, memory, and disk to satisfy the
+application requirements.
+3. Each Service port and each Service back-end has a corresponding entry in
+iptables. The number of back-ends of a given service impact the size of the
+endpoints objects, which impacts the size of data that is being sent all over
+the system.
+--
+[[scaling-performance-3-11-route-maximums]]
+=== Route Maximums
+
+In {product-title} 3.11.53, router tests were completed in a 3-node environment
+on Amazon Web Services (AWS). There were 100 HTTP routes, specifically 100
+back-end Nginx pods, with `keepalive` set to `100`. The results were:
+
+* 1 connection per target route = 24,327 requests per second
+* 40 connections per target route = 20,729 requests per second
+* 200 connections per target route = 17,253 requests per second
 
 [[scaling-performance-tested-maximums-environment]]
 == Environment and configuration on which {product-title} cluster maximums are tested
@@ -163,14 +192,14 @@ Infrastructure as a service provider: OpenStack
 |===
 |Node |vCPU |RAM(MiB) |Disk size(GiB) |pass-through disk |Count
 
-| Master/Etcd footnoteref:masteretcdnvme[The master/etcd nodes are backed by NVMe disks as etcd is I/O intensive and latency sensitive.]
+| Master/Etcd ^[1]^
 | 16
 | 124672
 | 128
 | Yes, NVMe
 | 3
 
-| Infra footnoteref:infranodes[Infra nodes host the Router, Registry, Logging and Monitoring and are backed by NVMe disks.]
+| Infra ^[2]^
 | 40
 | 163584
 | 256
@@ -191,14 +220,14 @@ Infrastructure as a service provider: OpenStack
 | No
 | 1
 
-| Container Native Storage footnoteref:cns[Container Native Storage or Ceph storage nodes are backed by NVMe disks.]
+| Container Native Storage ^[3]^
 | 16
 | 65280
 | 200
 | Yes, NVMe
 | 3
 
-| Bastion footnoteref:bastionnode[The Bastion node is part of the OCP network and is used to orchestrate the performance and scale tests.]
+| Bastion ^[4]^
 | 16
 | 65280
 | 200
@@ -213,6 +242,14 @@ Infrastructure as a service provider: OpenStack
 | 2000
 
 |===
+
+[.small]
+--
+1. The master/etcd nodes are backed by NVMe disks as etcd is I/O intensive and latency sensitive.
+2. Infra nodes host the Router, Registry, Logging and Monitoring and are backed by NVMe disks.
+3. Container Native Storage or Ceph storage nodes are backed by NVMe disks.
+4. The Bastion node is part of the {product-title} network and is used to orchestrate the performance and scale tests.
+--
 
 [[scaling-performance-planning-your-environment-according-to-cluster-maximums]]
 == Planning Your Environment According to Cluster Maximums


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1879902

@mohit-sheth @chaitanyaenr PTAL, specifically at the new Route Maximums section 

Preview build: http://file.rdu.redhat.com/~ahardin/Sept-29-2020/3-11-route-limits/scaling_performance/cluster_maximums.html#scaling-performance-3-11-route-maximums