### PR TITLE
BZ1890005: Adding Thanos Querier to movable component example.

### DIFF
--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -78,6 +78,9 @@ data:
     openshiftStateMetrics:
       nodeSelector:
         foo: bar
+    thanosQuerier:
+      nodeSelector:
+        foo: bar
 ----
 
 . Save the file to apply the changes. The components affected by the new configuration are moved to new nodes automatically.


### PR DESCRIPTION
This applies to branch/enterprise-4.4 only.

From a review of the docs and then a discussion with our Monitoring team, I understand the following:

- Thanos Querier was introduced in OCP 4.3 when monitoring for user-defined projects became Tech Preview.
- The ability to move Thanos Querier between nodes was introduced in OCP 4.4, we believe. This needs QE testing for clarification before this PR is merged.

This PR adds Thanos Querier to the example YAML for OCP 4.4 in [Moving monitoring components to different nodes](https://docs.openshift.com/container-platform/4.4/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html#moving-monitoring-components-to-different-nodes_configuring-monitoring). The example is already present in that section in the 4.5 and 4.6 docs.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1890005 and https://github.com/openshift/openshift-docs/pull/26744.

The preview is [here](https://bz1890005_part2--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html#moving-monitoring-components-to-different-nodes_configuring-monitoring).