### PR TITLE
Bump OSDK to v0.19.4

### DIFF
--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -10,7 +10,7 @@ SDK.
 
 .Prerequisites
 
-* Operator SDK version 0.17.2
+* Operator SDK version 0.19.4
 * `podman` version 1.4.4+
 * An Operator project generated using the Operator SDK
 

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -44,7 +44,7 @@ endif::[]
 +
 [source,terminal]
 ----
-$ RELEASE_VERSION=v0.17.2
+$ RELEASE_VERSION=v0.19.4
 ----
 
 . Download the release binary.


### PR DESCRIPTION
Claiming support of OSDK v0.19.4 in OCP 4.6.