### PR TITLE
CNV BZ#1886794 VLAN param in brige NAD

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -34,10 +34,11 @@ spec:
     "plugins": [
       {
         "type": "cnv-bridge", <3>
-        "bridge": "br0" <4>
+        "bridge": "br0", <4>
+        "vlan": 1 <5>
       },
       {
-        "type": "cnv-tuning" <5>
+        "type": "cnv-tuning" <6>
       }
     ]
   }'
@@ -49,7 +50,8 @@ will only run on nodes that have the `br0` bridge connected.
 the network for this NetworkAttachmentDefinition. Do not change this field unless
 you want to use a different CNI.
 <4> You must substitute the actual name of the bridge, if it is not `br0`.
-<5> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
+<5> Optional: The VLAN tag.
+<6> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
 
 +
 [source,terminal]

--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -31,20 +31,22 @@ metadata:
   name: pxe-net-conf
 spec:
   config: '{
-      "cniVersion": "0.3.1",
-      "name": "pxe-net-conf",
-      "plugins": [
-        {
-          "type": "cnv-bridge",
-          "bridge": "br1"
-        },
-        {
-          "type": "cnv-tuning" <1>
-        }
-      ]
-    }'
+    "cniVersion": "0.3.1",
+    "name": "pxe-net-conf",
+    "plugins": [
+      {
+        "type": "cnv-bridge",
+        "bridge": "br1",
+        "vlan": 1 <1>
+      },
+      {
+        "type": "cnv-tuning" <2>
+      }
+    ]
+  }'
 ----
-<1> The `cnv-tuning` plug-in provides support for custom MAC addresses.
+<1> Optional: The VLAN tag.
+<2> The `cnv-tuning` plug-in provides support for custom MAC addresses.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Adding option vlan tag to the bridge NAD config examples. Also noticed the cnv-tuning plugin name had been accidentally changed, and remove some extra spaces in the config

BZ#1886794