### PR TITLE
4.6 Release Notes - Adding cluster-monitoring-operator GitHub changelog link

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1244,6 +1244,8 @@ For more information, see xref:../monitoring/understanding-the-monitoring-stack.
 Red Hat does not guarantee backward compatibility for metrics, recording rules, or alerting rules.
 ====
 
+For more information about changes to alerting rules and updates to monitoring component versions in {product-title} 4.6, see link:https://raw.githubusercontent.com/openshift/cluster-monitoring-operator/release-4.6/CHANGELOG.md[the `cluster-monitoring-operator` change log for `release-4.6`].
+
 [id="ocp-4-6-monitoring-prometheus-rule-validation"]
 ==== Prometheus rule validation
 


### PR DESCRIPTION
This PR adds a link to the upstream `cluster-monitoring-operator` `release-4.6` changelog on GitHub. Alerting rule changes and package version updates for OCP 4.6 are referenced in the changelog by the Monitoring team.

In addition to the alerting rule changes that are added to the 4.6 Release Notes [this related PR](https://github.com/openshift/openshift-docs/pull/26223), a link to the changelog provides readers with more detailed information about specific component updates.

Applies to branch/enterprise-4.6 only.

The preview is [here](https://monitoring_release_notes_4_6_github_link--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-monitoring).