### PR TITLE
RN-CNV-7170 CDI faster import, release note for 2.5

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -64,6 +64,7 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 //Placeholder for new content.
 
 //CNV-7170 - CDI import of container disks is faster and more efficient
+* The Containerized Data Importer (CDI) can now import containerDisk storage volumes from the container image registry at a faster speed and allocate storage capacity more efficiently. CDI can pull a containerDisk image from the registry in about the same amount of time as it would take to import from an HTTP endpoint. You can import the disk into a PersistentVolumeClaim (PVC) equal in size to the disk image to use the underlying storage more efficiently.
 
 //CNV-7168 - DataVolume and storage diagnostics
 


### PR DESCRIPTION
Storage-related release note for 2.5, CDI import of container disks is faster and more efficient.

https://issues.redhat.com/browse/CNV-7170