### PR TITLE
Fix Power changes from PR26184

### DIFF
--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -65,6 +65,8 @@ to use an ISO image or network PXE booting to create the machines.
 
 include::modules/installation-user-infra-machines-iso.adoc[leveloffset=+2]
 
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
+
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -81,7 +81,7 @@ the `coreos-installer` command instead of adding kernel arguments. If you
 run the live installer without options or interruption, the installer boots up to a
 shell prompt on the live system, ready for you to install {op-system} to disk.
 
-. Review the “Advanced {op-system} bare metal installation configuration”
+. Review the “Advanced {op-system} installation reference”
 section for different ways of configuring features, such as networking
 and disk partitions, before running the `coreos-installer`.
 

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -3,13 +3,25 @@
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 
 [id="installation-user-infra-machines-static-network_{context}"]
 = Advanced {op-system} installation reference
 
-If you install {op-system-first} from an ISO image, you can add kernel arguments
-when you boot that image to configure the node's networking.
-The following table describes and illustrates how to use those kernel arguments.
+This section illustrates the networking configuration and other advanced options that allow you to modify the {op-system-first} bare metal install process. The following tables describe the kernel arguments and command-line options you can use with the {op-system} live installer and the `coreos-installer` command.
+
+[discrete]
+== Routing and bonding options at {op-system} boot prompt
+
+If you install {op-system} from an ISO image, you can add kernel arguments manually when you boot that image to configure the node's networking. If no networking arguments are used, the installation defaults to using DHCP.
+
+[IMPORTANT]
+====
+When adding networking arguments, you must also add the `rd.neednet=1` kernel argument.
+====
+
+The following table describes how to use `ip=`, `nameserver=`, and `bond=` kernel arguments for live ISO installs.
 
 .Routing and bonding options for ISO
 [source,adoc]
@@ -30,14 +42,14 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 nameserver=4.4.4.41
 ----
 
-|Specify multiple network interfaces by specifying multiple `ip=` entries.
+a|Specify multiple network interfaces by specifying multiple `ip=` entries.
 a|
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
-|You can combine DHCP
+a|You can combine DHCP
 and static IP configurations on systems with
 multiple network interfaces.
 a|
@@ -46,14 +58,14 @@ ip=enp1s0:dhcp
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
-|You can provide multiple DNS servers by adding a `nameserver=` entry for each server.
+a|You can provide multiple DNS servers by adding a `nameserver=` entry for each server.
 a|
 ----
 nameserver=1.1.1.1
 nameserver=8.8.8.8
 ----
 
-a|Optional: Bonding multiple network interfaces to a single interface is optionally supported
+a|Optional: Bonding multiple network interfaces to a single interface is supported
 using the `bond=` option.  In these two examples:
 
 * The syntax for configuring a bonded interface is: `bond=name[:network_interfaces][:options]`

--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -42,9 +42,8 @@ registry to use storage.
 ifndef::ibm-z,ibm-power[bare metal.]
 ifdef::ibm-z[IBM Z.]
 ifdef::ibm-power[IBM Power.]
-* Persistent storage provisioned for your cluster, such as
-ifndef::ibm-z[Red Hat OpenShift Container Storage.]
-ifdef::ibm-z[NFS.]
+ifndef::ibm-z[* Persistent storage provisioned for your cluster, such as Red Hat OpenShift Container Storage.]
+ifdef::ibm-z[* Persistent storage provisioned for your cluster.]
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
Mostly, this PR fixes changes that were made in `modules/installation-user-infra-machines-static-network.adoc` in https://github.com/openshift/openshift-docs/pull/26184. (See my inline comments in that merged PR for more details.) 

IIUC, the changes that were made were cosmetic. In other words, they are not hiding any functionality to a certain set of users (i.e., Z-Power).

What was changed in that file minimizes the level of information that follows. The three bulleted items describe the three ways that a user can configure advanced networking: at the live installer boot prompt, by using specific `core.inst` boot options, or by passing arguments directly to `coreos-installer`. The tables that follow that intro cover these three scenarios.

It is my conclusion that the changes in this new PR should be acceptable without conditionals necessary, and that we should therefore be able to merge this PR and CP it to 4.6 with no additional tags added. But I might be missing the bigger picture.

@vikram-redhat or @codyhoag Do you see any issue with merging and CP'ing this to 4.6?

**PREVIEW LINKS**
- [Advanced RHCOS installation reference](https://fix-26490-power-z--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-static-network_installing-bare-metal)
- [Configuring registry storage for bare metal](https://fix-26490-power-z--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#registry-configuring-storage-baremetal_installing-bare-metal)