### PR TITLE
Updating css for collapsible dropdown arrow in Firefox

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -180,6 +180,55 @@ span.clipboard-button:hover {
 }
 /* End ClipboardJS edits */
 
+/* Collapsible content */
+details {
+  width: 100%;
+  margin-bottom: 10px;
+}
+ details > summary {
+  font-size: 0.92em;
+  padding: 4px 6px;
+  background-color: #f9f9f9;
+  border: none;
+  box-shadow: 2px 2px 2px #8a8a8a;
+  cursor: pointer;
+  margin-top: 0.8em;
+  display: list-item;
+}
+ details > div {
+  border-radius: 0 0 5px 5px;
+  background-color: #f9f9f9;
+  padding: 4px 6px;
+  margin: 0.5em 0.7em;
+  box-shadow: 2px 2px 2px #8a8a8a;
+}
+#collapsibleButtonDiv {
+  position: relative;
+  width: 100%;
+  padding: 1em 0em;
+  font-size: .92em;
+}
+button[name="button-collapse-expand-all"] {
+  position: absolute;
+  right: 100px;
+  bottom: 0px;
+  margin-right: 10px;
+  z-index: 1;
+}
+.span-collapse-expand-all {
+  display:inline-block;
+  width: 100px;
+  position: absolute;
+  right: 0px;
+  bottom: 0px;
+  text-align: justify;
+  z-index: 1;
+}
+.span-collapse-expand-all:hover {
+  cursor: pointer;
+}
+/* END Collapsible content */
+
 .fa-inverse:hover {
   color: #ccc;
 }
@@ -512,53 +561,6 @@ table > tbody > tr > td > div > div > p > code {
      line-height: 1.6;
      color: #6e6e6e;
 }
-/* Collapsible content */
-details {
-  width: 100%;
-  margin-bottom: 10px;
-}
- details > summary {
-  font-size: 0.92em;
-  padding: 4px 6px;
-  background-color: #f9f9f9;
-  border: none;
-  box-shadow: 2px 2px 2px #8a8a8a;
-  cursor: pointer;
-  margin-top: 0.8em;
-}
- details > div {
-  border-radius: 0 0 5px 5px;
-  background-color: #f9f9f9;
-  padding: 4px 6px;
-  margin: 0.5em 0.7em;
-  box-shadow: 2px 2px 2px #8a8a8a;
-}
-#collapsibleButtonDiv {
-  position: relative;
-  width: 100%;
-  padding: 1em 0em;
-  font-size: .92em;
-}
-button[name="button-collapse-expand-all"] {
-  position: absolute;
-  right: 100px;
-  bottom: 0px;
-  margin-right: 10px;
-  z-index: 1;
-}
-.span-collapse-expand-all {
-  display:inline-block;
-  width: 100px;
-  position: absolute;
-  right: 0px;
-  bottom: 0px;
-  text-align: justify;
-  z-index: 1;
-}
-.span-collapse-expand-all:hover {
-  cursor: pointer;
-}
-/* END Collapsible content */
  @media only screen and (min-width: 768px) {
      #toctitle, .sidebarblock > .content > .title {
          line-height: 1.4;


### PR DESCRIPTION
Moved the Collapsible content CSS section in master to match the 4.1 docs.css file. Added `display: list-item` to the `details > summary` so that the toggle arrow shows up in Firefox for the collapsible content dropdown.