### PR TITLE
Bug: 1883036 - Option to not redeploy the service signer 

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -207,6 +207,10 @@ signed by an intermediate certificate, provide the bundled certificate that
 contains the full chain of intermediate and root certificates for the CA.
 See xref:../install_config/redeploying_certificates.adoc#redeploying-new-custom-ca[Redeploying a New or Custom {product-title} CA]
 
+|`openshift_redeploy_service_signer`
+| If the parameter is set to `false`, the service signer is not redeployed when you run the `openshift-master/redeploy-certificates.yml` playbook.
+The default value is `true`.
+
 |`openshift_hosted_registry_cert_expire_days`
 |Validity of the auto-generated registry certificate in days. Defaults to `730` (2 years).
 

--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -437,6 +437,9 @@ by deleting existing secrets that contain service serving certificates or removi
 annotations to appropriate services.
 ====
 
+You can set the `openshift_redeploy_service_signer=false` parameter in the inventory file to skip the redeployment of the service signer certificate, if required.
+If you set `openshift_redeploy_openshift_ca=true` and `openshift_redeploy_service_signer=true` in the inventory file, the service signing certificate is redeployed when you redeploy the master certificates. If you set `openshift_redeploy_openshift_ca=false` or omit the parameter, the service signer certificate is never redeployed.
+
 [[redeploying-named-certificates]]
 === Redeploying Only Named Certificates
 
@@ -454,8 +457,6 @@ $ ansible-playbook -i <inventory_file> \
 ====
 The *_ openshift_master_named_certificates_* parameter in ansible inventory file must contain certificates with the same name as in the *_master-config.yaml_* file. If the names of `certfile` and `keyfile` are changed, you must update the xref:../install_config/certificate_customization.adoc#configuring-custom-certificates[named certificate parameters] in the *_master-config.yaml_* file on each master node and restart the `api` and `controllers` services. The `cafile` with the full ca chain is added to `/etc/origin/master/ca-bundle.crt`.
 ====
-
-
 
 [[redeploying-etcd-certificates]]
 === Redeploying etcd Certificates Only


### PR DESCRIPTION
The docs for the Bug - 1883036. Adding option to skip the service signer deployment when redeploying certificates.