### PR TITLE
Add alpha scorecard to OSDK

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -890,7 +890,7 @@ Topics:
   - Name: Working with bundle images
     File: osdk-working-bundle-images
   - Name: Validating Operators using the scorecard
-    File: osdk-scorecard
+    File: osdk-new-scorecard
   - Name: Configuring built-in monitoring with Prometheus
     File: osdk-monitoring-prometheus
   - Name: Configuring leader election

--- a/operators/operator_sdk/osdk-new-scorecard.adoc
+++ b/operators/operator_sdk/osdk-new-scorecard.adoc
@@ -1,0 +1,359 @@
+[id="osdk-new-scorecard"]
+= Validating Operators using the scorecard
+include::modules/common-attributes.adoc[]
+:context: osdk-new-scorecard
+
+toc::[]
+
+:FeatureName: The enhanced Operator SDK scorecard
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+Operator authors should validate that their Operator is packaged correctly and
+free of syntax errors. As an Operator author, you can use the scorecard tool in
+the Operator SDK to validate your Operator packaging and run tests.
+
+[NOTE]
+====
+The implementation of the scorecard tool supported in earlier versions of
+{product-title} 4, which was available using the `operator-sdk scorecard`
+command, has been replaced by the Technology Preview version of the enhanced
+scorecard tool, which is currently available using the `operator-sdk alpha
+scorecard` command.
+====
+
+The `operator-sdk alpha scorecard` command executes tests on your Operator based
+upon a configuration file and test images. Tests are implemented within test
+images that are configured and constructed to be executed by scorecard.
+
+Scorecard assumes it is being executed with access to a configured Kubernetes
+cluster. Each test is executed within a pod by scorecard, from which pod logs
+are aggregated and test results sent to the console.
+
+Scorecard has built-in basic and Operator Lifecycle Manager (OLM) tests, but
+also provides a means to execute custom test definitions.
+
+[id="osdk-new-scorecard-requirements"]
+== Requirements
+
+The scorecard tests make no assumptions as to the state of the Operator being
+tested. Creating Operators and custom resources for an Operators are beyond the
+scope of scorecard itself.
+
+Scorecard tests can, however, create whatever resources they require if the
+tests are designed for resource creation.
+
+[id="osdk-new-scorecard-configuration"]
+== Scorecard configuration
+
+The scorecard test execution is driven by a configuration file typically named
+`config.yaml`. The configuration file is located at the following
+location within your bundle:
+
+[source,text]
+----
+tests/scorecard/config.yaml
+----
+
+[id="osdk-new-scorecard-configuration-file"]
+=== Configuration file
+
+A sample of the scorecard configuration file may look as follows:
+
+[source,yaml]
+----
+tests:
+- name: "basic-check-spec"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - basic-check-spec
+  labels:
+    suite: basic
+    test: basic-check-spec-test
+  description: check the spec test
+- name: "olm-bundle-validation"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-bundle-validation
+  labels:
+    suite: olm
+    test: olm-bundle-validation-test
+  description: validate the bundle test
+----
+
+[TIP]
+====
+See _Complete scorecard configuration file_ for an example that is used for
+running the scorecard pre-defined tests that ship with the Operator SDK.
+====
+
+The configuration file defines each test that scorecard can execute. The
+following fields of the scorecard configuration file define the test as follows:
+
+[cols="3,7",options="header"]
+|===
+|Configuration field |Description
+
+|`image`
+|The test container image name that implements a test
+
+|`entrypoint`
+|The command and arguments that are invoked in the test image to execute a test
+
+|`labels`
+|Scorecard-defined or custom labels that select which tests to run
+|===
+
+[id="osdk-new-scorecard-cmd-args"]
+=== Command arguments
+
+The scorecard command has the following syntax:
+
+[source,terminal]
+----
+$ operator-sdk alpha scorecard <bundle_path> | <bundle_path_image_name> <flags>
+----
+
+Scorecard requires a positional argument that holds either the on-disk path to
+your Operator bundle or the name of a bundle image.
+
+For further information about the flags, run:
+
+[source,terminal]
+----
+$ operator-sdk alpha scorecard -h
+----
+
+[id="osdk-new-scorecard-selecting-tests"]
+== Selecting tests
+
+Tests are selected by setting the `--selector` CLI flag to a set of label
+strings. If a selector flag is not supplied, then all the tests within the
+scorecard configuration file are executed.
+
+Tests are executed serially, one after the other, with test results
+being aggregated by scorecard and written to standard output (stdout).
+
+To select a single test, for example `basic-check-spec-test`:
+
+[source,terminal]
+----
+$ operator-sdk alpha scorecard ./ -o text --selector=test=basic-check-spec-test
+----
+
+To select a suite of tests, `olm` in this case, you can specify a label that is
+used by all the OLM tests:
+
+[source,terminal]
+----
+$ operator-sdk alpha scorecard ./ -o text --selector=suite=olm
+----
+
+To select multiple tests:
+
+[source,terminal]
+----
+$ operator-sdk alpha scorecard ./ -o text \
+    --selector='test in (basic-check-spec-test,olm-bundle-validation-test)'
+----
+
+[id="osdk-new-scorecard-tests"]
+== Built-in tests
+
+The scorecard ships with pre-defined tests that are arranged into suites.
+
+[id="osdk-new-scorecard-basic"]
+=== Basic test suite
+
+[cols="3,7,3",options="header"]
+|===
+|Test |Description |Short name
+
+|Spec Block Exists
+|This test checks the custom resource (CR) created in the cluster to make sure that all CRs have a `spec` block.
+|`basic-check-spec-test`
+|===
+
+[id="osdk-new-scorecard-olm"]
+=== OLM test suite
+
+[cols="3,7,3",options="header"]
+|===
+|Test |Description |Short name
+
+|Bundle Validation
+|This test validates the bundle manifests found in the bundle that is passed into scorecard. If the bundle contents contain errors, then the test result output includes the validator log as well as error messages from the validation library.
+|`olm-bundle-validation-test`
+
+|Provided APIs Have Validation
+|This test verifies that the custom resource definitions (CRDs) for the provided CRs contain a validation section and that there is validation for each `spec` and `status` field detected in the CR.
+|`olm-crds-have-validation-test`
+
+|Owned CRDs Have Resources Listed
+|This test makes sure that the CRDs for each CR provided via the `cr-manifest` option have a `resources` subsection in the `owned` CRDs section of the ClusterServiceVersion (CSV). If the test detects used resources that are not listed in the resources section, it lists them in the suggestions at the end of the test. Users are required to fill out the resources section after initial code generation for this test to pass.
+|`olm-crds-have-resources-test`
+
+|Spec Fields With Descriptors
+|This test verifies that every field in the CRs `spec` sections has a corresponding descriptor listed in the CSV.
+|`olm-spec-descriptors-test`
+
+|Status Fields With Descriptors
+|This test verifies that every field in the CRs `status` sections have a corresponding descriptor listed in the CSV.
+|`olm-status-descriptors-test`
+|===
+
+[id="osdk-new-scorecard-running-scorecard"]
+== Running the scorecard tool
+
+.Procedure
+
+. Define a scorecard configuration file at `tests/scorecard/config.yaml` within
+your project bundle directory. Unless you are executing custom tests, you can
+copy the provided sample from _Complete scorecard configuration file_ into your
+project.
++
+[NOTE]
+====
+You can override the default location of the configuration file by specifying
+the `--config` flag when running the scorecard tool.
+====
+
+. Run the scorecard from the root directory of your project bundle:
++
+[source,terminal]
+----
+$ operator-sdk alpha scorecard ./
+----
++
+The scorecard return code is `1` if any of the tests executed did not pass and
+`0` if all selected tests pass.
+
+[id="osdk-new-scorecard-output"]
+== Scorecard output
+
+The `--output` flag specifies the scorecard results output format.
+
+[id="osdk-new-scorecard-output-json"]
+=== JSON format
+
+See an example of the JSON format produced by a scorecard test:
+
+[source,json]
+----
+{
+  "spec": {
+    "image": ""
+  },
+  "status": {
+    "results": [
+      {
+        "name": "olm-bundle-validation",
+        "log": "time=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=debug msg=\"Found metadata directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level
+=debug msg=\"Getting mediaType info from manifests directory\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Found annotations file\" name=bundle-test\ntime=\"2020-06-10T19:02:49Z\" level=info msg=\"Could not find optio
+nal dependencies file\" name=bundle-test\n",
+        "state": "pass"
+      }
+    ]
+  }
+}
+----
+
+[id="osdk-new-scorecard-output-text"]
+=== Text format
+
+See an example of the text format produced by a scorecard test:
+
+[source,text]
+----
+        Labels:
+        olm-bundle-validation               : pass
+        Log:
+                time="2020-06-10T19:00:43Z" level=debug msg="Found manifests directory" name=bundle-test
+                time="2020-06-10T19:00:43Z" level=debug msg="Found metadata directory" name=bundle-test
+                time="2020-06-10T19:00:43Z" level=debug msg="Getting mediaType info from manifests directory" name=bundle-test
+                time="2020-06-10T19:00:43Z" level=info msg="Found annotations file" name=bundle-test
+                time="2020-06-10T19:00:43Z" level=info msg="Could not find optional dependencies file" name=bundle-test
+----
+
+[NOTE]
+====
+The output format spec matches the link:https://pkg.go.dev/github.com/operator-framework/operator-sdk@v0.19.1/pkg/apis/scorecard/v1alpha3?tab=doc#Test[Test]
+type layout.
+====
+
+[id="osdk-new-scorecard-custom-tests"]
+== Custom tests
+
+Scorecard executes custom tests if they follow these mandated conventions:
+
+* Tests are implemented within a container image.
+* Tests accept an entrypoint which include a command and arguments.
+* Tests produce `v1alpha3` scorecard output in JSON format with no extraneous logging in the test output.
+* Tests can obtain the bundle contents at a shared mount point of `/bundle`.
+* Tests can access the Kubernetes API using an in-cluster client connection.
+
+Writing custom tests in other programming languages is possible if the test
+image follows the above guidelines.
+
+[id="osdk-new-scorecard-complete-config"]
+== Complete scorecard configuration file
+
+[source,yaml]
+----
+tests:
+- name: "basic-check-spec"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - basic-check-spec
+  labels:
+    suite: basic
+    test: basic-check-spec-test
+  description: check the spec test
+- name: "olm-bundle-validation"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-bundle-validation
+  labels:
+    suite: olm
+    test: olm-bundle-validation-test
+  description: validate the bundle test
+- name: "olm-crds-have-validation"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-crds-have-validation
+  labels:
+    suite: olm
+    test: olm-crds-have-validation-test
+  description: CRDs have validation
+- name: "olm-crds-have-resources"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-crds-have-resources
+  labels:
+    suite: olm
+    test: olm-crds-have-resources-test
+  description: CRDs have resources
+- name: "olm-spec-descriptors"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-spec-descriptors
+  labels:
+    suite: olm
+    test: olm-spec-descriptors-test
+  description: OLM Spec Descriptors
+- name: "olm-status-descriptors"
+  image: quay.io/operator-framework/scorecard-test:master
+  entrypoint:
+  - scorecard-test
+  - olm-status-descriptors
+  labels:
+    suite: olm
+    test: olm-status-descriptors-test
+  description: OLM Status Descriptors
+----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1091

Preview (internal): http://file.rdu.redhat.com/~adellape/100920/46_scorecard/operators/operator_sdk/osdk-new-scorecard.html

TODO: After QE review, break assembly up into modules before peer review.