### PR TITLE
BZ1892610: missing pipe (|) in a bash command dealing with pull-secret

### DIFF
--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -155,7 +155,7 @@ Copy the pull secret file from the provisioner node to the registry node and mod
 +
 [source,terminal]
 ----
-[user@registry ~]$ b64auth=$( echo -n '<username>:<passwd>' openssl base64 )
+[user@registry ~]$ b64auth=$( echo -n '<username>:<passwd>' | openssl base64 )
 ----
 +
 Replace `<username>` with the user name and `<passwd>` with the password.


### PR DESCRIPTION
for https://bugzilla.redhat.com/show_bug.cgi?id=1892610