### PR TITLE
Bug 1889945: [DOCS] provide the prerequisite to enable ImageStream through mirror registry for must-gather IS

### DIFF
--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -150,5 +150,6 @@ include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -138,5 +138,6 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -106,5 +106,6 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -98,3 +98,4 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 .Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -99,3 +99,4 @@ include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffs
 .Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -47,6 +47,7 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 .Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * Learn how to xref:../../operators/admin/olm-restricted-networks.html#olm-understanding-operator-catalog-images_olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -90,5 +90,6 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/modules/support-gather-data.adoc
+++ b/modules/support-gather-data.adoc
@@ -31,7 +31,7 @@ If this command fails, for example if you cannot schedule a Pod on your cluster,
 +
 [NOTE]
 ====
-If your cluster is using a restricted network you must import the default must-gather image before running the `oc adm must-gather` command.
+If your cluster is using a restricted network, you must take additional steps. If your mirror registry has a trusted CA, you must first add the trusted CA to the cluster. For all clusters on restricted networks, you must import the default `must-gather` image as an `ImageStream` before you use the `oc adm must-gather` command.
 
 [source,terminal]
 ----


### PR DESCRIPTION
* Version: ocp v4.5+
* Description:
  If the mirror registry is configured with trusted CA, it needs to add it to the image CA bundle in order to use the image through ImageStream. But it's not mentioned.
* Reference: [[DOCS] provide the prerequisite to enable ImageStream through mirror registry for must-gather IS](https://bugzilla.redhat.com/show_bug.cgi?id=1889945)