### PR TITLE
Add collapsible content guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -820,6 +820,70 @@ Note the following:
 * To match the table cell's font size, start the ordered list with a `[.small]`
 style and wrap it in a `--` block.
 
+=== Collapsible content
+You can collapse sections of content by using the `collapsible` option, which converts the Asciidoctor markup to HTML `details` and `summary` sections. The `collapsible` option is used at the writer's discretion and is appropriate for considerably long code blocks, lists, or other such content that significantly increases the length of a module or assembly.
+
+[NOTE]
+====
+You must set a title for the `details` section. If a title is not set, the default title is "Details."
+====
+
+Collapsible content is formatted as shown:
+
+....
+.Title of the `details` dropdown
+[%collapsible]
+====
+This is content within the `summary` section.
+====
+....
+
+This renders as a dropdown with collapsed content:
+
+.Title of the `details` dropdown
+[%collapsible]
+====
+This is content within the `summary` section.
+====
+
+If your collapsible content includes an admonition such as a note or warning, the admonition must be nested:
+
+....
+.Collapsible content that includes an admonition
+[%collapsible]
+====
+This content includes an admonition.
+
+[source,terminal]
+----
+$ oc whoami
+----
+
+[NOTE]
+=====
+Nest admonitions when using the `collapsible` option.
+=====
+====
+....
+
+This renders as:
+
+.Collapsible content that includes an admonition
+[%collapsible]
+====
+This content includes an admonition.
+
+[source,terminal]
+----
+$ oc whoami
+----
+
+[NOTE]
+=====
+Nest admonitions when using the `collapsible` option.
+=====
+====
+
 === Quick reference
 
 .User accounts and info


### PR DESCRIPTION
Adding guidelines on how to use the `collapsible` option. This option is available in the 4.6 documentation.