### PR TITLE
OSSMDOC-125 and 131, configure external Elasticsearch.

### DIFF
--- a/modules/jaeger-config-storage.adoc
+++ b/modules/jaeger-config-storage.adoc
@@ -8,23 +8,11 @@ This REFERENCE module included in the following assemblies:
 
 You configure storage for the Collector, Ingester, and Query services under `spec:storage`.  Multiple instances of each of these components can be provisioned as required for performance and resilience purposes.
 
-.Restrictions
-
-* There can be only one Jaeger with self-provisioned Elasticsearch instance per namespace.
-* There can be only one Elasticsearch per namespace.
-* You cannot share or reuse a {ProductName} logging Elasticsearch instance with Jaeger.  The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
-
-[NOTE]
-====
-If you already have installed Elasticsearch as part of OpenShift logging, the Jaeger Operator can use the installed Elasticsearch Operator to provision storage.
-====
-
 .Jaeger general storage parameters
 [options="header"]
 [cols="l, a, a, a"]
 |===
 |Parameter |Description |Values |Default value
-
 |spec:
  storage:
   options: {}
@@ -39,71 +27,62 @@ If you already have installed Elasticsearch as part of OpenShift logging, the Ja
 Memory storage is only appropriate for development, testing, demonstrations, and proof of concept environments as the data does not persist if the pod is shut down. For production environments Jaeger supports Elasticsearch for persistent storage.
 |`memory`
 
-|===
-
-
-.Elasticsearch configuration parameters
-[options="header"]
-[cols="l, a, a, a"]
-|===
-|Parameter |Description |Values |Default value
-
-4+|General Elasticsearch configuration settings
-|elasticsearch:
-  server-urls:
-|URL of the Elasticsearch instance.
-|The fully-qualified domain name of the Elasticsearch server.  If you have specified `spec:storage:type`= `elasticsearch` but have not specified a value for `server-urls` parameter, the Jaeger Operator will use the Elasticsearch Operator to create an Elasticsearch cluster using the configuration in the `spec:storage:elasticsearch` section of the custom resource file.
-|`http://elasticsearch.<namespace>.svc:9200`
-
-|es:
-  max-num-spans:
-|The maximum number of spans to fetch at a time, per query, in Elasticsearch.
-|
-|10000
-
-|es:
-  max-span-age:
-|The maximum lookback for spans in Elasticsearch.
-|
-|72h0m0s
-
-|elasticsearch:
+|storage:
   secretname:
 |Name of the secret, for example `jaeger-secret`.
 |
 |N/A
+|===
 
-|es:
-  sniffer:
-|The sniffer configuration for Elasticsearch.  The client uses the sniffing process to find all nodes automatically. Disabled by default.
+.Elasticsearch index cleaner parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
+|storage:
+  esIndexCleaner:
+    enabled:
+|When using Elasticsearch storage, by default a job is created to clean old traces from the index.  This parameter enables or disables the index cleaner job.
 |`true`/ `false`
-|`false`
+|`true`
 
-|es:
-  timeout:
-|Timeout used for queries. When set to zero there is no  timeout.
-|
-|0s
+|storage:
+  esIndexCleaner:
+    numberOfDays:
+|Number of days to wait before deleting an index.
+|Integer value
+|`7`
 
-|es:
-  username:
-|The username required by Elasticsearch. The basic authentication also loads CA if it is specified.  See also `es.password`.
-|
-|
+|storage:
+  esIndexCleaner:
+    schedule:
+|Defines the schedule for how often to clean the Elasticsearch index.
+|Cron expression
+|"55 23 * * *"
+|===
 
-|es:
-  password:
-|The password required by Elasticsearch.   See also, `es.username`.
-|
-|
+[id="jaeger-config-auto-provisioning-es_{context}"]
+== Auto-provisioning an Elasticsearch instance
 
-|es:
-  version:
-|The major Elasticsearch version. If not specified, the value will be auto-detected from Elasticsearch.
-|
-|0
+When the `storage:type` is set to `elasticsearch` but there is no value set for `spec:storage:options:es:server-urls`, the Jaeger Operator uses the Elasticsearch Operator to create an Elasticsearch cluster based on the configuration provided in the `storage` section of the custom resource file.
 
