### PR TITLE
release_notes/ocp-4-6-release-notes: Drop CVO probe properties (rhbz#1847672)

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1583,8 +1583,6 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * When the Cluster Version Operator overrode upgrades, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until the administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])
 
-* The Cluster Version Operator ignored several probe properties, causing changes to not be applied correctly. Now, the Cluster Version Operator ensures that the in-cluster probe state matches the requested state from the Operator's release manifests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847672[*BZ#1847672*])
-
 * The Cluster Version Operator used to load trusted CAs from the ConfigMap referenced by the Proxy configuration's `trustedCA` property. The referenced ConfigMag is user-maintained, and a user setting corrupted certificates would interrupt the Operator's access to the Proxy. Now, the Operator loads the trustedCAs from the `openshift-config-managed/trusted-ca-bundle`, which the Network Operator populates when the Proxy configuration's referenced `trustedCA` ConfigMap is valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1797123[*BZ#1797123*])
 
 * HTTPS signatures retrieved serialized stores, causing potential time outs before the Cluster Version Operator could complete the tasks. Now, external HTTPS signature retrieval is parallel and all stores will be attempted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840343[*BZ#1840343*])


### PR DESCRIPTION
This was added in 2f55d96264 (#26546), based on Doc Text I'd added to the bug.  But the 4.5 backport made it out by 4.5's GA (slightly before [in 4.5.1][1]), so there's no need to call this out for 4.6.  I should not have set Doc Text on the 4.6 bug.

Like #26825, but for a different bug chain.

/assign @codyhoag

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1848729#c4