### PR TITLE
Adding note about AMQ Streams license requirement.

### DIFF
--- a/jaeger/jaeger_install/rhbjaeger-deploying.adoc
+++ b/jaeger/jaeger_install/rhbjaeger-deploying.adoc
@@ -32,6 +32,11 @@ In-memory storage is not persistent, which means that if the Jaeger instance shu
 * *production* - The production strategy is intended for production environments, where long term storage of trace data is important, as well as a more scalable and highly available architecture is required. Each of the backend components is therefore deployed separately.  The Agent can be injected as a sidecar on the instrumented application or as a daemonset. The Query and Collector services are configured with a supported storage type - currently Elasticsearch. Multiple instances of each of these components can be provisioned as required for performance and resilience purposes.
 
 * *streaming* - The streaming strategy is designed to augment the production strategy by providing a streaming capability that effectively sits between the Collector and the backend storage (Elasticsearch). This provides the benefit of reducing the pressure on the backend storage, under high load situations, and enables other trace post-processing capabilities to tap into the real time span data directly from the streaming platform (https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_streams_on_openshift/index[AMQ Streams]/ https://kafka.apache.org/documentation/[Kafka]).
++
+[NOTE]
+====
+The streaming strategy requires an additional Red Hat subscription for AMQ Streams.
+====
 
 [NOTE]
 ====

--- a/modules/jaeger-deploy-streaming.adoc
+++ b/modules/jaeger-deploy-streaming.adoc
@@ -10,6 +10,11 @@ The `streaming` deployment strategy is intended for production environments, whe
 
 The `streaming` strategy provides a streaming capability that sits between the collector and the storage (Elasticsearch). This reduces the pressure on the storage under high load situations, and enables other trace post-processing capabilities to tap into the real time span data directly from the streaming platform (Kafka).
 
+[NOTE]
+====
+The streaming strategy requires an additional Red Hat subscription for AMQ Streams. If you do not have an AMQ Streams subscription, contact your sales representative for more information.
+====
+
 .Prerequisites
 * The AMQ Streams Operator must be installed.  If using version 1.4.0 or higher you can use self-provisioning.  If otherwise, you need to create the Kafka instance.
 * The Jaeger Operator must be installed.


### PR DESCRIPTION
I added a small note to the description of the three deployment strategies and a larger callout to the topic about deploying the streaming strategy.