### PR TITLE
Update registry logs example

### DIFF
--- a/modules/registry-viewing-logs.adoc
+++ b/modules/registry-viewing-logs.adoc
@@ -14,7 +14,7 @@ image registry:
 +
 [source,terminal]
 ----
-$ oc logs deployments/image-registry
+$ oc logs deployments/image-registry -n openshift-image-registry
 ----
 +
 .Example output


### PR DESCRIPTION
The other example on [the page](https://docs.openshift.com/container-platform/latest/registry/accessing-the-registry.html)  ("Checking the status of the registry Pods") uses an explicit namespace; otherwise, if the user is in a different project (as I was), it wasn't immediately obvious why I couldn't see the logs.