### PR TITLE
BZ1897071: Remove filesystem storage from VM import modules

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -46,13 +46,6 @@ ifeval::["{VirtVersion}" < "2.5"]
 endif::[]
 endif::[]
 
-ifeval::["{VirtVersion}" >= "2.5"]
-ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
-|OpenShift Container Storage: RBD filesystem volumes
-|Yes
-endif::[]
-endif::[]
-
 |{VirtProductName} hostpath provisioner
 ifdef::virt-features-for-storage[]
 |No

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -110,7 +110,7 @@ EOF
 <3> If `storageMappings` are specified in both the ResourceMapping and the VirtualMachineImport CRs, the VirtualMachineImport CR takes precedence.
 <4> Specify the RHV storage domain.
 <5> Specify the target storage class as `nfs` or `ocs-storagecluster-ceph-rbd`.
-<6> Specify the volume mode as `Block` or `Filesystem`. If you specified the `ocs-storagecluster-ceph-rbd` storage class, you must specify the `Block` volume mode.
+<6> If you specified the `ocs-storagecluster-ceph-rbd` storage class, you must specify `Block` as the volume mode.
 endif::[]
 
 . Create the VirtualMachineImport CR by running the following command:

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -106,7 +106,7 @@ ifdef::virt-importing-rhv-vm[]
 +
 If you select *ocs-storagecluster-ceph-rbd*, you must set the *Volume Mode* of the disk to *Block*.
 
-** *Advanced* -> *Volume Mode*: Select *Block* or *Filesystem*.
+** *Advanced* -> *Volume Mode*: Select *Block*.
 * *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
 endif::[]
 ifdef::virt-importing-vmware-vm[]
@@ -136,7 +136,7 @@ If you select *ocs-storagecluster-ceph-rbd*, you must set the *Volume Mode* of t
 +
 Other storage classes might work, but they are not officially supported.
 
-** *Advanced* -> *Volume Mode*: Select *Block* or *Filesystem*.
+** *Advanced* -> *Volume Mode*: Select *Block*.
 ** *Advanced* -> *Access Mode*
 
 * *Advanced* -> *Cloud-init*:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1897071

CP to 4.5, 4.6, 4.7

Preview build with changes:
https://bz1897071-cnv-remove-filesystem--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-features-for-storage-matrix_virt-importing-rhv-vm

https://bz1897071-cnv-remove-filesystem--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-wizard_virt-importing-rhv-vm

https://bz1897071-cnv-remove-filesystem--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-cli_virt-importing-rhv-vm

https://bz1897071-cnv-remove-filesystem--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html#virt-features-for-storage-matrix_virt-importing-vmware-vm

https://bz1897071-cnv-remove-filesystem--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html#virt-importing-vm-wizard_virt-importing-vmware-vm