### PR TITLE
modules/update-service-overview: Simplify intro paragraph

### DIFF
--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -12,11 +12,9 @@
 = About the {product-title} update service
 
 The {product-title} update service is the hosted service that provides over-the-air
-updates to both {product-title} and {op-system-first}. It provides a graph,
-or diagram that contain _vertices_ and the _edges_ that connect them, of
-component Operators. The edges in the graph show which versions you can safely
-update to, and the vertices are update payloads that specify the intended state
-of the managed cluster components.
+updates to both {product-title} and {op-system-first}. It serves a graph of
+recommended update _edges_ between {product-title} release image _vertices_ that
+specify the intended state of the managed cluster components.
 
 The Cluster Version Operator (CVO) in your cluster checks with the
 {product-title} update service to see the valid updates and update paths based


### PR DESCRIPTION
I'd initially wanted to address "It provides a graph, or diagram that contain" -> "It provides a graph, or diagram, that contains".  But the "of component Operators" bit was confusing to me to.  So I've reworded to lead with "graph of recommended update(s)", and reduce to a single sentence.  I'd also be fine leading with a description of release images, and then introducing the recommended update edges that link them, but that seemed like a bigger refactor.  Wording I'm replacing is from 29016d7cf9 (#12880) and 6e1b894112 (#14991).

/assign @kalexand-rh