### PR TITLE
BZ-1870931 adding cluster logging must-gather

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -107,12 +107,160 @@ $ oc adm must-gather \
 <1> The default {product-title} `must-gather` image
 <2> The must-gather image for {VirtProductName}
 +
-For cluster logging, run the following command:
+You can use the `must-gather` tool with additional arguments to gather data that is specifically related to cluster logging and the Cluster Logging Operator in your cluster. For cluster logging, run the following command:
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=$(oc -n openshift-logging get deployment.apps/cluster-logging-operator -o jsonpath='{.spec.template.spec.containers[?(@.name == "cluster-logging-operator")].image}')
+$ oc adm must-gather --image=$(oc -n openshift-logging get deployment.apps/cluster-logging-operator \
+ -o jsonpath='{.spec.template.spec.containers[?(@.name == "cluster-logging-operator")].image}')
 ----
++
+.Example `must-gather` output for cluster logging
+[%collapsible]
+====
+[source,terminal]
+----
+├── cluster-logging
+│  ├── clo
+│  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+│  │  ├── clusterlogforwarder_cr
+│  │  ├── cr
+│  │  ├── csv
+│  │  ├── deployment
+│  │  └── logforwarding_cr
+│  ├── collector
+│  │  ├── fluentd-2tr64
+│  ├── curator
+│  │  └── curator-1596028500-zkz4s
+│  ├── eo
+│  │  ├── csv
+│  │  ├── deployment
+│  │  └── elasticsearch-operator-7dc7d97b9d-jb4r4
+│  ├── es
+│  │  ├── cluster-elasticsearch
+│  │  │  ├── aliases
+│  │  │  ├── health
+│  │  │  ├── indices
+│  │  │  ├── latest_documents.json
+│  │  │  ├── nodes
+│  │  │  ├── nodes_stats.json
+│  │  │  └── thread_pool
+│  │  ├── cr
+│  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+│  │  └── logs
+│  │     ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+│  ├── install
+│  │  ├── co_logs
+│  │  ├── install_plan
+│  │  ├── olmo_logs
+│  │  └── subscription
+│  └── kibana
+│     ├── cr
+│     ├── kibana-9d69668d4-2rkvz
+├── cluster-scoped-resources
+│  └── core
+│     ├── nodes
+│     │  ├── ip-10-0-146-180.eu-west-1.compute.internal.yaml
+│     └── persistentvolumes
+│        ├── pvc-0a8d65d9-54aa-4c44-9ecc-33d9381e41c1.yaml
+├── event-filter.html
+├── gather-debug.log
+└── namespaces
+   ├── openshift-logging
+   │  ├── apps
+   │  │  ├── daemonsets.yaml
+   │  │  ├── deployments.yaml
+   │  │  ├── replicasets.yaml
+   │  │  └── statefulsets.yaml
+   │  ├── batch
+   │  │  ├── cronjobs.yaml
+   │  │  └── jobs.yaml
+   │  ├── core
+   │  │  ├── configmaps.yaml
+   │  │  ├── endpoints.yaml
+   │  │  ├── events
+   │  │  │  ├── curator-1596021300-wn2ks.162634ebf0055a94.yaml
+   │  │  │  ├── curator.162638330681bee2.yaml
+   │  │  │  ├── elasticsearch-delete-app-1596020400-gm6nl.1626341a296c16a1.yaml
+   │  │  │  ├── elasticsearch-delete-audit-1596020400-9l9n4.1626341a2af81bbd.yaml
+   │  │  │  ├── elasticsearch-delete-infra-1596020400-v98tk.1626341a2d821069.yaml
+   │  │  │  ├── elasticsearch-rollover-app-1596020400-cc5vc.1626341a3019b238.yaml
+   │  │  │  ├── elasticsearch-rollover-audit-1596020400-s8d5s.1626341a31f7b315.yaml
+   │  │  │  ├── elasticsearch-rollover-infra-1596020400-7mgv8.1626341a35ea59ed.yaml
+   │  │  ├── events.yaml
+   │  │  ├── persistentvolumeclaims.yaml
+   │  │  ├── pods.yaml
+   │  │  ├── replicationcontrollers.yaml
+   │  │  ├── secrets.yaml
+   │  │  └── services.yaml
+   │  ├── openshift-logging.yaml
+   │  ├── pods
+   │  │  ├── cluster-logging-operator-74dd5994f-6ttgt
+   │  │  │  ├── cluster-logging-operator
+   │  │  │  │  └── cluster-logging-operator
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  └── cluster-logging-operator-74dd5994f-6ttgt.yaml
+   │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff
+   │  │  │  ├── cluster-logging-operator-registry
+   │  │  │  │  └── cluster-logging-operator-registry
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── cluster-logging-operator-registry-6df49d7d4-mxxff.yaml
+   │  │  │  └── mutate-csv-and-generate-sqlite-db
+   │  │  │     └── mutate-csv-and-generate-sqlite-db
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── curator-1596028500-zkz4s
+   │  │  ├── elasticsearch-cdm-lp8l38m0-1-794d6dd989-4jxms
+   │  │  ├── elasticsearch-delete-app-1596030300-bpgcx
+   │  │  │  ├── elasticsearch-delete-app-1596030300-bpgcx.yaml
+   │  │  │  └── indexmanagement
+   │  │  │     └── indexmanagement
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── fluentd-2tr64
+   │  │  │  ├── fluentd
+   │  │  │  │  └── fluentd
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── fluentd-2tr64.yaml
+   │  │  │  └── fluentd-init
+   │  │  │     └── fluentd-init
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  │  ├── kibana-9d69668d4-2rkvz
+   │  │  │  ├── kibana
+   │  │  │  │  └── kibana
+   │  │  │  │     └── logs
+   │  │  │  │        ├── current.log
+   │  │  │  │        ├── previous.insecure.log
+   │  │  │  │        └── previous.log
+   │  │  │  ├── kibana-9d69668d4-2rkvz.yaml
+   │  │  │  └── kibana-proxy
+   │  │  │     └── kibana-proxy
+   │  │  │        └── logs
+   │  │  │           ├── current.log
+   │  │  │           ├── previous.insecure.log
+   │  │  │           └── previous.log
+   │  └── route.openshift.io
+   │     └── routes.yaml
+   └── openshift-operators-redhat
+      ├── ...
+----
+====
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]


### PR DESCRIPTION
BZ-1870931 https://bugzilla.redhat.com/show_bug.cgi?id=1870931

@nekop PTAL. I have a few questions as well:

- I wasn't sure if the cluster logging must-gather needed to be added for openshift-origin as well. Did I add the information in the list that you were referring to in the BZ? 
- Also, I looked up the Cluster Logging Operator image on `registry.redhat.io` for the openshift-origin example. Did I use the correct image?
- What versions of the docs does this information need to be added? 4.4+ ?