### PR TITLE
Remove empty module from OSP UPI assemblies

### DIFF
--- a/installing/installing_openstack/installing-openstack-user-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-kuryr.adoc
@@ -40,7 +40,6 @@ include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1
 include::modules/installation-osp-accessing-api.adoc[leveloffset=+1]
 include::modules/installation-osp-accessing-api-floating.adoc[leveloffset=+2]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
-include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-custom-subnet.adoc[leveloffset=+2]

--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -35,7 +35,6 @@ include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1
 include::modules/installation-osp-accessing-api.adoc[leveloffset=+1]
 include::modules/installation-osp-accessing-api-floating.adoc[leveloffset=+2]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
-include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-custom-subnet.adoc[leveloffset=+2]

--- a/modules/installation-user-infra-generate.adoc
+++ b/modules/installation-user-infra-generate.adoc
@@ -5,7 +5,6 @@
 // * installing/installing_gcp/installing-gcp-user-infra.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
-// * installing/installing_openstack/installing-openstack-user.adoc
 
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :restricted:


### PR DESCRIPTION
This PR removes an empty module from the OSP UPI assemblies. Pretty simple. 

I don't think this requires QE.

Resolves #26299 