### PR TITLE
WIP: update_service: Add docs for the OpenShift Update Service

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1695,8 +1695,8 @@ Name: OpenShift Update Service
 Dir: update_service
 Distros: openshift-enterprise,openshift-origin,openshift-webscale
 Topics:
-- Name: Understanding the OpenShift Update Service
-  File: index
+- Name: Installing and configuring the OpenShift Update Service
+  File: installing-update-service
 ---
 Name: Scalability and performance
 Dir: scalability_and_performance

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1691,6 +1691,13 @@ Topics:
 - Name: Uninstalling metering
   File: metering-uninstall
 ---
+Name: OpenShift Update Service
+Dir: update_service
+Distros: openshift-enterprise,openshift-origin,openshift-webscale
+Topics:
+- Name: Understanding the OpenShift Update Service
+  File: index
+---
 Name: Scalability and performance
 Dir: scalability_and_performance
 Distros: openshift-origin,openshift-enterprise,openshift-webscale

--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -7,6 +7,12 @@
 
 Update the restricted network cluster to the {product-title} version that you downloaded the release images for.
 
+[NOTE]
+====
+// If you have xref FIXME ../update_service/index.adoc[a local {product-title} Update Service], you can update by using the connected xref FIXME ../updating/updating-cluster.adoc[web console] or xref FIXME ../updating/updating-cluster-cli.adoc[CLI] instructions.
+This section explains the update procedure in the absence of an available Update Service.
+====
+
 .Prerequisites
 
 * You mirrored the images for the new release to your registry.

--- a/modules/update-service-create-service-cli.adoc
+++ b/modules/update-service-create-service-cli.adoc
@@ -1,0 +1,74 @@
+[id="update-service-create-service-cli_{context}"]
+= Creating an Update Service by using the CLI
+
+You can use the {product-title} CLI to create an Update Service by using the {product-title} Update Service Operator.
+
+.Procedure
+
+To create an Update Service by using the {product-title} CLI:
+
+. Configure the Update Service target namespace:
++
+[source,terminal]
+----
+$ NAMESPACE=FIXME-default-operand-namespace
+----
++
+The namespace must match the `targetNamespaces` value from the OperatorGroup.
+
+. Configure the name of the Update Service:
++
+[source,terminal]
+----
+$ NAME=example
+----
+
+. Configure the local registry and repository for the release images:
++
+[source,terminal]
+----
+$ RELEASE_IMAGES=registry.example.com/openshift/release
+----
+
+. Configure the local pullspec for the graph-data image:
++
+[source,terminal]
+----
+$ GRAPH_DATA_IMAGE=registry.example.com/openshift/graph-data:latest
+----
+
+. Create an Update Service object:
++
+[source,terminal]
+----
+$ oc -n "${NAMESPACE}" create -f - <<EOF
+apiVersion: updateservice.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: ${NAME}
+spec:
+  replicas: 2
+  releases: ${RELEASE_IMAGES}
+  graphDataImage: ${GRAPH_DATA_IMAGE}
+EOF
+----
+
+. Verify the Update Service:
+
+.. Use the following command to obtain a policy engine route:
++
+[source,terminal]
+----
+$ while sleep 1; do POLICY_ENGINE_GRAPH_URI="$(oc -n "${NAMESPACE}" get -o jsonpath='{.status.policyEngineURI}/api/upgrades_info/v1/graph{"\n"}' updateservice "${NAME}")"; SCHEME="${POLICY_ENGINE_GRAPH_URI%%:*}"; if test "${SCHEME}" = http -o "${SCHEME}" = https; then break; fi; done
+----
++
+This polls until the operator populates `policyEngineURI`.
+
+.. Retrieve a graph from the policy engine:
++
+[source,terminal]
+----
+$ while sleep 10; do HTTP_CODE="$(curl --header Accept:application/json --output /dev/stderr --write-out "%{http_code}" "${POLICY_ENGINE_GRAPH_URI}?channel=stable-4.6")"; if test "${HTTP_CODE}" -eq 200; then break; fi; echo "${HTTP_CODE}"; done
+----
++
+This polls until the graph request succeeds, although depending on which release images you have mirrored, the resulting graph may be empty.

