### PR TITLE
BZ1897654: Deleting migration controller operands for CAM 1.2 upgrade

### DIFF
--- a/modules/migration-upgrading-migration-tool-4.adoc
+++ b/modules/migration-upgrading-migration-tool-4.adoc
@@ -23,9 +23,16 @@ The following procedure enables you to change the *Manual* approval option to *A
 Updating the subscription deploys the updated {mtc-short} Operator and updates the {mtc-short} components.
 endif::[]
 ifeval::["{mtc-version}" <= "1.3"]
-You can upgrade to {mtc-short} {mtc-version} on an {product-title} 4 cluster by uninstalling the CAM Operator and installing the {mtc-short} Operator.
+You can upgrade to {mtc-short} {mtc-version} on an {product-title} 4 cluster by deleting the `MigrationController` custom resource (CR), uninstalling the CAM Operator, and then installing the {mtc-short} Operator.
 
 .Procedure
+
+. Delete the `MigrationController` CR:
++
+[source,terminal]
+----
+$ oc delete migrationcontroller -n openshift-migration migration-controller
+----
 
 . In the {product-title} console, navigate to *Operators* > *Installed Operators*.
 . Click *CAM Operator*.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1897654

CP to 4.5, 4.6, 4.7