### PR TITLE
New collapsible js functionality and collapsing UPI templates

### DIFF
--- a/_javascripts/collapsible.js
+++ b/_javascripts/collapsible.js
@@ -1,0 +1,36 @@
+const collapsibleButtonHTML = "<div id='collapsibleButtonDiv'><button type='button' name='button-collapse-expand-all' id='button-collapse-expand-all' aria-labelledby='label-collapse-expand-all' class='fa fa-angle-double-up button-collapse-expand' onclick='collapseExpandAll()'></button><span role='tooltip' id='label-collapse-expand-all' class='span-collapse-expand-all' onclick='collapseExpandAll()'>Collapse all</span></div>";
+
+const collapsibleDetails = document.getElementsByTagName("details");
+
+for (var i=0; i < collapsibleDetails.length; i++) {
+  collapsibleDetails[i].insertAdjacentHTML('beforebegin', collapsibleButtonHTML);
+}
+
+function collapseExpandAll() {
+  const collapseExpandButtons = document.getElementsByClassName("button-collapse-expand");
+  const collapsibleTooltip = document.getElementsByClassName("span-collapse-expand-all");
+
+  if (collapsibleTooltip[0].innerHTML == "Collapse all") {
+    for (var i=0; i < collapsibleDetails.length; i++) {
+        collapsibleDetails[i].removeAttribute("open");
+    }
+    for (var j=0; j < collapsibleTooltip.length; j++) {
+      collapsibleTooltip[j].innerHTML = "Expand all";
+    }
+    for (var k=0; k < collapseExpandButtons.length; k++) {
+      collapseExpandButtons[k].classList.remove("fa-angle-double-up");
+      collapseExpandButtons[k].classList.add("fa-angle-double-down");
+    }
+  } else {
+    for (var i=0; i < collapsibleDetails.length; i++) {
+        collapsibleDetails[i].setAttribute("open", "");
+    }
+    for (var j=0; j < collapsibleTooltip.length; j++) {
+        collapsibleTooltip[j].innerHTML = "Collapse all";
+    }
+    for (var k=0; k < collapseExpandButtons.length; k++) {
+      collapseExpandButtons[k].classList.remove("fa-angle-double-down");
+      collapseExpandButtons[k].classList.add("fa-angle-double-up");
+    }
+  }
+}

--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -512,6 +512,53 @@ table > tbody > tr > td > div > div > p > code {
      line-height: 1.6;
      color: #6e6e6e;
 }
+/* Collapsible content */
+details {
+  width: 100%;
+  margin-bottom: 10px;
+}
+ details > summary {
+  font-size: 0.92em;
+  padding: 4px 6px;
+  background-color: #f9f9f9;
+  border: none;
+  box-shadow: 2px 2px 2px #8a8a8a;
+  cursor: pointer;
+  margin-top: 0.8em;
+}
+ details > div {
+  border-radius: 0 0 5px 5px;
+  background-color: #f9f9f9;
+  padding: 4px 6px;
+  margin: 0.5em 0.7em;
+  box-shadow: 2px 2px 2px #8a8a8a;
+}
+#collapsibleButtonDiv {
+  position: relative;
+  width: 100%;
+  padding: 1em 0em;
+  font-size: .92em;
+}
+button[name="button-collapse-expand-all"] {
+  position: absolute;
+  right: 100px;
+  bottom: 0px;
+  margin-right: 10px;
+  z-index: 1;
+}
+.span-collapse-expand-all {
+  display:inline-block;
+  width: 100px;
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  text-align: justify;
+  z-index: 1;
+}
+.span-collapse-expand-all:hover {
+  cursor: pointer;
+}
+/* END Collapsible content */
  @media only screen and (min-width: 768px) {
      #toctitle, .sidebarblock > .content > .title {
          line-height: 1.4;

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -155,6 +155,7 @@
   <script src="https://docs.openshift.com/container-platform/4.1/_javascripts/page-loader.js" type="text/javascript"></script>
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
   <script src="https://docs.openshift.com/container-platform/4.1/_javascripts/clipboard.js" type="text/javascript"></script>
+  <script src="https://docs.openshift.com/container-platform/4.1/_javascripts/collapsible.js" type="text/javascript"></script>
 
   <script>
   var dk = '<%= distro_key %>';
@@ -196,6 +197,11 @@
       $("[id^='topicSubSubGroup']").on('hide.bs.collapse', function () {
         $(this).parent().find("[id^='ssgSpan']").toggleClass("fa-caret-right fa-caret-down");
       });
+
+      const collapsibleContent = document.getElementsByTagName("details");
+        for (var i=0; i < collapsibleContent.length; i++) {
+          collapsibleContent[i].setAttribute("open", "");
+        }
 
     });
     /*]]>*/

