### PR TITLE
Add new 4.6 optional bundle objects

### DIFF
--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -56,7 +56,7 @@ etcd
 
 [discrete]
 [id="olm-bundle-format-manifests-optional_{context}"]
-=== Optional objects
+=== Additionally supported objects
 
 The following objects can also be optionally included in the `/manifests`
 directory of a bundle:
@@ -64,6 +64,10 @@ directory of a bundle:
 .Supported optional objects
 * Secrets
 * ConfigMaps
+* Services
+* PodDisruptionBudget
+* PriorityClass
+* VerticalPodAutoScaler
 
 When these optional objects are included in a bundle, Operator Lifecycle Manager
 (OLM) can create them from the bundle and manage their lifecycle along with the


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1183

Adds a few newly-supported Kube objects to the optional objects list.

Preview (internal): http://file.rdu.redhat.com/~adellape/100720/46_new_obj_bundle/operators/understanding/olm-packaging-format.html#olm-bundle-format-manifests-optional_olm-packaging-format