### PR TITLE
BZ-1879167 Fixes copy button code block misalignment

### DIFF
--- a/_javascripts/clipboard.js
+++ b/_javascripts/clipboard.js
@@ -1,5 +1,5 @@
 // This file runs the Clipboard.js functionality
-document.querySelectorAll('div.listingblock').forEach((codeblock, index) => {
+document.querySelectorAll('div.listingblock, div.literalblock').forEach((codeblock, index) => {
   codeblock.getElementsByTagName('pre')[0].insertAdjacentHTML("beforebegin", "<p class='clipboard-button-container'><span class='clipboard-button fa fa-clipboard'></span></p>");
   document.getElementsByTagName('pre')[index].setAttribute('id',`clipboard-${index}`);
 });


### PR DESCRIPTION
BZ-1879167 https://bugzilla.redhat.com/show_bug.cgi?id=1879167

Updated `clipboard.js` file so that a copy button is also added to any `divs` with class `literalblock`.

A preview is available here: http://file.bos.redhat.com/lbarbeev/10022020/BZ-1879167-copy-button-code-block-misaligned/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html

Changes to `_templates/_page_openshift.html.erb` are to only whitespaces. I have to update that file to build and preview the javascript changes locally. I reverted the changes back before committing.