### PR TITLE
[enterprise-4.6] Re-add restricted OSP IPI assembly

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -245,6 +245,8 @@ Topics:
     File: installing-openstack-user
   - Name: Installing a cluster on OpenStack with Kuryr on your own infrastructure
     File: installing-openstack-user-kuryr
+  - Name: Installing a cluster on OpenStack in a restricted network
+    File: installing-openstack-installer-restricted
   # - Name: Load balancing deployments on OpenStack
   #   File: installing-openstack-load-balancing
   - Name: Uninstalling a cluster on OpenStack

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -1,0 +1,57 @@
+[id="installing-openstack-installer-restricted"]
+= Installing a cluster on OpenStack in a restricted network
+include::modules/common-attributes.adoc[]
+:context: installing-openstack-installer-restricted
+
+toc::[]
+
+In {product-title} {product-version}, you can install a cluster on
+{rh-openstack-first} in a restricted network by creating an internal mirror of the installation release content.
+
+.Prerequisites
+
+* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host]
+ and obtain the `imageContentSources` data for your version of {product-title}.
++
+[IMPORTANT]
+====
+Because the installation media is on the bastion host, use that computer
+to complete all installation steps.
+====
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes].
+** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by consulting the architecture documentation's xref:../../architecture/architecture-installation.html#available-platforms_architecture-installation[list of available platforms]. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+
+* Have the metadata service enabled in {rh-openstack}.
+
+include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
+include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]
+include::modules/installation-osp-control-compute-machines.adoc[leveloffset=+2]
+include::modules/installation-osp-bootstrap-machine.adoc[leveloffset=+2]
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+include::modules/installation-osp-enabling-swift.adoc[leveloffset=+1]
+// Do we need an equivalent for this in a restricted flow?
+// include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1]
+include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
+// This is completely contained in the bastion assembly?
+// include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+include::modules/installation-osp-creating-image-restricted.adoc[leveloffset=+1]
+include::modules/installation-initializing.adoc[leveloffset=+1]
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+include::modules/installation-osp-restricted-config-yaml.adoc[leveloffset=+2]
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+include::modules/installation-osp-accessing-api.adoc[leveloffset=+1]
+include::modules/installation-osp-accessing-api-floating.adoc[leveloffset=+2]
+include::modules/installation-osp-accessing-api-no-floating.adoc[leveloffset=+2]
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+include::modules/installation-osp-configuring-floating-ip.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* Learn how to xref:../../operators/admin/olm-restricted-networks.html#olm-understanding-operator-catalog-images_olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -5,11 +5,15 @@
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc 
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc 
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
 endif::[]
 
 [id="installation-about-restricted-networks_{context}"]
@@ -38,6 +42,7 @@ installation media. You can create this registry on a mirror host, which can
 access both the internet and your closed network, or by using other methods
 that meet your restrictions.
 
+ifndef::osp[]
 [IMPORTANT]
 ====
 Restricted network installations always use user-provisioned infrastructure.
@@ -47,6 +52,7 @@ you attempt a restricted network installation. Completing this test installation
 make it easier to isolate and troubleshoot any issues that might arise
 during your installation in a restricted network.
 ====
+endif::osp[]
 
 [id="installation-restricted-network-limits{context}"]
 == Additional limits
