### PR TITLE
fix: country vs CN (BZ:1892606)

### DIFF
--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -61,7 +61,7 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
 [source,terminal]
 ----
 [user@registry ~]$ host_fqdn=$( hostname --long )
-[user@registry ~]$ cert_c="<Common Name>"    # Certificate Common Name (CN)
+[user@registry ~]$ cert_c="<Country Name>"   # Country Name (C, 2 letter code)
 [user@registry ~]$ cert_s="<State>"          # Certificate State (S)
 [user@registry ~]$ cert_l="<Locality>"       # Certificate Locality (L)
 [user@registry ~]$ cert_o="<Organization>"   # Certificate Organization (O)
@@ -79,7 +79,7 @@ Generate a self-signed certificate for the registry node and put it in the `/opt
     -subj "/C=${cert_c}/ST=${cert_s}/L=${cert_l}/O=${cert_o}/OU=${cert_ou}/CN=${cert_cn}"
 ----
 +
-NOTE: When replacing `<Comman Name>`, ensure it only contains two letters. For example, `US`.
+NOTE: When replacing `<Country Name>`, ensure that it only contains two letters. For example, `US`.
 
 . Update the registry node's `ca-trust` with the new certificate.
 +


### PR DESCRIPTION
Clarify that C is is for the 2 letter
country code and not the common name.