--- a/modules/update-service-create-service-cli.adoc
+++ b/modules/update-service-create-service-cli.adoc
@@ -42,13 +42,15 @@ $ GRAPH_DATA_IMAGE=registry.example.com/openshift/graph-data:latest
 [source,terminal]
 ----
 $ oc -n "${NAMESPACE}" create -f - <<EOF
-apiVersion: updateservice.openshift.io/v1
+apiVersion: updateservice.operator.openshift.io/v1
 kind: UpdateService
 metadata:
   name: ${NAME}
 spec:
   replicas: 2
-  releases: ${RELEASE_IMAGES}
+  repository:
+  registry:
+  releaseImages: ${RELEASE_IMAGES}  # FIXME: aspirational
   graphDataImage: ${GRAPH_DATA_IMAGE}
 EOF
 ----
@@ -62,7 +64,7 @@ EOF
 $ while sleep 1; do POLICY_ENGINE_GRAPH_URI="$(oc -n "${NAMESPACE}" get -o jsonpath='{.status.policyEngineURI}/api/upgrades_info/v1/graph{"\n"}' updateservice "${NAME}")"; SCHEME="${POLICY_ENGINE_GRAPH_URI%%:*}"; if test "${SCHEME}" = http -o "${SCHEME}" = https; then break; fi; done
 ----
 +
-This polls until the operator populates `policyEngineURI`.
+You might need to poll until the command succeeds.
 
 .. Retrieve a graph from the policy engine:
 +
@@ -71,4 +73,4 @@ This polls until the operator populates `policyEngineURI`.
 $ while sleep 10; do HTTP_CODE="$(curl --header Accept:application/json --output /dev/stderr --write-out "%{http_code}" "${POLICY_ENGINE_GRAPH_URI}?channel=stable-4.6")"; if test "${HTTP_CODE}" -eq 200; then break; fi; echo "${HTTP_CODE}"; done
 ----
 +
-This polls until the graph request succeeds, although depending on which release images you have mirrored, the resulting graph may be empty.
+This polls until the graph request succeeds, although depending on which release images you have mirrored, the resulting graph might be empty.

--- a/modules/update-service-create-service-web-console.adoc
+++ b/modules/update-service-create-service-web-console.adoc
@@ -27,16 +27,18 @@ metadata:
   name: <name> <1>
 spec:
   replicas: 2
-  releases: <releases> <2>
+  releaseImages: <release-images> <2>
   graphDataImage: <graph-data-image> <3>
 ----
 +
 <1> For `<name>`, specify a name for your Update Service, such as `openshift`.
-<2> For `<releases>`, specify the local registry and repository for the release images, such as `registry.example.com/openshift/release`.
+<2> FIXME: aspirational.  For `<release-images>`, specify the local registry and repository for the release images, such as `registry.example.com/openshift/release`.
 <3> For `<graph-data-image>`, specify the local pullspec for the graph-data image, such as `registry.example.com/openshift/graph-data:latest`.
 
 .. Click *Create* to create the Update Service components.
 
+////
 . Verify the Update Service:
 
 .. FIXME: check the UpdateService YAML for status...
+////

--- a/modules/update-service-create-service-web-console.adoc
+++ b/modules/update-service-create-service-web-console.adoc
@@ -1,0 +1,42 @@
+[id="update-service-create-service-web-console_{context}"]
+= Creating an Update Service by using the web console
+
+You can use the {product-title} web console to create an Update Service by using the {product-title} Update Service Operator.
+
+.Procedure
+
+To create an Update Service by using the {product-title} web console:
+
+. Switch to the *Administration* -> *Custom Resource Definitions* page.
+
+. On the *Custom Resource Definitions* page, click *UpdateService*.
+
+. On the *Custom Resource Definition Overview* page, select *View Instances* from the *Actions* menu.
+
+. On the *UpdateServices* page, click *Create UpdateService*.
++
+You might have to refresh the page to load the data.
+
+.. In the YAML field, replace the code with the following YAML:
++
+[source,yaml]
+----
+apiVersion: updateservice.openshift.io/v1
+kind: UpdateService
+metadata:
+  name: <name> <1>
+spec:
+  replicas: 2
+  releases: <releases> <2>
+  graphDataImage: <graph-data-image> <3>
+----
++
+<1> For `<name>`, specify a name for your Update Service, such as `openshift`.
+<2> For `<releases>`, specify the local registry and repository for the release images, such as `registry.example.com/openshift/release`.
+<3> For `<graph-data-image>`, specify the local pullspec for the graph-data image, such as `registry.example.com/openshift/graph-data:latest`.
+
+.. Click *Create* to create the Update Service components.
+
+. Verify the Update Service:
+
+.. FIXME: check the UpdateService YAML for status...

