### PR TITLE
OSSMDOC-141 update upstream/downstream differences topic.

### DIFF
--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -11,7 +11,26 @@ An installation of {ProductName} differs from an installation of Istio in multip
 [id="ossm-cli-tool_{context}"]
 == Command line tool
 
-The command line tool for {ProductName} is oc.  {ProductName}  does not support istioctl.
+The command line tool for {ProductName} is oc.  {ProductName} does not support istioctl.
+
+
+[id="ossm-installation-upgrade_{context}"]
+== Installation and upgrades
+
+{ProductName} does not support Istio installation profiles.
+
+{ProductName} does not support canary upgrades of the service mesh.
+
+
+[id="ossm-federation-multicluster_{context}"]
+== Federation and multicluster
+
+{ProductName} does not yet support federated or multiclustered service meshes.
+
+* *Federated*: a set of Service Mesh control planes which interact with each other and are configured independently.
+
+* *Clustered*: a set of Service Mesh control planes which act as a single control plane and are configured as a single entity.
+
 
 [id="ossm-automatic-injection_{context}"]
 == Automatic injection
@@ -20,50 +39,16 @@ The upstream Istio community installation automatically injects the sidecar into
 
 {ProductName} does not automatically inject the sidecar to any pods, but requires you to opt in to injection using an annotation without labeling projects. This method requires fewer privileges and does not conflict with other OpenShift capabilities such as builder pods. To enable automatic injection you specify the `sidecar.istio.io/inject` annotation as described in the Automatic sidecar injection section.
 
-[id="ossm-rbac_{context}"]
-== Istio Role Based Access Control features
-
-Istio Role Based Access Control (RBAC) provides a mechanism you can use to control access to a service. You can identify subjects by user name or by specifying a set of properties and apply access controls accordingly.
-
-The upstream Istio community installation includes options to perform exact header matches, match wildcards in headers, or check for a header containing a specific prefix or suffix.
-
-{ProductName} extends the ability to match request headers by using a regular expression. Specify a property key of `request.regex.headers` with a regular expression.
-
-.Upstream Istio community matching request headers example
-[source,yaml]
-----
-apiVersion: "rbac.istio.io/v1alpha1"
-kind: ServiceRoleBinding
-metadata:
-  name: httpbin-client-binding
-  namespace: httpbin
-spec:
-  subjects:
-  - user: "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-    properties:
-      request.headers[<header>]: "value"
-----
-
-.{ProductName} matching request headers by using regular expressions
-[source,yaml]
-----
-apiVersion: "rbac.istio.io/v1alpha1"
-kind: ServiceRoleBinding
-metadata:
-  name: httpbin-client-binding
-  namespace: httpbin
-spec:
-  subjects:
-  - user: "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
-    properties:
-      request.regex.headers[<header>]: "<regular expression>"
-----
-
-
 [id="ossm-openssl_{context}"]
 == OpenSSL
 
 {ProductName} replaces BoringSSL with OpenSSL. OpenSSL is a software library that contains an open source implementation of the Secure Sockets Layer (SSL) and Transport Layer Security (TLS) protocols. The {ProductName} Proxy binary dynamically links the OpenSSL libraries (libssl and libcrypto) from the underlying Red Hat Enterprise Linux operating system.
+
+
+[id="ossm-external-workloads_{context}"]
+== External workloads
+
+{ProductName} does not support external workloads (virtual machines).
 
 [id="ossm-component-modifications_{context}"]
 == Component modifications
@@ -74,11 +59,10 @@ spec:
 * Godebug has been removed from all templates
 * The `istio-multi` ServiceAccount and ClusterRoleBinding have been removed, as well as the `istio-reader` ClusterRole.
 
-[id="ossm-envoy-sds-ca_{context}"]
-== Envoy, Secret Discovery Service, and certificates
+[id="ossm-envoy-services_{context}"]
+== Envoy services
 
 * {ProductName} does not support QUIC-based services.
-* Deployment of TLS certificates using the Secret Discovery Service (SDS) functionality of Istio is not currently supported in {ProductName}. The Istio implementation depends on a nodeagent container that uses hostPath mounts.
 
 [id="ossm-cni_{context}"]
 == Istio Container Network Interface (CNI) plug-in
@@ -103,3 +87,9 @@ Subdomains (e.g.: "*.domain.com") are supported. However this ability doesn't co
 [id="ossm-tls_{context}"]
 === Transport layer security
 Transport Layer Security (TLS) is supported. This means that, if the Gateway contains a `tls` section, the OpenShift Route will be configured to support TLS.
+
+
+[id="ossm-wasm_{context}"]
+=== WebAssembly Extensions
+
+{ProductName} 2.0 introduces WebAssembly extensions to Envoy Proxy as a link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview].  Note that WASM extensions are not included in the proxy binary and that WASM filters from the upstream Istio community are not supported in {ProductName} 2.0.


### PR DESCRIPTION
This PR

- Removes the Istio Role Based Access Control section, as ServiceRoleBinding is no longer supported in v2.0
- Removes the bullet that SSD is not supported, as this is a new feature

Adds headings for 

- Installation and Upgrades,
- Federation and multicluster
- External workloads
- WebAssembly Extensions