### PR TITLE
GH#27212 - Use only the node name in the command

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -25,7 +25,7 @@ It is important to take an etcd backup before performing this procedure so that 
 +
 [source,terminal]
 ----
-$ nodes=$(oc get nodes -o name)
+$ nodes=$(oc get nodes -o wide -o jsonpath='{.items[*].metadata.name}')
 ----
 
 .. Shut down all of the nodes:


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/27212

This update ensures that only the node name itself is in the output.