### PR TITLE
Cleanup bundle/index image steps

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -21,7 +21,7 @@ cluster has network access to, such as a mirror registry created during a
 restricted network cluster installation.
 
 For this example, the procedure assumes use of a mirror registry that has access
-to both your network and the internet.
+to both your network and the Internet.
 
 .Prerequisites
 
@@ -65,14 +65,16 @@ target mirror registry:
 ----
 $ podman login <registry_host_name>
 ----
-+
-Also authenticate with `registry.redhat.io` so that the base image can be pulled
+
+ifndef::openshift-origin[]
+. Authenticate with `registry.redhat.io` so that the base image can be pulled
 during the build:
 +
 [source,terminal]
 ----
 $ podman login registry.redhat.io
 ----
+endif::[]
 
 . Build a catalog image based on the `redhat-operators` catalog from Quay.io,
 tagging and pushing it to your mirror registry:

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -11,7 +11,7 @@ You can create an index image using the `opm` CLI.
 
 * `opm` version 1.12.3+
 * `podman` version 1.4.4+
-* A bundle image built and pushed to a registry.
+* A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 
 .Procedure
 
@@ -20,17 +20,26 @@ You can create an index image using the `opm` CLI.
 [source,terminal]
 ----
 $ opm index add \
-    --bundles quay.io/<namespace>/test-operator:v0.1.0 \//<1>
-    --tag quay.io/<namespace>/test-catalog:latest \//<2>
+    --bundles <registry>/<namespace>/<bundle_image_name>:<tag> \//<1>
+    --tag <registry>/<namespace>/<index_image_name>:<tag> \//<2>
     [--binary-image <registry_base_image>] <3>
 ----
 <1> Comma-separated list of bundle images to add to the index.
 <2> The image tag that you want the index image to have.
 <3> Optional: An alternative registry base image to use for serving the catalog.
 
-. Push the index image to a registry:
+. Push the index image to a registry.
+
+.. If required, authenticate with your target registry:
 +
 [source,terminal]
 ----
-$ podman push quay.io/<namespace>/test-catalog:latest
+$ podman login <registry>
+----
+
+.. Push the index image:
++
+[source,terminal]
+----
+$ podman push <registry>/<namespace>/test-catalog:latest
 ----

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * operators/admin/olm-restricted-networks.adoc
-// * operators/admin/olm-managing-custom-catalogs.adoc
 // * migration/migrating_3_4/deploying-cam-3-4.adoc
 // * migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
@@ -11,36 +10,24 @@ ifdef::openshift-origin[]
 :index-image: upstream-community-operators
 :tag: latest
 :catalog-name: upstream-community-operators
+:example-registry: example.com
 endif::[]
 ifndef::openshift-origin[]
 :index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v4.6
 :index-image: redhat-operator-index
 :tag: v4.6
 :catalog-name: redhat-operators
+:example-registry: registry.redhat.io
 endif::[]
 
 [id="olm-mirror-catalog_{context}"]
 = Mirroring an Operator catalog
 
-You can mirror the Operator content of a Red Hat-provided catalog, or a custom
-catalog, into a container image registry using the `oc adm catalog mirror`
-command. The target registry must support
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]. For a
-cluster on a restricted network, this registry can be a registry that the
-cluster has network access to, such as a mirror registry created during a
-restricted network cluster installation.
+You can mirror the Operator content of a Red Hat-provided catalog, or a custom catalog, into a container image registry using the `oc adm catalog mirror` command. The target registry must support link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]. For a cluster on a restricted network, this registry can be a registry that the cluster has network access to, such as a mirror registry created during a restricted network cluster installation.
 
-You must also mirror the Red Hat-provided index image from Quay.io, or push your
-own custom-built index image, to the target registry using the `oc image mirror`
-command. You can then use the mirrored index image to create a CatalogSource
-that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto
-your {product-title} cluster.
+You must also mirror the Red Hat-provided index image, or push your own custom-built index image, to the target registry by using the `oc image mirror` command. You can then use the mirrored index image to create a CatalogSource that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto your {product-title} cluster.
 
