### PR TITLE
CNV-7522 - nmstate more config example

### DIFF
--- a/modules/virt-about-nmstate.adoc
+++ b/modules/virt-about-nmstate.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * virt/node_network/virt-observing-node-network-state.adoc
+// * virt/node_network/virt-updating-node-network-config.adoc
 
 [id="virt-about-nmstate_{context}"]
 = About nmstate
@@ -12,3 +13,13 @@ Node networking is monitored and updated by the following objects:
 `NodeNetworkState`:: Reports the state of the network on that node.
 `NodeNetworkConfigurationPolicy`:: Describes the requested network configuration on nodes. You update the node network configuration, including adding and removing interfaces, by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster. 
 `NodeNetworkConfigurationEnactment`:: Reports the network policies enacted upon each node.
+
+{VirtProductName} supports the use of the following nmstate interface types:
+
+* Linux Bridge
+
+* VLAN
+
+* Bond
+
+* Ethernet

--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -39,9 +39,9 @@ spec:
             - name: eth1
 ----
 <1> Name of the Policy.
-<2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
-<4> Optional. Human-readable description for the interface.
+<4> Optional: Human-readable description for the interface.
 
 . Create the Policy:
 +

--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -50,15 +50,15 @@ spec:
       mtu: 1450 <13>
 ----
 <1> Name of the Policy.
-<2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
-<5> Optional. Human-readable description of the interface.
+<5> Optional: Human-readable description of the interface.
 <6> The type of interface. This example creates a bond.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
+<8> Optional: If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> The driver mode for the bond. This example uses an active backup mode.
-<11> Optional. This example uses miimon to inspect the bond link every 140ms.
+<11> Optional: This example uses miimon to inspect the bond link every 140ms.
 <12> The subordinate node NICs in the bond.
-<13> Optional. The maximum transmission unit (MTU) for the bond. If not specified, this value is set to `1500` by default.
+<13> Optional: The maximum transmission unit (MTU) for the bond. If not specified, this value is set to `1500` by default.

--- a/modules/virt-example-bridge-nncp.adoc
+++ b/modules/virt-example-bridge-nncp.adoc
@@ -37,13 +37,13 @@ spec:
             - name: eth1 <11>
 ----
 <1> Name of the Policy.
-<2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
-<5> Optional. Human-readable description of the interface.
+<5> Optional: Human-readable description of the interface.
 <6> The type of interface. This example creates a bridge.
 <7> The requested state for the interface after creation.
-<8> Optional. If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
+<8> Optional: If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
 <9> Enables `ipv4` in this example.
 <10> Disables `stp` in this example.
 <11> The node NIC to which the bridge attaches.

--- a/modules/virt-example-ethernet-nncp.adoc
+++ b/modules/virt-example-ethernet-nncp.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * virt/node_network/virt-updating-node-network-config.adoc
+
+[id="virt-example-ethernet-nncp_{context}"]
+= Example: Ethernet interface NodeNetworkConfigurationPolicy
+
+Configure an Ethernet interface on nodes in the cluster by applying a `NodeNetworkConfigurationPolicy` manifest to the cluster.
+
+The following YAML file is an example of a manifest for an Ethernet interface.
+It includes sample values that you must replace with your own information.
+
+[source,yaml]
+----
+apiVersion: nmstate.io/v1alpha1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: eth1-policy <1>
+spec:
+  nodeSelector: <2>
+    kubernetes.io/hostname: <node01> <3>
+  desiredState:
+    interfaces:
+    - name: eth1 <4>
+      description: Configuring eth1 on node01 <5>
+      type: ethernet <6>
+      state: up <7>
+      ipv4:
+        dhcp: true <8>
+        enabled: true <9>
+----
+<1> Name of the Policy.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<3> This example uses a `hostname` node selector.
+<4> Name of the interface.
+<5> Optional: Human-readable description of the interface.
+<6> The type of interface. This example creates an Ethernet networking interface.
+<7> The requested state for the interface after creation.
+<8> Optional: If you do not use `dhcp`, you can either set a static IP or leave the interface without an IP address.
+<9> Enables `ipv4` in this example.

