### PR TITLE
BZ 1884538: config map warning

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -143,6 +143,9 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 
 * If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. As a workaround, you can use a secondary network interface connected to your host or switch to the OpenShift SDN default CNI provider. link:https://bugzilla.redhat.com/show_bug.cgi?id=1887456[(*BZ#1887456*)]
 
+//This defect is on Verified status but the fix is not ideal. This known issue is likely to be removed for 2.6.
+* If you xref:../virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc#virt-creating-vddk-image_virt-importing-vmware-vm[add a VMware Virtual Disk Development Kit (VDDK) image] to the `openshift-cnv/v2v-vmware` config map by using the web console, a *Managed resource* error message displays. You can safely ignore this error. Save the config map by clicking *Save*. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1884538[*BZ#1884538*])
+
 //The issues below are from the 2.4 release. See items above for new known issues for 2.5.
 
 //This defect is on Verified status


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1884538
Preview build: https://configmap-error--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-5-release-notes.html#virt-2-5-known-issues