--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -1,0 +1,87 @@
+[id="update-service-graph-data_{context}"]
+= Mirroring the {product-title} Update Service graph data
+
+The {product-title} Update Service requires a graph-data container image, from which the Update Service retrieves information about channel membership and blocked update edges.
+
+.Prerequisites
+
+* An link:https://cloud.redhat.com/openshift/install/pull-secret[{product-title} pull secret].
+* A pull secret for the local registry.
+
+.Procedure
+
+. On a machine connected to the internet, retrieve the graph-data container image from the hosted services.
+
+.. Configure the path to the directory on your removable media to host the mirrored images:
++
+[source,terminal]
+----
+$ REMOVABLE_MEDIA_PATH=<path>
+----
+
+.. Configure the path to your {product-title} pull secret:
++
+[source,terminal]
+----
+$ OCP_PULL_SECRET=<path>
+----
+
+.. Mirror the graph-data container image to the removable media:
++
+[source,terminal]
+----
+$ oc image mirror -a "${OCP_PULL_SECRET}" --dir="${REMOVABLE_MEDIA_PATH}" FIXME-where-registry.redhat.ren:5443/ocp4/openshift4 file://openshift/graph-data:latest
+----
+
+. Transfer the removable media to your restricted network.
+
+. On a computer that is connected to your restricted network, upload the graph-data container image to your local registry.
+
+.. Configure the path to the directory that contains the mirrored images:
++
+[source,terminal]
+----
+$ REMOVABLE_MEDIA_PATH=<path>
+----
+
+.. Configure the path to your local registry pull secret:
++
+[source,terminal]
+----
+$ LOCAL_PULL_SECRET=<path>
+----
+
+.. Configure the local registry name and host port:
++
+[source,terminal]
+----
+$ LOCAL_REGISTRY='<local_registry_host_name>:<local_registry_host_port>'
+----
++
+For `<local_registry_host_name>`, specify the registry domain name for your mirror
+repository, and for `<local_registry_host_port>`, specify the port that it
+serves content on.
+
+.. Configure the local repository name:
++
+[source,terminal]
+----
+$ LOCAL_REPOSITORY='<local_repository_name>'
+----
++
+For `<local_repository_name>`, specify the name of the repository to create in your
+registry, such as `openshift/graph-data`.
+
+.. Configure the local image tag:
++
+[source,terminal]
+----
+$ LOCAL_TAG=latest
+----
+
+.. Mirror the graph-data container image to the local registry:
++
+[source,terminal]
+----
+$ oc image mirror -a "${LOCAL_PULL_SECRET}" --from-dir="${REMOVABLE_MEDIA_PATH}" file://openshift/graph-data:latest "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${LOCAL_TAG}"
+----

