### PR TITLE
BZ#1891515 - Clarify OVN-Kubernetes egress IP address platform support

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -26,16 +26,24 @@ An egress IP address is implemented as an additional IP address on the primary n
 [id="nw-egress-ips-platform-support_{context}"]
 == Platform support
 
-While you can use the egress IP address functionality on any platform that {product-title} supports, the following platform specific considerations apply:
+Support for the egress IP address functionality on various platforms is summarized in the following table:
 
-Cloud platforms::
-Additional IP addresses must be assigned manually to appropriate nodes by an administrator.
+[IMPORTANT]
+====
+The egress IP address implementation is not compatible with Amazon Web Services (AWS), Azure Cloud, or any other public cloud platform incompatible with the automatic layer 2 network manipulation required by the egress IP feature.
+====
 
-{rhosp}::
-Additional configuration by an administrator is necessary to allow {product-title} to automatically assign additional IP addresses to nodes.
+[cols="1,1",options="header"]
+|===
 
-vSphere::
-Additional configuration by an administrator is necessary to allow {product-title} to automatically assign additional IP addresses to nodes.
+| Platform | Supported
+
+| Bare metal | Yes
+| vSphere | Yes
+| {rhosp} | No
+| Public cloud | No
+
+|===
 
 [id="nw-egress-ips-considerations_{context}"]
 == Assignment of egress IPs to pods


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1891515

@alexanderConstantinescu, the update will live here once identified.

@vikram-redhat, this update will need to go in to clarify platform support for this feature in 4.6.

Preview:

- [Configuring an egress IP address](https://bz-1891515--ocpdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html)