### PR TITLE
OSDOCS-1563: Re-use OLM arch modules in Op ref guide

### DIFF
--- a/modules/olm-arch-catalog-operator.adoc
+++ b/modules/olm-arch-catalog-operator.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/understanding/olm/olm-arch.adoc
+// * operators/operator-reference.adoc
 
 [id="olm-arch-catalog-operator_{context}"]
 = Catalog Operator

--- a/modules/olm-arch-catalog-registry.adoc
+++ b/modules/olm-arch-catalog-registry.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/understanding/olm/olm-arch.adoc
+// * operators/operator-reference.adoc
 
 [id="olm-arch-catalog-registry_{context}"]
 = Catalog Registry

--- a/modules/olm-arch-olm-operator.adoc
+++ b/modules/olm-arch-olm-operator.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operators/understanding/olm/olm-arch.adoc
+// * operators/operator-reference.adoc
 
 [id="olm-arch-olm-operator_{context}"]
 = OLM Operator

--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -1,9 +1,15 @@
 // Module included in the following assemblies:
 //
 // * operators/understanding/olm/olm-understanding-olm.adoc
+// * operators/operator-reference.adoc
 
 [id="olm-architecture_{context}"]
+ifeval::["{context}" != "red-hat-operators"]
 = Component responsibilities
+endif::[]
+ifeval::["{context}" == "red-hat-operators"]
+= CRDs
+endif::[]
 
 Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM Operator
 and the Catalog Operator.

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -1,16 +1,23 @@
 // Module included in the following assemblies:
 //
 // * operators/understanding/olm/olm-understanding-olm.adoc
+// * operators/operator-reference.adoc
 
 [id="olm-overview_{context}"]
+ifeval::["{context}" != "red-hat-operators"]
 = What is Operator Lifecycle Manager?
+endif::[]
+ifeval::["{context}" == "red-hat-operators"]
+= Purpose
+endif::[]
 
-In {product-title} {product-version}, _Operator Lifecycle Manager_ (OLM) helps users
-install, update, and manage the lifecycle of all Operators and their associated
-services running across their clusters. It is part of the
-link:https://github.com/operator-framework[Operator Framework],
-an open source toolkit designed to manage Kubernetes native applications
-(Operators) in an effective, automated, and scalable way.
+
+_Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the
+lifecycle of all Operators and their associated services running across their
+{product-title} clusters. It is part of the
+link:https://operatorframework.io/[Operator Framework], an open source toolkit
+designed to manage Kubernetes native applications (Operators) in an effective,
+automated, and scalable way.
 
 .Operator Lifecycle Manager workflow
 image::olm-workflow.png[]

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -28,5 +28,24 @@ include::modules/machine-api-operator.adoc[leveloffset=+1]
 include::modules/machine-config-operator.adoc[leveloffset=+1]
 include::modules/operator-marketplace.adoc[leveloffset=+1]
 include::modules/node-tuning-operator.adoc[leveloffset=+1]
+
+[id="red-hat-operators-olm"]
+== Operator Lifecycle Manager Operators
+[discrete]
+include::modules/olm-overview.adoc[leveloffset=+2]
+[discrete]
+include::modules/olm-architecture.adoc[leveloffset=+2]
+[discrete]
+include::modules/olm-arch-olm-operator.adoc[leveloffset=+2]
+[discrete]
+include::modules/olm-arch-catalog-operator.adoc[leveloffset=+2]
+[discrete]
+include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
+[discrete]
+[id="red-hat-operators-olm-addtl-resources"]
+=== Additional resources
+
+For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
+
 include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
 include::modules/prometheus-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1563

Re-using the OLM architecture-related modules that currently appear up in the [Operators -> Understanding Operators -> OLM](http://file.rdu.redhat.com/~adellape/102220/opref_olm/operators/understanding/olm/olm-understanding-olm.html) sections to also be included down in the [Red Hat Operators reference](http://file.rdu.redhat.com/~adellape/102220/opref_olm/operators/operator-reference.html#red-hat-operators-olm) guide.

Preview (internal): http://file.rdu.redhat.com/~adellape/102220/opref_olm/operators/operator-reference.html