### PR TITLE
Bug 1895270 : [DOCS] RHEL7 worker node needs additional package repository as of OCPv4.6 for scaling up

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -59,7 +59,9 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 [source,terminal]
 ----
 # subscription-manager repos --disable=rhel-7-server-ose-4.5-rpms \
-                             --enable=rhel-7-server-ose-4.6-rpms
+                             --enable=rhel-7-server-ose-4.6-rpms  \
+                             --enable=rhel-7-fast-datapath-rpms   \
+                             --enable=rhel-7-server-optional-rpms
 ----
 
 . Update a RHEL worker machine:

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -77,7 +77,9 @@ Note that this might take a few minutes if you have a large number of available 
 ----
 # subscription-manager repos \
     --enable="rhel-7-server-rpms" \
+    --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-server-optional-rpms" \
     --enable="rhel-7-server-ose-4.6-rpms"
 ----
 


### PR DESCRIPTION
 * Version: v4.6+
* Description:
  Added `NetworkManager-OVS` and `openvswitch2.13` as of v4.6 are required additional package repositories.
  There is `NetworkManager-ovs` in `rhel-7-server-optional-rpms`, and is `openvswitch2.13` in `rhel-7-fast-datapath-rpms`.
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1895270