--- a/modules/installation-arm-bootstrap.adoc
+++ b/modules/installation-arm-bootstrap.adoc
@@ -9,7 +9,10 @@ You can use the following Azure Resource Manager (ARM) template to deploy the
 bootstrap machine that you need for your {product-title} cluster:
 
 .`04_bootstrap.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/04_bootstrap.json[]
 ----
+====

--- a/modules/installation-arm-control-plane.adoc
+++ b/modules/installation-arm-control-plane.adoc
@@ -9,7 +9,10 @@ You can use the following Azure Resource Manager (ARM) template to deploy the
 control plane machines that you need for your {product-title} cluster:
 
 .`05_masters.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/05_masters.json[]
 ----
+====

--- a/modules/installation-arm-dns.adoc
+++ b/modules/installation-arm-dns.adoc
@@ -10,7 +10,10 @@ networking objects and load balancers that you need for your {product-title}
 cluster:
 
 .`03_infra.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/03_infra.json[]
 ----
+====

--- a/modules/installation-arm-image-storage.adoc
+++ b/modules/installation-arm-image-storage.adoc
@@ -9,7 +9,10 @@ You can use the following Azure Resource Manager (ARM) template to deploy the
 stored {op-system-first} image that you need for your {product-title} cluster:
 
 .`02_storage.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/02_storage.json[]
 ----
+====

--- a/modules/installation-arm-vnet.adoc
+++ b/modules/installation-arm-vnet.adoc
@@ -9,7 +9,10 @@ You can use the following Azure Resource Manager (ARM) template to deploy the
 VNet that you need for your {product-title} cluster:
 
 .`01_vnet.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/01_vnet.json[]
 ----
+====

--- a/modules/installation-arm-worker.adoc
+++ b/modules/installation-arm-worker.adoc
@@ -9,7 +9,10 @@ You can use the following Azure Resource Manager (ARM) template to deploy the
 worker machines that you need for your {product-title} cluster:
 
 .`06_workers.json` ARM template
+[%collapsible]
+====
 [source,json]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/azure/06_workers.json[]
 ----
+====

--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -12,6 +12,8 @@ you grant that user all of the required permissions. To deploy all components of
 cluster, the IAM user requires the following permissions:
 
 .Required EC2 permissions for installation
+[%collapsible]
+====
 * `ec2:AllocateAddress`
 * `ec2:AssociateAddress`
 * `ec2:AuthorizeSecurityGroupEgress`
@@ -58,8 +60,11 @@ cluster, the IAM user requires the following permissions:
 * `ec2:RevokeSecurityGroupIngress`
 * `ec2:RunInstances`
 * `ec2:TerminateInstances`
+====
 
 .Required permissions for creating network resources during installation
+[%collapsible]
+====
 * `ec2:AssociateDhcpOptions`
 * `ec2:AssociateRouteTable`
 * `ec2:AttachInternetGateway`
@@ -75,11 +80,14 @@ cluster, the IAM user requires the following permissions:
 * `ec2:ModifyVpcAttribute`
 
 [NOTE]
-====
+=====
 If you use an existing VPC, your account does not require these permissions for creating network resources.
+=====
 ====
 
 .Required Elasticloadbalancing permissions for installation
+[%collapsible]
+====
 * `elasticloadbalancing:AddTags`
 * `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer`
 * `elasticloadbalancing:AttachLoadBalancerToSubnets`
@@ -104,8 +112,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `elasticloadbalancing:RegisterInstancesWithLoadBalancer`
 * `elasticloadbalancing:RegisterTargets`
 * `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
+====
 
 .Required IAM permissions for installation
+[%collapsible]
+====
 * `iam:AddRoleToInstanceProfile`
 * `iam:CreateInstanceProfile`
 * `iam:CreateRole`
@@ -124,8 +135,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `iam:RemoveRoleFromInstanceProfile`
 * `iam:SimulatePrincipalPolicy`
 * `iam:TagRole`
