### PR TITLE
Fix merge conflict and apply SME feedback

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -47,7 +47,7 @@ Download the following files:
 ... The machine host and domain name in the form `hostname.domainname`. Omit this value to let {op-system} decide set it.
 ... The network interface name. Omit this value to let {op-system} decide set it.
 ... If you use static IP addresses, an empty string.
-** For `coreos.inst.ignition_url=`, specify the Ignition file for the machine role. Use `bootstrap.ign`, `master.ign`, or `worker.ign`.
+** For `coreos.inst.ignition_url=`, specify the Ignition file for the machine role. Use `bootstrap.ign`, `master.ign`, or `worker.ign`. Only HTTP and HTTPS protocols are supported.
 ** All other parameters can stay as they are.
 +
 Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
@@ -55,7 +55,7 @@ Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 ----
 rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=dasda coreos.inst.image_url=ftp://
 cl1.provide.example.com:8080/assets/rhcos-42.80.20191105.0-metal-dasd.raw.gz
-coreos.inst.ignition_url=ftp://cl1.provide.example.com:8080/ignition-bootstrap-0
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition-bootstrap-0
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
 rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
 !condev rd.dasd=0.0.3490

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -70,7 +70,7 @@ the `coreos-installer` command instead of adding kernel arguments. If you
 run the live installer without options or interruption, the installer boots up to a
 shell prompt on the live system, ready for you to install {op-system} to disk.
 
-. Review the “Advanced {op-system} bare metal installation configuration” 
+. Review the “Advanced {op-system} bare metal installation configuration”
 section for different ways of configuring features, such as networking
 and disk partitions, before running the `coreos-installer`.
 

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -7,13 +7,7 @@
 [id="installation-user-infra-machines-static-network_{context}"]
 = Advanced {op-system} installation reference
 
-This section illustrates the networking configuration and other advanced options that allow you to modify the {op-system-first} bare metal install process. The following tables describe the kernel arguments and command-line options you can use with:
-
-* The {op-system} live installer boot prompt by using routing and bonding.
-
-* The {op-system} live installer by using `core.inst` for ISO or PXE installs.
-
-* The `coreos-installer` command for ISO installs.
+This section illustrates the networking configuration and other advanced options that allow you to modify the {op-system-first} bare metal install process. The following tables describe the kernel arguments and command-line options you can use with the {op-system} live installer and the `coreos-installer` command.
 
 [discrete]
 == Routing and bonding options at {op-system} boot prompt
@@ -32,7 +26,7 @@ The following table describes how to use `ip=`, `nameserver=`, and `bond=` kerne
 |===
 |Description |Examples
 
-a|To configure an IP address, either use DHCP (`ip=dhcp`) or set an individual static IP address (`ip=<host_ip>`). Then identify the DNS server IP address (`nameserver=<dns_ip>`) on each node. This example sets: +
+a|To configure an IP address, either use DHCP (`ip=dhcp`) or set an individual static IP address (`ip=<host_ip>`). If setting a static IP, you must then identify the DNS server IP address (`nameserver=<dns_ip>`) on each node. This example sets: +
 
 * The node's IP address to `10.10.10.2` +
 * The gateway address to `10.10.10.254` +
@@ -101,24 +95,40 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 |===
 
 [discrete]
-== `core.inst` boot options for ISO or PXE install
+== `coreos.inst` boot options for ISO or PXE install
 
-While you can pass most standard installation boot arguments to the live installer, there are several arguments that are specific to the {op-system} live installer.
+While you can pass most standard boot arguments to the live installer, there are several arguments that are specific to the {op-system} live installer.
 
-* For ISO, these options can be added by interrupting the {op-system} installer.
+* For ISO, these options can be added by interrupting the boot at the bootloader menu.
 
-* For PXE or iPXE, these options must be added to the `APPEND` line before starting the PXE kernel. You cannot interrupt a live PXE install.
+* For PXE or iPXE, these options must be added to the `APPEND` line before starting the PXE kernel.
 
 The following table shows the {op-system} live installer boot options for ISO and PXE installs.
 
-.`core.inst` boot options
+.`coreos.inst` boot options
 [source,adoc]
 |===
 |Argument |Description
 
 a|`coreos.inst.install_dev`
 
