### PR TITLE
[enterprise-4.5] Fix mismatched chrony config info

### DIFF
--- a/modules/installation-special-config-crony.adoc
+++ b/modules/installation-special-config-crony.adoc
@@ -38,7 +38,7 @@ additional MachineConfig for the `worker` role:
 +
 [source,terminal]
 ----
-$ cat << EOF > ./99-masters-chrony-configuration.yaml
+$ cat << EOF > ./masters-chrony-configuration.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -58,7 +58,7 @@ spec:
     storage:
       files:
       - contents:
-          source: data:text/plain;charset=utf-8;base64,c2VydmVyIGNsb2NrLnJlZGhhdC5jb20gaWJ1cnN0CmRyaWZ0ZmlsZSAvdmFyL2xpYi9jaHJvbnkvZHJpZnQKbWFrZXN0ZXAgMS4wIDMKcnRjc3luYwpsb2dkaXIgL3Zhci9sb2cvY2hyb255Cg==
+          source: data:text/plain;charset=utf-8;base64,ICAgIHNlcnZlciBjbG9jay5yZWRoYXQuY29tIGlidXJzdAogICAgZHJpZnRmaWxlIC92YXIvbGliL2Nocm9ueS9kcmlmdAogICAgbWFrZXN0ZXAgMS4wIDMKICAgIHJ0Y3N5bmMKICAgIGxvZ2RpciAvdmFyL2xvZy9jaHJvbnkK
           verification: {}
         filesystem: root
         mode: 420


### PR DESCRIPTION
Fixes BZ1881827 - https://bugzilla.redhat.com/show_bug.cgi?id=1881827

Manual CP of #26731 