### PR TITLE
Update collapsible option guidelines to switch details and summary wording

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -825,25 +825,25 @@ You can collapse sections of content by using the `collapsible` option, which co
 
 [NOTE]
 ====
-You must set a title for the `details` section. If a title is not set, the default title is "Details."
+You must set a title for the `summary` section. If a title is not set, the default title is "Details."
 ====
 
 Collapsible content is formatted as shown:
 
 ....
-.Title of the `details` dropdown
+.Title of the `summary` dropdown
 [%collapsible]
 ====
-This is content within the `summary` section.
+This is content within the `details` section.
 ====
 ....
 
 This renders as a dropdown with collapsed content:
 
-.Title of the `details` dropdown
+.Title of the `summary` dropdown
 [%collapsible]
 ====
-This is content within the `summary` section.
+This is content within the `details` section.
 ====
 
 If your collapsible content includes an admonition such as a note or warning, the admonition must be nested:


### PR DESCRIPTION
I mixed up the `summary` and `details` section. Updating the guidelines to switch the wording around.