### PR TITLE
Add allowlist item for firewall config.

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -102,6 +102,9 @@ There are no special configuration considerations for services running on only c
 
 |`cloud.redhat.com/openshift`
 |Required for your cluster token.
+
+|`registry.access.redhat.com`
+|Required for `odo` CLI . 
 |===
 +
 Operators require route access to perform health checks. Specifically, the


### PR DESCRIPTION
The original issue can be found here:
https://bugzilla.redhat.com/show_bug.cgi?id=1878800
https://bugzilla.redhat.com/show_bug.cgi?id=1871160#c2

This configuration is only necessary if `odo` is going to be used on the cluster.