-4+|Elasticsearch resource configuration settings
+.Restrictions
+
+* There can be only one Elasticsearch per namespace.
+* You cannot share or reuse a {ProductName} logging Elasticsearch instance with Jaeger.  The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
+
+[NOTE]
+====
+If you already have installed Elasticsearch as part of OpenShift logging, the Jaeger Operator can use the installed Elasticsearch Operator to provision storage.
+====
+
+The following configuration parameters are for a _self-provisioned_ Elasticsearch instance, that is an instance created by the Jaeger Operator using the Elasticsearch Operator.  You specify configuration options for self-provisioned Elasticsearch under `spec:storage:elasticsearch`  in your configuration file.
+
+.Elasticsearch resource configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |elasticsearch:
   nodeCount:
 |Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as “split brain” problem can happen.
@@ -147,16 +126,152 @@ Minimum deployment =1
 Minimum deployment = 16Gi*
 |
 
-|
-3+|*Each Elasticsearch node can operate with a lower memory setting though this is NOT recommended for production deployments. For production use, you should have no less than 16Gi allocated to each Pod by default, but preferably allocate as much as you can, up to 64Gi per Pod.
-
-4+|Elasticsearch data replication options
 |elasticsearch:
   redundancyPolicy:
 |Data replication policy defines how Elasticsearch shards are replicated across data nodes in the cluster. If not specified,the Jaeger Operator automatically determines the most appropriate replication based on number of nodes.
 |`ZeroRedundancy`(no replica shards), `SingleRedundancy`(one replica shard), `MultipleRedundancy`(each index is spread over half of the Data nodes), `FullRedundancy` (each index is fully replicated on every Data node in the cluster).
 |
 
+|
+3+|*Each Elasticsearch node can operate with a lower memory setting though this is NOT recommended for production deployments. For production use, you should have no less than 16Gi allocated to each Pod by default, but preferably allocate as much as you can, up to 64Gi per Pod.
+|===
+
+.Production storage example
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simple-prod
+spec:
+  strategy: production
+  storage:
+    type: elasticsearch
+    elasticsearch:
+      nodeCount: 3
+      resources:
+        requests:
+          cpu: 1
+          memory: 16Gi
+        limits:
+          memory: 16Gi
+----
+
+.Storage example with persistent storage:
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: Jaeger
+metadata:
+  name: simple-prod
+spec:
+  strategy: production
+  storage:
+    type: elasticsearch
+    elasticsearch:
+      nodeCount: 1
+      storage: # <1>
+        storageClassName: gp2
+        size: 5Gi
+      resources:
+        requests:
+          cpu: 200m
+          memory: 4Gi
+        limits:
+          memory: 4Gi
+      redundancyPolicy: ZeroRedundancy
+----
+
+<1> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When no value is specified, Jaeger uses `emptyDir`. The Elasticsearch Operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. You can mount the same volumes if you create a Jaeger instance with the same name and namespace.
+
+
+[id="jaeger-config-external-es_{context}"]
+== Connecting to an existing Elasticsearch instance
+
+Jaeger also allows you to use an existing (self-provisioned) Elasticsearch cluster for storage.  You do this by specifying the URL of the existing cluster as the `spec:storage:options:es:server-urls` value in your configuration.
+
+.Restrictions
+
+* There can be only one Jaeger with self-provisioned Elasticsearch instance per namespace.
+
+[NOTE]
+====
+Red Hat does not provide support for your external Elasticsearch instance. You can review the tested integrations matrix on the link:https://access.redhat.com/articles/5381021[Customer Portal].
+====
+
+The following configuration parameters are for an _external_ Elasticsearch instance, that is, an instance that was not created using the Elasticsearch Operator. You specify configuration options for external Elasticsearch under `spec:storage:options:es` in your configuration file.
+
+.General ES configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
+|es:
+  server-urls:
+|URL of the Elasticsearch instance.
+|The fully-qualified domain name of the Elasticsearch server.
+|`http://elasticsearch.<namespace>.svc:9200`
+
+|es:
+  max-doc-count:
+|The maximum document count to return from an Elasticsearch query. This will also apply to aggregations. If you set both `es.max-doc-count` and `es.max-num-spans`, Elasticsearch will use the smaller value of the two.
+|
+|10000
+
+|es:
+  max-num-spans:
+|[*Deprecated* - Will be removed in a future release, use `es.max-doc-count` instead.] The maximum number of spans to fetch at a time, per query, in Elasticsearch. If you set both `es.max-num-spans` and `es.max-doc-count`, Elasticsearch will use the smaller value of the two.
+|
+|10000
+
+|es:
+  max-span-age:
+|The maximum lookback for spans in Elasticsearch.
+|
+|72h0m0s
+
+|es:
+  sniffer:
+|The sniffer configuration for Elasticsearch.  The client uses the sniffing process to find all nodes automatically. Disabled by default.
+|`true`/ `false`
+|`false`
+
+|es:
+  sniffer-tls-enabled:
+|Option to enable TLS when sniffing an Elasticsearch Cluster,  The client uses the sniffing process to find all nodes automatically.  Disabled by default
+|`true`/ `false`
+|`false`
+
+|es:
+  timeout:
+|Timeout used for queries. When set to zero there is no  timeout.
+|
+|0s
+
+|es:
+  username:
+|The username required by Elasticsearch. The basic authentication also loads CA if it is specified.  See also `es.password`.
+|
+|
+
+|es:
+  password:
+|The password required by Elasticsearch.   See also, `es.username`.
+|
+|
+
+|es:
+  version:
+|The major Elasticsearch version. If not specified, the value will be auto-detected from Elasticsearch.
+|
+|0
+|===
+
+.ES data replication parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |es:
   num-replicas:
 |The number of replicas per index in Elasticsearch.
