### PR TITLE
[enterprise-4.5] GIT22380: Added clarification for number 7 standard node pod selector.

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -57,7 +57,7 @@ status:
 <5> `keepYoungerThan`: Deprecated. The same as `keepYoungerThanDuration`, but the duration is specified as an integer in nanoseconds. This is an optional field. When `keepYoungerThanDuration` is set, this field is ignored.
 <6> `resources`: Standard Pod resource requests and limits. This is an optional field.
 <7> `affinity`: Standard Pod affinity. This is an optional field.
-<8> `nodeSelector`: Standard Pod node selector. This is an optional field.
+<8> `nodeSelector`: Standard Pod node selector for the image pruner pod. This is an optional field.
 <9> `tolerations`: Standard Pod tolerations. This is an optional field.
 <10> `successfulJobsHistoryLimit`: The maximum number of successful jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
 <11> `failedJobsHistoryLimit`: The maximum number of failed jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.


### PR DESCRIPTION
From https://github.com/openshift/openshift-docs/pull/26366