-For this example, the procedure assumes the target registry is a previously
-created mirror registry that has access to both your restricted network and the
-internet. This example also shows mirroring the default `{catalog-name}`
-catalog, however it can be repeated for the other default catalogs, as well as
-custom catalogs.
+For the steps in this procedure, the target registry is an existing mirror registry that is accessible by both your cluster and a workstation with unrestricted network access. This example also shows mirroring the default `{catalog-name}` catalog, but the process is the same for all catalogs.
 
 .Prerequisites
 
@@ -48,9 +35,7 @@ custom catalogs.
 * `podman` version 1.4.4+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
-* If you are working with private registries, set the `REG_CREDS` environment
-variable to the file path of your registry credentials for use in later steps.
-For example, for the `podman` CLI:
+* If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
 ----
@@ -59,43 +44,31 @@ $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 
 .Procedure
 
-. On your workstation with unrestricted network access, use the `podman login`
-command to authenticate with the registries to be used in this procedure.
-
-.. Authenticate with the target mirror registry:
+. On your workstation with unrestricted network access, use the `podman login` command to authenticate with the your target mirror registry:
 +
 [source,terminal]
 ----
 $ podman login <mirror_registry>
 ----
 
-.. Authenticate with `registry.redhat.io`:
+ifndef::openshift-origin[]
+. Authenticate with `registry.redhat.io`:
 +
 [source,terminal]
 ----
 $ podman login registry.redhat.io
 ----
+endif::[]
 
-. The `oc adm catalog mirror` command extracts the contents of an index image to
-generate the manifests required for mirroring. You can choose either of the
-following:
+. The `oc adm catalog mirror` command extracts the contents of an index image to generate the manifests required for mirroring. You can choose either of the following:
 +
 --
-* Allow the default behavior of the command to automatically mirror all of the
-image content from the index image to your mirror registry after generating
-manifests.
-* Add the `--manifests-only` flag to only generate the manifests required for
-mirroring, but do not actually mirror the image content to the registry yet.
-This can be useful for reviewing what will be mirrored, and it allows you to
-make any changes to the mapping list if you only require a subset of packages.
-You can then use that file with the `oc image mirror` command to mirror the
-modified list of images in a later step.
+* Allow the default behavior of the command to automatically mirror all of the image content from the index image to your mirror registry after generating manifests.
+* Add the `--manifests-only` flag to only generate the manifests required for mirroring, but do not actually mirror the image content to the registry yet. This can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you only require a subset of packages. You can then use that file with the `oc image mirror` command to mirror the modified list of images in a later step.
 +
 [NOTE]
 ====
-The `--manifests-only` flag is intended for advanced selective mirroring of
-content from the catalog. The `opm index prune` command, if you used it
-previously to prune the index image, is suitable for most use cases.
+The `--manifests-only` flag is intended for advanced selective mirroring of content from the catalog. The `opm index prune` command, if you used it previously to prune the index image, is suitable for most use cases.
 ====
 --
 +
@@ -111,18 +84,11 @@ $ oc adm catalog mirror \
     [--filter-by-os="<os>/<arch>"] \//<5>
     [--manifests-only] <6>
 ----
-<1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<2> Specify the target registry to mirror the Operator content to.
-<3> Optional: If required, specify the location of your registry credentials
-file.
-<4> Optional: If you do not want to configure trust for the target registry, add
-the `--insecure` flag.
-<5> Optional: Because the catalog might reference images that support multiple
-architectures and operating systems, you can filter by architecture and
-operating system to mirror only the images that match. Valid values are
-`linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
-<6> Optional: Only generate the manifests required for mirroring and do not actually
-mirror the image content to a registry.
+<1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`. <2> Specify the target registry to mirror the Operator content to.
+<3> Optional: If required, specify the location of your registry credentials file.
+<4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<5> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<6> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
 +
 .Example output
 [source,terminal,subs="attributes+"]
@@ -135,32 +101,20 @@ wrote mirroring manifests to {index-image}-manifests
 ----
 <1> Directory for the temporary `index.db` database generated by the command.
 +
-After running the command, a `<image_name>-manifests/` directory is created in
-the current directory and generates the following files:
+After running the command, a `<image_name>-manifests/` directory is created in the current directory and generates the following files:
 +
 --
-* The `imageContentSourcePolicy.yaml` file defines an ImageContentSourcePolicy
-object that can configure nodes to translate between the image references stored
-in Operator manifests and the mirrored registry.
-* The `mapping.txt` file contains all of the source images and where to map them
-in the target registry. This file is compatible with the `oc image mirror`
-command and can be used to further customize the mirroring configuration.
+* The `imageContentSourcePolicy.yaml` file defines an ImageContentSourcePolicy object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
+* The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
 --
 