@@ -168,8 +283,13 @@ Minimum deployment = 16Gi*
 |The number of shards per index in Elasticsearch.
 |
 |5
+|===
 
-4+|Elasticsearch index and index cleaner configuration options
+.ES index configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |es:
   create-index-templates:
 |Automatically create index templates at application startup when set to `true`. When templates are installed manually, set to `false`.
@@ -181,32 +301,13 @@ Minimum deployment = 16Gi*
 |Optional prefix for Jaeger indices. For example, setting this to "production" creates indices named "production-jaeger-*".
 |
 |
+|===
 
-|esIndexCleaner:
-  enabled:
-|When using Elasticsearch storage, by default a job is created to clean old traces from the index.  This parameter enables or disables the index cleaner job.
-|`true`/ `false`
-|`true`
-
-|esIndexCleaner:
-  numberOfDays:
-|Number of days to wait before deleting an index.
-|Integer value
-|`7`
-
-|esIndexCleaner:
-  schedule:
-|Defines the schedule for how often to clean the Elasticsearch index.
-|Cron expression
-|"55 23 * * *"
-
-|esRollover:
-  schedule:
-|Defines the schedule for how often to rollover to a new Elasticsearch index.
-|Cron expression
-|'*/30 * * * *'
-
-4+|Configuration settings for Elasticsearch bulk processor
+.ES bulk processor configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |es:
   bulk:
     actions:
@@ -235,8 +336,13 @@ Minimum deployment = 16Gi*
 |The number of workers that are able to receive and commit bulk requests to Elasticsearch.
 |
 |1
+|===
 
-4+|Elasticsearch TLS configuration settings
+.ES TLS configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |es:
   tls:
     ca:
@@ -277,8 +383,13 @@ Minimum deployment = 16Gi*
 |Path to a file containing the bearer token. This flag also loads the Certification Authority (CA) file if it is specified.
 |
 |
+|===
 
-4+|Elasticsearch archive configuration settings
+.ES archive configuration parameters
+[options="header"]
+[cols="l, a, a, a"]
+|===
+|Parameter |Description |Values |Default value
 |es-archive:
   bulk:
     actions:
