### PR TITLE
Fixing typos Openshift to OpenShift

### DIFF
--- a/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.adoc
@@ -34,7 +34,7 @@ ifdef::openshift-enterprise,openshift-webscale[]
 
 To create serverless applications, in addition to the preceding prerequisites, ensure that:
 
-* You have xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[installed the Openshift Serverless Operator].
+* You have xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[installed the OpenShift Serverless Operator].
 * You have xref:../../serverless/installing_serverless/installing-knative-serving.adoc#installing-knative-serving[created a knative-serving namespace and a KnativeServing resource in the knative-serving namespace].
 
 endif::[]

--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 [WARNING]
 ====
-Due to a known issue with installing {product-title} versions 4.4 and 4.5 on {rh-virtualization-first} 4.4.1, you must customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[Openshift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"]. This defect is fixed in {rh-virtualization} 4.4.2.
+Due to a known issue with installing {product-title} versions 4.4 and 4.5 on {rh-virtualization-first} 4.4.1, you must customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[OpenShift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"]. This defect is fixed in {rh-virtualization} 4.4.2.
 ====
 
 You can customize and install an {product-title} cluster on {rh-virtualization-first}, similar to the one shown in the following diagram.

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -11,7 +11,7 @@ Due to a known issue, this default installation procedure does not work with {pr
 
 Instead, follow the steps in link:https://docs.openshift.com/container-platform/4.5/installing/installing_rhv/installing-rhv-customizations.html[Installing a cluster on RHV with customizations].
 
-During that procedure, customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[Openshift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"].
+During that procedure, customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[OpenShift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"].
 ====
 
 You can quickly install a default, non-customized, {product-title} cluster on a {rh-virtualization-first} cluster, similar to the one shown in the following diagram.

--- a/modules/developer-cli-odo-developer-setup.adoc
+++ b/modules/developer-cli-odo-developer-setup.adoc
@@ -6,7 +6,7 @@
 
 = Developer setup
 
-With {odo-title} you can create and deploy application on {product-title} clusters from a terminal.  Code editor plug-ins use {odo-title} which allows users to interact with {product-title} clusters from their IDE terminals. Examples of plug-ins that use {odo-title}: VS Code Openshift Connector, Openshift Connector for Intellij, Codewind for Eclipse Che. 
+With {odo-title} you can create and deploy application on {product-title} clusters from a terminal.  Code editor plug-ins use {odo-title} which allows users to interact with {product-title} clusters from their IDE terminals. Examples of plug-ins that use {odo-title}: VS Code OpenShift Connector, OpenShift Connector for Intellij, Codewind for Eclipse Che. 
 
 {odo-title} works on Windows, macOS, and Linux operating systems and from any terminal. {odo-title} provides autocompletion for bash and zsh command line shells.
 

--- a/modules/developer-cli-odo-linking-both-components.adoc
+++ b/modules/developer-cli-odo-linking-both-components.adoc
@@ -19,7 +19,7 @@ $ odo list
 .Example output
 [source,terminal]
 ----
-Openshift Components: 
+OpenShift Components: 
 APP     NAME         PROJECT     TYPE          SOURCETYPE     STATE
 app     backend      testpro     openjdk18     binary         Pushed
 app     frontend     testpro     nodejs        local          Pushed

--- a/modules/developer-cli-odo-openshift-cluster-objects.adoc
+++ b/modules/developer-cli-odo-openshift-cluster-objects.adoc
@@ -30,7 +30,7 @@ The `copy-supervisord` Init container copies necessary files onto an `emptyDir` 
 ** `s2i-setup` is a script that creates files and directories which are necessary for the `assemble-and-restart` and run scripts to execute successfully. The script is executed whenever the application container starts.
 
 * Directories:
-** `language-scripts`: Openshift S2I allows custom `assemble` and `run` scripts. A few language specific custom scripts are present in the `language-scripts` directory. The custom scripts provide additional configuration to make {odo-title} debug work.
+** `language-scripts`: OpenShift S2I allows custom `assemble` and `run` scripts. A few language specific custom scripts are present in the `language-scripts` directory. The custom scripts provide additional configuration to make {odo-title} debug work.
 
 The `emtpyDir Volume` is mounted at the `/opt/odo` mount point for both the Init container and the application container.
 

--- a/modules/developer-cli-odo-openshift-source-to-image.adoc
+++ b/modules/developer-cli-odo-openshift-source-to-image.adoc
@@ -6,5 +6,5 @@
 
 = OpenShift source-to-image 
 
-Openshift Source-to-Image (S2I) is an open-source project which helps in building artifacts from source code and injecting these into container images. S2I produces ready-to-run images by building source code without the need of a Dockerfile.
+OpenShift Source-to-Image (S2I) is an open-source project which helps in building artifacts from source code and injecting these into container images. S2I produces ready-to-run images by building source code without the need of a Dockerfile.
 {odo-title} uses S2I builder image for executing developer source code inside a container.

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -113,7 +113,7 @@ ifdef::rhv[]
 
 [WARNING]
 ====
-Due to a known issue with installing {product-title} versions 4.4 and 4.5 on {rh-virtualization-first} 4.4.1, you must customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[Openshift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"].  This defect is fixed in {rh-virtualization} 4.4.2.
+Due to a known issue with installing {product-title} versions 4.4 and 4.5 on {rh-virtualization-first} 4.4.1, you must customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[OpenShift IPI installation on RHV-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"].  This defect is fixed in {rh-virtualization} 4.4.2.
 ====
 endif::rhv[]
 ifdef::vsphere[]

--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -7,7 +7,7 @@
 
 = Creating a disconnected registry (optional)
 
-In some cases, you may want to install an Openshift KNI cluster using a local copy of the installation registry. This could be for enhancing network efficiency because the cluster nodes are on a network that does not have access to the internet.
+In some cases, you may want to install an OpenShift KNI cluster using a local copy of the installation registry. This could be for enhancing network efficiency because the cluster nodes are on a network that does not have access to the internet.
 
 A local, or mirrored, copy of the registry requires the following:
 

--- a/modules/ipi-install-creating-the-openshift-manifests.adoc
+++ b/modules/ipi-install-creating-the-openshift-manifests.adoc
@@ -14,7 +14,7 @@
 ----
 INFO Consuming Install Config from target directory
 WARNING Making control-plane schedulable by setting MastersSchedulable to true for Scheduler cluster settings
-WARNING Discarding the Openshift Manifest that was provided in the target directory because its dependencies are dirty and it needs to be regenerated
+WARNING Discarding the OpenShift Manifest that was provided in the target directory because its dependencies are dirty and it needs to be regenerated
 ----
 
 . If you are you working in {product-title} 4.3 and you created the `metal3-config.yaml` file, copy the

--- a/modules/metering-use-mysql-or-postgresql-for-hive.adoc
+++ b/modules/metering-use-mysql-or-postgresql-for-hive.adoc
@@ -11,7 +11,7 @@ There are three configuration options you can use to control the database used b
 
 Create your MySQL or Postgres instance with a username and password. Then create a secret by using the OpenShift CLI or a YAML file. The secretName you create for this secret must map to the spec.hive.spec.config.db.secretName field in the MeteringConfig resource.
 
-To create a secret in Openshift CLI you can use the following command:
+To create a secret in OpenShift CLI you can use the following command:
 
 [source,terminal]
 ----

--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, OpenShift SDN supports using NetworkPolicy
 
 [NOTE]
 ====
-IPBlock is supported in NetworkPolicy with limitations for OpenshiftSDN; it
+IPBlock is supported in NetworkPolicy with limitations for OpenShift SDN; it
 supports IPBlock without except clauses. If you create a policy with an IPBlock
 section including an except clause, the SDN Pods log generates warnings and the
 entire IPBlock section of that policy is ignored.

--- a/modules/op-release-notes-1-0.adoc
+++ b/modules/op-release-notes-1-0.adoc
@@ -119,7 +119,7 @@ Alternatively, you can also modify the `buildah` ClusterTask YAML file directly 
 * Previously, the `DeploymentConfig` Task triggered a new deployment build even when an image build was already in progress. This caused the deployment of the Pipeline to fail. With this fix, the `deploy task` command  is now replaced with the `oc rollout status` command which waits for the in-progress deployment to finish.
 * Support for `APP_NAME` parameter is now added in Pipeline templates.
 * Previously, the Pipeline template for Java S2I failed to look up the image in the registry. With this fix, the image is looked up using the existing image PipelineResources instead of the user provided `IMAGE_NAME` parameter.
-* All the Openshift Pipelines images are now based on the Red Hat Universal Base Images (UBI).
+* All the OpenShift Pipelines images are now based on the Red Hat Universal Base Images (UBI).
 * Previously, when the Pipeline was installed in a namespace other than `tekton-pipelines`, the `tkn version` command displayed the Pipeline version as `unknown`. With this fix, the `tkn version` command now displays the correct Pipeline version in any namespace.
 * The `-c` flag is no longer supported for the `tkn version` command.
 * Non-admin users can now list the ClusterTriggerBindings.

--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -78,7 +78,7 @@ a pool with an `OpenShift` subscription to it:
     --enable="rhel-7-server-ose-4.5-rpms"
 ----
 
-. Install the required packages, including `Openshift-Ansible`:
+. Install the required packages, including `OpenShift-Ansible`:
 +
 [source,terminal]
 ----

--- a/rest_api/config_apis/network-config-openshift-io-v1.adoc
+++ b/rest_api/config_apis/network-config-openshift-io-v1.adoc
@@ -128,7 +128,7 @@ Type::
 
 | `autoAssignCIDRs`
 | `array (string)`
-| autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In Openshift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
+| autoAssignCIDRs is a list of CIDRs from which to automatically assign Service.ExternalIP. These are assigned when the service is of type LoadBalancer. In general, this is only useful for bare-metal clusters. In OpenShift 3.x, this was misleadingly called "IngressIPs". Automatically assigned External IPs are not affected by any ExternalIPPolicy rules. Currently, only one entry may be provided.
 
 | `policy`
 | `object`


### PR DESCRIPTION
Fixes #25783.

Also, see commit [a8204b16d16f69cc39c08cf2b2a774632aa67aa3](https://github.com/kcclemo/openshift-docs/commit/a8204b16d16f69cc39c08cf2b2a774632aa67aa3). I found another instance of this typo under:
`rest_api/config_apis/network-config-openshift-io-v1.adoc`

