### PR TITLE
BZ1894537: CNV RHV VM disk too large for Ceph RBD block

### DIFF
--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -4,13 +4,16 @@
 [id="virt-importing-vm-prerequisites_{context}"]
 = Prerequisites for importing a virtual machine
 
-Importing a virtual machine into {VirtProductName} has the following prerequisites:
+Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductName} has the following prerequisites:
 
 * You must have admin user privileges.
-* The {VirtProductName} local and shared persistent storage classes must support VM import.
+* Storage:
+** The {VirtProductName} local and shared persistent storage classes must support VM import.
+** If you are using Ceph RBD block-mode volumes, the storage must be large enough to accommodate the virtual disk. If the disk is too large for the available storage, the import process fails and the PV that is used to copy the virtual disk is not released.
+
 * Networks:
-** The source and target networks must either have the same name or be mapped to each other.
-** The source network interface must be `e1000`, `rtl8139`, or `virtio`.
+** The RHV and {VirtProductName} networks must either have the same name or be mapped to each other.
+** The RHV VM network interface must be `e1000`, `rtl8139`, or `virtio`.
 
 * VM disks:
 ** The disk interface must be `sata`, `virtio_scsi`, or `virtio`.
@@ -27,3 +30,4 @@ Importing a virtual machine into {VirtProductName} has the following prerequisit
 ** The VM must not have been created with {product-title} and subsequently added to RHV.
 ** The VM must not be configured for USB devices.
 ** The watchdog model must not be `diag288`.
+

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -26,7 +26,7 @@ endif::[]
 +
 [WARNING]
 ====
-If you try to import a virtual machine with a disk that is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage back end.
+If you are using Ceph RBD block-mode volumes, the storage must be large enough to accommodate the virtual disk. If the disk is too large for the available storage, the import process fails and the PV that is used to copy the virtual disk is not released. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage back end.
 ====
 endif::[]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1894537
CP to 4.5, 4.6, 4.7. If there is a problem with CP to 4.5, I will create a separate PR.