### PR TITLE
CNV (no tracker): Reorganizing vm import prerequisites

### DIFF
--- a/modules/virt-creating-configmap.adoc
+++ b/modules/virt-creating-configmap.adoc
@@ -3,7 +3,7 @@
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
 
 [id="virt-creating-configmap_{context}"]
-= Creating a ConfigMap for importing a Red Hat Virtualization virtual machine
+= Creating a ConfigMap for importing a VM
 
 You can create a ConfigMap to map the Red Hat Virtualization (RHV) virtual machine operating system to an {VirtProductName} template if you want to override the default `vm-import-controller` mapping or to add additional mappings.
 

--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -8,7 +8,7 @@
 = {VirtProductName} storage feature matrix
 
 ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
-The following table describes local and shared persistent storage that support VM import.
+The following table describes the {VirtProductName} storage types that support VM import.
 endif::[]
 
 .{VirtProductName} storage feature matrix

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -3,9 +3,9 @@
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
 
 [id="virt-importing-vm-cli_{context}"]
-= Importing a Red Hat Virtualization virtual machine with the CLI
+= Importing a virtual machine with the CLI
 
-You can import a Red Hat Virtualization (RHV) virtual machine with the CLI by creating the Secret and VirtualMachineImport Custom Resources (CRs). The Secret CR stores the RHV Manager credentials and CA certificate. The VirtualMachineImport CR defines the parameters of the VM import process.
+You can import a virtual machine with the CLI by creating the Secret and VirtualMachineImport Custom Resources (CRs). The Secret CR stores the RHV Manager credentials and CA certificate. The VirtualMachineImport CR defines the parameters of the VM import process.
 
 Optional: You can create a ResourceMapping CR that is separate from the VirtualMachineImport CR. A ResourceMapping CR provides greater flexibility, for example, if you import additional RHV VMs.
 

--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -1,23 +1,18 @@
 // Module included in the following assemblies:
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
-// * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
-[id='virt-importing-vm-prerequisites_{context}']
+
+[id="virt-importing-vm-prerequisites_{context}"]
 = Prerequisites for importing a virtual machine
 
-ifdef::virt-importing-rhv-vm[]
-Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductName} has the following prerequisites.
+Importing a virtual machine into {VirtProductName} has the following prerequisites:
 
-== Red Hat Virtualization prerequisites
+* You must have admin user privileges.
+* The {VirtProductName} local and shared persistent storage classes must support VM import.
+* Networks:
+** The source and target networks must either have the same name or be mapped to each other.
+** The source network interface must be `e1000`, `rtl8139`, or `virtio`.
 
-The Red Hat Virtualization (RHV) environment has the following prerequisites for VM import:
-
-* Network:
-
-** The VM network must be mapped to a single network in the {product-title} environment. The networks must either have the same name or be mapped to each other.
-** The network interface must be `e1000`, `rtl8139`, or `virtio`.
-
-* Disk:
-
+* VM disks:
 ** The disk interface must be `sata`, `virtio_scsi`, or `virtio`.
 ** The disk must not be configured as a direct LUN.
 ** The disk status must not be `illegal` or `locked`.
@@ -25,33 +20,10 @@ The Red Hat Virtualization (RHV) environment has the following prerequisites for
 ** SCSI reservation must be disabled.
 ** `ScsiGenericIO` must be disabled.
 
-* Configuration:
-
+* VM configuration:
 ** If the VM uses GPU resources, the nodes providing the GPUs must be configured.
 ** The VM must not be configured for vGPU resources.
 ** The VM must not have snapshots with disks in an `illegal` state.
 ** The VM must not have been created with {product-title} and subsequently added to RHV.
 ** The VM must not be configured for USB devices.
 ** The watchdog model must not be `diag288`.
