### PR TITLE
Adding warning about exercising care when editing the KubeletConfig

### DIFF
--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -30,3 +30,12 @@ spec:
 When setting the value, consider the number of worker nodes that can be
 unavailable without affecting the applications running on the cluster.
 ====
+
+[IMPORTANT]
+====
+Care must be exercised when modifying the `KubeletConfig` as improper 
+modifications to the `KubeletConfig` may render the kubelet unable to 
+start.  This will result in the impacted node(s) becoming `NotReady`.
+If this occurs it will be necessary to collect a `sosreport` to diagnose 
+the reason for the node not becoming `Ready`.  
+====


### PR DESCRIPTION
Modifications to the `KubeletConfig` can result in the kubelet not starting.  This pull-request adds a brief warning about this possibility and instructions to retrieve a sosreport if the node(s) become persistently `NotReady` after applying a problematic `KubeletConfig`.  This PR is related to an issue encountered in `https://bugzilla.redhat.com/show_bug.cgi?id=1880088`