### PR TITLE
CNV-1403 Importing container disks into PVC by using DataVolumes

### DIFF
--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+
+[id="virt-disabling-tls-for-registry_{context}"]
+= Disabling TLS for a container registry to use as insecure registry
+
+You can disable TLS (transport layer security) for a container registry by adding the registry to the `cdi-insecure-registries` ConfigMap.
+
+.Prerequisites
+
+* Log in to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Add the registry to the `cdi-insecure-registries` ConfigMap in the `cdi` namespace.
++
+[source,terminal]
+----
+$ oc patch configmap cdi-insecure-registries -n cdi \
+  --type merge -p '{"data":{"mykey": "<insecure-registry-host>:5000"}}' <1>
+----
+<1> Replace `<insecure-registry-host>` with the registry hostname.

--- a/modules/virt-importing-vm-datavolume.adoc
+++ b/modules/virt-importing-vm-datavolume.adoc
@@ -3,28 +3,29 @@
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
 
 [id="virt-importing-vm-datavolume_{context}"]
-= Importing a virtual machine image into an object with DataVolumes
+= Importing a virtual machine image into a PersistentVolumeClaim by using a DataVolume
 
-To create a virtual machine from an imported image, specify the image location
-in the `VirtualMachine` configuration file before you create the virtual machine.
+You can import a virtual machine image into a PersistentVolumeClaim (PVC) by using a DataVolume. 
+
+The virtual machine image can be hosted at an HTTP or HTTPS endpoint, or the image can be built into a container disk and stored in a container registry.
+
+To create a virtual machine from an imported virtual machine image, specify the image or container disk endpoint in the `VirtualMachine` configuration file before you create the virtual machine.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* A virtual machine disk image, in RAW, ISO, or QCOW2 format, optionally
+* You have installed the OpenShift CLI (`oc`).
+* Your cluster has at least one available PersistentVolume.
+* To import a virtual machine image you must have the following:
+** A virtual machine disk image in RAW, ISO, or QCOW2 format, optionally
 compressed by using `xz` or `gz`.
-* An `HTTP` endpoint where the image is hosted, along with any authentication
-credentials needed to access the data source.
-* At least one available PersistentVolume.
+** An HTTP endpoint where the image is hosted, along with any authentication
+credentials needed to access the data source. For example: `http://www.example.com/path/to/data`
+* To import a container disk you must have the following:
+** A container disk built from a virtual machine image stored in your container image registry, along with any authentication credentials needed to access the data source. For example: `docker://registry.example.com/container-image`
 
 .Procedure
 
-. Identify an `HTTP` file server that hosts the virtual disk image that you want
-to import. You need the complete URL in the correct format:
-+
-* `http://www.example.com/path/to/data`
-
-. If your data source requires authentication credentials, edit the
+. Optional: If your data source requires authentication credentials, edit the
 `endpoint-secret.yaml` file, and apply the updated configuration to the cluster:
 +
 [source,yaml]
@@ -49,7 +50,7 @@ $ oc apply -f endpoint-secret.yaml
 ----
 
 . Edit the virtual machine configuration file, specifying the data source for
-the image you want to import. In this example, a Fedora image is imported:
+the virtual machine image you want to import. In this example, a Fedora image is imported from an `http` source:
 +
 [source,yaml]
 ----
@@ -71,15 +72,15 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 2Gi
+            storage: 10Gi
         storageClassName: local
       source:
-        http:
-          url: https://download.fedoraproject.org/pub/fedora/linux/releases/28/Cloud/x86_64/images/Fedora-Cloud-Base-28-1.1.x86_64.qcow2 <1>
-          secretRef: "" <2>
-          certConfigMap: "" <3>
-    status: {}
-  running: false
+        http: <1> 
+          url: "https://download.fedoraproject.org/pub/fedora/linux/releases/33/Cloud/x86_64/images/Fedora-Cloud-Base-33-1.2.x86_64.qcow2" <2>
+          secretRef: "" <3>
+          certConfigMap: "" <4>
+    status: {}	
+  running: true
   template:
     metadata:
       creationTimestamp: null
