### PR TITLE
CNV - JIRA story CNV3520 Adding information about RunStrategies to Creating…

### DIFF
--- a/modules/virt-about-runstrategies-vms.adoc
+++ b/modules/virt-about-runstrategies-vms.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-create-vms.adoc
+
+[id="virt-about-runstrategies-vms_{context}"]
+= About RunStrategies for virtual machines
+
+A `RunStrategy` for virtual machines determines a virtual machine instance's (VMI) behavior, depending on a series of conditions. The `spec.runStrategy` setting exists in the virtual machine configuration process as an alternative to the `spec.running` setting.
+The `spec.runStrategy` setting allows greater flexibility for how VMIs are created and managed, in contrast to the `spec.running` setting with only `true` or `false` responses. However, the two settings are mutually exclusive. Only either `spec.running` or `spec.runStrategy` can be used. An error occurs if both are used.
+
+There are four defined RunStrategies.
+
+`Always`::
+A VMI is always present when a virtual machine is created. A new VMI is created if the original stops for any reason, which is the same behavior as `spec.running: true`.
+`RerunOnFailure`::
+A VMI is re-created if the previous instance fails due to an error. The instance is not re-created if the virtual machine stops successfully, such as when it shuts down.
+`Manual`::
+The `start`, `stop`, and `restart` virtctl client commands can be used to control the VMI's state and existence.
+`Halted`::
+No VMI is present when a virtual machine is created, which is the same behavior as `spec.running: false`.
+
+Different combinations of the `start`, `stop` and `restart` virtctl commands affect which `RunStrategy` is used.
+
+The following table follows a VM’s transition from different states. The first column shows the VM's initial `RunStrategy`. Each additional column shows a virtctl command and the new `RunStrategy` after that command is run.
+
+|===
+|Initial RunStrategy |start |stop |restart
+
+|Always
+|-
+|Halted
+|Always
+
+|RerunOnFailure
+|-
+|Halted
+|RerunOnFailure
+
+|Manual
+|Manual
+|Manual
+|Manual
+
+|Halted
+|Always
+|-
+|-
+|===
+
+[NOTE]
+====
+In {VirtProductName} clusters installed using installer-provisioned infrastructure, when a node fails the MachineHealthCheck and becomes unavailable to the cluster, VMs with a RunStrategy of `Always` or `RerunOnFailure` are rescheduled on a new node.
+====
+
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+spec:
+  RunStrategy: Always <1>
+  template:
+...
+----
+<1> The VMI's current `RunStrategy` setting.

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -9,6 +9,13 @@ Before you install {VirtProductName}, ensure that your {product-title} cluster m
 * Your cluster must be installed on
 xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal] infrastructure with Red Hat Enterprise Linux CoreOS workers.
 
+* Additionally, your cluster must use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks] to maintain high availability (HA) of virtual machines.
+
+[NOTE]
+====
+In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
+====
+
 * You must manage your Compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
 
 {VirtProductName} works with {product-title} by default, but the following installation configurations are recommended:

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -39,12 +39,16 @@ include::modules/virt-creating-vm.adoc[leveloffset=+1]
 :virtualmachine!:
 
 include::modules/virt-vm-storage-volume-types.adoc[leveloffset=+1]
+include::modules/virt-about-runstrategies-vms.adoc[leveloffset=+1]
 
 == Additional resources
 
-The `VirtualMachineSpec` definition in the link:https://kubevirt.io/api-reference/{KubeVirtVersion}/definitions.html#_v1_virtualmachinespec[KubeVirt {KubeVirtVersion} API Reference] provides broader context for the parameters and hierarchy of the virtual machine specification.
-
+* The `VirtualMachineSpec` definition in the link:https://kubevirt.io/api-reference/{KubeVirtVersion}/definitions.html#_v1_virtualmachinespec[KubeVirt {KubeVirtVersion} API Reference] provides broader context for the parameters and hierarchy of the virtual machine specification.
++
 [NOTE]
 ====
-The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {VirtProductName}. 
+The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {VirtProductName}.
 ====
+
+* See xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[Deploying machine health checks] for further details on deploying and enabling machine health checks.
+* See xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installer-provisioned infrastructure overview] for further details on installer-provisioned infrastructure.


### PR DESCRIPTION
This PR address JIRA story [CNV-3520](https://issues.redhat.com/browse/CNV-3520) (https://issues.redhat.com/browse/CNV-3520) for Enterprise 4.6.

Added new information about RunStrategies, Installer-provisioned installation, and machine health checks to the "Creating virtual machines" assembly and the "Preparing cluster for virt" assembly.

Preview links: 
1) https://cnv3520--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-about-runstrategies-vms_virt-create-vms

2) https://cnv3520--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html