### PR TITLE
Minor change to --dry-run=client in htpasswd secret update

### DIFF
--- a/modules/identity-provider-htpasswd-update-users.adoc
+++ b/modules/identity-provider-htpasswd-update-users.adoc
@@ -55,7 +55,7 @@ Deleting password for user <username>
 +
 [source,terminal]
 ----
-$ oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd --dry-run -o yaml -n openshift-config | oc replace -f -
+$ oc create secret generic htpass-secret --from-file=htpasswd=users.htpasswd --dry-run=client -o yaml -n openshift-config | oc replace -f -
 ----
 
 . If you removed one or more users, you must additionally remove existing resources for each user.


### PR DESCRIPTION
oc cli will deprecate --dry-run in favor of --dry-run=client or --dry-run=server. This should be --dry-run=client to avoid getting an error message.