### PR TITLE
Updated podman version required for opm index prune

### DIFF
--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -39,7 +39,7 @@ endif::[]
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
 endif::[]
-* `podman` version 1.4.4+
+* `podman` version 2.1.1+
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 * `opm` version 1.12.3+
 * Access to a registry that supports

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -39,7 +39,7 @@ endif::[]
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
 endif::[]
-* `podman` version 2.1.1+
+* `podman` version 2.0.0+
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 * `opm` version 1.12.3+
 * Access to a registry that supports


### PR DESCRIPTION
Hi

I've updated the podman version as the current documented version is incorrect and results in being unable to follow the steps for creating a pruned index image. This is only relevant for OCP 4.6+. 

See the below Bugzilla bug report for further details:
https://bugzilla.redhat.com/show_bug.cgi?id=1894167 

Thanks 