### PR TITLE
GH#27131 - The `openshift` namespace is a namespace

### DIFF
--- a/builds/running-entitled-builds.adoc
+++ b/builds/running-entitled-builds.adoc
@@ -13,7 +13,7 @@ include::modules/builds-source-secrets-entitlements.adoc[leveloffset=+1]
 There are two paths to pulling in the base RHEL image:
 
 * Add the pull secret to registry.redhat.io to your project.
-* Create an imagestream in the OpenShift namespace for the RHEL-based
+* Create an imagestream in the `openshift` namespace for the RHEL-based
 image. This makes the imagestream available across the cluster.
 
 == Running builds with Subscription Manager

--- a/modules/configuration-resource-overview.adoc
+++ b/modules/configuration-resource-overview.adoc
@@ -29,9 +29,9 @@ You can customize the following Configuration Resources:
 | * *ManagementState:*
 ** *Managed.* The operator updates the samples as the configuration dictates.
 ** *Unmanaged.* The operator ignores updates to the samples resource object and
-any imagestreams or templates in the OpenShift namespace.
+any imagestreams or templates in the `openshift` namespace.
 ** *Removed.* The operator removes the set of managed imagestreams
-and templates in the OpenShift namespace. It ignores new samples created by
+and templates in the `openshift` namespace. It ignores new samples created by
 the cluster administrator or any samples in the skipped lists. After the removals are
 complete, the operator works like it is in the `Unmanaged` state and ignores
 any watch events on the sample resources, imagestreams, or templates. It

--- a/modules/installation-restricted-network-samples.adoc
+++ b/modules/installation-restricted-network-samples.adoc
@@ -14,7 +14,7 @@ endif::[]
 [id="installation-restricted-network-samples_{context}"]
 = Using Cluster Samples Operator imagestreams with alternate or mirrored registries
 
-Most imagestreams in the OpenShift namespace managed by the Cluster Samples Operator
+Most imagestreams in the `openshift` namespace managed by the Cluster Samples Operator
 point to images located in the Red Hat registry at link:https://registry.redhat.io[registry.redhat.io].
 ifdef::restrictednetwork[]
 Mirroring
@@ -116,7 +116,7 @@ Cluster Samples Operator configuration object.
 The Cluster Samples Operator issues alerts if imagestream imports are failing but the Cluster Samples Operator is either periodically retrying or does not appear to be retrying them.
 ====
 +
-Many of the templates in the OpenShift namespace
+Many of the templates in the `openshift` namespace
 reference the imagestreams. So using `Removed` to purge both the imagestreams
 and templates will eliminate the possibility of attempts to use them if they
 are not functional because of any missing imagestreams.

--- a/modules/registry-authentication-enabled-registry-overview.adoc
+++ b/modules/registry-authentication-enabled-registry-overview.adoc
@@ -40,8 +40,8 @@ All imagestreams point to the new registry, which uses the installation pull sec
 
 You must place your credentials in either of the following places:
 
-* *OpenShift namespace*. Your credentials must exist in the OpenShift
-namespace so that the imagestreams in the OpenShift namespace can import.
+* *`openshift` namespace*. Your credentials must exist in the OpenShift
+namespace so that the imagestreams in the `openshift` namespace can import.
 * *Your host*. Your credentials must exist on your host because Kubernetes
 uses the credentials from your host when it goes to pull images.
 

--- a/modules/samples-operator-configuration.adoc
+++ b/modules/samples-operator-configuration.adoc
@@ -17,10 +17,10 @@ The samples resource offers the following configuration fields:
 dictates.
 
 `Unmanaged`: The Cluster Samples Operator ignores updates to its configuration
-resource object and any imagestreams or templates in the OpenShift namespace.
+resource object and any imagestreams or templates in the `openshift` namespace.
 
 `Removed`: The Cluster Samples Operator removes the set of `Managed` imagestreams
-and templates in the OpenShift namespace. It ignores new samples created by the
+and templates in the `openshift` namespace. It ignores new samples created by the
 cluster administrator or any samples in the skipped lists. After the removals are
 complete, the Cluster Samples Operator works like it is in the `Unmanaged` state and ignores
 any watch events on the sample resources, imagestreams, or templates.
@@ -85,7 +85,7 @@ The samples resource maintains the following conditions in its status:
 |Condition |Description
 
 |`SamplesExists`
-|Indicates the samples are created in the OpenShift namespace.
+|Indicates the samples are created in the `openshift` namespace.
 
 |`ImageChangesInProgress`
 |`True` when imagestreams are created or updated, but

--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -12,7 +12,7 @@ quickstart templates.
 
 [NOTE]
 ====
-To facilitate imagestream imports from other registries that require credentials, a cluster administrator can create any additional secrets that contain the content of a Docker `config.json` file in the OpenShift namespace needed for image import.
+To facilitate imagestream imports from other registries that require credentials, a cluster administrator can create any additional secrets that contain the content of a Docker `config.json` file in the `openshift` namespace needed for image import.
 ====
 
 The Cluster Samples Operator configuration is a cluster-wide resource, and the deployment is contained within the `openshift-cluster-samples-operator` namespace.

--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -4,7 +4,7 @@ include::modules/common-attributes.adoc[]
 :context: configuring-samples-operator
 toc::[]
 
-The Cluster Samples Operator, which operates in the OpenShift namespace, installs and
+The Cluster Samples Operator, which operates in the `openshift` namespace, installs and
 updates the Red Hat Enterprise Linux (RHEL)-based {product-title} imagestreams
 and {product-title} templates.
 


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/27131

This replaces _OpenShift_ with `openshift` as necessary.