### PR TITLE
BZ1879469 - Add Manila SC note

### DIFF
--- a/modules/persistent-storage-csi-manila-dynamic-provisioning.adoc
+++ b/modules/persistent-storage-csi-manila-dynamic-provisioning.adoc
@@ -5,15 +5,20 @@
 [id="persistent-storage-csi-manila-dynamic-provisioning_{context}"]
 = Dynamically provisioning Manila CSI volumes
 
-{product-title} installs a StorageClass for each available Manila share type.
+{product-title} installs a storage class for each available Manila share type.
 
-The YAML files that are created are completely decoupled from Manila and from its Container Storage Interface (CSI) plug-in. As an application developer, you can dynamically provision ReadWriteMany (RWX) storage and deploy Pods with applications that safely consume the storage using YAML manifests. You can also provision other access modes, such as ReadWriteOnce (RWO).
+The YAML files that are created are completely decoupled from Manila and from its Container Storage Interface (CSI) plug-in. As an application developer, you can dynamically provision ReadWriteMany (RWX) storage and deploy pods with applications that safely consume the storage using YAML manifests.
 
-You can use the same Pod and persistent volume claim (PVC) definitions on-premise that you use with {product-title} on AWS, GCP, Azure, and other platforms, with the exception of the storage class reference in the PVC definition.
+You can use the same pod and persistent volume claim (PVC) definitions on-premise that you use with {product-title} on AWS, GCP, Azure, and other platforms, with the exception of the storage class reference in the PVC definition.
+
+[NOTE]
+====
+Manila service is optional. If the service is not enabled in {rh-openstack-first}, the Manila CSI driver is not installed and the storage classes for Manila are not created.
+====
 
 .Prerequisites
 
-* {rh-openstack-first} is deployed with appropriate Manila share infrastructure so that it can be used to dynamically provision and mount volumes in {product-title}.
+* {rh-openstack} is deployed with appropriate Manila share infrastructure so that it can be used to dynamically provision and mount volumes in {product-title}.
 
 .Procedure (UI)
 
@@ -25,7 +30,7 @@ To dynamically create a Manila CSI volume using the web console:
 
 . Define the required options on the resulting page.
 
-.. Select the appropriate StorageClass.
+.. Select the appropriate storage class.
 
 .. Enter a unique name for the storage claim.
 
@@ -33,9 +38,7 @@ To dynamically create a Manila CSI volume using the web console:
 +
 [IMPORTANT]
 ====
-* Use RWX if you want the persistent volume (PV) that fulfills this PVC to be mounted to multiple Pods on multiple nodes in the cluster.
-
-* Use RWO mode if you want to prevent additional Pods from being dynamically provisioned.
+Use RWX if you want the persistent volume (PV) that fulfills this PVC to be mounted to multiple pods on multiple nodes in the cluster.
 ====
 
 . Define the size of the storage claim.
@@ -65,8 +68,8 @@ spec:
   storageClassName: csi-manila-gold <2>
 ----
 +
-<1> Use RWX if you want the persistent volume (PV) that fulfills this PVC to be mounted to multiple Pods on multiple nodes in the cluster. Use ReadWriteOnce (RWO) mode to prevent additional Pods from being dynamically provisioned.
-<2> The name of the storage class that provisions the storage back end. Manila StorageClasses are provisioned by the Operator and have the `csi-manila-` prefix.
+<1> Use RWX if you want the persistent volume (PV) that fulfills this PVC to be mounted to multiple pods on multiple nodes in the cluster.
+<2> The name of the storage class that provisions the storage back end. Manila storage classes are provisioned by the Operator and have the `csi-manila-` prefix.
 +
 . Create the object you saved in the previous step by running the following command:
 +
@@ -86,4 +89,4 @@ $ oc get pvc pvc-manila
 +
 The `pvc-manila` shows that it is `Bound`.
 
-You can now use the new PVC to configure a Pod.
+You can now use the new PVC to configure a pod.


### PR DESCRIPTION
[BZ1879469](https://bugzilla.redhat.com/show_bug.cgi?id=1879469) - adds note that Manila service is optional, and that a storage class is not created if it is not enabled.

Also, fixes spelling conventions to align with our new terminology formatting (Pod -> pod, StorageClass -> storage class).