### PR TITLE
RPM repo version name is not matched with release version(OCPv4.6)

### DIFF
--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -75,7 +75,7 @@ a pool with an `OpenShift` subscription to it:
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ansible-2.9-rpms" \
-    --enable="rhel-7-server-ose-4.5-rpms"
+    --enable="rhel-7-server-ose-4.6-rpms"
 ----
 
 . Install the required packages, including `openshift-ansible`:


### PR DESCRIPTION
* Version: v4.6
* Description:
  Released OCP version is `v4.6`, but the package repository `rhel-7-server-ose-4.5-rpms` has not matched version in the name.

   