### PR TITLE
Fix the subscription of PAO

### DIFF
--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -85,7 +85,7 @@ metadata:
   namespace: openshift-performance-addon-operator
 spec:
   channel: <channel> <1>
-  name: openshift-performance-addon-operator
+  name: performance-addon-operator
   source: redhat-operators <2>
   sourceNamespace: openshift-marketplace
 ----


### PR DESCRIPTION
The subscription need to request performance-addon-operator. The openshift- prefix is invalid.