### PR TITLE
tang: Note that rd.neednet=1 is needed

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -96,6 +96,8 @@ spec:
         mode: 420
         overwrite: true
         path: /etc/clevis.json
+  kernelArguments:
+    - rd.neednet=1
 EOF
 ----
 
@@ -122,6 +124,8 @@ spec:
         mode: 420
         overwrite: true
         path: /etc/clevis.json
+  kernelArguments:
+    - rd.neednet=1
 EOF
 ----
 . Continue with the remainder of the {product-title} deployment.


### PR DESCRIPTION
When encrypting with tang, we need networking in the initramfs.
This came up in e.g. https://bugzilla.redhat.com/show_bug.cgi?id=1853068
as well as a few times on Slack and other channels.