### PR TITLE
Revert "BZ#1893520: Remove CPMA from MTC documentation"

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1557,6 +1557,8 @@ Topics:
     File: configuring-replication-repository-3-4
   - Name: Migrating your applications
     File: migrating-applications-with-cam-3-4
+  - Name: Migrating your control plane settings
+    File: migrating-with-cpma
   - Name: Troubleshooting
     File: troubleshooting-3-4
 - Name: Migrating from OpenShift Container Platform 4.1

--- a/migration/migrating_3_4/about-migration.adoc
+++ b/migration/migrating_3_4/about-migration.adoc
@@ -13,4 +13,7 @@ xref:../../migration/migrating_3_4/planning-migration-3-to-4.adoc#planning-migra
 Learn about the differences between {product-title} versions 3 and 4. Prior to transitioning, be sure that you have reviewed and prepared for storage, networking, logging, security, and monitoring considerations.
 
 xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#migrating-application-workloads-3-4[Performing your migration]::
-Learn about and use the {mtc-full} ({mtc-short}) to migrate your application workloads.
+Learn about and use the tools to perform your migration:
+
+* {mtc-full} ({mtc-short}) to migrate your application workloads
+* Control Plane Migration Assistant (CPMA) to migrate your control plane

--- a/migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+++ b/migration/migrating_3_4/migrating-application-workloads-3-4.adoc
@@ -21,6 +21,8 @@ The service catalog is deprecated in {product-title} 4. You can migrate workload
 The {mtc-short} web console displays a message if the service catalog resources cannot be migrated.
 ====
 
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
+
 [IMPORTANT]
 ====
 Before you begin your migration, be sure to review the information on xref:../../migration/migrating_3_4/planning-migration-3-to-4.adoc#planning-migration-3-to-4[planning your migration].
@@ -30,4 +32,5 @@ include::modules/migration-prerequisites.adoc[leveloffset=+1]
 include::modules/migration-understanding-cam.adoc[leveloffset=+1]
 include::modules/migration-understanding-data-copy-methods.adoc[leveloffset=+1]
 include::modules/migration-understanding-migration-hooks.adoc[leveloffset=+1]
+include::modules/migration-understanding-cpma.adoc[leveloffset=+1]
 :!migrating-3-4:

--- a/migration/migrating_3_4/migrating-with-cpma.adoc
+++ b/migration/migrating_3_4/migrating-with-cpma.adoc
@@ -1,0 +1,13 @@
+[id='migrating-with-cpma']
+= Migrating your control plane settings
+include::modules/common-attributes.adoc[]
+:context: migrating-3-4
+:migrating-3-4:
+
+toc::[]
+
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane from {product-title} 3.7 (or later) to {product-version}. The CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
+
+include::modules/migration-installing-cpma.adoc[leveloffset=+1]
+include::modules/migration-using-cpma.adoc[leveloffset=+1]
+:!migrating-3-4:

--- a/modules/migration-installing-cpma.adoc
+++ b/modules/migration-installing-cpma.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// * migration/migrating_3_4/migrating-application-workloads-3-to-4.adoc
+[id='migration-installing-cpma_{context}']
+= Installing the Control Plane Migration Assistant
+
+You can download the Control Plane Migration Assistant (CPMA) binary file from the Red Hat Customer Portal and install it on Linux, macOS, or Windows operating systems.
+
+.Procedure
+
+. In the link:https://access.redhat.com[Red Hat Customer Portal], navigate to *Downloads* -> *Red Hat {product-title}*.
+. On the *Download Red Hat {product-title}* page, select *Red Hat {product-title}* from the *Product Variant* list.
+. Select *CPMA 1.0 for RHEL 7* from the *Version* list. This binary works on RHEL 7 and RHEL 8.
+. Click *Download Now* to download `cpma` for Linux and macOS or `cpma.exe` for Windows.
+. Save the file in a directory defined as `$PATH` for Linux and macOS or `%PATH%` for Windows.
+. For Linux, make the file executable:
++
+[source,terminal]
+----
+$ sudo chmod +x cpma
+----

