### PR TITLE
OSSMDOC-152 connect to existing Jaeger OSSM 1.1.

### DIFF
--- a/modules/ossm-configuring-jaeger-existing-v1x.adoc
+++ b/modules/ossm-configuring-jaeger-existing-v1x.adoc
@@ -1,0 +1,94 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/ossm-custom-resources.adoc
+
+[id="ossm-configuring-jaeger-existing-v1x_{context}"]
+= Connecting to an existing Jaeger instance
+
+In order for the SMCP to connect to an existing Jaeger instance, the following must be true:
+
+* The Jaeger instance is deployed in the same namespace as the control plane, for example, into the `istio-system` namespace.
+
+* To enable secure communication between services, you should enable the oauth-proxy, which secures communication to your Jaeger instance, and make sure the secret is mounted into your Jaeger instance so Kiali can communicate with it.
+
+* To use a custom or already existing Jaeger instance, set `spec.istio.tracing.enabled` to "false" to disable the deployment of a Jaeger instance.
+
+* Supply the correct jaeger-collector endpoint to Mixer by setting `spec.istio.global.tracer.zipkin.address` to the hostname and port of your jaeger-collector service. The hostname of the service is usually `<jaeger-instance-name>-collector.<namespace>.svc.cluster.local`.
+
+* Supply the correct jaeger-query endpoint to Kiali for gathering traces by setting `spec.istio.kiali.jaegerInClusterURL` to the hostname of your jaeger-query service - the port is normally not required, as it uses 443 by default. The hostname of the service is usually  `<jaeger-instance-name>-query.<namespace>.svc.cluster.local`.
+
+* Supply the dashboard URL of your Jaeger instance to Kiali to enable accessing Jaeger through the Kiali console. You can retrieve the URL from the OpenShift route that is created by the Jaeger Operator. If your Jaeger resource is called `external-jaeger` and resides in the `istio-system` project, you can retrieve the route using the following command:
++
+[source,terminal]
+----
+$ oc get route -n istio-system external-jaeger
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   HOST/PORT                                     PATH   SERVICES               [...]
+external-jaeger        external-jaeger-istio-system.apps.test        external-jaeger-query  [...]
+----
++
+The value under `HOST/PORT` is the externally accessible URL of the Jaeger dashboard.
+
+
+.Example Jaeger resource
+[source,yaml]
+----
+apiVersion: jaegertracing.io/v1
+kind: "Jaeger"
+metadata:
+  name: "external-jaeger"
+  # Deploy to the Control Plane Namespace
+  namespace: istio-system
+spec:
+  # Set Up Authentication
+  ingress:
+    enabled: true
+    security: oauth-proxy
+    openshift:
+      # This limits user access to the Jaeger instance to users who have access
+      # to the control plane namespace. Make sure to set the correct namespace here
+      sar: '{"namespace": "istio-system", "resource": "pods", "verb": "get"}'
+      htpasswdFile: /etc/proxy/htpasswd/auth
+
+  volumeMounts:
+  - name: secret-htpasswd
+    mountPath: /etc/proxy/htpasswd
+  volumes:
+  - name: secret-htpasswd
+    secret:
+      secretName: htpasswd
+
+----
+
+The following `ServiceMeshControlPlane` example assumes that you have deployed Jaeger using the Jaeger Operator and the example Jaeger resource.
+
+.Example `ServiceMeshControlPlane` with external Jaeger
+[source,yaml]
+----
+apiVersion: maistra.io/v1
+kind: ServiceMeshControlPlane
+metadata:
+  name: external-jaeger
+  namespace: istio-system
+spec:
+  version: v1.1
+  istio:
+    tracing:
+      # Disable Jaeger deployment by service mesh operator
+      enabled: false
+    global:
+      tracer:
+        zipkin:
+          # Set Endpoint for Trace Collection
+          address: external-jaeger-collector.istio-system.svc.cluster.local:9411
+    kiali:
+      # Set Jaeger dashboard URL
+      dashboard:
+        jaegerURL: https://external-jaeger-istio-system.apps.test
+      # Set Endpoint for Trace Querying
+      jaegerInClusterURL: external-jaeger-query.istio-system.svc.cluster.local
+----

