### PR TITLE
Reduce IPv6 references in documents that are base for 4.3..4.6 docs w…

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -112,7 +112,7 @@ ifeval::[{release} > 4.3]
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. This option is required when using IPv6 addressing on the `provisioning` network.
+|The CIDR for the network to use for provisioning. This option is required when not using the default address range on the `provisioning` network.
 endif::[]
 
 |`clusterProvisioningIP`


### PR DESCRIPTION
Using ipv6 references, invalidates this module to be used with 4.3 release.

In upstream we do keep 4.3..4.6 docs, and we think that the prior version of it worked better:

![image](https://user-images.githubusercontent.com/312463/96978664-e465a180-151e-11eb-9c0d-424fcea6dac8.png)