--- a/modules/migration-understanding-cpma.adoc
+++ b/modules/migration-understanding-cpma.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+[id='migration-understanding-cpma_{context}']
+= About the Control Plane Migration Assistant
+
+The Control Plane Migration Assistant (CPMA) is a CLI-based tool that assists you in migrating the control plane from {product-title} 3.7 (or later) to {product-version}. CPMA processes the {product-title} 3 configuration files and generates Custom Resource (CR) manifest files, which are consumed by {product-title} {product-version} Operators.
+
+Because {product-title} 3 and 4 have significant configuration differences, not all parameters are processed. CPMA can generate a report that describes whether features are supported fully, partially, or not at all.
+
+.Configuration files
+
+CPMA uses the Kubernetes and {product-title} APIs to access the following configuration files on an {product-title} 3 cluster:
+
+* Master configuration file (default: `/etc/origin/master/master-config.yaml`)
+* CRI-O configuration file (default: `/etc/crio/crio.conf`)
+* etcd configuration file (default: `/etc/etcd/etcd.conf`)
+* Image registries file (default: `/etc/containers/registries.conf`)
+* Dependent configuration files:
+** Password files (for example, HTPasswd)
+** ConfigMaps
+** Secrets
+
+.CR Manifests
+
+CPMA generates CR manifests for the following configurations:
+
+* API server CA certificate: `100_CPMA-cluster-config-APISecret.yaml`
++
+[NOTE]
+====
+If you are using an unsigned API server CA certificate, you must add the certificate manually to the target cluster.
+====
+
+* CRI-O: `100_CPMA-crio-config.yaml`
+* Cluster resource quota: `100_CPMA-cluster-quota-resource-x.yaml`
+* Project resource quota: `100_CPMA-resource-quota-x.yaml`
+* Portable image registry (`/etc/registries/registries.conf`) and portable image policy (`etc/origin/master/master-config.yam`): `100_CPMA-cluster-config-image.yaml`
+* OAuth providers: `100_CPMA-cluster-config-oauth.yaml`
+* Project configuration: `100_CPMA-cluster-config-project.yaml`
+* Scheduler: `100_CPMA-cluster-config-scheduler.yaml`
+* SDN: `100_CPMA-cluster-config-sdn.yaml`

