### PR TITLE
GH#20647 - An additional network cannot be deleted from a pod

### DIFF
--- a/modules/nw-multus-remove-pod.adoc
+++ b/modules/nw-multus-remove-pod.adoc
@@ -3,86 +3,26 @@
 // * networking/multiple_networks/removing-pod.adoc
 
 [id="nw-multus-remove-pod_{context}"]
-= Removing a Pod from an additional network
+= Removing a pod from an additional network
 
-You can remove a Pod from an additional network.
+You can remove a pod from an additional network only by deleting the pod.
 
 .Prerequisites
 
-* You have configured an additional network for your cluster.
-* You have an additional network attached to the Pod.
+* An additional network is attached to the pod.
 * Install the OpenShift CLI (`oc`).
-* You must log in to the cluster.
+* Log in to the cluster.
 
 .Procedure
 
-To remove a Pod from an additional network, complete the following steps:
-
-. Edit the Pod resource definition by running the following command. Replace
-`<name>` with the name of the Pod to edit.
+* To delete the pod, enter the following command:
 +
 [source,terminal]
 ----
-$ oc edit pod <name>
-----
-
-. Update the `annotations` mapping to remove the additional network from the
-Pod by performing one of the following actions:
-
-* To remove all additional networks from a Pod, remove the
-`k8s.v1.cni.cncf.io/networks` parameter from the Pod resource definition as in
-the following example:
-+
-[source,yaml] 
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  name: example-pod
-  annotations: {}
-spec:
-  containers:
-  - name: example-pod
-    command: ["/bin/bash", "-c", "sleep 2000000000000"]
-    image: centos/tools
-----
-
-* To remove a specific additional network from a Pod, update the
-`k8s.v1.cni.cncf.io/networks` parameter by removing the name of the
-NetworkAttachmentDefinition for the additional network.
-
-. Optional: Confirm that the Pod is no longer attached to the additional network
-by running the following command. Replace `<name>` with the name of the Pod.
-+
-[source,terminal]
-----
-$ oc describe pod <name>
+$ oc delete pod <name> -n <namespace>
 ----
 +
-In the following example, the `example-pod` Pod is attached only to the default
-cluster network.
-+
-[source,terminal]
-----
-$ oc describe pod example-pod
-----
-+
-.Example output
-[source,terminal]
-----
-Name:               example-pod
-...
-Annotations:        k8s.v1.cni.cncf.io/networks-status:
-                      [{
-                          "name": "openshift-sdn",
-                          "interface": "eth0",
-                          "ips": [
-                              "10.131.0.13"
-                          ],
-                          "default": true, <1>
-                          "dns": {}
-                      }]
-Status:             Running
-...
-----
-<1> Only the default cluster network is attached to the Pod.
+--
+* `<name>` is the name of the pod.
+* `<namespace>` is the namespace that contains the pod.
+--

--- a/networking/multiple_networks/removing-pod.adoc
+++ b/networking/multiple_networks/removing-pod.adoc
@@ -1,10 +1,10 @@
 [id="removing-pod"]
-= Removing a Pod from an additional network
+= Removing a pod from an additional network
 include::modules/common-attributes.adoc[]
 :context: removing-pod
 
 toc::[]
 
-As a cluster user you can remove a Pod from an additional network.
+As a cluster user you can remove a pod from an additional network.
 
 include::modules/nw-multus-remove-pod.adoc[leveloffset=+1]


### PR DESCRIPTION
A pod must be deleted to remove an additional network.

- https://github.com/openshift/openshift-docs/issues/20647

Preview: https://gh-20647--ocpdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/removing-pod.html