### PR TITLE
Clarify ose variables in oc adm registry (Fix Issue 19346)

### DIFF
--- a/install_config/registry/deploy_registry_existing_clusters.adoc
+++ b/install_config/registry/deploy_registry_existing_clusters.adoc
@@ -60,7 +60,7 @@ administrator].
 <2> `--service-account` is the service account used to run the registry's pod.
 endif::[]
 ifdef::openshift-enterprise[]
-<3> Required to pull the correct image for {product-title}.
+<3> Required to pull the correct image for {product-title}. `${component}` and `${version}` are dynamically replaced during installation.
 endif::[]
 
 ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
@@ -270,9 +270,10 @@ ifdef::openshift-enterprise[]
 ----
 $ oc adm registry --service-account=registry \
     --config=/etc/origin/master/admin.kubeconfig \
-    --images='registry.redhat.io/openshift3/ose-${component}:${version}' \
+    --images='registry.redhat.io/openshift3/ose-${component}:${version}' \ <1>
     --mount-host=<path>
 ----
+<1> Required to pull the correct image for {product-title}. `${component}` and `${version}` are dynamically replaced during installation.
 endif::[]
 
 [IMPORTANT]


### PR DESCRIPTION
Fix for https://github.com/openshift/openshift-docs/issues/19346
The note was derived from this description found in https://medium.com/@zhimin.wen/airgap-disconnected-installation-of-openshift-3-11-18f371dbdcef: 

> Notice the oreg_url variable points to the local file server with the place holder ${component} and ${version} which will be substituted dynamically during installation.