### PR TITLE
Hide deprecated function in favor of roothints

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -182,7 +182,9 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 |
 | The MAC address of the NIC the host will use to boot on the `provisioning`  network.
 
+ifeval::[{release} < 4.6]
 | [[hardwareProfile]]`hardwareProfile`
 | `default`
 | This parameter exposes the device name that the installer attempts to deploy the {product-title} cluster for the control plane and worker nodes. The value defaults to `default` for control plane nodes and `unknown` for worker nodes. The list of profiles includes: `default`, `libvirt`, `dell`, `dell-raid`, and `openstack`. The `default` parameter attempts to install on `/dev/sda` of the {product-title} cluster nodes.
+endif::[]
 |===


### PR DESCRIPTION
In 4.6 roothints is the default, even if hardwareprofile might be used is something we should not be highlighting