### PR TITLE
Fix 4.4 relnote bundle format link to OKD

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -707,8 +707,7 @@ is also deprecated in this release, to be replaced by the new _Bundle Format_ in
 future release. As a result, the `oc adm catalog build` command, which builds
 catalogs in the Package Manifest Format, is also deprecated.
 
-For more information on the upcoming Bundle Format and Operator
-Package Manager CLI (`opm`), see the link:https://docs.okd.io/latest/operators/understanding_olm/olm-understanding-olm.html#olm-new-bundle-opm_olm-understanding-olm[upstream OKD documentation].
+For more information on the upcoming Bundle Format and the `opm` CLI, see the link:https://docs.okd.io/latest/operators/understanding/olm-packaging-format.html#olm-bundle-format_olm-packaging-format[upstream OKD documentation].
 
 [id="ocp-4-4-marketplace-apis-deprecated"]
 ===== Converting custom OperatorSources and CatalogSourceConfigs


### PR DESCRIPTION
Old link to OKD doc was broken due to recent restructure.