### PR TITLE
CNV-BZ-1885964 release note for 2.5

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -121,6 +121,8 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 //BZ-1874403
 * The default `cloud-init` user password is now auto-generated for virtual machines that are created from templates.
 
+//BZ-1885964 - Host assisted cloning is now faster
+* When using host-assisted cloning, you can now clone virtual machine disks at a faster speed because of a more efficient compression algorithm.
 
 [id="virt-2-5-known-issues"]
 == Known issues


### PR DESCRIPTION
Added note about host-assisted cloning performance in the notable technical changes section of the 2.5 release notes.

https://bugzilla.redhat.com/show_bug.cgi?id=1885964