--- a/modules/migration-using-cpma.adoc
+++ b/modules/migration-using-cpma.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+// * migration/migrating_3_4/migrating-application-workloads-3-4.adoc
+[id='migration-using-cpma_{context}']
+= Using the Control Plane Migration Assistant
+
+The Control Plane Migration Assistant (CPMA) generates CR manifests, which are consumed by {product-title} {product-version} Operators, and a report that indicates which {product-title} 3 features are supported fully, partially, or not at all.
+
+CPMA can run in remote mode, retrieving the configuration files from the source cluster using SSH, or in local mode, using local copies of the source cluster's configuration files.
+
+.Prerequisites
+
+* The source cluster must be {product-title} 3.7 or later.
+* The source cluster must be updated to the latest synchronous release.
+* An environment health check must be run on the source cluster to confirm that there are no diagnostic errors or warnings.
+* The CPMA binary must be executable.
+* You must have `cluster-admin` privileges for the source cluster.
+
+.Procedure
+
+. Log in to the {product-title} 3 cluster:
++
+[source,terminal]
+----
+$ oc login https://<master1.example.com> <1>
+----
+<1> Specify the master node. You must be logged in to receive a token for the Kubernetes and {product-title} APIs.
+
+. Run the CPMA:
++
+[source,terminal]
+----
+$ cpma --manifests=false <1>
+----
+<1> The `--manifests=false` option runs the CPMA without generating CR manifests.
++
+Each prompt requires you to provide input, as in the following example:
++
+.Example output
+[source,terminal]
+----
+? Do you wish to save configuration for future use? true
+? What will be the source for OCP3 config files? Remote host <1>
+? Path to crio config file /etc/crio/crio.conf
+? Path to etcd config file /etc/etcd/etcd.conf
+? Path to master config file /etc/origin/master/master-config.yaml
+? Path to node config file /etc/origin/node/node-config.yaml
+? Path to registries config file /etc/containers/registries.conf
+? Do wish to find source cluster using KUBECONFIG or prompt it? KUBECONFIG
+? Select cluster obtained from KUBECONFIG contexts master1-example-com:443
+? Select master node master1.example.com
+? SSH login root <2>
+? SSH Port 22
+? Path to private SSH key /home/user/.ssh/openshift_key
+? Path to application data, skip to use current directory .
+INFO[29 Aug 19 00:07 UTC] Starting manifest and report generation
+INFO[29 Aug 19 00:07 UTC] Transform:Starting for - API
+INFO[29 Aug 19 00:07 UTC] APITransform::Extract
+INFO[29 Aug 19 00:07 UTC] APITransform::Transform:Reports
+INFO[29 Aug 19 00:07 UTC] Transform:Starting for - Cluster
+INFO[29 Aug 19 00:08 UTC] ClusterTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportQuotas
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportPVs
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportNamespaces
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportNodes
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportRBAC
+INFO[29 Aug 19 00:08 UTC] ClusterReport::ReportStorageClasses
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - Crio
+INFO[29 Aug 19 00:08 UTC] CrioTransform::Extract
+WARN[29 Aug 19 00:08 UTC] Skipping Crio: No configuration file available
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - Docker
+INFO[29 Aug 19 00:08 UTC] DockerTransform::Extract
+INFO[29 Aug 19 00:08 UTC] DockerTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - ETCD
+INFO[29 Aug 19 00:08 UTC] ETCDTransform::Extract
+INFO[29 Aug 19 00:08 UTC] ETCDTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - OAuth
+INFO[29 Aug 19 00:08 UTC] OAuthTransform::Extract
+INFO[29 Aug 19 00:08 UTC] OAuthTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - SDN
+INFO[29 Aug 19 00:08 UTC] SDNTransform::Extract
+INFO[29 Aug 19 00:08 UTC] SDNTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - Image
+INFO[29 Aug 19 00:08 UTC] ImageTransform::Extract
+INFO[29 Aug 19 00:08 UTC] ImageTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Transform:Starting for - Project
+INFO[29 Aug 19 00:08 UTC] ProjectTransform::Extract
+INFO[29 Aug 19 00:08 UTC] ProjectTransform::Transform:Reports
+INFO[29 Aug 19 00:08 UTC] Flushing reports to disk
+INFO[29 Aug 19 00:08 UTC] Report:Added: report.json
+INFO[29 Aug 19 00:08 UTC] Report:Added: report.html
+INFO[29 Aug 19 00:08 UTC] Successfully finished transformations
+----
+<1> The `Remote host` option runs the CPMA in remote mode.
+<2> `SSH login`: The SSH user must have `sudo` permissions on the {product-title} 3 cluster in order to access the configuration files.
++
+The CPMA creates the following files and directory in the current directory if you did not specify an output directory:
+
+* `cpma.yaml` file: Configuration options that you provided when you ran the CPMA
+* `master1.example.com/`: Configuration files from the master node
+* `report.json`: JSON-encoded report
+* `report.html`: HTML-encoded report
+
+. Open the `report.html` file in a browser to view the CPMA report.
+
+. If you generate CR manifests, apply the CR manifests to the {product-title} {product-version} cluster, as shown in the following example:
++
+[source,terminal]
+----
+$ oc apply -f 100_CPMA-cluster-config-secret-htpasswd-secret.yaml
+----


### PR DESCRIPTION
This reverts commit 17ca9147bca0771ca76d76c0a359873ee4882c92.

PR: https://github.com/openshift/openshift-docs/pull/26965

@sferich888 

@apinnick  - Audrey sent an email to revert this commit.