### PR TITLE
Remove duplicate credentials file warning

### DIFF
--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -31,10 +31,6 @@ ifdef::restricted[]
 This process requires that you have write access to a container image registry on the mirror registry and adds the credentials to a registry pull secret.
 ====
 
-[IMPORTANT]
-====
-Do not use this image registry credentials file as the pull secret when you install a cluster. If you provide this file when you install cluster, all of the machines in the cluster will have write access to your mirror registry.
-====
 endif::restricted[]
 
 .Prerequisites


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/24809

This same change already lives in _master_ and _4.6_.