### PR TITLE
BZ#1804764 - Clarify when instance metadata endpoint is in `status.noProxy`

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -53,7 +53,9 @@ endif::bare-metal[]
 +
 [NOTE]
 ====
-The Proxy object's `status.noProxy` field is populated by default with the instance metadata endpoint (`169.254.169.254`) and with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The Proxy object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+
+For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
 
 .Procedure

--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -18,7 +18,9 @@ The cluster-wide proxy is only supported if you used a user-provisioned infrastr
 +
 [NOTE]
 ====
-The Proxy object's `status.noProxy` field is populated by default with the instance metadata endpoint (`169.254.169.254`) and with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The Proxy object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+
+For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
 
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1804764

Previews
- [Configuring the cluster-wide proxy during installation (Azure)](https://bz-1804764--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private.html#installation-configure-proxy_installing-azure-private)
- [Configuring the cluster-wide proxy](https://bz-1804764--ocpdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html)