### PR TITLE
CCXDEV-3330: Updated "About the Insights Operator" and "Information collected by the Insights Operator"

### DIFF
--- a/modules/insights-operator-about.adoc
+++ b/modules/insights-operator-about.adoc
@@ -5,10 +5,17 @@
 [id="insights-operator-about_{context}"]
 = About the Insights Operator
 
-The Insights Operator periodically gathers anonymized configuration and component failure status and reports that to Red Hat. This is a subset of the information captured by the `must-gather` tool and allows Red Hat to assess important configuration and deeper failure data than is reported via Telemetry. This data is sent several times a day and describes:
+The Insights Operator periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red Hat. This information enables Red Hat to assess configuration and deeper failure data than is reported through Telemetry.
 
-* Important configuration information about the environment that the cluster runs in
-* Details about the state of the cluster and its major components
-* Debugging information about infrastructure Pods or nodes that are reporting failures
+Users of {product-title} can display the report of each cluster in {cloud-redhat-com}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
 
-This debugging information is available to Red Hat Support and engineering teams with the same restrictions as accessing data reported via support cases. All connected cluster information is used by Red Hat to help make {product-title} better and more intuitive to use. None of the information is shared with third parties.
+The Insights Operator does not collect identifying information, such as user names, passwords, or certificates. However, to provide specific remediation steps, the Insights Operator does not anonymize certain information internal to the cluster, such as IP addresses and host names of nodes.
+
+Red Hat uses all connected cluster information to:
+
+* Proactively identify potential cluster issues and provide a solution and preventive actions in {cloud-redhat-com}
+* Improve {product-title}
+* Make {product-title} more intuitive
+
+The information the Insights Operator sends is available only to Red Hat Support and engineering teams with the same restrictions as accessing data reported in support cases. Red Hat does not share this information with third parties.
+

--- a/modules/insights-operator-what-information-is-collected.adoc
+++ b/modules/insights-operator-what-information-is-collected.adoc
@@ -5,21 +5,12 @@
 [id="insights-operator-what-information-is-collected_{context}"]
 = Information collected by the Insights Operator
 
-Primary information collected by the Insights Operator includes:
+The Insights Operator collects:
 
-* The version of the cluster and its components, as well as the unique cluster identifier
-* Channel and image repository used for an update
-* Details about errors that have occurred in the cluster components
-* Progress and health information of running updates and the status of any component upgrades
-* Anonymized details about the cluster configuration that is relevant to Red Hat Support
-* Details about any Technology Preview or unsupported configurations that might impact Red Hat Support
+* General information about your cluster and its components to identify issues that are specific to your {product-title} version and environment
+* Configuration files, such as the image registry configuration, of your cluster to determine incorrect settings and issues that are specific to parameters you set
+* Error that occurred in the cluster components
+* Progress and health information of running updates, and the status of any component upgrades
 * Details of the platform that {product-title} is deployed on, such as Amazon Web Services, and the region that the cluster is located in
-* Information about Pods of degraded {product-title} cluster Operators
-* Information about nodes marked as `NotReady`
-* Events for all name spaces listed as "related objects" for Degraded operator
-* Anonymized certificate signing requests (CSR) and information about the validity of certificates
-* Configuration settings stored in `ConfigMap` objects in the `openshift-config` name space
-* The image pruner configuration, as well as how often {product-title} prunes images and the status of pruning jobs.
-* The image registry configuration, such as where {product-title} stores images.
+* Information about infrastructure Pods
 
-The Insights Operator does not collect identifying information such as user names, passwords, certificates, or the names or addresses of user resources.


### PR DESCRIPTION
With this update, two Insights Operator modules have been rewritten. The list of collected data is now more general because the previous one was too detailed, missing several information, and it was also hard to maintain, because had to be updated frequently to be up-to-date. It's planned that changes in what is collected are announced in release notes in future.

@openshift/team-documentation Please include this change in master, 4.6, and 4.5. Thanks.