### PR TITLE
Bulk statistics are recorded under index threadpool

### DIFF
--- a/modules/cluster-logging-elasticsearch-rules.adoc
+++ b/modules/cluster-logging-elasticsearch-rules.adoc
@@ -13,9 +13,6 @@ You can view these alerting rules in Prometheus.
 |Description
 |Severity
 
-|ElasticsearchBulkRequestsRejectionJumps
-|Elasticsearch is experiencing an increase in bulk rejections on the specified node. This node might not be keeping up with the indexing speed."
-|Warning
 
 |ElasticsearchClusterNotHealthy
 |The cluster health status has been RED for at least 2 minutes. The cluster does not accept writes, shards may be missing, or themaster
@@ -54,6 +51,10 @@ nodes if possible. Make sure more disk space is added to the node or drop old in
 |ElasticsearchJVMHeapUseHigh
 |The JVM Heap usage on the specified node is too high.
 |alert
+
+|ElasticsearchWriteRequestsRejectionJumps
+|Elasticsearch is experiencing an increase in write rejections on the specified node. This node might not be keeping up with the indexing speed.
+|Warning
 
 |AggregatedLoggingSystemCPUHigh
 |The CPU used by the system on the specified node is too high.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1543

The alert was changed in https://github.com/openshift/elasticsearch-operator/pull/511 and changed again in
https://github.com/openshift/elasticsearch-operator/pull/533