### PR TITLE
Fix ROSA AWS table

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -68,4 +68,4 @@ If you need to modify or increase a specific quota, please refer to Amazon's doc
 |elasticloadbalancing
 |L-E9E9831D
 |20
-|
+|===


### PR DESCRIPTION
Technically looked fine in the built docs (presumably because it was the last assembly in the guide), but was throwing an error in asciibinder:

```
asciidoctor: WARNING: modules/rosa-required-aws-service-quotas.adoc: line 14: unterminated table block
```