### PR TITLE
Updated commands, added new commands and procedures.

### DIFF
--- a/getting_started_rosa/creating-first-rosa-cluster.adoc
+++ b/getting_started_rosa/creating-first-rosa-cluster.adoc
@@ -5,11 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide walks through setting up your first {product-title} cluster using `rosa`, the {product-title} command line utility.
+This Getting Started section walks you through setting up your first {product-title} cluster using `rosa`, the {product-title} command line utility.
 
 include::modules/rosa-quickstart-instructions.adoc[leveloffset=+1]
-
-For additional help, consult the rest of this guide. By the end of this guide you will have an {product-title} cluster running in your AWS account.
 
 include::modules/rosa-installing-prerequisites.adoc[leveloffset=+1]
 
@@ -18,5 +16,9 @@ include::modules/rosa-creating-cluster.adoc[leveloffset=+1]
 include::modules/rosa-accessing-your-cluster.adoc[leveloffset=+1]
 
 include::modules/rosa-create-dedicated-cluster-admins.adoc[leveloffset=+1]
+
+include::modules/rosa-delete-dedicated-admins.adoc[leveloffset=+1]
+
+include::modules/rosa-delete-cluster-admins.adoc[leveloffset=+1]
 
 include::modules/rosa-deleting-cluster.adoc[leveloffset=+1]

--- a/modules/rosa-create-dedicated-cluster-admins.adoc
+++ b/modules/rosa-create-dedicated-cluster-admins.adoc
@@ -4,8 +4,8 @@
 
 
 [id="rosa-create-dedicated-cluster-admins.adoc"]
-= Creating dedicated-admins and cluster-admins
-As the user that created the cluster, add the `cluster-admin` user role to your account to have the maximum administrator privileges. You can create additional `cluster-admin` or `dedicated-admin` users. `dedicated-admin` users have fewer privileges.
+= Granting dedicated-admin and cluster-admin access
+As the user that created the cluster, add the `cluster-admin` user role to your account to have the maximum administrator privileges. Additionally, only the user who created the cluster can grant cluster access to other `cluster-admin` or `dedicated-admin` users. `dedicated-admin` users have fewer privileges.
 
 .Prerequisites
 
@@ -15,12 +15,12 @@ As the user that created the cluster, add the `cluster-admin` user role to your 
 
 .Procedure
 
-. Create a `dedicated-admin` user.
+. To grant cluster access to a `dedicated-admin` user:
 .. Enter the following command to promote your user to a `dedicated-admin`:
 +
 [source,terminal]
 ----
-$ rosa create user --cluster <cluster_name> --dedicated-admins=<idp_user_name>
+$ rosa grant user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
 ----
 +
 .. Enter the following command to verify that your user now has `dedicated-admin` access. As a `dedicated-admin` you should see output similar to the example output when entering the following command:
@@ -42,7 +42,7 @@ dedicated-admins   rh-rosa-test-user
 A Forbidden error displays if user without `dedicated-admin` privileges runs this command.
 ====
 +
-. Create a `cluster-admin` user.
+. To grant cluster access to an `cluster-admin` user:
 .. Enable `cluster-admin` capability on the cluster:
 +
 [source,terminal]
@@ -54,7 +54,7 @@ $ rosa edit cluster <cluster_name> --enable-cluster-admins
 +
 [source,terminal]
 ----
-$ rosa create user --cluster <cluster_name> --cluster-admins <idp_user_name>
+$ rosa grant user cluster-admin --user <idp_user_name> --cluster <cluster_name>
 ----
 +
 .. Verify your user is listed as a `cluster-admin`:
@@ -72,7 +72,7 @@ cluster-admins    rh-rosa-test-user
 dedicated-admins  rh-rosa-test-user
 ----
 +
-. Enter the following command to verify that your user now has `cluster-admin` access. As a `cluster-admin` you should be able to enter the following command without errors.
+.. Enter the following command to verify that your user now has `cluster-admin` access. As a `cluster-admin` you should be able to enter the following command without errors.
 +
 [source,terminal]
 ----

