### PR TITLE
OSSMDOC-72 OSSM 2.0 installation changes

### DIFF
--- a/modules/jaeger-install.adoc
+++ b/modules/jaeger-install.adoc
@@ -33,9 +33,9 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Install Operator* page, select the *stable* Update Channel. This will automatically update Jaeger as new versions are released.  If you select a maintenance channel, for example, *1.17-stable*, you will receive bug fixes and security patches for the length of the support cycle for that version.
 
-. Select the *stable* Update Channel. This will automatically update Jaeger as new versions are released.  If you select a maintenance channel, for example, *1.17-stable*, you will receive bug fixes and security patches for the length of the support cycle for that version.
+. Select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 * Select an Approval Strategy. You can select *Automatic* or *Manual* updates. If you choose Automatic updates for an installed Operator, when a new version of that Operator is available, the Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention. If you select Manual updates, when a newer version of an Operator is available, the OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.
 +

--- a/modules/ossm-control-plane-deploy-1x.adoc
+++ b/modules/ossm-control-plane-deploy-1x.adoc
@@ -55,7 +55,7 @@ Follow this procedure to deploy the {ProductName} control plane by using the web
 For additional information about customizing the control plane, see customizing the {ProductName} installation. For production, you _must_ change the default Jaeger template.
 ====
 
-. Click *Create* to create the control plane.  The Operator creates Pods, services, and {ProductShortName} control plane components based on your configuration parameters.
+. Click *Create* to create the control plane.  The Operator creates pods, services, and {ProductShortName} control plane components based on your configuration parameters.
 
 . Click the *Istio Service Mesh Control Plane* tab.
 
@@ -108,11 +108,11 @@ $ oc create -n istio-system -f istio-installation.yaml
 $ oc get smcp -n istio-system
 ----
 +
-The installation has finished successfully when the READY column is true.
+The installation has finished successfully when the STATUS column is `InstallSuccessful`.
 +
 ----
-NAME           READY
-basic-install   True
+NAME            READY   STATUS              TEMPLATE   VERSION   AGE
+basic-install   9/9     InstallSuccessful   default    v1.1      4m25s
 ----
 +
 . Run the following command to watch the progress of the Pods during the installation process:

--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -9,14 +9,16 @@
 TODO - Flesh out how multitenancy affects this, link to control plate template topic.
 ////
 
-The `ServiceMeshControlPlane` resource defines the configuration to be used during installation. You can deploy the default configuration provided by Red Hat or customize the `ServiceMeshControlPlane` file to fit your business needs.
+The `ServiceMeshControlPlane` resource defines the configuration to be used during installation.
 
-You can deploy the {ProductShortName} control plane by using the {product-title} web console or from the command line using the `oc` client tool.
+You can deploy a basic installation of the {ProductShortName} control plane by using the {product-title} web console or from the command line using the `oc` client tool.
+
+To get started, deploy the basic installation with the following steps. You can customize the `ServiceMeshControlPlane` resource later.
 
 [id="ossm-control-plane-deploy-operatorhub_{context}"]
 == Deploying the control plane from the web console
 
-Follow this procedure to deploy the {ProductName} control plane by using the web console.
+Follow this procedure to deploy a basic {ProductName} control plane by using the web console.
 
 .Prerequisites
 
@@ -40,22 +42,15 @@ Follow this procedure to deploy the {ProductName} control plane by using the web
 
 . Navigate to *Operators* -> *Installed Operators*.
 
-. If necessary, select `istio-system` from the Project menu.  You may have to wait a few moments for the Operators to be copied to the new project.
+. In the Project menu, select `istio-system`. You may have to wait a few moments for the Operators to be copied to the new project.
 
-. Click the {ProductName} Operator.  Under *Provided APIs*, the Operator provides links to create two resource types:
-** A `ServiceMeshControlPlane` resource
-** A `ServiceMeshMemberRoll` resource
+. Click the {ProductName} Operator, then click *Istio Service Mesh Control Plane*.
 
-. Under *Istio Service Mesh Control Plane* click *Create ServiceMeshControlPlane*.
+. On the *Istio Service Mesh Control Plane* page, click *Create ServiceMeshControlPlane*.
 
