### PR TITLE
OpenShift Virtualization GA placeholder

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -4,9 +4,8 @@ include::modules/virt-document-attributes.adoc[]
 :context: about-virt
 toc::[]
 
-Documentation for OpenShift Virtualization, formerly known as container-native virtualization, will be available for {product-title} 4.5 in the near future.
+Documentation for OpenShift Virtualization will be available for {product-title} 4.6 in the near future.
 
-In the meantime, the https://docs.openshift.com/container-platform/4.4/cnv/cnv-about-cnv.html[container-native virtualization 2.3 documentation] is available as part of the {product-title} 4.4 documentation.
+In the meantime, the https://docs.openshift.com/container-platform/4.5/virt/about-virt.html[OpenShift Virtualization 2.4 documentation] is available as part of the {product-title} 4.5 documentation.
 
 // Container-native virtualization 2.3 is also supported for use in {product-title} 4.5.
-


### PR DESCRIPTION
Replacing content with placeholder content for OCP 4.6 docs pre-CNV 2.5.

All virt and cnv links for OCP 4.6 will be redirected to this placeholder text until OpenShift Virtualization 2.5 is released, at which time this will be reverted to the previous text.

@vikram-redhat @aburdenthehand @ctomasko @aspauldi 