### PR TITLE
virt-attaching-vm-to-sriov: fix yaml example

### DIFF
--- a/modules/virt-attaching-vm-to-sriov-network.adoc
+++ b/modules/virt-attaching-vm-to-sriov-network.adoc
@@ -19,21 +19,24 @@ spec:
   domain:
     devices:
       interfaces:
-      - masquerade: {} <1>
-        name: default
-      - name: <sriov-network> <2>
+      - name: <default> <1>
+        masquerade: {} <2>
+      - name: <nic1> <3>
         sriov: {}
   networks:
-  - name: default <3>
+  - name: <default> <4>
     pod: {}
-  - multus:
-    name: <sriov-network> <4>
+  - name: <nic1> <5>
+    multus:
+        networkName: <sriov-network> <6>
 ...
 ----
-<1> The `masquerade` binding to the default Pod network.
-<2> The name of the SR-IOV network.
-<3> The default Pod network.
-<4> The name of the SR-IOV network. This is the same value as the `interfaces.name`.
+<1> A unique name for the interface that is connected to the Pod network.
+<2> The `masquerade` binding to the default Pod network.
+<3> A unique name for the SR-IOV interface.
+<4> The name of the Pod network interface. This must be the same as the `interfaces.name` that you defined earlier.
+<5> The name of the SR-IOV interface. This must be the same as the `interfaces.name` that you defined earlier.
+<6> The name of the SR-IOV network attachment definition.
 
 . Apply the virtual machine configuration:
 +


### PR DESCRIPTION
The former yaml had inconsistent ordering of dictionary items (sometimes
"name" came first, sometimes second) and one serious mistake: the multus
dictionary should have the networkName of the SR-IOV network. The other
names are internal references to interfaces in the VM yaml.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>