### PR TITLE
MachineHealthcheck timeout improvements

### DIFF
--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -17,4 +17,13 @@ You cannot apply a machine health check to a machine with the master role.
 
 The controller that observes a `MachineHealthCheck` resource checks for the status that you defined. If a machine fails the health check, it is automatically deleted and a new one is created to take its place. When a machine is deleted, you see a `machine deleted` event. To limit disruptive impact of the machine deletion, the controller drains and deletes only one node at a time. If there are more unhealthy machines than the `maxUnhealthy` threshold allows for in the targeted pool of machines, remediation stops so that manual intervention can take place.
 
+[NOTE]
+====
+Consider the timeouts carefully, depending on your workloads and needs:
+
+  - Long timeouts can result in long periods of downtime for the workload on the unhealthy Machine.
+  - Too short timeouts can result in a remediation loop, e.g. when checking the `NotReady` status, but the machine does
+    not get ready in time on startup.
+====
+
 To stop the check, you remove the resource.

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -8,7 +8,7 @@
 
 Machine health checks automatically repair unhealthy machines in a particular machine pool.
 
-To monitor machine health, you create a resource to define the configuration for a controller. You set a condition to check for, such as staying in the `NotReady` status for 15 minutes or displaying a permanent condition in the node-problem-detector, and a label for the set of machines to monitor.
+To monitor machine health, you create a resource to define the configuration for a controller. You set a condition to check for, such as staying in the `NotReady` status for 5 minutes or displaying a permanent condition in the node-problem-detector, and a label for the set of machines to monitor.
 
 [NOTE]
 ====


### PR DESCRIPTION
- Aligned doc text and example yaml with regards to the example timeout of 300s
- Added note about timeout considerations (moved part of it from example yaml module)

Context; https://issues.redhat.com/browse/MGMT-1796