### PR TITLE
BZ1890005: Adding Thanos Querier to moving node example

### DIFF
--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -50,6 +50,9 @@ data:
     openshiftStateMetrics:
       nodeSelector:
         node-role.kubernetes.io/infra: ""
+    thanosQuerier:
+      nodeSelector:
+        node-role.kubernetes.io/infra: ""
 ----
 +
 Running this ConfigMap forces the components of the monitoring stack to redeploy


### PR DESCRIPTION
This applies to master, branch/enterprise-4.4, branch/enterprise-4.5 and branch/enterprise-4.6.

From a review of the docs and then a discussion with our Monitoring team, I understand the following:

- Thanos Querier was introduced in OCP 4.3 when monitoring for user-defined projects became Tech Preview.
- The ability to move Thanos Querier between nodes was introduced in OCP 4.4, we believe. This needs QE testing for clarification before this PR is merged.

This PR adds Thanos Querier to the example YAML in [Moving the monitoring solution](https://docs.openshift.com/container-platform/4.5/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-monitoring_creating-infrastructure-machinesets).

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1890005 and https://github.com/openshift/openshift-docs/pull/26745.

The preview is [here](https://bz1890005--ocpdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-monitoring_creating-infrastructure-machinesets).