### PR TITLE
Document causes of automated reboots and MCO pause behavior

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -13,3 +13,7 @@ include::modules/operators-overview.adoc[leveloffset=+2]
 include::modules/update-service-overview.adoc[leveloffset=+3]
 
 include::modules/understanding-machine-config-operator.adoc[leveloffset=+3]
+
+.Additional information
+
+For information on preventing the control plane machines from after the Machine Congig Operator makes changes to the machine config, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * architecture/architecture.adoc
+// * architecture/control-plane.adoc
 [id="understanding-machine-config-operator_{context}"]
 = Understanding the Machine Config Operator
 
@@ -41,5 +41,8 @@ KubeletConfig custom resource (CR).
 
 [IMPORTANT]
 ====
-To prevent control plane nodes from autorebooting after machine config changes are applied, you must pause the autoreboot process by setting the `spec.paused` field to `true` in the machine pool config.
+When changes are made to a machine configuration, the Machine Config Operator automatically reboots all corresponding nodes in order for the changes to take effect.
+
+To prevent the nodes from automatically rebooting after machine configuration changes, before making the changes, you must pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
 ====
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1886712

Added to the note created here: https://github.com/openshift/openshift-docs/pull/26829
Copied the text here:
https://github.com/openshift/openshift-docs/pull/26829/files#diff-7c4392ac3894b8af0cb70e0770dfec2ace9c0e650d162d278172c7325e2d62c9R8