### PR TITLE
OSD: Fix directions to cluster logging instance

### DIFF
--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -73,8 +73,10 @@ the *Status* column for any errors or failures.
 
 .. Click the installed *Cluster Logging* Operator.
 
-.. Under the *Overview* tab, click *Create Instance* . Paste the following YAML
-definition into the window that displays.
+.. Under the *Details* tab, in the *Provided APIs* section, in the
+*Cluster Logging* box, click *Create Instance* . Select the *YAML View*
+radio button and paste the following YAML definition into the window
+that displays.
 +
 .Cluster Logging Custom Resource (CR)
 [source,yaml]


### PR DESCRIPTION
I was walking through these instructions today and had to do things a bit differently from what the doc said. Updated accordingly.