### PR TITLE
Remove refs to master in RT kernel

### DIFF
--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -13,19 +13,17 @@ kernel includes a preemptive scheduler that provides the operating
 system with real-time characteristics.
 
 If your {product-title} workloads require these real-time characteristics,
-you can switch your compute (worker) and/or master machines to the Linux
+you can switch your machines to the Linux
 real-time kernel. For {product-title}, {product-version} you can make this
 switch using a MachineConfig object. Although making the change is as simple
 as changing a MachineConfig `kernelType` setting to `realtime`, there are a few
 other considerations before making the change:
 
-[NOTE]
-====
-This procedure is fully supported with bare metal installations using
+* Currently, real-time kernel is supported only on worker nodes, and only for radio access network (RAN) use.
+* The following procedure is fully supported with bare metal installations that use
 systems that are certified for Red Hat Enterprise Linux for Real Time 8.
-Real time support in {product-title} is also limited to specific subscriptions.
-This procedure is also supported for use with Google Cloud Platform
-====
+* Real-time support in {product-title} is limited to specific subscriptions.
+* The following procedure is also supported for use with Google Cloud Platform.
 
 .Prerequisites
 * Have a running {product-title} cluster (version 4.4 or later).
@@ -35,7 +33,7 @@ This procedure is also supported for use with Google Cloud Platform
 
 . Create a MachineConfig for the real-time kernel: Create a YAML file
 (for example, `99-worker-realtime.yaml`) that contains a MachineConfig
-object  for the `realtime` kernelType. This example tells the cluster to
+object for the `realtime` kernelType. This example tells the cluster to
 use a real-time kernel for all worker nodes:
 +
 [source,terminal]
@@ -52,8 +50,6 @@ spec:
 EOF
 ----
 +
-You can change `worker` to `master` to add kernel arguments to master nodes instead.
-Create a separate YAML file to add to both master and worker nodes.
 
 . Add the MachineConfig to the cluster. Type the following to add the MachineConfig
 to the cluster:
@@ -65,7 +61,7 @@ $ oc create -f 99-worker-realtime.yaml
 
 . Check the real-time kernel: Once each impacted node reboots, log in to the cluster
 and run the following commands to make sure that the real-time kernel has
-replaced the regular kernel for the set of worker or master nodes you
+replaced the regular kernel for the set of nodes you
 configured:
 +
 [source,terminal]
@@ -77,11 +73,8 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.19.0
 ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.19.0
 ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.19.0
-ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.19.0
-ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.19.0
 ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.19.0
 ----
 +


### PR DESCRIPTION
Per Go/No Go meeting on 14 Oct:

[1887007](https://bugzilla.redhat.com/show_bug.cgi?id=1887007)  Creating cluster with realtime kernel almost always fails.  Moved to RHEL 8. Not a blocker for 4.6 per Mark M.
Requires documentation update: 

- (Xiaoli) For this one, we need to make sure we have explicit documentation to indicate that RT kernel is only supported on worker nodes so far. 
- (Tim R) Simply put, "No support for RT on control plane nodes", that statement would then include 3 node configurations etc. +1 Jeff L
- (Jeff L) RT kernel team says they were told only worker nodes. The docs say worker or master, but should only say worker for RAN use cases only.

Hence, this PR removes reference to `master` and `control plane` in body text and example output.

I also reorganized text in the overview so that items are in a bulleted list, with a note about worker-only/RAN-only support for RT kernel.

@jtligon and @marrusl PTAL and let me know if this looks good to you. Thanks!