### PR TITLE
Bug 1876474 - Remove qemu guest requirement

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2277,6 +2277,10 @@ Topics:
     File: virt-controlling-vm-states
   - Name: Accessing virtual machine consoles
     File: virt-accessing-vm-consoles
+  - Name: Installing the QEMU guest agent on virtual machines
+    File: virt-installing-qemu-guest-agent
+  - Name: Viewing the QEMU guest agent information for virtual machines
+    File: virt-viewing-qemu-guest-agent-web
   - Name: Managing ConfigMaps, secrets, and service accounts in virtual machines
     File: virt-managing-configmaps-secrets-service-accounts
   - Name: Installing VirtIO driver on an existing Windows virtual machine
@@ -2339,10 +2343,6 @@ Topics:
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network
       File: virt-attaching-vm-to-sriov-network
-    - Name: Installing the QEMU guest agent on virtual machines
-      File: virt-installing-qemu-guest-agent
-    - Name: Viewing the QEMU guest agent information for virtual machines
-      File: virt-viewing-qemu-guest-agent-web
     - Name: Viewing the IP address of NICs on a virtual machine
       File: virt-viewing-ip-of-vm-nic
     - Name: Using a MAC address pool for virtual machines

--- a/modules/virt-about-qemu-guest-agent-web.adoc
+++ b/modules/virt-about-qemu-guest-agent-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-viewing-qemu-guest-agent-information.adoc
+// * virt/virtual_machines/virt-viewing-qemu-guest-agent-information.adoc
 
 [id="About-the-qemu-guest-agent-web_{context}"]
 = About the QEMU guest agent information in the web console

--- a/modules/virt-installing-qemu-guest-agent-on-linux-vm.adoc
+++ b/modules/virt-installing-qemu-guest-agent-on-linux-vm.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
+// * virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
 
 [id="virt-installing-qemu-guest-agent-on-linux-vm_{context}"]
 = Installing QEMU guest agent on a Linux virtual machine

--- a/modules/virt-installing-qemu-guest-agent-on-windows-vm.adoc
+++ b/modules/virt-installing-qemu-guest-agent-on-windows-vm.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
+// * virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
 
 [id="installing-qemu-guest-agent-on-a-windows-virtual-machine"]
 = Installing QEMU guest agent on a Windows virtual machine

--- a/modules/virt-installing-virtio-drivers-existing-windows.adoc
+++ b/modules/virt-installing-virtio-drivers-existing-windows.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
+// * virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
 // * virt/virtual_machines/virt-installing-virtio-drivers-on-existing-windows-vm.adoc
 
 [id="virt-installing-virtio-drivers-existing-windows_{context}"]

--- a/modules/virt-installing-virtio-drivers-installing-windows.adoc
+++ b/modules/virt-installing-virtio-drivers-installing-windows.adoc
@@ -1,30 +1,29 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc
+// * virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
 // * virt/virtual_machines/virt-installing-virtio-drivers-on-new-windows-vm.adoc
 
 [id="virt-installing-virtio-drivers-installing-windows_{context}"]
 = Installing VirtIO drivers during Windows installation
 
-Install the VirtIO drivers from the attached SATA CD driver during Windows installation. 
+Install the VirtIO drivers from the attached SATA CD driver during Windows installation.
 
 [NOTE]
 ====
-This procedure uses a generic approach to the Windows installation and the 
-installation method might differ between versions of Windows. Refer to the 
+This procedure uses a generic approach to the Windows installation and the
+installation method might differ between versions of Windows. Refer to the
 documentation for the version of Windows that you are installing.
 ====
 
 .Procedure
 
 . Start the virtual machine and connect to a graphical console.
-. Begin the Windows installation process. 
+. Begin the Windows installation process.
 . Select the *Advanced* installation.
-. The storage destination will not be recognized until the driver is loaded. 
-Click `Load driver`. 
+. The storage destination will not be recognized until the driver is loaded.
+Click `Load driver`.
 . The drivers are attached as a SATA CD drive. Click *OK* and browse the CD drive