-. If you used the `--manifests-only` flag in the previous step and want to further
-trim the subset of packages to be mirrored:
+. If you used the `--manifests-only` flag in the previous step and want to further trim the subset of packages to be mirrored:
 
-.. Modify the list of images in your `mapping.txt` file to your specifications. If
-you are unsure of the exact names and versions of the subset of images you want
-to mirror, use the following steps to find them:
+.. Modify the list of images in your `mapping.txt` file to your specifications. If you are unsure of the exact names and versions of the subset of images you want to mirror, use the following steps to find them:
 
-... Run the `sqlite3` tool against the temporary database that was generated by the
-`oc adm catalog mirror` command to retrieve a list of images matching a general
-search query. The output helps inform how you will later edit your `mapping.txt`
-file.
+... Run the `sqlite3` tool against the temporary database that was generated by the `oc adm catalog mirror` command to retrieve a list of images matching a general search query. The output helps inform how you will later edit your `mapping.txt` file.
 +
-For example, to retrieve a list of images that are similar to the string
-`jaeger`:
+For example, to retrieve a list of images that are similar to the string `jaeger`:
 +
 [source,terminal]
 ----
@@ -168,48 +122,41 @@ $ echo "select * from related_image \
     where operatorbundle_name like '%jaeger%';" \
     | sqlite3 -line /tmp/153048078/index.db <1>
 ----
-<1> Refer to the previous output of the `oc adm catalog mirror` command to find the
-path of the database file.
+<1> Refer to the previous output of the `oc adm catalog mirror` command to find the path of the database file.
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 ...
-image = registry.redhat.io/distributed-tracing/jaeger-all-in-one-rhel7@sha256:41f769c2c32f3f050aa42d86f084b739914ff9ba2f0aed2d9b0b69357b48459d
+image = {example-registry}/distributed-tracing/jaeger-all-in-one-rhel7@sha256:41f769c2c32f3f050aa42d86f084b739914ff9ba2f0aed2d9b0b69357b48459d
 operatorbundle_name = jaeger-operator.v1.17.6
 
-image = registry.redhat.io/distributed-tracing/jaeger-es-index-cleaner-rhel7@sha256:c64ac461d96523516a199bd132ad4d7148317e503a735028f0d8f7ba063a61cb
+image = {example-registry}/distributed-tracing/jaeger-es-index-cleaner-rhel7@sha256:c64ac461d96523516a199bd132ad4d7148317e503a735028f0d8f7ba063a61cb
 operatorbundle_name = jaeger-operator.v1.17.6
 
-image = registry.redhat.io/distributed-tracing/jaeger-rhel7-operator:1.13.2
+image = {example-registry}/distributed-tracing/jaeger-rhel7-operator:1.13.2
 operatorbundle_name = jaeger-operator.v1.13.2-1
 ----
 
-... Use the results from the previous step to help you edit the `mapping.txt` file
-to only include the subset of images you want to mirror.
+... Use the results from the previous step to help you edit the `mapping.txt` file to only include the subset of images you want to mirror.
 +
-For example, you can use the `image` values from the previous example output to
-find that the following matching lines exist in your `mapping.txt` file:
+For example, you can use the `image` values from the previous example output to find that the following matching lines exist in your `mapping.txt` file:
 +
 .Matching image mappings in `mapping.txt`
-[source,txt]
+[source,terminal,subs="attributes+"]
 ----
 ...
-registry.redhat.io/distributed-tracing/jaeger-all-in-one-rhel7@sha256:41f769c2c32f3f050aa42d86f084b739914ff9ba2f0aed2d9b0b69357b48459d=quay.io/adellape/distributed-tracing-jaeger-all-in-one-rhel7:5cf7a033
+{example-registry}/distributed-tracing/jaeger-all-in-one-rhel7@sha256:41f769c2c32f3f050aa42d86f084b739914ff9ba2f0aed2d9b0b69357b48459d=quay.io/adellape/distributed-tracing-jaeger-all-in-one-rhel7:5cf7a033
 ...
