### PR TITLE
odo fixes.

### DIFF
--- a/cli_reference/developer_cli_odo/understanding-odo.adoc
+++ b/cli_reference/developer_cli_odo/understanding-odo.adoc
@@ -1,5 +1,5 @@
 [id="understanding-odo"]
-= Understanding `{odo-title}`
+= Understanding `odo`
 include::modules/developer-cli-odo-attributes.adoc[]
 include::modules/common-attributes.adoc[]
 :context: understanding-odo

--- a/modules/developer-cli-odo-deploying-the-back-end-component.adoc
+++ b/modules/developer-cli-odo-deploying-the-back-end-component.adoc
@@ -116,7 +116,7 @@ $ mvn package
 +
 [source,terminal]
 ----
-$ odo create openjdk18 backend --binary target/wildwest-1.0.jar
+$ odo create --s2i openjdk18 backend --binary target/wildwest-1.0.jar
 ----
 +
 .Example output

--- a/modules/developer-cli-odo-deploying-the-front-end-component.adoc
+++ b/modules/developer-cli-odo-deploying-the-front-end-component.adoc
@@ -55,7 +55,7 @@ The front-end component is written in an interpreted language (Node.js); it does
 +
 [source,terminal]
 ----
-$ odo create nodejs frontend
+$ odo create --s2i nodejs frontend
 ----
 +
 .Example output


### PR DESCRIPTION
Branch 4.6 and 4.7

- Adding an appropriate flag for the `odo create` command
- Removing an attribute from the heading because for some reason it does not render on the Customer Portal :(
![Screenshot from 2020-11-03 13-29-28](https://user-images.githubusercontent.com/24560978/99001272-e11c6f00-253a-11eb-8ea9-aff3ca7c90a7.png)
