### PR TITLE
Remove  kernel-devel extension

### DIFF
--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -11,15 +11,12 @@ While adding software packages to {op-system} systems is generally
 discouraged, the MCO provides an `extensions` feature you can use to add
 a minimal set of features to {op-system} nodes.
 
-Currently, the following extensions are available:
+Currently, the following extension is available:
 
 * **usbguard**: Adding the `usbguard` extension protects {op-system} systems
 from attacks from intrusive USB devices.
 See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#usbguard_protecting-systems-against-intrusive-usb-devices[USBGuard]
 for details.
-* **kernel-devel**: Adding `kernel-devel` allows you to build modules
-on your {op-system} systems to allow it to be able to build third-party
-kernel modules directly on the {op-system} system.
 
 The following procedure describes how to use a MachineConfig to add
 one or more extensions to your {op-system} nodes.


### PR DESCRIPTION
Remove `kernel-devel` extension option as currently supported. https://issues.redhat.com/browse/GRPA-1352?focusedCommentId=15329777&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-15329777

Leaving structure as is, even though it currently lists only one extension, so that it subtly implies that more are available and/or coming.