### PR TITLE
GIT25663: Added information about startup probe.

### DIFF
--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -86,6 +86,26 @@ FirstSeen LastSeen    Count   From            SubobjectPath           Type      
 2s        2s      1   {kubelet worker0}   spec.containers{liveness}   Warning     Unhealthy   Liveness probe failed: cat: can't open '/tmp/healthy': No such file or directory
 ----
 
+Startup Probe::
+Legacy applications can require additional startup time on their first initialization. This situation can make it difficult to set up liveness probe parameters without compromising the fast response to deadlocks that a liveness probe provides. To prevent containers from starting slowly, configure a startup probe using the same command, HTTP or TCP check, with a `failureThreshold * periodSeconds` value long enough to handle the worst case startup time.
+
+For example, add the startup probe to the to the previous liveness check sample using a maximum of 5 minutes (30 * 10 = 300s). After the startup probe succeeds the first time, the liveness probe takes over to provide a fast response to container deadlocks. If the startup probe never succeeds within the specified time period, the container is killed and is subject to the pod's `restartPolicy`.
+
+
+.Sample Startup Check
+[source, yaml]
+----
+ startupProbe:
+   httpGet:
+     path: /healthz
+     port: liveness-port <1>
+   failureThreshold: 30 <2>
+   periodSeconds: 10 <3>
+----
+<1> Specifies the liveness port number.
+<2> Specifies the maximum number of startup attempts before the container is killed.
+<3> Specifies the number of seconds the application has to attempt starting.
+
 
 [id="application-health-about_types_{context}"]
 == Understanding the types of health checks


### PR DESCRIPTION
Fixes #25663 

The new section "Startup Probe" was added to the Monitoring Application Health page.

QE and peer review needed. Merge and CP to 4.5 and 4.6. Thanks.

**Note to peer reviewer:** Ran asciibinder build locally. Formatting is correct.