### PR TITLE
WIP Use dedicated admin group on OSD

### DIFF
--- a/modules/nw-disabling-multicast.adoc
+++ b/modules/nw-disabling-multicast.adoc
@@ -20,7 +20,13 @@ You can disable multicast between Pods for your project.
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster with a user that has the `cluster-admin` role.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egress-ips-automatic.adoc
+++ b/modules/nw-egress-ips-automatic.adoc
@@ -11,7 +11,13 @@ for a specific namespace across one or more nodes.
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egress-ips-static.adoc
+++ b/modules/nw-egress-ips-static.adoc
@@ -10,7 +10,13 @@ In {product-title} you can associate one or more egress IP addresses with a name
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egressnetworkpolicy-create.adoc
+++ b/modules/nw-egressnetworkpolicy-create.adoc
@@ -28,7 +28,13 @@ If the project already has an {kind} object defined, you must edit the existing 
 
 * A cluster that uses the {cni} default Container Network Interface (CNI) network provider plug-in.
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster as a cluster administrator.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egressnetworkpolicy-delete.adoc
+++ b/modules/nw-egressnetworkpolicy-delete.adoc
@@ -23,7 +23,13 @@ As a cluster administrator, you can remove an egress firewall from a project.
 
 * A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster as a cluster administrator.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egressnetworkpolicy-edit.adoc
+++ b/modules/nw-egressnetworkpolicy-edit.adoc
@@ -23,7 +23,13 @@ As a cluster administrator, you can update the egress firewall for a project.
 
 * A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster as a cluster administrator.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-egressnetworkpolicy-view.adoc
+++ b/modules/nw-egressnetworkpolicy-view.adoc
@@ -22,8 +22,8 @@ You can view an {kind} object in your cluster.
 .Prerequisites
 
 * A cluster using the {cni} default Container Network Interface (CNI) network provider plug-in.
-* Install the OpenShift Command-line Interface (CLI), commonly known as `oc`.
-* You must log in to the cluster.
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster.
 
 .Procedure
 

--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -20,7 +20,13 @@ You can enable multicast between Pods for your project.
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster with a user that has the `cluster-admin` role.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -15,7 +15,13 @@ in your cluster, you can create NetworkPolicy objects.
 
 * Your cluster is using a default CNI network provider that supports NetworkPolicy objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-networkpolicy-delete.adoc
+++ b/modules/nw-networkpolicy-delete.adoc
@@ -13,7 +13,13 @@ You can delete a NetworkPolicy object.
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -12,7 +12,13 @@ You can edit a NetworkPolicy object in a namespace.
 
 * Your cluster is using a default CNI network provider that supports NetworkPolicy objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -14,7 +14,13 @@ project namespaces.
 
 * Your cluster is using a default CNI network provider that supports NetworkPolicy objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 
 .Procedure
 

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -14,7 +14,13 @@ As a cluster administrator, you can add network policy objects to the default te
 
 * Your cluster is using a default CNI network provider that supports NetworkPolicy objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You must log in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster using an account with
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+`cluster-admin` permissions.
+endif::[]
+ifdef::openshift-dedicated[]
+`dedicated-admins` permissions.
+endif::[]
 * You must have created a custom default project template for new projects.
 
 .Procedure

--- a/modules/nw-networkpolicy-view.adoc
+++ b/modules/nw-networkpolicy-view.adoc
@@ -13,7 +13,7 @@ You can list the NetworkPolicy objects in your cluster.
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* Log in to an {product-title} cluster.
 
 .Procedure
 


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/25441

So this applies in bits and pieces everywhere.

For OSD, a different administrator user is required.

But does OSD include any of the following:

- Multicast
- Egress IPs

Preview:

- [Deleting a network policy](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/deleting-network-policy.html)
- [Editing a network policy](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/editing-network-policy.html)
- [Viewing a network policy](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/viewing-network-policy.html)
- [Creating a network policy](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/creating-network-policy.html)
- [Configuring an egress firewall for a project](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/openshift_sdn/configuring-egress-firewall.html#nw-networkpolicy-create_openshift-sdn-egress-firewall)
- [Editing an egress firewall for a project](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/openshift_sdn/editing-egress-firewall.html)
- [Removing an egress firewall from a project](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/openshift_sdn/removing-egress-firewall.html)
- [Creating default network policies for a new project](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/default-network-policy.html#nw-networkpolicy-project-defaults_default-network-policy)
- [Configuring multitenant mode with network policy](https://gh-25441--ocpdocs.netlify.app/openshift-dedicated/latest/networking/network_policy/multitenant-network-policy.html)