### PR TITLE
CNV-4356: stable channel

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -12,9 +12,10 @@
 :VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
-:VirtVersion: 2.4
+:VirtVersion: 2.5
 :KubeVirtVersion: v0.30.5
-:HCOVersion: 2.4.1
+:HCOVersion: 2.5.0
+:LastHCOVersion: 2.4.2
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -17,7 +17,7 @@ available information.
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role.
+* Log in to the cluster as a user with the `cluster-admin` role.
 * Install the OpenShift CLI (`oc`).
 
 .Procedure
@@ -32,11 +32,11 @@ $ oc get csv
 . Review the output, checking the `PHASE` field. For example:
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 VERSION  REPLACES                                        PHASE
-2.2.1    kubevirt-hyperconverged-operator.v2.2.0         Installing
-2.2.0                                                    Replacing
+{HCOVersion}    kubevirt-hyperconverged-operator.v{LastHCOVersion}         Installing
+{LastHCOVersion}                                                    Replacing
 ----
 
 . Optional: Monitor the aggregated status of all {VirtProductName} component

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -39,10 +39,13 @@ spec:
   sourceNamespace: openshift-marketplace
   name: kubevirt-hyperconverged
   startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
-  channel: "{VirtVersion}"
+  channel: "stable" <1>
 ----
+<1> Using the `stable` channel ensures that you install the version of
+{VirtProductName} that is compatible with your {product-title} version.
 
-. Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects for {VirtProductName} by running the following command:
+. Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects
+for {VirtProductName} by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/virt-subscribing-to-the-catalog.adoc
+++ b/modules/virt-subscribing-to-the-catalog.adoc
@@ -31,7 +31,11 @@ is automatically created if it does not exist.
 Attempting to install the {VirtProductName} Operator in a namespace other than
 `openshift-cnv` causes the installation to fail.
 ====
-.. Select *{VirtVersion}* from the list of available *Update Channel* options.
+
+.. Select *stable* from the list of available *Update Channel* options. This ensures
+that you install the version of {VirtProductName} that is compatible with your
+{product-title} version.
+
 .. For *Approval Strategy*, ensure that *Automatic*, which is the default value,
 is selected.
 {VirtProductName} automatically updates when a new z-stream release is

--- a/modules/virt-upgrading-virt.adoc
+++ b/modules/virt-upgrading-virt.adoc
@@ -10,7 +10,7 @@ You can manually upgrade {VirtProductName} to the next minor version by using th
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role.
+* Log in to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
@@ -23,8 +23,8 @@ You can manually upgrade {VirtProductName} to the next minor version by using th
 . In the *Channel* pane, click the pencil icon on the right side of the
 version number to open the *Change Subscription Update Channel* window.
 
-. Select the next minor version. For example, if you want to upgrade to {VirtProductName}
-{VirtVersion}, select *{VirtVersion}*.
+. Select *stable*. This ensures that you install the version of {VirtProductName}
+that is compatible with your {product-title} version.
 
 . Click *Save*.
 


### PR DESCRIPTION
There is now a "stable" channel that must be selected during OpenShift Virtualization installation and upgrade.

Jira: https://issues.redhat.com/browse/CNV-4356
Previews:
- [Upgrade](https://stable-channel--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-upgrading-virt_upgrading-virt)
- [Install (web)](https://stable-channel--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-web.html#virt-subscribing-to-the-catalog_installing-virt-web)
- [Install (cli)](https://stable-channel--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html#virt-subscribing-cli_installing-virt-cli)

[enterprise-4.6 only]