### PR TITLE
modules/update-configuring-image-signature: Fix <11> reference

### DIFF
--- a/modules/update-configuring-image-signature.adoc
+++ b/modules/update-configuring-image-signature.adoc
@@ -29,7 +29,7 @@ to update the cluster, such as `4.4.0`.
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture> <11>
+$ ARCHITECTURE=<server_architecture> <1>
 ----
 <1> For `server_architecture`, specify the architecture of the server, such as `x86_64`.
 


### PR DESCRIPTION
Fix:

    asciidoctor: WARNING: includes/update-configuring-image-signature.adoc: line 34: no callout found for <1>

from 8a31e1793a (#21993).

I noticed the warning [here][1].  Looks like there are a number of other reasonable warnings vs. the tip content; might be worth someone doing a more thorough audit/cleanup.

[1]: https://travis-ci.com/github/openshift/openshift-docs/builds/188729829#L340