### PR TITLE
OSDOCS#1524 - Update OVN-Kubernetes migration procedure

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -721,9 +721,9 @@ Topics:
   Topics:
   - Name: About the OVN-Kubernetes network provider
     File: about-ovn-kubernetes
-  - Name: Migrate from the OpenShift SDN default CNI network provider
+  - Name: Migrate from the OpenShift SDN cluster network provider
     File: migrate-from-openshift-sdn
-  - Name: Rollback to the OpenShift SDN default CNI network provider
+  - Name: Rollback to the OpenShift SDN cluster network provider
     File: rollback-to-openshift-sdn
   - Name: Configuring an egress firewall for a project
     File: configuring-egress-firewall-ovn

--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+
+[id="nw-ovn-kubernetes-migration-about_{context}"]
+= Migration to the OVN-Kubernetes network provider
+
+Migrating to the OVN-Kubernetes Container Network Interface (CNI) default network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+
+[NOTE]
+====
+A migration to the OVN-Kubernetes network provider is supported on installer-provisioned clusters on only bare metal hardware.
+
+Performing a migration on a user-provisioned cluster on bare metal hardware is not supported.
+====
+
+[id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
+== Considerations for migrating to the OVN-Kubernetes network provider
+
+The subnets assigned to nodes and the IP addresses assigned to individual pods are not preserved during the migration.
+
+While the OVN-Kubernetes network provider implements many of the capabilities present in the OpenShift SDN network provider, the configuration is not the same.
+
+If your cluster uses any of the following OpenShift SDN capabilities, you must manually configure the same capability in OVN-Kubernetes:
+
+* Namespace isolation
+* Egress IP addresses
+* Egress network policies
+* Egress router pods
+* Multicast
+* Network policies
+
+The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN.
+
+[id="how-the-migration-process-works_{context}"]
+== How the migration process works
+
+The migration process works as follows:
+
+. Set a temporary annotation set on the Cluster Network Operator (CNO) configuration object. This annotation triggers the CNO to watch for a change to the `defaultNetwork` field.
+
+. Suspend the Machine Config Operator (MCO) to ensure that it does not interrupt the migration.
+
+. Update the `defaultNetwork` field. The update causes the CNO to destroy the OpenShift SDN control plane pods and deploy the OVN-Kubernetes control plane pods. Additionally, it updates the Multus objects to reflect the new cluster network provider.
+
+. Reboot each node in the cluster. Because the existing pods in the cluster are unaware of the change to the cluster network provider, rebooting each node ensures that each node is drained of pods. New pods are attached to the new cluster network provided by OVN-Kubernetes.
+
+. Enable the MCO after all nodes in the cluster reboot. The MCO rolls out an update to the systemd configuration necessary to complete the migration. The MCO updates a single machine per pool at a time by default, so the total time the migration takes increases with the size of the cluster.
+
+[discrete]
+[id="namespace-isolation_{context}"]
+=== Namespace isolation
+
+OVN-Kubernetes supports only the network policy isolation mode.
+
+[IMPORTANT]
+====
+If your cluster is using OpenShift SDN configured in either the multitenant or subnet isolation modes, you cannot migrate to the OVN-Kubernetes network provider.
+====
+
+[discrete]
+[id="egress-ip-addresses_{context}"]
+=== Egress IP addresses
+
+The differences in configuring an egress IP address between OVN-Kubernetes and OpenShift SDN is described in the following table:
+
+.Differences in egress IP address configuration
+[cols="1a,1a",options="header"]
+|===
+|OVN-Kubernetes|OpenShift SDN
+
+|
+* Create an `EgressIPs` object
+* Add an annotation on a `Node` object
+
+|
+* Patch a `NetNamespace` object
+* Patch a `HostSubnet` object
+|===
+
+For more information on using egress IP addresses in OVN-Kubernetes, see "Configuring an egress IP address".
+
+[discrete]
+[id="egress-network-policies_{context}"]
+=== Egress network policies
+
+The difference in configuring an egress network policy, also known as an egress firewall, between OVN-Kubernetes and OpenShift SDN is described in the following table:
+
+.Differences in egress network policy configuration
+[cols="1a,1a",options="header"]
+|===
+|OVN-Kubernetes|OpenShift SDN
+
+|
+* Create an `EgressFirewall` object in a namespace
+
+|
+* Create an `EgressNetworkPolicy` object in a namespace
+|===
+
+For more information on using an egress firewall in OVN-Kubernetes, see "Configuring an egress firewall for a project".
+
+[discrete]
+[id="egress-router-pods_{context}"]
+=== Egress router pods
+
+OVN-Kubernetes does not support using egress router pods in {product-title} 4.6.
+
+[discrete]
+[id="multicast_{context}"]
+=== Multicast
+
+The difference between enabling multicast traffic on OVN-Kubernetes and OpenShift SDN is described in the following table:
+
+.Differences in multicast configuration
+[cols="1a,1a",options="header"]
+|===
+|OVN-Kubernetes|OpenShift SDN
+
+|
+* Add an annotation on a `Namespace` object
+
+|
+* Add an annotation on a `NetNamespace` object
+|===
+
+For more information on using an egress firewall in OVN-Kubernetes, see "Enabling multicast for a project".
+
+[discrete]
+[id="network-policies_{context}"]
+=== Network policies
+
+OVN-Kubernetes fully supports the Kubernetes `NetworkPolicy` API in the `networking.k8s.io/v1` API group. No changes are necessary in your network policies when migrating from OpenShift SDN.

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -16,9 +16,10 @@ Perform the migration only when an interruption in service is acceptable.
 
 .Prerequisites
 
+* A cluster installed on bare metal installer-provisioned infrastructure and configured with the OpenShift SDN default CNI network provider in the network policy isolation mode.
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
-* A cluster installed on bare metal infrastructure configured with the OpenShift SDN default CNI network provider.
+* A recent backup of the etcd database is available.
 * The cluster is in a known good state, without any errors.
 
 .Procedure
@@ -38,7 +39,25 @@ $ oc annotate Network.operator.openshift.io cluster \
   'networkoperator.openshift.io/network-migration'=""
 ----
 
-. To change the default CNI network provider, enter the following command:
+. Stop all of the machine configuration pools managed by the Machine Config Operator (MCO):
+
+** Stop the master configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool master --type='merge' --patch \
+  '{ "spec": { "paused": true } }'
+----
+
+** Stop the worker configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool worker --type='merge' --patch \
+  '{ "spec":{ "paused" :true } }'
+----
+
+. To configure the OVN-Kubernetes cluster network provider, enter the following command:
 +
 [source,terminal]
 ----
@@ -46,14 +65,65 @@ $ oc patch Network.config.openshift.io cluster \
   --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
 ----
 
-. To confirm the migration disabled the OpenShift SDN default CNI network provider and removed all OpenShift SDN pods, enter the following command. It might take several moments for all the OpenShift SDN pods to stop.
+. Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
++
+--
+* Maximum transmission unit (MTU)
+* Geneve (Generic Network Virtualization Encapsulation) overlay network port
+--
++
+To customize either of the previously noted settings, enter and customize the following command. If you do not need to change the default value, omit the key from the patch.
 +
 [source,terminal]
 ----
-$ watch oc get pod -n openshift-sdn
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":<mtu>,
+          "genevePort":<port>
+    }}}}'
+----
++
+--
+`mtu`::
+The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+`port`::
+The UDP port for the Geneve overlay network.
+--
++
+.Example patch command to update `mtu` field
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "mtu":1200
+    }}}}'
 ----
 
