### PR TITLE
BZ#1871145 - An IPAM static address must be specified with CIDR

### DIFF
--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -84,7 +84,7 @@ spec:
         type: static
         staticIPAMConfig:
           addresses:
-          - address: 10.1.1.7
+          - address: 10.1.1.7/24
 ----
 endif::yaml[]
 ifdef::json[]
@@ -111,7 +111,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23"
+            "address": "191.168.1.23/24"
           }
         ]
       }
@@ -160,7 +160,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23"
+            "address": "191.168.1.23/24"
           }
         ]
       }
@@ -188,7 +188,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23"
+            "address": "191.168.1.23/24"
           }
         ]
       }

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -79,13 +79,13 @@ The following JSON describes the configuration for static IP address assignment:
 <1> An array describing IP addresses to assign to the virtual interface. Both
 IPv4 and IPv6 IP addresses are supported.
 
-<2> An IP address that you specify.
+<2> An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the additional network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
 
 <3> The default gateway to route egress network traffic to.
 
 <4> An array describing routes to configure inside the Pod.
 
-<5> The IP address range in CIDR format.
+<5> The IP address range in CIDR format, such as `192.168.17.0/24`, or `0.0.0.0/0` for the default route.
 
 <6> The gateway where network traffic is routed.
 
@@ -276,13 +276,13 @@ ipamConfig:
 <1> A collection of mappings that define IP addresses to assign to the virtual
 interface. Both IPv4 and IPv6 IP addresses are supported.
 
-<2> An IP address that you specify.
+<2> An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the additional network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
 
 <3> The default gateway to route egress network traffic to.
 
 <4> A collection of mappings describing routes to configure inside the Pod.
 
-<5> The IP address range in CIDR format.
+<5> The IP address range in CIDR format, such as `192.168.17.0/24`, or `0.0.0.0/0` for the default route.
 
 <6> The gateway where network traffic is routed.
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1871145

Reality and the documentation must match.