### PR TITLE
fix: missing '.'

### DIFF
--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -22,7 +22,8 @@ include::modules/rhel-removing-rhcos.adoc[leveloffset=+2]
 [id="post-installation-config-deploying-machine-health-checks"]
 == Deploying MachineHealthChecks
 
-Understand and deploy MachineHealthChecks
+Understand and deploy MachineHealthChecks.
+
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+2]
 include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 include::modules/machine-health-checks-resource.adoc[leveloffset=+2]


### PR DESCRIPTION
Continuation of https://github.com/openshift/openshift-docs/pull/26633/

Confirmed the fix built correctly to fix the issue and squashed the commits.