### PR TITLE
CNV-7169 RN for Golden Images

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -101,6 +101,7 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 //CNV-7318 - Open the vnc/serial console in a new window
 
 //CNV-7169 - Auto-clone base images when creating VM in UI
+* You can now create default OS images and automatically upload them using the {product-title} web console. A _default OS image_ is a bootable disk containing an operating system and all of the operating system's configuration settings, such as drivers. You use a default OS image to create bootable virtual machines with specific configurations.
 
 //CNV-7314 - Expose VM image upload in UI
 


### PR DESCRIPTION
First draft of Release Note for Golden Image stories [CNV-5259](https://issues.redhat.com/browse/CNV-5259) and [CNV-7193](https://issues.redhat.com/browse/CNV-7193):

https://issues.redhat.com/browse/CNV-5259
https://issues.redhat.com/browse/CNV-7193

Draft text of note:

_You can now create default OS images and automatically upload them using the {product-title} Web Console. A _default OS image_ is a bootable disk containing an operating system and all of the operating system's configuration settings, such as drivers. You use a default OS image to create bootable virtual machines with specific configurations._

Tagging @aglitke for code review, will add Tomas in Jira.
Tagging @demilyc for QE review.

Thanks
Bob
