### PR TITLE
[Branch 4.7] post ga ior update

### DIFF
--- a/modules/ossm-auto-route-1x.adoc
+++ b/modules/ossm-auto-route-1x.adoc
@@ -1,6 +1,6 @@
 ////
 This TASK module included in the following assemblies:
-// * service_mesh/v2x/ossm-traffic-manage.adoc
+// * service_mesh/v1x/ossm-traffic-manage.adoc
 ////
 
 [id="ossm-auto-route_{context}"]
@@ -9,19 +9,29 @@ This TASK module included in the following assemblies:
 OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
 [id="ossm-auto-route-enable_{context}"]
-== Disabling Automatic Route Creation
+== Enabling Automatic Route Creation
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route. Enable IOR as part of the control plane deployment.
 
-By default, the `ServiceMeshControlPlane` automatically synchronizes the Gateway resources with OpenShift routes.
+If the Gateway contains a TLS section, the OpenShift Route will be configured to support TLS.
 
-You can disable integration between Istio Gateways and OpenShift Routes by setting the `ServiceMeshControlPlane` field `gateways.openshiftRoute.enabled` to `false`. For example, see the following resource snippet.
+. In the `ServiceMeshControlPlane` resource, add the `ior_enabled` parameter and set it to `true`. For example, see the following resource snippet:
 
 [source,yaml]
 ----
 spec:
-  gateways:
-    openshiftRoute:
-      enabled: false
+  istio:
+    gateways:
+     istio-egressgateway:
+       autoscaleEnabled: false
+       autoscaleMin: 1
+       autoscaleMax: 5
+     istio-ingressgateway:
+       autoscaleEnabled: false
+       autoscaleMin: 1
+       autoscaleMax: 5
+       ior_enabled: true
 ----
+
 
 [id="ossm-auto-route-subdomains_{context}"]
 == Subdomains

