### PR TITLE
Fix margin and padding for definition lists

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -1300,6 +1300,13 @@ table > tbody > tr > td > div > div > p > code {
  span.footnote a:active, span.footnoteref a:active {
      text-decoration: underline;
 }
+.dlist dt {
+  padding-bottom: 0.5em;
+}
+/* This overrides the 0 margin from subdomain.css */
+.dlist dd {
+  margin-left: 1.5em;
+}
  #footnotes {
      padding-top: 0.75em;
      padding-bottom: 0.75em;


### PR DESCRIPTION
@bergerhoffer, how about this?

<img width="706" alt="Screen Shot 2020-10-28 at 11 43 22 AM" src="https://user-images.githubusercontent.com/354496/97499797-e7102e80-1944-11eb-8128-5875a07f1d60.png">
