### PR TITLE
release_notes/ocp-4-6-release-notes: Reword CVO overrides (rbhz#1822844)

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1581,7 +1581,7 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * The Cluster Version Operator served metrics using HTTP instead of HTTPS, and was subject to man-in-the-middle attacks as a result of unencrypted data. Now, The Cluster Version Operator serves metrics using HTTPS and data is encrypted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809195[*BZ#1809195*])
 
-* When the Cluster Version Operator overrode upgrades, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until the administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])
+* When cluster administrators had configured ClusterVersion overrides, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until an administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])
 
 * The Cluster Version Operator ignored several probe properties, causing changes to not be applied correctly. Now, the Cluster Version Operator ensures that the in-cluster probe state matches the requested state from the Operator's release manifests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847672[*BZ#1847672*])
 


### PR DESCRIPTION
This was added in 2f55d96264 (#26546), based on Doc Text I'd added to the bug.  Adjust to get closer to the bug's "When ClusterVersion overrides are set" wording, to make it clear that the previous, sticking updates were the fault of whoever set the ClusterVersion `spec.overrides`, and not the fault of the CVO deciding to override something on its own.

/assign @codyhoag