### PR TITLE
Removing unneeded + character

### DIFF
--- a/modules/cluster-logging-elasticsearch-exposing.adoc
+++ b/modules/cluster-logging-elasticsearch-exposing.adoc
@@ -42,7 +42,7 @@ elasticsearch   ClusterIP   172.30.183.229   <none>        9200/TCP   22h
 ----
 
 You can check the cluster IP address with a command similar to the following:
-+
+
 [source,terminal]
 ----
 $ oc exec elasticsearch-cdm-oplnhinv-1-5746475887-fj2f8 -- curl -tlsv1.2 --insecure -H "Authorization: Bearer ${token}" "https://172.30.183.229:9200/_cat/health"


### PR DESCRIPTION
Noticed a stray `+` character. Possibly introduced when we were adding the [source,terminal] labels and splitting code blocks