### PR TITLE
GH#16954 - Add examples for route allow list

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -27,7 +27,8 @@ and "-". The default is the hashed internal key name for the route. |
 |`haproxy.router.openshift.io/rate-limit-connections.rate-tcp`| Limits the rate at which an IP address can make TCP connections. |
 |`haproxy.router.openshift.io/timeout` | Sets a server-side timeout for the route. (TimeUnits) | `ROUTER_DEFAULT_SERVER_TIMEOUT`
 |`router.openshift.io/haproxy.health.check.interval`| Sets the interval for the back-end health checks. (TimeUnits) | `ROUTER_BACKEND_CHECK_INTERVAL`
-|`haproxy.router.openshift.io/ip_whitelist` | Sets a whitelist for the route. |
+|`haproxy.router.openshift.io/ip_whitelist`
+| Sets a whitelist for the route. The whitelist is a space-separated list of IP addresses and CIDR ranges for the approved source addresses. Requests from IP addresses that are not in the whitelist are dropped. |
 |`haproxy.router.openshift.io/hsts_header` | Sets a Strict-Transport-Security header for the edge terminated or re-encrypt route. |
 |`haproxy.router.openshift.io/log-send-hostname` | Sets the `hostname` field in the Syslog header. Uses the host name of the system. `log-send-hostname` is enabled by default if any Ingress API logging method, such as sidecar or Syslog facility, is enabled for the router. |
 |`haproxy.router.openshift.io/rewrite-target` | Sets the rewrite path of the request on the backend. |
@@ -35,7 +36,7 @@ and "-". The default is the hashed internal key name for the route. |
 
 [NOTE]
 ====
-Environment variables can not be edited.
+Environment variables cannot be edited.
 ====
 
 .A route setting custom timeout
@@ -56,6 +57,37 @@ Setting a server-side timeout value for passthrough routes too low can cause
 WebSocket connections to timeout frequently on that route.
 ====
 
+.A route that allows only one specific IP address
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/ip_whitelist: 192.168.1.10
+----
+
+.A route that allows several IP addresses
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/ip_whitelist: 192.168.1.10 192.168.1.11 192.168.1.12
+----
+
+.A route that allows an IP address CIDR network
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/ip_whitelist: 192.168.1.0/24
+----
+
+.A route that allows both IP an address and IP address CIDR networks
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/ip_whitelist: 180.5.61.153 192.168.1.0/24 10.0.0.0/8
+----
 
 .A route specifying a rewrite target
 [source,yaml]


### PR DESCRIPTION
Pull this forward from OCP 3.11:

- https://github.com/openshift/openshift-docs/issues/16954

Preview: https://gh-16954--ocpdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration