### PR TITLE
release_notes/ocp-4-6-release-notes: Fix routing bug descriptions

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1973,19 +1973,13 @@ $ coreos-installer install ... ＼
 As a result, the Ingress Operator repeatedly attempts to update the NodePort Services in response to the blank.
 The Ingress Operator was changed to consider unspecified values and default values to be equal when comparing NodePort service. The operator no longer updates an IngressController NodePort service in response to API defaulting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842742[*BZ#1842742*])
 
-* The `e2e-aws-scaleup-rhel7` job creates pods from the `openshift-dns` Daemonset that do not come online immediately. As a consequence, DNS availability might be impacted shortly after the node comes online and Prometheus issues alerts. The Prometheus e2e test was changed to retry DNS failures a few times in the event that a new worker nodes almost ready DNS pod is hit allowing the Prometheus e2e test to pass.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1826094[*BZ#1826094*])
-
-* Because the Ingress Operator and DNS Operator end-to-end (e2e) tests were failing  fail on networking/API issues unrelated to the operator itself, determining which cluster component is causing the error is more difficult. The e2e tests were changed to not fail on errors outside the Ingress Operator and DNS Operator, only only log the errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1828618[*BZ#1828618*])
-
-* Previously, if you updated a cluster that has improper routes, the HAProxy correctly initialize in a defunct state. However, the update does not trigger any alerts and the cluster incorrectly reports the Ingress Controller as available. HAProxy initial sync logic was fixed so that upgrades with broken routes fail.  As a result, upgrading a cluster with improper routes is not successful and the HAProxyReloadFail or HAProxyDown alerts are reported.
+* Previously, if you updated a cluster with improper routes, HAProxy would initialize into a defunct state. However, the update would not trigger any alerts and the cluster would incorrectly report the Ingress Controller as available. HAProxy initial sync logic was fixed so that upgrades with broken routes fail.  As a result, upgrading a cluster with improper routes is not successful and the HAProxyReloadFail or HAProxyDown alerts are reported.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861455[*BZ#1861455*])
 
 * Because of the risk of connection re-use/coalescing when using HTTP/2 ALPN, a warning message was added to the output of the Ingress Controller in the CLI to use to enable HTTP/2 ALPN only on a route that uses custom (non-wildcard) certificate. As a result, routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1827364[*BZ#1827364*])
 
-* Because the HAProxy is reloaded when the router changes the configuration file, the Prometheus counter metrics were decreasing across reloads, which explicitly violates the definition of a counter metric. The router code was fixed to note the time of the last metrics scrape. This prevents scraping beyond the preserved counter values during a reload. As a result the counter metrics do not show a sudden increase followed by a decrease when the router is reloading. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1752814[*BZ#1752814*])
+* Previously, when HAProxy was reloaded, HAProxy Prometheus counter metrics would decrease in value, which explicitly violates the definition of a counter metric. The router code was fixed to note the time of the last metrics scrape. This prevents scraping beyond the preserved counter values during a reload. As a result the counter metrics do not show a sudden increase followed by a decrease when the router is reloading. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1752814[*BZ#1752814*])
 
 *Samples*
 


### PR DESCRIPTION
Remove unnecessary routing bug doc texts and clean up some grammatical errors in the doc texts that are staying.

See https://coreos.slack.com/archives/C2ZA5QGMV/p1603824155091900 for more context.