### PR TITLE
cnv 2.5: Added CNV-7102 to virt 2.5 RN

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -93,6 +93,7 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 //CNV-7293 - Use OLM stable channel for installation
 
 //CNV-7102 - Block based storage support using vm-import-controller
+* You can now import VMs with block-based storage into {VirtProductName}.
 
 //CNV-7296 - HCO and HPP CRs moved to v1beta1
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CNV-7102

Added [CNV-7102](https://issues.redhat.com/browse/CNV-7102), importing VMs with block-based storage, to virt 2.5 RN