### PR TITLE
Fix a typo in Serverless Broker injection annotation

### DIFF
--- a/modules/serverless-creating-broker-admin.adoc
+++ b/modules/serverless-creating-broker-admin.adoc
@@ -22,7 +22,7 @@ Brokers created due to annotation will not be removed if you remove the annotati
 +
 [source,terminal]
 ----
-$ oc label namespace <namespace> eventing.knative.dev/injection=enable
+$ oc label namespace <namespace> eventing.knative.dev/injection=enabled
 ----
 
 .Verification steps

--- a/modules/serverless-rn-1-10-0.adoc
+++ b/modules/serverless-rn-1-10-0.adoc
@@ -12,7 +12,7 @@
 * {ServerlessProductName} uses Knative Eventing 0.16.0.
 * {ServerlessProductName} now uses Kourier 0.16.0.
 * {ServerlessProductName} now uses Knative `kn` CLI 0.16.1.
-* The annotation `knative-eventing-injection=enabled` that was previously used to annotate namespaces for broker creation is now deprecated. The new annotation is `eventing.knative.dev/injection=enable`. For more information, see the documentation on _Creating a broker as a cluster administrator using namespace annotation_.
+* The annotation `knative-eventing-injection=enabled` that was previously used to annotate namespaces for broker creation is now deprecated. The new annotation is `eventing.knative.dev/injection=enabled`. For more information, see the documentation on _Creating a broker as a cluster administrator using namespace annotation_.
 * Multi-container support is now available on Knative as a Technology Preview feature. You can enable multi-container support in the `config-features` config map. For more information, see the https://knative.dev/docs/serving/feature-flags/#multi-containers[Knative documentation].
 
 [id="fixed-issues-1-10-0_{context}"]


### PR DESCRIPTION
Fix a typo in Serverless Broker injection annotation that is used for the auto injection 