### PR TITLE
Include VMware hardware address ranges for all installs

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -1,10 +1,24 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
+
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere:
+endif::[]
+
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:vsphere:
+endif::[]
+
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
 
 ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
@@ -215,7 +229,7 @@ A working configuration for the Ingress router is required for an
 plane initializes.
 ====
 
-ifeval::["{context}" == "installing-vsphere"]
+ifdef::vsphere[]
 [discrete]
 == Ethernet adaptor hardware address requirements
 
@@ -230,6 +244,10 @@ Identifier (OUI) allocation ranges:
 
 If a MAC address outside the VMware OUI is used, the cluster installation will
 not succeed.
+endif::vsphere[]
+
+ifdef::vsphere[]
+:!vsphere:
 endif::[]
 
 ifeval::["{context}" == "installing-ibm-z"]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/22342

This adds _Ethernet adaptor hardware address requirements_ for all user-provisioned VMware installs, and shouldn't require QE.