### PR TITLE
BZ1898444: Removing thanosQuerier from movable components example

### DIFF
--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -54,7 +54,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    *prometheusOperator:
+    prometheusOperator:
       nodeSelector:
         foo: bar
     prometheusK8s:
@@ -74,11 +74,8 @@ data:
         foo: bar
     k8sPrometheusAdapter:
       nodeSelector:
-        foo: bar*
-    openshiftStateMetrics:
-      nodeSelector:
         foo: bar
-    thanosQuerier:
+    openshiftStateMetrics:
       nodeSelector:
         foo: bar
 ----


### PR DESCRIPTION
Applies to branch/enterprise-4.4 only.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1898444.