### PR TITLE
Adding monitoring assembly to troubleshooting guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -371,6 +371,8 @@ Topics:
     File: troubleshooting-s2i
   - Name: Troubleshooting storage issues
     File: troubleshooting-storage-issues
+  - Name: Investigating monitoring issues
+    File: investigating-monitoring-issues
   - Name: Diagnosing OpenShift CLI (oc) issues
     File: diagnosing-oc-issues
 ---

--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/troubleshooting-monitoring-issues.adoc
+// * support/troubleshooting/investigating-monitoring-issues.adoc
 
 [id="determining-why-prometheus-is-consuming-disk-space_{context}"]
 = Determining why Prometheus is consuming a lot of disk space

--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/troubleshooting-monitoring-issues.adoc
+// * support/troubleshooting/investigating-monitoring-issues.adoc
 
 [id="investigating-why-user-defined-metrics-are-unavailable_{context}"]
 = Investigating why user-defined metrics are unavailable

--- a/support/troubleshooting/investigating-monitoring-issues.adoc
+++ b/support/troubleshooting/investigating-monitoring-issues.adoc
@@ -1,0 +1,26 @@
+[id="investigating-monitoring-issues"]
+= Investigating monitoring issues
+include::modules/common-attributes.adoc[]
+:context: investigating-monitoring-issues
+
+toc::[]
+
+{product-title} includes a pre-configured, pre-installed, and self-updating monitoring stack that provides monitoring for core platform components. In {product-title} {product-version}, cluster administrators can optionally enable monitoring for user-defined projects.
+
+// Note - please update the following sentence if you add further modules to this assembly.
+You can follow these procedures if your own metrics are unavailable or if Prometheus is consuming a lot of disk space.
+
+// Investigating why user-defined metrics are unavailable
+include::modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../monitoring/configuring-the-monitoring-stack.adoc#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[Creating a user-defined workload monitoring ConfigMap]
+* See xref:../../monitoring/managing-metrics.adoc#specifying-how-a-service-is-monitored_managing-metrics[Specifying how a service is monitored] for details on how to create a ServiceMonitor or PodMonitor
+
+// Determining why Prometheus is consuming a lot of disk space
+include::modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../../monitoring/configuring-the-monitoring-stack.adoc#setting-a-scrape-sample-limit-for-user-defined-projects_configuring-the-monitoring-stack[Setting a scrape sample limit for user-defined projects] for details on how to set a scrape sample limit and create related alerting rules


### PR DESCRIPTION
This PR adds the troubleshooting modules that were merged in [this related PR](https://github.com/openshift/openshift-docs/pull/24722) to the Troubleshooting Guide.

Applies to master and branch/enterprise-4.6.

The preview is [here](https://troubleshooting_guide_4_6_monitoring_addition--ocpdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/investigating-monitoring-issues.html).