### PR TITLE
Add OSP IPI restricted to installation types table

### DIFF
--- a/installing/install_config/installation-types.adoc
+++ b/installing/install_config/installation-types.adoc
@@ -48,6 +48,17 @@ Not all installation options are currently available for all platforms, as shown
 |
 |
 
+|Restricted network
+|
+|
+|
+|xref:../../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
+|
+|
+|
+|
+|
+
 |Private clusters
 |xref:../../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[X]
 |xref:../../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[X]
@@ -115,7 +126,7 @@ Not all installation options are currently available for all platforms, as shown
 |xref:../../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[X]
 |
 |xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[X]
-|xref:../../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
+|
 |
 |xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[X]
 |xref:../../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[X]


### PR DESCRIPTION
Context: https://bugzilla.redhat.com/show_bug.cgi?id=1833833

This change reflects the addition from #25509. QE should not be necessary.