### PR TITLE
RN for Pipelines TP 1-2

### DIFF
--- a/modules/op-release-notes-1-0.adoc
+++ b/modules/op-release-notes-1-0.adoc
@@ -3,7 +3,7 @@
 // * openshift_pipelines/op-release-notes.adoc
 
 [id="op-release-notes-1-0_{context}"]
-= Release notes for Red Hat {pipelines-title} Technology Preview 1.0
+= Release notes for {pipelines-title} Technology Preview 1.0
 
 [id="new-features-1-0_{context}"]
 == New features

--- a/modules/op-release-notes-1-1.adoc
+++ b/modules/op-release-notes-1-1.adoc
@@ -3,7 +3,7 @@
 // * openshift_pipelines/op-release-notes.adoc
 
 [id="op-release-notes-1-1_{context}"]
-= Release notes for Red Hat {pipelines-title} Technology Preview 1.1
+= Release notes for {pipelines-title} Technology Preview 1.1
 
 [id="new-features-1-1_{context}"]
 == New features

--- a/modules/op-release-notes-1-2.adoc
+++ b/modules/op-release-notes-1-2.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assembly:
+//
+// * openshift_pipelines/op-release-notes.adoc
+
+[id="op-release-notes-1-2_{context}"]
+= Release notes for {pipelines-title} Technology Preview 1.2
+
+[id="new-features-1-2_{context}"]
+== New features
+{pipelines-title} Technology Preview (TP) 1.2 is now available on {product-title} {product-version}. {pipelines-title} TP 1.2 is updated to support:
+
+* Tekton Pipelines 0.16.3
+* Tekton `tkn` CLI 0.13.1
+* Tekton Triggers 0.8.1
+* ClusterTasks based on Tekton Catalog 0.16
+
+In addition to the fixes and stability improvements, here is a highlight of what’s new in OpenShift Pipelines 1.2.
+
+=== Pipelines
+
+* This release of {pipelines-title} adds support for a disconnected installation.
+//* The `PodSecurityPolicy` configuration was changed to enable {pipelines-title} in a restricted environment by running the tekton pipelines controller and tekton pipelines webhook as non-root users.
+//needs confirmation from Gabe if this needs to be added.
+* You can now use the `when` field, instead of `conditions`, to run a task only when certain criteria are met. The key components of `WhenExpressions` are `Input`, `Operator`, and `Values`. If all the `WhenExpressions` evaluate to `True`, then the task is run. If any of the `WhenExpressions` evaluate to `False`, the task is skipped.
+* Step statuses are now updated if a task run is canceled or times out.
+* Support for Git Large File Storage (LFS) is now available to build the base image used by `git-init`.
+* You can now use the `taskSpec` field to specify metadata, such as labels and annotations, when a task is embedded in a pipeline.
+* Cloud events are now supported by pipeline runs. Retries with `backoff` are now enabled for cloud events sent by the cloud event pipeline resource.
+* You can now set a default `Workspace` configuration for any workspace that a `Task` resource declares, but that a `TaskRun` resource does not explicitly provide.
+* Support is available for namespace variable interpolation for the `PipelineRun` namespace and `TaskRun` namespace.
+* Validation for `TaskRun` objects is now added to check that not more than one persistent volume claim workspace is used when a `TaskRun` resource is associated with an Affinity Assistant. If more than one persistent volume claim workspace is used, the task run fails with a `TaskRunValidationFailed` condition. Note that by default, the Affinity Assistant is disabled in {pipelines-title}, so you will need to enable the assistant to use it.
+
+=== Pipelines CLI
+
+* The `tkn task describe`, `tkn taskrun describe`,  `tkn clustertask describe`, `tkn pipeline describe`, and `tkn pipelinerun describe` commands now:
+** Automatically select the `Task`, `TaskRun`, `ClusterTask`, `Pipeline` and `PipelineRun` resource, respectively, if only one of them is present.
+** Display the results of the `Task`, `TaskRun`, `ClusterTask`, `Pipeline` and `PipelineRun` resource in their outputs, respectively.
+** Display workspaces declared in the `Task`, `TaskRun`, `ClusterTask`, `Pipeline` and `PipelineRun` resource in their outputs, respectively.
+* You can now use the `--prefix-name` option with the `tkn clustertask start` command to specify a prefix for the name of a task run.
+* Interactive mode support has now been provided to the `tkn clustertask start` command.
+* You can now specify `PodTemplate` properties supported by pipelines using local or remote file definitions for `TaskRun` and `PipelineRun` objects.
+* You can now use the `--use-params-defaults` option with the `tkn clustertask start` command to use the default values set in the `ClusterTask` configuration and create the task run.
+* The `--use-param-defaults` flag for the `tkn pipeline start` command now prompts the interactive mode if the default values have not been specified for some of the parameters.
+
+=== Triggers
+
+* The Common Expression Language (CEL) function named `parseYAML` has been added to parse a YAML string into a map of strings.
+* Error messages for parsing CEL expressions have been improved to make them more granular while evaluating expressions and when parsing the hook body for creating the evaluation environment.
+* Support is now available for marshaling boolean values and maps if they are used as the values of expressions in a CEL overlay mechanism.
+* The following fields have been added to the `EventListener` object:
+** The `replicas` field enables the event listener to run more than one pod by specifying the number of replicas in the YAML file.
+** The `NodeSelector` field enables the `EventListener` object to schedule the event listener pod to a specific node.
+* Webhook interceptors can now parse the `EventListener-Request-URL` header to extract parameters from the original request URL being handled by the event listener.
+* Annotations from the event listener can now be propagated to the deployment, services, and other pods. Note that custom annotations on services or deployment are overwritten, and hence, must be added to the event listener annotations so that they are propagated.
+* Proper validation for replicas in the `EventListener` specification is now available for cases when a user specifies the `spec.replicas` values as `negative` or `zero`.
+* You can now specify the `TriggerCRD` object inside the `EventListener` spec as a reference using the `TriggerRef` field to create the `TriggerCRD` object separately and then bind it inside the `EventListener` spec.
+* Validation and defaults for the `TriggerCRD` object are now available.
+
+[id="deprecated-features-1-2_{context}"]
+== Deprecated features
+
+* `$(params)` are now deprecated and replaced by `$(tt.params)` to avoid confusion between the `resourcetemplate` and `triggertemplate` parameters.
+* The `ServiceAccount` reference of the optional `EventListenerTrigger`-based authentication level has changed from an object reference to a `ServiceAccountName` string. This ensures that the `ServiceAccount` reference is in the same namespace as the `EventListenerTrigger` object.
+* The `Conditions` custom resource definition (CRD) is now deprecated; use the `WhenExpressions` CRD instead.
+* The `PipelineRun.Spec.ServiceAccountNames` object is being deprecated and replaced by the `PipelineRun.Spec.TaskRunSpec[].ServiceAccountName` object.
+
+[id="known-issues-1-2_{context}"]
+== Known issues
+
+* This release of {pipelines-title} adds support for a disconnected installation. However, some images used by the cluster tasks must be mirrored for them to work in disconnected clusters.
+* Pipelines in the `openshift` namespace are not deleted after you uninstall the {pipelines-title} Operator. Use the `oc delete pipelines -n openshift --all` command to delete the pipelines.
+* Uninstalling the {pipelines-title} Operator does not remove the event listeners.
++
+As a workaround, to remove the `EventListener` and `Pod` CRDs:
++
+. Edit the `EventListener` object with the `foregroundDeletion` finalizers:
++
+[source,terminal]
+----
+oc patch el/<eventlistener_name> -p '{"metadata":{"finalizers":["foregroundDeletion"]}}' --type=merge
+----
++
+For example:
++
+[source,terminal]
+----
+oc patch el/github-listener-interceptor -p '{"metadata":{"finalizers":["foregroundDeletion"]}}' --type=merge
+----
++
+. Delete the `EventListener` CRD:
++
+[source,terminal]
+----
+oc patch crd/eventlisteners.triggers.tekton.dev -p '{"metadata":{"finalizers":[]}}' --type=merge
+----
+
+[id="fixed-issues-1-2_{context}"]
+== Fixed issues
+
+* A simple syntax validation to check the CEL filter, overlays in the Webhook validator, and the expressions in the interceptor has now been added.
+* Triggers no longer overwrite annotations set on the underlying deployment and service objects.
+* Previously, an event listener would stop accepting events. This fix adds an idle timeout of 120 seconds for the `EventListener` sink to resolve this issue.
+* Previously, canceling a pipeline run with a `Failed(Canceled)` state gave a success message. This has been fixed to display an error instead.
+* The `tkn eventlistener list` command now provides the status of the listed event listeners, thus enabling you to easily identify the available ones.
+* Consistent error messages are now displayed for the `triggers list` and `triggers describe` commands when triggers are not installed or when a resource cannot be found.
+* Previously, a large number of idle connections would build up during cloud event delivery. The `DisableKeepAlives: true` parameter was added to the `cloudeventclient` config to fix this issue. Thus, a new connection is set up for every cloud event.
+* Previously, the `creds-init` code would write empty files to the disk even if credentials of a given type were not provided. This fix modifies the `creds-init` code to write files for only those credentials that have actually been mounted from correctly annotated secrets.

--- a/pipelines/op-release-notes.adoc
+++ b/pipelines/op-release-notes.adoc
@@ -27,6 +27,8 @@ visit the Red Hat Customer Portal to learn more about link:https://access.redhat
 For questions and feedback, you can send an email to the product team at pipelines-interest@redhat.com.
 
 // Modules included, most to least recent
+include::modules/op-release-notes-1-2.adoc[leveloffset=+1]
+
 include::modules/op-release-notes-1-1.adoc[leveloffset=+1]
 
 include::modules/op-release-notes-1-0.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds Release Notes for the Pipelines TP 1.2 release.
It needs to be merged with OCP 4.6 and later versions. 
It has been approved by the SMEs and the QEs.