--- a/modules/update-service-install-cli.adoc
+++ b/modules/update-service-install-cli.adoc
@@ -1,0 +1,121 @@
+[id="update-service-install-cli_{context}"]
+= Installing the {product-title} Update Service by using the CLI
+
+You can use the {product-title} CLI to install the {product-title} Update Service Operator.
+
+.Procedure
+
+To install the {product-title} Update Service Operator by using the {product-title} CLI:
+
+. Create a Namespace for the {product-title} Update Service Operator:
+
+.. Create a Namespace object YAML file, for example, `update-service-namespace.yaml`, for the {product-title} Update Service Operator:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: FIXME-default-namespace
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true" <1>
+----
+<1> Set the `openshift.io/cluster-monitoring` label to enable operator recommended cluster monitoring on this namespace.
+
+.. Create the Namespace:
++
+[source,terminal]
+----
+$ oc create -f <file-name>.yaml
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc create -f update-service-namespace.yaml
+----
+
+. Install the {product-title} Update Service Operator by creating the following objects:
+
+.. Create an Operator Group object YAML file, for example, `update-service-operator-group.yaml`:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: update-service-operator-group
+spec:
+  targetNamespaces:
+  - FIXME-default-operand-namespace
+----
+
+.. Create an Operator Group object:
++
+[source,terminal]
+----
+$ oc -n FIXME-default-namespace create -f <file-name>.yaml
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc -n FIXME-default-namespace create -f update-service-operator-group.yaml
+----
+
+.. Create a Subscription object YAML file, for example, `update-service-subscription.yaml`:
++
+.Example Subscription
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: update-service-subscription
+spec:
+  channel: "{product-version}" <1>
+  installPlanApproval: "Automatic"
+  source: "redhat-operators" <2>
+  sourceNamespace: "openshift-marketplace"
+  name: "FIXME-update-service-operator"
+----
+<1> Specify `{product-version}` as the channel.
+<2> Specify the name of the Operator channel. For clusters that do not use a custom Operator Lifecycle Manager (OLM), specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
+
+.. Create the Subscription object:
++
+[source,terminal]
+----
+$ oc create -f <file-name>.yaml
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc -n FIXME-default-namespace create -f update-service-subscription.yaml
+----
++
+The Update Service Operator is installed to the `FIXME-default-namespace` Namespace and targets the `FIXME-default-operand-namespace` namespace.
+
+. Verify the Operator installation:
++
+[source,terminal]
+----
+$ oc -n FIXME-default-operand-namespace get clusterserviceversions
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE       NAME                                            DISPLAY                  VERSION                 REPLACES   PHASE
+default         elasticsearch-operator.4.6.0-202007012112.p0    Elasticsearch Operator   4.6.0-202007012112.p0              Succeeded
+FIXME
+...
+----
++
+If the {product-title} Update Service Operator is listed, installation succeeded. The version number might be different than shown.

