### PR TITLE
Rm remaining instances of OperatorSources

### DIFF
--- a/installing/install_config/customizations.adoc
+++ b/installing/install_config/customizations.adoc
@@ -448,12 +448,6 @@ new values. If it is deleted, it recreates automatically.
 |Namespaced
 |
 
-|OperatorSource
-|operators.coreos.com
-|
-|Namespaced
-|
-
 |Project
 |config.openshift.io
 |

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -5,10 +5,7 @@
 [id="olm-catalogsource_{context}"]
 = CatalogSource
 
-A CatalogSource represents a store of metadata that OLM can query to discover
-and install Operators and their dependencies. The spec of a CatalogSource
-indicates how to construct a Pod or how to communicate with a service that
-serves the Operator Registry gRPC API.
+A CatalogSource represents a store of metadata that OLM can query to discover and install Operators and their dependencies. The spec of a CatalogSource indicates how to construct a Pod or how to communicate with a service that serves the Operator Registry gRPC API.
 
 There are three primary `sourceTypes` for a CatalogSource:
 
@@ -26,10 +23,16 @@ metadata:
  namespace: olm
 spec:
  sourceType: grpc
- image: quay.io/operator-framework/upstream-community-operators:latest
+ image: quay.io/operatorhubio/catalog:latest <1>
+ priority: -400
  displayName: Community Operators
  publisher: OperatorHub.io
+ updateStrategy:
+  registryPoll: <2>
+    interval: 30m
 ----
+<1> Specify catalog image.
+<2> Automatically check for new versions at a given interval to keep up to date.
 
 This example defines a CatalogSource for OperatorHub.io content. The name of
 the CatalogSource is used as input to a Subscription, which instructs OLM where

--- a/modules/olm-operatorhub-architecture.adoc
+++ b/modules/olm-operatorhub-architecture.adoc
@@ -5,28 +5,14 @@
 [id="olm-operatorhub-arch_{context}"]
 = OperatorHub architecture
 
-The OperatorHub UI component is driven by the Marketplace Operator by default on
-{product-title} in the `openshift-marketplace` namespace.
-
-The Marketplace Operator manages OperatorHub and OperatorSource Custom Resource
-Definitions (CRDs).
-
-[NOTE]
-====
-Although some OperatorSource information is exposed through OperatorHub's UI
-interface, it is only used directly by those who are creating their own
-Operators.
-====
+The OperatorHub UI component is driven by the Marketplace Operator by default on {product-title} in the `openshift-marketplace` namespace.
 
 [id="olm-operatorhub-arch-operatorhub_crd_{context}"]
-== OperatorHub CRD
+== OperatorHub custom resource
 
-You can use the OperatorHub CRD to change the state of the default
-OperatorSources provided with OperatorHub on the cluster between enabled and
-disabled. This capability is useful when configuring {product-title} in
-restricted network environments.
+The Marketplace Operator manages an OperatorHub custom resource (CR) named `cluster` that manages the default CatalogSource objects provided with OperatorHub. You can modify this resource to enable or disable the default catalogs, which is useful when configuring {product-title} in restricted network environments.
 
-.Example OperatorHub Custom Resource
+.Example OperatorHub custom resource
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -42,38 +28,5 @@ spec:
     }
   ]
 ----
-<1> `disableAllDefaultSources` is an override that controls availability of all
-default OperatorSources that are configured by default during an {product-title}
-installation.
-<2> Disable default OperatorSources individually by changing the `disabled`
-parameter value per source.
-
-[id="olm-operatorhub-arch-operatorsource_crd_{context}"]
-== OperatorSource CRD
-
-For each Operator, the OperatorSource CRD is used to define the external data
-store used to store Operator bundles.
-
-.Example OperatorSource Custom Resource
-[source,yaml]
-----
-apiVersion: operators.coreos.com/v1
-kind: OperatorSource
-metadata:
-  name: community-operators
-  namespace: marketplace
-spec:
-  type: appregistry <1>
-  endpoint: https://quay.io/cnr <2>
-  registryNamespace: community-operators <3>
-  displayName: "Community Operators" <4>
-  publisher: "Red Hat" <5>
-----
-<1> To identify the data store as an application registry, `type` is set to `appregistry`.
-<2> Currently, Quay is the external data store used by OperatorHub, so
-the endpoint is set to `\https://quay.io/cnr` for the Quay.io `appregistry`.
-<3> For a Community Operator, `registryNamespace` is set to `community-operator`.
-<4> Optionally, set `displayName` to a name that appears for the Operator in the
-OperatorHub UI.
-<5> Optionally, set `publisher` to the person or organization publishing the
-Operator that appears in the OperatorHub UI.
+<1> `disableAllDefaultSources` is an override that controls availability of all default catalogs that are configured by default during an {product-title} installation.
+<2> Disable default catalogs individually by changing the `disabled` parameter value per source.

