### PR TITLE
modules/dynamic-provisioning-available-plugins: Drop xref

### DIFF
--- a/modules/dynamic-provisioning-available-plugins.adoc
+++ b/modules/dynamic-provisioning-available-plugins.adoc
@@ -24,7 +24,7 @@ configured provider's API to create new storage resources:
 
 |{rh-openstack} Manila Container Storage Interface (CSI)
 |`manila.csi.openstack.org`
-|Once installed, the xref:../storage/container_storage_interface/persistent-storage-csi-manila.adoc#persistent-storage-csi-manila[OpenStack Manila CSI Driver Operator] and ManilaDriver automatically create the required storage classes for all available Manila share types needed for dynamic provisioning.
+|Once installed, the OpenStack Manila CSI Driver Operator and ManilaDriver automatically create the required storage classes for all available Manila share types needed for dynamic provisioning.
 
 |AWS Elastic Block Store (EBS)
 |`kubernetes.io/aws-ebs`


### PR DESCRIPTION
xrefs aren't allowed in modules:

```console
$ grep -A1 'You must not include xrefs' modules/mod-docs-ocp-conventions.adoc
You must not include xrefs in modules or create an xref to a module. You can
only use xrefs to link from one assembly to another.
```

And we can't move this module out into an assembly directory, because it is consumed from two places:

```console
$ git --no-pager grep dynamic-provisioning-available-plugins
post_installation_configuration/storage-configuration.adoc:include::modules/dynamic-provisioning-available-plugins.adoc[leveloffset=+3]
storage/dynamic-provisioning.adoc:include::modules/dynamic-provisioning-available-plugins.adoc[leveloffset=+1]
```

We could:

a. Trim down post_installation_configuration to just xref the storage assembly, instead of duping so much of it's content via modules.
b. Drop the module and instead inline (some of) it with copy/paste in both assemblies.
c. Remove the xref.

With this commit, I'm going with (c), removing the xref which was added in 57961f1117 (#22199).  CC @bobfuru