### PR TITLE
CNV-1018 Scheduling virtual machines

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2269,6 +2269,8 @@ Topics:
       File: virt-using-huge-pages-with-vms
     - Name: Enabling dedicated resources for a virtual machine
       File: virt-dedicated-resources-vm
+    - Name: Scheduling virtual machines
+      File: virt-schedule-vms
 # Importing virtual machines
   - Name: Importing virtual machines
     Dir: importing_vms

--- a/modules/virt-schedule-cpu-host-model-vms.adoc
+++ b/modules/virt-schedule-cpu-host-model-vms.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+
+[id="virt-schedule-cpu-host-model-vms_{context}"]
+= Scheduling virtual machines with the host model
+
+When the CPU model for a virtual machine (VM) is set to `host-model`, the VM inherits the CPU model of the node where it is scheduled.
+
+.Procedure
+
+* Edit the `domain` spec of your VM configuration file. The following example shows `host-model` being specified for the virtual machine instance (VMI):
++
+[source,yaml]
+----
+apiVersion: kubevirt/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: myvmi
+spec:
+  domain:
+    cpu:
+      model: host-model <1>
+----
+<1> The VM or VMI that inherits the CPU model of the node where it is scheduled.

--- a/modules/virt-schedule-supported-cpu-model-vms.adoc
+++ b/modules/virt-schedule-supported-cpu-model-vms.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+
+[id="virt-schedule-supported-cpu-model-vms_{context}"]
+= Scheduling virtual machines with the supported CPU model
+
+You can configure a CPU model for a virtual machine (VM) or a virtual machine instance (VMI) to schedule it on a node where its CPU model is supported.
+
+.Procedure
+
+* Edit the `domain` spec of your virtual machine configuration file. The following example shows a specific CPU model defined for a VMI:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: myvmi
+spec:
+  domain:
+    cpu:
+      model: Conroe <1>
+----
+<1> CPU model for the VMI.

--- a/modules/virt-setting-policy-attributes.adoc
+++ b/modules/virt-setting-policy-attributes.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+
+[id="virt-setting-policy-attributes_{context}"]
+= Setting a policy attribute and CPU feature
+
+You can set a policy attribute and CPU feature for each virtual machine (VM) to ensure that it is scheduled on a node according to policy and feature. The CPU feature that you set is verified to ensure that it is supported by the host CPU or emulated by the hypervisor.
+
+.Procedure
+
+* Edit the `domain` spec of your VM configuration file. The following example sets the CPU feature and the `require` policy for a virtual machine instance (VMI):
++
+[source,yaml]
+----
+apiVersion: v1
+kind: VirtualMachine
+metadata:
+  name: myvmi
+spec:
+  domain:
+    cpu:
+      features:
+      - name: apic <1>
+        policy: require <2>
+----
+<1> Name of the CPU feature for the VM or VMI.
+<2> Policy attribute for the VM or VMI.

--- a/modules/virt-understanding-policy-attributes.adoc
+++ b/modules/virt-understanding-policy-attributes.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assembly:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+//
+
+[id="understanding-policy-attributes_{context}"]
+= Understanding policy attributes
+
+You can schedule a virtual machine (VM) by specifying a policy attribute and a CPU feature that is matched for compatibility when the VM is scheduled on a node. A policy attribute specified for a VM determines how that VM is scheduled on a node.
+
+[cols="30,70"]
+|===
+|Policy attribute | Description
+
+|force
+|The VM is forced to be scheduled on a node. This is true even if the host CPU does not support the VM's CPU.
+
+|require
+|Default policy that applies to a VM if the VM is not configured with a specific CPU model and feature specification. If a node is not configured to support CPU node discovery with this default policy attribute or any one of the other policy attributes, VMs are not scheduled on that node. Either the host CPU must support the VM's CPU or the hypervisor must be able to emulate the supported CPU model.
+
+|optional
+|The VM is added to a node if that VM is supported by the host's physical machine CPU.
+
+|disable
+|The VM cannot be scheduled with CPU node discovery.
+
+|forbid
+|The VM is not scheduled even if the feature is supported by the host CPU and CPU node discovery is enabled.
+|===

--- a/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc
@@ -1,0 +1,13 @@
+[id="virt-schedule-vms"]
+= Scheduling virtual machines
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-schedule-vms
+toc::[]
+
+You can schedule a virtual machine (VM) on a node by ensuring that the VM's CPU model and policy attribute are matched for compatibility with the CPU models and policy attributes supported by the node.
+
+include::modules/virt-understanding-policy-attributes.adoc[leveloffset=+1]
+include::modules/virt-setting-policy-attributes.adoc[leveloffset=+1]
+include::modules/virt-schedule-supported-cpu-model-vms.adoc[leveloffset=+1]
+include::modules/virt-schedule-cpu-host-model-vms.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is associated with https://issues.redhat.com/browse/CNV-1018.

Please note the following:
CNV-1000 (CPU node discovery) and CNV-1000 (scheduling virtual machines) are related to each other.

When CPU node discovery is enabled,  virtual machines can be scheduled. This PR focuses only on scheduling virtual machines in an environment where CPU node discovery is already configured and enabled. The content presented in this PR complies with the principles of minimalism followed by CCS. 

The PR for CNV-1000 on CPU node discovery is work in progress and will be released for technical review soon.

Requesting SME review:
@ksimon1 @fabiand @stu-gott @omeryahud @yanirq 
