### PR TITLE
[enterprise-4.7] Update max rules for egress firewall

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -60,9 +60,9 @@ An egress firewall has the following limitations:
 
 * No project can have more than one {kind} object.
 
-* A maximum of one {Kind} object with a maximum of 50 rules can be defined per project.
-
 ifdef::openshift-sdn[]
+* A maximum of one {kind} object with a maximum of 1,000 rules can be defined per project.
+
 * The `default` project cannot use an egress firewall.
 
 * When using the OpenShift SDN default Container Network Interface (CNI) network provider in multitenant mode, the following limitations apply:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1887312

Refs https://github.com/openshift/openshift-docs/pull/27166.

`cherry-pick` bizarrely failed, but it looks like it ought to have succeeded.