### PR TITLE
Remove duplicate title in installation overview

### DIFF
--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -244,9 +244,6 @@ needed for the day-to-day operation, including the creation of worker machines
 in supported environments.
 
 [discrete]
-=== Installation process details
-
-[discrete]
 == Installation scope
 
 The scope of the {product-title} installation program is intentionally narrow.


### PR DESCRIPTION
Applies to master, branch/enterprise-4.4, branch/enterprise-4.5, branch/enterprise-4.6 and branch/enterprise-4.7.

This PR removes a duplicate 'Installation process details' title in the [OpenShift Container Platform installation overview](https://docs.openshift.com/container-platform/4.6/architecture/architecture-installation.html#installation-overview_architecture-installation) section of the 
[Installation and update](https://docs.openshift.com/container-platform/4.6/architecture/architecture-installation.html) assembly.

The preview is [here](https://remove_duplicate_installation_title--ocpdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-installation.html#installation-process_architecture-installation).