- for the storage driver to load. The drivers are arranged hierarchically 
-according to their driver type, operating system, and CPU architecture. 
-. Repeat the previous two steps for all required drivers. 
-. Complete the Windows installation. 
-
+ for the storage driver to load. The drivers are arranged hierarchically
+according to their driver type, operating system, and CPU architecture.
+. Repeat the previous two steps for all required drivers.
+. Complete the Windows installation.

--- a/modules/virt-viewing-qemu-guest-agent-information-web.adoc
+++ b/modules/virt-viewing-qemu-guest-agent-information-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/vm_networking/virt-viewing-qemu-guest-agent-information.adoc
+// * virt/virtual_machines/virt-viewing-qemu-guest-agent-information.adoc
 
 [id="virt-viewing-qemu-guest-agent-information-web_{context}"]
 = Viewing the QEMU guest agent information in the web console

--- a/virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
+++ b/virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
@@ -4,9 +4,7 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-installing-qemu-guest-agent
 toc::[]
 
-The QEMU guest agent is a daemon that runs on the virtual machine. The agent
-passes network information on the virtual machine, notably the IP address of
-additional networks, to the host.
+The xref:../../virt/virtual_machines/virt-viewing-qemu-guest-agent-web.adoc#virt-viewing-qemu-guest-agent-web[QEMU guest agent] is a daemon that runs on the virtual machine and passes information to the host about the virtual machine, users, file systems, and secondary networks.
 
 == Prerequisites
 

--- a/virt/virtual_machines/virt-viewing-qemu-guest-agent-web.adoc
+++ b/virt/virtual_machines/virt-viewing-qemu-guest-agent-web.adoc
@@ -4,11 +4,11 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-viewing-qemu-guest-agent-web
 toc::[]
 
-The QEMU guest agent runs on the virtual machine and passes information to the host about the virtual machine, users, and file systems. You can view this information in the web console.
+When the QEMU guest agent runs on the virtual machine, you can use the web console to view information about the virtual machine, users, file systems, and secondary networks.
 
 == Prerequisites
 
-* Install the xref:../../../virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] on the virtual machine.
+* Install the xref:../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] on the virtual machine.
 
 include::modules/virt-about-qemu-guest-agent-web.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -18,7 +18,7 @@ include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 
 == Prerequisites
 
-* A Linux bridge must be configured and attached on every node. 
+* A Linux bridge must be configured and attached on every node.
 See the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking] section for more information.
 
 include::modules/virt-creating-bridge-nad-web.adoc[leveloffset=+2]
@@ -35,5 +35,3 @@ in the previous section.
 include::modules/virt-vm-create-nic-web.adoc[leveloffset=+1]
 
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+1]
-
-Install the optional xref:../../../virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] on the virtual machine so that the host can display relevant information about the additional networks.

--- a/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
+++ b/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
@@ -4,17 +4,7 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-viewing-ip-of-vm-vnic
 toc::[]
 
-The QEMU guest agent runs on the virtual machine and passes the IP address of attached NICs to the host, allowing you to view the IP address from both the web console and the `oc` client.
-
-== Prerequisites
-
-. Verify that the guest agent is installed and running by entering the following command:
-+
-----
-$ systemctl status qemu-guest-agent
-----
-+
-. If the guest agent is not installed and running, xref:../../../virt/virtual_machines/vm_networking/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[install and run the guest agent on the virtual machine].
+You can view the IP address for a Network Interface Card (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
 
 include::modules/virt-viewing-vmi-ip-cli.adoc[leveloffset=+1]
 include::modules/virt-viewing-vmi-ip-web.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is associated with the bug: https://bugzilla.redhat.com/show_bug.cgi?id=1876474
(QEMU guest agent does not pass the IP address)

Removed content stating that the QEMU guest agent is required to view the IP address for network interface cards.

CP to OCP 4.5, 4.6