-a|Required. The block device on the system to install to. It is recommended to use the full path, such as `/dev/sda`.
+a|Required. The block device on the system to install to. It is recommended to use the full path, such as `/dev/sda`, although `/sda` is allowed.
+
+a|`coreos.inst.ignition_url`
+
+a|Optional: The URL of the Ignition config to embed into the installed system. If no URL is specified, no Ignition config is embedded. Only HTTP and HTTPS protocols are supported.
+
+a|`coreos.inst.save_partlabel`
+
+a|Optional: Comma-separated labels of partitions to preserve during the install. Glob-style wildcards are permitted. The specified partitions do not need to exist.
+
+a|`coreos.inst.save_partindex`
+
+a|Optional: Comma-separated indexes of partitions to preserve during the install. Ranges `m-n` are permitted, and either `m` or `n` can be omitted. The specified partitions do not need to exist.
+
+a|`coreos.inst.insecure`
+
+a|Optional: Permits the OS image that is specified by `coreos.inst.image_url` to be unsigned.
 
 a|`coreos.inst.image_url`
 
@@ -129,22 +139,6 @@ a|Optional: Download and install the specified {op-system} image.
 * While this argument can be used to install a version of {op-system} that does not match the live media, it is recommended that you instead use the image that matches the version you want to install.
 
 * If you are using `coreos.inst.image_url`, you must also use `coreos.inst.insecure`. This is because the bare-metal media are not GPG-signed for {product-title}.
-
-a|`coreos.inst.ignition_url`
-
-a|Optional: The URL of the Ignition config to embed into the installed system. If no URL is specified, no Ignition config is embedded.
-
-a|`coreos.inst.save_partlabel`
-
-a|Optional: Comma-separated labels of partitions to preserve during the install. Glob-style wildcards are permitted. The specified partitions do not need to exist.
-
-a|`coreos.inst.save_partindex`
-
-a|Optional: Comma-separated indexes of partitions to preserve during the install. Ranges `m`-`n` are permitted, and either `m` or `n` can be omitted. The specified partitions do not need to exist.
-
-a|`coreos.inst.insecure`
-
-a|Optional: Permits the OS image that is specified by `coreos.inst.image_url` to be unsigned.
 
 a|`coreos.inst.skip_reboot`
 
@@ -162,11 +156,11 @@ a|Optional: The URL of the Ignition config for the live boot. For example, this 
 [discrete]
 == `coreos-installer` options for ISO install
 
-You can run the `coreos-installer` command to identify various artifacts to include, to work with disk partitions, and to set up networking. In some cases, you can configure features on the live system and copy them to the installed system.
+The `coreos-installer` command is another way for you to add boot options to the {op-system} live installer.
 
-This allows you to prepare the permanent system in a variety of ways before first boot.
+The kernel arguments in the previous table can provide a shortcut for invoking the `coreos-installer` program, but the `coreos-installer` command options are similar to those arguments, and you can run them directly from a shell prompt.
 
-The following table shows the options and subcommands you can pass to the `coreos-installer` command from a shell prompt during a live install.
+The following table shows the options and subcommands you can pass to the `coreos-installer` command during a live install.
 
 .`coreos-installer` command-line options, arguments, and subcommands
 [source,adoc]
