### PR TITLE
OSSMDOC-40 and OSSMDOC-113 New SMCP and configuration topics

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2179,6 +2179,8 @@ Topics:
 #     File: ossm-security
 #   - Name: Traffic management
 #     File: ossm-traffic-manage
+#   - Name: Custom resources
+#     File: ossm-custom-resources
 #   - Name: Extensions
 #     File: ossm-extensions
 #   - Name: Using the 3scale Istio adapter
@@ -2206,6 +2208,8 @@ Topics:
     File: ossm-security
   - Name: Traffic management
     File: ossm-traffic-manage
+  - Name: Custom resources
+    File: ossm-custom-resources
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
 ---

--- a/modules/ossm-auto-route.adoc
+++ b/modules/ossm-auto-route.adoc
@@ -64,7 +64,7 @@ Then, the following OpenShift Routes are created automatically. You can check th
 
 [source,terminal]
 ----
-$ oc -n <your-control-plane-namespace> get routes
+$ oc -n <control_plane_namespace> get routes
 ----
 
 .Expected output

--- a/modules/ossm-cr-example.adoc
+++ b/modules/ossm-cr-example.adoc
@@ -18,63 +18,262 @@ This example `ServiceMeshControlPlane` definition contains all of the supported 
 
 [IMPORTANT]
 ====
