### PR TITLE
BZ-1844449 Updating hostname in syslog protocol examples 4.4

### DIFF
--- a/modules/cluster-logging-collector-syslog.adoc
+++ b/modules/cluster-logging-collector-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-syslog_{context}"]
 = Forwarding logs using the syslog protocol
 
-You can use the *syslog* protocol to send a copy of your logs to an external syslog server, 
+You can use the *syslog* protocol to send a copy of your logs to an external syslog server,
 instead of the default Elasticsearch logstore. Note the following about this *syslog* protocol:
 
 * uses syslog protocol (RFC 3164), not RFC 5424;
@@ -22,11 +22,11 @@ There are two versions of the *syslog* protocol:
 * *out_syslog*: The non-buffered implementation, which communicates through UDP, does not buffer data and writes out results immediately.
 * *out_syslog_buffered*: The buffered implementation, which communicates through TCP, link:https://docs.fluentd.org/buffer[buffers data into chunks].
 
-To configure log forwarding using the *syslog* protocol, create a configuration file, called `syslog.conf`, with the information needed to forward the logs. Then use that file to create a ConfigMap called `syslog` in the `openshift-logging` namespace, which {product-title} uses when forwarding the logs. You are responsible to configure your syslog server to receive the logs from {product-title}. 
+To configure log forwarding using the *syslog* protocol, create a configuration file, called `syslog.conf`, with the information needed to forward the logs. Then use that file to create a ConfigMap called `syslog` in the `openshift-logging` namespace, which {product-title} uses when forwarding the logs. You are responsible to configure your syslog server to receive the logs from {product-title}.
 
 [IMPORTANT]
 ====
-Starting with the {product-title} 4.3, the process for using the *syslog* protocol has changed. You now need to create a ConfigMap, as described below. 
+Starting with the {product-title} 4.3, the process for using the *syslog* protocol has changed. You now need to create a ConfigMap, as described below.
 ====
 
 You can forward logs to multiple syslog servers by specifying separate `<store>` stanzas in the configuration file.
@@ -37,7 +37,7 @@ You can forward logs to multiple syslog servers by specifying separate `<store>`
 @type syslog_buffered <1>
 remote_syslog rsyslogserver.openshift-logging.svc.cluster.local <2>
 port 514 <3>
-hostname fluentd-4nzfz <4>
+hostname ${hostname} <4>
 remove_tag_prefix tag <5>
 tag_key ident,systemd.u.SYSLOG_IDENTIFIER <6>
 facility local0 <7>
@@ -77,7 +77,7 @@ data:
      @type syslog_buffered
      remote_syslog syslogserver.openshift-logging.svc.cluster.local
      port 514
-     hostname fluentd-4nzfz
+     hostname ${hostname}
      remove_tag_prefix tag
      tag_key ident,systemd.u.SYSLOG_IDENTIFIER
      facility local0
@@ -100,7 +100,7 @@ parameters within the `<store>` stanza:
 @type syslog_buffered <1>
 ----
 +
-<1> Specify the protocol to use, either: `syslog` or `syslog_buffered`. 
+<1> Specify the protocol to use, either: `syslog` or `syslog_buffered`.
 
 .. Configure the name, host, and port for your external syslog server:
 +
@@ -154,7 +154,7 @@ The configuration file appears similar to the following:
 @type syslog_buffered
 remote_syslog syslogserver.openshift-logging.svc.cluster.local
 port 514
-hostname fluentd-4nzfz
+hostname ${hostname}
 tag_key ident,systemd.u.SYSLOG_IDENTIFIER
 facility local0
 severity info


### PR DESCRIPTION
BZ-1844449 - https://bugzilla.redhat.com/show_bug.cgi?id=1844449

Updates to the hostname value fluentd-4nzfz in examples when "Forwarding logs using the syslog protocol". The correct value is ${hostname}. This PR covers the update to 4.4. Cluster logging was restructured, so updates to 4.5 and 4.6 will be made in separate PRs.

[PR for 4.6](https://github.com/openshift/openshift-docs/pull/26828)
[PR for 4.5](https://github.com/openshift/openshift-docs/pull/26836)