### PR TITLE
Clarify release notes wording for Bug 1822513

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1585,7 +1585,7 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * HTTPS signatures retrieved serialized stores, causing potential time outs before the Cluster Version Operator could complete the tasks. Now, external HTTPS signature retrieval is parallel and all stores will be attempted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840343[*BZ#1840343*])
 
-* The Cluster Version Operator `currentMinor` version was acquired from `cv.Status.History[0].Version`, which contained the version upgraded to and not the current version. Now, the version history is stored in `CompletedUpdate`  and will display the `currentMinor` version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822513[*BZ#1822513*])
+* Previously, during z-stream cluster upgrades using the option `--to-image`, for example `oc adm upgrade --to-image`, the Cluster Version Operator was using the cluster version being upgraded to, rather than the current cluster version for validation purposes. This caused z-stream upgrades to fail. Now z-stream cluster upgrades using the option `--to-image` are allowed even when Cluster Version Operator has `Upgradeable=false`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822513[*BZ#1822513*])
 
 * Previously, the Cluster Version Operator (CVO) was not syncing the shareProcessNamespace parameter in the Pod spec, which caused the Registry Operator to not update the shareProcessNamespace setting. The CVO now syncs shareProcessNamespace, DNSPolicy, and TerminationGracePeriodSeconds, fixing the Registry Operator update issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866554[*BZ#1866554*])
 


### PR DESCRIPTION
Current wording has technical specifics of the fix but does not
communicate how the fix helps a user.