### PR TITLE
Rm plus sign in virtctl module

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -10,7 +10,7 @@ resources. The following table contains the `virtctl` commands used throughout
 the {VirtProductName} documentation.
 
 To view a list of options that you can use with a command, run it with the `-h` or `--help` flag. For example:
-+
+
 [source,terminal]
 ----
 $ virtctl image-upload -h


### PR DESCRIPTION
Plus sign isn't needed since it's not in a step and is currently showing up verbatim.