### PR TITLE
BZ1865805 - Updating ConfigMap additional resources references

### DIFF
--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -9,7 +9,9 @@ You can assign tolerations to any of the monitoring stack components to enable m
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -9,7 +9,9 @@ Using the external labels feature of Prometheus, you can attach additional custo
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -9,7 +9,9 @@ For the Prometheus or Alertmanager to use a persistent volume (PV), you first mu
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
@@ -9,7 +9,9 @@ You can configure the Prometheus Cluster Monitoring stack using ConfigMaps. Conf
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
+++ b/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
@@ -9,7 +9,9 @@ You can enable monitoring your own services by setting the `techPreviewUserWorkl
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
@@ -9,7 +9,9 @@ By default, the Prometheus Cluster Monitoring stack configures the retention tim
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -9,7 +9,9 @@ You can move any of the monitoring stack components to specific nodes.
 
 .Prerequisites
 
-* Make sure you have the `cluster-monitoring-config` ConfigMap object with the `data/config.yaml` section.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (oc).
+* You have created the `cluster-monitoring-config` ConfigMap object.
 
 .Procedure
 
@@ -83,7 +85,3 @@ data:
 ----
 
 . Save the file to apply the changes. The components affected by the new configuration are moved to new nodes automatically.
-
-.Additional resources
-
-* See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint.

--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -18,12 +18,25 @@ This section explains what configuration is supported, shows how to configure th
 include::modules/monitoring-maintenance-and-support.adoc[leveloffset=+1]
 include::modules/monitoring-creating-cluster-monitoring-configmap.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-the-cluster-monitoring-stack.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+
 include::modules/monitoring-configurable-monitoring-components.adoc[leveloffset=+1]
 include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors] for more information about using node selectors.
+* See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint.
+
 include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[leveloffset=+1]
 
 .Additional resources
 
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
 * See the xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[{product-title} documentation] on taints and tolerations.
 * See the link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes documentation] on taints and tolerations.
 
@@ -47,13 +60,11 @@ See xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-c
 include::modules/monitoring-configuring-a-local-persistent-volume-claim.adoc[leveloffset=+2]
 include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc[leveloffset=+2]
 
-// .Additional resources
+.Additional resources
 
-// * See LINK for details.
-// FIXME link to the persistent storage docs once they are available
-// used to link to ../architecture/additional_concepts/storage.adoc#persistent-volumes[Persistent Storage]
-// * See LINK for storage recommendations.
-// FIXME add link to storage recommendations
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 
 [id="configuring-alertmanager"]
 == Configuring Alertmanager
@@ -77,6 +88,10 @@ include::modules/monitoring-listing-acting-alerting-rules.adoc[leveloffset=+2]
 * See also link:https://prometheus.io/docs/alerting/alertmanager/[the Alertmanager documentation].
 
 include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
 
 == Next steps
 

--- a/monitoring/monitoring-your-own-services.adoc
+++ b/monitoring/monitoring-your-own-services.adoc
@@ -20,7 +20,7 @@ include::modules/monitoring-enabling-monitoring-of-your-own-services.adoc[levelo
 
 .Additional resources
 
-* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configuring the monitoring stack] to learn how to create `cluster-monitoring-config`.
+* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
 
 include::modules/monitoring-deploying-a-sample-service.adoc[leveloffset=+1]
 include::modules/monitoring-granting-user-permissions-using-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to branch/enterprise-4.3, branch/enterprise-4.4 and branch/enterprise-4.5.

Does not apply to master or branch/enterprise-4.6, following the restructuring of the Monitoring book in those branches.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1865805.

The preview is [here](https://bz1865805--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/monitoring-your-own-services.html#enabling-monitoring-of-your-own-services_monitoring-your-own-services) and [here](https://bz1865805--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html).