### PR TITLE
_distro_map.yml: rename OKD Latest to OKD 4

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -7,7 +7,7 @@ openshift-origin:
   site_url: https://docs.okd.io/
   branches:
     master:
-      name: Latest
+      name: '4'
       dir: latest
     enterprise-3.2:
       name: '1.2'


### PR DESCRIPTION

This has been confusing a few community members that there is no OKD 4 documentation, just vague "OKD Latest". This ensures the entity is named "OKD 4" and path is still "latest"