-. To complete the migration, reboot each node in your cluster. For example, you could use a bash script similar to the following. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
+. Wait until the Multus daemon set pods restart.
++
+[source,terminal]
+----
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
+----
+
+. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
 +
 [source,bash]
 ----
@@ -66,7 +136,72 @@ do
 done
 ----
 
-. After the nodes in your cluster have rebooted, confirm that the migration succeeded:
+. After the nodes in your cluster have rebooted, start all of the machine configuration pools:
++
+--
+* Start the master configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool master --type='merge' --patch \
+  '{ "spec": { "paused": false } }'
+----
+
+* Start the worker configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool worker --type='merge' --patch \
+  '{ "spec": { "paused": false } }'
+----
+--
++
+As the MCO updates machines in each config pool, it reboots each node.
++
+By default the MCO updates a single machine per pool at a time, so the time that the migration requires to complete grows with the size of the cluster.
+
+. Confirm the status of the new machine configuration on the hosts:
+.. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc describe node | egrep "hostname|machineconfig"
+----
++
+.Example output
+[source,terminal]
+----
+kubernetes.io/hostname=master-0
+machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/reason:
+machineconfiguration.openshift.io/state: Done
+----
++
+Verify that the following statements are true:
++
+--
+ * The value of `machineconfiguration.openshift.io/state` field is `Done`.
+ * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+--
+
+.. To confirm that the machine config is correct, enter the following command:
++
+[source,terminal]
+----
+$ oc get machineconfig <config_name> -o yaml | grep ExecStart
+----
++
+where `<config_name>` is the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
++
+The machine config must include the following update to the systemd configuration:
++
+[source,plain]
+----
+ExecStart=/usr/local/bin/configure-ovs.sh OVNKubernetes
+----
+
+. Confirm that the migration succeeded:
 
 .. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
 +
