### PR TITLE
Added module: "Displaying the Insights status in the web console" (CCXDEV-3375)

### DIFF
--- a/modules/displaying-the-insights-status-in-the-web-console.adoc
+++ b/modules/displaying-the-insights-status-in-the-web-console.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+
+[id="displaying-the-insights-status-in-the-web-console_{context}"]
+= Displaying the Insights status in the web console
+
+Insights repeatedly analyzes your cluster and you can display the status of identified potential issues of your cluster in the {product-title} web console. This status shows the number of issues in the different categories and, for further details, links to the reports in the {cloud-redhat-com}.
+
+.Prerequisites
+
+* Your cluster is registered in the {cloud-redhat-com}.
+* Remote health reporting is enabled, which is the default.
+* You are logged in to the {product-title} web console.
+
+.Procedure
+
+. Navigate to *Home* -> *Overview* in the {product-title} web console.
+
+. Click *Insights* on the *Status* card.
++
+The pop-up window lists potential issues grouped by priority. Click the individual categories or *View all in {product-title}* to display further details.
+

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -7,3 +7,4 @@ toc::[]
 Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report on the *Insights* tab of each cluster in {cloud-redhat-com}.
 
 include::modules/displaying-potential-issues-with-your-cluster.adoc[leveloffset=+1]
+include::modules/displaying-the-insights-status-in-the-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
This adds a new module about displaying the Insights status in the web console.
This documentation is for a 4.7 feature.

@openshift/team-documentation