--- a/modules/olm-operatorhub-overview.adoc
+++ b/modules/olm-operatorhub-overview.adoc
@@ -5,15 +5,9 @@
 [id="olm-operatorhub-overview_{context}"]
 = About OperatorHub
 
-_OperatorHub_ is available via the {product-title} web console and is the
-interface that cluster administrators use to discover and install Operators.
-With one click, an Operator can be pulled from their off-cluster source,
-installed and subscribed on the cluster, and made ready for engineering teams to
-self-service manage the product across deployment environments using the
-Operator Lifecycle Manager (OLM).
+_OperatorHub_ is the web console interface in {product-title} that cluster administrators use to discover and install Operators. With one click, an Operator can be pulled from its off-cluster source, installed and subscribed on the cluster, and made ready for engineering teams to self-service manage the product across deployment environments using the Operator Lifecycle Manager (OLM).
 
-Cluster administrators can choose from OperatorSources grouped into
-the following categories:
+Cluster administrators can choose from catalogs grouped into the following categories:
 
 [cols="2a,8a",options="header"]
 |===
@@ -23,18 +17,16 @@ the following categories:
 |Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
 
 |Certified Operators
-|Products from leading independent software vendors (ISVs). Red Hat partners with
-ISVs to package and ship. Supported by the ISV.
+|Products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
+
+|Red Hat Marketplace
+|Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
 
 |Community Operators
-|Optionally-visible software maintained by relevant representatives in the
-link:https://github.com/operator-framework/community-operators[operator-framework/community-operators]
-GitHub repository. No official support.
+|Optionally-visible software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
 
 |Custom Operators
-|Operators you add to the cluster yourself.
-If you have not added any Custom Operators, the Custom category does not appear in
-the web console on your OperatorHub.
+|Operators you add to the cluster yourself. If you have not added any Custom Operators, the Custom category does not appear in the web console on your OperatorHub.
 |===
 
 [NOTE]
@@ -42,14 +34,6 @@ the web console on your OperatorHub.
 OperatorHub content automatically refreshes every 60 minutes.
 ====
 
-Operators on OperatorHub are packaged to run on OLM. This includes a YAML
-file called a ClusterServiceVersion (CSV) containing all of the CRDs, RBAC
-rules, Deployments, and container images required to install and securely run the
-Operator. It also contains user-visible information like a description of its
-features and supported Kubernetes versions.
+Operators on OperatorHub are packaged to run on OLM. This includes a YAML file called a ClusterServiceVersion (CSV) containing all of the CRDs, RBAC rules, Deployments, and container images required to install and securely run the Operator. It also contains user-visible information like a description of its features and supported Kubernetes versions.
 
-The Operator SDK can be used to assist developers packaging their Operators for
-use on OLM and OperatorHub. If you have a commercial application that you
-want to make accessible to your customers, get it included using the
-certification workflow provided by Red Hat's ISV partner portal at
-link:https://connect.redhat.com[connect.redhat.com].
+The Operator SDK can be used to assist developers packaging their Operators for use on OLM and OperatorHub. If you have a commercial application that you want to make accessible to your customers, get it included using the certification workflow provided by Red Hat's ISV partner portal at link:https://connect.redhat.com[connect.redhat.com].

--- a/operators/understanding/olm-understanding-operatorhub.adoc
+++ b/operators/understanding/olm-understanding-operatorhub.adoc
@@ -13,6 +13,7 @@ include::modules/olm-operatorhub-architecture.adoc[leveloffset=+1]
 [id="olm-understanding-operatorhub-resources"]
 == Additional resources
 
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[CatalogSource]
 * xref:../../operators/operator_sdk/osdk-getting-started.adoc#osdk-getting-started[Getting started with the Operator SDK]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-generating-csvs[Generating a ClusterServiceVersion (CSV)]
 * xref:../../operators/understanding/olm/olm-workflow.adoc#olm-upgrades_olm-workflow[Operator installation and upgrade workflow in OLM]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1569

After this, the only remaining modules that mention OperatorSource are:

- https://github.com/openshift/openshift-docs/blob/master/modules/olm-restricted-networks-configuring-operatorhub.adoc, which is being updated via https://github.com/openshift/openshift-docs/pull/26067
- https://github.com/openshift/openshift-docs/blob/master/modules/odc-connecting-components.adoc (chatted with @Preeticp offline, her team will address separately)

Preview (internal): http://file.rdu.redhat.com/~adellape/100920/rm_operatorsources/operators/understanding/olm-understanding-operatorhub.html