### PR TITLE
Mentioning that sensitive objects aren't logged

### DIFF
--- a/modules/nodes-nodes-audit-config-about.adoc
+++ b/modules/nodes-nodes-audit-config-about.adoc
@@ -18,10 +18,14 @@ Audit log profiles define how to log requests that come to the OpenShift API ser
 |Logs only metadata for read and write requests; does not log request bodies. This is the default policy.
 
 |`WriteRequestBodies`
-|In addition to logging metadata for all requests, logs request bodies for every write request to the API servers (`create`, `update`, `patch`). This profile has more resource overhead than the `Default` profile.
+|In addition to logging metadata for all requests, logs request bodies for every write request to the API servers (`create`, `update`, `patch`). This profile has more resource overhead than the `Default` profile. ^[1]^
 
 |`AllRequestBodies`
-|In addition to logging metadata for all requests, logs request bodies for  every read and write request to the API servers (`get`, `list`, `create`, `update`, `patch`). This profile has the most resource overhead.
+|In addition to logging metadata for all requests, logs request bodies for  every read and write request to the API servers (`get`, `list`, `create`, `update`, `patch`). This profile has the most resource overhead. ^[1]^
 |===
+[.small]
+--
+1. Sensitive resources, such as `Secret`, `Route`, and `OAuthClient` objects, are never logged past the metadata level. OAuth tokens are not logged at all if your cluster was upgraded from {product-title} 4.5, because their object names might contain secret information.
+--
 
 By default, {product-title} uses the `Default` audit log profile. You can use another audit policy profile that also logs request bodies, but be aware of the increased resource usage (CPU, memory, and I/O).


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1173

Preview: https://osdocs-1173-update--ocpdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-audit-config.html#about-audit-log-profiles_nodes-nodes-audit-config