@@ -81,8 +216,45 @@ $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 ----
 $ oc get nodes
 ----
+
+.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
+
+... To list the pods, enter the following command:
 +
-If a node is stuck in the `NotReady` state, reboot the node again.
+[source,terminal]
+----
+$ oc get pod -n openshift-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+machine-config-controller-75f756f89d-sjp8b   1/1     Running   0          37m
+machine-config-daemon-5cf4b                  2/2     Running   0          43h
+machine-config-daemon-7wzcd                  2/2     Running   0          43h
+machine-config-daemon-fc946                  2/2     Running   0          43h
+machine-config-daemon-g2v28                  2/2     Running   0          43h
+machine-config-daemon-gcl4f                  2/2     Running   0          43h
+machine-config-daemon-l5tnv                  2/2     Running   0          43h
+machine-config-operator-79d9c55d5-hth92      1/1     Running   0          37m
+machine-config-server-bsc8h                  1/1     Running   0          43h
+machine-config-server-hklrm                  1/1     Running   0          43h
+machine-config-server-k9rtx                  1/1     Running   0          43h
+----
++
+The names for the config daemon pods are in the following format: `machine-config-daemon-<seq>`. The `<seq>` value is a random five character alphanumeric sequence.
+
+... Display the pod log for the first machine config daemon pod shown in the previous output by enter the following command:
++
+[source,terminal]
+----
+$ oc logs <pod> -n openshift-machine-config-operator
+----
++
+where `pod` is the name of a machine config daemon pod.
+
+... Resolve any errors in the logs shown by the output from the previous command.
 
 .. To confirm that your pods are not in an error state, enter the following command:
 +
@@ -109,3 +281,36 @@ $ oc annotate Network.operator.openshift.io cluster \
 ----
 $ oc delete namespace openshift-sdn
 ----
+
+// https://bugzilla.redhat.com/show_bug.cgi?id=1898159
+////
+. Configure the OVN-Kubernetes cluster network provider with one of the following commands:
+
+** To specify the network provider without changing the cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
+----
+
+.. To specify a different cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{
+    "spec": {
+      "clusterNetwork": [
+        "cidr": "<cidr>",
+        "hostPrefix": "<prefix>"
+      ]
+      "networkType": "OVNKubernetes"
+    } 
+  }'
+----
++
+where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster.
++
+IMPORTANT: You cannot change the service network address block during the migration.
+////

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -10,7 +10,7 @@ During the rollback, you must reboot every node in your cluster.
 
 [IMPORTANT]
 ====
-Only rollback to OpenShift SDN if the migration to OVN-Kubernetes is unsuccessful.
+Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 ====
 
 .Prerequisites
@@ -18,6 +18,8 @@ Only rollback to OpenShift SDN if the migration to OVN-Kubernetes is unsuccessfu
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
 * A cluster installed on bare metal infrastructure configured with the OVN-Kubernetes default CNI network provider.
