### PR TITLE
Updating wording for AWS Spot Instances to match wording in 4.6

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -37,10 +37,8 @@ Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
-AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
-which can save you on costs compared to On-Demand Instance prices. You can
-xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
-by adding SpotMarketOptions to the MachineSet YAML file.
+MachineSets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances]. You can save on costs by using Spot Instances at a lower price compared to
+On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances] by adding `spotMarketOptions` to the MachineSet YAML file.
 
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -3,9 +3,9 @@
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
 
 [id="machineset-creating-non-guaranteed-instance_{context}"]
-= Creating Spot Instances
+= Creating Spot Instances by using MachineSets
 
-You can launch a Spot Instance on AWS by adding SpotMarketOptions to your MachineSet YAML file.
+You can launch a Spot Instance on AWS by adding `spotMarketOptions` to your `MachineSet` YAML file.
 
 .Procedure
 * Add the following line under the `providerSpec` field:
@@ -14,9 +14,12 @@ You can launch a Spot Instance on AWS by adding SpotMarketOptions to your Machin
 ----
 providerSpec:
   value:
-    spotMarketOptions: {} <1>
+    spotMarketOptions: {}
 ----
-<1> You can optionally set the `maxPrice` for the `spotMarketOptions` field to limit the cost of the Spot Instance, for example `maxPrice: '2.50'`. If the `maxPrice` is set, this value is used as the hourly maximum spot price. If not set, the maximum price defaults to charge up to the On-Demand Instance price.
+
+Optional: You can set the `spotMarketOptions.maxPrice` field to limit the cost of the Spot Instance. For example, you can set `maxPrice: '2.50'`.
+
+If the `maxPrice` is set, this value is used as the hourly maximum spot price. If it is not set, the maximum price defaults to charge up to the On-Demand Instance price.
 
 [NOTE]
 ====

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -3,30 +3,21 @@
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
 
 [id="machineset-non-guaranteed-instance_{context}"]
-= MachineSet Spot Instances
+= MachineSets that deploy machines as Spot Instances
 
-You can save on costs by creating an AWS MachineSet that deploys machines as non-guaranteed Spot Instances.
-Spot Instances utilize unused AWS EC2 capacity and are less expensive than On-Demand Instances.
-You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless,
-horizontally scalable workloads.
+You can save on costs by creating a MachineSet running on AWS that deploys machines as non-guaranteed Spot Instances. Spot Instances use available AWS EC2 capacity and are less expensive than On-Demand Instances. You can use Spot Instances for workloads that can tolerate interruptions, such as batch or stateless, horizontally scalable workloads.
 
 [IMPORTANT]
 ====
-It is strongly recommended that control plane machines are not created on Spot Instances
-due to the increased likelihood of the instance being terminated. Manual intervention is
-required to replace a terminated control plane node.
+It is strongly recommended that control plane machines are not created on Spot Instances due to the increased likelihood of the instance being terminated. Manual intervention is required to replace a terminated control plane node.
 ====
 
-AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to
-the user when an interruption occurs. The {product-title} begins to remove the workloads
-from the affected instances when AWS issues the termination warning.
+AWS EC2 can terminate a Spot Instance at any time. AWS gives a two-minute warning to the user when an interruption occurs. {product-title} begins to remove the workloads from the affected instances when AWS issues the termination warning.
 
-Interruptions can occur when using Spot Instances if:
+Interruptions can occur when using Spot Instances for the following reasons:
 
 * The instance price exceeds your maximum price.
 * The demand for Spot Instances increases.
 * The supply of Spot Instances decreases.
 
-When AWS terminates an instance, a termination handler running on the Spot Instance
-node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the
-MachineSet creates a new machine that then requests a new Spot Instance.
+When AWS terminates an instance, a termination handler running on the Spot Instance node deletes the machine resource. To satisfy the MachineSet `replicas` quantity, the MachineSet creates a machine that requests a Spot Instance.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -46,10 +46,8 @@ Use the sample MachineSet for your cloud.
 
 include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
 
-AWS MachineSets support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances],
-which can save you on costs compared to On-Demand Instance prices. You can
-xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[configure Spot Instances]
-by adding SpotMarketOptions to the MachineSet YAML file.
+MachineSets running on AWS support non-guaranteed xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-non-guaranteed-instance_creating-machineset-aws[Spot Instances]. You can save on costs by using Spot Instances at a lower price compared to
+On-Demand Instances on AWS. xref:../machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating-non-guaranteed-instance_creating-machineset-aws[Configure Spot Instances] by adding `spotMarketOptions` to the MachineSet YAML file.
 
 include::modules/machineset-yaml-azure.adoc[leveloffset=+3]
 include::modules/machineset-yaml-gcp.adoc[leveloffset=+3]


### PR DESCRIPTION
I am updating the wording for the 4.5 AWS Spot Instances content to match that in 4.6. I did not change any xrefs. Also removed some hard wraps.

@openshift/team-documentation PTAL. 