### PR TITLE
Transition ipam to dedicated topic

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -1,11 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-macvlan.adoc
-// * networking/multiple_networks/configuring-ipvlan.adoc
-// * networking/multiple_networks/configuring-bridge.adoc
-// * networking/multiple_networks/configuring-host-device.adoc
-// * networking/hardware_networks/configuring-sriov-net-attach.adoc
-// * virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc
+// * ?
 
 // Because the Cluster Network Operator abstracts the configuration for
 // Macvlan, including IPAM configuration, this must be provided as YAML


### PR DESCRIPTION
WIP

The first pass at this, with a module included with every single CNI plug-in that supports it, appeared reasonable at first.

But now the ipam content is huge, and it is monopolizing entire topics, rather than aiding them.

This might introduce a new topic, dedicated to ipam, with a combined discussion of JSON and YAML configuration approaches, in a single place. Then it can appear as an _Additional resource_ in every other location, possibly with a direct mention in the assembly introduction as well.

Ideally each module would `xref` when appropriate, but that's invalid.