### PR TITLE
CNV-7295 Rel_Note download virtctl from web console

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -45,7 +45,7 @@ The SVVP Certification applies to:
 ** `virtctl userlist <vmi_name>` returns a full list of logged-in users on the guest machine.
 
 //CNV-7295 - Download virtctl binary from the CLI Tools page
-
+* You can now download the `virtctl` client from the xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl-client-web_virt-installing-virtctl[*Command Line Tools* page in the web console].
 
 //CNV-4572-Guest-OS Should we still keep this info from the 2.4 release notes?
 [id="virt-guest-os-new"]


### PR DESCRIPTION
Rel note for downloading virtctl from web console. xref to feature doc

[CNV-7295](https://issues.redhat.com/browse/CNV-7295)