### PR TITLE
OSSMDOC-133 Roll back autoscaling options in 4.3, 4.4, 4.5 branches.

### DIFF
--- a/modules/jaeger-config-collector.adoc
+++ b/modules/jaeger-config-collector.adoc
@@ -10,7 +10,29 @@ The Jaeger Collector is the component responsible for receiving the spans that w
 
 The collectors are stateless and thus many instances of Jaeger Collector can be run in parallel. Collectors require almost no configuration, except for the location of the Elasticsearch cluster.
 
-.Jaeger Collector parameters
+.Jaeger Collector parameters used by the Operator
+[options="header"]
+[cols="l, a, a"]
+|===
+|Parameter |Description |Values
+|collector:
+  num-workers:
+|The number of workers pulling from the queue.
+|Integer, for example, `50`
+
+|collector:
+  queue-size:
+|The size of the Collector queue.
+|Integer, for example, `2000`
+
+|collector:
+  replicas:
+|Specifies the number of Collector replicas to create.
+|Integer, for example, `5`
+|===
+
+
+.Jaeger parameters passed to the Collector
 [options="header"]
 [cols="l, a, a"]
 |===
@@ -21,70 +43,22 @@ The collectors are stateless and thus many instances of Jaeger Collector can be 
 |Configuration options that define the Jaeger Collector.
 |
 
-|autoscale:
-|This parameter controls whether to enable/disable autoscaling for the Collector.  Set to `false` to explicitly disable autoscaling.  Note that autoscaling is only supported for Jaeger 1.20 or later.
-|`true`/`false`
-
-|kafka:
-  producer:
-    topic: jaeger-spans
+|options:
+  kafka:
+    producer:
+      topic: jaeger-spans
 |The `topic` parameter identifies the Kafka configuration used by the collector to produce the messages, and the ingester to consume the messages.
 |Label for the producer
 
-|kafka:
-  producer:
-    brokers: my-cluster-kafka-brokers.kafka:9092
+|options:
+  kafka:
+    producer:
+      brokers: my-cluster-kafka-brokers.kafka:9092
 |Identifies the Kafka configuration used by the Collector to produce the messages.  If brokers are not specified, and you have AMQ Streams 1.4.0+ installed, Jaeger will self-provision Kafka.
 |
 
-|log-level:
+|options:
+  log-level:
 |Logging level for the collector.
 |`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`
-
-|maxReplicas:
-|Specifies the maximum number of replicas to create when autoscaling the Collector.
-|Integer, for example, `100`
-
-|num-workers:
-|The number of workers pulling from the queue.
-|Integer, for example, `50`
-
-|queue-size:
-|The size of the Collector queue.
-|Integer, for example, `2000`
-
-|replicas:
-|Specifies the number of Collector replicas to create.
-|Integer, for example, `5`
 |===
-
-
-== Configuring the Collector for autoscaling
-
-[NOTE]
-====
-Autoscaling is only supported for Jaeger 1.20 or later.
-====
-
-You can configure the Collector to autoscale; the Collector will scale up or down based on the CPU and/or memory consumption.  Configuring the Collector to autoscale can help you ensure your Jaeger environment scales up during times of increased load, and scales down when less resources are needed, saving on costs.  You configure autoscaling by setting the `autoscale` parameter to `true` and specifying a value for `.spec.collector.maxReplicas` along with a reasonable value for the resources that you expect the Collector’s pod to consume. If you do not set a value for `.spec.collector.maxReplicas` the Operator will set it to `100`.
-
-By default, when there is no value provided for `.spec.collector.replicas`, the Jaeger Operator creates  a horizontal pod autoscaler (HPA) configuration for the Collector.  For more information about HPA, refer to the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Kubernetes documentation].
-
-The following is an example autoscaling configuration, setting the Collector’s limits as well as the maximum number of replicas:
-
-.Collector autoscaling example
-[source,yaml]
-----
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: simple-prod
-spec:
-  strategy: production
-  collector:
-    maxReplicas: 5
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
-----

--- a/modules/jaeger-config-ingester.adoc
+++ b/modules/jaeger-config-ingester.adoc
@@ -8,7 +8,20 @@ This REFERENCE module included in the following assemblies:
 
 Ingester is a service that reads from a Kafka topic and writes to another storage backend (Elasticsearch).  If you are using the `allInOne` or `production` deployment strategies, you do not need to configure the Ingester service.
 
