### PR TITLE
Update user workload monitoring example output

### DIFF
--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -72,8 +72,8 @@ $ oc -n openshift-user-workload-monitoring get pod
 ----
 NAME                                   READY   STATUS        RESTARTS   AGE
 prometheus-operator-6f7b748d5b-t7nbg   2/2     Running       0          3h
-prometheus-user-workload-0             5/5     Running       1          3h
-prometheus-user-workload-1             5/5     Running       1          3h
+prometheus-user-workload-0             4/4     Running       1          3h
+prometheus-user-workload-1             4/4     Running       1          3h
 thanos-ruler-user-workload-0           3/3     Running       0          3h
 thanos-ruler-user-workload-1           3/3     Running       0          3h
 ----


### PR DESCRIPTION
Changes the number of `ready` containers from `5/5` to `4/4` in the expected output of the `oc -n openshift-user-workload-monitoring get pod` command

Fixes #26639