### PR TITLE
adding missing components allowed for infrastructure nodes

### DIFF
--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -6,7 +6,7 @@
 [id="infrastructure-components_{context}"]
 = {product-title} infrastructure components
 
-The following {product-title} components are infrastructure components:
+The following is the list of eligible infrastructure components that do not incur OpenShift Worker Subscriptions:
 
 * Kubernetes and {product-title} control plane services that run on masters
 * The default router
@@ -16,6 +16,7 @@ The following {product-title} components are infrastructure components:
 * Service brokers
 * Red Hat Quay
 * Red Hat OpenShift Container Storage
+* Red Hat Advanced Cluster Manager
 
 Any node that runs any other container, pod, or component is a worker node that
 your subscription must cover.

--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -10,10 +10,12 @@ The following {product-title} components are infrastructure components:
 
 * Kubernetes and {product-title} control plane services that run on masters
 * The default router
-* The container image registry
+* The integrated container image registry
 * The cluster metrics collection, or monitoring service
 * Cluster aggregated logging
 * Service brokers
+* Red Hat Quay
+* Red Hat OpenShift Container Storage
 
 Any node that runs any other container, pod, or component is a worker node that
 your subscription must cover.


### PR DESCRIPTION
OpenShift Container Storage and Red Hat Quay may also be installed on infrastructure nodes. I'm also trying to clarify that OpenShift built-in container registry is allowed in infrastructure nodes, as "the container image registry" could be misinterpreted. 