### PR TITLE
BZ1890663 Storage matrix needs updating for CNV 2.5 

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -13,11 +13,13 @@ endif::[]
 
 .{VirtProductName} storage feature matrix
 ifdef::virt-features-for-storage[]
-[cols="40%,30%,30%",options="header"]
+[cols="40%,15%,15%,15%,15%",options="header"]
 |===
 |
 |Virtual machine live migration
 |Host-assisted virtual machine disk cloning
+|Storage-assisted virtual machine disk cloning
+|Virtual machine snapshots
 endif::[]
 ifdef::virt-importing-rhv-vm[]
 [cols="50%,50%",options="header",caption]
@@ -36,6 +38,8 @@ endif::[]
 ifdef::virt-features-for-storage[]
 |Yes
 |Yes
+|Yes
+|Yes
 endif::[]
 ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
 ifeval::["{VirtVersion}" >= "2.5"]
@@ -50,6 +54,8 @@ endif::[]
 ifdef::virt-features-for-storage[]
 |No
 |Yes
+|No
+|No
 endif::[]
 ifdef::virt-importing-rhv-vm[]
 |No
@@ -66,7 +72,9 @@ endif::[]
 |Other multi-node writable storage
 ifdef::virt-features-for-storage[]
 |Yes ^[1]^
-|Yes ^[1]^
+|Yes
+|Yes ^[2]^
+|Yes ^[2]^
 endif::[]
 ifdef::virt-importing-rhv-vm[]
 |Yes ^[1]^
@@ -83,6 +91,8 @@ endif::[]
 |Other single-node writable storage
 ifdef::virt-features-for-storage[]
 |No
+|Yes
+|Yes ^[2]^
 |Yes ^[2]^
 endif::[]
 ifdef::virt-importing-rhv-vm[]
@@ -111,7 +121,13 @@ ifeval::["{VirtVersion}" >= "2.5"]
 endif::[]
 --
 endif::[]
-ifdef::virt-features-for-storage,virt-importing-rhv-vm[]
+ifdef::virt-features-for-storage[]
+--
+1. PVCs must request a ReadWriteMany access mode.
+2. Storage provider must support both Kubernetes and CSI snapshot APIs
+--
+endif::[]
+ifdef::virt-importing-rhv-vm[]
 --
 1. PVCs must request a ReadWriteMany access mode.
 2. PVCs must request a ReadWriteOnce access mode.


### PR DESCRIPTION
Revising matrix to add the column: **Storage-assisted virtual machine disk cloning**

See Netify link for test build.

@aglitke - Questions:

1. Do we want to add back the row **OpenShift Container Platform container storage: RBD filesystem volumes**? Or stick to block-only? Sorry, I probably asked you this before. 
2. I am also requesting this be labeled for merge to OpenShift 4.5 and 4.6... correct? I think you said that Cloning was supported last release? 
3. Who would you recommend to tag for QE sign-off?

*Peer review needed* and label *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).5* and *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).6*.

Bob