### PR TITLE
CNV-7296 RelNot - HCO and HPP version bump

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -127,6 +127,12 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 * You can now import VMs with block-based storage into {VirtProductName}.
 
 //CNV-7296 - HCO and HPP CRs moved to v1beta1
+* The HyperConverged Operator (HCO), Containerized Data Importer (CDI), Hostpath Provisioner (HPP), and VM import custom resources have moved to API version `v1beta1`. The respective API version for these components is now:
++
+`hco.kubevirt.io/v1beta1` +
+`cdi.kubevirt.io/v1beta1` +
+`hostpathprovisioner.kubevirt.io/v1beta1` +
+`v2v.kubevirt.io/v1beta1`
 
 //BZ-1874403
 * The default `cloud-init` user password is now auto-generated for virtual machines that are created from templates.


### PR DESCRIPTION
Release Note added. no xref req'd

[CNV-7296](https://issues.redhat.com/browse/CNV-7296)
#25100 also included version change to CDI and V2V - should they also be mentioned here?