### PR TITLE
CCXDEV-3313: Moved remote health monitoring, linked Insights docs in "Getting support"

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -347,12 +347,6 @@ Topics:
 - Name: Getting support
   File: getting-support
   Distros: openshift-enterprise,openshift-dedicated
-- Name: Gathering data about your cluster
-  File: gathering-cluster-data
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
-- Name: Summarizing cluster specifications
-  File: summarizing-cluster-specifications
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 - Name: Remote health monitoring with connected clusters
   Dir: remote_health_monitoring
   Distros: openshift-enterprise,openshift-dedicated,openshift-webscale,openshift-origin
@@ -365,6 +359,12 @@ Topics:
     File: opting-out-of-remote-health-reporting
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
+- Name: Gathering data about your cluster
+  File: gathering-cluster-data
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Summarizing cluster specifications
+  File: summarizing-cluster-specifications
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 - Name: Troubleshooting
   Dir: troubleshooting
   Distros: openshift-enterprise,openshift-dedicated,openshift-webscale,openshift-origin

--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -14,6 +14,8 @@ If you experience difficulty with a procedure described in this documentation, o
 // TODO: xref
 * Access other product documentation.
 
+To identify issues with your cluster, you can use Insights in {cloud-redhat-com}. Insights provides details about issues and, if available, information on how to solve a problem.
+
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
 If you have a suggestion for improving this documentation or have found an
 error, please submit a link:http://bugzilla.redhat.com[Bugzilla report] against the

--- a/support/getting-support.adoc
+++ b/support/getting-support.adoc
@@ -14,3 +14,7 @@ include::modules/support-knowledgebase-search.adoc[leveloffset=+1]
 include::modules/support-submitting-a-case.adoc[leveloffset=+1]
 
 endif::openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-origin[]
+
+== Additional resources
+
+* For details about identifying issues with your cluster, see xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster].


### PR DESCRIPTION
This moves the "Using Insights to identify issues with your cluster" page from its current location ("Remote health monitoring with connected clusters") to "Support".

This change should be applied to master, 4.6, and 4.5.

@openshift/team-documentation, please review this PR. Thanks.