### PR TITLE
Always include padding in regular literal blocks

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -912,7 +912,7 @@ table > tbody > tr > td > div > div > p > code {
  .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] {
      background-color: #f9f9f9;
      border: 1px #aab7b8 solid;
-     padding: 0 0.5em;
+     padding: 1.75em 2em;
      word-wrap: break-word;
      color: #404040;
      font-family: "Roboto Mono", monospace;
@@ -926,8 +926,10 @@ table > tbody > tr > td > div > div > p > code {
      display: block;
 }
 /* this adds overflow for code blocks */
+/* negative padding undoes the parent padding for .iteralblock pre */
 .listingblock pre.rouge code {
   padding: 22px;
+  margin: -1.75em -2em;
   white-space: pre;
   overflow-x: auto;
 }


### PR DESCRIPTION
- This adds back in the original padding for literals
- This uses negative padding to remove it for rouge code blocks

Without the negative padding, code blocks get double padding.

<img width="884" alt="Screen Shot 2020-09-30 at 7 50 36 PM" src="https://user-images.githubusercontent.com/354496/94751315-4125d000-0356-11eb-95f4-c224e2b1020b.png">

FYI @lbarbeevargas @vikram-redhat @bergerhoffer 