### PR TITLE
CNV - JIRA Story CNV7160 Adding guest agent virtctl command info to 2.5 Release Notes

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -36,7 +36,13 @@ The SVVP Certification applies to:
 
 //CNV-7294 - Cluster admin can now influence node placement using new API on HCO CR
 
-//CNV-7160 - New virtctl commands to expose raw qemu guest agent data
+//CNV-7160 - New virtctl commands to expose raw QEMU guest agent data
+
+* {VirtProductName} {VirtVersion} adds three new xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[`virtctl` commands] to manage QEMU guest agent data:
+
+** `virtctl fslist <vmi_name>` returns a full list of file systems available on the guest machine.
+** `virtctl guestosinfo <vmi_name>` returns guest agent information about the operating system.
+** `virtctl userlist <vmi_name>` returns a full list of logged-in users on the guest machine.
 
 //CNV-7295 - Download virtctl binary from the CLI Tools page
 


### PR DESCRIPTION
This PR address JIRA story [CNV-7160](https://issues.redhat.com/browse/CNV-7160) (https://issues.redhat.com/browse/CNV-7160).

Added information about new fslist, guestosinfo, and userlist virtctl commands to 2.5 release notes.

Preview link - https://cnv7160--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-5-release-notes.html#virt-2-5-new