--- a/modules/update-service-install-cli.adoc
+++ b/modules/update-service-install-cli.adoc
@@ -16,7 +16,7 @@ To install the {product-title} Update Service Operator by using the {product-tit
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: FIXME-default-namespace
+  name: openshift-updateservice
   annotations:
     openshift.io/node-selector: ""
   labels:
@@ -57,14 +57,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc -n FIXME-default-namespace create -f <file-name>.yaml
+$ oc -n openshift-updateservice create -f <file-name>.yaml
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc -n FIXME-default-namespace create -f update-service-operator-group.yaml
+$ oc -n openshift-updateservice create -f update-service-operator-group.yaml
 ----
 
 .. Create a Subscription object YAML file, for example, `update-service-subscription.yaml`:
@@ -84,7 +84,7 @@ spec:
   name: "FIXME-update-service-operator"
 ----
 <1> Specify `{product-version}` as the channel.
-<2> Specify the name of the Operator channel. For clusters that do not use a custom Operator Lifecycle Manager (OLM), specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
+<2> Specify the name of the CatalogSource that provides the Operator For clusters that do not use a custom Operator Lifecycle Manager (OLM), specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
 
 .. Create the Subscription object:
 +
@@ -97,10 +97,10 @@ For example:
 +
 [source,terminal]
 ----
-$ oc -n FIXME-default-namespace create -f update-service-subscription.yaml
+$ oc -n openshift-updateservice create -f update-service-subscription.yaml
 ----
 +
-The Update Service Operator is installed to the `FIXME-default-namespace` Namespace and targets the `FIXME-default-operand-namespace` namespace.
+The Update Service Operator is installed to the `openshift-updateservice` namespace and targets the `FIXME-default-operand-namespace` namespace.
 
 . Verify the Operator installation:
 +

--- a/modules/update-service-install-web-console.adoc
+++ b/modules/update-service-install-web-console.adoc
@@ -1,0 +1,34 @@
+[id="update-service-install-web-console_{context}"]
+= Installing the {product-title} Update Service by using the web console
+
+You can use the {product-title} web console to install the {product-title} Update Service Operator.
+
+.Procedure
+
+To install the {product-title} Update Service Operator using the {product-title} web console:
+
+. In the {product-title} web console, click *Operators* -> *OperatorHub*.
+
+. Choose *{product-title} Update Service* from the list of available Operators, and click *Install*.
+
+. FIXME: Does this apply? Ensure that the *All namespaces on the cluster* is selected under *Installation Mode*.
+
+. Select a namespace for *Installed Namespace*, such as the default FIXME-default-namespace.
+
+. FIXME: Does this apply? Select *Enable operator recommended cluster monitoring on this namespace*.
++
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object.
+
+. Select *{product-version}* as the *Update Channel*.
+
+. Select an *Approval Strategy*:
++
+** The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
++
+** The *Manual* strategy requires a user with FIXME credentials to approve the Operator update.
+
+. Click *Install*.
+
+. Verify that the {product-title} Update Service Operator installed by switching to the *Operators* → *Installed Operators* page.
+
+. Ensure that *{product-title} Update Service* is listed in all projects with a *Status* of *Succeeded*.

--- a/modules/update-service-install-web-console.adoc
+++ b/modules/update-service-install-web-console.adoc
@@ -13,11 +13,11 @@ To install the {product-title} Update Service Operator using the {product-title}
 
 . FIXME: Does this apply? Ensure that the *All namespaces on the cluster* is selected under *Installation Mode*.
 
-. Select a namespace for *Installed Namespace*, such as the default FIXME-default-namespace.
+. Select a namespace for *Installed Namespace*, such as the default `openshift-updateservice` namespace.
 
 . FIXME: Does this apply? Select *Enable operator recommended cluster monitoring on this namespace*.
 +
-This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object.
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the namespace object.
 
 . Select *{product-version}* as the *Update Channel*.
 
@@ -29,6 +29,6 @@ This option sets the `openshift.io/cluster-monitoring: "true"` label in the Name
 
 . Click *Install*.
 
-. Verify that the {product-title} Update Service Operator installed by switching to the *Operators* → *Installed Operators* page.
+. Verify that the {product-title} Update Service Operator installed by switching to the *Operators* -> *Installed Operators* page.
 
 . Ensure that *{product-title} Update Service* is listed in all projects with a *Status* of *Succeeded*.

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -9,9 +9,9 @@
 // * updating/updating-disconnected-cluster.adoc
 
 [id="update-service-overview_{context}"]
-= About the {product-title} update service
+= About the {product-title} Update Service
 
-The {product-title} update service is the hosted service that provides over-the-air
+The {product-title} Update Service is the service that provides over-the-air
 updates to both {product-title} and {op-system-first}. It provides a graph,
 or diagram that contain _vertices_ and the _edges_ that connect them, of
 component Operators. The edges in the graph show which versions you can safely
@@ -19,7 +19,7 @@ update to, and the vertices are update payloads that specify the intended state
 of the managed cluster components.
 
 The Cluster Version Operator (CVO) in your cluster checks with the
-{product-title} update service to see the valid updates and update paths based
+{product-title} Update Service to see the valid updates and update paths based
 on current component versions and information in the graph. When you request an
 update, the {product-title} CVO uses the release image for that update to
 upgrade your cluster. The release artifacts are hosted in Quay as container
@@ -29,20 +29,20 @@ By accepting automatic updates, you can automatically
 keep your cluster up to date with the most recent compatible components.
 ////
 
-To allow the {product-title} update service to provide only compatible updates,
+To allow the {product-title} Update Service to provide only compatible updates,
 a release verification pipeline exists to drive automation. Each release
 artifact is verified for compatibility with supported cloud platforms and system
 architectures as well as other component packages. After the pipeline confirms
-the suitability of a release, the {product-title} update service notifies you
+the suitability of a release, the {product-title} Update Service notifies you
 that it is available.
 
 [IMPORTANT]
 ====
-Because the update service displays all valid updates, you must not force an update to a version that the update service does not display.
+Because the Update Service displays all valid updates, you must not force an update to a version that the Update Service does not display.
 ====
 
 ////
-The interaction between the registry and the {product-title} update service is different during
+The interaction between the registry and the {product-title} Update Service is different during
 bootstrap and continuous update modes. When you bootstrap the initial
 infrastructure, the Cluster Version Operator finds
 the fully qualified image name for the shortname of the images that it needs to
@@ -54,7 +54,7 @@ plane to come up and load the Cluster Version Operator.
 During continuous update mode, two controllers run. One continuously updates
 the payload manifests, applies them to the cluster, and outputs the status of
 the controlled rollout of the Operators, whether they are available, upgrading,
-or failed. The second controller polls the {product-title} update service to
+or failed. The second controller polls the {product-title} Update Service to
 determine if updates are available.
 
 [IMPORTANT]

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -11,30 +11,15 @@
 [id="update-service-overview_{context}"]
 = About the {product-title} Update Service
 
-The {product-title} Update Service is the service that provides over-the-air
-updates to both {product-title} and {op-system-first}. It provides a graph,
-or diagram that contain _vertices_ and the _edges_ that connect them, of
-component Operators. The edges in the graph show which versions you can safely
-update to, and the vertices are update payloads that specify the intended state
-of the managed cluster components.
+The {product-title} Update Service is the service that provides over-the-air updates to both {product-title} and {op-system-first}. It provides a graph, or diagram, that contains _vertices_ and the _edges_ that connect them, of component Operators. The edges in the graph show which versions you can safely update to, and the vertices are update payloads that specify the intended state of the managed cluster components.
 
-The Cluster Version Operator (CVO) in your cluster checks with the
-{product-title} Update Service to see the valid updates and update paths based
-on current component versions and information in the graph. When you request an
-update, the {product-title} CVO uses the release image for that update to
-upgrade your cluster. The release artifacts are hosted in Quay as container
-images.
+The Cluster Version Operator (CVO) in your cluster checks with the {product-title} Update Service to see the valid updates and update paths based on current component versions and information in the graph. When you request an update, the {product-title} CVO uses the release image for that update to upgrade your cluster. The release artifacts are hosted in Quay as container images.
 ////
 By accepting automatic updates, you can automatically
 keep your cluster up to date with the most recent compatible components.
 ////
 
-To allow the {product-title} Update Service to provide only compatible updates,
-a release verification pipeline exists to drive automation. Each release
-artifact is verified for compatibility with supported cloud platforms and system
-architectures as well as other component packages. After the pipeline confirms
-the suitability of a release, the {product-title} Update Service notifies you
-that it is available.
+To allow the {product-title} Update Service to provide only compatible updates, a release verification pipeline exists to drive automation. Each release artifact is verified for compatibility with supported cloud platforms and system architectures as well as other component packages. After the pipeline confirms the suitability of a release, the {product-title} Update Service notifies you that it is available.
 
 [IMPORTANT]
 ====
@@ -42,25 +27,14 @@ Because the Update Service displays all valid updates, you must not force an upd
 ====
 
 ////
-The interaction between the registry and the {product-title} Update Service is different during
-bootstrap and continuous update modes. When you bootstrap the initial
-infrastructure, the Cluster Version Operator finds
-the fully qualified image name for the shortname of the images that it needs to
-apply to the server during installation. It looks at the imagestream that it needs
-to apply and renders it to disk. It calls bootkube and waits for a temporary minimal control
-plane to come up and load the Cluster Version Operator.
+The interaction between the registry and the {product-title} Update Service is different during bootstrap and continuous update modes. When you bootstrap the initial infrastructure, the Cluster Version Operator finds the fully qualified image name for the shortname of the images that it needs to apply to the server during installation. It looks at the imagestream that it needs to apply and renders it to disk. It calls bootkube and waits for a temporary minimal control plane to come up and load the Cluster Version Operator.
 ////
 
-During continuous update mode, two controllers run. One continuously updates
-the payload manifests, applies them to the cluster, and outputs the status of
-the controlled rollout of the Operators, whether they are available, upgrading,
-or failed. The second controller polls the {product-title} Update Service to
-determine if updates are available.
+During continuous update mode, two controllers run. One continuously updates the payload manifests, applies them to the cluster, and outputs the status of the controlled rollout of the Operators, whether they are available, upgrading, or failed. The second controller polls the {product-title} Update Service to determine if updates are available.
 
 [IMPORTANT]
 ====
-Reverting your cluster to a previous version, or a rollback, is not supported.
-Only upgrading to a newer version is supported.
+Reverting your cluster to a previous version, or a rollback, is not supported. Only upgrading to a newer version is supported.
 ====
 
 During the upgrade process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. It cordons the number of nodes that is specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. It then applies the new configuration and reboots the machine. If you use Red Hat Enterprise Linux (RHEL) machines as workers, the MCO does not update the kubelet on these machines because you must update the OpenShift API on them first. Because the specification for the new version is applied to the old kubelet, the RHEL machine cannot return to the `Ready` state. You cannot complete the update until the machines are available. However, the maximum number of nodes that are unavailable is set to ensure that normal cluster operations are likely to continue with that number of machines out of service.

--- a/update_service/index.adoc
+++ b/update_service/index.adoc
@@ -1,0 +1,41 @@
+:context: update-service
+[id="update-service"]
+= Understanding the {product-title} Update Service
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+// The following include statements pull in the module files that comprise
+// the assembly. Include any combination of concept, procedure, or reference
+// modules required to cover the user story. You can also include other
+// assemblies.
+
+include::modules/update-service-overview.adoc[leveloffset=+1]
+
+[id="update-service-install"]
+== Installing the {product-title} Update Service
+
+You can install the {product-title} Update Service by deploying the Update Service Operator by using the {product-title} web console or CLI.
+
+include::modules/update-service-install-web-console.adoc[leveloffset=+2]
+
+include::modules/update-service-install-cli.adoc[leveloffset=+2]
+
+== Additional resources
+
+* For more information on installing Operators, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Installing Operators from the OperatorHub].
+
+include::modules/update-service-graph-data.adoc[leveloffset=+2]
+
+[id="update-service-create-service"]
+== Creating an Update Service
+
+You can create Update Services by using the {product-title} web console or CLI.
+
+include::modules/update-service-create-service-web-console.adoc[leveloffset=+2]
+
+include::modules/update-service-create-service-cli.adoc[leveloffset=+2]
+
+FIXME-deleting-a-service?
+
+FIXME-uninstalling-the-operator?

