### PR TITLE
Warning note about ipam definition in NAD for VMs

### DIFF
--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -21,6 +21,11 @@ include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 * A Linux bridge must be configured and attached on every node. 
 See the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking] section for more information.
 
+[WARNING]
+====
+Configuring ipam in a NetworkAttachmentDefinition for virtual machines is not supported.
+====
+
 include::modules/virt-creating-bridge-nad-web.adoc[leveloffset=+2]
 
 include::modules/virt-creating-bridge-nad-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
After discussing this topic with engineering team, the idea to explicitly warn users about ipam definition in a network attachment definition for VMs was brought, thus, added the warning note in the OpenShift Virtualization section.

BZ 1892343

@openshift/team-documentation 
