### PR TITLE
API obj terminology update - "Updating clusters"

### DIFF
--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -107,14 +107,14 @@ spec:
 <1> Indicates the name of the image registry and repository
 <2> Indicates the registry and repository containing the content that is mirrored
 
-. Create the new `ImageContentSourcePolicy`:
+. Create the new `ImageContentSourcePolicy` object:
 +
 [source,terminal]
 ----
 $ oc create -f registryrepomirror.yaml
 ----
 +
-After the `ImageContentSourcePolicy` is created,
+After the `ImageContentSourcePolicy` object is created,
 the new settings are deployed to each node
 and shortly start using the mirrored repository
 for requests to the source repository.
@@ -192,7 +192,7 @@ unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 ----
 
 .. Pull an image digest to the node from the source and check if it is actually
-resolved by the mirror. The `ImageContentSourcePolicy` supports image digests only, not image tags.
+resolved by the mirror. `ImageContentSourcePolicy` objects support image digests only, not image tags.
 +
 [source,terminal]
 ----
@@ -210,4 +210,3 @@ troubleshoot the problem.
 * From the system context, the `Insecure` flags are used as fallback.
 * The format of the `/etc/containers/registries` file has
 changed recently. It is now version 2 and in TOML format.
-*

--- a/modules/update-configuring-image-signature.adoc
+++ b/modules/update-configuring-image-signature.adoc
@@ -3,9 +3,9 @@
 // * updating/updating-restricted-network-cluster.adoc
 
 [id="update-configuring-image-signature"]
-= Creating an image signature ConfigMap manually
+= Creating an image signature config map manually
 
-Create and apply the image signature ConfigMap to the cluster that you want to update.
+Create and apply the image signature config map to the cluster that you want to update.
 
 [NOTE]
 ====
@@ -61,7 +61,7 @@ $ DIGEST_ENCODED="${DIGEST#*:}"
 $ SIGNATURE_BASE64=$(curl -s "https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release/${DIGEST_ALGO}=${DIGEST_ENCODED}/signature-1" | base64 -w0 && echo)
 ----
 
-. Create the ConfigMap:
+. Create the config map:
 +
 [source,terminal]
 ----
@@ -78,7 +78,7 @@ binaryData:
 EOF
 ----
 
-. Apply the ConfigMap to the cluster to update:
+. Apply the config map to the cluster to update:
 +
 [source,terminal]
 ----

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -108,7 +108,7 @@ $ oc image mirror  -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mi
 +
 <1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
 
-** If the local container registry and the cluster are connected to the mirror host, directly push the release images to the local registry and apply the ConfigMap to the cluster by using following command:
+** If the local container registry and the cluster are connected to the mirror host, directly push the release images to the local registry and apply the config map  to the cluster by using following command:
 +
 [source,terminal]
 ----
@@ -118,5 +118,5 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON} --from=quay.io/${PRODUCT_REPO}/$
 +
 [NOTE]
 ====
-If you include the `--apply-release-image-signature` option, do not create the ConfigMap for image signature verification.
+If you include the `--apply-release-image-signature` option, do not create the config map for image signature verification.
 ====

--- a/modules/update-oc-configmap-signature-verification.adoc
+++ b/modules/update-oc-configmap-signature-verification.adoc
@@ -3,13 +3,13 @@
 // * updating/updating-restricted-network-cluster.adoc
 
 [id="update-oc-configmap-signature-verification_{context}"]
-= Creating the ConfigMap for image signature verification by using the `oc` CLI
+= Creating the config map for image signature verification by using the `oc` CLI
 
-Before you update your cluster, you must manually create a ConfigMap that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
+Before you update your cluster, you must manually create a config map that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
 
 [NOTE]
 ====
-If you are upgrading from a release prior to version 4.4.8, you must use the manual method for creating the ConfigMap instead of this procedure. The commands that this procedure uses are not in earlier versions of the `oc` command-line interface (CLI).
+If you are upgrading from a release prior to version 4.4.8, you must use the manual method for creating the config map instead of this procedure. The commands that this procedure uses are not in earlier versions of the `oc` command-line interface (CLI).
 ====
 
 .Prerequisites
@@ -22,7 +22,7 @@ If you are upgrading from a release prior to version 4.4.8, you must use the man
 
 . Use `oc` command-line interface (CLI) to log into the cluster that you are upgrading.
 
-. Apply the mirrored release image signature ConfigMap to the connected cluster:
+. Apply the mirrored release image signature config map to the connected cluster:
 +
 [source,terminal]
 ----

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -36,11 +36,11 @@ include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]
 include::modules/update-mirror-repository.adoc[leveloffset=+1]
 
 [id="updating-restricted-network-image-signature-configmap"]
-== Creating the image signature ConfigMap
+== Creating the image signature config map
 
-Before you update your cluster, you must manually create a ConfigMap that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
+Before you update your cluster, you must manually create a config map that contains the signatures of the release images that you use. This signature allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
 
-If you are upgrading from version 4.4.8 or later, you can use the `oc` CLI to create the ConfigMap. If you are upgrading from an earlier version, you must use the manual method.
+If you are upgrading from version 4.4.8 or later, you can use the `oc` CLI to create the config map. If you are upgrading from an earlier version, you must use the manual method.
 
 include::modules/update-oc-configmap-signature-verification.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Implementing [style changes](https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#api-object-formatting) for all modules that are included in "Updating clusters" assemblies. 