### PR TITLE
Bug 1883686: restore-replace-stopped-etcd-member: add section covering forcing new etcd revision

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -279,3 +279,12 @@ etcd-ip-10-0-133-53.ec2.internal                 3/3     Running     0          
 etcd-ip-10-0-164-97.ec2.internal                 3/3     Running     0          123m
 etcd-ip-10-0-154-204.ec2.internal                3/3     Running     0          124m
 ----
++
+If the output from the previous command only lists two pods, you can manually force an etcd redeployment. In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
++
+[source,terminal]
+----
+$ oc patch etcd cluster -p='{"spec": {"forceRedeploymentReason": "recovery-'"$( date --rfc-3339=ns )"'"}}' --type=merge <1>
+----
+<1> The `forceRedeploymentReason` value must be unique, which is why a timestamp is appended.
++


### PR DESCRIPTION
As outlined in the bug user was nervous about forcing new revision because it was not a documented step. In general, I have questions about how/where we document master node replacement. I wonder at its core if that is the root problem of the bug but I think we should consider the addition of this step as a fallback procedure.

Signed-off-by: Sam Batschelet <sbatsche@redhat.com>