--- a/modules/rosa-delete-cluster-admins.adoc
+++ b/modules/rosa-delete-cluster-admins.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// getting_started_rosa/creating-first-rosa-cluster.adoc
+
+
+[id="rosa-delete-cluster-admins"]
+= Revoking cluster-admin access
+Only the user who created the cluster can revoke access for `cluster-admin` users.
+
+.Prerequisites
+
+* You have added an Identity Provider (IDP) to your cluster.
+* You have the IDP user name for the user whose privileges you are revoking.
+* You are logged in to the cluster.
+
+.Procedure
+
+. Revoke the user `cluster-admin` privileges:
++
+[source,terminal]
+----
+$ rosa revoke user --cluster <cluster_name> --cluster-admins <idp_user_name>
+----
++
+. Verify your user is no longer listed as a `cluster-admin`:
++
+[source,terminal]
+----
+$ rosa list users --cluster <cluster_name>
+----

--- a/modules/rosa-delete-dedicated-admins.adoc
+++ b/modules/rosa-delete-dedicated-admins.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// getting_started_rosa/creating-first-rosa-cluster.adoc
+
+
+[id="rosa-delete-dedicated-admins"]
+= Revoking dedicated-admin access
+Only the user who created the cluster can revoke access for a `dedicated-admin` users.
+
+.Prerequisites
+
+* You have added an Identity Provider (IDP) to your cluster.
+* You have the IDP user name for the user whose privileges you are revoking.
+* You are logged in to the cluster.
+
+.Procedure
+
+. Enter the following command to revoke access for a `dedicated-admin`:
++
+[source,terminal]
+----
+$ rosa revoke user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
+----
++
+. Enter the following command to verify that your user no longer has `dedicated-admin` access. As a `dedicated-admin` you should no longer see the user in the output.
++
+[source,terminal]
+----
+$ oc get groups dedicated-admins
+----
++
+[NOTE]
+====
+A Forbidden error displays if user without `dedicated-admin` privileges runs this command.
+====

--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -17,7 +17,7 @@ Enter the following command to delete your cluster and watch the logs, replacing
 $ rosa delete cluster <my-cluster> --watch
 ----
 
-To clean up your CloudFormation stack. enter the following command. Your CloudFormation stack is initially created when you run the `rosa init` command as part of the prerequisites.
+To clean up your CloudFormation stack, enter the following command. Your CloudFormation stack is initially created when you run the `rosa init` command as part of the prerequisites.
 
 [source, terminal]
 ----

--- a/modules/rosa-quickstart-instructions.adoc
+++ b/modules/rosa-quickstart-instructions.adoc
@@ -14,15 +14,15 @@ If you have already installed the required prerequisites, here are the commands 
 $ rosa init
 
 ## Starts the cluster creation process (~30-40minutes) and watches the logs
-$ rosa create cluster --cluster-name <my_cluster_name> --watch
+$ rosa create cluster --cluster-name <cluster_name> --watch
 
 ## Connect your IDP to your cluster
-$ rosa create idp --cluster <my_cluster_name> --interactive
+$ rosa create idp --cluster <cluster_name> --interactive
 
-## Promotes a user from your IDP to admin level
-$ rosa create user --cluster <my_cluster_name> --dedicated-admins <admin_username>
+## Promotes a user from your IDP to dedicated-admin level
+$ rosa grant user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
 
 ## Checks if your install is ready (look for State: Ready),
 ## and provides your Console URL to login to the web console.
-$ rosa describe cluster <my_cluster_name>
+$ rosa describe cluster <cluster_name>
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1628

Note: The Creating dedcated-admins & cluster admins topic remains as one topic because the user that created the cluster is supposed to assign both sets of permissions to their own IDP username before they create additional admins. I'm still trying to get better clarification around that, but that is not related to this card. This card is about changing the command from create to grant/revoke.