+====
 
 .Required Route53 permissions for installation
+[%collapsible]
+====
 * `route53:ChangeResourceRecordSets`
 * `route53:ChangeTagsForResource`
 * `route53:CreateHostedZone`
@@ -137,8 +151,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `route53:ListResourceRecordSets`
 * `route53:ListTagsForResource`
 * `route53:UpdateHostedZoneComment`
+====
 
 .Required S3 permissions for installation
+[%collapsible]
+====
 * `s3:CreateBucket`
 * `s3:DeleteBucket`
 * `s3:GetAccelerateConfiguration`
@@ -159,8 +176,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `s3:PutBucketAcl`
 * `s3:PutBucketTagging`
 * `s3:PutEncryptionConfiguration`
+====
 
 .S3 permissions that cluster Operators require
+[%collapsible]
+====
 * `s3:DeleteObject`
 * `s3:GetObject`
 * `s3:GetObjectAcl`
@@ -169,8 +189,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `s3:PutObject`
 * `s3:PutObjectAcl`
 * `s3:PutObjectTagging`
+====
 
 .Required permissions to delete base cluster resources
+[%collapsible]
+====
 * `autoscaling:DescribeAutoScalingGroups`
 * `ec2:DeleteNetworkInterface`
 * `ec2:DeleteVolume`
@@ -184,8 +207,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `s3:DeleteObject`
 * `s3:ListBucketVersions`
 * `tag:GetResources`
+====
 
 .Required permissions to delete network resources
+[%collapsible]
+====
 * `ec2:DeleteDhcpOptions`
 * `ec2:DeleteInternetGateway`
 * `ec2:DeleteNatGateway`
@@ -199,11 +225,14 @@ If you use an existing VPC, your account does not require these permissions for 
 * `ec2:ReplaceRouteTableAssociation`
 
 [NOTE]
-====
+=====
 If you use an existing VPC, your account does not require these permissions to delete network resources.
+=====
 ====
 
 .Additional IAM and S3 permissions that are required to create manifests
+[%collapsible]
+====
 * `iam:CreateAccessKey`
 * `iam:CreateUser`
 * `iam:DeleteAccessKey`
@@ -221,3 +250,4 @@ If you use an existing VPC, your account does not require these permissions to d
 * `s3:HeadBucket`
 * `s3:ListBucketMultipartUploads`
 * `s3:AbortMultipartUpload`
+====

--- a/modules/installation-cloudformation-bootstrap.adoc
+++ b/modules/installation-cloudformation-bootstrap.adoc
@@ -9,7 +9,11 @@
 You can use the following CloudFormation template to deploy the bootstrap
 machine that you need for your {product-title} cluster.
 
+.CloudFormation template for the bootstrap machine
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/04_cluster_bootstrap.yaml[]
 ----
+====

--- a/modules/installation-cloudformation-control-plane.adoc
+++ b/modules/installation-cloudformation-control-plane.adoc
@@ -9,7 +9,11 @@
 You can use the following CloudFormation template to deploy the control plane
 machines that you need for your {product-title} cluster.
 
+.CloudFormation template for control plane machines
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/05_cluster_master_nodes.yaml[]
 ----
+====

--- a/modules/installation-cloudformation-dns.adoc
+++ b/modules/installation-cloudformation-dns.adoc
@@ -9,10 +9,14 @@
 You can use the following CloudFormation template to deploy the networking
 objects and load balancers that you need for your {product-title} cluster.
 
+.CloudFormation template for the network and load balancers
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/02_cluster_infra.yaml[]
 ----
+====
 
 [IMPORTANT]
 ====

--- a/modules/installation-cloudformation-security.adoc
+++ b/modules/installation-cloudformation-security.adoc
@@ -9,7 +9,11 @@
 You can use the following CloudFormation template to deploy the security objects
 that you need for your {product-title} cluster.
 
+.CloudFormation template for security objects
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/03_cluster_security.yaml[]
 ----
+====

--- a/modules/installation-cloudformation-vpc.adoc
+++ b/modules/installation-cloudformation-vpc.adoc
@@ -9,7 +9,11 @@
 You can use the following CloudFormation template to deploy the VPC that
 you need for your {product-title} cluster.
 
+.CloudFormation template for the VPC
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/01_vpc.yaml[]
 ----
+====

