### PR TITLE
BZ1858776 - Updating user workload monitoring admonition

### DIFF
--- a/monitoring/monitoring-your-own-services.adoc
+++ b/monitoring/monitoring-your-own-services.adoc
@@ -10,7 +10,7 @@ Additionally, you can extend the access to the metrics of your services beyond c
 
 [NOTE]
 ====
-Opting into monitoring your own services is mutually exclusive with either a custom installation of Prometheus Operator or installing Prometheus Operator using Operator Lifecycle Manager (OLM).
+Custom Prometheus instances and the Prometheus Operator installed through Operator Lifecycle Manager (OLM) can cause issues with user-defined workload monitoring if it is enabled. Custom Prometheus instances are not supported in {product-title}.
 ====
 
 :FeatureName: Monitoring your own services


### PR DESCRIPTION
Applies to branch/enterprise-4.5, branch/enterprise-4.4 and branch/enterprise-4.3.

This does not apply to master or branch/enterprise-4.6 following the Monitoring book restructuring in those branches.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1858776.

The preview is [here](https://bz1858776--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/monitoring-your-own-services.html).