### PR TITLE
[virt] BZ 1869194: OpenShift Virtualization Operator Deployment tab

### DIFF
--- a/modules/virt-deleting-deployment-custom-resource.adoc
+++ b/modules/virt-deleting-deployment-custom-resource.adoc
@@ -1,18 +1,18 @@
 // Module included in the following assemblies:
 //
-// * virt/install/uninstalling-virt.adoc
+// * virt/install/uninstalling-virt-web.adoc
 
 //This file contains UI elements and/or package names that need to be updated.
 
-[id="virt-deleting-kubevirt-hyperconverged-custom-resource_{context}"]
-= Deleting the CNV Operator Deployment custom resource
+[id="virt-deleting-deployment-custom-resource_{context}"]
+= Deleting the {VirtProductName} Operator Deployment custom resource
 
 To uninstall {VirtProductName}, you must first delete the
-*CNV Operator Deployment* custom resource.
+*{VirtProductName} Operator Deployment* custom resource.
 
 .Prerequisites
 
-* An active *CNV Operator Deployment* custom resource
+* Create the *{VirtProductName} Operator Deployment* custom resource.
 
 .Procedure
 
@@ -23,7 +23,7 @@ the *Projects* list.
 
 . Click *{VirtProductName}*.
 
-. Click the *CNV Operator Deployment* tab.
+. Click the *{VirtProductName} Operator Deployment* tab.
 
 . Click the Options menu {kebab} in the row containing the *kubevirt-hyperconverged*
 custom resource. In the expanded menu, click *Delete HyperConverged Cluster*.

--- a/modules/virt-deploying-virt.adoc
+++ b/modules/virt-deploying-virt.adoc
@@ -8,12 +8,12 @@
 = Deploying {VirtProductName}
 
 After subscribing to the *{VirtProductName}* catalog,
-create the *CNV Operator Deployment* custom resource
+create the *{VirtProductName} Operator Deployment* custom resource
 to deploy {VirtProductName}.
 
 .Prerequisites
 
-* An active subscription to the *{VirtProductName}* catalog in the `openshift-cnv` namespace
+* Subscribe to the *{VirtProductName}* catalog in the `openshift-cnv` namespace.
 
 .Procedure
 
@@ -21,7 +21,7 @@ to deploy {VirtProductName}.
 
 . Click *{VirtProductName}*.
 
-. Click the *CNV Operator Deployment* tab and click
+. Click the *{VirtProductName} Operator Deployment* tab and click
 *Create HyperConverged Cluster*.
 +
 [WARNING]

--- a/virt/install/uninstalling-virt-web.adoc
+++ b/virt/install/uninstalling-virt-web.adoc
@@ -20,7 +20,7 @@ Attempting to uninstall {VirtProductName} without deleting these objects
 results in failure.
 ====
 
-include::modules/virt-deleting-custom-resource.adoc[leveloffset=+1]
+include::modules/virt-deleting-deployment-custom-resource.adoc[leveloffset=+1]
 
 include::modules/virt-deleting-catalog-subscription.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1869194
- This tab has been updated for 2.4.2, so this PR is for both enterprise-4.5 and 4.6.

Previews:
- [install](https://deployment-tab--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-web.html#virt-deploying-virt_installing-virt-web)
- [uninstall](https://deployment-tab--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt-web.html#virt-deleting-custom-resource_uninstalling-virt-web)