### PR TITLE
Bug-1882726 minor updates to ssh access doc

### DIFF
--- a/modules/virt-accessing-vmi-ssh.adoc
+++ b/modules/virt-accessing-vmi-ssh.adoc
@@ -5,28 +5,27 @@
 [id="virt-accessing-vmi-ssh_{context}"]
 = Accessing a virtual machine instance via SSH
 
-You can use SSH to access a virtual machine after you expose port
-22 on it.
+You can use SSH to access a virtual machine (VM) after you expose port 22 on it.
 
-The `virtctl expose` command forwards a virtual machine instance port to a node
+The `virtctl expose` command forwards a virtual machine instance (VMI) port to a node
 port and creates a service for enabled access. The following example creates
-the `fedora-vm-ssh` service that forwards port 22 of the `<fedora-vm>` virtual
-machine to a port on the node:
+the `fedora-vm-ssh` service that forwards traffic from a specific port of cluster nodes to port 22 of the `<fedora-vm>` virtual
+machine.
 
 .Prerequisites
-* You must be in the same project as the virtual machine instance.
-* The virtual machine instance you want to access must be connected
+* You must be in the same project as the VMI.
+* The VMI you want to access must be connected
 to the default Pod network by using the `masquerade` binding method.
-* The virtual machine instance you want to access must be running.
+* The VMI you want to access must be running.
 * Install the OpenShift CLI (`oc`).
 
 .Procedure
 . Run the following command to create the `fedora-vm-ssh` service:
 +
 ----
-$ virtctl expose vm <fedora-vm> --port=20022 --target-port=22 --name=fedora-vm-ssh --type=NodePort <1>
+$ virtctl expose vm <fedora-vm> --port=22 --name=fedora-vm-ssh --type=NodePort <1>
 ----
-<1> `<fedora-vm>` is the name of the virtual machine that you run the
+<1> `<fedora-vm>` is the name of the VM that you run the
 `fedora-vm-ssh` service on.
 
 . Check the service to find out which port the service acquired:
@@ -40,13 +39,13 @@ $ oc get svc
 [source,terminal]
 ----
 NAME            TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)           AGE
-fedora-vm-ssh   NodePort   127.0.0.1      <none>        20022:32551/TCP   6s
+fedora-vm-ssh   NodePort   127.0.0.1      <none>        22:32551/TCP   6s
 ----
 +
 In this example, the service acquired the `32551` port.
 
-. Log in to  the virtual machine instance via SSH. Use the `ipAddress` of the
-node and the port that you found in the previous step:
+. Log in to  the VMI via SSH. Use the `ipAddress` of any of the cluster
+nodes and the port that you found in the previous step:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
This PR is associated with:
https://bugzilla.redhat.com/show_bug.cgi?id=1882726

It focuses on adding some edits and minor changes to the existing procedure and output associated with accessing a VMI by using ssh. The defect has notes regarding the changes made to the doc.

Previously, this PR was generated but it picked up commits that did not belong to the PR:
https://github.com/openshift/openshift-docs/pull/26724
Conferred with peer reviewer and determined that a fresh PR would be the most effective and efficient way to resolve the issue. 

The content changes for this PR are identical to the content changes that were made in the previous PR:
https://github.com/openshift/openshift-docs/pull/26724 

All content changes were approved by SME and QE in that PR and those same content changes are reflected in this PR.