--- a/modules/virt-example-nmstate-IP-management.adoc
+++ b/modules/virt-example-nmstate-IP-management.adoc
@@ -1,0 +1,137 @@
+// Module included in the following assemblies:
+//
+// * virt/node_network/virt-updating-node-network-config.adoc
+
+[id="virt-example-nmstate-IP-management_{context}"]
+= Examples: IP management
+
+The following example configuration snippets demonstrate different methods of IP management. 
+
+These examples use the `ethernet` interface type to simplify the example while showing the related context in the Policy configuration. These IP management examples can be used with the other interface types. 
+
+[id="virt-example-nmstate-IP-management-static_{context}"]
+== Static
+
+The following snippet statically configures an IP address on the Ethernet interface:
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth1
+      description: static IP on eth1
+      type: ethernet
+      state: up
+      ipv4:
+        address:
+        - ip: 192.168.122.250 <1>
+          prefix-length: 24
+        enabled: true
+...
+----
+<1> Replace this value with the static IP address for the interface.
+
+[id="virt-example-nmstate-IP-management-no-ip_{context}"]
+== No IP address
+
+The following snippet ensures that the interface has no IP address:
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth1
+      description: No IP on eth1
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: false
+...
+----
+
+[id="virt-example-nmstate-IP-management-dhcp_{context}"]
+== Dynamic host configuration
+
+The following snippet configures an Ethernet interface that uses a dynamic IP address, gateway address, and DNS:
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth1
+      description: DHCP on eth1
+      type: ethernet
+      state: up
+      ipv4:
+        dhcp: true
+        enabled: true
+...
+----
+
+The following snippet configures an Ethernet interface that uses a dynamic IP address but does not use a dynamic gateway address or DNS:
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth1
+      description: DHCP without gateway or DNS on eth1
+      type: ethernet
+      state: up
+      ipv4:
+        dhcp: true
+        auto-gateway: false
+        auto-dns: false
+        enabled: true
+...
+----
+
+[id="virt-example-nmstate-IP-management-dns_{context}"]
+== DNS
+
+The following snippet sets DNS configuration on the host.
+
+[source,yaml]
+----
+...
+    interfaces:
+       ...
+    dns-resolver:
+      config:
+        search:
+        - example.com
+        - example.org
+        server:
+        - 8.8.8.8
+...
+----
+
+[id="virt-example-nmstate-IP-management-static-routing_{context}"]
+== Static routing
+
+The following snippet configures a static route and a static IP on interface `eth1`. 
+
+[source,yaml]
+----
+...
+    interfaces:
+    - name: eth1
+      description: Static routing on eth1
+      type: ethernet
+      state: up
+      ipv4:
+        address:
+        - ip: 192.0.2.251 <1>
+          prefix-length: 24
+        enabled: true
+    routes:
+      config:
+      - destination: 198.51.100.0/24
+        metric: 150
+        next-hop-address: 192.0.2.1 <2>
+        next-hop-interface: eth1
+        table-id: 254
+...
+----
+<1> The static IP address for the Ethernet interface.
+<2> Next hop address for the node traffic. This must be in the same subnet as the IP address set for the Ethernet interface.

--- a/modules/virt-example-nmstate-multiple-interfaces.adoc
+++ b/modules/virt-example-nmstate-multiple-interfaces.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * virt/node_network/virt-updating-node-network-config.adoc
+
+[id="virt-example-nmstate-multiple-interfaces_{context}"]
+= Example: Multiple interfaces in the same Policy
+
+You can create multiple interfaces in the same Policy. These interfaces can reference each other, allowing you to build and deploy a network configuration by using a single Policy manifest.
+
+The following example snippet creates a bond that is named `bond10` across two NICs and a Linux bridge that is named `br1` that connects to the bond.
+
+[source,yaml]
+----
+...
+interfaces:
+    - name: bond10
+      description: Bonding eth2 and eth3 for Linux bridge
+      type: bond
+      state: up
+      link-aggregation:
+        slaves:
+        - eth2
+        - eth3
+    - name: br1
+      description: Linux bridge on bond
+      type: linux-bridge
+      state: up
+      bridge:
+        port:
+        - name: bond10
+...
+----

