### PR TITLE
adding log forwarding and links to Understanding cluster logging

### DIFF
--- a/logging/cluster-logging.adoc
+++ b/logging/cluster-logging.adoc
@@ -46,14 +46,26 @@ endif::[]
 
 include::modules/cluster-logging-about.adoc[leveloffset=+1]
 
+For information, see xref:../logging/cluster-logging-deploying.adoc#cluster-logging-deploying[Configuring the log collector].
+
 include::modules/cluster-logging-about-components.adoc[leveloffset=+2]
 
 include::modules/cluster-logging-about-collector.adoc[leveloffset=+2]
 
+For information, see xref:../logging/config/cluster-logging-collector.adoc#cluster-logging-collector[Configuring the log collector].
+
 include::modules/cluster-logging-about-logstore.adoc[leveloffset=+2]
+
+For information, see xref:../logging/config/cluster-logging-log-store.adoc#cluster-logging-store[Configuring the log store].
 
 include::modules/cluster-logging-about-visualizer.adoc[leveloffset=+2]
 
+For information, see xref:../logging/config/cluster-logging-visualizer.adoc#cluster-logging-visualizer[Configuring the log visualizer].
+
 include::modules/cluster-logging-eventrouter-about.adoc[leveloffset=+2]
 
+For information, see xref:../logging/cluster-logging-eventrouter.adoc#cluster-logging-eventrouter[Collecting and storing Kubernetes events].
 
+include::modules/cluster-logging-forwarding-about.adoc[leveloffset=+2]
+
+For information, see xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third party systems].

--- a/modules/cluster-logging-forwarding-about.adoc
+++ b/modules/cluster-logging-forwarding-about.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging.adoc
+
+[id="cluster-logging-forwarding-about_{context}"]
+= About log forwarding
+
+By default, {product-title} cluster logging sends logs to the default internal Elasticsearch log store, defined in the Cluster Logging Custom Resource. If you want to forward logs to other log aggregators, you can use the log forwarding features to send logs to specific endpoints within or outside your cluster.
+


### PR DESCRIPTION
Addding links to configuring page for each component and added log forwarding to the understanding cluster logging page.