### PR TITLE
Sync PTP Operator installation to match SR-IOV Network Operator procedure

### DIFF
--- a/modules/nw-ptp-installing-operator.adoc
+++ b/modules/nw-ptp-installing-operator.adoc
@@ -8,7 +8,7 @@
 As a cluster administrator, you can install the PTP Operator using the {product-title} CLI or the web console.
 
 [id="install-ptp-operator-cli_{context}"]
-== Installing the Operator using the CLI
+== CLI: Installing the PTP Operator
 
 As a cluster administrator, you can install the Operator using the CLI.
 
@@ -20,11 +20,11 @@ As a cluster administrator, you can install the Operator using the CLI.
 
 .Procedure
 
-. Create a namespace for the PTP Operator by completing the following actions:
-
-.. Create the following Namespace Custom Resource (CR) that defines the `openshift-ptp` namespace, and then save the YAML in the `ptp-namespace.yaml` file:
+. To create a namespace for the PTP Operator, enter the following command:
 +
+[source,terminal]
 ----
+$ cat << EOF| oc create -f -
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -32,21 +32,14 @@ metadata:
   labels:
     name: openshift-ptp
     openshift.io/cluster-monitoring: "true"
+EOF
 ----
 
-.. Create the namespace by running the following command:
+. To create an Operator group for the Operator, enter the following command:
 +
 [source,terminal]
 ----
-$ oc create -f ptp-namespace.yaml
-----
-
-. Install the PTP Operator in the namespace you created in the previous step by creating the following objects:
-
-.. Create the following OperatorGroup CR and save the YAML in the `ptp-operatorgroup.yaml` file:
-+
-[source,yaml]
-----
+$ cat << EOF| oc create -f -
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -55,64 +48,55 @@ metadata:
 spec:
   targetNamespaces:
   - openshift-ptp
+EOF
 ----
 
-.. Create the OperatorGroup CR by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f ptp-operatorgroup.yaml
-----
+. Subscribe to the PTP Operator.
 
-.. Run the following command to get the `channel` value required for the next
+.. Run the following command to set the {product-title} major and minor version as an environment variable, which is used as the `channel` value in the next
 step.
 +
 [source,terminal]
 ----
-$ oc get packagemanifest ptp-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
+$ OC_VERSION=$(oc version -o yaml | grep openshiftVersion | \
+    grep -o '[0-9]*[.][0-9]*' | head -1)
 ----
 
-.. Create the following Subscription CR and save the YAML in the `ptp-sub.yaml` file:
+.. To create a subscription for the PTP Operator, enter the following command:
 +
-.Example Subscription
-[source,yaml]
+[source,terminal]
 ----
+$ cat << EOF| oc create -f -
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: ptp-operator-subscription
   namespace: openshift-ptp
 spec:
-  channel: <channel> <1>
+  channel: "${OC_VERSION}"
   name: ptp-operator
-  source: redhat-operators <2>
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
+EOF
 ----
-<1> Specify the value from you obtained in the previous step for the `.status.defaultChannel` parameter.
-<2> You must specify the `redhat-operators` value.
 
-.. Create the Subscription object by running the following command:
+. To verify that the Operator is installed, enter the following command:
 +
 [source,terminal]
 ----
-$ oc create -f ptp-sub.yaml
-----
-
-.. Change to the `openshift-ptp` project:
-+
-[source,terminal]
-----
-$ oc project openshift-ptp
+$ oc get csv -n openshift-ptp \
+  -o custom-columns=Name:.metadata.name,Phase:.status.phase
 ----
 +
 .Example output
 [source,terminal]
 ----
-Now using project "openshift-ptp"
+Name                                        Phase
+ptp-operator.4.4.0-202006160135             Succeeded
 ----
 
 [id="install-ptp-operator-web-console_{context}"]
-== Installing the Operator using the web console
+== Web console: Installing the PTP Operator
 
 As a cluster administrator, you can install the Operator using the web console.
 


### PR DESCRIPTION
The older procedure won't return the proper channel; this does.

Preview: https://refresh-ptp-install--ocpdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-ptp.html