### PR TITLE
CNV-7317 RN-guest agent details view in the web console

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -105,6 +105,7 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 //CNV-7314 - Expose VM image upload in UI
 
 //CNV-7317 - Expose qemu guest agent data in the UI
+* When the QEMU guest agent runs on the virtual machine, you can use the web console to view information about the virtual machine, users, file systems, and secondary networks.
 
 [id="virt-2-5-changes"]
 == Notable technical changes


### PR DESCRIPTION
This Release Note PR about viewing the QEMU guest agent in the web console is associated with:
https://issues.redhat.com/browse/CNV-7317?filter=12355089
CP to 4.6 release.

Background details for reference:
New feature content for QEMU guest agent was presented through this PR:
https://issues.redhat.com/browse/CNV-5092

In a different PR, the new feature content for the QEMU guest agent was moved from the networking section to the virtual machines section:
https://bugzilla.redhat.com/show_bug.cgi?id=1876474