### PR TITLE
Adding topic to update Log Forward CR

### DIFF
--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -25,4 +25,6 @@ Due to the nature of these changes, you are not required to update your cluster 
 
 include::modules/cluster-logging-updating-logging.adoc[leveloffset=+1]
 
-include::modules/cluster-logging-visualizer-indices.adoc[leveloffset=+1]
+include::modules/cluster-logging-log-forward-update.adoc[leveloffset=+1]
+
+For information on the new capabilities of the Log Forwarding API, see xref:../logging/cluster-logging-external.html#cluster-logging-external[Forwarding logs to third party systems].

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -18,7 +18,7 @@ Forwarding cluster logs to external third-party systems requires a combination o
 
 * `kafka`. A Kafka broker. The `kafka` output can use a TCP or TLS connection.
 
-* `default`. The  internal {product-title} Elasticsearch instance using `default` in the pipeline. You do not need to configure the default output. If you do configure a `default` output, you receive an error message because the `default` output is reserved for the Cluster Logging Operator.
+* `default`. The internal {product-title} Elasticsearch instance. You are not required to configure the default output. If you do configure a `default` output, you receive an error message because the `default` output is reserved for the Cluster Logging Operator.
 --
 +
 If the output URL scheme requires TLS (HTTPS, TLS, or UDPS), then TLS server-side authentication is enabled. To also enable client authentication, the output must name a secret in the `openshift-logging` project. The secret must have keys of: *tls.crt*, *tls.key*, and *ca-bundle.crt* that point to the respective certificates that they represent.

