### PR TITLE
GIT22380: Added clarification for number 7 standard node pod selector.

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -61,7 +61,7 @@ status:
 <4> `keepYoungerThan`: Retain images younger than this duration. This is an optional field, and it defaults `60m` if not set.
 <5> `resources`: Standard Pod resource requests and limits. This is an optional field.
 <6> `affinity`: Standard Pod affinity. This is an optional field.
-<7> `nodeSelector`: Standard Pod node selector. This is an optional field.
+<7> `nodeSelector`: Standard Pod node selector for the image pruner pod. This is an optional field.
 <8> `tolerations`: Standard Pod tolerations. This is an optional field.
 <9> `startingDeadlineSeconds`: Start deadline for `CronJob`. This is an optional field.
 <10> `successfulJobsHistoryLimit`: The maximum number of successful jobs to retain. Must be `>= 1` to ensure metrics are reported. Defaults to `3` if not set.


### PR DESCRIPTION
Fixes #22380 

Under "Automatically pruning images" section, added clarification to call out description 7.

Please merge and CP to 4.4, 4.5, 4.6, 4.7. Thanks.