### PR TITLE
Add TP for Storage in Release Notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -279,7 +279,7 @@ Deployment now performs introspection on nodes to ensure that nodes meet install
 [id="ocp-4-6-compliance-operator"]
 ==== Compliance Operator
 
-The Compliance Operator is now available. This feature allows the use of OpenSCAP tools to check that a deployment complies with security standards and provides remediation options. See xref:../security/compliance_operator/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator] for more information. 
+The Compliance Operator is now available. This feature allows the use of OpenSCAP tools to check that a deployment complies with security standards and provides remediation options. See xref:../security/compliance_operator/compliance-operator-understanding.adoc#compliance-operator-understanding[Understanding the Compliance Operator] for more information.
 
 [id="ocp-4-6-oauth-token-inactivity-timeout"]
 ==== Configure OAuth token inactivity timeout
@@ -548,11 +548,13 @@ If you installed a CSI Driver Operator and driver on an {product-title} 4.5 clus
 ====
 
 [id="ocp-4-6-lso-automation"]
-==== Automatic device discovery and provisioning with the Local Storage Operator
+==== Automatic device discovery and provisioning with the Local Storage Operator (Technology Preview)
 The Local Storage Operator now has the ability to:
 
 * Automatically discover a list of available disks in a cluster. You can select a list of nodes, or all nodes, for auto-discovery to be continuously applied to.
 * Automatically provision local persistent volumes from attached devices. Appropriate devices are filtered and persistent volumes are provisioned based on the filtered devices.
+
+For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#local-storage-discovery_persistent-storage-local[Automating discovery and provisioning for local storage devices].
 
 [id="ocp-4-6-operators"]
 === Operator lifecycle
@@ -978,7 +980,7 @@ feature enabled. The default catalogs poll for new updates in their referenced
 index images every 15 minutes.
 
 [id="ocp-4-6-bug-fixes"]
-== Bug fixes 
+== Bug fixes
 
 *Web console (Developer perspective)*
 
@@ -1109,17 +1111,17 @@ In the table below, features are marked with the following statuses:
 |Raw Block with Cinder
 |TP
 |TP
-|
+|TP
 
 |External provisioner for AWS EFS
 |TP
 |TP
-|
+|TP
 
 |CSI volume snapshots
 |TP
 |TP
-|
+|TP
 
 |CSI volume cloning
 |TP
@@ -1144,6 +1146,11 @@ In the table below, features are marked with the following statuses:
 |CSI inline ephemeral volumes
 |-
 |TP
+|TP
+
+|Automatic device discovery and provisioning with Local Storage Operator
+|-
+|-
 |TP
 
 |OpenShift Pipelines


### PR DESCRIPTION
Adds to 4.6 Release Notes:
- Docs link for LSO auto-disco/provision (link is placeholder until PR merge).
- TP note in LSO entry of RNs.
- 4.6 TP status for Storage features in TP tracker.