### PR TITLE
Missing '.<lf>'.

### DIFF
--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -23,6 +23,7 @@ include::modules/rhel-removing-rhcos.adoc[leveloffset=+2]
 == Deploying MachineHealthChecks
 
 Understand and deploy MachineHealthChecks.
+
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+2]
 include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 include::modules/machine-health-checks-resource.adoc[leveloffset=+2]

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -22,7 +22,7 @@ include::modules/rhel-removing-rhcos.adoc[leveloffset=+2]
 [id="post-installation-config-deploying-machine-health-checks"]
 == Deploying MachineHealthChecks
 
-Understand and deploy MachineHealthChecks
+Understand and deploy MachineHealthChecks.
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+2]
 include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 include::modules/machine-health-checks-resource.adoc[leveloffset=+2]


### PR DESCRIPTION
I'm not familiar with adoc. Looks like text need to be separated from 'include' statement.
It produces 'Understand and deploy MachineHealthChecks :leveloffset: +2' in HTML currently.