### PR TITLE
Fix incorrect instance of exiting

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -12,7 +12,7 @@ You can use the {product-title} CLI to install the Elasticsearch and Cluster Log
 * Ensure that you have the necessary persistent storage for Elasticsearch. Note that each Elasticsearch node
 requires its own storage volume.
 +
-Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, you should add more Elasticsearch nodes to your cluster rather than increasing the memory on exiting nodes.
+Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
 .Procedure
 

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -12,7 +12,7 @@ You can use the {product-title} web console to install the Elasticsearch and Clu
 * Ensure that you have the necessary persistent storage for Elasticsearch. Note that each Elasticsearch node
 requires its own storage volume.
 +
-Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, you should add more Elasticsearch nodes to your cluster rather than increasing the memory on exiting nodes.
+Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
 .Procedure
 


### PR DESCRIPTION
", you should add more Elasticsearch nodes to your cluster rather than increasing the memory on exiting nodes."
"exiting" word should be "existing"

https://bugzilla.redhat.com/show_bug.cgi?id=1885660#c4