--- a/modules/ossm-jaeger-config-elasticsearch-v1x.adoc
+++ b/modules/ossm-jaeger-config-elasticsearch-v1x.adoc
@@ -2,61 +2,8 @@
 //
 // * service_mesh/v1x/ossm-custom-resources.adoc
 
-[id="ossm-configuring-jaeger_{context}"]
-= Configuring Jaeger
-
-When the {ProductShortName} Operator creates the `ServiceMeshControlPlane` resource it can also create the resources for distributed tracing. {ProductShortName} uses Jaeger for distributed tracing.
-
-You can specify your Jaeger configuration in either of two ways:
-
-* Configure Jaeger in the `ServiceMeshControlPlane` resource. There are some limitations with this approach.
-
-* Configure Jaeger in a custom `Jaeger` resource and then reference that Jaeger instance in the  `ServiceMeshControlPlane` resource. If a Jaeger resource matching the value of `name` exists, the control plane will use the existing installation. This approach lets you fully customize your Jaeger configuration.
-
-The default Jaeger parameters specified in the `ServiceMeshControlPlane` are as follows:
-
-.Default `all-in-one` Jaeger parameters
-[source,yaml]
-----
-  apiVersion: maistra.io/v1
-  kind: ServiceMeshControlPlane
-  spec:
-    version: v1.1
-    istio:
-      tracing:
-        enabled: true
-        jaeger:
-          template: all-in-one
-----
-
-.Jaeger parameters
-[options="header"]
-[cols="l, a, a, a"]
-|===
-|Parameter |Description |Values |Default value
-
-|tracing:
-   enabled:
-|This parameter enables/disables installing and deploying tracing by the Service Mesh Operator. Installing Jaeger is enabled by default.  To use an existing Jaeger deployment, set this value to `false`.
-|`true`/`false`
-|`true`
-
-|jaeger:
-   template:
-|This parameter specifies which Jaeger deployment strategy to use.
-|* `all-in-one`- For development, testing, demonstrations, and proof of concept.
-* `production-elasticsearch` - For production use.
-|`all-in-one`
-|===
-
-[NOTE]
-====
-The default template in the `ServiceMeshControlPlane` resource is the `all-in-one` deployment strategy which uses in-memory storage. For production, the only supported storage option is Elasticsearch, therefore you must configure the `ServiceMeshControlPlane` to request the `production-elasticsearch` template when you deploy {ProductShortName} within a production environment.
-====
-
-
-[id="ossm-configuring-jaeger-elasticsearch_{context}"]
-== Configuring Elasticsearch
+[id="ossm-jaeger-config-elasticsearch-v1x_{context}"]
+= Configuring Elasticsearch
 
 The default Jaeger deployment strategy uses the `all-in-one` template so that the installation can be completed using minimal resources.  However, because the `all-in-one` template uses in-memory storage, it is only recommended for development, demo, or testing purposes and should NOT be used for production environments.
 

--- a/modules/ossm-jaeger-config-es-cleaner-v1x.adoc
+++ b/modules/ossm-jaeger-config-es-cleaner-v1x.adoc
@@ -1,7 +1,6 @@
-////
-This PROCEDURE module included in the following assemblies:
-// * service_mesh/v1x/customizing-installation-ossm.adoc
-////
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/ossm-custom-resources.adoc
 
 [id="ossm-jaeger-config-es-cleaner-v1x_{context}"]
 = Configuring the Elasticsearch index cleaner job

--- a/service_mesh/v1x/ossm-custom-resources.adoc
+++ b/service_mesh/v1x/ossm-custom-resources.adoc
@@ -29,6 +29,10 @@ include::modules/ossm-configuring-kiali.adoc[leveloffset=+1]
 
 include::modules/ossm-configuring-jaeger-v1x.adoc[leveloffset=+1]
 
+include::modules/ossm-configuring-jaeger-existing-v1x.adoc[leveloffset=+2]
+
+include::modules/ossm-jaeger-config-elasticsearch-v1x.adoc[leveloffset=+2]
+
 include::modules/ossm-jaeger-config-es-cleaner-v1x.adoc[leveloffset=+2]
 
 For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store].


### PR DESCRIPTION
This PR documents how to connect the service mesh control plane to an existing Jaeger instance.

(For 2.0 instructions see #27415)