@@ -65,4 +71,7 @@ ifeval::["{context}" == "installing-ibm-power"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
 endif::[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -84,6 +84,10 @@ endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
+:osp-custom:
+endif::[]
 
 
 [id="installation-configuration-parameters_{context}"]
@@ -373,7 +377,7 @@ endif::aws[]
 
 ifdef::osp[]
 .Additional {rh-openstack-first} parameters
-[%header, cols=".^2,.^3,.^5a"]
+[cols=".^2m,.^3a,^5a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -480,8 +484,6 @@ If you deploy to a custom subnet, you cannot specify an external DNS server to t
 
 |A UUID as a string. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
 |====
-
-
 endif::osp[]
 
 ifdef::azure[]
@@ -788,4 +790,8 @@ ifeval::["{context}" == "installing-rhv-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
+:!osp-custom:
 endif::[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -23,6 +23,7 @@
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 
+// * installing/installing_gcp/installing-openstack-installer-restricted.adoc
 // Consider also adding the installation-configuration-parameters.adoc module.
 //YOU MUST SET AN IFEVAL FOR EACH NEW MODULE
 
@@ -91,6 +92,10 @@ endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:osp:
+:restricted:
+endif::[]
 
 [id="installation-initializing_{context}"]
 = Creating the installation configuration file
@@ -117,7 +122,14 @@ endif::vsphere[]
 
 .Prerequisites
 
-* Download the {product-title} installation program and the pull secret for your cluster.
+* Obtain the {product-title} installation program and the pull secret for your cluster.
+ifdef::restricted[For a restricted network installation, these files are on your bastion host.]
+
+ifdef::osp+restricted[]
+* Retrieve a {op-system-first} image and upload it to an accessible location.
+
+* Have the `imageContentSources` values that were generated during mirror registry creation.
+endif::osp+restricted[]
 
 .Procedure
 
@@ -308,8 +320,62 @@ compute:
 <1> Set to `0`.
 endif::[]
 
+ifndef::restricted[]
 . Modify the `install-config.yaml` file. You can find more information about
 the available parameters in the *Installation configuration parameters* section.
+endif::restricted[]
+
+ifdef::osp+restricted[]
+. In `install-config.yaml`, set the value of `platform.openstack.clusterOSImage` to the image location or name. For example:
++
+[source,yaml]
+----
+platform:
+  openstack:
+      clusterOSImage: http://mirror.example.com/images/rhcos-43.81.201912131630.0-openstack.x86_64.qcow2.gz?sha256=ffebbd68e8a1f2a245ca19522c16c86f67f9ac8e4e0c1f0a812b068b16f7265d
+----
+
+. Edit the `install-config.yaml` file to provide the additional information that
+is required for an installation in a restricted network.
+.. Update the `pullSecret` value to contain the authentication information for
+your registry:
++
+----
+pullSecret: '{"auths":{"<bastion_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'
+----
++
+For `<bastion_host_name>`, specify the registry domain name
+that you specified in the certificate for your mirror registry, and for
+`<credentials>`, specify the base64-encoded user name and password for
+your mirror registry.
+.. Add the `additionalTrustBundle` parameter and value.
++
+----
+additionalTrustBundle: |
+  -----BEGIN CERTIFICATE-----
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  -----END CERTIFICATE-----
+----
++
+The value must be the contents of the certificate file that you used for your mirror registry, which can be an exiting, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
+
+.. Add the image content resources, which look like this excerpt:
++
+----
+imageContentSources:
+- mirrors:
+  - <bastion_host_name>:5000/<repo_name>/release
+  source: quay.example.com/openshift-release-dev/ocp-release
+- mirrors:
+  - <bastion_host_name>:5000/<repo_name>/release
+  source: registry.example.com/ocp/release
+----
++
+To complete these values, use the `imageContentSources` that you recorded during mirror registry creation.
+
+. Make any other modifications to the `install-config.yaml` file that you require. You can find more information about
+the available parameters in the *Installation configuration parameters* section.
+endif::osp+restricted[]
 
 . Back up the `install-config.yaml` file so that you can use
 it to install multiple clusters.
@@ -383,4 +449,8 @@ ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!osp:
+:!restricted:
 endif::[]

--- a/modules/installation-osp-creating-image-restricted.adoc
+++ b/modules/installation-osp-creating-image-restricted.adoc
@@ -1,0 +1,58 @@
+//Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+
+[id="installation-osp-creating-image-restricted_{context}"]
+= Creating the {op-system} image for restricted network installations
+
+Download the {op-system-first} image to install {product-title} on a restricted-network {rh-openstack-first} environment.
+
+.Prerequisites
+
+* Obtain the {product-title} installation program. For a restricted network installation, the program is on your bastion host.
+
+.Procedure
+
+. Log in to the Red Hat Customer Portal's https://access.redhat.com/downloads/content/290[Product Downloads page].
+
+. Under *Version*, select the most recent release of {product-title} {product-version} for RHEL 8.
++
+[IMPORTANT]
+====
+The {op-system} images might not change with every release of {product-title}.
+You must download images with the highest version that is less than or equal to
+the {product-title} version that you install. Use the image versions that match
+your {product-title} version if they are available.
+====
+
+. Download the *{op-system-first} - OpenStack Image (QCOW)*.
+
+. Decompress the image.
++
+[NOTE]
+====
+You must decompress the {rh-openstack} image before the cluster can use it. The name of the downloaded file might not contain a compression extension, like `.gz` or `.tgz`. To find out if or how the file is compressed, in a command line, enter:
+
+----
+$ file <name_of_downloaded_file>
+----
+
+====
+
+. Upload the image that you decompressed to a location that is accessible from the bastion server, like Glance. For example:
++
+----
+$ openstack image create --file rhcos-44.81.202003110027-0-openstack.x86_64.qcow2 --disk-format qcow2 rhcos-${RHCOS_VERSION}
+----
++
+[IMPORTANT]
+====
+Depending on your {rh-openstack} environment, you might be able to upload the image in either link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/15/html/instances_and_images_guide/index[`.raw` or `.qcow2` formats]. If you use Ceph, you must use the `.raw` format.
+====
++
+[CAUTION]
+====
+If the installation program finds multiple images with the same name, it chooses one of them at random. To avoid this behavior, create unique names for resources in {rh-openstack}.
+====
+
+The image is now available for a restricted installation. Note the image name or location for use in {product-title} deployment.

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+
+[id="installation-osp-restricted-config-yaml_{context}"]
+= Sample customized `install-config.yaml` file for restricted OpenStack installations
+
+This sample `install-config.yaml` demonstrates all of the possible {rh-openstack-first}
+customization options.
+
+[IMPORTANT]
+====
+This sample file is provided for reference only. You must obtain your
+`install-config.yaml` file by using the installation program.
+====
+
+[source, yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+clusterID: os-test
+controlPlane:
+  name: master
+  platform: {}
+  replicas: 3
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: ml.large
+  replicas: 3
+metadata:
+  name: example
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineCIDR: 10.0.0.0/16
+  serviceNetwork:
+  - 172.30.0.0/16
+  networkType: OpenShiftSDN
+platform:
+  openstack:
+    region: region1
+    cloud: mycloud
+    externalNetwork: external
+    computeFlavor: m1.xlarge
+    lbFloatingIP: 128.0.0.1
+fips: false
+pullSecret: '{"auths": ...}'
+sshKey: ssh-ed25519 AAAA...
+additionalTrustBundle: |
+
+  -----BEGIN CERTIFICATE-----
+
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+
+  -----END CERTIFICATE-----
+
+imageContentSources:
+- mirrors:
+  - <mirror_registry>/<repo_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <mirror_registry>/<repo_name>/release
+  source: registry.svc.ci.openshift.org/ocp/release
+----


### PR DESCRIPTION
Plus:
* Split OSP install-config tables
* Add clusterOSImage param to install config table
* Peer review changes

Manual CP of https://github.com/openshift/openshift-docs/pull/22478