### PR TITLE
Remove manila xref from obj def module

### DIFF
--- a/modules/dynamic-provisioning-manila-csi-definition.adoc
+++ b/modules/dynamic-provisioning-manila-csi-definition.adoc
@@ -5,4 +5,4 @@
 [id="openstack-manila-csi-definition_{context}"]
 = {rh-openstack} Manila Container Storage Interface (CSI) object definition
 
-Once installed, the xref:../storage/container_storage_interface/persistent-storage-csi-manila.adoc#persistent-storage-csi-manila[OpenStack Manila CSI Driver Operator] and ManilaDriver automatically create the required storage classes for all available Manila share types needed for dynamic provisioning.
+Once installed, the OpenStack Manila CSI Driver Operator and ManilaDriver automatically create the required storage classes for all available Manila share types needed for dynamic provisioning.


### PR DESCRIPTION
Related to https://github.com/openshift/openshift-docs/pull/26255 but removes the xref in another module. 