--- a/modules/virt-example-vlan-nncp.adoc
+++ b/modules/virt-example-vlan-nncp.adoc
@@ -31,10 +31,10 @@ spec:
         id: 102 <9>
 ----
 <1> Name of the Policy. 
-<2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses a `hostname` node selector.
 <4> Name of the interface.
-<5> Optional. Human-readable description of the interface.
+<5> Optional: Human-readable description of the interface.
 <6> The type of interface. This example creates a VLAN.
 <7> The requested state for the interface after creation.
 <8> The node NIC to which the VLAN is attached. 

--- a/modules/virt-removing-interface-from-nodes.adoc
+++ b/modules/virt-removing-interface-from-nodes.adoc
@@ -35,7 +35,7 @@ spec:
         state: absent <4>
 ----
 <1> Name of the Policy.
-<2> Optional. If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
+<2> Optional: If you do not include the `nodeSelector`, the Policy applies to all nodes in the cluster.
 <3> This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
 <4> Changing the state to `absent` removes the interface.
 

--- a/virt/node_network/virt-updating-node-network-config.adoc
+++ b/virt/node_network/virt-updating-node-network-config.adoc
@@ -1,4 +1,4 @@
-[id="virt-updating-node-network"]
+[id="virt-updating-node-network-config"]
 = Updating node network configuration
 include::modules/virt-document-attributes.adoc[]
 :context: virt-updating-node-network-config 
@@ -11,15 +11,31 @@ include::modules/virt-about-nmstate.adoc[leveloffset=+1]
 
 include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]
 
+[discrete]
+== Additional resources
+* xref:virt-nmstate-example-policy-configurations[Example Policy configurations for different interfaces]
+* xref:virt-example-nmstate-multiple-interfaces_virt-updating-node-network-config[Example for creating multiple interfaces in the same Policy]
+* xref:virt-example-nmstate-IP-management_virt-updating-node-network-config[Examples of different IP management methods in Policies]
+
 include::modules/virt-confirming-policy-updates-on-nodes.adoc[leveloffset=+1]
 
 include::modules/virt-removing-interface-from-nodes.adoc[leveloffset=+1]
 
 include::modules/virt-restoring-node-network-configuration.adoc[leveloffset=+1]
 
-include::modules/virt-example-bridge-nncp.adoc[leveloffset=+1]
+[id="virt-nmstate-example-policy-configurations"]
+== Example Policy configurations for different interfaces
 
-include::modules/virt-example-vlan-nncp.adoc[leveloffset=+1]
+include::modules/virt-example-bridge-nncp.adoc[leveloffset=+2]
 
-include::modules/virt-example-bond-nncp.adoc[leveloffset=+1]
+include::modules/virt-example-vlan-nncp.adoc[leveloffset=+2]
+
+include::modules/virt-example-bond-nncp.adoc[leveloffset=+2]
+
+include::modules/virt-example-ethernet-nncp.adoc[leveloffset=+2]
+
+include::modules/virt-example-nmstate-multiple-interfaces.adoc[leveloffset=+2]
+
+// Dropping offset by one again
+include::modules/virt-example-nmstate-IP-management.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Adding some new nmstate configuration examples and snippets, which required a bit of rejigging of current content
And it looks like I name my branch the epic ID. Oh well. 

https://issues.redhat.com/browse/CNV-7522

Build link: https://cnv-7521-nmstate-examples--ocpdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html