### PR TITLE
Fixing typos in Monitoring book

### DIFF
--- a/modules/monitoring-configuring-alert-receivers.adoc
+++ b/modules/monitoring-configuring-alert-receivers.adoc
@@ -17,7 +17,7 @@ You can configure alert receivers to ensure that you learn about important issue
 +
 [NOTE]
 ====
-Alternatively you can navigate to the same page through the notification draw. Select the bell icon at the top right of the {product-title} web console and choose *Configure* in the *AlertmanagerReceiverNotConfigured* alert.
+Alternatively you can navigate to the same page through the notification drawer. Select the bell icon at the top right of the {product-title} web console and choose *Configure* in the *AlertmanagerReceiverNotConfigured* alert.
 ====
 
 . Select *Create Receiver* in the *Receivers* section of the page.

--- a/modules/monitoring-expiring-silences.adoc
+++ b/modules/monitoring-expiring-silences.adoc
@@ -1,4 +1,4 @@
-f// Module included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
 


### PR DESCRIPTION
Fixing a couple of typos in the Monitoring book.

Applies to master and branch/enterprise-4.6 only.