### PR TITLE
remove aro regions

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -50,48 +50,7 @@ a| * Overview of OpenShift architecture
 * Developing on OpenShift
 * Managing your cluster
 |===
-
-== Available Regions
-
-{product-title} is currently available in the following regions:
-
-[cols="1,1"]
-|===
-| Australia East (Public/Australia)
-| North Europe (Public/Europe)
-
-| Brazil South (Public/Brazil)
-| South Africa North (Public/Africa)
-
-| Canada Central (Public/Canada)
-| South Central US (Public/United States)
-
-| Canada East (Public/Canada)
-| Southeast Asia (Public/Asia Pacific)
-
-| Central US (Public/United States)
-| Switzerland North (Public/Switzerland)
-
-| East US (Public/United States)
-| UK South (Public/United Kingdom)
-
-| East US 2 (Public/United States)
-| UK West (Public/United Kingdom)
-
-| Japan East (Public/Japan)
-| West Europe (Public/Europe)
-
-| Japan West (Public/Japan)
-| West US (Public/United States)
-
-| Korea Central (Public/Korea)
-| West US 2 (Public/United States)
-
-| North Central US (Public/United States)
-|
-
-|===
-endif::[]
+endif::openshift-aro[]
 
 ifdef::partner-roks[]
 


### PR DESCRIPTION
Deleting the "Available Regions" section from the ARO4 docs. This content is now available and maintained in the MSFT docs - https://azure.microsoft.com/en-us/global-infrastructure/services/?products=openshift

@sfortner-RH Can you take a quick look when you have a chance?