### PR TITLE
GH#22344 - Always specify `ipam` for SriovNetwork objects

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -37,10 +37,10 @@ metadata:
   name: <name> <1>
   namespace: openshift-sriov-network-operator <2>
 spec:
-  networkNamespace: <target_namespace> <3>
-  ipam: <ipam> <4>
+  resourceName: <sriov_resource_name> <3>
+  networkNamespace: <target_namespace> <4>
   vlan: <vlan> <5>
-  resourceName: <sriov_resource_name> <6>
+  ipam: {} <6>
   linkState: <link_state> <7>
   maxTxRate: <max_tx_rate> <8>
   minTxRate: <min_rx_rate> <9>
@@ -51,10 +51,10 @@ spec:
 ----
 <1> Replace `<name>` with a name for the CR. The SR-IOV Network Operator creates a NetworkAttachmentDefinition CR with same name.
 <2> Specify the namespace where the SR-IOV Operator is installed.
-<3> Optional: Replace `<target_namespace>` with the namespace where the NetworkAttachmentDefinition CR is created. The default value is `openshift-sriov-network-operator`.
-<4> Optional: Replace `<ipam>` a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
+<3> Replace `<sriov_resource_name>` with the value for the `.spec.resourceName` parameter from the SriovNetworkNodePolicy CR that defines the SR-IOV hardware for this additional network.
+<4> Optional: Replace `<target_namespace>` with the namespace where the NetworkAttachmentDefinition CR is created. The default value is `openshift-sriov-network-operator`.
 <5> Optional: Replace `<vlan>` with a Virtual LAN (VLAN) ID for the additional network. The integer value must be from `0` to `4095`. The default value is `0`.
-<6> Replace `<sriov_resource_name>` with the value for the `.spec.resourceName` parameter from the SriovNetworkNodePolicy CR that defines the SR-IOV hardware for this additional network.
+<6> A configuration object for the IPAM CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
 <7> Optional: Replace `<link_state>` with the link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
 <8> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
 <9> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.


### PR DESCRIPTION
This change is already applied to 4.5+. It never made it to 4.4.

- https://github.com/openshift/openshift-docs/issues/22344