### PR TITLE
Reverting distro_map for openshift-enterprise and changing version to 4.5

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,11 +1,11 @@
 ---
-openshift-moa:
-  name: Amazon Red Hat OpenShift
+openshift-enterprise:
+  name: OpenShift Container Platform
   author: OpenShift Documentation Project <dev@lists.openshift.redhat.com>
   site: commercial
   site_name: Documentation
   site_url: https://docs.openshift.com/
   branches:
-    moa-to-45:
-      name: 'moa'
-      dir: moa
+    enterprise-4.5:
+      name: '4.5'
+      dir: container-platform/4.5


### PR DESCRIPTION
distro_map in enterprise-4.5 changed and prevented new builds for 4.5
Reverting back to working map and updating version to 4.5 while I'm here.

@lamek - I'm guessing this impacts what you were doing with moa