### PR TITLE
Add watch note to OperatorHub files

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -3,6 +3,9 @@
 // * operators/user/olm-installing-operators-in-namespace.adoc
 // * operators/admin/olm-adding-operators-to-cluster.adoc
 // * post_installation_configuration/preparing-for-users.adoc
+//
+// Module watched for changes by Ecosystem Catalog team:
+// https://projects.engineering.redhat.com/projects/RHEC/summary
 
 ifeval::["{context}" == "olm-installing-operators-in-namespace"]
 :olm-user:

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -3,6 +3,9 @@
 // * operators/user/olm-installing-operators-in-namespace.adoc
 // * operators/admin/olm-adding-operators-to-cluster.adoc
 // * post_installation_configuration/preparing-for-users.adoc
+//
+// Module watched for changes by Ecosystem Catalog team:
+// https://projects.engineering.redhat.com/projects/RHEC/summary
 
 // Add additional ifevals here, but before context == olm-adding-operators-to-a-cluster
 ifeval::["{context}" != "olm-adding-operators-to-a-cluster"]

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -3,6 +3,9 @@
 // * operators/user/olm-installing-operators-in-namespace.adoc
 // * operators/admin/olm-adding-operators-to-cluster.adoc
 // * post_installation_configuration/preparing-for-users.adoc
+//
+// Module watched for changes by Ecosystem Catalog team:
+// https://projects.engineering.redhat.com/projects/RHEC/summary
 
 ifeval::["{context}" == "olm-installing-operators-in-namespace"]
 :olm-user:

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -3,6 +3,9 @@
 include::modules/common-attributes.adoc[]
 :context: olm-adding-operators-to-a-cluster
 
+// Assembly and included modules watched for changes by Ecosystem Catalog team:
+// https://projects.engineering.redhat.com/projects/RHEC/summary
+
 toc::[]
 
 This guide walks cluster administrators through installing Operators to an


### PR DESCRIPTION
E.g., content being watched for use in https://catalog.redhat.com/software/operators/detail/5ec534ee110f56bd24f2ddbf/deploy