### PR TITLE
modules/pruning-groups: '//Future' prefixes for xrefs

### DIFF
--- a/modules/pruning-groups.adoc
+++ b/modules/pruning-groups.adoc
@@ -50,6 +50,6 @@ $ oc adm prune groups --sync-config=ldap-sync-config.yaml --confirm
 ////
 Needs "Additional resources" links when converted:
 
-xref:../install_config/syncing_groups_with_ldap.adoc#configuring-ldap-sync[Configuring LDAP Sync]
-xref:../install_config/syncing_groups_with_ldap.adoc#overview[Syncing Groups With LDAP]
+//Future xref:../install_config/syncing_groups_with_ldap.adoc#configuring-ldap-sync[Configuring LDAP Sync]
+//Future xref:../install_config/syncing_groups_with_ldap.adoc#overview[Syncing Groups With LDAP]
 ////


### PR DESCRIPTION
Make it more obvious to folks grepping through that these xrefs are aspirational.

```console
$ grep -A1 'You must not include xrefs' modules/mod-docs-ocp-conventions.adoc
You must not include xrefs in modules or create an xref to a module. You can
only use xrefs to link from one assembly to another.
```