### PR TITLE
CNV-BZ-1874403 release note for 2.5

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -113,6 +113,9 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 
 //CNV-7296 - HCO and HPP CRs moved to v1beta1
 
+//BZ-1874403
+* The default `cloud-init` user password is now auto-generated for virtual machines that are created from templates.
+
 
 [id="virt-2-5-known-issues"]
 == Known issues


### PR DESCRIPTION
Added fix for https://bugzilla.redhat.com/show_bug.cgi?id=1874403 in the Notable technical changes section of the 2.5 release notes.

branch/enterprise-4.6