### PR TITLE
Fix admonition note formatting

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -16,7 +16,7 @@ following the instructions in the
 xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[installation procedure].
 
 [IMPORTANT]
-===
+====
 When adding additional compute machines to your {product-title} cluster, use the
 {op-system} boot media that matches the same minor version that was used to
 install the {product-title} cluster. For example, if you installed
@@ -26,7 +26,7 @@ boot media.
 Adding additional compute machines to your cluster using newer {op-system} boot
 media is not supported. After adding the compute machines, they will automatically
 update to the current version of the {product-title} cluster.
-===
+====
 
 [id="creating-machines-bare-metal"]
 == Creating {op-system-first} machines

--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -13,7 +13,7 @@ vSphere.
 * You xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[installed a cluster on vSphere].
 
 [IMPORTANT]
-===
+====
 When adding additional compute machines to your {product-title} cluster, use the
 {op-system} boot media that matches the same minor version that was used to
 install the {product-title} cluster. For example, if you installed
@@ -23,7 +23,7 @@ boot media.
 Adding additional compute machines to your cluster using newer {op-system} boot
 media is not supported. After adding the compute machines, they will automatically
 update to the current version of the {product-title} cluster.
-===
+====
 
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixes a minor formatting issue introduced in https://github.com/openshift/openshift-docs/pull/26215/ where the `IMPORTANT` admonition note formatting was missing an `=`.

Preview links:
- vsphere: https://fix-boot-media-formatting--ocpdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-vsphere-compute-user-infra.html

- bare metal: https://fix-boot-media-formatting--ocpdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html