### PR TITLE
ossmdoc-161

### DIFF
--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -96,6 +96,7 @@ apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
+  namespace: openshift-operators
 spec:
   version: v2.0
   tracing:

--- a/modules/ossm-control-plane-deploy.adoc
+++ b/modules/ossm-control-plane-deploy.adoc
@@ -96,7 +96,6 @@ apiVersion: maistra.io/v2
 kind: ServiceMeshControlPlane
 metadata:
   name: basic
-  namespace: openshift-operators
 spec:
   version: v2.0
   tracing:

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -84,6 +84,8 @@ $ oc new-project istio-system-upgrade
 +
 . Update the `metadata.namespace` field in your v2 `ServiceMeshControlPlane` with your new project name. In this example, use `istio-system-upgrade`.
 +
+. Update the `version` field from 1.1 to 2.0 or remove it in your v2 `ServiceMeshControlPlane`.
++
 . Create a `ServiceMeshControlPlane` in the new namespace. On the command line, run the following command to deploy the control plane with the v2 version of the `ServiceMeshControlPlane` that you retrieved. In this example, replace `<smcp_name.v2> `with the path to your file.
 +
 [source,terminal]

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -82,6 +82,8 @@ $ oc get smcp <smcp_name> -o yaml > <smcp_name>.v2.yaml
 $ oc new-project istio-system-upgrade
 ----
 +
+. Update the `metadata.namespace` field in your v2 `ServiceMeshControlPlane` with your new project name. In this example, use `istio-system-upgrade`.
++
 . Create a `ServiceMeshControlPlane` in the new namespace. On the command line, run the following command to deploy the control plane with the v2 version of the `ServiceMeshControlPlane` that you retrieved. In this example, replace `<smcp_name.v2> `with the path to your file.
 +
 [source,terminal]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSSMDOC-161
https://issues.redhat.com/browse/OSSMDOC-173

Fixes customer feedback in the migration documentation.

Cherrypick to 4.6 and 4.7 only.