+
+.Procedure
 
 . To enable the migration, set an annotation on the Cluster Network Operator configuration object by entering the following command:
 +
@@ -27,7 +29,25 @@ $ oc annotate Network.operator.openshift.io cluster \
   'networkoperator.openshift.io/network-migration'=""
 ----
 
-. To change the default CNI network provider, enter the following command:
+. Stop all of the machine configuration pools managed by the Machine Config Operator (MCO):
+
+** Stop the master configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool master --type='merge' --patch \
+  '{ "spec": { "paused": true } }'
+----
+
+** Stop the worker configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool worker --type='merge' --patch \
+  '{ "spec":{ "paused" :true } }'
+----
+
+. To configure the OpenShift SDN cluster network provider, enter the following command:
 +
 [source,terminal]
 ----
@@ -35,18 +55,62 @@ $ oc patch Network.config.openshift.io cluster \
   --type='merge' --patch '{ "spec": { "networkType": "OpenShiftSDN" } }'
 ----
 
-. Optional: Use the backup of the cluster network configuration that you created before the migration to restore any customizations to the network configuration that you might have made. To restore the customizations, enter the following command to edit the Cluster Network Operator configuration:
+. Optional: You can customize the following settings for OpenShift SDN to meet your network infrastructure requirements:
++
+--
+* Maximum transmission unit (MTU)
+* VXLAN port
+--
++
+To customize either or both of the previously noted settings, customize and enter the following command. If you do not need to change the default value, omit the key from the patch.
 +
 [source,terminal]
 ----
-$ oc edit Network.config.openshift.io cluster
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "openshiftSDNConfig":{
+          "mtu":<mtu>,
+          "vxlanPort":<port>
+    }}}}'
+----
++
+--
+`mtu`::
+The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+`port`::
+The UDP port for the Geneve overlay network.
+--
++
+.Example patch command 
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+  --patch '{
+    "spec":{
+      "defaultNetwork":{
+        "openshiftSDNConfig":{
+          "mtu":1200
+    }}}}'
 ----
 
-. To confirm that the migration disabled the OVN-Kubernetes default CNI network provider and removed all the OVN-Kubernetes pods, enter the following command. It might take several moments for all the OVN-Kubernetes pods to stop.
+. Wait until the Multus daemon set pods restart.
 +
 [source,terminal]
 ----
-$ watch oc get pod -n openshift-ovn-kubernetes
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
 ----
 
 . To complete the rollback, reboot each node in your cluster. For example, you could use a bash script similar to the following. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
@@ -62,21 +126,131 @@ do
 done
 ----
 
-. After the nodes in your cluster have rebooted, enter the following command to confirm that the default CNI network provider is OpenShift SDN. The value of `status.networkType` must be `OpenShiftSDN`.
+. After the nodes in your cluster have rebooted, start all of the machine configuration pools:
++
+--
+* Start the master configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool master --type='merge' --patch \
+  '{ "spec": { "paused": false } }'
+----
+
+* Start the worker configuration pool:
++
+[source,terminal]
+----
+$ oc patch MachineConfigPool worker --type='merge' --patch \
+  '{ "spec": { "paused": false } }'
+----
+--
++
+As the MCO updates machines in each config pool, it reboots each node.
++
+By default the MCO updates a single machine per pool at a time, so the time that the migration requires to complete grows with the size of the cluster.
+
+. Confirm the status of the new machine configuration on the hosts:
+.. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc describe node | egrep "hostname|machineconfig"
+----
++
+.Example output
+[source,terminal]
+----
+kubernetes.io/hostname=master-0
+machineconfiguration.openshift.io/currentConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/desiredConfig: rendered-master-c53e221d9d24e1c8bb6ee89dd3d8ad7b
+machineconfiguration.openshift.io/reason:
+machineconfiguration.openshift.io/state: Done
+----
++
+Verify that the following statements are true:
++
+--
+ * The value of `machineconfiguration.openshift.io/state` field is `Done`.
+ * The value of the `machineconfiguration.openshift.io/currentConfig` field is equal to the value of the `machineconfiguration.openshift.io/desiredConfig` field.
+--
+
+.. To confirm that the machine config is correct, enter the following command:
++
+[source,terminal]
+----
+$ oc get machineconfig <config_name> -o yaml
+----
++
+where `<config_name>` is the name of the machine config from the `machineconfiguration.openshift.io/currentConfig` field.
+
+. Confirm that the migration succeeded:
+
+.. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
 +
 [source,terminal]
 ----
 $ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
 ----
 
