### PR TITLE
Fix ISSUE-23216 - add RHEL note

### DIFF
--- a/modules/storage-persistent-storage-nfs-selinux.adoc
+++ b/modules/storage-persistent-storage-nfs-selinux.adoc
@@ -5,20 +5,17 @@
 [id="nfs-selinux_{context}"]
 = SELinux
 
-By default, SELinux does not allow writing from a Pod to a remote
-NFS server. The NFS volume mounts correctly, but is read-only.
+{op-system-base-full} and {op-system-first} systems are configured to use SELinux on remote NFS servers by default.
 
-To enable writing to a remote NFS server, follow the below procedure.
+For non-{op-system-base} and non-{op-system} systems, SELinux does not allow writing from a pod to a remote NFS server. The NFS volume mounts correctly but it is read-only. You will need to enable the correct SELinux permissions by using the following procedure.
 
 .Prerequisites
 
-* The `container-selinux` package must be installed. This package provides
-the `virt_use_nfs` SELinux boolean.
+* The `container-selinux` package must be installed. This package provides the `virt_use_nfs` SELinux boolean.
 
 .Procedure
 
-* Enable the `virt_use_nfs` boolean using the following command.
-The `-P` option makes this boolean persistent across reboots.
+* Enable the `virt_use_nfs` boolean using the following command. The `-P` option makes this boolean persistent across reboots.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/23216 - adds note to clarify that this procedure is only required for RHEL nodes. Also removed hard-wraps.

**PREVIEW LINK:**
https://issue-23216--ocpdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-nfs.html#nfs-selinux_persistent-storage-nfs