### PR TITLE
Add Kuryr caveats related to ShiftStack availability zone support

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -393,6 +393,8 @@ ifdef::osp[]
 
 |`compute.platform.openstack.zones`
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+
+On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.additionalNetworkIDs`
@@ -405,6 +407,8 @@ ifdef::osp[]
 
 |`controlPlane.platform.openstack.zones`
 |{rh-openstack} Compute (Nova) availability zones (AZs) to install machines on. If this parameter is not set, the installer relies on the default settings for Nova that the {rh-openstack} administrator configured.
+
+On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |`platform.openstack.clusterOSImage`
@@ -415,10 +419,6 @@ You must set this parameter to perform an installation in a restricted network.
 
 For example, `\http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d`.
 The value can also be the name of an existing Glance image, for example `my-rhcos`.
-
-|`platform.openstack.externalDNS`
-|IP addresses for external DNS servers that cluster instances use for DNS resolution.
-|A list of IP addresses as strings, for example `["8.8.8.8", "192.168.1.12"]`.
 
 |`platform.openstack.defaultMachinePlatform`
 |The default machine pool platform configuration.
@@ -446,7 +446,6 @@ The first item in `networking.machineNetwork` must match the value of `machinesS
 If you deploy to a custom subnet, you cannot specify an external DNS server to the {product-title} installer. Instead, link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/subnet[add DNS to the subnet in {rh-openstack}].
 
 |A UUID as a string. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
-
 |====
 endif::osp[]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -416,6 +416,10 @@ You must set this parameter to perform an installation in a restricted network.
 For example, `\http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d`.
 The value can also be the name of an existing Glance image, for example `my-rhcos`.
 
+|`platform.openstack.externalDNS`
+|IP addresses for external DNS servers that cluster instances use for DNS resolution.
+|A list of IP addresses as strings, for example `["8.8.8.8", "192.168.1.12"]`.
+
 |`platform.openstack.defaultMachinePlatform`
 |The default machine pool platform configuration.
 |


### PR DESCRIPTION
Context: https://issues.redhat.com/browse/OSDOCS-1492

@luis5tb Does this address what you were talking about here?

https://github.com/openshift/openshift-docs/pull/24834#issuecomment-685077426