### PR TITLE
cnv 2.5: VMware imported VM name must not contain forward slash

### DIFF
--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -63,6 +63,13 @@ ifdef::virt-importing-rhv-vm[]
 endif::[]
 ifdef::virt-importing-vmware-vm[]
 . Select a virtual machine or a template to import.
+ifeval::["{VirtVersion}" < "2.5"]
++
+[IMPORTANT]
+====
+The VMware VM name must not contain a forward slash (`/`).
+====
+endif::[]
 endif::[]
 
 . Click *Next*.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1884012

CP for 4.5, 4.6