--- a/update_service/installing-update-service.adoc
+++ b/update_service/installing-update-service.adoc
@@ -1,7 +1,7 @@
-:context: update-service
-[id="update-service"]
-= Understanding the {product-title} Update Service
+[id="installing-update-service"]
+= Installing and configuring the {product-title} Update Service
 include::modules/common-attributes.adoc[]
+:context: update-service
 
 toc::[]
 
@@ -9,6 +9,8 @@ toc::[]
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
+
+You can install and configure the {product-title} Update Service to provide over-the-air updates for your cluster and its underlying operating system.
 
 include::modules/update-service-overview.adoc[leveloffset=+1]
 
@@ -21,7 +23,7 @@ include::modules/update-service-install-web-console.adoc[leveloffset=+2]
 
 include::modules/update-service-install-cli.adoc[leveloffset=+2]
 
-== Additional resources
+. Additional resources
 
 * For more information on installing Operators, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Installing Operators from the OperatorHub].
 
@@ -36,6 +38,8 @@ include::modules/update-service-create-service-web-console.adoc[leveloffset=+2]
 
 include::modules/update-service-create-service-cli.adoc[leveloffset=+2]
 
+////
 FIXME-deleting-a-service?
 
 FIXME-uninstalling-the-operator?
+////

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -231,7 +231,7 @@ There is a separate process for
 xref:../updating/updating-disconnected-cluster.adoc#updating-disconnected-cluster[updating a cluster on a restricted network].
 ////
 
