### PR TITLE
OSDOCS-1605 - add vSphere static IP config procedure from 4-6 RNs

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -71,13 +71,11 @@ Available resources vary between clusters. The number of possible clusters withi
 [id="installation-vsphere-installer-infra-requirements-networking_{context}"]
 == Networking requirements
 
-You must use DHCP for the network and ensure that the DHCP server is configured to provide persistent IP addresses and host names to the cluster machines.
-Additionally, you must create the following networking resources before you install the {product-title} cluster:
+You must use DHCP for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. Additionally, you must create the following networking resources before you install the {product-title} cluster:
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-_{context}"]
-=== Required IP addresses
-
+=== Required IP Addresses
 An installer-provisioned vSphere installation requires two static IP addresses:
 
 * The **API** address is used to access the cluster API.
@@ -88,7 +86,6 @@ You must provide these IP addresses to the installation program when you install
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-dns-records_{context}"]
 === DNS records
-
 You must create DNS records for two static IP addresses in the appropriate DNS server for the vCenter instance that hosts your {product-title} cluster. In each record, `<cluster_name>` is the cluster name and `<base_domain>` is the cluster base domain that you specify when you install the cluster. A complete DNS record takes the form: `<component>.<cluster_name>.<base_domain>.`.
 
 .Required DNS records

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -7,77 +7,20 @@
 [id="installation-vsphere-machines_{context}"]
 = Creating {op-system-first} machines in vSphere
 
-Before you install a cluster that contains user-provisioned infrastructure on
-VMware vSphere, you must create {op-system} machines on vSphere hosts for it to
-use.
+Before you install a cluster that contains user-provisioned infrastructure on VMware vSphere, you must create {op-system} machines on vSphere hosts for it to use.
 
 .Prerequisites
 
 * Obtain the Ignition config files for your cluster.
-* Have access to an HTTP server that you can access from your computer and that
-the machines that you create can access.
+* Have access to an HTTP server that you can access from your computer and that the machines that you create can access.
 * Create a link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.vcenterhost.doc/GUID-B1018F28-3F14-4DFE-9B4B-F48BBDB72C10.html[vSphere cluster].
 
 .Procedure
 
-. Upload the bootstrap Ignition config file, which is named
-`<installation_directory>/bootstrap.ign`, that the installation program created
-to your HTTP server. Note the URL of this file.
-+
-You must host the bootstrap Ignition config file because it is too large to
-fit in a vApp property.
+. Convert the control plane, compute, and bootstrap Ignition config files to Base64 encoding.
 
-. Save the following secondary Ignition config file for your bootstrap node to
-your computer as `<installation_directory>/append-bootstrap.ign`.
 +
-ifndef::openshift-origin[]
-----
-{
-  "ignition": {
-    "config": {
-      "merge": [
-        {
-          "source": "<bootstrap_ignition_config_url>" <1>
-        }
-      ]
-    },
-    "version": "3.1.0"
-  }
-}
-----
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-----
-{
-  "ignition": {
-    "config": {
-      "merge": [
-        {
-          "source": "<bootstrap_ignition_config_url>", <1>
-          "verification": {}
-        }
-      ]
-    },
-    "timeouts": {},
-    "version": "3.0.0"
-  },
-  "networkd": {},
-  "passwd": {},
-  "storage": {},
-  "systemd": {}
-}
-----
-endif::openshift-origin[]
-<1> Specify the URL of the bootstrap Ignition config file that you hosted.
-+
-When you create the virtual machine (VM) for the bootstrap machine, you use
-this Ignition config file.
-
-. Convert the master, worker, and secondary bootstrap Ignition config files to base64
-encoding.
-+
-For example, if you use a Linux operating system, you can use the `base64`
-command to encode the files.
+For example, if you use a Linux operating system, you can use the `base64` command to encode the files.
 +
 [source,terminal]
 ----
@@ -96,31 +39,21 @@ $ base64 -w0 <installation_directory>/append-bootstrap.ign > <installation_direc
 +
 [IMPORTANT]
 ====
-If you plan to add more compute machines to your cluster after you finish
-installation, do not delete these files.
+If you plan to add more compute machines to your cluster after you finish installation, do not delete these files.
 ====
 
 ifndef::openshift-origin[]
-. Obtain the {op-system} OVA image from the
-link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
-Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/[{op-system} image mirror]
-page.
+. Obtain the {op-system} OVA image from the link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red Hat Customer Portal or the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/[{op-system} image mirror] page.
 +
 [IMPORTANT]
 ====
-The {op-system} images might not change with every release of {product-title}.
-You must download an image with the highest version that is
-less than or equal to the {product-title} version that you install. Use the image version
-that matches your {product-title} version if it is available.
+The {op-system} images might not change with every release of {product-title}. You must download an image with the highest version that is less than or equal to the {product-title} version that you install. Use the image version that matches your {product-title} version if it is available.
 ====
 +
-The file name contains the {product-title} version number in the format
-`rhcos-<version>-vmware.<architecture>.ova`.
+The filename contains the {product-title} version number in the format `rhcos-<version>-vmware.<architecture>.ova`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-. Obtain the {op-system} images from the
-link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+. Obtain the {op-system} images from the link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
 endif::openshift-origin[]
 
 . In the vSphere Client, create a folder in your datacenter to store your VMs.
