### PR TITLE
Improve info on Operator channel naming & approval strategy

### DIFF
--- a/modules/olm-changing-update-channel.adoc
+++ b/modules/olm-changing-update-channel.adoc
@@ -5,31 +5,16 @@
 [id="olm-changing-update-channel_{context}"]
 = Changing the update channel for an Operator
 
-The Subscription of an installed Operator specifies an update channel, which is
-used to track and receive updates for the Operator. To upgrade the Operator to
-start tracking and receiving updates from a newer channel, you can change the
-update channel in the Subscription.
+The Subscription of an installed Operator specifies an update channel, which is used to track and receive updates for the Operator. To upgrade the Operator to start tracking and receiving updates from a newer channel, you can change the update channel in the Subscription.
 
-The names of update channels in a Subscription can differ between Operators, but
-should follow a common convention within a given Operator. Some naming
-schemes include:
-
-- `4.3`, `4,4`, `4.5`
-- `stable-4.3`, `stable-4.4`, `stable-4.5`
-- `alpha`, `beta`, `stable`, `latest`
-
-Alternatively, the channel names might follow the version numbers of the
-application provided by the Operator.
+The names of update channels in a Subscription can differ between Operators, but the naming scheme should follow a common convention within a given Operator. For example, channel names might follow a minor release update stream for the application provided by the Operator (`1.2`, `1.3`) or a simple release frequency (`stable`, `fast`).
 
 [NOTE]
 ====
-Installed Operators cannot change to a channel that is older than the current
-channel.
+Installed Operators cannot change to a channel that is older than the current channel.
 ====
 
-If the approval strategy in the Subscription is set to *Automatic*, the upgrade
-process initiates immediately. If the approval strategy is set to *Manual*, you
-must manually approve the pending upgrade.
+If the approval strategy in the Subscription is set to *Automatic*, the upgrade process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending upgrades.
 
 .Prerequisites
 
@@ -37,8 +22,7 @@ must manually approve the pending upgrade.
 
 .Procedure
 
-. In the *Administrator* perspective of the {product-title} web console, navigate
-to *Operators -> Installed Operators*.
+. In the *Administrator* perspective of the {product-title} web console, navigate to *Operators -> Installed Operators*.
 
 . Click the name of the Operator you want to change the update channel for.
 
@@ -48,9 +32,6 @@ to *Operators -> Installed Operators*.
 
 . Click the newer update channel that you want to change to, then click *Save*.
 
-. For Subscriptions with an *Automatic* approval strategy, the upgrade begins automatically. Navigate back to the *Operators -> Installed Operators*
-page to monitor the progress of the upgrade. When complete, the status changes
-to *Succeeded* and *Up to date*.
+. For Subscriptions with an *Automatic* approval strategy, the upgrade begins automatically. Navigate back to the *Operators -> Installed Operators* page to monitor the progress of the upgrade. When complete, the status changes to *Succeeded* and *Up to date*.
 +
-For Subscriptions with a *Manual* approval strategy, you can manually approve
-the upgrade from the Subscription tab.
+For Subscriptions with a *Manual* approval strategy, you can manually approve the upgrade from the Subscription tab.

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -12,23 +12,14 @@ endif::[]
 = Installing Operators from OperatorHub
 
 ifndef::olm-user[]
-As a cluster administrator, you can install an Operator from OperatorHub
-using the {product-title}
+As a cluster administrator, you can install an Operator from OperatorHub using the {product-title}
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-web console or CLI. You can then subscribe the Operator to one or more
-namespaces to make it available for developers on your cluster.
+web console or CLI. You can then subscribe the Operator to one or more namespaces to make it available for developers on your cluster.
 endif::[]
 ifdef::openshift-dedicated[]
-web console. You can then subscribe the Operator to the default
-`openshift-operators` namespace to make it available for developers on your
-cluster. When you subscribe the Operator to all namespaces, the Operator is
-installed in the `openshift-operators` namespace; this installation method is
-not supported by all Operators.
+web console. You can then subscribe the Operator to the default `openshift-operators` namespace to make it available for developers on your cluster. When you subscribe the Operator to all namespaces, the Operator is installed in the `openshift-operators` namespace; this installation method is not supported by all Operators.
 
-In {product-title} clusters, a curated list of Operators is made available for
-installation from OperatorHub. Administrators can only install Operators to
-the default `openshift-operators` namespace, except for the Logging Operator,
-which requires the `openshift-logging` namespace.
+In {product-title} clusters, a curated list of Operators is made available for installation from OperatorHub. Administrators can only install Operators to the default `openshift-operators` namespace, except for the Logging Operator, which requires the `openshift-logging` namespace.
 
 [NOTE]
 ====
@@ -41,36 +32,20 @@ ifdef::olm-user[]
 As a user with the proper permissions, you can install an Operator from OperatorHub using the {product-title} web console or CLI.
 endif::[]
 
-During installation, you must determine the following initial settings for the
-Operator:
+During installation, you must determine the following initial settings for the Operator:
 
 ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-Installation Mode:: Choose *All namespaces on the cluster (default)* to have the
-Operator installed on all namespaces or choose individual namespaces, if
-available, to only install the Operator on selected namespaces. This example
-chooses *All namespaces...* to make the Operator available to all users and
-projects.
+Installation Mode:: Choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces or choose individual namespaces, if available, to only install the Operator on selected namespaces. This example chooses *All namespaces...* to make the Operator available to all users and projects.
 endif::[]
 ifdef::openshift-dedicated[]
-Installation Mode:: In {product-title} clusters, you can choose *All namespaces on the cluster (default)*
-to have the Operator installed on all namespaces. This makes the Operator
-available to all users and projects.
+Installation Mode:: In {product-title} clusters, you can choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces. This makes the Operator available to all users and projects.
 endif::[]
 endif::[]
 ifdef::olm-user[]
-Installation Mode:: Choose a specific namespace in which to install the
-Operator.
+Installation Mode:: Choose a specific namespace in which to install the Operator.
 endif::[]
 
-Update Channel:: If an Operator is available through multiple channels, you can
-choose which channel you want to subscribe to. For example, to deploy from the
-*stable* channel, if available, select it from the list.
+Update Channel:: If an Operator is available through multiple channels, you can choose which channel you want to subscribe to. For example, to deploy from the *stable* channel, if available, select it from the list.
 
-Approval Strategy:: You can choose Automatic or Manual updates. If you choose
-Automatic updates for an installed Operator, when a new version of that Operator
-is available, Operator Lifecycle Manager (OLM) automatically upgrades the
-running instance of your Operator without human intervention. If you select
-Manual updates, when a newer version of an Operator is available, OLM creates an
-update request. As a cluster administrator, you must then manually approve that
-update request to have the Operator updated to the new version.
+Approval Strategy:: You can choose automatic or manual updates. If you choose automatic updates for an installed Operator, when a new version of that Operator is available in the selected channel, Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention. If you select manual updates, when a newer version of an Operator is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.


### PR DESCRIPTION
Minor tweaks to some language, but also un-hard-wrapping any modules I'm touching here. I'll point out where actual content changes are happening inline below, while the rest is just wrapping changes.

Preview (internal):

* [Changing the update channel for an Operator](http://file.rdu.redhat.com/~adellape/110320/channel_naming/operators/admin/olm-upgrading-operators.html#olm-changing-update-channel_olm-upgrading-operators)

* [Installing Operators from OperatorHub](http://file.rdu.redhat.com/~adellape/110320/channel_naming/operators/user/olm-installing-operators-in-namespace.html#olm-installing-operators-from-operatorhub_olm-installing-operators-in-namespace)