--- a/modules/installation-cloudformation-worker.adoc
+++ b/modules/installation-cloudformation-worker.adoc
@@ -9,7 +9,11 @@
 You can use the following CloudFormation template to deploy the worker machines
 that you need for your {product-title} cluster.
 
+.CloudFormation template for worker machines
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/aws/cloudformation/06_cluster_worker_node.yaml[]
 ----
+====

--- a/modules/installation-deployment-manager-bootstrap.adoc
+++ b/modules/installation-deployment-manager-bootstrap.adoc
@@ -6,11 +6,14 @@
 [id="installation-deployment-manager-bootstrap_{context}"]
 = Deployment Manager template for the bootstrap machine
 
-You can use the following Deployment Mananger template to deploy the bootstrap
+You can use the following Deployment Manager template to deploy the bootstrap
 machine that you need for your {product-title} cluster:
 
 .`04_bootstrap.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/04_bootstrap.py[]
 ----
+====

--- a/modules/installation-deployment-manager-control-plane.adoc
+++ b/modules/installation-deployment-manager-control-plane.adoc
@@ -10,7 +10,10 @@ You can use the following Deployment Mananger template to deploy the control
 plane machines that you need for your {product-title} cluster:
 
 .`05_control_plane.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/05_control_plane.py[]
 ----
+====

--- a/modules/installation-deployment-manager-ext-lb.adoc
+++ b/modules/installation-deployment-manager-ext-lb.adoc
@@ -8,7 +8,10 @@
 You can use the following Deployment Manager template to deploy the external load balancer that you need for your {product-title} cluster:
 
 .`02_lb_ext.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/02_lb_ext.py[]
 ----
+====

--- a/modules/installation-deployment-manager-firewall-rules.adoc
+++ b/modules/installation-deployment-manager-firewall-rules.adoc
@@ -8,7 +8,10 @@
 You can use the following Deployment Manager template to deploy the firewall rues that you need for your {product-title} cluster:
 
 .`03_firewall.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/03_firewall.py[]
 ----
+====

--- a/modules/installation-deployment-manager-iam-shared-vpc.adoc
+++ b/modules/installation-deployment-manager-iam-shared-vpc.adoc
@@ -8,7 +8,10 @@
 You can use the following Deployment Manager template to deploy the IAM roles that you need for your {product-title} cluster:
 
 .`03_iam.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/03_iam.py[]
 ----
+====

--- a/modules/installation-deployment-manager-int-lb.adoc
+++ b/modules/installation-deployment-manager-int-lb.adoc
@@ -8,7 +8,10 @@
 You can use the following Deployment Manager template to deploy the internal load balancer that you need for your {product-title} cluster:
 
 .`02_lb_int.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/02_lb_int.py[]
 ----
+====

--- a/modules/installation-deployment-manager-private-dns.adoc
+++ b/modules/installation-deployment-manager-private-dns.adoc
@@ -8,7 +8,10 @@
 You can use the following Deployment Manager template to deploy the private DNS that you need for your {product-title} cluster:
 
 .`02_dns.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/02_dns.py[]
 ----
+====

--- a/modules/installation-deployment-manager-vpc.adoc
+++ b/modules/installation-deployment-manager-vpc.adoc
@@ -10,7 +10,10 @@ You can use the following Deployment Manager template to deploy the VPC that
 you need for your {product-title} cluster:
 
 .`01_vpc.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/01_vpc.py[]
 ----
+====

--- a/modules/installation-deployment-manager-worker.adoc
+++ b/modules/installation-deployment-manager-worker.adoc
@@ -10,7 +10,10 @@ You can use the following Deloyment Manager template to deploy the worker machin
 that you need for your {product-title} cluster:
 
 .`06_worker.py` Deployment Manager template
+[%collapsible]
+====
 [source,python]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/gcp/06_worker.py[]
 ----
+====

