### PR TITLE
4.6 Release Notes Metering Operator Deprecated

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1460,6 +1460,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
+|Metering Operator
+|GA
+|GA
+|DEP
+
 |====
 
 [id="ocp-4-6-deprecated-features"]
@@ -1476,6 +1481,11 @@ for removal in {product-title} 4.9.
 ==== TLS verification falling back to the Common Name field
 
 The behavior of falling back to the Common Name field on X.509 certificates as a host name when no Subject Alternative Names are present is deprecated. In a future release, this behavior will be removed, and certificates must properly set the Subject Alternative Names field.
+
+[id="ocp-4-6-metering-operator-deprecated"]
+==== Metering Operator
+
+The Metering Operator is deprecated and will be removed in a future release.
 
 [id="ocp-4-6-removed-features"]
 === Removed features


### PR DESCRIPTION
Per Paul Weil's email on 10/26/2020, Metering is deprecated as of 4.6 GA.