### PR TITLE
Add GVK to term glossary

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -168,9 +168,9 @@ A resource implemented through the Kubernetes `CustomResourceDefinition` API. A 
 Do not capitalize.
 
 ''''
-=== custom resource definition
+=== custom resource definition (CRD)
 
-Usage: custom resource definition
+Usage: custom resource definition (CRD) for the first time reference; CRD thereafter.
 
 Create a custom resource definition to define a new custom resource.
 
@@ -232,6 +232,21 @@ When referencing the actual object, write as `Event`. See link:doc_guidelines.ad
 
 // NOTE: This is inconsistently used, e.g. https://docs.openshift.com/container-platform/4.5/rest_api/metadata_apis/event-core-v1.html
 See: link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#event-v1-core[Event v1 core API], link:https://github.com/cloudevents/spec/blob/master/primer.md#cloudevents-concepts[CloudEvents concepts], and link:https://github.com/cloudevents/spec/blob/master/spec.md#event[CloudEvents specification].
+
+== F
+
+== G
+
+''''
+=== group/version/kind (GVK)
+
+Usage: group/version/kind (GVK) for the first time reference; GVK thereafter.
+
+A unique identifier for a Kubernetes API, specifying its _group_ (a collection of related APIs), _version_ (defines the release and level of stability), and _kind_ (an individual API type or name).
+
+While "GroupVersionKind" does appear in the API guide, typically there should not be a reason to mark up in reference to a specific object. Favor simply "GVK", or "GVKs" for pluralization, after the first time reference as much as possible. Avoid pluralizing the long form (e.g., group/version/kinds or groups/versions/kinds).
+
+== H
 
 == I
 
@@ -296,6 +311,8 @@ cluster runs on, it is an installer-provisioned infrastructure installation.
 
 Do not use: IPI
 
+== J
+
 == K
 
 ''''
@@ -321,6 +338,8 @@ master, so it is generally preferred to use the term OpenShift master.
 === Kubernetes API server
 
 Usage: Kubernetes API server
+
+== L
 
 == M
 
@@ -474,6 +493,8 @@ from Kubernetes.
 
 When referencing the actual object, write as `Project`. See link:doc_guidelines.adoc#api-object-formatting[API object formatting] for more details.
 
+== Q
+
 == R
 
 ''''
@@ -531,7 +552,7 @@ Kubernetes API object that holds secret data of a certain type.
 See link:https://kubernetes.io/docs/concepts/configuration/secret/[Secrets - Kubernetes].
 
 ''''
-=== security context constraints
+=== security context constraints (SCC)
 
 Usage: security context constraints
 
@@ -614,6 +635,8 @@ When referencing the actual object, write as `StorageClass`. See link:doc_guidel
 
 See link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage Classes - Kubernetes].
 
+== T
+
 == U
 
 ''''
@@ -628,3 +651,13 @@ installation.
 Do not use: UPI
 
 ''''
+
+== V
+
+== W
+
+== X
+
+== Y
+
+== Z


### PR DESCRIPTION
From some light googling at other docs/blogs references, everyone seems to be all over the place, e.g.:

GroupVersionKind
Group-Version-Kind
group, version, kind
group, version, and kind 
group/version/kind

Just starting with "Group Version Kind" to get the ball rolling.