### PR TITLE
[virt] Replacing link to ConfigMap docs with OCP xref

### DIFF
--- a/virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.adoc
+++ b/virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.adoc
@@ -27,5 +27,4 @@ include::modules/virt-removing-secret-configmap-service-account-vm.adoc[leveloff
 
 * xref:../../authentication/understanding-and-creating-service-accounts.adoc#service-accounts-overview[Understanding and creating service accounts]
 
-* link:https://kubernetes.io/docs/concepts/configuration/configmap/[ConfigMaps]
-// replace the above link with ocp configmap docs when available
+* xref:../../builds/builds-configmaps.adoc#builds-configmap-overview_builds-configmaps[Understanding ConfigMaps]


### PR DESCRIPTION
- No bug, just had this on my to-do list.
- [Preview](https://new-configmap-docs--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.html#additional-resources)
- For enterprise 4.5 and 4.6