### PR TITLE
install: ignition_url/rootfs_url only supports HTTP and HTTPS

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -47,7 +47,7 @@ Download the following files:
 ... The machine host and domain name in the form `hostname.domainname`. Omit this value to let {op-system} decide set it.
 ... The network interface name. Omit this value to let {op-system} decide set it.
 ... If you use static IP addresses, an empty string.
-** For `coreos.inst.ignition_url=`, specify the Ignition file for the machine role. Use `bootstrap.ign`, `master.ign`, or `worker.ign`.
+** For `coreos.inst.ignition_url=`, specify the Ignition file for the machine role. Use `bootstrap.ign`, `master.ign`, or `worker.ign`. Only HTTP and HTTPS are supported.
 ** All other parameters can stay as they are.
 +
 Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
@@ -55,7 +55,7 @@ Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 ----
 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=dasda coreos.inst.image_url=ftp://
 cl1.provide.example.com:8080/assets/rhcos-42.80.20191105.0-metal-dasd.raw.gz
-coreos.inst.ignition_url=ftp://cl1.provide.example.com:8080/ignition-bootstrap-0
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition-bootstrap-0
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
 rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
 !condev rd.dasd=0.0.3490

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -85,7 +85,7 @@ bond=<bonded_interface> <6>
 ----
 <1> Specify the block device of the system to install to.
 <2> Specify the URL of the RAW image that you uploaded to your server.
-<3> Specify the URL of the Ignition config file for this machine type.
+<3> Specify the URL of the Ignition config file for this machine type. Only HTTP and HTTPS are supported.
 <4> Set `ip=dhcp` or set an individual static IP address (`ip=`) and DNS server (`nameserver=`) on each node.
 See _Configure advanced networking_ for details.
 <5>  If you use multiple network interfaces or DNS servers,

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -91,7 +91,8 @@ server.
 server. The `initrd` parameter value is the location of the live `initramfs`
 file, the `coreos.inst.ignition_url` parameter value is the location of the
 bootstrap Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.inst.rootfs_url` parameters only supports HTTP and HTTPS.
 
 ** For iPXE:
 +
@@ -103,7 +104,8 @@ initrd=http://<HTTP_server>/rhcos-<version>-installer-live-initramfs.<architectu
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
 the `coreos.inst.ignition_url` parameter value is the location of the bootstrap
 Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.inst.rootfs_url` parameters only supports HTTP and HTTPS.
 <2> Specify the location of the `initramfs` file that you uploaded to your HTTP
 server.
 

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -134,7 +134,7 @@ a|Optional: Download and install the specified {op-system} image, overriding `co
 
 a|`coreos.inst.ignition_url`
 
-a|Optional: The URL of the Ignition config. If no URL is specified, no Ignition config will be embedded.
+a|Optional: The URL of the Ignition config. If no URL is specified, no Ignition config will be embedded. Only HTTP and HTTPS are supported.
 
 a|`coreos.inst.platform_id`
 

--- a/modules/machine-user-infra-machines-iso.adoc
+++ b/modules/machine-user-infra-machines-iso.adoc
@@ -34,7 +34,7 @@ coreos.inst.ignition_url=http://example.com/worker.ign <3>
 ----
 <1> Specify the block device of the system to install to.
 <2> Specify the URL of the UEFI or BIOS image that you uploaded to your server.
-<3> Specify the URL of the compute Ignition config file.
+<3> Specify the URL of the compute Ignition config file. Only HTTP and HTTPS are supported.
 
 . Press `Enter` to complete the installation. After {op-system} installs, the system
 reboots. After the system reboots, it applies the Ignition config file that you

--- a/modules/machine-user-infra-machines-pxe.adoc
+++ b/modules/machine-user-infra-machines-pxe.adoc
@@ -42,7 +42,8 @@ server.
 server. The `initrd` parameter value is the location of the live `initramfs`
 file, the `coreos.inst.ignition_url` parameter value is the location of the
 worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.inst.rootfs_url` parameters only supports HTTP and HTTPS.
 
 ** For iPXE:
 +
@@ -54,7 +55,8 @@ initrd=http://<HTTP_server>/rhcos-<version>-installer-live-initramfs.<architectu
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
 the `coreos.inst.ignition_url` parameter value is the location of the worker
 Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.inst.rootfs_url` parameters only supports HTTP and HTTPS.
 <2> Specify the location of the `initramfs` file that you uploaded to your HTTP
 server.
 


### PR DESCRIPTION
We want to be clear that the `coreos.inst.ignition_url` and
`coreos.inst.rootfs_url` parameters only supports HTTP and HTTPS
when installing RHCOS via ISO/PXE.