### PR TITLE
RN-CNV-7168 Prevent incorrect use of DataVolume in VM spec 

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -67,6 +67,10 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 * The Containerized Data Importer (CDI) can now import containerDisk storage volumes from the container image registry at a faster speed and allocate storage capacity more efficiently. CDI can pull a containerDisk image from the registry in about the same amount of time as it would take to import from an HTTP endpoint. You can import the disk into a PersistentVolumeClaim (PVC) equal in size to the disk image to use the underlying storage more efficiently.
 
 //CNV-7168 - DataVolume and storage diagnostics
+* It is now easier to diagnose and troubleshoot issues when preparing virtual machine (VM) disks that are managed by DataVolumes:
++
+** For asynchronous image upload, if the virtual size of the disk image is larger than the size of the target DataVolume, an error message is returned before the connection is closed.
+** You can use the `oc describe dv` command to monitor changes in the PersistentVolumeClaim (PVC) `Bound` conditions or transfer failures. If the value of the `Status:Phase` field is `Succeeded`, then the DataVolume is ready to be used.
 
 //CNV-6824 - Offline virtual machine snapshots
 * You can create, restore, and delete virtual machine (VM) snapshots in the CLI for VMs that are powered off (offline). {VirtProductName} supports


### PR DESCRIPTION
Storage-related release note for 2.5: https://issues.redhat.com/browse/CNV-7168