-
-== {VirtProductName} prerequisites
-
-The {VirtProductName} environment has the following prerequisites for VM import:
-endif::[]
-ifdef::virt-importing-vmware-vm[]
-Importing a VMware VM into {VirtProductName} has the following prerequisites:
-
-* You must create a VMware Virtual Disk Development Kit (VDDK) image, push it to an image registry that is accessible to your {VirtProductName} environment, and add it to the `v2v-vmware` ConfigMap.
-* If you are importing a VM with a Windows operating system, you must disable hibernation.
-* You must power off the VM.
-* You must have sufficient storage space for the imported disk.
-+
-[WARNING]
-====
-If you try to import a virtual machine with a disk that is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage backend.
-====
-
-* Virtual disks must be connected to an IDE or SCSI controller. If a disk is connected to a SATA controller, you can change it to an IDE controller and then migrate the VM.
-endif::[]
-* You must be an admin user.
-* The local and shared persistent storage must support VM import.

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -2,20 +2,31 @@
 //
 // * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
-[id='virt-importing-vm-wizard_{context}']
+
+[id="virt-importing-vm-wizard_{context}"]
+= Importing a virtual machine with the VM Import wizard
+
+You can import a single virtual machine with the VM Import wizard.
+
 ifdef::virt-importing-vmware-vm[]
-= Importing a VMware virtual machine or template with the virtual machine wizard
+You can also import a VM template. If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
 
-You can import a VMware virtual machine or template by using the virtual machine wizard.
+.Prerequisites
+
+* You must have admin user privileges.
+* The VMware Virtual Disk Development Kit (VDDK) image must be in an image registry that is accessible to your {VirtProductName} environment.
+* The VDDK image must be added to the `v2v-vmware` ConfigMap.
+* The VM must be powered off.
+* Virtual disks must be connected to IDE or SCSI controllers. If virtual disks are connected to a SATA controller, you can change them to IDE controllers and then migrate the VM.
+ifeval::["{VirtVersion}" < "2.5"]
+* The VM name must not contain a forward slash (`/`).
 endif::[]
-ifdef::virt-importing-rhv-vm[]
-= Importing a Red Hat Virtualization virtual machine with the virtual machine wizard
-
-You can import a Red Hat Virtualization (RHV) virtual machine by using the virtual machine wizard.
-
-[IMPORTANT]
+* The {VirtProductName} local and shared persistent storage classes must support VM import.
+* The target storage must be large enough to accommodate the virtual disk.
++
+[WARNING]
 ====
-Cinder, the default {VirtProductName} storage class, does not support VM import.
+If you try to import a virtual machine with a disk that is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage back end.
 ====
 endif::[]
 
@@ -23,7 +34,6 @@ endif::[]
 
 . In the web console, click *Workloads* -> *Virtual Machines*.
 . Click *Create Virtual Machine* and select *Import with Wizard*.
-
 ifdef::virt-importing-vmware-vm[]
 . Select *VMware* from the *Provider* list.
 . Select *Connect to New Instance* or a saved vCenter instance.
@@ -31,7 +41,6 @@ ifdef::virt-importing-vmware-vm[]
 * If you select *Connect to New Instance*, enter the *vCenter hostname*, *Username*, and *Password*.
 * If you select a saved vCenter instance, the wizard connects to the vCenter instance using the saved credentials.
 endif::[]
-
 ifdef::virt-importing-rhv-vm[]
 . Select *Red Hat Virtualization (RHV)* from the *Provider* list.
 . Select *Connect to New Instance* or a saved RHV instance.
@@ -63,13 +72,6 @@ ifdef::virt-importing-rhv-vm[]
 endif::[]
 ifdef::virt-importing-vmware-vm[]
 . Select a virtual machine or a template to import.
-ifeval::["{VirtVersion}" < "2.5"]
-+
-[IMPORTANT]
-====
-The VMware VM name must not contain a forward slash (`/`).
-====
-endif::[]
 endif::[]
 
 . Click *Next*.
@@ -82,28 +84,18 @@ endif::[]
 . Click *Edit* to update the following settings:
 
 ifdef::virt-importing-rhv-vm[]
-* *General* -> *Name*: The VM name is limited to 63 characters. link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]
+* *General* -> *Name*: The VM name is limited to 63 characters.
 * *General* -> *Description*: Optional description of the VM.
-ifeval::["{VirtVersion}" < "2.5"]
-* *Storage* -> *Storage Class*: Select *NFS*.
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
 * *Storage*:
-
 ** *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd*.
 +
 If you select *ocs-storagecluster-ceph-rbd*, you must set the *Volume Mode* of the disk to *Block*.
 
 ** *Advanced* -> *Volume Mode*: Select *Block* or *Filesystem*.