-. On the *Create Service Mesh Control Plane* page, modify the YAML for the default `ServiceMeshControlPlane` template as needed.
-+
-[NOTE]
-====
-For additional information about customizing the control plane, see customizing the {ProductName} installation. For production, you _must_ change the default Jaeger template.
-====
+. On the *Create ServiceMeshControlPlane* page, you can modify the default `ServiceMeshControlPlane` template with the form, or select the YAML view to customize your installation.
 
-. Click *Create* to create the control plane.  The Operator creates Pods, services, and {ProductShortName} control plane components based on your configuration parameters.
+. Click *Create* to create the control plane. The Operator creates pods, services, and {ProductShortName} control plane components based on your configuration parameters.
 
 . Click the *Istio Service Mesh Control Plane* tab.
 
@@ -67,7 +62,7 @@ For additional information about customizing the control plane, see customizing 
 [id="ossm-control-plane-deploy-cli_{context}"]
 == Deploying the control plane from the CLI
 
-Follow this procedure to deploy the {ProductName} control plane the command line.
+Follow this procedure to deploy a basic {ProductName} control plane the command line.
 
 .Prerequisites
 
@@ -84,21 +79,47 @@ Follow this procedure to deploy the {ProductName} control plane the command line
 ----
 $ oc login https://{HOSTNAME}:6443
 ----
-
++
 . Create a project named `istio-system`.
 +
 [source,terminal]
 ----
 $ oc new-project istio-system
 ----
-
-. Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the example found in "Customize the {ProductName} installation". You can customize the values as needed to match your use case.  For production deployments you _must_ change the default Jaeger template.
-
-. Run the following command to deploy the control plane:
++
+. Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the following example in "Customize the {ProductName} installation". For production deployments you _must_ customize the default link:https://github.com/maistra/istio-operator/blob/maistra-2.0/deploy/examples/maistra_v2_servicemeshcontrolplane_cr_auth.yaml[template].
++
+.Example version 2.0 istio-installation.yaml
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: openshift-operators
+spec:
+  version: v2.0
+  tracing:
+    type: Jaeger
+    sampling: 10000
+  addons:
+    jaeger:
+      name: jaeger
+      install:
+        storage:
+          type: Memory
+    kiali:
+      enabled: true
+      name: kiali
+    grafana:
+      enabled: true
+----
++
+. Run the following command to deploy the control plane, where `<istio_installation.yaml>` includes the full path to your file.
 +
 [source,terminal]
 ----
-$ oc create -n istio-system -f istio-installation.yaml
+$ oc create -n istio-system -f <istio_installation.yaml>
 ----
 +
 . Execute the following command to see the status of the control plane installation.
@@ -108,35 +129,9 @@ $ oc create -n istio-system -f istio-installation.yaml
 $ oc get smcp -n istio-system
 ----
 +
-The installation has finished successfully when the READY column is true.
+The installation has finished successfully when the `STATUS` column is `ComponentsReady`.
 +
 ----
-NAME           READY
-basic-install   True
-----
-+
-. Run the following command to watch the progress of the Pods during the installation process:
-+
-----
-$ oc get pods -n istio-system -w
-----
-+
-You should see output similar to the following:
-+
-.Example output
-[source,terminal]
-----
-NAME                                     READY   STATUS             RESTARTS   AGE
-grafana-7bf5764d9d-2b2f6                 2/2     Running            0          28h
-istio-citadel-576b9c5bbd-z84z4           1/1     Running            0          28h
-istio-egressgateway-5476bc4656-r4zdv     1/1     Running            0          28h
-istio-galley-7d57b47bb7-lqdxv            1/1     Running            0          28h
-istio-ingressgateway-dbb8f7f46-ct6n5     1/1     Running            0          28h
-istio-pilot-546bf69578-ccg5x             2/2     Running            0          28h
-istio-policy-77fd498655-7pvjw            2/2     Running            0          28h
-istio-sidecar-injector-df45bd899-ctxdt   1/1     Running            0          28h
-istio-telemetry-66f697d6d5-cj28l         2/2     Running            0          28h
-jaeger-896945cbc-7lqrr                   2/2     Running            0          11h
-kiali-78d9c5b87c-snjzh                   1/1     Running            0          22h
-prometheus-6dff867c97-gr2n5              2/2     Running            0          28h
+NAME            READY   STATUS            PROFILES      VERSION   AGE     IMAGE REGISTRY
+basic   9/9     ComponentsReady   ["default"]   2.0.0     3m31s   
 ----

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -12,8 +12,8 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.1.9
-:MaistraVersion: 1.1
+:ProductVersion: 2.0
+:MaistraVersion: 2.0
 :product-build:
 :DownloadURL: registry.redhat.io
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/ossm-install-kiali.adoc
+++ b/modules/ossm-install-kiali.adoc
@@ -30,9 +30,9 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 . Click *Install*.
 
-. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
+. On the *Operator Installation* page, select the *stable* Update Channel.
 
-. Select the *stable* Update Channel.
+. Select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Select the *Automatic* Approval Strategy.
 +

--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -23,11 +23,11 @@
 
 . Click the {ProductName} Operator to display information about the Operator.
 
-. On the *Install Operator* page, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
-
 . Click *Install*.
 
-. Select the *stable* Update Channel.
+. On the *Operator Installation* page, select the *stable* Update Channel.
+
+. In the *Installation Mode* section, select *All namespaces on the cluster (default)*. This installs the Operator in the default `openshift-operators` project and makes the Operator available to all projects in the cluster.
 
 . Select the *Automatic* Approval Strategy.
 +
@@ -37,5 +37,3 @@ The Manual approval strategy requires a user with appropriate credentials to app
 ====
 
 . Click *Install*.
-
-. The *Installed Operators* page displays the {ProductName} Operator's installation progress.

--- a/service_mesh/v2x/installing-ossm.adoc
+++ b/service_mesh/v2x/installing-ossm.adoc
@@ -8,11 +8,6 @@ Installing the {ProductShortName} involves installing the Elasticsearch, Jaeger,
 
 [NOTE]
 ====
-Mixer’s policy enforcement is disabled by default. You must enable it to run policy tasks. See xref:../../service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc#ossm-mixer-policy_deploying-applications-ossm[Update Mixer policy enforcement] for instructions on enabling Mixer policy enforcement.
-====
-
-[NOTE]
-====
 Multi-tenant control plane installations are the default configuration starting with {ProductName} 1.0.
 ====
 
@@ -57,7 +52,7 @@ OLM uses CatalogSources, which use the Operator Registry API, to query for avail
 
 include::modules/ossm-update-app-sidecar.adoc[leveloffset=+2]
 
-= Removing {ProductName}
+== Removing {ProductName}
 
 This process allows you to remove {ProductName} from an existing {product-title} instance. Remove the control plane before removing the operators.
 

--- a/service_mesh/v2x/ossm-architecture.adoc
+++ b/service_mesh/v2x/ossm-architecture.adoc
@@ -12,7 +12,7 @@ include::modules/ossm-architecture.adoc[leveloffset=+1]
 
 include::modules/ossm-vs-istio.adoc[leveloffset=+1]
 
-= Understanding Kiali
+== Understanding Kiali
 
 Kiali provides visibility into your service mesh by showing you the microservices in your service mesh, and how they are connected.
 
@@ -22,7 +22,7 @@ include::modules/ossm-kiali-architecture.adoc[leveloffset=+1]
 
 include::modules/ossm-kiali-features.adoc[leveloffset=+1]
 
-= Understanding Jaeger
+== Understanding Jaeger
 
 Every time a user takes an action in an application, a request is executed by the architecture that may require dozens of different services to participate in order to produce a response.
 The path of this request is a distributed transaction.
@@ -41,7 +41,6 @@ include::modules/jaeger-product-overview.adoc[leveloffset=+1]
 include::modules/jaeger-architecture.adoc[leveloffset=+1]
 
 include::modules/jaeger-features.adoc[leveloffset=+1]
-
 
 == Next steps
 

--- a/service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc
+++ b/service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc
@@ -20,8 +20,6 @@ include::modules/ossm-sidecar-injection.adoc[leveloffset=+1]
 
 include::modules/ossm-automatic-sidecar-injection.adoc[leveloffset=+2]
 
-include::modules/ossm-mixer-policy.adoc[leveloffset=+1]
-
 include::modules/ossm-config-network-policy.adoc[leveloffset=+1]
 
 include::modules/ossm-tutorial-bookinfo-overview.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses changes in the installation procedure for ossm20.
https://issues.redhat.com/browse/OSSMDOC-72

It will be merged with https://github.com/openshift/openshift-docs/pull/26354, which contains the migration information, and https://github.com/openshift/openshift-docs/pull/26265, which contains changes in the SMCP and configuration topics.