### PR TITLE
Add 4.6 Monitoring Release Notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -821,6 +821,54 @@ New Fluentd parameters allow you to performance-tune your Fluentd log collector.
 
 These parameters can help you determine the trade-offs between latency and throughput in your cluster logging instance.
 
+[id="ocp-4-6-monitoring"]
+=== Monitoring
+
+[id="ocp-4-6-monitoring-for-user-defined-projects"]
+==== Monitoring for user-defined projects
+
+In {product-title} 4.6, you can enable monitoring for user-defined projects in addition to the default platform monitoring. You can now monitor your own projects in {product-title} without the need for an additional monitoring solution. Using this new feature centralizes monitoring for core platform components and user-defined projects.
+
+With this new feature, you can perform the following tasks:
+
+* Enable and configure monitoring for user-defined projects
+* Create recording and alerting rules that use metrics from your own pods and services
+* Access metrics and information about alerts through a single, multi-tenant interface
+* Cross-correlate the metrics for user-defined projects with platform metrics
+
+For more information, see xref:../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Understanding the monitoring stack].
+
+[id="ocp-4-6-monitoring-alerting-rule-changes"]
+==== Alerting rule changes
+
+{product-title} 4.6 includes the following alerting rule changes:
+
+* The `PrometheusOperatorListErrors` alert is added. The alert provides notification of errors when running list operations on controllers.
+* The `PrometheusOperatorWatchErrors` alert is added. The alert provides notification of errors when running watch operations on controllers.
+* The `KubeQuotaExceeded` alert is replaced by `KubeQuotaFullyUsed`. Previously, the `KubeQuotaExceeded` alert fired if a resource quota exceeded a 90% threshold. The `KubeQuotaFullyUsed` alert fires if a resource quota is fully used.
+* etcd alerts now support the addition of custom labels for metrics.
+* The `KubeAPILatencyHigh` and `KubeAPIErrorsHigh` alerts are replaced by the `KubeAPIErrorBudgetBurn` alert. `KubeAPIErrorBudgetBurn` combines API error and latency alerts and fires only when the conditions are severe enough.
+* The readiness and liveness probe metrics exposed by the kubelet are now scraped. This provides historical liveness and readiness data for containers, which can be helpful when troubleshooting container issues.
+* The alerting rules for the Thanos Ruler are updated so that alerts are paged if recording rules and alerting rules are not correctly evaluated. This update ensures that critical alerts are not lost when rule and alert evaluation in the Thanos Ruler is not completed.
+* The `KubeStatefulSetUpdateNotRolledOut` alert is updated so that it does not fire when a stateful set is being deployed.
+* The `KubeDaemonSetRolloutStuck` alert is updated to account for daemon set roll out progress.
+* The severity of cause-based alerts are adjusted from *critical* to *warning*.
+
+[NOTE]
+====
+Red Hat does not guarantee backward compatibility for metrics, recording rules, or alerting rules.
+====
+
+[id="ocp-4-6-monitoring-prometheus-rule-validation"]
+==== Prometheus rule validation
+
+{product-title} 4.6 introduces validation of Prometheus rules through a webhook that calls the validating admission plug-in. With this enhancement, PrometheusRule custom resources in all projects are checked against the Prometheus Operator rule validation API.
+
+[id="ocp-4-6-monitoring-metrics-and-alerting-rules-added-for-thanos-querier"]
+==== Metrics and alerting rules added for the Thanos Querier
+
+The Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface. In {product-title} 4.6, a service monitor and alerting rules are now deployed for the Thanos Querier, which enables monitoring of the Thanos Querier by the monitoring stack.
+
 [id="ocp-4-6-notable-technical-changes"]
 == Notable technical changes
 
@@ -1098,10 +1146,10 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|User workload monitoring
+|Monitoring for user-defined projects
 |TP
 |TP
-|
+|GA
 
 |Compute Node Topology Manager
 |TP
@@ -1262,6 +1310,20 @@ Once the firewall rule of the machine with the missing infrastructure ID is remo
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1801968[*BZ#1801968*])
 
 * The `opm alpha bundle build` command fails on Windows 10. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883773[*BZ#1883773*])
+
+* In {product-title} 4.6, the resource metrics API server provides support for custom metrics. The resource metrics API server does not implement the OpenAPI specification, and the following messages are sent to the `kube-apiserver` logs:
++
+[source,terminal]
+----
+controller.go:114] loading OpenAPI spec for "v1beta1.metrics.k8s.io" failed with: OpenAPI spec does not exist
+controller.go:127] OpenAPI AggregationController: action for item v1beta1.metrics.k8s.io: Rate Limited Requeue.
+----
++
+In some cases, these errors might cause the `KubeAPIErrorsHigh` alert to fire, but the underlying issue is not known to degrade {product-title} functionality.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1819053[*BZ#1819053*])
+
+* Rules API back-ends are sometimes not detected if Store API stores are discovered before Rules API stores. When this occurs, a store reference is created without a Rules API client, and the Rules API endpoint from Thanos Querier does not return any rules.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1870287[*BZ#1870287*])
 
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adding Monitoring 4.6 Release Notes for the following features:

* Monitoring for user-defined projects
* Prometheus rule validation
* Metrics and alerting rules added for the Thanos Querier

This applies to branch/enterprise-4.6 only.

[This related PR](https://github.com/openshift/openshift-docs/pull/24722) needs to be merged before I can include an xref to the 'Understanding the monitoring stack' page from the 'Monitoring for user-defined projects' section in 'New features and enhancements'.

The preview is [here](https://monitoring_release_notes_4_6--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html).