### PR TITLE
BZ 1886795: nonexistent virt-tuning plugin

### DIFF
--- a/modules/virt-pxe-booting-with-mac-address.adoc
+++ b/modules/virt-pxe-booting-with-mac-address.adoc
@@ -39,12 +39,12 @@ spec:
           "bridge": "br1"
         },
         {
-          "type": "virt-tuning" <1>
+          "type": "cnv-tuning" <1>
         }
       ]
     }'
 ----
-<1> The `virt-tuning` plug-in provides support for custom MAC addresses.
+<1> The `cnv-tuning` plug-in provides support for custom MAC addresses.
 +
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1886795

The `cnv-tuning` plugin must have been inadvertently changed to `virt-tuning` when we updated the docs from `cnv-*` to `virt-*`. This fixes it.

cherrypick to 4.5, 4.6, and 4.7