### PR TITLE
BZ1869035 - Update perms in vCenter Requirements doc

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -5,40 +5,99 @@
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 
 [id="installation-vsphere-installer-infra-requirements_{context}"]
-= vCenter requirements
+= Requirements for vCenter cluster install
 
-Before you install an {product-title} cluster on your vCenter that uses infrastructure that the installer provisions, you must prepare your environment.
+Before you install an {product-title} cluster on your vCenter that uses installer-provisioned infrastructure, you must prepare your environment. Logging in to a user account or group that has administrative privileges is the simplest way to access all of the necessary permissions in vCenter.
+
+By configuring roles and permissions, vCenter authentication determines how a group or user can access vSphere components and objects, both globally and locally.
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-account_{context}"]
-== Required vCenter account privileges
+== Applying vCenter account privileges
 
-To install an {product-title} cluster in a vCenter, the installation program requires access to an account with privileges to read and create the required resources. Using an account that has administrative privileges is the simplest way to access all of the necessary permissions.
+To install an {product-title} cluster in a vCenter, the installation program requires access to an account with privileges to read and create the required resources.
 
-A user requires the following privileges to install an {product-title} cluster:
+[IMPORTANT]
+====
+It is recommended that you apply role access privileges globally to ensure that the required permissions are met. If these permissions are not applied globally, you must determine which entities to grant the role permissions to. At minimum, the user or group must have read-only access for both the vCenter and the vSphere entities.
+====
 
-* Datastore
-** *Allocate space*
-** *Browse datastore*
-** *Low level file operations*
-** *Remove file*
-* Folder
-** *Create folder*
-** *Delete folder*
-* vSphere Tagging
-** All privileges
-* Network
-** *Assign network*
-* Resource
-** *Assign virtual machine to resource pool*
-* Profile-driven storage
-** All privileges
-* vApp
-** All privileges
-* Virtual machine
-** All privileges
+.Procedure
+To configure your vCenter environment so that a user or group in {product-title} has the necessary privileges to provision storage for the installer:
 
-For more information about creating an account with only the required privileges, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html[vSphere Permissions and User Management Tasks] in the vSphere documentation.
+. Assign the `ReadOnly` role in vCenter to the vSphere user or group that manages {product-title} volumes. This allows them to view the node VM object state and details.
+
+. Grant the user or group with read-only privileges on the node VM object.
+
+. Propagate the `ReadOnly` role set to all the parent entities of the node VM object at the vCenter level, as shown in the following table:
++
+.Required vSphere parent entities
+[cols="1a,5a,5a",options="header"]
+|===
+
+|Role
+|Privileges
+|Entities
+
+|`Read-only`
+|`System.Anonymous`, `System.Read`, `System.View`
+|vCenter, Datacenter, Datastore Cluster, Datastore Storage Folder
+|===
+
+. Create a custom role in vCenter with read-only privileges.
+
+. Apply the new custom role to the {product-title} user at the vCenter level.
+
+. Propagate the new custom role set to all the child entities of the node VM object at the vCenter level, as shown in the following table:
++
+.Required vSphere levels
+[cols="1a,5a",options="header"]
+|===
+
+|Level
+|Privileges
+
+|Datastore
+|* *Allocate space*
+* *Browse datastore*
+* *Low level file operations*
+* *Remove file*
+
+|Folder
+|* *Create folder*
+* *Delete folder*
+
+|vSphere Tagging
+|* All privileges
+
+|Network
+|* *Assign network*
+
+|Resource
+|* *Assign virtual machine to resource pool*
+
+|Profile-driven storage
+|* All privileges
+
+|Tasks
+|* All privileges
+
+|vApp
+|* All privileges
+
+|Virtual machine
+|* All privileges
+
+|===
++
+[NOTE]
+====
+It might be possible to further refine the categories where "All privileges" are granted.
+====
+
+. Verify that the vCenter user or group permissions are now inherited by the role you created.
+
+For more information about creating an account with the required privileges, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-5372F580-5C23-4E9C-8A4E-EF1B4DD9033E.html[vSphere Permissions and User Management Tasks] in the vSphere documentation.
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-vmotion_{context}"]


### PR DESCRIPTION
Fix requested in [BZ1869035](https://bugzilla.redhat.com/show_bug.cgi?id=1869035) to update vSphere Install docs to show required account privs for Tasks. The "Edit Role -> Tasks" options in vCenter are shown as check boxes for "All Tasks Privileges", "Create task", and "Update task". There is no "Delete task" check box.

@gnufied PTAL to verify this is accurate and what you have in mind.

@qinpingli PTAL for QE review.

**PREVIEW LINK:**
https://bz1869035--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned-network-customizations

Original permissions doc was based on a dev draft that installer team added for vSphere IPI work here: https://github.com/openshift/installer/blob/master/docs/user/vsphere/privileges.md