### PR TITLE
4.6 Release Notes for Image Registry

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -822,6 +822,61 @@ The Local Storage Operator now has the ability to:
 
 For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#local-storage-discovery_persistent-storage-local[Automating discovery and provisioning for local storage devices].
 
+[id="ocp-4-6-registry"]
+=== Registry
+
+[id="ocp-4-6-pruner-tolerates-invalid-images"]
+==== Image pruner tolerates invalid images
+
+The image pruner now tolerates invalid image references by default on new installations of {product-title}, which allows pruning to continue even if it finds invalid images.
+
+[id="ocp-4-6-pruner-loglevel"]
+==== Change the image pruner's log level
+
+Cluster administrators can now configure `logLevel` in the Pruning Custom Resource to debug logs.
+
+//See xre:../applications/pruning-objects.adoc#pruning-images_pruning-objects[Automatically pruning images] for more information.
+
+[id="ocp-4-6-registry-azure-gov"]
+==== Image registry supports Azure Government
+
+The image registry can now be set up and configured for Azure Government.
+
+See xref:../registry/configuring_registry_storage/configuring-registry-storage-azure-user-infrastructure.adoc#registry-configuring-storage-azure-gov-cloud_configuring-registry-storage-azure-user-infrastructure[Configuring registry storage for Azure Government] for more information.
+
+[id="ocp-4-6-image-registry-operator-loglevel"]
+==== Change the Image Registry Operator's log level
+
+Cluster administrators can now configure `logLevel` in the Image Registry Operator to debug logs.
+
+The supported values for `logLevel` are:
+
+* `Normal`
+* `Debug`
+* `Trace`
+* `TraceAll`
+
+.Example Image Registry Operator YAML file
+[source,yaml]
+----
+spec:
+logLevel: Normal
+operatorLogLevel: Normal
+----
+
+//See xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview[Image Registry Operator configuration parameters] for more information.
+
+[id="ocp-4-6-image-registry-operator-storage"]
+==== Change the Image Registry Operator's `spec.storage.managementState`
+
+The Image Registry Operator now sets the `spec.storage.managementState` parameter to `Managed` on new installations or upgrades of clusters using installer-provisioned infrastructure on AWS or Azure.
+
+* `Managed`: Determines that the Image Registry Operator manages underlying storage. If the Image Registry Operator's `managementState` is set to `Removed`, then the storage is deleted.
+** If the `managementState` is set to `Managed`, the Image Registry Operator attempts to apply some default configuration on the underlying storage unit. For example, if set to `Managed`, the Operator tries to enable encryption on the S3 bucket before making it available to the registry. If you do not want the default settings to be applied on the storage you are providing, make sure the `managementState` is set to `Unmanaged`.
+* `Unmanaged`: Determines that the Image Registry Operator ignores the storage settings. If the Image Registry Operator's `managementState` is set to `Removed`, then the storage is not deleted. If you provided an underlying storage unit configuration, such as a bucket or container name, and the `spec.storage.managementState` is not yet set to any value, then the Image Registry Operator configures it to `Unmanaged`.
+
+//See xref:../registry/configuring-registry-operator.adoc#registry-operator-configuration-resource-overview[Image Registry Operator configuration parameters] for more information.
+
 [id="ocp-4-6-operators"]
 === Operator lifecycle
 
@@ -2094,6 +2149,10 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 
+|Docker Registry v1 API
+|
+|
+|DEP
 |====
 
 [id="ocp-4-6-known-issues"]


### PR DESCRIPTION
Replaces https://github.com/openshift/openshift-docs/pull/26422.