### PR TITLE
machine_management: add note about using original boot media

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -19,7 +19,7 @@ xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installin
 ===
 When adding additional compute machines to your {product-title} cluster, use the
 {op-system} boot media that matches the same minor version that was used to
-install the {product-title} cluster.  For example, if you installed
+install the {product-title} cluster. For example, if you installed
 {product-title} 4.4, you must add additional compute machines using {op-system} 4.4
 boot media.
 

--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -24,7 +24,7 @@ install the {product-title} cluster. For example, if you installed
 boot media.
 
 Adding additional compute machines to your cluster using newer {op-system} boot
-media is not supported.  After adding the compute machines, they will automatically
+media is not supported. After adding the compute machines, they will automatically
 update to the current version of the {product-title} cluster.
 ===
 

--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -15,6 +15,19 @@ create your cluster. If you do not have these files, you must obtain them by
 following the instructions in the
 xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[installation procedure].
 
+[IMPORTANT]
+===
+When adding additional compute machines to your {product-title} cluster, use the
+{op-system} boot media that matches the same minor version that was used to
+install the {product-title} cluster.  For example, if you installed
+{product-title} 4.4, you must add additional compute machines using {op-system} 4.4
+boot media.
+
+Adding additional compute machines to your cluster using newer {op-system} boot
+media is not supported.  After adding the compute machines, they will automatically
+update to the current version of the {product-title} cluster.
+===
+
 [id="creating-machines-bare-metal"]
 == Creating {op-system-first} machines
 

--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -16,7 +16,7 @@ vSphere.
 ===
 When adding additional compute machines to your {product-title} cluster, use the
 {op-system} boot media that matches the same minor version that was used to
-install the {product-title} cluster.  For example, if you installed
+install the {product-title} cluster. For example, if you installed
 {product-title} 4.4, you must add additional compute machines using {op-system} 4.4
 boot media.
 

--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -12,6 +12,19 @@ vSphere.
 
 * You xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[installed a cluster on vSphere].
 
+[IMPORTANT]
+===
+When adding additional compute machines to your {product-title} cluster, use the
+{op-system} boot media that matches the same minor version that was used to
+install the {product-title} cluster.  For example, if you installed
+{product-title} 4.4, you must add additional compute machines using {op-system} 4.4
+boot media.
+
+Adding additional compute machines to your cluster using newer {op-system} boot
+media is not supported.  After adding the compute machines, they will automatically
+update to the current version of the {product-title} cluster.
+===
+
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]

--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -21,7 +21,7 @@ install the {product-title} cluster.  For example, if you installed
 boot media.
 
 Adding additional compute machines to your cluster using newer {op-system} boot
-media is not supported.  After adding the compute machines, they will automatically
+media is not supported. After adding the compute machines, they will automatically
 update to the current version of the {product-title} cluster.
 ===
 


### PR DESCRIPTION
We don't support using newer boot media to add nodes to a clusters.