-endif::[]
 * *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
-
 endif::[]
-
-// VMware import options
 ifdef::virt-importing-vmware-vm[]
 * *General*:
-
 ** *Description*
 ** *Operating System*
 ** *Flavor*
@@ -112,7 +104,6 @@ ifdef::virt-importing-vmware-vm[]
 ** *Workload Profile*
 
 * *Networking*:
-
 ** *Name*
 ** *Model*
 ** *Network*
@@ -120,27 +111,13 @@ ifdef::virt-importing-vmware-vm[]
 ** *MAC Address*
 
 * *Storage*: Click the Options menu {kebab} of the VM disk and select *Edit* to update the following fields:
-
 ** *Name*
 ** *Source*: For example, *Import Disk*.
 ** *Size*
 ** *Interface*
-ifeval::["{VirtVersion}" < "2.5"]
-** *Storage Class*: The following storage classes are supported for VMware VM import:
-
-*** VM disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
-*** `v2v-conversion-template` disk: *ocs-storagecluster-ceph-rbd (ceph-rbd)*
-+
-_or_
-
-*** VM disk: *NFS*
-*** `v2v-conversion-template` disk: *hostpath-provisioner (HPP)*
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
 ** *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd (ceph-rbd)*.
 +
 If you select *ocs-storagecluster-ceph-rbd*, you must set the *Volume Mode* of the disk to *Block*.
-endif::[]
 +
 Other storage classes might work, but they are not officially supported.
 
@@ -148,13 +125,11 @@ Other storage classes might work, but they are not officially supported.
 ** *Advanced* -> *Access Mode*
 
 * *Advanced* -> *Cloud-init*:
-
 ** *Form*: Enter the *Hostname* and *Authenticated SSH Keys*.
 ** *Custom script*: Enter the `cloud-init` script in the text field.
 
 * *Advanced* -> *Virtual Hardware*: You can attach a virtual CD-ROM to the imported virtual machine.
 endif::[]
-
 . Click *Import* or *Review and Import*, if you have edited the import settings.
 +
 A *Successfully created virtual machine* message and a list of resources created for the virtual machine are displayed. The virtual machine appears in *Workloads* -> *Virtual Machines*.

--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -1,48 +1,28 @@
 [id="virt-importing-rhv-vm"]
-= Importing a single {rh-virtualization} virtual machine
+= Importing a single Red Hat Virtualization virtual machine
 include::modules/virt-document-attributes.adoc[]
 :context: virt-importing-rhv-vm
 :virt-importing-rhv-vm:
 toc::[]
 
-You can import a single {rh-virtualization-first} virtual machine into your {product-title} cluster by using the virtual machine wizard or the CLI.
+You can import a single Red Hat Virtualization (RHV) virtual machine into {VirtProductName} by using the VM Import wizard or the CLI.
 
+include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
 include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
-
-[discrete]
-include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+2]
-
-ifeval::["{VirtVersion}" < "2.5"]
-include::modules/virt-checking-storage-class.adoc[leveloffset=+1]
-
-[discrete]
-include::modules/dynamic-provisioning-change-default-class.adoc[leveloffset=+2]
-endif::[]
-
-include::modules/virt-creating-configmap.adoc[leveloffset=+1]
-
-== Importing a virtual machine
-
-include::modules/virt-importing-vm-wizard.adoc[leveloffset=+2]
+include::modules/virt-importing-vm-wizard.adoc[leveloffset=+1]
 :!virt-importing-rhv-vm:
 
 :virtualmachine:
 [discrete]
-include::modules/virt-vm-wizard-fields-web.adoc[leveloffset=+3]
-
+include::modules/virt-vm-wizard-fields-web.adoc[leveloffset=+2]
 [discrete]
-include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+3]
-
+include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 [discrete]
-include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+3]
+include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 :virtualmachine!:
 
 :virt-importing-rhv-vm:
