### PR TITLE
OSSMDOC-133  Add note that autoscaling supported 1.20 or later.

### DIFF
--- a/modules/jaeger-config-collector.adoc
+++ b/modules/jaeger-config-collector.adoc
@@ -22,7 +22,7 @@ The collectors are stateless and thus many instances of Jaeger Collector can be 
 |
 
 |autoscale:
-|This parameter controls whether to enable/disable autoscaling for the Collector.  Set to `false` to explicitly disable autoscaling.
+|This parameter controls whether to enable/disable autoscaling for the Collector.  Set to `false` to explicitly disable autoscaling.  Note that autoscaling is only supported for Jaeger 1.20 or later.
 |`true`/`false`
 
 |kafka:
@@ -60,6 +60,11 @@ The collectors are stateless and thus many instances of Jaeger Collector can be 
 
 
 == Configuring the Collector for autoscaling
+
+[NOTE]
+====
+Autoscaling is only supported for Jaeger 1.20 or later.
+====
 
 You can configure the Collector to autoscale; the Collector will scale up or down based on the CPU and/or memory consumption.  Configuring the Collector to autoscale can help you ensure your Jaeger environment scales up during times of increased load, and scales down when less resources are needed, saving on costs.  You configure autoscaling by setting the `autoscale` parameter to `true` and specifying a value for `.spec.collector.maxReplicas` along with a reasonable value for the resources that you expect the Collector’s pod to consume. If you do not set a value for `.spec.collector.maxReplicas` the Operator will set it to `100`.
 

--- a/modules/jaeger-config-ingester.adoc
+++ b/modules/jaeger-config-ingester.adoc
@@ -21,7 +21,7 @@ Ingester is a service that reads from a Kafka topic and writes to another storag
 |
 
 |autoscale:
-|This parameter controls whether to enable/disable autoscaling for the Ingester.  Autoscaling is enabled by default. Set to `false` to explicitly disable autoscaling.
+|This parameter controls whether to enable/disable autoscaling for the Ingester.  Autoscaling is enabled by default. Set to `false` to explicitly disable autoscaling. Note that autoscaling is only supported for Jaeger 1.20 or later.
 |`true`/`false`
 
 |kafka:
@@ -82,6 +82,11 @@ spec:
 ----
 
 == Configuring Ingester for autoscaling
+
+[NOTE]
+====
+Autoscaling is only supported for Jaeger 1.20 or later.
+====
 
 You can configure the Ingester to autoscale; the Ingester will scale up or down based on the CPU and/or memory consumption.  Configuring the Ingester to autoscale can help you ensure your Jaeger environment scales up during times of increased load, and scales down when less resources are needed, saving on costs. You configure autoscaling by setting the `autoscale` parameter to `true` and specifying a value for `.spec.ingester.maxReplicas` along with a reasonable value for the resources that you expect the Ingester's pod to consume. If you do not set a value for `.spec.ingester.maxReplicas` the Operator will set it to `100`.
 


### PR DESCRIPTION
Part one of two.  Updating the Jaeger docs to note that autoscaling the Collector and Ingester is only possible with Jaeger 1.20 or later.

Branch 4.6 and 4.7 only.