### PR TITLE
[enterprise-4.4] Simplify command to change managementState

### DIFF
--- a/modules/registry-change-management-state.adoc
+++ b/modules/registry-change-management-state.adoc
@@ -9,38 +9,15 @@
 // * cnv/cnv_virtual_machines/cnv_importing_vms/cnv-importing-vmware-vm.adoc
 
 [id="registry-change-management-state_{context}"]
-= Change image registry ManagementState
+= Changing the image registry's management state
 
-To start the image registry, you must change `ManagementState` Image Registry Operator configuration from `Removed` to `Managed`.
+To start the image registry, you must change the Image Registry Operator configuration's `managementState` from `Removed` to `Managed`.
 
 .Procedure
 
 * Change `ManagementState` Image Registry Operator configuration from `Removed` to `Managed`. For example:
 +
-[source,yaml]
+[source,terminal]
 ----
-apiVersion: imageregistry.operator.openshift.io/v1
-kind: Config
-metadata:
-  creationTimestamp: <time>
-  finalizers:
-    - imageregistry.operator.openshift.io/finalizer
-  generation: 3
-  name: cluster
-  resourceVersion:  <version>
-  selfLink: <link>
-spec:
-  readOnly: false
-  disableRedirect: false
-  requests:
-    read:
-      maxInQueue: 0
-      maxRunning: 0
-      maxWaitInQueue: 0s
-    write:
-      maxInQueue: 0
-      maxRunning: 0
-      maxWaitInQueue: 0s
-  defaultRoute: true
-  managementState: Managed
+$ oc patch configs.imageregistry.operator.openshift.io cluster --type merge --patch '{"spec":{"managementState":"Managed"}}'
 ----


### PR DESCRIPTION
The working example shows the image registry operator config object, but the command to change the ManagementState by editing it is not provided.  As a reference, this would suffice: `oc edit configs.imageregistry.operator.openshift.io`.  However, a simpler instruction for the user would be to patch in place, command provided by this proposed commit.

From https://github.com/openshift/openshift-docs/pull/19591