### PR TITLE
Network security group requirements - Adding Machine Config Server Port

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -79,6 +79,11 @@ The network security group rules must be in place before you install the cluster
 |x
 |x
 
+|`22623`
+|Allows communication to the machine config server.
+|x
+|x
+
 |===
 
 


### PR DESCRIPTION
The 22623 is a key port, overall during the bootstraping process. 

If the client, for any reason, changes the default `vNet` inbound rules [1], the IPI installer doesn't take care about that and won't be able to deploy the control plane VMs as they will never get the `ignition` file. 

[1] [Default security rules](https://docs.microsoft.com/en-us/azure/virtual-network/network-security-groups-overview#default-security-rules)