### PR TITLE
Fix 'ports' field indentation in EgressFirewall CR.

### DIFF
--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -79,7 +79,7 @@ egress:
 - type: <type> <1>
   to: <2>
     cidrSelector: <cidr> <3>
-    ports: <4>
+  ports: <4>
       ...
 ----
 <1> The type of rule. The value must be either `Allow` or `Deny`.
@@ -143,10 +143,10 @@ spec:
   - type: Deny
     to:
       cidrSelector: 172.16.1.1
-      ports:
-      - port: 80
-        protocol: TCP
-      - port: 443
+    ports:
+    - port: 80
+      protocol: TCP
+    - port: 443
 ----
 endif::ovn[]
 


### PR DESCRIPTION
This is the fix for issue #27346 