--- a/modules/installation-osp-creating-bootstrap-machine.adoc
+++ b/modules/installation-osp-creating-bootstrap-machine.adoc
@@ -18,10 +18,14 @@ Create a bootstrap machine and give it the network access it needs to run on {rh
 
 . Insert the following content into a local file that is called `03_bootstrap.yaml`:
 +
+.`03_bootstrap.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/bootstrap.yaml[]
 ----
+====
 
 . On a command line, run the playbook:
 +

--- a/modules/installation-osp-creating-compute-machines.adoc
+++ b/modules/installation-osp-creating-compute-machines.adoc
@@ -20,10 +20,14 @@ After standing up the control plane, create compute machines.
 
 . Insert the following content into a local file that is called `05_compute-nodes.yaml`:
 +
+.`05_compute-nodes.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/compute-nodes.yaml[]
 ----
+====
 
 . On a command line, run the playbook:
 +

--- a/modules/installation-osp-creating-control-plane.adoc
+++ b/modules/installation-osp-creating-control-plane.adoc
@@ -21,10 +21,14 @@ Create three control plane machines by using the Ignition config files that you 
 
 . Insert the following content into a local file that is called `04_control-plane.yaml`:
 +
+.`04_control-plane.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/control-plane.yaml[]
 ----
+====
 
 . On a command line, run the playbook:
 +

--- a/modules/installation-osp-creating-network-resources.adoc
+++ b/modules/installation-osp-creating-network-resources.adoc
@@ -11,16 +11,25 @@ Create the network resources that an {product-title} on {rh-openstack-first} ins
 
 . Insert the following content into a local file that is called `common.yaml`:
 +
+.`common.yaml` Ansible playbook
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/common.yaml[]
 ----
+====
+
 . Insert the following content into a local file that is called `inventory.yaml`:
 +
+.`inventory.yaml` Ansible playbook
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/inventory.yaml[]
 ----
+====
 +
 [IMPORTANT]
 ====
@@ -31,18 +40,27 @@ If you do not define a value for `os_bootstrap_fip`, the installer cannot downlo
 See "Enabling access to the environment" for more information.
 ====
 
-. Insert the following content into a local file that is called `01_security-groups.yaml`
+. Insert the following content into a local file that is called `01_security-groups.yaml`:
 +
+.`01_security-groups.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/security-groups.yaml[]
 ----
-. Insert the following content into a local file that is called `02_network.yaml`
+====
+
+. Insert the following content into a local file that is called `02_network.yaml`:
 +
+.`02_network.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/network.yaml[]
 ----
+====
 
 . On a command line, create security groups by running the first numbered playbook:
 +

--- a/modules/installation-osp-deleting-bootstrap-resources.adoc
+++ b/modules/installation-osp-deleting-bootstrap-resources.adoc
@@ -18,10 +18,14 @@ Delete the bootstrap resources that you no longer need.
 
 . Insert the following content into a local file that is called `down-03_bootstrap.yaml`:
 +
+.`down-03_bootstrap.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-bootstrap.yaml[]
 ----
+====
 
 . On a command line, run the playbook:
 +

--- a/modules/installation-uninstall-infra.adoc
+++ b/modules/installation-uninstall-infra.adoc
@@ -19,59 +19,91 @@ You may have the `common.yaml` and `inventory.yaml` playbooks left over from whe
 
 . Insert the following content into a local file called `common.yaml`:
 +
+.`common.yaml` Ansible playbook
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/common.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `inventory.yaml`, and edit the values to match your own:
 +
+.`inventory.yaml` Ansible playbook
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/inventory.yaml[]
 ----
+====
 
 . _Optional_: If your cluster uses Kuryr, insert the following content into a local file called `down-06_load-balancers.yaml`:
 +
+.`down-06_load-balancers.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-load-balancers.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `down-05_compute-nodes.yaml`:
 +
+.`down-05_compute-nodes.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-compute-nodes.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `down-04_control-plane.yaml`:
 +
+.`down-04_control-plane.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-control-plane.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `down-03_bootstrap.yaml`:
 +
+.`down-03_bootstrap.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-bootstrap.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `down-02_network.yaml`:
 +
+.`down-02_network.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-network.yaml[]
 ----
+====
 
 . Insert the following content into a local file called `down-01_security-groups.yaml`:
 +
+.`down-01_security-groups.yaml`
+[%collapsible]
+====
 [source,yaml]
 ----
 include::https://raw.githubusercontent.com/openshift/installer/release-4.6/upi/openstack/down-security-groups.yaml[]
 ----
+====
 
 . On a command line, run the playbooks you created:
 +


### PR DESCRIPTION
New `collapsible.js` file that allows writers to collapse content by adding `[%collapsible]` in asciidoctor.

The initial feature is applied to the ARM templates in the `installing/installing_azure/installing-azure-user-infra.adoc` assembly.