### PR TITLE
Revert optional step to oc annotate

### DIFF
--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -20,20 +20,17 @@ The Local Storage Operator is not installed in {product-title} by default. Use t
 $ oc new-project local-storage
 ----
 
-. Optional: Allow local storage creation on master and infrastructure nodes.
+. Optional: Allow local storage creation on infrastructure nodes.
 +
-You might want to use the Local Storage Operator to create volumes on master and infrastructure nodes, and not just worker nodes, to support components such as logging and monitoring.
+You might want to use the Local Storage Operator to create volumes on infrastructure nodes in support of components such as logging and monitoring.
 +
-To allow local storage creation on master and infrastructure nodes, add a toleration to the DaemonSet by entering the following commands:
+You must adjust the default node selector so that the Local Storage Operator includes the infrastructure nodes, and not just worker nodes.
 +
-[source,terminal]
-----
-$ oc patch ds local-storage-local-diskmaker -n local-storage -p '{"spec": {"template": {"spec": {"tolerations":[{"operator": "Exists"}]}}}}'
-----
+To block the Local Storage Operator from inheriting the cluster-wide default selector, enter the following command:
 +
 [source,terminal]
 ----
-$ oc patch ds local-storage-local-provisioner -n local-storage -p '{"spec": {"template": {"spec": {"tolerations":[{"operator": "Exists"}]}}}}'
+$ oc annotate project local-storage openshift.io/node-selector=''
 ----
 
 .From the UI


### PR DESCRIPTION
Related to https://github.com/openshift/openshift-docs/pull/26912 - this PR reverts the optional node selector step from `oc patch` to `oc annotate` for the OCP 4.5 branch only.

@openshift/team-documentation PTAL

**PREVIEW LINK:**
https://bz1848623-4-5--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-storage-install_persistent-storage-local