@@ -327,8 +438,14 @@ Minimum deployment = 16Gi*
 |
 
 |es-archive:
+  max-doc-count:
+|The maximum document count to return from an Elasticsearch query. This will also apply to aggregations.
+|
+|0
+
+|es-archive:
   max-num-spans:
-|The maximum number of spans to fetch at a time, per query, in Elasticsearch.
+|[*Deprecated* - Will be removed in a future release, use `es-archive.max-doc-count` instead.] The maximum number of spans to fetch at a time, per query, in Elasticsearch.
 |
 |0
 
@@ -365,6 +482,12 @@ Minimum deployment = 16Gi*
 |es-archive:
   sniffer:
 |The sniffer configuration for Elasticsearch.  The client uses the sniffing process to find all nodes automatically. Disabled by default.
+|`true`/ `false`
+|`false`
+
+|es-archive:
+  sniffer-tls-enabled:
+|Option to enable TLS when sniffing an Elasticsearch Cluster,  The client uses the sniffing process to find all nodes automatically.  Disabled by default.
 |`true`/ `false`
 |`false`
 
@@ -429,27 +552,6 @@ Minimum deployment = 16Gi*
 |0
 |===
 
-.Production storage example
-[source,yaml]
-----
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: simple-prod
-spec:
-  strategy: production
-  storage:
-    type: elasticsearch
-    elasticsearch:
-      nodeCount: 3
-      resources:
-        requests:
-          cpu: 1
-          memory: 16Gi
-        limits:
-          memory: 16Gi
-----
-
 
 .Storage example with volume mounts
 [source,yaml]
@@ -479,8 +581,9 @@ spec:
         secretName: quickstart-es-http-certs-public
 ----
 
+The following example shows a Jaeger CR using an external Elasticsearch cluster with TLS CA certificate mounted from a volume and user/password stored in a secret.
 
-.Storage example with persistent storage:
+.External Elasticsearch example:
 [source,yaml]
 ----
 apiVersion: jaegertracing.io/v1
@@ -491,18 +594,24 @@ spec:
   strategy: production
   storage:
     type: elasticsearch
-    elasticsearch:
-      nodeCount: 1
-      storage: # <1>
-        storageClassName: gp2
-        size: 5Gi
-      resources:
-        requests:
-          cpu: 200m
-          memory: 4Gi
-        limits:
-          memory: 4Gi
-      redundancyPolicy: ZeroRedundancy
-----
+    options:
+      es:
+        server-urls: https://quickstart-es-http.default.svc:9200 # <1>
+        index-prefix: my-prefix
+        tls: # <2>
+          ca: /es/certificates/ca.crt
+    secretName: jaeger-secret # <3>
+  volumeMounts: # <4>
+    - name: certificates
+      mountPath: /es/certificates/
+      readOnly: true
+  volumes:
+    - name: certificates
+      secret:
+        secretName: quickstart-es-http-certs-public
 
-<1> Persistent storage configuration. In this case AWS `gp2` with `5Gi` size. When no value is specified, Jaeger uses `emptyDir`. The Elasticsearch Operator provisions `PersistentVolumeClaim` and `PersistentVolume` which are not removed with Jaeger instance. You can mount the same volumes if you create a Jaeger instance with the same name and namespace.
+----
+<1> URL to Elasticsearch service running in default namespace.
+<2> TLS configuration. In this case only CA certificate, but it can also contain es.tls.key and es.tls.cert when using mutual TLS.
+<3> Secret which defines environment variables ES_PASSWORD and ES_USERNAME. Created by kubectl create secret generic jaeger-secret --from-literal=ES_PASSWORD=changeme --from-literal=ES_USERNAME=elastic
+<4> Volume mounts and volumes which are mounted into all storage components.


### PR DESCRIPTION
This PR addresses both [OSSMDOC-125](https://issues.redhat.com/browse/OSSMDOC-125) (Document external Elasticsearch) and [OSSMDOC-131](https://issues.redhat.com/browse/OSSMDOC-131) (split out auto-provision and self-provisioned Elasticsearch options).