### PR TITLE
CNV-920 managing offline VM snapshots

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2346,6 +2346,8 @@ Topics:
       File: virt-uploading-local-disk-images-virtctl
     - Name: Uploading a local disk image to a block storage DataVolume
       File: virt-uploading-local-disk-images-block
+    - Name: Managing offline virtual machine snapshots
+      File: virt-managing-offline-vm-snapshots
     - Name: Moving a local virtual machine disk to a different node
       File: virt-moving-local-vm-disk-to-different-node
     - Name: Expanding virtual storage by adding blank disk images

--- a/modules/virt-about-vm-snapshots.adoc
+++ b/modules/virt-about-vm-snapshots.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-about-vm-snapshots_{context}"]
+= About virtual machine snapshots
+
+A _snapshot_ represents the state and data of a virtual machine (VM) at a specific point in time. You can use a snapshot to restore an existing VM to a previous state (represented by
+the snapshot) for backup and disaster recovery or to rapidly roll back to a previous development version.
+
+An offline VM snapshot is created from a VM that is powered off (Stopped state). The snapshot stores a copy of each Container Storage Interface (CSI) volume attached to the VM and a copy of the VM
+specification and metadata. Snapshots cannot be changed after creation.
+
+With the offline VM snapshots feature, cluster administrators and application developers can:
+
+* Create a new snapshot
+* List all snapshots attached to a specific VM
+* Restore a VM from a snapshot
+* Delete an existing VM snapshot
+
+== Virtual machine snapshot controller and Custom Resource Definitions (CRDs)
+
+The VM snapshot feature introduces three new API objects defined as CRDs for managing snapshots:
+
+* `VirtualMachineSnapshot`: Represents a user request to create a snapshot. It contains information about the current state of the VM.
+* `VirtualMachineSnapshotContent`: Represents a provisioned resource on the cluster (a snapshot). It is created by the VM snapshot controller and contains references to all resources required to restore the VM.
+* `VirtualMachineRestore`: Represents a user request to restore a VM from a snapshot.
+
+The VM snapshot controller binds a `VirtualMachineSnapshotContent` object with the `VirtualMachineSnapshot` object for which it was created, with a one-to-one mapping.

--- a/modules/virt-creating-offline-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-offline-vm-snapshot-cli.adoc
@@ -1,0 +1,99 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-creating-offline-vm-snapshot-cli_{context}"]
+= Creating an offline virtual machine snapshot in the CLI
+
+You can create a virtual machine (VM) snapshot for an offline VM by creating a `VirtualMachineSnapshot` object.
+
+.Prerequisites
+
+* Ensure that the persistent volume claims (PVCs) are in a storage class that supports Container Storage Interface (CSI) volume snapshots.
+* Install the OpenShift CLI (`oc`).
+* Power down the VM for which you want to create a snapshot.
+
+.Procedure
+
+. Create a YAML file to define a `VirtualMachineSnapshot` object that specifies the name of the new `VirtualMachineSnapshot` and the name of the source VM.
++
+For example:
++
+[source,yaml]
+
+----
+apiVersion: snapshot.kubevirt.io/v1alpha1
+kind: VirtualMachineSnapshot
+metadata:
+  name: my-vmsnapshot <1>
+spec:
+  source:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: my-vm <2>
+----
+<1> The name of the new `VirtualMachineSnapshot` object.
+<2> The name of the source VM.
+
+. Create the `VirtualMachineSnapshot` resource. The snapshot controller creates a `VirtualMachineSnapshotContent` object, binds it to the `VirtualMachineSnapshot` and updates the `status` and `readyToUse` fields
+of the `VirtualMachineSnapshot` object.
++
+[source,terminal]
+----
+$ oc create -f <my-vmsnapshot>.yaml
+----
+
+.Verification steps
+
+. Verify that the `VirtualMachineSnapshot` object is created and bound with `VirtualMachineSnapshotContent`. The `readyToUse` flag must be set to `true`.
++
+[source,terminal]
+----
+$ oc describe vmsnapshot <my-vmsnapshot>
+----
++
+.Example output
+
+[source, yaml]
+
+----
+apiVersion: snapshot.kubevirt.io/v1alpha1
+kind: VirtualMachineSnapshot
+metadata:
+creationTimestamp: "2020-09-30T14:41:51Z"
+finalizers:
+- snapshot.kubevirt.io/vmsnapshot-protection
+generation: 5
+name: mysnap
+namespace: default
+resourceVersion: "3897"
+selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
+uid: 28eedf08-5d6a-42c1-969c-2eda58e2a78d
+spec:
+source:
+apiGroup: kubevirt.io
+kind: VirtualMachine
+name: my-vm
+status:
+conditions:
+  - lastProbeTime: null
+  lastTransitionTime: "2020-09-30T14:42:03Z"
+  reason: Operation complete
+  status: "False" <1>
+  type: Progressing
+  - lastProbeTime: null
+  lastTransitionTime: "2020-09-30T14:42:03Z"
+  reason: Operation complete
+  status: "True" <2>
+  type: Ready
+creationTime: "2020-09-30T14:42:03Z"
+readyToUse: true <3>
+sourceUID: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
+virtualMachineSnapshotContentName: vmsnapshot-content-28eedf08-5d6a-42c1-969c-2eda58e2a78d <4>
+----
+<1> The `status` field of the `Progressing` condition specifies if the snapshot is still being created.
+<2> The `status` field of the `Ready` condition specifies if the snapshot creation process is complete.
+<3> Specifies if the snapshot is ready to be used.
+<4> Specifies that the snapshot is bound to a `VirtualMachineSnapshotContent` object created by the snapshot controller.
+
+. Check the `spec:volumeBackups` property of the `VirtualMachineSnapshotContent` resource to verify that the expected PVCs are included in the snapshot.

