### PR TITLE
release_notes/ocp-4-6-release-notes: Drop rhbz#1838497 (CVO race)

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1577,8 +1577,6 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 *Cluster Version Operator*
 
-* The Cluster Version Operator had a race condition where it would consider a timed-out update reconciliation cycle as a successful update. As a result, the Operator would enter its shuffled-manifest reconciliation mode, causing potential issues for the cluster if the manifests were not applied in order. Now, the Cluster Version Operator observes the timed-out updates as failures and no longer enters the reconciliation race condition. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1838497[*BZ#1838497*])
-
 * The Cluster Version Operator served metrics using HTTP instead of HTTPS, and was subject to man-in-the-middle attacks as a result of unencrypted data. Now, The Cluster Version Operator serves metrics using HTTPS and data is encrypted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809195[*BZ#1809195*])
 
 * When the Cluster Version Operator overrode upgrades, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until the administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])


### PR DESCRIPTION
This was added in 2f55d96264 (#26546), based on Doc Text I'd added to the bug.  But the 4.5 backport made it out by 4.5's GA (slightly before [in 4.5.1][1]), so there's no need to call this out for 4.6.  I should not have set Doc Text on the 4.6 bug.

/assign @codyhoag

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1843526#c4