### PR TITLE
OSDOCS 1504 - Update adding dedicated admin "check" to use a new command

### DIFF
--- a/modules/moa-create-dedicated-cluster-admins.adoc
+++ b/modules/moa-create-dedicated-cluster-admins.adoc
@@ -5,10 +5,13 @@
 
 [id="moa-create-dedicated-cluster-admins.adoc"]
 = Creating dedicated-admins and cluster-admins
+As the user that created the cluster, add the `cluster-admin` user role to your account to have the maximum administrator privileges. You can create additional `cluster-admin` or `dedicated-admin` users. `dedicated-admin` users have fewer privileges.
 
 .Prerequisites
 
-You have added an Identity Provider (IDP) to your cluster.
+* You have added an Identity Provider (IDP) to your cluster.
+* You have the IDP user name for the user you are creating.
+* You are logged in to the cluster.
 
 .Procedure
 
@@ -17,55 +20,48 @@ You have added an Identity Provider (IDP) to your cluster.
 +
 [source,terminal]
 ----
-$ moactl create user --cluster rh-moa-test-cluster1 --dedicated-admins=rh-moa-test-user
+$ rosa create user --cluster <cluster_name> --dedicated-admins=<idp_user_name>
 ----
 +
-.. Enter the following command to verify that your user now has `dedicated-admin` access. As a `dedicated-admin` you should receive some errors when entering the following command:
+.. Enter the following command to verify that your user now has `dedicated-admin` access. As a `dedicated-admin` you should see output similar to the example output when entering the following command:
 +
 [source,terminal]
 ----
-$ oc get all -n openshift-apiserver
+$ oc get groups dedicated-admins
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME                  READY   STATUS    RESTARTS   AGE
-pod/apiserver-6ndg2   1/1     Running   0          17h
-pod/apiserver-lrmxs   1/1     Running   0          17h
-pod/apiserver-tsqhz   1/1     Running   0          17h
-NAME          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
-service/api   ClusterIP   172.30.23.241   <none>        443/TCP   17h
-NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
-daemonset.apps/apiserver   3         3         3       3            3           node-role.kubernetes.io/master=   17h
-Error from server (Forbidden): horizontalpodautoscalers.autoscaling is forbidden: User "rh-moa-test-user" cannot list resource "horizontalpodautoscalers" in API group "autoscaling" in the namespace 
-"openshift-apiserver"
-Error from server (Forbidden): jobs.batch is forbidden: User "rh-moa-test-user" cannot list resource "jobs" in API group "batch" in the namespace "openshift-apiserver"
-Error from server (Forbidden): cronjobs.batch is forbidden: User "rh-moa-test-user" cannot list resource "cronjobs" in API group "batch" in the namespace "openshift-apiserver"
-Error from server (Forbidden): imagestreams.image.openshift.io is forbidden: User "rh-moa-test-user" cannot list resource "imagestreams" in API group "image.openshift.io" in the namespace "openshift
--apiserver"
+NAME               USERS
+dedicated-admins   rh-moa-test-user
 ----
++
+[NOTE]
+====
+A Forbidden error displays if user without `dedicated-admin` privileges runs this command.
+====
 +
 . Create a `cluster-admin` user.
 .. Enable `cluster-admin` capability on the cluster:
 +
 [source,terminal]
 ----
-$ moactl edit cluster rh-moa-test-cluster1 --enable-cluster-admins
+$ rosa edit cluster <cluster_name> --enable-cluster-admins
 ----
 +
 .. Give your user `cluster-admin` privileges:
 +
 [source,terminal]
 ----
-$ moactl create user --cluster rh-moa-test-cluster1 --cluster-admins rh-moa-test-user
+$ rosa create user --cluster <cluster_name> --cluster-admins <idp_user_name>
 ----
 +
 .. Verify your user is listed as a `cluster-admin`:
 +
 [source,terminal]
 ----
-$ moactl list users --cluster rh-moa-test-cluster1
+$ rosa list users --cluster <cluster_name>
 ----
 +
 .Example output
@@ -80,7 +76,7 @@ dedicated-admins  rh-moa-test-user
 +
 [source,terminal]
 ----
-$ oc get all -n openshift-apiserver                       
+$ oc get all -n openshift-apiserver
 ----
 +
 .Example output


### PR DESCRIPTION
For Service Delivery/MOA:

https://issues.redhat.com/browse/OSDOCS-1504

Replaced command and output for step 1B as verification under Creating a Dedicated Admin section.

Please peer review and merge to MOA docs (enterprise 4.5)