### PR TITLE
BZ-1844449 Updating hostname in syslog protocol example 4.6 4.7

### DIFF
--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-syslog_{context}"]
 = Forwarding logs using the legacy syslog method
 
-You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster instead of the default Elasticsearch log store by creating a configuration file and ConfigMap. You are responsible for configuring the external log aggregator to receive the logs from {product-title}. 
+You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster instead of the default Elasticsearch log store by creating a configuration file and ConfigMap. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 [IMPORTANT]
 ====
@@ -26,7 +26,7 @@ To send logs using the *syslog* protocol, create a configuration file called `sy
 @type syslog_buffered
 remote_syslog rsyslogserver.example.com
 port 514
-hostname fluentd-4nzfz
+hostname ${hostname}
 remove_tag_prefix tag
 facility local0
 severity info
@@ -36,7 +36,7 @@ rfc 3164
 </store>
 ----
 
-You can configure the following `syslog` parameters. For more information, see the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164]. 
+You can configure the following `syslog` parameters. For more information, see the syslog link:https://tools.ietf.org/html/rfc3164[RFC3164].
 
 * facility: The link:https://tools.ietf.org/html/rfc3164#section-4.1.1[syslog facility]. The value can be a decimal integer or a case-insensitive keyword:
 ** `0` or `kern` for kernel messages
@@ -78,7 +78,7 @@ To configure {product-title} to forward logs using the legacy configuration meth
 +
 ----
 <store>
-@type <tpye> <1>
+@type <type> <1>
 remote_syslog <syslog-server> <2>
 port 514 <3>
 hostname <host> <4>
@@ -87,10 +87,10 @@ facility <value>
 severity <value>
 use_record <value>
 payload_key message
-rfc 3164 <6> 
+rfc 3164 <6>
 </store>
 ----
-<1> Specify the protocol to use, either: `syslog` or `syslog_buffered`. 
+<1> Specify the protocol to use, either: `syslog` or `syslog_buffered`.
 <2> Specify the FQDN or IP address of the syslog server.
 <3> Specify the port of the syslog server.
 <4> Specify a name for this syslog server.
@@ -98,7 +98,7 @@ rfc 3164 <6>
 ** Parameter to  remove the specified `tag` field from the syslog prefix.
 ** Parameter to set the specified field as the syslog key.
 ** Parameter to specify the syslog log facility or source.
-** Parameter to specify the syslog log severity. 
+** Parameter to specify the syslog log severity.
 ** Parameter to use the severity and facility from the record if available. If `true`, the `container_name`, `namespace_name`, and `pod_name` are included in the output content.
 ** Parameter to specify the key to set the payload of the syslog message. Defaults to `message`.
 <6> Specify the RFC protocol to use: `3164`.


### PR DESCRIPTION
BZ-1844449 - https://bugzilla.redhat.com/show_bug.cgi?id=1844449

Updates to the hostname value `fluentd-4nzfz` in examples when "Forwarding logs using the syslog protocol". The correct value is `${hostname}`. This PR covers the update to [master and] 4.6 and 4.7. Cluster logging was restructured, so updates to 4.4 and 4.5 will be made in separate PRs.