### PR TITLE
Moving audit log content to security section

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -459,6 +459,8 @@ Topics:
 - Name: Certificate types and descriptions
   File: certificate-types-descriptions
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Viewing audit logs
+  File: audit-log-view
 - Name: Allowing JavaScript-based access to the API server from additional hosts
   File: allowing-javascript-access-api-server
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
@@ -1222,8 +1224,6 @@ Topics:
     File: nodes-nodes-resources-configuring
 #  - Name: Monitoring for problems in your nodes
 #    File: nodes-nodes-problem-detector
-  - Name: Viewing node audit logs
-    File: nodes-nodes-audit-log
   - Name: Machine Config Daemon metrics
     File: nodes-nodes-machine-config-daemon-metrics
 - Name: Working with containers

--- a/modules/nodes-nodes-audit-log-basic-viewing.adoc
+++ b/modules/nodes-nodes-audit-log-basic-viewing.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes-audit-log.adoc
+// * security/audit-log-view.adoc
 
 [id="nodes-nodes-audit-log-basic-viewing_{context}"]
 = Viewing the audit log

--- a/modules/nodes-nodes-audit-log-basic.adoc
+++ b/modules/nodes-nodes-audit-log-basic.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/nodes-audit-log.adoc
+// * security/audit-log-view.adoc
 
 [id="nodes-pods-audit-log-basic_{context}"]
 = About the API audit log

--- a/security/audit-log-view.adoc
+++ b/security/audit-log-view.adoc
@@ -1,6 +1,6 @@
-:context: nodes-nodes-audit-log
-[id="nodes-nodes-audit-log"]
-= Viewing node audit logs
+:context: audit-log-view
+[id="audit-log-view"]
+= Viewing audit logs
 include::modules/common-attributes.adoc[]
 
 toc::[]
@@ -20,4 +20,3 @@ administrators, or other components of the system.
 include::modules/nodes-nodes-audit-log-basic.adoc[leveloffset=+1]
 
 include::modules/nodes-nodes-audit-log-basic-viewing.adoc[leveloffset=+1]
-

--- a/security/container_security/security-monitoring.adoc
+++ b/security/container_security/security-monitoring.adoc
@@ -24,4 +24,4 @@ include::modules/security-monitoring-audit-logging.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../nodes/clusters/nodes-containers-events.adoc#nodes-containers-events[List of system events]
 * xref:../../logging/cluster-logging.adoc#cluster-logging[Understanding cluster logging]
-* xref:../../nodes/nodes/nodes-nodes-audit-log.adoc#nodes-nodes-audit-log[Viewing node audit logs]
+* xref:../../security/audit-log-view.adoc#audit-log-view[Viewing audit logs]


### PR DESCRIPTION
Since there will be conflicts when cherry picking #26698 to 4.4 and 4.5, opening this PR for those versions.