-The 3scale Istio Adapter is deployed and configured in the custom resource file. It also requires a working 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html/infrastructure/onpremises-installation[On-Premises]).
+The 3scale Istio Adapter is deployed and configured in the custom resource file. It also requires an active 3scale account (link:https://www.3scale.net/signup/[SaaS] or link:https://access.redhat.com/documentation/en-us/red_hat_3scale_api_management/2.4/html/infrastructure/onpremises-installation[On-Premises]).
 ====
 
-.Example istio-installation.yaml
+.Example `ServiceMeshControlPlane` resource
 
 [source,yaml]
 ----
-apiVersion: maistra.io/v1
+apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
-  name: basic-install
+  name: basic
 spec:
+  proxy:
+    resources:
+      requests:
+        cpu: 100m
+        memory: 128Mi
+      limits:
+        cpu: 500m
+        memory: 128Mi
+  tracing:
+    type: Jaeger
+  gateways:
+    ingress: # istio-ingressgateway
+      service:
+        type: ClusterIP
+        ports:
+        - name: status-port
+          port: 15020
+        - name: http2
+          port: 80
+          targetPort: 8080
+        - name: https
+          port: 443
+          targetPort: 8443
+      meshExpansionPorts: []
+    egress: # istio-egressgateway
+      service:
+        type: ClusterIP
+        ports:
+        - name: status-port
+          port: 15020
+        - name: http2
+          port: 80
+          targetPort: 8080
+        - name: https
+          port: 443
+          targetPort: 8443
+    additionalIngress:
+      some-other-ingress-gateway: {}
+    additionalEgress:
+      some-other-egress-gateway: {}
 
-  istio:
-    global:
-      proxy:
-        resources:
-          requests:
-            cpu: 100m
-            memory: 128Mi
-          limits:
-            cpu: 500m
-            memory: 128Mi
+  policy:
+    type: Istiod # or Mixer
+    mixer: # only applies if policy.type: Mixer
+      enableChecks: false 
+      failOpen: false 
 
-    gateways:
-      istio-egressgateway:
-        autoscaleEnabled: false
-      istio-ingressgateway:
-        autoscaleEnabled: false
-        ior_enabled: false
-
-    mixer:
-      policy:
-        autoscaleEnabled: false
-
-      telemetry:
-        autoscaleEnabled: false
-        resources:
-          requests:
-            cpu: 100m
-            memory: 1G
-          limits:
-            cpu: 500m
-            memory: 4G
-
-    pilot:
-      autoscaleEnabled: false
-      traceSampling: 100
-
-    kiali:
-      enabled: true
-
+  telemetry:
+    type: Istiod # or Mixer
+    mixer: # only applies if telemetry.type: Mixer, for v1 telemetry
+      sessionAffinity: false
+      batching:
+        maxEntries: 100
+        maxTime: 1s
+      adapters:
+        kubernetesenv: true
+        stdio:
+          enabled: true
+          outputAsJSON: true
+  addons:
     grafana:
       enabled: true
-
-    tracing:
+      install: 
+        config:
+          env: {} 
+          envSecrets: {} 
+        persistence:
+          storageClassName: ""
+          accessMode: ReadWriteOnce
+          capacity: 5Gi 
+        service: 
+          ingress:
+            contextPath: /grafana
+            tls:
+              termination: reencrypt
+    kiali:
+      name: kiali
       enabled: true
-      jaeger:
-        template: all-in-one
+      install: # install kiali CR if not present
+        dashboard:
+          viewOnly: false
+          enableGrafana: true
+          enableTracing: true
+          enablePrometheus: true
+      service: 
+        ingress:
+          contextPath: /kiali
+    jaeger:
+      name: jaeger
+      install:
+        storage:
+          type: Memory # or Elasticsearch
+          memory:
+            maxTraces: 100000
+          elasticsearch:
+            nodeCount: 3
+            storage: {}
+            redundancyPolicy: SingleRedundancy
+            indexCleaner: {}
+        ingress: {} # jaeger ingress configuration
+  runtime:
+    components:
+      pilot:
+        deployment:
+          replicas: 2
+        pod:
+          affinity: {}
+        container:
+          resources:
+          limits: {}
+          requirements: {}
+      grafana:
+        deployment: {}
+        pod: {}
+      kiali:
+        deployment: {}
+        pod: {}
 ----
+
+The following table lists the parameters for the `ServiceMeshControlPlane` resource.
+
+.`ServiceMeshControlPlane` resource parameters
+|===
+|Name |Description |Type
+
+|`apiVersion`
+|APIVersion defines the versioned schema of this representation of an object. Servers convert recognized schemas to the latest internal value, and may reject unrecognized values. The value for {ProductName} version 2.0 is `maistra.io/v2`.
+|The value for {ProductName} version 2.0 is maistra.io/v2.
+
+|kind
+|Kind is a string value representing the REST resource this object represents. Servers may infer this from the endpoint the client submits requests to. Cannot be updated.
+|CamelCase string
+
+|metadata
+|Metadata about this `ServiceMeshControlPlane` instance You can provide a name for your control plane installation to keep track of your work, for example, `basic-install`, or `production`.
+|string
+
+|spec
+|The specification of the desired state of this `ServiceMeshControlPlane`. This includes the configuration options for all components that comprise the control plane.
+|For more information, see Table 2.
+
+|status
+|The current status of this `ServiceMeshControlPlane` and the components that comprise the control plane. 
+|For more information, see Table 3.
+|===
+
+The following table lists the specifications for the `ServiceMeshControlPlane` resource. These parameters configure {ProductName} for your microservices and apps.
+
+.`ServiceMeshControlPlane` resource spec
+|===
+|Name |Description |Configurable parameters
+
+|addons
+|Addons is used to configure additional features beyond core control plane components, such as visualization, or metric storage.
+|`3scale`, `grafana`, `jaeger`, `kiali`, and `prometheus`.
+
+|cluster
+|Cluster is the general configuration of the cluster (cluster name, network name, multi-cluster, mesh expansion, etc.)
+|`meshExpansion`, `multiCluster`, `name`, and `network`
+
+|gateways
+|Gateways configures ingress and egress gateways for the mesh.
+|`enabled`, `additionalEgress`, `additionalIngress`, `egress`, `ingress`, and  `openshiftRoute`
+
+|general
+|General represents general control plane configuration that does not fit anywhere else.
+|`logging` and `validationMessages`
+
+|policy
+|Policy configures policy checking for the control plane. If `spec.policy.enabled` is set to `true`, policy checking is enabled.
+|`mixer` `remote`, or `type`. `type` can be set to `Istiod`, `Mixer` or `None`.
+
+|profiles
+|Profiles selects the `ServiceMeshControlPlane` profile to use for default values.
+|`default`
+
+|proxy
+|Proxy configures the default behavior for sidecars. 
+|`accessLogging`, `adminPort`, `concurrency`, and `envoyMetricsService`
+
+|runtime
+|Runtime configuration for the control plane components.
+|`components`, and `defaults`
+
+|security
+|Security configures aspects of security for the control plane.
+|`certificateAuthority`, `controlPlane`, `identity`, `dataPlane` and `trust`
+
+|techPreview
+|TechPreview is used to enable early access to features that are technology previews.
+|N/A
+
+|telemetry
+|If spec.mixer.telemetry.enabled is set to true, telemetry is enabled.
+|`mixer`, `remote`, and `type`. `type` can be set to `Istiod`, `Mixer` or `None`.
+
+|tracing
+|Tracing enables distributed tracing for the mesh.
+|`sampling`, `type`. `type` can be set to `Jaeger` or `None`.
+
+|version
+|Version specifies what Maistra version of the control plane to install. When creating a `ServiceMeshControlPlane` with an empty version, the admission webhook sets the version to the current version. New `ServiceMeshControlPlanes` with an empty version are set to v2.0. Existing `ServiceMeshControlPlanes` with an empty version keep their setting.
+|string
+|===
+
+ControlPlaneStatus represents the current state of your service mesh.
+
+.`ServiceMeshControlPlane` resource `ControlPlaneStatus`
+|===
+|Name |Description |Type
+
+|annotations
+|Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the `ServiceMeshControlPlane`. These statuses are used by the command line tool, `oc`, which does not yet allow counting objects in JSONPath expressions.
+|Not configurable
+
+|conditions
+Represents the latest available observations of the object’s current state. `Reconciled` indicates whether the operator has finished reconciling the actual state of deployed components with the the configuration in the `ServiceMeshControlPlane` resource. `Installed` indicates whether the control plane has been installed. `Ready` indicates whether all control plane components are ready
+|string
+
+|components
+|Shows the status of each deployed control plane component.
+|string
+
+|appliedSpec
+|The resulting specification of the configuration options after all profiles have been applied.
+|`ControlPlaneSpec`
+
+|appliedValues
+|The resulting values.yaml used to generate the charts.
+|`ControlPlaneSpec`
+
+|chartVersion
+|The version of the charts that were last processed for this resource.
+|string
+
+|observedGeneration
+|The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object. The `status.conditions` are not up-to-date if the `status.observedGeneration` field doesn't match `metadata.generation`.
+|integer
+
+|operatorVersion
+|The version of the operator that last processed this resource.
+|string
+
+|readiness
+|The readiness status of components & owned resources
+|string
+|===

--- a/modules/ossm-cr-istio-global-1x.adoc
+++ b/modules/ossm-cr-istio-global-1x.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/customizing-installation-ossm.adoc
+// * service_mesh/v2x/customizing-installation-ossm.adoc
+
+[id="ossm-cr-istio-global_{context}"]
+= Istio global example
+
+Here is an example that illustrates the Istio global parameters for the `ServiceMeshControlPlane` and a description of the available parameters with appropriate values.
+
+[NOTE]
+====
+In order for the 3scale Istio Adapter to work, `disablePolicyChecks` must be `false`.
+====
+
+.Example global parameters
+[source,yaml]
+----
+  istio:
+    global:
+      tag: 1.1.0
+      hub: registry.redhat.io/openshift-service-mesh/
+      proxy:
+        resources:
+          requests:
+            cpu: 10m
+            memory: 128Mi
+          limits:
+      mtls:
+        enabled: false
+      disablePolicyChecks: true
+      policyCheckFailOpen: false
+      imagePullSecrets:
+        - MyPullSecret
+----
+
+.Global parameters
+|===
+|Parameter |Description |Values |Default value
+
+|`disablePolicyChecks`
+|This parameter enables/disables policy checks.
+|`true`/`false`
+|`true`
+
+|`policyCheckFailOpen`
+|This parameter indicates whether traffic is allowed to pass through to the Envoy sidecar when the Mixer policy service cannot be reached.
+|`true`/`false`
+|`false`
+
+|`tag`
+|The tag that the Operator uses to pull the Istio images.
+|A valid container image tag.
+|`1.1.0`
+
+|`hub`
+|The hub that the Operator uses to pull Istio images.
+|A valid image repository.
+|`maistra/` or `registry.redhat.io/openshift-service-mesh/`
+
+|`mtls`
+|This parameter controls whether to enable/disable Mutual Transport Layer Security (mTLS) between services by default.
+|`true`/`false`
+|`false`
+
+|`imagePullSecrets`
+|If access to the registry providing the Istio images is secure, list an link:https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod[imagePullSecret] here.
+|redhat-registry-pullsecret OR quay-pullsecret
+|None
+|===
+
+These parameters are specific to the proxy subset of global parameters.
+
+.Proxy parameters
+|===
+|Type |Parameter |Description |Values |Default value
+
+|Resources
+|`cpu`
+|The amount of CPU resources requested for Envoy proxy.
+|CPU resources, specified in cores or millicores (for example, 200m, 0.5, 1) based on your environment’s configuration.
+|`10m`
+
+|
+|`memory`
+|The amount of memory requested for Envoy proxy
+|Available memory in bytes(for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
+|`1024Mi`
+
+|Limits
+|`cpu`
+|The maximum amount of CPU resources requested for Envoy proxy.
+|CPU resources, specified in cores or millicores (for example, 200m, 0.5, 1) based on your environment’s configuration.
+|`2000m`
+
+|
+|`memory`
+|The maximum amount of memory Envoy proxy is permitted to use.
+|Available memory in bytes (for example, 200Ki, 50Mi, 5Gi) based on your environment’s configuration.
+|`128Mi`
+|===

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -23,7 +23,7 @@
 // Changing the value changes the generated URL.
 //
 :DocInfoProductName: OpenShift Service Mesh
-:DocInfoProductNumber: 1.0
+:DocInfoProductNumber: 2.0
 //
 // Book Names:
 //     Defining the book names in document attributes instead of hard-coding them in

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -28,7 +28,7 @@ Follow this procedure to add one or more projects to the {ProductShortName} memb
 
 .Procedure
 
-. If you don't already have projects for your mesh, or you are starting from scratch, create a project. It must be different from `istio-system`.
+. If you do not already have projects for your mesh, or you are starting from scratch, create a project. It must be different from `istio-system`.
 
 .. Navigate to *Home* -> *Projects*.
 
@@ -111,10 +111,10 @@ spec:
 `ServiceMeshMember` resources can be created by service mesh users who don't have privileges to add members to the `ServiceMeshMemberRoll` directly. While project administrators are automatically given permission to create the `ServiceMeshMember` resource in their project, they cannot point it to any `ServiceMeshControlPlane` until the service mesh administrator explicitly grants access to the service mesh. Administrators can grant users permissions to access the mesh by granting them the `mesh-user` user role, for example:
 
 ----
-$ oc policy add-role-to-user -n <control-plane-namespace> --role-namespace <control-plane-namespace> mesh-user <user-name>.
+$ oc policy add-role-to-user -n <control_plane_namespace> --role-namespace <control_plane_namespace> mesh-user <user_name>.
 ----
 
-Administrators can modify the `mesh user` role binding in the control plane project to specify the users and groups that are granted access. The `ServiceMeshMember` adds the project to the `ServiceMeshMemberRoll` within the control plane project it references.
+Administrators can modify the `mesh user` role binding in the control plane project to specify the users and groups that are granted access. The `ServiceMeshMember` adds the project to the `ServiceMeshMemberRoll` within the control plane project that it references.
 
 [source,yaml]
 ----
@@ -124,7 +124,7 @@ metadata:
   name: default
 spec:
   controlPlaneRef:
-    namespace: control-plane-namespace
+    namespace: <control_plane_namespace>
     name: minimal-install
 ----
 
@@ -143,7 +143,7 @@ This example adds a role binding for `alice`:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: control-plane-namespace
+  namespace: <control_plane_namespace>
   name: mesh-users
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/modules/ossm-security-mtls.adoc
+++ b/modules/ossm-security-mtls.adoc
@@ -15,17 +15,16 @@ By default, {ProductName} is set to permissive mode, where the sidecars in {Prod
 [id="ossm-security-enabling-strict-mtls_{context}"]
 == Enabling strict mTLS across the mesh
 
-If your workloads do not communicate with services outside your mesh and communication will not be interrupted by only accepting encrypted connections, you can enable mTLS across your mesh quickly. Set `spec.istio.global.mtls.enabled` to `true` in your `ServiceMeshControlPlane` resource. The operator creates the required resources.
+You can quickly enable mTLS across your mesh if your workloads do not communicate with outside services, and communication will not be interrupted by accepting only encrypted connections. Set `spec.security.controlPlane.mtls` to `true` in your `ServiceMeshControlPlane` resource. The operator creates the required resources.
 
 [source,yaml]
 ----
-apiVersion: maistra.io/v1
 kind: ServiceMeshControlPlane
 spec:
-  istio:
-    global:
-      mtls:
-        enabled: true
+  version: v2.0
+  security:
+    controlPlane:
+      mtls: true
 ----
 
 [id="ossm-security-mtls-sidecars-incoming-services_{context}"]
@@ -35,7 +34,6 @@ You can also configure mTLS for individual services or namespaces by creating a 
 
 [source,yaml]
 ----
-apiVersion: "authentication.istio.io/v1alpha1"
 kind: "Policy"
 metadata:
   name: "default"
@@ -52,7 +50,6 @@ Create a destination rule to configure {ProductShortName} to use mTLS when sendi
 
 [source,yaml]
 ----
-apiVersion: "networking.istio.io/v1alpha3"
 kind: "DestinationRule"
 metadata:
   name: "default"
@@ -71,7 +68,6 @@ If your environment has specific requirements for encrypted traffic in your serv
 
 [source,yaml]
 ----
-apiVersion: maistra.io/v1
 kind: ServiceMeshControlPlane
 spec:
   istio:

--- a/modules/ossm-updating-smcp.adoc
+++ b/modules/ossm-updating-smcp.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/customizing-installation-ossm.adoc
+// * service_mesh/v2x/customizing-installation-ossm.adoc
+
+[id="ossm-updating-smcp_{context}"]
+= Updating the ServiceMeshControlPlane
+
+Configure {ProductName} to work with your app by creating and configuring a `ServiceMeshControlPlane`. The `ServiceMeshControlPlane` resource defines the configuration to be used during installation. You can deploy the default configuration provided by Red Hat or customize the `ServiceMeshControlPlane` resource for your microservices and workflows.
+
+[id="ossm-control-plane-deploy-operatorhub_{context}"]
+== Editing the `ServiceMeshControlPlane` from the web console
+
+Follow this procedure to edit the `ServiceMeshControlPlane` with the {product-title} web console.
+
+.Procedure
+
+. In the {product-title} web console, click *Operators* -> *Installed Operators*.
+
+. Select the project where you installed the control plane, for example `istio-system`, from the Project menu.
+
+. Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane`, for example `basic-install`.
+
+. On the *Create ServiceMeshControlPlane Details* page, click `YAML` to modify your configuration.
+
+. Click *Save*.
+
+[id="ossm-control-plane-deploy-cli_{context}"]
+== Editing the `ServiceMeshControlPlane` from the CLI
+
+Follow this procedure to create or edit the `ServiceMeshControlPlane` with the command line.
+
+.Procedure
+
+. Log in to the {product-title} CLI as a user with the `cluster-admin` role. Enter the following command. Then, enter your username and password when prompted.
++
+[source,terminal]
+----
+$ oc login https://{HOSTNAME}:6443
+----
++
+. Change to the project where you installed the control plane, for example istio-system.
++
+[source,terminal]
+----
+$ oc project istio-system
+----
++
+. Edit the `ServiceMeshControlPlane` file.
+
+. Run the following command to edit the control plane where `<istio-installation.yaml>` includes a full path to the file you edited:
++
+[source,terminal]
+----
+$ oc edit -n istio-system -f <istio-installation.yaml>
+----
++
+. Execute the following command to see the status of the control plane installation.
++
+[source,terminal]
+----
+$ oc get smcp -n istio-system
+----
++
+The installation has finished successfully when the READY column is true.
++
+----
+NAME            READY   STATUS              TEMPLATE   VERSION   AGE
+basic-install   9/9     InstallSuccessful   default    v2.0      4m25s
+----
+

--- a/service_mesh/v1x/customizing-installation-ossm.adoc
+++ b/service_mesh/v1x/customizing-installation-ossm.adoc
@@ -4,41 +4,10 @@ include::modules/ossm-document-attributes-1x.adoc[]
 :context: customizing-installation-ossm-v1x
 toc::[]
 
-You can customize your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
-
-== Prerequisites
-* An account with the `cluster-admin` role.
-* Completed the xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[Preparing to install {ProductName}] process.
-* Have installed the operators.
-
-
-include::modules/ossm-cr-example-1x.adoc[leveloffset=+1]
-
-include::modules/ossm-cr-parameters.adoc[leveloffset=+1]
-
-include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
-
-include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
-
-include::modules/ossm-auto-route.adoc[leveloffset=+2]
-
-Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
-
-include::modules/ossm-cr-mixer-1x.adoc[leveloffset=+2]
-
-include::modules/ossm-cr-pilot-1x.adoc[leveloffset=+2]
-
-include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
-
-include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
-
-include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+2]
-
-For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].
-
-include::modules/ossm-cr-threescale-1x.adoc[leveloffset=+1]
-
+include::modules/ossm-updating-smcp.adoc[leveloffset=+1]
 
 == Next steps
 
 * xref:../../service_mesh/v1x/prepare-to-deploy-applications-ossm.adoc#deploying-applications-ossm-v1x[Prepare to deploy applications] on {ProductName}.
+
+// point to the reference topic

--- a/service_mesh/v1x/ossm-custom-resources.adoc
+++ b/service_mesh/v1x/ossm-custom-resources.adoc
@@ -1,0 +1,38 @@
+[id="ossm-custom-resources-v1x"]
+= Custom resources
+include::modules/ossm-document-attributes.adoc[]
+:context: ossm-controler-items-v1x
+toc::[]
+
+You can customize your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
+
+== Prerequisites
+* An account with the `cluster-admin` role.
+* Completed the xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[Preparing to install {ProductName}] process.
+* Have installed the operators.
+
+include::modules/ossm-cr-example-1x.adoc[leveloffset=+1]
+
+include::modules/ossm-cr-parameters.adoc[leveloffset=+1]
+
+include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
+
+include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
+
+include::modules/ossm-auto-route.adoc[leveloffset=+2]
+
+Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
+
+include::modules/ossm-cr-mixer.adoc[leveloffset=+2]
+
+include::modules/ossm-cr-pilot.adoc[leveloffset=+2]
+
+include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
+
+include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+2]
+
+For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].
+
+include::modules/ossm-cr-threescale.adoc[leveloffset=+1]

--- a/service_mesh/v2x/customizing-installation-ossm.adoc
+++ b/service_mesh/v2x/customizing-installation-ossm.adoc
@@ -1,43 +1,21 @@
-[id="customize-installation-ossm"]
-= Customizing the {ProductName} installation
+[id="customize-installation-ossm-v2x"]
+= Configuring the {ProductName} installation
 include::modules/ossm-document-attributes.adoc[]
-:context: customizing-installation-ossm
+:context: customizing-installation-ossm-v2x
 toc::[]
 
-You can customize your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
+After your default `ServiceMeshControlPlane` resource is deployed, you can configure the resource to suit your environment. 
 
-== Prerequisites
-* An account with the `cluster-admin` role.
-* Completed the xref:../../service_mesh/v2x/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
-* Have installed the operators.
+== Resources for configuring your `ServiceMeshControlPlane` resource
 
+Read more about how to configure your `ServiceMeshControlPlane` resource further, or skip ahead to Updating the `ServiceMeshControlPlane`.
 
-include::modules/ossm-cr-example.adoc[leveloffset=+1]
+* See xref:../../service_mesh/v2x/ossm-observability.adoc#ossm-observability[Data visualization and observability] for more information about Kiali and visualizing your data.
+* See xref:../../service_mesh/v2x/ossm-security.adoc#ossm-security[Security] for configuring mTLS, cipher suites, and external certificate authorities.
+* See xref:../../service_mesh/v2x/ossm-traffic-manage.adoc#ossm-routing-traffic[Traffic management] to configure your routing. 
+* See xref:../../service_mesh/v2x/ossm-custom-resources.adoc#ossm-custom-resources-v2x[Custom resources] for more information about all the configurable fields in your `ServiceMeshControlPlane` resource.
 
-include::modules/ossm-cr-parameters.adoc[leveloffset=+1]
-
-include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
-
-include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
-
-include::modules/ossm-auto-route.adoc[leveloffset=+2]
-
-Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
-
-include::modules/ossm-cr-mixer.adoc[leveloffset=+2]
-
-include::modules/ossm-cr-pilot.adoc[leveloffset=+2]
-
-include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
-
-include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
-
-include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+2]
-
-For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].
-
-include::modules/ossm-cr-threescale.adoc[leveloffset=+1]
-
+include::modules/ossm-updating-smcp.adoc[leveloffset=+1]
 
 == Next steps
 

--- a/service_mesh/v2x/installing-ossm.adoc
+++ b/service_mesh/v2x/installing-ossm.adoc
@@ -64,6 +64,6 @@ include::modules/ossm-operatorhub-remove.adoc[leveloffset=+1]
 
 == Next steps
 
-* xref:../../service_mesh/v2x/customizing-installation-ossm.adoc#customize-installation-ossm[Customize the {ProductName} installation].
+* xref:../../service_mesh/v2x/customizing-installation-ossm.adoc#customize-installation-ossm-v2x[Customize the {ProductName} installation].
 
 * xref:../../service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc#deploying-applications-ossm[Prepare to deploy applications] on {ProductName}.

--- a/service_mesh/v2x/ossm-custom-resources.adoc
+++ b/service_mesh/v2x/ossm-custom-resources.adoc
@@ -1,0 +1,38 @@
+[id="ossm-custom-resources-v2x"]
+= Custom resources
+include::modules/ossm-document-attributes.adoc[]
+:context: ossm-custom-resources-v2x
+toc::[]
+
+You can configure your {ProductName} by modifying the default {ProductShortName} custom resource or by creating a new custom resource.
+
+== Prerequisites
+* An account with the `cluster-admin` role.
+* Completed the xref:../../service_mesh/v2x/preparing-ossm-installation.adoc#preparing-ossm-installation[Preparing to install {ProductName}] process.
+* Have installed the operators.
+
+include::modules/ossm-cr-example.adoc[leveloffset=+1]
+
+include::modules/ossm-cr-parameters.adoc[leveloffset=+1]
+
+include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
+
+include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
+
+include::modules/ossm-auto-route.adoc[leveloffset=+2]
+
+Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
+
+include::modules/ossm-cr-mixer.adoc[leveloffset=+2]
+
+include::modules/ossm-cr-pilot.adoc[leveloffset=+2]
+
+include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
+
+include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-jaeger-config-elasticsearch.adoc[leveloffset=+2]
+
+For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].
+
+include::modules/ossm-cr-threescale.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses changes in the configuration documentation and SMCP for ossm20.

It will be merged with https://github.com/openshift/openshift-docs/pull/26354 for migration, and https://github.com/openshift/openshift-docs/pull/26261 for installation.

https://issues.redhat.com/browse/OSSMDOC-40
https://issues.redhat.com/browse/OSSMDOC-113