### PR TITLE
Add macOS/Windows install for opm

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -2,10 +2,17 @@
 //
 // * operators/olm-managing-custom-catalogs.adoc
 
+ifdef::openshift-origin[]
+:registry-image: quay.io/openshift/origin-operator-registry:4.6.0
+endif::[]
+ifndef::openshift-origin[]
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v4.6
+endif::[]
+
 [id="olm-installing-opm_{context}"]
 = Installing `opm`
 
-You can install the `opm` CLI tool on your workstation.
+You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Prerequisites
 
@@ -13,9 +20,9 @@ You can install the `opm` CLI tool on your workstation.
 
 .Procedure
 
-ifdef::openshift-enterprise,openshift-webscale[]
+ifndef::openshift-origin[]
 . Set the `REG_CREDS` environment variable to the file path of your registry
-credentials for use in later steps. For example, for the `podman` CLI:
+credentials for use in later steps. For example, for the `podman` CLI on Linux:
 +
 [source,terminal]
 ----
@@ -30,40 +37,98 @@ $ podman login registry.redhat.io
 ----
 endif::[]
 
-. Extract the `opm` binary from the Operator Registry image and copy it to your
-local file system:
+. Extract the `opm` binary for the operating system you want from the Operator
+Registry image and copy it to your local file system.
++
+--
+* For Linux:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc image extract {registry-image} \
+ifndef::openshift-origin[]
+    -a ${REG_CREDS} \
+endif::[]
+    --path /usr/bin/opm:. \
+    --confirm
+----
+
+* For macOS:
+
+.. Extract the binary:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc image extract {registry-image} \
+ifndef::openshift-origin[]
+    -a ${REG_CREDS} \
+endif::[]
+    --path /usr/bin/darwin-amd64-opm:. \
+    --confirm
+----
+
+.. Rename the file to `opm`:
 +
 [source,terminal]
-ifdef::openshift-origin[]
 ----
-$ oc image extract quay.io/openshift/origin-operator-registry:4.6.0 \
-    --path /usr/bin/opm:. \
-    --confirm
+$ mv darwin-amd64-opm opm
 ----
-endif::[]
-ifdef::openshift-enterprise,openshift-webscale[]
-----
-$ oc image extract registry.redhat.io/openshift4/ose-operator-registry:v4.6 \
-    -a ${REG_CREDS} \//<1>
-    --path /usr/bin/opm:. \
-    --confirm
-----
-<1> Specify the location of your registry credentials file.
-endif::[]
 
-. Make the binary executable:
+* For Windows:
+
+.. Extract the binary:
++
+[source,terminal,subs="attributes+"]
+----
+C:\> oc image extract {registry-image} \
+ifndef::openshift-origin[]
+    -a ${REG_CREDS} \
+endif::[]
+    --path /usr/bin/windows-amd64-opm:. \
+    --confirm
+----
+
+.. Rename the file to `opm.exe`:
++
+[source,terminal]
+----
+C:\> rename windows-amd64-opm opm.exe
+----
+--
+
+. For Linux or macOS, make the binary executable:
 +
 [source,terminal]
 ----
 $ chmod +x ./opm
 ----
 
-. Place the file anywhere in your `PATH`, such as `/usr/local/bin/`.
+. Place the file anywhere in your `PATH`. For example:
++
+--
+* For Linux or macOS:
 +
 [source,terminal]
 ----
 $ sudo mv ./opm /usr/local/bin/
 ----
+
+* For Windows:
+
+.. Check your `PATH`:
++
+[source,terminal]
+----
+C:\> path
+----
+
+.. Move the file:
++
+[source,terminal]
+----
+C:\> move opm.exe <directory>
+----
+--
 
 . Verify that the client was installed correctly:
 +
@@ -77,3 +142,5 @@ $ opm version
 ----
 Version: version.Version{OpmVersion:"1.12.3", GitCommit:"", BuildDate:"2020-07-01T23:18:58Z", GoOs:"linux", GoArch:"amd64"}
 ----
+
+:!registry-image:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1413

Different registry images / steps used between OCP and OKD.

OCP version: http://file.rdu.redhat.com/~adellape/100920/opm_distros/operators/admin/olm-managing-custom-catalogs.html#olm-installing-opm_olm-managing-custom-catalogs

OKD version: http://file.rdu.redhat.com/~adellape/100920/okd/opm_distros/operators/admin/olm-managing-custom-catalogs.html#olm-installing-opm_olm-managing-custom-catalogs