### PR TITLE
Improve disconnected OLM intro

### DIFF
--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -5,26 +5,26 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-For {product-title} clusters installed on restricted networks, also known as
-disconnected clusters, Operator Lifecycle Manager (OLM) by default cannot access
-the Red Hat-provided OperatorHub sources hosted on Quay.io because they require
-full Internet connectivity. However, cluster administrators can disable those
-remote sources, create local mirrors of that same content, and configure OLM to
-install and manage Operators from the local sources instead.
+For {product-title} clusters that are installed on restricted networks, also known as disconnected clusters, Operator Lifecycle Manager (OLM) by default cannot access the Red Hat-provided OperatorHub sources hosted remotely on Quay.io because those remote sources require full Internet connectivity.
+
+However, as a cluster administrator you can still enable your cluster to use OLM in a restricted network if you have a workstation that has full Internet access. The workstation is used to prepare local mirrors of the remote OperatorHub sources, and requires full Internet access to pull the remote content.
+
+This guide describes the following process that is required to enable OLM in restricted networks:
+
+* Disable the default remote OperatorHub sources for OLM.
+* Use a workstation with full Internet access to create local mirrors of the OperatorHub content.
+* Configure OLM to install and manage Operators from the local sources instead of the default remote sources.
+
+After enabling OLM in a restricted network, you can continue to use your unrestricted workstation to keep your local OperatorHub sources updated as newer versions of Operators are released.
 
 [IMPORTANT]
 ====
-While OLM can manage Operators from local sources, the ability for a given
-Operator to run successfully in a restricted network still depends on the
-Operator itself. The Operator must:
+While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a restricted network still depends on the Operator itself. The Operator must:
 
-* List any related images, or other container images that the Operator might
-require to perform their functions, in the `relatedImages` parameter of its
-ClusterServiceVersion (CSV) object.
+* List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its ClusterServiceVersion (CSV) object.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
-See the following Red Hat Knowledgebase Article for a list of Red Hat Operators
-that support running in disconnected mode:
+See the following Red Hat Knowledgebase Article for a list of Red Hat Operators that support running in disconnected mode:
 
 link:https://access.redhat.com/articles/4740011[]
 ====


### PR DESCRIPTION
Unwraps some paragraphs but updates the assembly's intro to provide more clarity about the requirement of the unrestricted workstation.

Preview (internal): http://file.rdu.redhat.com/~adellape/110620/dis_olm_intro/operators/admin/olm-restricted-networks.html