### PR TITLE
Add glibc version 2.28+ limitation for using opm

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -16,7 +16,9 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Prerequisites
 
-* `podman` version 1.4.4+
+* For Linux, you must provide the following packages:
+** `podman` version 1.4.4+ (version 2.0+ recommended)
+** `glibc` version 2.28+
 
 .Procedure
 


### PR DESCRIPTION
* Version: v4.6+
* Description:
  If the linux has not glibc more than v2.28, you can face error `/lib/x86_64-linux-gnu/libc.so.6: version 'GLIBC_2.28' not found (required by ./opm)`, when you run the `opm`.

* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1892004#c3
~~~
At this time our proposed solution is to update the official openshift 4.6 docs to describe these limitations for the opm build on linux.
~~~