### PR TITLE
RN - CNV-7315 UX release note for 2.5

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -78,6 +78,14 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 //Placeholder for new content.
 
 //CNV-7315 - Expose next run configuration in the UI
+If the virtual machine is running, changes made to the following fields and tabs in the web console will not take effect until you restart the virtual machine:
+
+* *Boot Order* and *Flavor* in the *Details* tab
+* The *Network Interfaces* tab
+* The *Disks* tab
+* The *Environment* tab
+
+The *Pending Changes* banner at the top of the page displays a list of all changes that will be applied when the virtual machine restarts.
 
 //CNV-7318 - Open the vnc/serial console in a new window
 


### PR DESCRIPTION
UX release note for 2.5: https://issues.redhat.com/browse/CNV-7315

If the virtual machine is running, changes to select fields in the UI will not take effect until you restart the virtual machine. This is displayed in the Pending Changes banner at the top of the page.

cc: @gouyang for QE review