### PR TITLE
BZ 1877457: updating Operator name in 4.4 docs to reflect reality

### DIFF
--- a/modules/cnv-deleting-catalog-subscription.adoc
+++ b/modules/cnv-deleting-catalog-subscription.adoc
@@ -3,19 +3,18 @@
 // * cnv/cnv_install/uninstalling-container-native-virtualization.adoc
 
 [id="cnv-deleting-catalog-subscription_{context}"]
-= Deleting the {CNVProductNameStart} catalog subscription
+= Deleting the catalog subscription
 
-To finish uninstalling {CNVProductName}, delete the
-*{CNVProductNameStart}* catalog subscription.
+To finish uninstalling {CNVProductName}, delete your catalog subscription.
 
 .Prerequisites
 
-* An active subscription to the *{CNVProductNameStart}* catalog
+* An active subscription to the {CNVProductName} catalog.
 
 .Procedure
 
 . Navigate to the *Operators* -> *OperatorHub* page.
 
-. Search for *{CNVProductNameStart}* and then select it.
+. Search for *OpenShift Virtualization* and then select it.
 
 . Click *Uninstall*.

--- a/modules/cnv-deleting-custom-resource.adoc
+++ b/modules/cnv-deleting-custom-resource.adoc
@@ -10,7 +10,7 @@ To uninstall {CNVProductName}, you must first delete the
 
 .Prerequisites
 
-* An active *CNV Operator Deployment* custom resource
+* An active *CNV Operator Deployment* custom resource.
 
 .Procedure
 
@@ -19,7 +19,7 @@ the *Projects* list.
 
 . Navigate to the *Operators* -> *Installed Operators* page.
 
-. Click *{CNVProductNameStart}*.
+. Click *OpenShift Virtualization*.
 
 . Click the *CNV Operator Deployment* tab.
 

--- a/modules/cnv-deploying-cnv.adoc
+++ b/modules/cnv-deploying-cnv.adoc
@@ -5,19 +5,17 @@
 [id="cnv-deploying-cnv_{context}"]
 = Deploying {CNVProductName}
 
-After subscribing to the *{CNVProductNameStart}* catalog,
-create the *CNV Operator Deployment* custom resource
-to deploy {CNVProductName}.
+Create the *CNV Operator Deployment* custom resource to deploy {CNVProductName}.
 
 .Prerequisites
 
-* An active subscription to the *{CNVProductNameStart}* catalog in the `openshift-cnv` namespace
+* An active subscription to the {CNVProductName} catalog in the `openshift-cnv` namespace.
 
 .Procedure
 
 . Navigate to the *Operators* -> *Installed Operators* page.
 
-. Click *{CNVProductNameStart}*.
+. Click *OpenShift Virtualization*.
 
 . Click the *CNV Operator Deployment* tab and click
 *Create HyperConverged Cluster*.
@@ -28,6 +26,9 @@ To avoid deployment errors, do not rename the custom resource. Before you procee
 to the next step, ensure that the custom resource is named the default
 `kubevirt-hyperconverged`.
 ====
+
+. View the YAML to ensure that `BareMetalPlatform: true`. If necessary, change
+the value from `false` to `true` before continuing.
 
 . Click *Create* to launch {CNVProductName}.
 

--- a/modules/cnv-subscribing-to-the-catalog.adoc
+++ b/modules/cnv-subscribing-to-the-catalog.adoc
@@ -3,10 +3,10 @@
 // * cnv/cnv_install/installing-container-native-virtualization.adoc
 
 [id="cnv-subscribing-to-the-catalog_{context}"]
-= Subscribing to the {CNVProductNameStart} catalog
+= Subscribing to the {CNVProductName} catalog
 
 Before you install {CNVProductName}, subscribe to the
-*{CNVProductNameStart}* catalog from the {product-title} web console.
+{CNVProductName} catalog from the {product-title} web console.
 Subscribing gives the `openshift-cnv` namespace access to the {CNVProductName}
 Operators.
 
@@ -16,7 +16,7 @@ Operators.
 
 . Navigate to the *Operators* → *OperatorHub* page.
 
-. Search for *{CNVProductNameStart}* and then select it.
+. Search for *OpenShift Virtualization* and then select it.
 
 . Read the information about the Operator and click *Install*.
 

--- a/modules/cnv-upgrading-cnv.adoc
+++ b/modules/cnv-upgrading-cnv.adoc
@@ -16,7 +16,7 @@ You can manually upgrade {CNVProductName} to the next minor version by using the
 
 . Access the {product-title} web console and navigate to *Operators* -> *Installed Operators*.
 
-. Click *{CNVProductNameStart}* to open the *Operator Details* page.
+. Click *OpenShift Virtualization* to open the *Operator Details* page.
 
 . Click the *Subscription* tab to open the *Subscription Overview* page.
 


### PR DESCRIPTION
Even though CNV is still called CNV in 4.4 (and earlier) versions of OCP, the Operator has been renamed to OpenShift Virtualization in the app registry. This fix enables the user to find the correct Operator when installing/uninstalling/upgrading CNV 2.3. This PR also adds an extra deployment step for changing the `BareMetalPlatform` CR value to `true`, which was also brought up in the BZ.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1877457
Previews:
- [install](https://cnv-to-virt-4-4--ocpdocs.netlify.app/openshift-enterprise/latest/cnv/cnv_install/installing-container-native-virtualization.html#cnv-subscribing-to-the-catalog_installing-container-native-virtualization)
- [uninstall](https://cnv-to-virt-4-4--ocpdocs.netlify.app/openshift-enterprise/latest/cnv/cnv_install/uninstalling-container-native-virtualization.html#cnv-deleting-kubevirt-hyperconverged-custom-resource_uninstalling-container-native-virtualization)
- [upgrade](https://cnv-to-virt-4-4--ocpdocs.netlify.app/openshift-enterprise/latest/cnv/upgrading-container-native-virtualization.html#cnv-upgrading-cnv_upgrading-container-native-virtualization)
