### PR TITLE
Fixed kubectl docs redirect link cherry pick back to 4.4

### DIFF
--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -27,4 +27,4 @@ The `kubectl` binary is provided as a means to support existing workflows and sc
 
 You can install the supported `kubectl` binary by following the steps to xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-installing-cli_cli-developer-commands[Install the CLI]. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.
 
-For more information, see the link:https://www.google.com/url?q=https://kubernetes.io/docs/reference/kubectl/overview/&sa=D&ust=1576620297762000&usg=AFQjCNGBR2LsVeM-JuLDz1rA5U9n-WwcPw[kubectl documentation].
+For more information, see the link:https://kubernetes.io/docs/reference/kubectl/overview/[kubectl documentation].


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/blob/master/cli_reference/openshift_cli/usage-oc-kubectl.adoc

Fixed kubectl docs redirect link.
To be cherry picked back to 4.4