### PR TITLE
OSSMDOC-126 Roll back updates to serverless XREFs

### DIFF
--- a/serverless/networking/serverless-ossm-custom-domains.adoc
+++ b/serverless/networking/serverless-ossm-custom-domains.adoc
@@ -18,7 +18,7 @@ You can customize the domain for your Knative service by configuring the service
 
 .Prerequisites
 * Install the xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] and xref:../../serverless/installing_serverless/installing-knative-serving.adoc#installing-knative-serving[Knative Serving].
-* Install xref:../../service_mesh/v2x/preparing-ossm-installation.adoc#preparing-ossm-installation[{ProductName}].
+* Install xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[{ProductName}].
 * Complete the configuration steps in xref:../../serverless/networking/serverless-ossm.adoc#serverless-ossm[Using {ProductShortName} with {ServerlessProductName}].
 * You can configure a custom domain for an existing Knative service, or create a new sample service. To create a new service, see xref:../../serverless/serving-creating-managing-apps.adoc#serving-creating-managing-apps[Creating and managing serverless applications].
 
@@ -27,4 +27,4 @@ include::modules/serverless-service-mesh-resources.adoc[leveloffset=+1]
 include::modules/serverless-access-custom-domain.adoc[leveloffset=+1]
 
 == Additional resources
-* For more information about {ProductName}, see xref:../../service_mesh/v2x/ossm-architecture.adoc#ossm-architecture[Understanding {ProductName}].
+* For more information about {ProductName}, see xref:../../service_mesh/v1x/ossm-architecture.adoc#ossm-architecture-v1x[Understanding {ProductName}].

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -11,7 +11,7 @@ You can enable JSON Web Token (JWT) authentication for Knative services.
 
 .Prerequisites
 * Install xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessProductName}].
-* Install xref:../../service_mesh/v2x/preparing-ossm-installation.adoc#preparing-ossm-installation[{ProductName}].
+* Install xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[{ProductName}].
 * Configure xref:../../serverless/networking/serverless-ossm.adoc#serverless-ossm[{ProductShortName} with {ServerlessProductName}], including enabling sidecar injection for your Knative services.
 
 [IMPORTANT]
@@ -102,5 +102,5 @@ Hello OpenShift!
 ----
 
 == Additional resources
-* See xref:../../service_mesh/v2x/ossm-architecture.adoc#ossm-architecture[{ProductName} architecture].
+* See xref:../../service_mesh/v1x/ossm-architecture.adoc#ossm-architecture-v1x[{ProductName} architecture].
 * For more information about verifying Knative services and using `curl` requests, see xref:../../serverless/serving-creating-managing-apps.adoc#verifying-serverless-app-deployment_serving-creating-managing-apps[Verifying your serverless application deployment].

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -12,10 +12,10 @@ These options include setting custom domains, using TLS certificates, and using 
 
 .Prerequisites
 . Install the xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] and xref:../../serverless/installing_serverless/installing-knative-serving.adoc#installing-knative-serving[Knative Serving].
-. Install xref:../../service_mesh/v2x/preparing-ossm-installation.adoc#preparing-ossm-installation[{ProductName}].
+. Install xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[{ProductName}].
 
 .Procedure
-. Add the `default` namespace to the xref:../../service_mesh/v2x/installing-ossm.adoc#ossm-member-roll-create_installing-ossm[ServiceMeshMemberRoll] as a member:
+. Add the `default` namespace to the xref:../../service_mesh/v1x/installing-ossm.adoc#ossm-member-roll-create_installing-ossm[ServiceMeshMemberRoll] as a member:
 +
 
 [source,yaml]


### PR DESCRIPTION
This PR rolls back updates to the serverless XREFs from #27183 while retaining the updates to post-installation config and Jaeger XREFs.

Cherry pick to 4.6 and 4.7 branch only.