@@ -133,25 +66,17 @@ endif::openshift-origin[]
 +
 [NOTE]
 ====
-In the following steps, you use the same template for all of your cluster
-machines and provide the location for the Ignition config file for that machine
-type when you provision the VMs.
+In the following steps, you use the same template for all of your cluster machines and provide the location for the Ignition config file for that machine type when you provision the VMs.
 ====
-.. From the *Hosts and Clusters* tab, right-click your cluster's name and
-click *Deploy OVF Template*.
-.. On the *Select an OVF* tab, specify the name of the {op-system} OVA file
-that you downloaded.
-.. On the *Select a name and folder* tab, set a *Virtual machine name*, such
-as {op-system}, click the name of your vSphere cluster, and select the folder you created in the previous step.
-.. On the *Select a compute resource* tab, click the name of your vSphere
-cluster.
+.. From the *Hosts and Clusters* tab, right-click your cluster name and select *Deploy OVF Template*.
+.. On the *Select an OVF* tab, specify the name of the {op-system} OVA file that you downloaded.
+.. On the *Select a name and folder* tab, set a *Virtual machine name*, such as {op-system}. Click the name of your vSphere cluster and select the folder you created in the previous step.
+.. On the *Select a compute resource* tab, click the name of your vSphere cluster.
 .. On the *Select storage* tab, configure the storage options for your VM.
 *** Select *Thin Provision* or *Thick Provision*, based on your storage preferences.
 *** Select the datastore that you specified in your `install-config.yaml` file.
-.. On the *Select network* tab, specify the network that you configured
-for the cluster, if available.
-.. If you plan to use the same template for all cluster machine types, do not
-specify values on the *Customize template* tab.
+.. On the *Select network* tab, specify the network that you configured for the cluster, if available.
+.. If you plan to use the same template for all cluster machine types, do not specify values on the *Customize template* tab.
 +
 [IMPORTANT]
 ====
@@ -160,40 +85,55 @@ installation, do not delete this template.
 ====
 
 . After the template deploys, deploy a VM for a machine in the cluster.
-.. Right-click the template's name and click *Clone* -> *Clone to Virtual Machine*.
-.. On the *Select a name and folder* tab, specify a name for the VM. You might
-include the machine type in the name, such as `control-plane-0` or `compute-1`.
-.. On the *Select a name and folder* tab, select the name of the folder that
-you created for the cluster.
-.. On the *Select a compute resource* tab, select the name of a host in your
-datacenter.
+.. Right-click the template name and click *Clone* -> *Clone to Virtual Machine*.
+.. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `control-plane-0` or `compute-1`.
+.. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
+.. On the *Select a compute resource* tab, select the name of a host in your datacenter.
++
+For a bootstrap machine, specify the URL of the bootstrap Ignition config file that you hosted.
++
 .. Optional: On the *Select storage* tab, customize the storage options.
 .. On the *Select clone options*, select
 *Customize this virtual machine's hardware*.
 .. On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
+*** Optional: Override default DHCP networking in vSphere. To enable static IP networking:
++
+... Set your static IP configuration:
++
+[source,terminal]
+----
+$ export IPCFG="ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none nameserver=srv1 [nameserver=srv2 [nameserver=srv3 [...]]]"
+----
++
+.Example command
+[source,terminal]
+----
+$ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameserver=8.8.8.8"
+----
+
+... Set the `guestinfo.afterburn.initrd.network-kargs` property before booting a VM from an OVA in vSphere:
++
+[source,terminal]
+----
+$ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${IPCFG}"
+----
++
 *** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*.
-*** Click *Edit Configuration*, and on the *Configuration Parameters* window,
-click *Add Configuration Params*. Define the following parameter names and values:
-**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded
-Ignition config file for this machine type.
+*** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
+**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded Ignition config file for this machine type.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
-*** Alternatively, prior to powering on the virtual machine add via vApp properties:
+*** Alternatively, prior to powering on the virtual machine, use vApp properties to:
 **** Navigate to a virtual machine from the vCenter Server inventory.
 **** On the *Configure* tab, expand *Settings* and select *vApp options.*
-**** Scroll down and under *Properties* apply the configurations from above.
-.. In the *Virtual Hardware* panel of the
-*Customize hardware* tab, modify the specified values as required. Ensure that
-the amount of RAM, CPU, and disk storage meets the minimum requirements for the
+**** Scroll down and under *Properties*, apply the configurations that you just edited.
+.. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 .. Complete the configuration and power on the VM.
 
-. Create the rest of the machines for your cluster by following the preceding
-steps for each machine.
+. Create the rest of the machines for your cluster by following the preceding steps for each machine.
 +
 [IMPORTANT]
 ====
-You must create the bootstrap and control plane machines at this time. Because
-some pods are deployed on compute machines by default, also create at least two
-compute machines before you install the cluster.
+You must create the bootstrap and control plane machines at this time. Because some pods are deployed on compute machines by default, also create at least two compute machines before you install the cluster.
 ====


### PR DESCRIPTION
[OSDOCS-1605](https://issues.redhat.com/browse/OSDOCS-1605) - this PR adds a procedure in the vSphere Install docs to add a procedure for overriding default DHCP in favor of static IP addresses, as outlined in the 4.6 Release Notes: https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-static-ip-config-with-ova

**Cc:**@codyhoag

Preview link: https://osdocs-1605--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere