### PR TITLE
Add more explanations for custom domain example for serverless

### DIFF
--- a/modules/serverless-service-mesh-resources.adoc
+++ b/modules/serverless-service-mesh-resources.adoc
@@ -54,13 +54,14 @@ spec:
   - default-gateway
   http:
   - rewrite:
-      authority: hello.default.svc
+      authority: hello.default.svc <1>
     route:
     - destination:
-        host: hello.default.svc
+        host: hello.default.svc <1>
         port:
           number: 80
 ----
+<1> Your Knative service in the format `<service_name>.<namespace>.svc`.
 
 .. Apply the YAML file:
 +
@@ -82,7 +83,7 @@ metadata:
   name: hello.default.svc
 spec:
   hosts:
-  - hello.default.svc
+  - hello.default.svc <1>
   location: MESH_EXTERNAL
   endpoints:
   - address: kourier-internal.knative-serving-ingress.svc
@@ -92,6 +93,7 @@ spec:
     protocol: HTTP
   resolution: DNS
 ----
+<1> Your Knative service in the format `<service_name>.<namespace>.svc`.
 
 .. Apply the YAML file:
 +
@@ -111,6 +113,7 @@ apiVersion: route.openshift.io/v1
 kind: Route
 metadata:
   name: hello
+  namespace: istio-system <1>
 spec:
   host: custom-ksvc-domain.example.com
   port:
@@ -120,10 +123,14 @@ spec:
     name: istio-ingressgateway
 ----
 
+<1> The {product-title} route must be created in the same namespace as the
+ServiceMeshControlPlane. In this example, the ServiceMeshControlPlane is
+deployed in the `istio-system` namespace.
+
 .. Apply the YAML file:
 +
 
 [source,terminal]
 ----
-$ oc apply -n istio-system -f <filename>
+$ oc apply -f <filename>
 ----


### PR DESCRIPTION
The doc assumes that we deploy `default` namespace for knative service and `istio-system` for ServiceMesh. We should add more explanation for users who deploy different namespace. 

Related to this feedback https://github.com/openshift/openshift-docs/pull/25706#discussion_r494238880

/cc @abrennan89 @cardil @maschmid 