-registry.redhat.io/distributed-tracing/jaeger-es-index-cleaner-rhel7@sha256:c64ac461d96523516a199bd132ad4d7148317e503a735028f0d8f7ba063a61cb=quay.io/adellape/distributed-tracing-jaeger-es-index-cleaner-rhel7:ecfd2ca7
+{example-registry}/distributed-tracing/jaeger-es-index-cleaner-rhel7@sha256:c64ac461d96523516a199bd132ad4d7148317e503a735028f0d8f7ba063a61cb=quay.io/adellape/distributed-tracing-jaeger-es-index-cleaner-rhel7:ecfd2ca7
 ...
-registry.redhat.io/distributed-tracing/jaeger-rhel7-operator:1.13.2=quay.io/adellape/distributed-tracing-jaeger-rhel7-operator:1.13.2
+{example-registry}/distributed-tracing/jaeger-rhel7-operator:1.13.2=quay.io/adellape/distributed-tracing-jaeger-rhel7-operator:1.13.2
 ...
 ----
 +
-In this example, if you only want to mirror these images, you would then remove
-all other entries in the `mapping.txt` file and leave only the above matching
-image mapping lines.
+In this example, if you only want to mirror these images, you would then remove all other entries in the `mapping.txt` file and leave only the above matching image mapping lines.
 
-.. Still on your workstation with unrestricted network access, use your modified
-`mapping.txt` file to mirror the images to your registry using the `oc image
-mirror` command:
+.. Still on your workstation with unrestricted network access, use your modified `mapping.txt` file to mirror the images to your registry using the `oc image mirror` command:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -225,8 +172,7 @@ $ oc image mirror \
 $ oc apply -f ./{index-image}-manifests/imageContentSourcePolicy.yaml
 ----
 
-. If you are not using a custom, pruned version of an index image, push
-the Red Hat-provided index image from Quay.io to your registry:
+. If you are not using a custom, pruned version of an index image, push the Red Hat-provided index image to your registry:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -235,14 +181,13 @@ $ oc image mirror \
     {index-image-pullspec} \//<1>
     <mirror_registry>:<port>/<namespace>/{index-image}:{tag} <2>
 ----
-<1> Specify the index image for catalog that you mirrored content for in the
-previous step.
+<1> Specify the index image for catalog that you mirrored content for in the previous step.
 <2> Specify where to mirror the index image.
 
-You can now create a CatalogSource to reference your mirrored index image and
-Operator content.
+You can now create a CatalogSource to reference your mirrored index image and Operator content.
 
 :!index-image-pullspec:
 :!index-image:
 :!tag:
 :!catalog-name:
+:!example-registry:

--- a/modules/olm-operatorhub-overview.adoc
+++ b/modules/olm-operatorhub-overview.adoc
@@ -7,6 +7,7 @@
 
 _OperatorHub_ is the web console interface in {product-title} that cluster administrators use to discover and install Operators. With one click, an Operator can be pulled from its off-cluster source, installed and subscribed on the cluster, and made ready for engineering teams to self-service manage the product across deployment environments using the Operator Lifecycle Manager (OLM).
 
+ifndef::openshift-origin[]
 Cluster administrators can choose from catalogs grouped into the following categories:
 
 [cols="2a,8a",options="header"]
@@ -28,6 +29,7 @@ Cluster administrators can choose from catalogs grouped into the following categ
 |Custom Operators
 |Operators you add to the cluster yourself. If you have not added any Custom Operators, the Custom category does not appear in the web console on your OperatorHub.
 |===
+endif::[]
 
 [NOTE]
 ====

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -7,6 +7,7 @@
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 
 ifdef::openshift-origin[]
+:catalog-name: upstream-community-operators
 :index-image-pullspec: quay.io/operator-framework/upstream-community-operators:latest
 :index-image: upstream-community-operators:latest
 :package1: couchdb-operator
@@ -14,6 +15,7 @@ ifdef::openshift-origin[]
 :package3: etcd
 endif::[]
 ifndef::openshift-origin[]
+:catalog-name: redhat-operators
 :index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v4.6
 :index-image: redhat-operator-index:v4.6
 :package1: advanced-cluster-management
@@ -24,35 +26,46 @@ endif::[]
 [id="olm-pruning-index-image_{context}"]
 = Pruning an index image
 
