### PR TITLE
GH issue 25155 OCP Online and Dedicated are not supported for Service…

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -13,7 +13,7 @@ The following are the only supported configurations for the {ProductName}:
 
 [NOTE]
 ====
-OpenShift Online and OpenShift Dedicated are not supported for {ProductName} {ProductVersion}.
+OpenShift Online and OpenShift Dedicated are not supported for {ProductName}.
 ====
 
 * The deployment must be contained to a single {product-title} cluster that is not federated.


### PR DESCRIPTION
… Mesh

Fixes #25155

Removed the specific Service Mesh version because OCP Online and OCP Dedication are not supported right now for Service Mesh.