### PR TITLE
Reorganizing node selector topic

### DIFF
--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -2,48 +2,225 @@
 //
 // * nodes/nodes-scheduler-node-selector.adoc
 
-[id="nodes-scheduler-node-selector-about_{context}"]
-= Understanding node selectors
+[id="nodes-scheduler-node-selectors-about_{context}"]
+= About node selectors
 
-Using _node selectors_, you can ensure that pods are only placed onto nodes with specific labels. As a cluster administrator, you can
-use the Pod Node Constraints admission controller to set a policy that prevents users without the `pods/binding` permission 
-from using node selectors to schedule pods.
+You can use node selectors on pods and labels on nodes to control where the pod is scheduled. With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
-The `nodeSelectorLabelBlacklist` admission controller field gives you control over the labels that certain roles can specify in a pod configuration's
-`nodeSelector` field. Users, service accounts, and groups that have the
-`pods/binding` permission role can specify any node selector. Those without the
-`pods/binding` permission are prohibited from setting a `nodeSelector` for any
-label that appears in `nodeSelectorLabelBlacklist`.
+You can use a node selector to place specific pods on specific nodes, cluster-wide node selectors to place new pods on specific nodes anywhere in the cluster, and project node selectors to place new pods in a project on specific nodes.
 
-For example, an {product-title} cluster might consist of five data
-centers spread across two regions. In the U.S., `us-east`, `us-central`, and
-`us-west`; and in the Asia-Pacific region (APAC), `apac-east` and `apac-west`.
-Each node in each geographical region is labeled accordingly. For example,
-`region: us-east`.
+For example, as a cluster administrator, you can create an infrastructure where application developers can deploy pods only onto the nodes closest to their geographical location by including a node selector in every pod they create. In this example, the cluster consists of five data centers spread across two regions. In the U.S., label the nodes as `us-east`, `us-central`, or `us-west`. In the Asia-Pacific region (APAC), label the nodes as `apac-east` or `apac-west`. The developers can add a node selector to the pods they create to ensure the pods get scheduled on those nodes.
 