-An index image, based on the Operator Bundle Format, is a containerized snapshot
-of an Operator catalog. You can prune an index of all but a specified list of
-packages, creating a copy of the source index containing only the Operators
-that you want.
+An index image, based on the Operator Bundle Format, is a containerized snapshot of an Operator catalog. You can prune an index of all but a specified list of packages, creating a copy of the source index containing only the Operators that you want.
 
-ifeval::["{context}" == "olm-restricted-networks"]
+ifeval::["{context}" != "olm-managing-custom-catalogs"]
 When configuring Operator Lifecycle Manager (OLM) to use mirrored content on restricted network {product-title} clusters, use this pruning method if you want to only mirror a subset of Operators from the default catalogs.
+
+For the steps in this procedure, the target registry is an existing mirror registry that is accessible by both your cluster and a workstation with unrestricted network access. This example also shows mirroring the default `{catalog-name}` catalog, but the process is the same for all catalogs.
 endif::[]
 
 .Prerequisites
 
+ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
+endif::[]
 * `podman` version 1.4.4+
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 * `opm` version 1.12.3+
-* Access to mirror registry that supports
+* Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
-* If you are working with private registries, set the `REG_CREDS` environment
-variable to the file path of your registry credentials for use in later steps.
-For example, for the `podman` CLI:
-+
-[source,terminal]
-----
-$ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
-----
 
 .Procedure
 
-. On your workstation with unrestricted network access, run the source index image that you want to prune in a container. For example:
+ifndef::openshift-origin[]
+ifeval::["{context}" != "olm-managing-custom-catalogs"]
+. Authenticate with `registry.redhat.io`:
++
+[source,terminal]
+----
+$ podman login registry.redhat.io
+----
+endif::[]
+endif::[]
+
+. Authenticate with your target registry:
++
+[source,terminal]
+----
+$ podman login <target_registry>
+----
+
+. Run the source index image that you want to prune in a container. For example:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -107,21 +120,25 @@ $ grpcurl -plaintext localhost:50051 api.Registry/ListPackages > packages.out
 $ opm index prune \
     -f {index-image-pullspec} \// <1>
     -p {package1},{package2},{package3} \// <2>
-    -t <mirror_registry>:<port>/<namespace>/{index-image} <3>
+    -t <target_registry>:<port>/<namespace>/{index-image} <3>
 ----
 <1> Index to prune.
 <2> Comma-separated list of packages to keep.
 <3> Custom tag for new index image being built.
 
-. Run the following command to push the new index image to your mirror registry:
+. Run the following command to push the new index image to your target registry:
 +
 [source,text,subs="attributes+"]
 ----
-$ podman push <mirror_registry>:<port>/<namespace>/{index-image}
+$ podman push <target_registry>:<port>/<namespace>/{index-image}
 ----
 +
-where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+where `<namespace>` is any existing namespace on the registry.
+ifeval::["{context}" != "olm-managing-custom-catalogs"]
+For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+endif::[]
 
+:!catalog-name:
 :!index-image-pullspec:
 :!index-image:
 :!package1:

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -9,15 +9,11 @@
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Disabling the default OperatorHub sources
 
-Operator catalogs that source content from Quay.io are configured for
-OperatorHub by default during an {product-title} installation. Before
-configuring OperatorHub to instead use local catalog sources in a restricted
-network environment, you must disable the default catalogs.
+Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation. Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs.
 
 .Procedure
 
-* Disable the sources for the default catalogs by adding
-`disableAllDefaultSources: true` to the OperatorHub spec:
+* Disable the sources for the default catalogs by adding `disableAllDefaultSources: true` to the OperatorHub spec:
 +
 [source,terminal]
 ----

--- a/modules/olm-understanding-operator-catalog-images.adoc
+++ b/modules/olm-understanding-operator-catalog-images.adoc
@@ -6,7 +6,7 @@
 [id="olm-understanding-operator-catalog-images_{context}"]
 = Understanding Operator catalogs
 
-An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog. As of {product-title} 4.6, Red Hat-provided catalogs are distributed using _index images_ from Quay.io.
+An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog. As of {product-title} 4.6, Red Hat-provided catalogs are distributed using _index images_.
 
 An index image, based on the Operator Bundle Format, is a containerized snapshot of a catalog. It is an immutable artifact that contains the database of pointers to a set of Operator manifest content. A catalog can reference an index image to source its content for OLM on the cluster.
 