-. To confirm that the OpenShift SDN pods are in the `READY` state, enter the following command:
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get pod -n openshift-sdn --watch
+$ oc get nodes
 ----
 
-. To remove the migration annotation from the Cluster Network Operator configuration object, enter the following command:
+.. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
+
+... To list the pods, enter the following command:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-machine-config-operator
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                         READY   STATUS    RESTARTS   AGE
+machine-config-controller-75f756f89d-sjp8b   1/1     Running   0          37m
+machine-config-daemon-5cf4b                  2/2     Running   0          43h
+machine-config-daemon-7wzcd                  2/2     Running   0          43h
+machine-config-daemon-fc946                  2/2     Running   0          43h
+machine-config-daemon-g2v28                  2/2     Running   0          43h
+machine-config-daemon-gcl4f                  2/2     Running   0          43h
+machine-config-daemon-l5tnv                  2/2     Running   0          43h
+machine-config-operator-79d9c55d5-hth92      1/1     Running   0          37m
+machine-config-server-bsc8h                  1/1     Running   0          43h
+machine-config-server-hklrm                  1/1     Running   0          43h
+machine-config-server-k9rtx                  1/1     Running   0          43h
+----
++
+The names for the config daemon pods are in the following format: `machine-config-daemon-<seq>`. The `<seq>` value is a random five character alphanumeric sequence.
+
+... To display the pod log for each machine config daemon pod shown in the previous output, enter the following command:
++
+[source,terminal]
+----
+$ oc logs <pod> -n openshift-machine-config-operator
+----
++
+where `pod` is the name of a machine config daemon pod.
+
+... Resolve any errors in the logs shown by the output from the previous command.
+
+.. To confirm that your pods are not in an error state, enter the following command:
++
+[source,terminal]
+----
+$ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
+----
++
+If pods on a node are in an error state, reboot that node.
+
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. To remove the migration annotation from the Cluster Network Operator configuration object, enter the following command:
 +
 [source,terminal]
 ----
@@ -84,7 +258,7 @@ $ oc annotate Network.operator.openshift.io cluster \
   networkoperator.openshift.io/network-migration-
 ----
 
-. To remove the OVN-Kubernetes network provider namespace, enter the following command:
+.. To remove the OVN-Kubernetes network provider namespace, enter the following command:
 +
 [source,terminal]
 ----

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -1,5 +1,5 @@
 [id="migrate-from-openshift-sdn"]
-= Migrate from the OpenShift SDN default CNI network provider
+= Migrate from the OpenShift SDN cluster network provider
 include::modules/common-attributes.adoc[]
 :context: migrate-from-openshift-sdn
 
@@ -9,4 +9,22 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes default Contai
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network provider].
 
+include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
+
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
+
+[id="migrate-from-openshift-sdn-additional-resources"]
+== Additional resources
+
+* xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes default CNI network provider]
+* xref:../../backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* OVN-Kubernetes capabilities
+- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+- xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
+- xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
+* OpenShift SDN capabilities
+- xref:../../networking/openshift_sdn/assigning-egress-ips.adoc#assigning-egress-ips[Configuring egress IPs for a project]
+- xref:../../networking/openshift_sdn/configuring-egress-firewall.adoc#configuring-egress-firewall[Configuring an egress firewall for a project]
+- xref:../../networking/openshift_sdn/enabling-multicast.adoc#enabling-multicast[Enabling multicast for a project]
+* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1524

Previews:
- [Migrate from the OpenShift SDN default CNI network provider](https://osdocs-1524--ocpdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)
- [Rollback to the OpenShift SDN network provider](https://osdocs-1524--ocpdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html)
