### PR TITLE
Updating distro map to 4.5 for moa

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -146,7 +146,7 @@ openshift-moa:
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    enterprise-4.3:
+    enterprise-4.5:
       name: '4'
       dir: moa/4
 partner-roks:


### PR DESCRIPTION
This PR updates the master-branch distro map to build the MOA distro off the 4.5 branch.

Associated PR for the MOA 4.5 content is here: https://github.com/openshift/openshift-docs/pull/26016

@vikram-redhat FYI.