### PR TITLE
BZ1892445 [CDI] Add a note for NFSv3 not supported

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -145,3 +145,10 @@ You cannot live migrate virtual machines that use:
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====
 endif::[]
+
+ifdef::virt-features-for-storage[]
+[NOTE]
+====
+The Containerized-Data-Importer (CDI) does not support protocol NFSv3. Only the NFSv4 protocol is supported.
+====
+endif::[]


### PR DESCRIPTION
Link to BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1892445

Added the following note to bottom of Storage Feature Matrix:

**The Containerized-Data-Importer (CDI) does not support protocol NFSv3. Only the NFSv4 protocol is supported.**

*Peer Review Needed* and label *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).5*, *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).6*, *[enterprise-4](https://issues.redhat.com/browse/enterprise-4).7*.

See Test Build: https://bz1892445--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-features-for-storage.html

Tagging @aglitke to ensure mentioning this is OK, as it does mention NFS.
Tagging @demilyc for QE review.

Thanks
Bob