### PR TITLE
Fix image repo mirroring step order

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -104,6 +104,8 @@ $ REMOVABLE_MEDIA_PATH=<path> <1>
 <1> Specify the full path, including the initial forward slash (/) character.
 
 . Mirror the version images to the internal container registry:
++
+--
 ** If your mirror host does not have internet access, take the following actions:
 ... Connect the removable media to a system that is connected to the internet.
 ... Review the images and configuration manifests to mirror:
@@ -148,11 +150,11 @@ the `imageContentSources` data that you require when you install your cluster.
 
 ... Record the entire `imageContentSources` section from the output of the previous
 command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
-
-
+--
++
 [NOTE]
 ====
-The image name gets patched to Quay.io during the mirroring process, and the podman images will show Quay.io in the registry on the bootstrap virtual machine.
+Some image names are patched during the mirroring process to include `quay.io` as the registry.
 ====
 
 . To create the installation program that is based on the content that you


### PR DESCRIPTION
The `[NOTE]` admonition without a `+` is causing the ordered list numbering to restart back to `1` for the (presumably) final step.

Preview: https://install_step--ocpdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations#installation-mirror-repository_installing-restricted-networks-preparations

Including screenshots since there's a question (inline) about the intended level for admonition to appear.

Before:
![before](https://user-images.githubusercontent.com/3442316/98851332-5725b680-2413-11eb-87c6-06fe8595442a.png)

After:
![Screenshot from 2020-11-11 11-44-13](https://user-images.githubusercontent.com/3442316/98851364-60af1e80-2413-11eb-8a99-d17a2a95b5c0.png)
