### PR TITLE
[enterprise-4.5] Do not instruct to create an empty configmap for monitoring operator

### DIFF
--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -3,14 +3,14 @@
 // * monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
 
 [id="creating-cluster-monitoring-configmap_{context}"]
-= Creating cluster monitoring ConfigMap
+= Creating a cluster monitoring ConfigMap
 
-To configure the Prometheus Cluster Monitoring stack, you must create the cluster monitoring ConfigMap.
+To configure the {product-title} monitoring stack, you must create the cluster monitoring ConfigMap.
 
 .Prerequisites
 
-* An installed `oc` CLI tool
-* Administrative privileges for the cluster
+* You have access to the cluster as a user with the cluster-admin role.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -21,21 +21,8 @@ To configure the Prometheus Cluster Monitoring stack, you must create the cluste
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
-. If it does not exist, create it:
-+
-[source,terminal]
-----
-$ oc -n openshift-monitoring create configmap cluster-monitoring-config
-----
-
-. Start editing the `cluster-monitoring-config` ConfigMap:
-+
-[source,terminal]
-----
-$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
-----
-
-. Create the `data` section if it does not exist yet:
+. If the ConfigMap does not exist:
+.. Create the following YAML manifest. In this example the file is called `cluster-monitoring-config.yaml`:
 +
 [source,yaml]
 ----
@@ -46,4 +33,11 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
+----
++
+.. Apply the configuration to create the ConfigMap:
++
+[source,terminal]
+----
+$ oc apply -f cluster-monitoring-config.yaml
 ----


### PR DESCRIPTION
Cherry Picked from 9fa88b53f7a10ff4658877919a832530a4f4e7ca xref: https://github.com/openshift/openshift-docs/pull/25060