### PR TITLE
CNV - Moved xref out of module and into assembly file

### DIFF
--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -44,5 +44,5 @@ If you have virtual machines running that cannot be live migrated, they might bl
 This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces.
 
 As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster upgrade. Remove the `evictionStrategy: LiveMigrate` field and
-set the `runStrategy` field to `Always`. Learn more about xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[configuring virtual machine eviction strategy].
+set the `runStrategy` field to `Always`.
 ====

--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -13,6 +13,8 @@ include::modules/virt-upgrading-virt.adoc[leveloffset=+1]
 
 include::modules/virt-monitoring-upgrade-status.adoc[leveloffset=+1]
 
-.Additional information
+== Additional resources
 
 * xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[ClusterServiceVersions (CSVs)]
+
+* xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[Configuring virtual machine eviction strategy]


### PR DESCRIPTION
Removed xref from module and moved the link into the assembly file per openshift-docs documentation guidelines.

Issue reported in https://github.com/openshift/openshift-docs/pull/26257 

Original PR: https://github.com/openshift/openshift-docs/pull/24172

Preview build: https://xref-fix-for-pr-24172--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html

Peer review needed
Merge/CP to enterprise-4.5 and enterprise-4.6