+A pod is not scheduled if the `Pod` object contains a node selector, but no node has a matching label. 
+
+[IMPORTANT]
+====
+If you are using node selectors and node affinity in the same pod configuration, the following rules control pod placement onto nodes:
+
+* If you configure both `nodeSelector` and `nodeAffinity`, both conditions must be satisfied for the pod to be scheduled onto a candidate node.
+
+* If you specify multiple `nodeSelectorTerms` associated with `nodeAffinity` types, then the pod can be scheduled onto a node if one of the `nodeSelectorTerms` is satisfied.
+
+* If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node only if all `matchExpressions` are satisfied.
+====
+
+Node selectors on specific pods and nodes::
++
+You can control which node a specific pod is scheduled on by using node selectors and labels.
++
+To use node selectors and labels, first label the node to avoid pods being descheduled, then add the node selector to the pod.
++
 [NOTE]
 ====
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-See Updating Labels on Nodes for details on assigning labels.
-endif::openshift-enterprise,openshift-webscale,openshift-origin[]
-ifdef::openshift-dedicated[]
-(request changes by opening a support case on the
-https://access.redhat.com/support/[Red Hat Customer Portal])
-endif::openshift-dedicated[]
+You cannot add a node selector directly to an existing scheduled pod. You must label the object that controls the pod, such as deployment config.
+====
++
+For example, the following `Node` object has the `region: east` label: 
++
+.Sample `Node` object with a label
+[source,yaml]
+----
+kind: Node
+apiVersion: v1
+metadata:
+  name: ip-10-0-131-14.ec2.internal
+  selfLink: /api/v1/nodes/ip-10-0-131-14.ec2.internal
+  uid: 7bc2580a-8b8e-11e9-8e01-021ab4174c74
+  resourceVersion: '478704'
+  creationTimestamp: '2019-06-10T14:46:08Z'
+  labels:
+    beta.kubernetes.io/os: linux
+    failure-domain.beta.kubernetes.io/zone: us-east-1a
+    node.openshift.io/os_version: '4.5'
+    node-role.kubernetes.io/worker: ''
+    failure-domain.beta.kubernetes.io/region: us-east-1
+    node.openshift.io/os_id: rhcos
+    beta.kubernetes.io/instance-type: m4.large
+    kubernetes.io/hostname: ip-10-0-131-14
+    beta.kubernetes.io/arch: amd64
+    region: east <1>
+----
+<1> Label to match the pod node selector.
++
+A pod has the `type: user-node,region: east` node selector:
++
+.Sample `Pod` object with node selectors
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+
+....
+
+spec:
+  nodeSelector: <1>
+    region: east
+    type: user-node
+----
+<1> Node selectors to match the node label.
++
+When you create the pod using the example pod spec, it can be scheduled on the example node.
+
+Default cluster-wide node selectors::
++
+With default cluster-wide node selectors, when you create a pod in that cluster, {product-title} adds the default node selectors to the pod and schedules
+the pod on nodes with matching labels. 
++
+For example, the following `Scheduler` object has the default cluster-wide `region=east` and `type=user-node` node selectors:
++
+.Example Scheduler Operator Custom Resource
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+...
+
+spec:
+  defaultNodeSelector: type=user-node,region=east
+...
+
+----
++
+A node in that cluster has the `type=user-node,region=east` labels:
++
+.Example `Node` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Node
+metadata:
+  name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
+...
+  labels:
+    region: east
+    type: user-node
+...
+
+---- 
++
+.Example `Pod` object with a node selector
+[source,terminal]
+----
+apiVersion: v1
+kind: Pod
+...
+
+spec:
+  nodeSelector:
+    region: east
+...
+
+----
++
+When you create the pod using the example pod spec in the example cluster, the pod is created with the cluster-wide node selector and is scheduled on the labeled node:
++
+[source,terminal]
+.Example pod list with the pod on the labeled node
+----
+NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
+pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
+----
++
+[NOTE]
+====
+If the project where you create the pod has a project node selector, that selector takes preference over a cluster-wide node selector. Your pod is not created or scheduled if the pod does not have the project node selector.
 ====
 
-As a cluster administrator, you can create an infrastructure where application
-developers should be deploying pods only onto the nodes closest to their
-geographical location. You can create a node selector, grouping the U.S. data centers into `superregion: us` and the APAC
-data centers into `superregion: apac`.
+Project node selectors::
++
+With project node selectors, when you create a pod in this project, {product-title} adds the node selectors to the pod and schedules the pods on a node with matching labels. If there is a cluster-wide default node selector, a project node selector takes preference.
++
+For example, the following project has the `region=east` node selector:
++
+.Example `Namespace` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: east-region
+  annotations:
+    openshift.io/node-selector: "region=east"
+...
 
-To maintain an even loading of resources per data center, you can add the
-desired `region` to the `nodeSelectorLabelBlacklist` section of a master
-configuration. Then, whenever a developer located in the U.S. creates a pod, it
-is deployed onto a node in one of the regions with the `superregion: us` label.
-If the developer tries to target a specific region for their pod (for example,
-`region: us-east`), they receive an error. If they try again, without the
-node selector on their pod, it can still be deployed onto the region they tried
-to target, because `superregion: us` is set as the project-level node selector,
-and nodes labeled `region: us-east` are also labeled `superregion: us`.
+----
++
+The following node has the `type=user-node,region=east` labels:
++
+.Example `Node` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Node
+metadata:
+  name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
+...
+  labels:
+    region: east
+    type: user-node
+...
+
+---- 
++
+When you create the pod using the example pod spec in this example project, the pod is created with the project node selectors and is scheduled on the labeled node:
++
+.Example Pod object
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: east-region
+...
+spec:
+  nodeSelector:
+    region: east
+    type: user-node
+...
+----
++
+[source,terminal]
+.Example pod list with the pod on the labeled node
+----
+NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
+pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
+----
++
+A pod in the project is not created or scheduled if the pod contains different node selectors. For example, if you deploy the following pod into the example project, it is not be created:
++
+.Example Pod object with an invalid node selector
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+...
+
+spec:
+  nodeSelector:
+    region: west
+
+....
+----
 

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -8,113 +8,27 @@
 You can use default cluster-wide node selectors on pods together with labels on nodes to constrain all pods created in a cluster to specific nodes.
 
 With cluster-wide node selectors, when you create a pod in that cluster, {product-title} adds the default node selectors to the pod and schedules
-the pod on nodes with matching labels.
+the pod on nodes with matching labels. 
 
-You configure cluster-wide node selectors by creating a Scheduler Operator custom resource (CR). You add labels to a node by editing a `Node` object, a `MachineSet` object, or a `MachineConfig` object. Adding the label to the machine set  ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
-
-For example, the Scheduler configures the cluster-wide `region=east` node selector:
-
-.Example Scheduler Operator custom resource
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: Scheduler
-metadata:
-  name: cluster
-...
-
-spec:
-  defaultNodeSelector: type=user-node,region=east <1>
-...
-
-----
-
-A node in that cluster has the `type=user-node,region=east` labels:
-
-.Example node object
-[source,yaml]
-----
-apiVersion: v1
-kind: Node
-metadata:
-  name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
-...
-  labels:
-    region: east
-    type: user-node
-...
-
-----
-
-If you create a pod in that cluster, the pod is created with the cluster-wide node selector and is scheduled on the labeled node:
-
-.Example Pod object
-[source,terminal]
-----
-apiVersion: v1
-kind: Pod
-...
-
-spec:
-  nodeSelector:
-    region: east
-...
-
-----
-
-
-
-[source,terminal]
-.Example pod list with the pod on the labeled node
-----
-NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
-pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
-----
+You configure cluster-wide node selectors by editing the Scheduler Operator custom resource (CR). You add labels to a node, a machine set, or a machine config. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
 
 [NOTE]
 ====
-If the project where you create the pod has a project node selector, that selector takes preference over a cluster-wide node selector. Your pod is not created or scheduled if the node selector in the `Pod` spec does not use the project node selector.
-====
-
-A pod is not created or scheduled if the `Pod` object contains a node selector that is not the cluster-wide node selector or not a project node selector. For example, if you deploy the following pod into the example project, it will not be created:
-
-.Example pod output with an invalid node selector
-[source,terminal]
-----
-apiVersion: v1
-kind: Pod
-....
-
-spec:
-  nodeSelector:
-    region: west
-----
-
-When you create a pod from that spec, you receive an error similar to the following message:
-
-.Example error message
-[source,terminal]
-----
-Error from server (Forbidden): error when creating "pod.yaml": pods "pod-4" is forbidden: pod node label selector conflicts with its project node label selector
-----
-
-[NOTE]
-====
-You can add additional key-value pairs to a pod. But you cannot add a different value for a default project key.
+You can add additional key/value pairs to a pod. But you cannot add a different value for a default key.
 ====
 
 .Procedure
 
-To add a default cluster-wide node selector:
+To add a default cluster-wide node selector: 
 
-. Edit the Scheduler Operator custom resource to add the cluster node selectors:
+. Edit the Scheduler Operator CR to add the default cluster-wide node selectors:
 +
 [source,terminal]
 ----
 $ oc edit scheduler cluster
 ----
 +
-.Example output
+.Example Scheduler Operator CR with a node selector
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -131,11 +45,11 @@ spec:
 ----
 <1> Add a node selector with the appropriate `<key>:<value>` pairs.
 +
-After making this change, wait for the pods in the `openshift-kube-apiserver` project to redeploy. This can take several minutes. The default cluster node selector does not take effect until the pods redeploy.
+After making this change, wait for the pods in the `openshift-kube-apiserver` project to redeploy. This can take several minutes. The default cluster-wide node selector does not take effect until the pods redeploy.
 
 . Add labels to a node by using a machine set or editing the node directly:
 
-* Use a `MachineSet` object to add labels to nodes managed by the machine set when a node is created:
+* Use a machine set to add labels to nodes managed by the machine set when a node is created:
 
 .. Run the following command to add labels to a `MachineSet` object:
 +
@@ -194,7 +108,7 @@ $ oc scale --replicas=0 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshi
 $ oc scale --replicas=1 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
 ----
 
-.. When the node is ready and available, verify that the label is added to the node by using the `oc get` command:
+.. When the nodes are ready and available, verify that the label is added to the nodes by using the `oc get` command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -5,17 +5,12 @@
 [id="nodes-scheduler-node-selectors-pod_{context}"]
 = Using node selectors to control pod placement
 
-You can use node selectors on pods to control where the pod is scheduled.
+You can use node selectors on pods and labels on nodes to control where the pod is scheduled. With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
-With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
+You add labels to a node, a machine set, or a machine config. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
 
 To add node selectors to an existing pod, add a node selector to the controlling object for that pod, such as a `ReplicaSet` object, `DaemonSet` object, `StatefulSet` object, `Deployment` object, or `DeploymentConfig` object.
 Any existing pods under that controlling object are recreated on a node with a matching label. If you are creating a new pod, you can add the node selector directly to the `Pod` spec.
-
-If you use cluster-wide node selectors, when you create a pod in that cluster, {product-title} adds the default node selectors to the pod and schedules the pod on nodes with labels that match the default node selectors and the pod node selectors.
-
-You can add labels to a node or machine config, but the labels will not persist if the node or machine goes down.
-Adding the label to the machine set ensures that new nodes or machines will have the label.
 
 [NOTE]
 ====
@@ -142,7 +137,7 @@ ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.18.3+002a51f
 +
 * To add a node selector to existing and future pods, add a node selector to the controlling object for the pods:
 +
-.Example `ReplicaSet` object
+.Example `ReplicaSet` object with labels
 [source,yaml]
 ----
 kind: ReplicaSet
@@ -167,25 +162,7 @@ spec:
 ----
 <1> Add the node selector.
 
-* To add a node selector to a specific pod, add the selector to the `Pod` object directly:
-+
-.Example `Pod` object
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-
-...
-
-spec:
-  nodeSelector:
-    <key>: <value>
-
-...
-
-----
-+
-For example:
+* To add a node selector to a specific, new pod, add the selector to the `Pod` object directly:
 +
 .Example `Pod` object with a node selector
 [source,yaml]
@@ -200,3 +177,8 @@ spec:
     region: east
     type: user-node
 ----
++
+[NOTE]
+====
+You cannot add a node selector directly to an existing scheduled pod.
+====

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -9,90 +9,20 @@ You can use node selectors in a project together with labels on nodes to constra
 
 When you create a pod in this project, {product-title} adds the node selectors to the pods in the project and schedules the pods on a node with matching labels in the project. If there is a cluster-wide default node selector, a project node selector takes preference.
 
-You add node selectors to a project by editing the `Namespace` object to add the `openshift.io/node-selector` parameter. You add labels to a node by editing the `Node` object, a `MachineSet` object, or a `MachineConfig` object. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
+You add node selectors to a project by editing the `Namespace` object to add the `openshift.io/node-selector` parameter. You add labels to a node, a machine set, or a machine config. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
 
-[NOTE]
-====
-You can add additional key-value pairs to a pod. But you cannot add a different value for a default project key.
-====
-
-For example, the following project has the `region=east` node selector:
-
-.Example `Namespace` object
-[source,yaml]
-----
-apiVersion: v1
-kind: Namespace
-metadata:
-  annotations:
-    openshift.io/node-selector: "region=east"
-...
-
-----
-
-The following node has the `type=user-node,region=east` labels:
-
-.Example `Node` object
-[source,yaml]
-----
-apiVersion: v1
-kind: Node
-metadata:
-  name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
-...
-  labels:
-    region: east
-    type: user-node
-...
-
-----
-
-If you create a pod in this example project, the pod is created with the project node selector and is scheduled on the labeled node:
-
-.Example `Pod` object
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-metadata:
-...
-spec:
-  nodeSelector:
-    region: east
-    type: user-node
-...
-----
-
-[source,terminal]
-.Example pod list with the pod on the labeled node
-----
-NAME     READY   STATUS    RESTARTS   AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
-pod-s1   1/1     Running   0          20s   10.131.2.6   ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4   <none>           <none>
-----
-
-A pod in the project is not created or scheduled if the pod contains different node selectors. For example, if you deploy the following pod into the example project, it will not be created:
-
-.Example `Pod` object with an invalid node selector
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-...
-
-spec:
-  nodeSelector:
-    region: west
-
-....
-----
-
-When you create the pod, you receive an error similar to the following message:
+A pod is not scheduled if the `Pod` object contains a node selector, but no project has a matching node selector. When you create a pod from that spec, you receive an error similar to the following message:
 
 .Example error message
 [source,terminal]
 ----
 Error from server (Forbidden): error when creating "pod.yaml": pods "pod-4" is forbidden: pod node label selector conflicts with its project node label selector
 ----
+
+[NOTE]
+====
+You can add additional key/value pairs to a pod. But you cannot add a different value for a project key.
+====
 
 .Procedure
 
@@ -191,7 +121,7 @@ $ oc scale --replicas=0 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshi
 $ oc scale --replicas=1 MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c -n openshift-machine-api
 ----
 
-.. Verify that the label is added to the `Node` object, when the node is ready and available, using the `oc get` command:
+.. When the nodes are ready and available, verify that the label is added to the nodes by using the `oc get` command:
 +
 [source,terminal]
 ----

--- a/nodes/scheduling/nodes-scheduler-node-selectors.adoc
+++ b/nodes/scheduling/nodes-scheduler-node-selectors.adoc
@@ -7,34 +7,23 @@ toc::[]
 
 
 
-A _node selector_ specifies a map of key-value pairs. The rules are defined using custom labels on nodes and selectors specified in pods.
-You can use specific node selectors to place specific pods on specific nodes, project node selectors to place new pods in a project on specific nodes in that project, or default cluster-wide node selectors to place new pods on specific nodes anywhere in the cluster.
+A _node selector_ specifies a map of key/value pairs that are defined using custom labels on nodes and selectors specified in pods.
 
-For the pod to be eligible to run on a node, the pod must have the same key-value node selector as the label on the node. 
-
-[IMPORTANT]
-====
-If you are using node selectors and node affinity in the same pod configuration, the following rules control pod placement onto nodes:
-
-* If you configure both `nodeSelector` and `nodeAffinity`, both conditions must be satisfied for the pod to be scheduled onto a candidate node.
-
-* If you specify multiple `nodeSelectorTerms` associated with `nodeAffinity` types, then the pod can be scheduled onto a node if one of the `nodeSelectorTerms` is satisfied.
-
-* If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node only if all `matchExpressions` are satisfied.
-====
+For the pod to be eligible to run on a node, the pod must have the same key/value node selector as the label on the node. 
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
+
+include::modules/nodes-scheduler-node-selectors-about.adoc[leveloffset=+1]
+
 include::modules/nodes-scheduler-node-selectors-pod.adoc[leveloffset=+1]
 
 include::modules/nodes-scheduler-node-selectors-cluster.adoc[leveloffset=+1]
 
 include::modules/nodes-scheduler-node-selectors-project.adoc[leveloffset=+1]
-
-// include::modules/nodes-scheduler-node-selectors-about.adoc[leveloffset=+1]
 
 // include::modules/nodes-scheduler-node-selectors-configuring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1859050

Reorganizing the node selectors topic. 
* Not much new text, most of it moved
* Moved examples from procedure topics to _About node selectors_
* No edits to the procedures, except for one update to the wording: https://github.com/openshift/openshift-docs/pull/26647/files#diff-eb7d189dc5ca115a44568ae53d2dd16ba5b10c2abff76e7135582953a34dde2aR116

Preview: https://deploy-preview-26647--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html