@@ -179,9 +173,6 @@ The following table shows the options and subcommands you can pass to the `coreo
 a| `-u`, `--image-url <url>`
 a|Specify the image URL manually.
 
-a| `-f`, `--image-file <path>`
-a|Specify a local image file manually.
-
 a|`-i,` `--ignition-file <path>`
 a|Embed an Ignition config from a file.
 
@@ -192,13 +183,13 @@ a|`--ignition-hash <digest>`
 a|Digest `type-value` of the Ignition config.
 
 a|`-p`, `--platform <name>`
-a|Override the Ignition platform ID.
+a|Override the Ignition platform ID for the installed system.
 
 a|`--append-karg <arg>...`
-a|Append the default kernel argument.
+a|Append a default kernel argument to the installed system.
 
 a|`--delete-karg <arg>...`
-a|Delete the default kernel argument.
+a|Delete a default kernel argument from the installed system.
 
 a|`-n`, `--copy-network`
 a|Copy the network configuration from the install environment.
@@ -211,9 +202,6 @@ a|Save partitions with this label glob.
 
 a|`--save-partindex <id>...`
 a|Save partitions with this number or range.
-
-a|`--offline`
-a|Force offline installation.
 
 a|`--insecure`
 a|Skip signature verification.
@@ -230,6 +218,12 @@ a|Do not clear partition table on error.
 a|`-h`, `--help`
 a|Print help information.
 
+a| `-f`, `--image-file <path>`
+a|Specify a local image file manually. Used for debugging.
+
+a|
+a|
+
 2+|_Command-line argument_
 
 |*Argument* |*Description*
@@ -237,18 +231,24 @@ a|Print help information.
 a|`<device>`
 a|The destination device.
 
+a|
+a|
+
 2+|_coreos-installer embedded Ignition commands_
 
 |*Command* |*Description*
 
-a|`$ coreos-installer iso ignition embed <options> <ISO_image> <Ignition_config>`
+a|`$ coreos-installer iso ignition embed --ignition-file <options> <ISO_image>`
 a|Embed an Ignition config in an ISO image.
 
-a|`coreos-installer iso ignition show <options> <ISO_image> <Ignition_config>`
+a|`coreos-installer iso ignition show --ignition-file <options> <ISO_image>`
 |Show the embedded Ignition config from an ISO image.
 
-a|`coreos-installer iso ignition remove <options> <ISO_image> <Ignition_config>`
+a|`coreos-installer iso ignition remove --ignition-file <options> <ISO_image>`
 a|Remove the embedded Ignition config from an ISO image.
+
+a|
+a|
 
 2+|_coreos-installer ISO Ignition options_
 
@@ -266,19 +266,29 @@ a|Write the ISO to a new output file.
 a|`-h`, `--help`
 a|Print help information.
 
+a|
+a|
+
 2+|_coreos-installer PXE Ignition commands_
 
 |*Command* |*Description*
 
-a|`coreos-installer pxe ignition wrap <options> <initrd_name>`
-a|Wrap an Ignition config in an `initrd` image.
+2+|Note that not all of these options are accepted by all subcommands.
 
-a|`coreos-installer pxe ignition unwrap <options> <initrd_name>`
-a|Show the wrapped Ignition config in an `initrd` image.
+a|`coreos-installer pxe ignition wrap <options> <image_name>`
+a|Wrap an Ignition config in an image.
+
+a|`coreos-installer pxe ignition unwrap <options> <image_name>`
+a|Show the wrapped Ignition config in an image.
+
+a|
+a|
 
 2+|_coreos-installer PXE Ignition options_
 
 |*Option* |*Description*
+
+2+|Note that not all of these options are accepted by all subcommands.
 
 a|`-i`, `--ignition-file <path>`
 a|The Ignition config to be used. Default is `stdin`.

--- a/modules/machine-user-infra-machines-iso.adoc
+++ b/modules/machine-user-infra-machines-iso.adoc
@@ -34,7 +34,7 @@ coreos.inst.ignition_url=http://example.com/worker.ign <3>
 ----
 <1> Specify the block device of the system to install to.
 <2> Specify the URL of the UEFI or BIOS image that you uploaded to your server.
-<3> Specify the URL of the compute Ignition config file.
+<3> Specify the URL of the compute Ignition config file. Only HTTP and HTTPS protocols are supported.
 
 . Press `Enter` to complete the installation. After {op-system} installs, the system
 reboots. After the system reboots, it applies the Ignition config file that you

--- a/modules/machine-user-infra-machines-pxe.adoc
+++ b/modules/machine-user-infra-machines-pxe.adoc
@@ -42,7 +42,8 @@ server.
 server. The `initrd` parameter value is the location of the live `initramfs`
 file, the `coreos.inst.ignition_url` parameter value is the location of the
 worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
 
 ** For iPXE:
 +
@@ -54,7 +55,8 @@ initrd=http://<HTTP_server>/rhcos-<version>-installer-live-initramfs.<architectu
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
 the `coreos.inst.ignition_url` parameter value is the location of the worker
 Ignition config file, and the `coreos.live.rootfs_url` parameter value is
-the location of the live `rootfs` file.
+the location of the live `rootfs` file. The `coreos.inst.ignition_url` and
+`coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
 <2> Specify the location of the `initramfs` file that you uploaded to your HTTP
 server.
 


### PR DESCRIPTION
This PR incorporates feedback from CoreOS SMEs, compiled from separate PRs:

- Replaces https://github.com/openshift/openshift-docs/pull/25989 due to a merge conflict. Addresses @miabbott's changes and @bgilbert's [note](https://github.com/openshift/openshift-docs/pull/25989#discussion_r498383919) about `coreos.live.rootfs_url`.
- Addresses the comments from @bgilbert in https://github.com/openshift/openshift-docs/pull/25656. Ben: I have responded to your edits in that PR, but it was already merged, so it might make more sense to just review this fresh PR for a sanity check. Much appreciated!

This work also relates to https://github.com/openshift/openshift-docs/pull/25709. It's likely that 25709 will be merged first, hopefully without resulting merge conflicts. 🤞 