--- a/modules/ossm-security-mtls-1x.adoc
+++ b/modules/ossm-security-mtls-1x.adoc
@@ -14,16 +14,17 @@ By default, {ProductName} is set to permissive mode, where the sidecars in {Prod
 [id="ossm-security-enabling-strict-mtls_{context}"]
 == Enabling strict mTLS across the mesh
 
-If your workloads do not communicate with services outside your mesh and communication will not be interrupted by only accepting encrypted connections, you can enable mTLS across your mesh quickly. Set `spec.security.controlPlane.mtls` to `true` in your `ServiceMeshControlPlane` resource. The operator creates the required resources.
+If your workloads do not communicate with services outside your mesh and communication will not be interrupted by only accepting encrypted connections, you can enable mTLS across your mesh quickly. Set `spec.istio.global.mtls.enabled` to `true` in your `ServiceMeshControlPlane` resource. The operator creates the required resources.
 
 [source,yaml]
 ----
-apiVersion: maistra.io/v2
+apiVersion: maistra.io/v1
 kind: ServiceMeshControlPlane
 spec:
-  security:
-    controlPlane:
-      mtls: true
+  istio:
+    global:
+      mtls:
+        enabled: true
 ----
 
 [id="ossm-security-mtls-sidecars-incoming-services_{context}"]

--- a/modules/ossm-vs-istio-1x.adoc
+++ b/modules/ossm-vs-istio-1x.adoc
@@ -90,7 +90,7 @@ spec:
 
 OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
-A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information see the "Automatic route creation" section.
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information, see Automatic route creation.
 
 [id="ossm-catch-all-domains_{context}"]
 === Catch-all domains

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -74,7 +74,7 @@ The upstream Istio community installation automatically injects the sidecar into
 
 OpenShift routes for Istio Gateways are automatically managed in {ProductName}. Every time an Istio Gateway is created, updated or deleted inside the service mesh, an OpenShift route is created, updated or deleted.
 
-A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information see the "Automatic route creation" section.
+A {ProductName} control plane component called Istio OpenShift Routing (IOR) synchronizes the gateway route.  For more information, see Automatic route creation.
 
 [id="ossm-catch-all-domains_{context}"]
 === Catch-all domains

--- a/service_mesh/v1x/customizing-installation-ossm.adoc
+++ b/service_mesh/v1x/customizing-installation-ossm.adoc
@@ -4,6 +4,17 @@ include::modules/ossm-document-attributes-1x.adoc[]
 :context: customizing-installation-ossm-v1x
 toc::[]
 
+After your default `ServiceMeshControlPlane` resource is deployed, you can configure the resource to suit your environment.
+
+== Resources for configuring your `ServiceMeshControlPlane` resource
+
+Read more about how to configure your `ServiceMeshControlPlane` resource further, or skip ahead to Updating the `ServiceMeshControlPlane`.
+
+* See xref:../../service_mesh/v2x/ossm-observability.adoc#ossm-observability[Data visualization and observability] for more information about Kiali and visualizing your data.
+* See xref:../../service_mesh/v2x/ossm-security.adoc#ossm-security[Security] for configuring mTLS, cipher suites, and external certificate authorities.
+* See xref:../../service_mesh/v2x/ossm-traffic-manage.adoc#ossm-routing-traffic[Traffic management] to configure your routing.
+* See xref:../../service_mesh/v2x/ossm-custom-resources.adoc#ossm-custom-resources[Custom resources] for more information about all the configurable fields in your `ServiceMeshControlPlane` resource.
+
 include::modules/ossm-updating-smcp.adoc[leveloffset=+1]
 
 == Next steps

--- a/service_mesh/v1x/ossm-custom-resources.adoc
+++ b/service_mesh/v1x/ossm-custom-resources.adoc
@@ -19,8 +19,6 @@ include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
 
 include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
 
-include::modules/ossm-auto-route.adoc[leveloffset=+2]
-
 Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
 
 include::modules/ossm-cr-mixer.adoc[leveloffset=+2]

--- a/service_mesh/v1x/ossm-traffic-manage.adoc
+++ b/service_mesh/v1x/ossm-traffic-manage.adoc
@@ -14,3 +14,5 @@ include::modules/ossm-routing.adoc[leveloffset=+1]
 include::modules/ossm-routing-ingress.adoc[leveloffset=+1]
 
 include::modules/ossm-routing-bookinfo-example.adoc[leveloffset=+1]
+
+include::modules/ossm-auto-route-1x.adoc[leveloffset=+1]

--- a/service_mesh/v2x/ossm-custom-resources.adoc
+++ b/service_mesh/v2x/ossm-custom-resources.adoc
@@ -19,8 +19,6 @@ include::modules/ossm-cr-istio-global.adoc[leveloffset=+2]
 
 include::modules/ossm-cr-gateway.adoc[leveloffset=+2]
 
-include::modules/ossm-auto-route.adoc[leveloffset=+2]
-
 Cluster administrators can refer to xref:../../networking/ingress-operator.html#using-wildcard-routes_configuring-ingress[Using wildcard routes] for instructions on how to enable subdomains.
 
 include::modules/ossm-cr-mixer.adoc[leveloffset=+2]

--- a/service_mesh/v2x/ossm-traffic-manage.adoc
+++ b/service_mesh/v2x/ossm-traffic-manage.adoc
@@ -14,3 +14,5 @@ include::modules/ossm-routing.adoc[leveloffset=+1]
 include::modules/ossm-routing-ingress.adoc[leveloffset=+1]
 
 include::modules/ossm-routing-bookinfo-example.adoc[leveloffset=+1]
+
+include::modules/ossm-auto-route.adoc[leveloffset=+1]


### PR DESCRIPTION
“Cherry Picked from <57010567572d910c9a5f08dfa0430f76d8e125e8> xref: <https://github.com/openshift/openshift-docs/pull/27104>”.  

Replaces https://github.com/openshift/openshift-docs/pull/27196 which had XREFs to v2x files in the v1x docs.