--- a/modules/virt-deleting-vm-snapshot-cli.adoc
+++ b/modules/virt-deleting-vm-snapshot-cli.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-deleting-vm-snapshot-cli_{context}"]
+= Deleting a virtual machine snapshot in the CLI
+
+You can delete an existing virtual machine (VM) snapshot by deleting the appropriate `VirtualMachineSnapshot` object.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+.Procedure
+
+* Delete the `VirtualMachineSnapshot` object. The snapshot controller deletes the `VirtualMachineSnapshot` along with the associated `VirtualMachineSnapshotContent` object.
++
+[source,terminal]
+----
+$ oc delete vmsnapshot <my-vmsnapshot>
+----
+
+.Verification steps
+
+* Verify that the snapshot is deleted and no longer attached to this VM:
++
+[source,terminal]
+----
+$ oc get vmsnapshot
+----

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-restoring-vm-from-snapshot-cli_{context}"]
+= Restoring a virtual machine from a snapshot in the CLI
+
+You can restore an existing virtual machine (VM) to a previous configuration by using a VM snapshot .
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Power down the VM you want to restore to a previous state.
+
+.Procedure
+
+. Create a YAML file to define a `VirtualMachineRestore` object that specifies the name of the VM you want to restore and the name of the snapshot to be used as the source.
++
+For example:
++
+[source,yaml]
+
+----
+apiVersion: snapshot.kubevirt.io/v1alpha1
+kind: VirtualMachineRestore
+metadata:
+  name: my-vmrestore <1>
+spec:
+  target:
+    apiGroup: kubevirt.io
+    kind: VirtualMachine
+    name: my-vm <2>
+  virtualMachineSnapshotName: my-vmsnapshot <3>
+----
+<1> The name of the new `VirtualMachineRestore` object.
+<2> The name of the target VM you want to restore.
+<3> The name of the `VirtualMachineSnapshot` object to be used as the source.
+
+. Create the `VirtualMachineRestore` resource. The snapshot controller updates the status fields of the `VirtualMachineRestore` object and replaces the existing VM configuration with the snapshot content.
++
+[source,terminal]
+----
+$ oc create -f <my-vmrestore>.yaml
+----
+
+.Verification steps
+
+* Verify that the VM is restored to the previous state represented by the snapshot. The `complete` flag must be set to `true`.
++
+[source,terminal]
+----
+$ oc get vmrestore <my-vmrestore>
+----
++
+.Example output
++
+[source, yaml]
+
+----
+apiVersion: snapshot.kubevirt.io/v1alpha1
+kind: VirtualMachineRestore
+metadata:
+creationTimestamp: "2020-09-30T14:46:27Z"
+generation: 5
+name: my-vmrestore
+namespace: default
+ownerReferences:
+- apiVersion: kubevirt.io/v1alpha3
+blockOwnerDeletion: true
+controller: true
+kind: VirtualMachine
+name: my-vm
+uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
+resourceVersion: "5512"
+selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
+uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
+spec:
+target:
+apiGroup: kubevirt.io
+kind: VirtualMachine
+name: my-vm
+virtualMachineSnapshotName: my-vmsnapshot
+status:
+complete: true <1>
+conditions:
+- lastProbeTime: null
+lastTransitionTime: "2020-09-30T14:46:28Z"
+reason: Operation complete
+status: "False" <2>
+type: Progressing
+- lastProbeTime: null
+lastTransitionTime: "2020-09-30T14:46:28Z"
+reason: Operation complete
+status: "True" <3>
+type: Ready
+deletedDataVolumes:
+- test-dv1
+restoreTime: "2020-09-30T14:46:28Z"
+restores:
+- dataVolumeName: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
+persistentVolumeClaim: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
+volumeName: datavolumedisk1
+volumeSnapshotName: vmsnapshot-28eedf08-5d6a-42c1-969c-2eda58e2a78d-volume-datavolumedisk1
+----
+<1> Specifies if the process of restoring the VM to the state represented by the snapshot is complete.
+<2> The `status` field of the `Progressing` condition specifies if the VM is still being restored.
+<3> The `status` field of the `Ready` condition specifies if the VM restoration process is complete.

--- a/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
@@ -1,0 +1,23 @@
+[id="virt-managing-offline-vm-snapshots"]
+= Managing offline virtual machine snapshots
+include::modules/virt-document-attributes.adoc[]
+:context: virt-managing-offline-vm-snapshots
+toc::[]
+
+You can create, restore, and delete virtual machine (VM) snapshots for VMs that are powered off (offline). {VirtProductName} supports
+offline VM snapshots on:
+
+* Red Hat OpenShift Container Storage
+* Any other storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
+
+include::modules/virt-about-vm-snapshots.adoc[leveloffset=+1]
+
+include::modules/virt-creating-offline-vm-snapshot-cli.adoc[leveloffset=+1]
+
+include::modules/virt-restoring-vm-from-snapshot-cli.adoc[leveloffset=+1]
+
+include::modules/virt-deleting-vm-snapshot-cli.adoc[leveloffset=+1]
+
+== Additional resources
+
+* xref:../../../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI Volume Snapshots]


### PR DESCRIPTION
These modules and assembly address https://issues.redhat.com/browse/CNV-920

Preview build: https://cnv-920--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.html

Applies to branch/enterprise-4.6

Code review requested from Adam Litke and Michael Henriksen (tagged in Jira)
QE review requested from Ying Cui @demilyc; review completed by feature owner Natalia Gavrilov

