### PR TITLE
CNV 2.5 Release Notes - Bob

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -76,8 +76,9 @@ xref:../virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.a
 ** Any other storage provider with the Container Storage Interface (CSI) driver that supports the Kubernetes Volume Snapshot API
 
 //CNV-6825 - Smart cloning with snapshots
-
 //CNV-4089 - Cloning a disk quickly using the storage array
+// These two release note stories are combined in a single release note.
+* You can now clone virtual disks efficiently and quickly using smart-cloning. Smart-cloning occurs automatically when you create a DataVolume with a PersistentVolumeClaim (PVC) source. Your storage provider must support the CSI Snapshots API to use smart-cloning.
 
 [id="virt-2-5-web-new"]
 === Web console


### PR DESCRIPTION
This PR contains all my release notes for 4.6/2.5.

Label *peer review needed* and *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).6*.

**Drafts of release notes:**
* [CNV-4089](https://issues.redhat.com/browse/CNV-4089) and [CNV-6825](https://issues.redhat.com/browse/CNV-6825) - Clone disks efficiently using smart-cloning, providing that your storage provider
supports the CSI Snapshots API. Cloning happens automatically
when you create a DataVolume with a PersistentVolumeClaim (PVC) source.

See Netify link for preview build.

Thanks
Bob