### PR TITLE
OSDOCS-1296: Adding docs for pod topology spread constriants

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1177,6 +1177,8 @@ Topics:
     File: nodes-scheduler-taints-tolerations
   - Name: Placing pods on specific nodes using node selectors
     File: nodes-scheduler-node-selectors
+  - Name: Controlling pod placement using pod topology spread constraints
+    File: nodes-scheduler-pod-topology-spread-constraints
 # - Name: Placing a pod on a specific node by name
 #   File: nodes-scheduler-node-names
 # - Name: Placing a pod in a specific project

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-about.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-about.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints
+
+[id="nodes-scheduler-pod-topology-spread-constraints-about_{context}"]
+= About pod topology spread constraints
+
+By using a _pod topology spread constraint_, you provide fine-grained control over the distribution of pods across failure domains to help achieve high availability and more efficient resource utilization.
+
+{product-title} administrators can label nodes to provide topology information, such as regions, zones, nodes, or other user-defined domains. After these labels are set on nodes, users can then define pod topology spread constraints to control the placement of pods across these topology domains.
+
+You specify which pods to group together, which topology domains they are spread among, and the acceptable skew. Only pods within the same namespace are matched and grouped together when spreading due to a constraint.
+
+// TODO Mention about relationship to affinity/anti-affinity?

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints
+
+[id="nodes-scheduler-pod-topology-spread-constraints-configuring_{context}"]
+= Configuring pod topology spread constraints
+
+The following steps demonstrate how to configure pod topology spread constraints to distribute pods that match the specified labels based on their zone.
+
+You can specify multiple pod topology spread constraints, but you must ensure that they do not conflict with each other. All pod topology spread constraints must be satisfied for a pod to be placed.
+
+.Prerequisites
+
+* A cluster administrator has added the required labels to nodes.
+
+.Procedure
+
+. Create a `Pod` spec and specify a pod topology spread constraint:
++
+.Example `pod-spec.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pod
+  labels:
+    foo: bar
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1 <1>
+    topologyKey: topology.kubernetes.io/zone <2>
+    whenUnsatisfiable: DoNotSchedule <3>
+    labelSelector: <4>
+      matchLabels:
+        foo: bar <5>
+  containers:
+  - image: "docker.io/ocpqe/hello-pod"
+    name: hello-pod
+----
+<1> The maximum difference in number of pods between any two topology domains. The default is `1`, and you cannot specify a value of `0`.
+<2> The key of a node label. Nodes with this key and identical value are considered to be in the same topology.
+<3> How to handle a pod if it does not satisfy the spread constraint. The default is `DoNotSchedule`, which tells the scheduler not to schedule the pod. Set to `ScheduleAnyway` to still schedule the pod, but the scheduler prioritizes honoring the skew to not make the cluster more imbalanced.
+<4> Pods that match this label selector are counted and recognized as a group when spreading to satisfy the constraint. Be sure to specify a label selector, otherwise no pods can be matched.
+<5> Be sure that this `Pod` spec also sets its labels to match this label selector if you want it to be counted properly in the future.
+
+. Create the pod:
++
+[source,terminal]
+----
+$ oc create -f pod-spec.yaml
+----

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints
+
+[id="nodes-scheduler-pod-topology-spread-constraints-examples_{context}"]
+= Example pod topology spread constraints
+
+The following examples demonstrate pod topology spread constraint configurations.
+
+[id="nodes-scheduler-pod-topology-spread-constraints-example-single_{context}"]
+== Single pod topology spread constraint example
+
+// TODO: Add a diagram?
+
+This example `Pod` spec defines one pod topology spread constraint. It matches on pods labeled `foo:bar`, distributes among zones, specifies a skew of `1`, and does not schedule the pod if it does not meet these requirements.
+
+[source,yaml]
+----
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-pod
+  labels:
+    foo: bar
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: topology.kubernetes.io/zone
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
+  containers:
+  - image: "docker.io/ocpqe/hello-pod"
+    name: hello-pod
+----
+
+[id="nodes-scheduler-pod-topology-spread-constraints-example-multiple_{context}"]
+== Multiple pod topology spread constraints example
+
+// TODO: Add a diagram?
+
+This example `Pod` spec defines two pod topology spread constraints. Both match on pods labeled `foo:bar`, specify a skew of `1`, and do not schedule the pod if it does not meet these requirements.
+
+The first constraint distributes pods based on a user-defined label `node`, and the second constraint distributes pods based on a user-defined label `rack`. Both constraints must be met for the pod to be scheduled.
+
+[source,yaml]
+----
+kind: Pod
+apiVersion: v1
+metadata:
+  name: my-pod-2
+  labels:
+    foo: bar
+spec:
+  topologySpreadConstraints:
+  - maxSkew: 1
+    topologyKey: node
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
+  - maxSkew: 1
+    topologyKey: rack
+    whenUnsatisfiable: DoNotSchedule
+    labelSelector:
+      matchLabels:
+        foo: bar
+  containers:
+  - image: "docker.io/ocpqe/hello-pod"
+    name: hello-pod
+----

--- a/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc
+++ b/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc
@@ -1,0 +1,21 @@
+[id="nodes-scheduler-pod-topology-spread-constraints"]
+= Controlling pod placement by using pod topology spread constraints
+include::modules/common-attributes.adoc[]
+:context: nodes-scheduler-pod-topology-spread-constraints
+
+toc::[]
+
+You can use pod topology spread constraints to control the placement of your pods across nodes, zones, regions, or other user-defined topology domains.
+
+// About pod topology spread constraints
+include::modules/nodes-scheduler-pod-topology-spread-constraints-about.adoc[leveloffset=+1]
+
+// Configuring pod topology spread constraints
+include::modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc[leveloffset=+1]
+
+// Sample pod topology spread constraints
+include::modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc[leveloffset=+1]
+
+== Additional resources
+
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1296

Preview: https://osdocs-1296--ocpdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html