### PR TITLE
Updates PR 26013 - add tang: Note that rd.neednet=1 is needed

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -14,18 +14,22 @@ settings and run `openshift-install` to install a cluster and `oc` to work with 
 for instructions. See link:https://youtu.be/2uLKvB8Z5D0[Securing Automated Decryption New Cryptography and Techniques]
 for a presentation on Tang.
 
-. Add kernel arguments to configure networking when you do the RHCOS installations for your cluster.
-If you miss this step, the second boot will fail.
-For example, to configure DHCP networking, identify `ip=dhcp`
-or set static networking when you add parameters to the kernel command line.
+. Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line.
 
+[IMPORTANT]
+====
+Skipping this step causes the second boot to fail.
+====
+
+[start=4]
 . Install the clevis package, if it is not already installed:
-+
+
 [source,terminal]
 ----
 $ sudo yum install clevis -y
 ----
 
+[start=5]
 . Generate a thumbprint from the Tang server.
 
 .. In the following command, replace the value of `url` with the Tang server URL:
@@ -72,7 +76,8 @@ EOM
 ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3psVExHYlhuUWFoUzBHdTAiCn0K
 ----
 
-. Replace the “source” in the TPM2 example with the Base64 encoded file for the type of node to update:
+. In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
+
 ** For worker nodes, use the following command:
 +
 [source,terminal]
@@ -103,7 +108,7 @@ EOF
 +
 [source,terminal]
 ----
-$ cat << EOF > ./99-openshift-master-encryption.yaml
+$ cat << EOF > ./99-openshift-master-tang-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -124,4 +129,25 @@ spec:
         path: /etc/clevis.json
 EOF
 ----
+
+. Add the `rd.neednet=1` kernel argument, as shown in the following example:
++
+[source,yaml]
+----
+  apiVersion: machineconfiguration.openshift.io/v1
+  kind: MachineConfig
+  metadata:
+    name: <node_type>-tang <.>
+  spec:
+    config:
+      ignition:
+        version: 3.1.0
+    kernelArguments:
+      - rd.neednet=1 <.>
+----
++
+<1> Use the name you defined in the previous examples based on the type of node you are configuring, for example: `name: worker-tang`.
++
+<2> Required.
+
 . Continue with the remainder of the {product-title} deployment.


### PR DESCRIPTION
This PR was opened to incorporate the updates suggested by @cgwalters in https://github.com/openshift/openshift-docs/pull/26013, as well as the [comment](https://github.com/openshift/openshift-docs/pull/26013#issuecomment-702126830) from @jlebon. 

Jira tracking: https://issues.redhat.com/browse/OSDOCS-1559

PREVIEW LINK: [Enabling Tang disk encryption](https://pr26013-updates--ocpdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk-tang_installing-customizing)