### PR TITLE
4-6 release notes for metering report expiration

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -296,6 +296,18 @@ The Local Storage Operator now has the ability to:
 * Automatically discover a list of available disks in a cluster. You can select a list of nodes, or all nodes, for auto-discovery to be continuously applied to.
 * Automatically provision local persistent volumes from attached devices. Appropriate devices are filtered and persistent volumes are provisioned based on the filtered devices.
 
+[id="ocp-4-6-operators"]
+=== Operators
+
+[id="ocp-4-6-metering-operator"]
+==== Configuring a retention period of metering Reports
+
+You can now set a retention period on a metering Report. The metering Report custom resource
+has a new `expiration` field. If the `expiration` duration value is set on a Report,
+and no other Reports or ReportQueries depend on the expiring Report, the Metering Operator
+removes the Report from your cluster at the end of its retention period. For more information,
+see metering Reports xref:../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[expiration].
+
 [id="ocp-4-6-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
This release note was reviewed and merged in a previous [PR-25526](https://github.com/openshift/openshift-docs/pull/25526) . The content was later removed due to a [merge conflict](https://github.com/openshift/openshift-docs/commit/9a84e33b9f3acd6ad6bad87157cbcbfea24e8d5b#diff-799468e7defe63964fd0a036625e2353).