-.Jaeger Ingester parameters
+.Jaeger Ingester parameters used by the Operator
+[options="header"]
+[cols="l, a, a"]
+|===
+|Parameter |Description |Values
+|ingester:
+  deadlockInterval:
+| Specifies the interval (in seconds or minutes) that the Ingester should wait for a message before terminating.
+The deadlock interval is disabled by default (set to 0), to avoid the Ingester being terminated when no messages arrive while the system is being initialized.
+|Minutes and seconds, for example, `1m0s`.  Default value is `0`.
+|===
+
+
+.Jaeger parameters passed to the Ingester
 [options="header"]
 [cols="l, a, a"]
 |===
@@ -20,35 +33,24 @@ Ingester is a service that reads from a Kafka topic and writes to another storag
 |Configuration options that define the Ingester service.
 |
 
-|autoscale:
-|This parameter controls whether to enable/disable autoscaling for the Ingester.  Autoscaling is enabled by default. Set to `false` to explicitly disable autoscaling. Note that autoscaling is only supported for Jaeger 1.20 or later.
-|`true`/`false`
-
-|kafka:
-  consumer:
-    topic:
+|options:
+  kafka:
+    consumer:
+      topic:
 |The `topic` parameter identifies the Kafka configuration used by the collector to produce the messages, and the ingester to consume the messages.
 |Label for the consumer. For example, `jaeger-spans`.
 
-|kafka:
-  consumer:
-    brokers:
+|options:
+  kafka:
+    consumer:
+      brokers:
 |Identifies the Kafka configuration used by the Ingester to consume the messages.
 |Label for the broker, for example, `my-cluster-kafka-brokers.kafka:9092`.
 
-|ingester:
-  deadlockInterval:
-| Specifies the interval (in seconds or minutes) that the Ingester should wait for a message before terminating.
-The deadlock interval is disabled by default (set to 0), to avoid the Ingester being terminated when no messages arrive while the system is being initialized.
-|Minutes and seconds, for example, `1m0s`.  Default value is `0`.
-
-|log-level:
+|options:
+  log-level:
 |Logging level for the Ingester.
 |Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
-
-|maxReplicas:
-|Specifies the maximum number of replicas to create when autoscaling the Ingester.
-|Integer, for example, `100`.
 |===
 
 .Streaming Collector and Ingester example
@@ -79,34 +81,4 @@ spec:
     options:
       es:
         server-urls: http://elasticsearch:9200
-----
-
-== Configuring Ingester for autoscaling
-
-[NOTE]
-====
-Autoscaling is only supported for Jaeger 1.20 or later.
-====
-
-You can configure the Ingester to autoscale; the Ingester will scale up or down based on the CPU and/or memory consumption.  Configuring the Ingester to autoscale can help you ensure your Jaeger environment scales up during times of increased load, and scales down when less resources are needed, saving on costs. You configure autoscaling by setting the `autoscale` parameter to `true` and specifying a value for `.spec.ingester.maxReplicas` along with a reasonable value for the resources that you expect the Ingester's pod to consume. If you do not set a value for `.spec.ingester.maxReplicas` the Operator will set it to `100`.
-
-By default, when there is no value provided for `.spec.ingester.replicas`, the Jaeger Operator creates  a horizontal pod autoscaler (HPA) configuration for the Ingester.  For more information about HPA, refer to the link:https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/[Kubernetes documentation].
-
-The following is an example autoscaling configuration, setting the Ingester’s limits as well as the maximum number of replicas:
-
-.Ingester autoscaling example
-[source,yaml]
-----
-apiVersion: jaegertracing.io/v1
-kind: Jaeger
-metadata:
-  name: simple-streaming
-spec:
-  strategy: streaming
-  ingester:
-    maxReplicas: 8
-    resources:
-      limits:
-        cpu: 100m
-        memory: 128Mi
 ----


### PR DESCRIPTION
Part two of two.

I made a mistake and the Jaeger autoscaling doc were merged and published prematurely.  This feature is only available on the latest release, so the content needs to be rolled back and removed from the 4.3, 4.4, and 4.5 branches,.