--- a/modules/cluster-logging-log-forward-update.adoc
+++ b/modules/cluster-logging-log-forward-update.adoc
@@ -1,0 +1,169 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-external.adoc
+
+// Might not be needed. See https://issues.redhat.com/browse/LOG-654
+
+[id="cluster-logging-log-forward-update_{context}"]
+= Updating log forwarding custom resources
+
+The {product-title} Log Forward API has been promoted from Technology Preview to Generally Available in {product-title} 4.6. The GA release contains some improvements and enhancements that require you to make a change to your Cluster Logging custom resource (CR) and to replace your `LogForwarding` custom resource (CR) with a `ClusterLogForwarder` CR.
+
+.Sample `ClusterLogForwarder` instance in {product-title} 4.6
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+  name: instance
+  namespace: openshift-logging
+....
+spec:
+  outputs:
+  - url: http://remote.elasticsearch.com:9200
+    name: elasticsearch
+    type: elasticsearch
+  - url: tls://fluentdserver.example.com:24224
+    name: fluentd
+    type: fluentdForward
+    secret:
+      name: fluentdserver
+  pipelines:
+  - inputRefs:
+      - infrastructure
+      - application   
+    name: mylogs
+    outputRefs:
+     - elasticsearch
+  - inputRefs:
+      - audit
+    name: auditlogs
+    outputRefs:
+      - fluentd
+      - default
+...
+----
+
+.Sample `LogForwarding` CR in {product-title} 4.5
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1alpha1
+kind: LogForwarding
+metadata:
+  name: instance
+  namespace: openshift-logging
+spec:
+  disableDefaultForwarding: true 
+  outputs:
+   - name: elasticsearch
+     type: elasticsearch
+     endpoint: remote.elasticsearch.com:9200
+   - name: fluentd
+     type: forward
+     endpoint: fluentdserver.example.com:24224
+     secret:
+       name: fluentdserver
+  pipelines:
+   - inputSource: logs.infra
+     name: infra-logs
+     outputRefs:
+     - elasticearch
+   - inputSource: logs.app
+     name: app-logs
+     outputRefs:
+      -  elasticearch
+   - inputSource: logs.audit
+     name: audit-logs
+     outputRefs:
+      -  fluentd
+----
+
+The following procedure shows each parameter you must change.
+
+.Procedure 
+
+To update the `LogForwarding` CR in 4.5 to the `ClusterLogForwarding` CR for 4.6, make the following modifications:
+
+. Edit the Cluster Logging custom resource (CR) to remove the `logforwardingtechpreview` annotation:
++
+.Sample Cluster Logging CR
+[source,yaml]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  annotations:
+    clusterlogging.openshift.io/logforwardingtechpreview: enabled <1>
+  name: "instance"
+  namespace: "openshift-logging"
+....
+
+----
+<1> Remove the `logforwardingtechpreview` annotation.
+
+. Export the `LogForwarding` CR to create a YAML file for the `ClusterLogForwarder` instance:
++
+[source,terminal]
+----
+$ oc get LogForwarding instance -n openshift-logging -o yaml| tee ClusterLogForwarder.yaml
+----
+
+. Edit the YAML file to make the following modifications:
++
+.Sample `ClusterLogForwarder` instance in {product-title} 4.6
+[source,yaml]
+----
+apiVersion: logging.openshift.io/v1 <1>
+kind: ClusterLogForwarder <2>
+metadata:
+  name: instance
+  namespace: openshift-logging
+....
+spec: <3>
+  outputs:
+  - url: http://remote.elasticsearch.com:9200 <4>
+    name: elasticsearch
+    type: elasticsearch
+  - url: tls://fluentdserver.example.com:24224
+    name: fluentd
+    type: fluentdForward <5>
+    secret:
+      name: fluentdserver
+  pipelines:
+  - inputRefs: <6>
+      - infrastructure
+      - application   
+    name: mylogs
+    outputRefs:
+     - elasticsearch
+  - inputRefs:
+      - audit
+    name: auditlogs
+    outputRefs:
+      - fluentd
+      - default <7>
+...
+----
+<1> Change the `apiVersion` from `"logging.openshift.io/v1alpha1"` to `"logging.openshift.io/v1"`.
+<2> Change the object kind from `kind: "LogForwarding"` to `kind: "ClusterLogForwarder"`.
+<3> Remove the `disableDefaultForwarding: true` parameter.
+<4> Change the output parameter from `spec.outputs.endpoint` to `spec.outputs.url`. Add a prefix to the URL, such as `https://`, `tcp://`, and so forth, if a prefix is not present.
+<5> For Fluentd outputs, change the `type` from `forward` to `fluentdForward`.
+<6> Change the pipelines:
+* Change `spec.pipelines.inputSource` to `spec.pipelines.inputRefs`
+* Change `logs.infra` to `infrastructure`
+* Change `logs.app` to `application`
+* Change `logs.audit` to `audit`
+<7> Optional: Add a `default` pipeline to send logs to the internal Elasticsearch instance. You are not required to configure a `default` output.
++
+[NOTE]
+====
+If you want to forward logs to only the internal {product-title} Elasticsearch instance, do not configure the Log Forwarding API.
+====
+
+. Create the CR object:
++
+[source,terminal]
+----
+$ oc create -f ClusterLogForwarder.yaml
+---- 

--- a/modules/cluster-logging-updating-logging.adoc
+++ b/modules/cluster-logging-updating-logging.adoc
@@ -264,7 +264,6 @@ cronjob.batch/elasticsearch-rollover-infra
 +
 You should see the `elasticsearch-delete-\*` and `elasticsearch-rollover-*` indices.
 
-== Post-update tasks
+.Post-update tasks
 
-If you use Kibana, after the Elasticsearch Operator and Cluster Logging Operator are fully updated to 4.6, you must recreate your Kibana index patterns and visualizations.
-Because of changes in the security plug-in, the cluster logging upgrade does not automatically create index patterns.
+If you use the Log Forwarding API to forward logs, after the Elasticsearch Operator and Cluster Logging Operator are fully updated to 4.6, you must replace your `LogForwarding` custom resource (CR) with a `ClusterLogForwarder` CR.


### PR DESCRIPTION
The update from 4.5 to 4.6 will not migrate the Log Forwarding CR to the new kind and parameters.