### PR TITLE
removing -o yaml from oc edit

### DIFF
--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -55,7 +55,7 @@ status:
 +
 [source,terminal]
 ----
-$ oc edit ingresscontroller default -n openshift-ingress-operator -o yaml
+$ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
 +
 Add the `nodeSelector` stanza that references the `infra` label to the


### PR DESCRIPTION
Description: `oc edit` prints yaml after exiting when following doc to edit ingress controller

After running:
oc edit ingresscontroller default -n openshift-ingress-operator -o yaml

The resultant yaml is printed to the screen which gives the appearance of an error with the command as it is not typical to use `-o yaml` with `oc edit`.  