-- **xref:../update_service/index.adoc[Understanding the {product-title} Update Service]**: Learn about installing and managing a local Update Service for recommending {product-title} updates in restricted network environments.
+- **xref:../update_service/installing-update-service.adoc#installing-update-service[Understanding the {product-title} Update Service]**: Learn about installing and managing a local Update Service for recommending {product-title} updates in restricted network environments.
 
 === Monitor the cluster
 

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -231,6 +231,8 @@ There is a separate process for
 xref:../updating/updating-disconnected-cluster.adoc#updating-disconnected-cluster[updating a cluster on a restricted network].
 ////
 
+- **xref:../update_service/index.adoc[Understanding the {product-title} Update Service]**: Learn about installing and managing a local Update Service for recommending {product-title} updates in restricted network environments.
+
 === Monitor the cluster
 
 - **xref:../logging/cluster-logging.adoc#cluster-logging[Work with OpenShift Logging]**: Learn about OpenShift Logging and configure different OpenShift Logging types, such as Elasticsearch, Fluentd, Kibana, and Curator.


### PR DESCRIPTION
Mixing in some precedent from `logging/`, [the Update Service blog post][1], [the GitHub docs][2], and some aspirational v1 goals ;).  Still quite a few WIPs and FIXMEs scattered throughout.

CC @openshift/openshift-team-cincinnati

[1]: https://www.openshift.com/blog/openshift-update-service-update-manager-for-your-cluster
[2]: https://github.com/openshift/cincinnati-operator/blob/2df239a8486d2ba3aa0d9925e5d505105ab36afe/docs/disconnected-cincinnati-operator.md