-include::modules/virt-importing-vm-cli.adoc[leveloffset=+2]
-
-ifeval::["{VirtVersion}" == "2.4"]
-include::modules/virt-canceling-vm-import.adoc[leveloffset=+1]
-endif::[]
-
+include::modules/virt-importing-vm-cli.adoc[leveloffset=+1]
+include::modules/virt-creating-configmap.adoc[leveloffset=+2]
 include::modules/virt-troubleshooting-vm-import.adoc[leveloffset=+1]
 :!virt-importing-rhv-vm:

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -5,68 +5,69 @@ include::modules/virt-document-attributes.adoc[]
 :virt-importing-vmware-vm:
 toc::[]
 
-You can import a single virtual machine or template from VMware vSphere 6.5, 6.7, or 7.0 into {VirtProductName}.
+You can import a VMware vSphere 6.5, 6.7, or 7.0 VM or VM template into {VirtProductName} by using the VM Import wizard.
 
-If you import a VMware template, {VirtProductName} creates a virtual machine based on the template.
+If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
 
-The import process uses the VMware Virtual Disk Development Kit (VDDK) to copy the VMware virtual disk. You must download the VDDK SDK, build a VDDK image, upload image to your image registry, and add it to the `v2v-vmware` ConfigMap.
+include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
 
-include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
+[id="preparing-a-vddk-image_{context}"]
+== Preparing a VDDK image
 
-[discrete]
-include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+2]
+The import process uses the VMware Virtual Disk Development Kit (VDDK) to copy the VMware virtual disk.
 
-== Configuring an image registry for the VDDK image
+You can download the VDDK SDK, create a VDDK image, upload the image to an image registry, and add it to the `v2v-vmware` ConfigMap.
 
-You can configure either an internal {product-title} image registry or a secure external image registry for the VDDK image.
+You can configure either an internal {product-title} image registry or a secure external image registry for the VDDK image. The registry must be accessible to your {VirtProductName} environment.
 
 [NOTE]
 ====
 Storing the VDDK image in a public registry might violate the terms of the VMware license.
 ====
 
+[id="configuring-an-internal-image-registry_{context}"]
 === Configuring an internal image registry
 
 You can configure the internal {product-title} image registry on bare metal by updating the Image Registry Operator configuration.
 
+You can access the registry directly, from within the {product-title} cluster, or externally, by exposing the registry with a route.
+
+[discrete]
 include::modules/registry-change-management-state.adoc[leveloffset=+3]
+[discrete]
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]
-
-=== Configuring access to an internal image registry
-
-You can access the {product-title} internal registry directly, from within the cluster, or externally, by exposing the registry with a route.
-
+[discrete]
 include::modules/registry-accessing-directly.adoc[leveloffset=+3]
+[discrete]
 include::modules/registry-exposing-secure-registry-manually.adoc[leveloffset=+3]
 
-=== Configuring access to an external image registry
+[id="configuring-an-external-image-registry_{context}"]
+=== Configuring an external image registry
 
 If you use an external image registry for the VDDK image, you can add the external image registry's certificate authorities to the {product-title} cluster.
 
 Optionally, you can create a pull secret from your Docker credentials and add it to your service account.
 
+[discrete]
 include::modules/configmap-adding-ca.adoc[leveloffset=+3]
+[discrete]
 include::modules/images-allow-pods-to-reference-images-from-secure-registries.adoc[leveloffset=+3]
-include::modules/virt-creating-vddk-image.adoc[leveloffset=+1]
+
+include::modules/virt-creating-vddk-image.adoc[leveloffset=+2]
 
 include::modules/virt-importing-vm-wizard.adoc[leveloffset=+1]
 :!virt-importing-vmware-vm:
-
 :virtualmachine:
 [discrete]
 include::modules/virt-vm-wizard-fields-web.adoc[leveloffset=+2]
-
 [discrete]
 include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+2]
-
 [discrete]
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
-
 [discrete]
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 :virtualmachine!:
-
 :virt-importing-vmware-vm:
-include::modules/virt-updating-imported-vm-network-name.adoc[leveloffset=+1]
+include::modules/virt-updating-imported-vm-network-name.adoc[leveloffset=+2]
 include::modules/virt-troubleshooting-vm-import.adoc[leveloffset=+1]
 :!virt-importing-vmware-vm:


### PR DESCRIPTION
Reorganizing the prerequisites for virt VM import.

No issue tracker. CP to 4.6, 4.7.