### PR TITLE
BZ#1845929 - A self signed trust bundle breaks image pulls

### DIFF
--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -7,9 +7,7 @@
 [id="nw-proxy-configure-object_{context}"]
 = Enabling the cluster-wide proxy
 
-The Proxy object is used to manage the cluster-wide egress proxy. When a cluster is
-installed or upgraded without the proxy configured, a Proxy object is still
-generated but it will have a nil `spec`. For example:
+The `Proxy` object is used to manage the cluster-wide egress proxy. When a cluster is installed or upgraded without the proxy configured, a `Proxy` object is still generated but it will have a nil `spec`. For example:
 
 [source,yaml]
 ----
@@ -24,10 +22,12 @@ status:
 ----
 
 A cluster administrator can configure the proxy for {product-title} by modifying
-this `cluster` Proxy object.
+the `Proxy` object named `cluster`.
 
-NOTE: Only the Proxy object named `cluster` is supported, and no additional
+NOTE: Only the `Proxy` object named `cluster` is supported, and no additional
 proxies can be created.
+
+IMPORTANT: When a pod pulls an image from an image registry, the use of a self-signed certificate in the trust bundle specified by the `trustCA` field is not supported. The image pull fails with an error.
 
 .Prerequisites
 
@@ -58,7 +58,7 @@ metadata:
 <1> This data key must be named `ca-bundle.crt`.
 <2> One or more PEM-encoded X.509 certificates used to sign the proxy's
 identity certificate.
-<3> The ConfigMap name that will be referenced from the Proxy object.
+<3> The ConfigMap name that will be referenced from the `Proxy` object.
 <4> The ConfigMap must be in the `openshift-config` namespace.
 
 .. Create the ConfigMap from this file:
@@ -68,7 +68,7 @@ identity certificate.
 $ oc create -f user-ca-bundle.yaml
 ----
 
-. Use the `oc edit` command to modify the Proxy object:
+. Use the `oc edit` command to modify the `Proxy` object:
 +
 [source,terminal]
 ----

--- a/modules/nw-proxy-remove.adoc
+++ b/modules/nw-proxy-remove.adoc
@@ -5,8 +5,7 @@
 [id="nw-proxy-remove_{context}"]
 = Removing the cluster-wide proxy
 
-The `cluster` Proxy object cannot be deleted. To remove the proxy from a cluster,
-remove all `spec` fields from the Proxy object.
+The `Proxy` object named `cluster` cannot be deleted. To remove the proxy from a cluster, remove all `spec` fields from the `Proxy` object.
 
 .Prerequisites
 

--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -9,16 +9,17 @@ Production environments can deny direct access to the Internet and instead have 
 
 [IMPORTANT]
 ====
-The cluster-wide proxy is only supported if you used a user-provisioned infrastructure installation or provide your own networking, such as a virtual private cloud or virual network, for a supported provider.
+The cluster-wide proxy is supported only if you used a user-provisioned infrastructure installation or provide your own networking, such as a virtual private cloud or virtual network, for a supported provider.
 ====
 
+[id="enable-cluster-wide-proxy-prerequisites"]
 == Prerequisites
 
-* Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. Add sites to the Proxy object's `spec.noProxy` field to bypass the proxy if necessary.
+* Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. Add sites to the `Proxy` object `spec.noProxy` field to bypass the proxy if necessary.
 +
 [NOTE]
 ====
-The Proxy object's `status.noProxy` field is populated by default with the instance metadata endpoint (`169.254.169.254`) and with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The `Proxy` object `status.noProxy` field is populated by default with the instance metadata endpoint (`169.254.169.254`) and with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
 ====
 
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1845929

Preview: [Enabling the cluster-wide proxy](https://bz-1845929--ocpdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html#nw-proxy-configure-object_config-cluster-wide-proxy)