### PR TITLE
Add new LSO proc xref to 4-6 RNs

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -105,7 +105,7 @@ Ignition snippets, they should be created using Ignition spec v3. However, the
 Machine Config Operator (MCO) still supports Ignition spec v2.
 
 [id="ocp-4-6-extensions-supported-for-rhcos-mco"]
-==== Extensions now supported for {op-system} and MCO 
+==== Extensions now supported for {op-system} and MCO
 
 {op-system} and the MCO now support the following extensions to the default
 {op-system} installation.
@@ -213,7 +213,7 @@ If the `credentialsMode` field is set to any of the three modes, the
 installation program does not check the credential for proper permissions prior
 to installing {product-title}. This is useful for when the supplied user
 credentials cannot be properly validated due to limitations in the cloud policy
-simulator. 
+simulator.
 
 // For more information on these modes, see operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator].
 
@@ -469,6 +469,8 @@ The Local Storage Operator now has the ability to:
 
 * Automatically discover a list of available disks in a cluster. You can select a list of nodes, or all nodes, for auto-discovery to be continuously applied to.
 * Automatically provision local persistent volumes from attached devices. Appropriate devices are filtered and persistent volumes are provisioned based on the filtered devices.
+
+For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#local-storage-discovery_persistent-storage-local[Automating discovery and provisioning for local storage devices].
 
 [id="ocp-4-6-operators"]
 === Operators


### PR DESCRIPTION
Added xref to not-yet-merged new module link for 4.6 Release Notes -> Storage. Module title ("Automating...") won't appear when you click the link until https://github.com/openshift/openshift-docs/pull/26275 is merged.