@@ -93,21 +94,22 @@ spec:
               bus: virtio
             name: datavolumedisk1
         machine:
-          type: "" <4>
+          type: "" <5>
         resources:
           requests:
-            memory: 64M
-      terminationGracePeriodSeconds: 0
+            memory: 1.5Gi
+      terminationGracePeriodSeconds: 60
       volumes:
       - dataVolume:
           name: fedora-dv
         name: datavolumedisk1
 status: {}
 ----
-<1> The `HTTP` source of the image you want to import.
-<2> The `secretRef` parameter is optional.
-<3> The `certConfigMap` is required for communicating with servers that use self-signed certificates or certificates not signed by the system CA bundle. The referenced ConfigMap must be in the same namespace as the DataVolume.
-<4> Specify `type: dataVolume` or `type: ""`. If you specify any other value for `type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual machine does not start.
+<1> The source type to import the image from. This example uses a HTTP endpoint. To import a container disk from a registry, replace `http` with `registry`.
+<2> The source of the virtual machine image you want to import. This example references a virtual machine image at an HTTP endpoint. An example of a container registry endpoint is `url: "docker://kubevirt/fedora-cloud-container-disk-demo:latest"`.
+<3> The `secretRef` parameter is optional.
+<4> The `certConfigMap` is required for communicating with servers that use self-signed certificates or certificates not signed by the system CA bundle. The referenced ConfigMap must be in the same namespace as the DataVolume.
+<5> Specify `type: dataVolume` or `type: ""`. If you specify any other value for `type`, such as `persistentVolumeClaim`, a warning is displayed, and the virtual machine does not start.
 
 . Create the virtual machine:
 +
@@ -129,7 +131,7 @@ import is complete.
 ====
 
 .Verification steps
-. The importer Pod downloads the image from the specified URL and stores it on the provisioned PV. View the status of the importer Pod by running the following command:
+. The importer Pod downloads the virtual machine image or container disk from the specified URL and stores it on the provisioned PV. View the status of the importer Pod by running the following command:
 +
 [source,terminal]
 ----
@@ -140,10 +142,10 @@ $ oc get pods
 +
 [source,terminal]
 ----
-$ oc describe dv <data-label> <1>
+$ oc describe dv <datavolume-name> <1>
 ----
-<1> The data label for the DataVolume specified in the virtual machine
-configuration file.
+<1> The name of the DataVolume as specified under `dataVolumeTemplates.metadata.name` in the virtual machine
+configuration file. In the example configuration above, this is `fedora-dv`.
 
 . To verify that provisioning is complete and that the VMI has started, try
 accessing its serial console by running the following command:

--- a/modules/virt-preparing-container-disk-for-vms.adoc
+++ b/modules/virt-preparing-container-disk-for-vms.adoc
@@ -9,18 +9,11 @@ You must build a container disk with a virtual machine image and push it to a co
 
 .Prerequisites
 
-* For RHEL users: You have root or sudo privileges on your local system to install `podman`.
+* Install `podman` if it is not already installed.
 
 * The virtual machine image must be either QCOW2 or RAW format.
 
 .Procedure
-
-. Install `podman` if it is not already installed:
-+
-[source,terminal]
-----
-$ sudo yum install podman -y
-----
 
 . Create a Dockerfile to build the virtual machine image into a container image. The virtual machine image must be owned by QEMU, which has a UID of `107`, and placed in the `/disk/` directory inside the container. Permissions for the `/disk/` directory must then be set to `0440`.
 +

--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
@@ -4,19 +4,15 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-importing-virtual-machine-images-datavolumes
 toc::[]
 
-You can import an existing virtual machine image into your {product-title}
-cluster. {VirtProductName} uses DataVolumes to automate the import of data and the
-creation of an underlying PersistentVolumeClaim (PVC).
+Use the Containerized Data Importer (CDI) to import a virtual machine image into a PersistentVolumeClaim (PVC) by using a DataVolume. You can attach a DataVolume to a virtual machine for persistent storage.
+
+The virtual machine image can be hosted at an HTTP or HTTPS endpoint, or built into a container disk and stored in a container registry.
 
 [IMPORTANT]
 ====
-When you import a disk image into a PVC, the disk image is
-expanded to use the full storage capacity that is requested in the PVC. To use
-this space, the disk partitions and file system(s) in the virtual machine
-might need to be expanded.
+When you import a disk image into a PVC, the disk image is expanded to use the full storage capacity that is requested in the PVC. To use this space, the disk partitions and file system(s) in the virtual machine might need to be expanded.
 
-The resizing procedure varies based on the operating system installed on the VM.
-Refer to the operating system documentation for details.
+The resizing procedure varies based on the operating system installed on the virtual machine. Refer to the operating system documentation for details.
 ====
 
 == Prerequisites
@@ -25,7 +21,11 @@ Refer to the operating system documentation for details.
 xref:../../../virt/virtual_machines/importing_vms/virt-tls-certificates-for-dv-imports.adoc#virt-adding-tls-certificates-for-authenticating-dv-imports_virt-tls-certificates-for-dv-imports[included in a ConfigMap]
 in the same namespace as the DataVolume and referenced in the DataVolume configuration.
 
-* You may need to xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass-in-cdi-configuration_virt-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space]
+* To import a container disk: 
+** You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-preparing-container-disk-for-vms_virt-using-container-disks-with-vms[prepare a container disk from a virtual machine image] and store it in your container registry before importing it.
+** If the container registry does not have TLS, you must xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms[add the registry to the `cdi-insecure-registries` ConfigMap] before you can import a container disk from it.
+
+* You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass-in-cdi-configuration_virt-preparing-cdi-scratch-space[define a StorageClass or prepare CDI scratch space]
 for this operation to complete successfully.
 
 include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
@@ -34,6 +34,7 @@ include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/virt-importing-vm-datavolume.adoc[leveloffset=+1]
 
-include::modules/virt-template-datavolume-vm.adoc[leveloffset=+1]
+// commenting out these as their value without maintenance plan seems questionable at this stage
+// include::modules/virt-template-datavolume-vm.adoc[leveloffset=+1]
 
-include::modules/virt-template-datavolume-import.adoc[leveloffset=+1]
+// include::modules/virt-template-datavolume-import.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
@@ -9,7 +9,13 @@ You can build a virtual machine image into a container disk and store it in your
 include::modules/virt-about-container-disks.adoc[leveloffset=+1]
 include::modules/virt-preparing-container-disk-for-vms.adoc[leveloffset=+1]
 
+If your container registry does not have TLS you must add it as an insecure registry before you can import container disks into persistent storage.
+
+include::modules/virt-disabling-tls-for-registry.adoc[leveloffset=+1]
+
 == Next steps
+
+* xref:../../../virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc#virt-importing-virtual-machine-images-datavolumes[Import the container disk into persistent storage for a virtual machine].
 
 * xref:../../../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[Create a virtual machine] that uses
 a containerDisk volume for ephemeral storage.


### PR DESCRIPTION
Originally created a separate assembly to cover importing container disks into DataVolume as a complete user story, however after discussing this with SME and docs folks I've compressed that into the existing 'Importing vm image into DV' assembly. This seems much neater.

Preview builds: https://cnv-1403-condensed--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.html
And the insecure registry: https://cnv-1403-condensed--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.html#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms


Original PR: #26591 
JIRA stories: [CNV-1398](https://issues.redhat.com/browse/CNV-1398) & [CNV-1403](https://issues.redhat.com/browse/CNV-1403)