@@ -15,6 +15,7 @@ An index image, based on the Operator Bundle Format, is a containerized snapshot
 Starting in {product-title} 4.6, index images provided by Red Hat replace the App Registry catalog images, based on the deprecated Package Manifest Format, that are distributed for previous versions of {product-title} 4. While App Registry catalog images are not distributed by Red Hat for {product-title} 4.6 and later, custom catalog images based on the Package Manifest Format are still supported.
 ====
 
+ifndef::openshift-origin[]
 The following catalogs are distributed by Red Hat:
 
 .Red Hat-provided Operator catalogs
@@ -39,10 +40,10 @@ The following catalogs are distributed by Red Hat:
 |`community-operators`
 |`registry.redhat.io/redhat/community-operator-index:latest`
 |Software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
-
 |===
+endif::[]
 
-As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. This behavior can cause problems maintaining reproducible installs over time. In addition, when OLM runs on an {product-title} cluster in a restricted network environment, it is unable to access the catalogs from Quay.io directly to pull the latest content.
+As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. In addition, when OLM runs on an {product-title} cluster in a restricted network environment, it is unable to access the catalogs directly from the Internet to pull the latest content.
 
 As a cluster administrator, you can create your own custom index image, either based on a Red Hat-provided catalog or from scratch, which can be used to source the catalog content on the cluster. Creating and updating your own index image provides a method for customizing the set of Operators available on the cluster, while also avoiding the aforementioned restricted network environment issues.
 

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -65,8 +65,8 @@ target mirror registry:
 ----
 $ podman login <registry_host_name>
 ----
-+
-Also authenticate with `registry.redhat.io` so that the base image can be pulled
+
+. Authenticate with `registry.redhat.io` so that the base image can be pulled
 during the build:
 +
 [source,terminal]

--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -13,6 +13,7 @@ SDK.
 * Operator SDK version 0.19.4
 * `podman` version 1.4.4+
 * An Operator project generated using the Operator SDK
+* Access to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 
 .Procedure
 
@@ -21,7 +22,7 @@ SDK.
 [source,terminal]
 ----
 $ operator-sdk bundle create \
-    quay.io/<namespace>/test-operator:v0.1.0 \//<1>
+    <registry>/<namespace>/<bundle_image_name>:<tag> \//<1>
     -b podman <2>
 ----
 <1> The image tag that you want the bundle image to have.
@@ -31,7 +32,7 @@ $ operator-sdk bundle create \
 [NOTE]
 ====
 If your local manifests are not located in the default
-`<project_root>/deploy/olm-catalog/test-operator/manifests`, specify the
+`<project_root>/deploy/olm-catalog/<bundle_name>/manifests`, specify the
 location with the `--directory` flag.
 ====
 
@@ -39,14 +40,14 @@ location with the `--directory` flag.
 +
 [source,terminal]
 ----
-$ podman login quay.io
+$ podman login <registry>
 ----
 
 . Push the bundle image to the registry:
 +
 [source,terminal]
 ----
-$ podman push quay.io/<namespace>/test-operator:v0.1.0
+$ podman push <registry>/<namespace>/<bundle_image_name>:<tag>
 ----
 
 . Validate the bundle image in the remote registry:
@@ -54,7 +55,7 @@ $ podman push quay.io/<namespace>/test-operator:v0.1.0
 [source,terminal]
 ----
 $ operator-sdk bundle validate \
-    quay.io/<namespace>/test-operator:v0.1.0 \
+    <registry>/<namespace>/<bundle_image_name>:<tag> \
     -b podman
 ----
 +


### PR DESCRIPTION
Tightening up a few things:

* Sprinkle a few extra `podman login` commands around where relevant
* Genericize some values with replaceables
* Improve OKD/OCP conditionals

OCP build:

* http://file.rdu.redhat.com/~adellape/101520/ocp/opm_cleanup/operators/admin/olm-managing-custom-catalogs.html
* http://file.rdu.redhat.com/~adellape/101520/ocp/opm_cleanup/operators/admin/olm-restricted-networks.html

OKD build:

* http://file.rdu.redhat.com/~adellape/101520/okd/opm_cleanup/operators/admin/olm-managing-custom-catalogs.html
* http://file.rdu.redhat.com/~adellape/101520/okd/opm_cleanup/operators/admin/olm-restricted-networks.html