### PR TITLE
[enterprise-4.4]Applying style updates to PerfScale docs

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -9,20 +9,14 @@
 [id="about-must-gather_{context}"]
 = About the must-gather tool
 
-The `oc adm must-gather` CLI command collects the information from your cluster
-that is most likely needed for debugging issues, such as:
+The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues, such as:
 
 * Resource definitions
 * Audit logs
 * Service logs
 
-You can specify one or more images when you run the command by including the
-`--image` argument. When you specify an image, the tool collects data related to
-that feature or product.
+You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product.
 
-When you run `oc adm must-gather`, a new Pod is created on the cluster. The data
-is collected on that Pod and saved in a new directory that starts with
-`must-gather.local`. This directory is created in the current working
-directory.
+When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that Pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
 
 // todo: table or ref module listing available images?

--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -15,17 +15,9 @@ Use this process to access an example Node Tuning Operator specification.
 $ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
-The default CR is meant for delivering standard node-level tuning for the
-{product-title} platform and it can only be modified to set the Operator
-Management state. Any other custom changes to the default CR will be
-overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly
-created CRs will be combined with the default CR and custom tuning applied to
-{product-title} nodes based on node or Pod labels and profile priorities.
+The default CR is meant for delivering standard node-level tuning for the {product-title} platform and it can only be modified to set the Operator Management state. Any other custom changes to the default CR will be overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly created CRs will be combined with the default CR and custom tuning applied to {product-title} nodes based on node or pod labels and profile priorities.
 
-While in certain situations the support for Pod labels can be a convenient way
-of automatically delivering required tuning, this practice is discouraged and
-strongly advised against, especially in large-scale clusters. The default Tuned
-CR ships without Pod label matching. If a custom profile is created with Pod
-label matching, then the functionality will be enabled at that time. The Pod
-label functionality might be deprecated in future versions of the Node Tuning
-Operator.
+[WARNING]
+====
+While in certain situations the support for pod labels can be a convenient way of automatically delivering required tuning, this practice is discouraged and strongly advised against, especially in large-scale clusters. The default Tuned CR ships without pod label matching. If a custom profile is created with pod label matching, then the functionality will be enabled at that time. The pod label functionality might be deprecated in future versions of the Node Tuning Operator.
+====

--- a/modules/available-persistent-storage-options.adoc
+++ b/modules/available-persistent-storage-options.adoc
@@ -26,7 +26,7 @@ bypassing the file system
 a| * Presented to the OS as a file system export to be mounted
 * Also referred to as Network Attached Storage (NAS)
 * Concurrency, latency, file locking mechanisms, and other capabilities vary widely between protocols, implementations, vendors, and scales.
-|RHEL NFS, NetApp NFS footnote:[NetApp NFS supports dynamic PV provisioning when using the Trident plug-in.], and Vendor NFS
+|RHEL NFS, NetApp NFS ^[1]^, and Vendor NFS
 // Azure File, AWS EFS
 
 | Object
@@ -37,6 +37,10 @@ a| * Accessible through a REST API endpoint
 // Aliyun OSS, Ceph Object Storage (RADOS Gateway)
 // Google Cloud Storage, Azure Blob Storage, OpenStack Swift
 |===
+[.small]
+--
+1. NetApp NFS supports dynamic PV provisioning when using the Trident plug-in.
+--
 
 [IMPORTANT]
 ====

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -27,7 +27,7 @@ tuned-vvxwx                                     1/1     Running   1          6d3
 tuned-zqrwq                                     1/1     Running   1          6d3h   10.0.161.51    ip-10-0-161-51.eu-west-3.compute.internal    <none>           <none>
 ----
 
-. Extract the profile applied from each Pod and match them against the previous list:
+. Extract the profile applied from each pod and match them against the previous list:
 +
 ----
 $ for p in `oc get pods -n openshift-cluster-node-tuning-operator -l openshift-app=tuned -o=jsonpath='{range .items[*]}{.metadata.name} {end}'`; do printf "\n*** $p ***\n" ; oc logs pod/$p -n openshift-cluster-node-tuning-operator | grep applied; done

--- a/modules/cnf-configuring-huge-pages.adoc
+++ b/modules/cnf-configuring-huge-pages.adoc
@@ -8,12 +8,9 @@
 Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the
 Performance Addon Operator to allocate huge pages on a specific node.
 
-{product-title} provides a method for creating and allocating huge pages.
-Performance Addon Operator provides an easier method for doing this using the
-PerformanceProfile.
+{product-title} provides a method for creating and allocating huge pages. Performance Addon Operator provides an easier method for doing this using the performance profile.
 
-For example, in the `hugepages` `pages` section of the PerformanceProfile,
-you can specify multiple blocks of `size`, `count`, and, optionally, `node`:
+For example, in the `hugepages` `pages` section of the performance profile, you can specify multiple blocks of `size`, `count`, and, optionally, `node`:
 
 ----
 hugepages:
@@ -28,7 +25,7 @@ hugepages:
 
 [NOTE]
 ====
-Wait for the relevant machineconfigpool status that indicates the update is finished.
+Wait for the relevant machine config pool status that indicates the update is finished.
 ====
 
 These are the only configuration steps you need to do to allocate huge pages.

--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -43,8 +43,7 @@ $ oc create -f pao-namespace.yaml
 
 . Install the Performance Addon Operator in the namespace you created in the previous step by creating the following objects:
 
-.. Create the following OperatorGroup CR and save the YAML in the
-pao-operatorgroup.yaml` file:
+.. Create the following `OperatorGroup` CR and save the YAML in the `pao-operatorgroup.yaml` file:
 +
 [source,yaml]
 ----
@@ -58,14 +57,13 @@ spec:
   - openshift-performance-addon-operator
 ----
 
-.. Create the OperatorGroup CR by running the following command:
+.. Create the `OperatorGroup` CR by running the following command:
 +
 ----
 $ oc create -f pao-operatorgroup.yaml
 ----
 
-.. Run the following command to get the `channel` value required for the next
-step.
+.. Run the following command to get the `channel` value required for the next step.
 +
 ----
 $ oc get packagemanifest performance-addon-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
@@ -111,8 +109,7 @@ As a cluster administrator, you can install the Performance Addon Operator using
 
 [NOTE]
 ====
-You have to create the Namespace CR and OperatorGroup CR as mentioned
-in the previous section.
+You must create the `Namespace` CR and `OperatorGroup` CR as mentioned in the previous section.
 ====
 
 .Procedure
@@ -123,8 +120,7 @@ in the previous section.
 
 .. Choose  *Performance Addon Operator* from the list of available Operators, and then click *Install*.
 
-.. On the *Create Operator Subscription* page, under *A specific namespace on the cluster*
-select *openshift-performance-addon-operator*. Then, click *Subscribe*.
+.. On the *Install Operator* page, under *A specific namespace on the cluster* select *openshift-performance-addon-operator*. Then, click *Install*.
 
 . Optional: Verify that the performance-addon-operator installed successfully:
 
@@ -134,16 +130,13 @@ select *openshift-performance-addon-operator*. Then, click *Subscribe*.
 +
 [NOTE]
 ====
-During installation an Operator might display a *Failed* status.
-If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
+During installation an Operator might display a *Failed* status. If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
 ====
 
 +
 If the Operator does not appear as installed, to troubleshoot further:
 
 +
-* Go to the *Operators* -> *Installed Operators* page and inspect
-the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors
+* Go to the *Operators* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors
 under *Status*.
-* Go to the *Workloads* -> *Pods* page and check the logs for pods in the
-`performance-addon-operator` project.
+* Go to the *Workloads* -> *Pods* page and check the logs for pods in the `performance-addon-operator` project.

--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -9,10 +9,9 @@ This feature could cause nodes to reboot and not be available.
 ====
 
 [id="cnf-tuning-nodes-for-low-latency-via-performanceprofile_{context}"]
-= Tuning nodes for low latency via PerformanceProfile
+= Tuning nodes for low latency with the performance profile
 
-The PerformanceProfile lets you control latency tuning aspects of nodes that belong to a certain MachineConfigPool.
-After you have specified your settings, the `PerformanceProfile` object is compiled into multiple objects that perform the actual node level tuning:
+The performance profile lets you control latency tuning aspects of nodes that belong to a certain machine config pool. After you specify your settings, the `PerformanceProfile` object is compiled into multiple objects that perform the actual node level tuning:
 
 * A `MachineConfig` file that manipulates the nodes.
 * A `KubeletConfig` file that configures the Topology Manager, the CPU Manager, and the {product-title} nodes.
@@ -22,13 +21,11 @@ After you have specified your settings, the `PerformanceProfile` object is compi
 
 . Prepare a cluster.
 
-. Create a Machine Config Pool.
+. Create a machine config pool.
 
 . Install the Performance Addon Operator.
 
-. Create a performance profile that is appropriate for your hardware and topology.
-In the PerformanceProfile, you can specify whether to update the kernel to kernel-rt, allocation of hugepages, the CPUs that
-will be reserved for operating system housekeeping processes and CPUs that will be used for running the workloads.
+. Create a performance profile that is appropriate for your hardware and topology. In the performance profile, you can specify whether to update the kernel to kernel-rt, allocation of huge pages, the CPUs that will be reserved for operating system housekeeping processes and CPUs that will be used for running the workloads.
 +
 This is a typical performance profile:
 +
@@ -60,17 +57,11 @@ realTimeKernel:
 
 == Partitioning the CPUs
 
-You can reserve cores, or threads, for operating system housekeeping tasks from a single NUMA node and put your workloads on another NUMA node.
-The reason for this is that the housekeeping processes might be using the CPUs in a way that would impact latency sensitive processes
-running on those same CPUs.
-Keeping your workloads on a separate NUMA node prevents the processes from interfering with each other.
-Additionally, each NUMA node has its own memory bus that is not shared.
+You can reserve cores, or threads, for operating system housekeeping tasks from a single NUMA node and put your workloads on another NUMA node. The reason for this is that the housekeeping processes might be using the CPUs in a way that would impact latency sensitive processes running on those same CPUs. Keeping your workloads on a separate NUMA node prevents the processes from interfering with each other. Additionally, each NUMA node has its own memory bus that is not shared.
 
 Specify two groups of CPUs in the `spec` section:
 
 * `isolated` - Has the lowest latency. Processes in this group have no interruptions and so can, for example,
 reach much higher DPDK zero packet loss bandwidth.
 
-* `reserved` - The housekeeping CPUs. Threads in the reserved group tend to be very busy, so latency-sensitive
-applications should be run in the isolated group.
-See link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[Create a Pod that gets assigned a QoS class of `Guaranteed`].
+* `reserved` - The housekeeping CPUs. Threads in the reserved group tend to be very busy, so latency-sensitive applications should be run in the isolated group. See link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[Create a pod that gets assigned a QoS class of `Guaranteed`].

--- a/modules/configuring-cluster-loader.adoc
+++ b/modules/configuring-cluster-loader.adoc
@@ -5,8 +5,7 @@
 [id="configuring_cluster_loader_{context}"]
 = Configuring Cluster Loader
 
-The tool creates multiple namespaces (projects), which contain multiple
-templates or pods.
+The tool creates multiple namespaces (projects), which contain multiple templates or pods.
 
 == Example Cluster Loader configuration file
 
@@ -67,19 +66,15 @@ ClusterLoader:
           delay: 0 ms
 ----
 <1> Optional setting for end-to-end tests. Set to `local` to avoid extra log messages.
-<2> The tuning sets allow rate limiting and stepping, the ability to create several
-batches of pods while pausing in between sets. Cluster Loader monitors
-completion of the previous step before continuing.
+<2> The tuning sets allow rate limiting and stepping, the ability to create several batches of pods while pausing in between sets. Cluster Loader monitors completion of the previous step before continuing.
 <3> Stepping will pause for `M` seconds after each `N` objects are created.
 <4> Rate limiting will wait `M` milliseconds between the creation of objects.
 
-This example assumes that references to any external template files or podspec
-files are also mounted into the container.
+This example assumes that references to any external template files or pod spec files are also mounted into the container.
 
 [IMPORTANT]
 ====
-If you are running Cluster Loader on Microsoft Azure, then you must set the
-`AZURE_AUTH_LOCATION` variable to a file that contains the output of
+If you are running Cluster Loader on Microsoft Azure, then you must set the `AZURE_AUTH_LOCATION` variable to a file that contains the output of
 `terraform.azure.auto.tfvars.json`, which is present in the installer directory.
 ====
 
@@ -90,22 +85,16 @@ If you are running Cluster Loader on Microsoft Azure, then you must set the
 |Field |Description
 
 |`cleanup`
-|Set to `true` or `false`. One definition per configuration. If set to `true`,
-`cleanup` deletes all namespaces (projects) created by Cluster Loader at the
-end of the test.
+|Set to `true` or `false`. One definition per configuration. If set to `true`, `cleanup` deletes all namespaces (projects) created by Cluster Loader at the end of the test.
 
 |`projects`
-|A sub-object with one or many definition(s). Under `projects`, each
-namespace to create is defined and `projects` has several mandatory subheadings.
+|A sub-object with one or many definition(s). Under `projects`, each namespace to create is defined and `projects` has several mandatory subheadings.
 
 |`tuningsets`
-|A sub-object with one definition per configuration. `tuningsets` allows the user
-to define a tuning set to add configurable timing to project or object creation
-(Pods, templates, and so on).
+|A sub-object with one definition per configuration. `tuningsets` allows the user to define a tuning set to add configurable timing to project or object creation (pods, templates, and so on).
 
 |`sync`
-|An optional sub-object with one definition per configuration. Adds synchronization
-possibilities during object creation.
+|An optional sub-object with one definition per configuration. Adds synchronization possibilities during object creation.
 |===
 
 .Fields under `projects`
@@ -116,25 +105,19 @@ possibilities during object creation.
 |An integer. One definition of the count of how many projects to create.
 
 |`basename`
-|A string. One definition of the base name for the project. The count of
-identical namespaces will be appended to `Basename` to prevent collisions.
+|A string. One definition of the base name for the project. The count of identical namespaces will be appended to `Basename` to prevent collisions.
 
 |`tuning`
-|A string. One definition of what tuning set you want to apply to the objects,
-which you deploy inside this namespace.
+|A string. One definition of what tuning set you want to apply to the objects, which you deploy inside this namespace.
 
 |`ifexists`
-|A string containing either `reuse` or `delete`. Defines what the tool does if
-it finds a project or namespace that has the same name of the project or
-namespace it creates during execution.
+|A string containing either `reuse` or `delete`. Defines what the tool does if it finds a project or namespace that has the same name of the project or namespace it creates during execution.
 
 |`configmaps`
-|A list of key-value pairs. The key is the ConfigMap name and the value is a
-path to a file from which you create the ConfigMap.
+|A list of key-value pairs. The key is the config map name and the value is a path to a file from which you create the config map.
 
 |`secrets`
-|A list of key-value pairs. The key is the secret name and the value is a path to
-a file from which you create the secret.
+|A list of key-value pairs. The key is the secret name and the value is a path to a file from which you create the secret.
 
 |`pods`
 |A sub-object with one or many definition(s) of pods to deploy.
@@ -157,11 +140,10 @@ a file from which you create the secret.
 | A string. One definition of the base name for the template (or pod) that you want to create.
 
 |`file`
-|A string. The path to a local file, which is either a PodSpec or template to be created.
+|A string. The path to a local file, which is either a pod spec or template to be created.
 
 |`parameters`
-|Key-value pairs. Under `parameters`, you can specify a list of values to
-override in the pod or template.
+|Key-value pairs. Under `parameters`, you can specify a list of values to override in the pod or template.
 |===
 
 .Fields under `tuningsets`
@@ -169,8 +151,7 @@ override in the pod or template.
 |Field |Description
 
 |`name`
-|A string. The name of the tuning set which will match the name specified when
-defining a tuning in a project.
+|A string. The name of the tuning set which will match the name specified when defining a tuning in a project.
 
 |`pods`
 |A sub-object identifying the `tuningsets` that will apply to pods.
@@ -184,12 +165,10 @@ defining a tuning in a project.
 |Field |Description
 
 |`stepping`
-|A sub-object. A stepping configuration used if you want to create an object in a
-step creation pattern.
+|A sub-object. A stepping configuration used if you want to create an object in a step creation pattern.
 
 |`rate_limit`
-|A sub-object. A rate-limiting tuning set configuration to limit the object
-creation rate.
+|A sub-object. A rate-limiting tuning set configuration to limit the object creation rate.
 |===
 
 .Fields under `tuningsets` `pods` or `tuningsets` `templates`, `stepping`
@@ -200,12 +179,10 @@ creation rate.
 |An integer. How many objects to create before pausing object creation.
 
 |`pause`
-|An integer. How many seconds to pause after creating the number of objects
-defined in `stepsize`.
+|An integer. How many seconds to pause after creating the number of objects defined in `stepsize`.
 
 |`timeout`
-|An integer. How many seconds to wait before failure if the object creation is
-not successful.
+|An integer. How many seconds to wait before failure if the object creation is not successful.
 
 |`delay`
 |An integer. How many milliseconds (ms) to wait between creation requests.
@@ -216,23 +193,17 @@ not successful.
 |Field |Description
 
 |`server`
-|A sub-object with `enabled` and `port` fields. The boolean `enabled` defines
-whether to start an HTTP server for pod synchronization. The integer `port`
-defines the HTTP server port to listen on (`9090` by default).
+|A sub-object with `enabled` and `port` fields. The boolean `enabled` defines whether to start an HTTP server for pod synchronization. The integer `port` defines the HTTP server port to listen on (`9090` by default).
 
 |`running`
-|A boolean. Wait for pods with labels matching `selectors` to go into `Running`
-state.
+|A boolean. Wait for pods with labels matching `selectors` to go into `Running` state.
 
 |`succeeded`
-|A boolean. Wait for pods with labels matching `selectors` to go into `Completed`
-state.
+|A boolean. Wait for pods with labels matching `selectors` to go into `Completed` state.
 
 |`selectors`
 |A list of selectors to match pods in `Running` or `Completed` states.
 
 |`timeout`
-|A string. The synchronization timeout period to wait for pods in `Running` or
-`Completed` states. For values that are not `0`, use units:
-[ns\|us\|ms\|s\|m\|h].
+|A string. The synchronization timeout period to wait for pods in `Running` or `Completed` states. For values that are not `0`, use units: [ns\|us\|ms\|s\|m\|h].
 |===

--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -5,13 +5,11 @@
 [id="configuring-huge-pages_{context}"]
 = Configuring huge pages
 
-Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the
-Node Tuning Operator to allocate huge pages on a specific node.
+Nodes must pre-allocate huge pages used in an {product-title} cluster. Use the Node Tuning Operator to allocate huge pages on a specific node.
 
 .Procedure
 
-. Label the node so that the Node Tuning Operator knows on which node to apply the
-tuned profile, which describes how many huge pages should be allocated:
+. Label the node so that the Node Tuning Operator knows on which node to apply the tuned profile, which describes how many huge pages should be allocated:
 +
 ----
 $ oc label node <node_using_hugepages> hugepages=true
@@ -54,9 +52,7 @@ spec:
 $ oc create -f hugepages_tuning.yaml
 ----
 
-. After creating the profile, the Operator applies the new profile to the correct
-node and allocates huge pages. Check the logs of a tuned pod on a node using
-huge pages to verify:
+. After creating the profile, the Operator applies the new profile to the correct node and allocates huge pages. Check the logs of a tuned pod on a node using huge pages to verify:
 +
 ----
 $ oc logs <tuned_pod_on_node_using_hugepages> \

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -3,13 +3,10 @@
 // * scalability_and_performance/recommended-host-practices.adoc
 
 [id="create-a-kubeletconfig-crd-to-edit-kubelet-parameters_{context}"]
-= Create a KubeletConfig CRD to edit kubelet parameters
+= Creating a `KubeletConfig` CRD to edit kubelet parameters
 
-The kubelet configuration is currently serialized as an ignition configuration,
-so it can be directly edited. However, there is also a new
-kubelet-config-controller added to the Machine Config Controller (MCC). This
-allows you to create a KubeletConfig custom resource (CR) to edit the
-kubelet parameters.
+The kubelet configuration is currently serialized as an ignition configuration, so it can be directly edited. However, there is also a new
+`kubelet-config-controller` added to the Machine Config Controller (MCC). This allows you to create a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
 
 .Procedure
 
@@ -19,9 +16,7 @@ kubelet parameters.
 $ oc get machineconfig
 ----
 +
-This provides a list of the available machine configuration objects you can
-select. By default, the two kubelet-related configs are `01-master-kubelet` and
-`01-worker-kubelet`.
+This provides a list of the available machine configuration objects you can select. By default, the two kubelet-related configs are `01-master-kubelet` and `01-worker-kubelet`.
 
 . To check the current value of max pods per node, run:
 +
@@ -48,8 +43,7 @@ Allocatable:
  pods:                        250
 ----
 
-. To set the max pods per node on the worker nodes, create a custom resource file
-that contains the kubelet configuration. For example, `change-maxPods-cr.yaml`:
+. To set the max pods per node on the worker nodes, create a custom resource file that contains the kubelet configuration. For example, `change-maxPods-cr.yaml`:
 +
 [source,yaml]
 ----
@@ -65,11 +59,7 @@ spec:
     maxPods: 500
 ----
 +
-The rate at which the kubelet talks to the API server depends on queries per
-second (QPS) and burst values. The default values, `50` for `kubeAPIQPS` and `100`
-for `kubeAPIBurst`, are good enough if there are limited pods running on each
-node. Updating the kubelet QPS and burst rates is recommended if there are
-enough CPU and memory resources on the node:
+The rate at which the kubelet talks to the API server depends on queries per second (QPS) and burst values. The default values, `50` for `kubeAPIQPS` and `100` for `kubeAPIBurst`, are good enough if there are limited pods running on each node. Updating the kubelet QPS and burst rates is recommended if there are enough CPU and memory resources on the node:
 +
 [source,yaml]
 ----
@@ -107,9 +97,7 @@ $ oc get kubeletconfig
 +
 This should return `set-max-pods`.
 +
-Depending on the number of worker nodes in the cluster, wait for the worker
-nodes to be rebooted one by one. For a cluster with 3 worker nodes, this could
-take about 10 to 15 minutes.
+Depending on the number of worker nodes in the cluster, wait for the worker nodes to be rebooted one by one. For a cluster with 3 worker nodes, this could take about 10 to 15 minutes.
 
 . Check for `maxPods` changing for the worker nodes:
 +

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -5,14 +5,9 @@
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
 
-The custom resource (CR) for the Operator has two major sections. The first
-section, `profile:`, is a list of Tuned profiles and their names. The second,
-`recommend:`, defines the profile selection logic.
+The custom resource (CR) for the Operator has two major sections. The first section, `profile:`, is a list of Tuned profiles and their names. The second, `recommend:`, defines the profile selection logic.
 
-Multiple custom tuning specifications can co-exist as multiple CRs in the
-Operator's namespace. The existence of new CRs or the deletion of old CRs is
-detected by the Operator. All existing custom tuning specifications are merged
-and appropriate objects for the containerized Tuned daemons are updated.
+Multiple custom tuning specifications can co-exist as multiple CRs in the Operator's namespace. The existence of new CRs or the deletion of old CRs is detected by the Operator. All existing custom tuning specifications are merged and appropriate objects for the containerized Tuned daemons are updated.
 
 *Profile data*
 
@@ -43,7 +38,7 @@ profile:
 
 *Recommended profiles*
 
-The `profile:` selection logic is defined by the `recommend:` section of the CR:
+The `profile:` selection logic is defined by the `recommend:` section of the CR. The `recommend:` section is a list of items to recommend the profiles based on a selection criteria.
 
 ----
 recommend:
@@ -71,12 +66,7 @@ If `<match>` is omitted, a profile match (for example, `true`) is assumed.
   <match>                 # an optional <match> array
 ----
 
-If `<match>` is not omitted, all nested `<match>` sections must also evaluate to
-`true`. Otherwise, `false` is assumed and the profile with the respective
-`<match>` section will not be applied or recommended. Therefore, the nesting
-(child `<match>` sections) works as logical AND operator. Conversely, if any
-item of the `<match>` array matches, the entire `<match>` array evaluates to
-`true`. Therefore, the array acts as logical OR operator.
+If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` array matches, the entire `<match>` array evaluates to `true`. Therefore, the array acts as logical OR operator.
 
 .Example
 
@@ -98,26 +88,11 @@ item of the `<match>` array matches, the entire `<match>` array evaluates to
   profile: openshift-node
 ----
 
-The CR above is translated for the containerized Tuned daemon into its
-`recommend.conf` file based on the profile priorities. The profile with the
-highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is
-considered first. The containerized Tuned daemon running on a given node looks
-to see if there is a Pod running on the same node with the
-`tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>`
-section evaluates as `false`. If there is such a Pod with the label, in order for
-the `<match>` section to evaluate to `true`, the node label also needs to be
-`node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
+The CR above is translated for the containerized Tuned daemon into its `recommend.conf` file based on the profile priorities. The profile with the
+highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized Tuned daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
-If the labels for the profile with priority `10` matched,
-`openshift-control-plane-es` profile is applied and no other profile is
-considered. If the node/Pod label combination did not match, the second highest
-priority profile (`openshift-control-plane`) is considered. This profile is
-applied if the containerized Tuned Pod runs on a node with labels
-`node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
+If the labels for the profile with priority `10` matched, `openshift-control-plane-es` profile is applied and no other profile is considered. If the node/pod label combination did not match, the second highest priority profile (`openshift-control-plane`) is considered. This profile is applied if the containerized Tuned pod runs on a node with labels `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
-Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks
-the `<match>` section and, therefore, will always match. It acts as a profile
-catch-all to set `openshift-node` profile, if no other profile with higher
-priority matches on a given node.
+Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks the `<match>` section and, therefore, will always match. It acts as a profile catch-all to set `openshift-node` profile, if no other profile with higher priority matches on a given node.
 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]

--- a/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
+++ b/modules/how-to-plan-your-environment-according-to-cluster-maximums.adoc
@@ -7,40 +7,30 @@
 
 [IMPORTANT]
 ====
-Oversubscribing the physical resources on a node affects resource guarantees the
-Kubernetes scheduler makes during pod placement. Learn what measures you can
-take to avoid memory swapping.
+Oversubscribing the physical resources on a node affects resource guarantees the Kubernetes scheduler makes during pod placement. Learn what measures you can take to avoid memory swapping.
 
-Some of the tested maximums are stretched only in a single dimension. They will vary
-when many objects are running on the cluster.
+Some of the tested maximums are stretched only in a single dimension. They will vary when many objects are running on the cluster.
 
-The numbers noted in this documentation are based on Red Hat's test methodology,
-setup, configuration, and tunings. These numbers can vary based on your own
-individual setup and environments.
+The numbers noted in this documentation are based on Red Hat's test methodology, setup, configuration, and tunings. These numbers can vary based on your own individual setup and environments.
 ====
 
-While planning your environment, determine how many pods are expected to fit per
-node:
+While planning your environment, determine how many pods are expected to fit per node:
 
 ----
-Required pods per Cluster / pods per Node = Total Number of Nodes Needed
+required pods per cluster / pods per node = total number of nodes needed
 ----
 
-The current maximum number of pods per node is 250. However, the number of pods
-that fit on a node is dependent on the application itself. Consider the application's
-memory, CPU, and storage requirements, as described in _How to plan your environment according to application requirements_.
+The current maximum number of pods per node is 250. However, the number of pods that fit on a node is dependent on the application itself. Consider the application's memory, CPU, and storage requirements, as described in _How to plan your environment according to application requirements_.
 
 .Example scenario
 
-If you want to scope your cluster for 2200 pods per cluster, you would need at
-least five nodes, assuming that there are 500 maximum pods per node:
+If you want to scope your cluster for 2200 pods per cluster, you would need at least five nodes, assuming that there are 500 maximum pods per node:
 
 ----
 2200 / 500 = 4.4
 ----
 
-If you increase the number of nodes to 20, then the pod distribution changes to
-110 pods per node:
+If you increase the number of nodes to 20, then the pod distribution changes to 110 pods per node:
 
 ----
 2200 / 20 = 110
@@ -49,5 +39,5 @@ If you increase the number of nodes to 20, then the pod distribution changes to
 Where:
 
 ----
-Required pods per Cluster / Total Number of Nodes = Expected pods per Node
+required pods per cluster / total number of nodes = expected pods per node
 ----

--- a/modules/infrastructure-moving-monitoring.adoc
+++ b/modules/infrastructure-moving-monitoring.adoc
@@ -6,16 +6,11 @@
 = Moving the monitoring solution
 
 
-By default, the Prometheus Cluster Monitoring stack, which contains Prometheus,
-Grafana, and AlertManager, is deployed to
-provide cluster monitoring. It is managed by the Cluster Monitoring Operator.
-To move its components to different machines, you create and apply a custom
-ConfigMap.
+By default, the Prometheus Cluster Monitoring stack, which contains Prometheus, Grafana, and AlertManager, is deployed to provide cluster monitoring. It is managed by the Cluster Monitoring Operator. To move its components to different machines, you create and apply a custom config map.
 
 .Procedure
 
-. Save the following ConfigMap definition as the
-`cluster-monitoring-configmap.yaml` file:
+. Save the following `ConfigMap` definition as the `cluster-monitoring-configmap.yaml` file:
 +
 [source,yaml]
 ----
@@ -55,10 +50,9 @@ data:
         node-role.kubernetes.io/infra: ""
 ----
 +
-Running this ConfigMap forces the components of the monitoring stack to redeploy
-to infrastructure nodes.
+Running this config map forces the components of the monitoring stack to redeploy to infrastructure nodes.
 
-. Apply the new ConfigMap:
+. Apply the new config map:
 +
 ----
 $ oc create -f cluster-monitoring-configmap.yaml
@@ -70,8 +64,7 @@ $ oc create -f cluster-monitoring-configmap.yaml
 $ watch 'oc get pod -n openshift-monitoring -o wide'
 ----
 
-. If a component has not moved to the `infra` node, delete the pod with this
-component:
+. If a component has not moved to the `infra` node, delete the pod with this component:
 +
 ----
 $ oc delete pod -n openshift-monitoring <pod>

--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -9,7 +9,7 @@ You configure the registry Operator to deploy its pods to different nodes.
 
 .Prerequisites
 
-* Configure additional MachineSets in your {product-title} cluster.
+* Configure additional machine sets in your {product-title} cluster.
 
 .Procedure
 
@@ -65,10 +65,9 @@ $ oc edit config/cluster
     node-role.kubernetes.io/infra: ""
 ----
 
-. Verify the registry Pod has been moved to the infrastructure node.
+. Verify the registry pod has been moved to the infrastructure node.
 +
-.. Run the following command to identify the node where the registry Pod is
-located:
+.. Run the following command to identify the node where the registry pod is located:
 +
 ----
 $ oc get pods -o wide -n openshift-image-registry
@@ -80,5 +79,4 @@ $ oc get pods -o wide -n openshift-image-registry
 $ oc describe node <node_name>
 ----
 +
-Review the command output and confirm that `node-role.kubernetes.io/infra` is in
-the `LABELS` list.
+Review the command output and confirm that `node-role.kubernetes.io/infra` is in the `LABELS` list.

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -5,16 +5,15 @@
 [id="infrastructure-moving-router_{context}"]
 = Moving the router
 
-You can deploy the router Pod to a different MachineSet. By default, the Pod
-is deployed to a worker node.
+You can deploy the router pod to a different machine set. By default, the pod is deployed to a worker node.
 
 .Prerequisites
 
-* Configure additional MachineSets in your {product-title} cluster.
+* Configure additional machine sets in your {product-title} cluster.
 
 .Procedure
 
-. View the `IngressController` Custom Resource for the router Operator:
+. View the `IngressController` custom resource for the router Operator:
 +
 ----
 $ oc get ingresscontroller default -n openshift-ingress-operator -o yaml
@@ -49,15 +48,13 @@ status:
   selector: ingresscontroller.operator.openshift.io/deployment-ingresscontroller=default
 ----
 
-. Edit the `ingresscontroller` resource and change the `nodeSelector` to use the
-`infra` label:
+. Edit the `ingresscontroller` resource and change the `nodeSelector` to use the `infra` label:
 +
 ----
 $ oc edit ingresscontroller default -n openshift-ingress-operator
 ----
 +
-Add the `nodeSelector` stanza that references the `infra` label to the
-`spec` section, as shown:
+Add the `nodeSelector` stanza that references the `infra` label to the `spec` section, as shown:
 +
 [source,yaml]
 ----

--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -3,28 +3,17 @@
 // * machine_management/deploying-machine-health-checks.adoc
 
 [id="machine-health-checks-about_{context}"]
-= About MachineHealthChecks
+= About machine health checks
 
-MachineHealthChecks automatically repairs unhealthy Machines in a particular
-MachinePool.
+Machine health checks automatically repair unhealthy machines in a particular machine pool.
 
-To monitor machine health, you create a resource to define the
-configuration for a controller. You set a condition to check for, such as
-staying in the `NotReady` status for 15 minutes or displaying a permanent condition
-in the node-problem-detector, and a label for the set of machines to monitor.
+To monitor machine health, you create a resource to define the configuration for a controller. You set a condition to check for, such as staying in the `NotReady` status for 15 minutes or displaying a permanent condition in the node-problem-detector, and a label for the set of machines to monitor.
 
 [NOTE]
 ====
-You cannot apply a MachineHealthCheck to a machine with the master role.
+You cannot apply a machine health check to a machine with the master role.
 ====
 
-The controller that observes a MachineHealthCheck resource checks for the status
-that you defined. If a machine fails the health check, it is automatically deleted
-and a new one is created to take its place. When a machine is deleted, you
-see a `machine deleted` event. To limit disruptive impact of the machine
-deletion, the controller drains and deletes only one node at a time. If there
-are more unhealthy machines than the `maxUnhealthy` threshold allows for in the
-targeted pool of machines, remediation stops so that manual intervention can take
-place.
+The controller that observes a `MachineHealthCheck` resource checks for the status that you defined. If a machine fails the health check, it is automatically deleted and a new one is created to take its place. When a machine is deleted, you see a `machine deleted` event. To limit disruptive impact of the machine deletion, the controller drains and deletes only one node at a time. If there are more unhealthy machines than the `maxUnhealthy` threshold allows for in the targeted pool of machines, remediation stops so that manual intervention can take place.
 
 To stop the check, you remove the resource.

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -3,10 +3,9 @@
 // * machine_management/deploying-machine-health-checks.adoc
 
 [id="machine-health-checks-creating_{context}"]
-= Creating a MachineHealthCheck resource
+= Creating a `MachineHealthCheck` resource
 
-You can create a MachineHealthCheck resource for all MachinePools in your
-cluster except the `master` pool.
+You can create a `MachineHealthCheck` resource for all machine pools in your cluster except the `master` pool.
 
 .Prerequisites
 
@@ -14,8 +13,7 @@ cluster except the `master` pool.
 
 .Procedure
 
-. Create a `healthcheck.yml` file that contains the definition of your
-MachineHealthCheck.
+. Create a `healthcheck.yml` file that contains the definition of your machine health check.
 
 . Apply the `healthcheck.yml` file to your cluster:
 +

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -4,11 +4,11 @@
 
 
 [id="machine-health-checks-resource_{context}"]
-= Sample MachineHealthCheck resource
+= Sample `MachineHealthCheck` resource
 
-The MachineHealthCheck resource resembles the following YAML file:
+The `MachineHealthCheck` resource resembles the following YAML file:
 
-.MachineHealthCheck
+.`MachineHealthCheck`
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -31,16 +31,13 @@ spec:
     status: "Unknown"
   maxUnhealthy: "40%" <5>
 ----
-<1> Specify the name of the MachineHealthCheck to deploy.
+<1> Specify the name of the machine health check to deploy.
 <2> Specify a label for the machine pool that you want to check.
-<3> Specify the MachineSet to track in `<cluster_name>-<label>-<zone>`
-format. For example, `prod-node-us-east-1a`.
-<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the Machine will be remediated. Long timeouts can result in long periods of downtime for the workload on the unhealthy Machine.
-<5> Specify the amount of unhealthy machines allowed in the targeted pool of
-machines. This can be set as a percentage or an integer.
+<3> Specify the machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
+<4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for the workload on the unhealthy machine.
+<5> Specify the amount of unhealthy machines allowed in the targeted pool of machines. This can be set as a percentage or an integer.
 
 [NOTE]
 ====
-The `matchLabels` are examples only; you must map your machine groups based on
-your specific needs.
+The `matchLabels` are examples only; you must map your machine groups based on your specific needs.
 ====

--- a/modules/machineset-modifying.adoc
+++ b/modules/machineset-modifying.adoc
@@ -5,37 +5,31 @@
 // * scalability_and_performance/recommended-cluster-scaling-practices.adoc
 
 [id="machineset-modifying_{context}"]
-= Modifying a MachineSet
+= Modifying a machine set
 
-To make changes to a MachineSet, edit the MachineSet YAML. Then, remove all
-machines associated with the MachineSet by deleting each machine 'or scaling
-down the MachineSet to 0 replicas. Then, scale the replicas back to the desired
-number. Changes you make to a MachineSet do not affect existing machines.
+To make changes to a machine set, edit the `MachineSet` YAML. Then, remove all machines associated with the machine set by deleting each machine or scaling down the machine set to `0` replicas. Then, scale the replicas back to the desired number. Changes you make to a machine set do not affect existing machines.
 
-If you need to scale a MachineSet without making other changes, you do not need
-to delete the machines.
+If you need to scale a machine set without making other changes, you do not need to delete the machines.
 
 [NOTE]
 ====
-By default, the {product-title} router pods are deployed on workers. Because the router
-is required to access some cluster resources, including the web console,
-do not scale the worker MachineSet to `0` unless you first relocate the router pods.
+By default, the {product-title} router pods are deployed on workers. Because the router is required to access some cluster resources, including the web console, do not scale the worker machine set to `0` unless you first relocate the router pods.
 ====
 
 .Prerequisites
 
-* Install an {product-title} cluster and the oc command line.
-* Log in to  `oc` as a user with `cluster-admin` permission.
+* Install an {product-title} cluster and the `oc` command line.
+* Log in to `oc` as a user with `cluster-admin` permission.
 
 .Procedure
 
-. Edit the MachineSet:
+. Edit the machine set:
 +
 ----
 $ oc edit machineset <machineset> -n openshift-machine-api
 ----
 
-. Scale down the MachineSet to `0`:
+. Scale down the machine set to `0`:
 +
 ----
 $ oc scale --replicas=0 machineset <machineset> -n openshift-machine-api
@@ -47,8 +41,8 @@ $ oc edit machineset <machineset> -n openshift-machine-api
 ----
 +
 Wait for the machines to be removed.
-+
-. Scale up the MachineSet as needed:
+
+. Scale up the machine set as needed:
 +
 ----
 $ oc scale --replicas=2 machineset <machineset> -n openshift-machine-api
@@ -59,5 +53,4 @@ Or:
 $ oc edit machineset <machineset> -n openshift-machine-api
 ----
 +
-Wait for the machines to start. The new Machines contain changes you made
-to the Machineset.
+Wait for the machines to start. The new machines contain changes you made to the machine set.

--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -3,7 +3,7 @@
 // * scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
 
 [id="cluster-maximums-major-releases_{context}"]
-= {product-title} Tested cluster maximums for major releases
+= {product-title} tested cluster maximums for major releases
 
 Tested Cloud Platforms for {product-title} 3.x: {rh-openstack-first}, Amazon Web Services and Microsoft Azure.
 Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft Azure and Google Cloud Platform.
@@ -12,7 +12,7 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 |===
 | Maximum type |3.x tested maximum |4.x tested maximum
 
-| Number of Nodes
+| Number of nodes
 | 2,000
 | 2,000
 
@@ -28,11 +28,11 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 | There is no default value.
 | There is no default value.
 
-| Number of Namespaces ^[3]^
+| Number of namespaces ^[3]^
 | 10,000
 | 10,000
 
-| Number of Builds
+| Number of builds
 | 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
@@ -40,19 +40,19 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 | 25,000
 | 25,000
 
-| Number of Services ^[5]^
+| Number of services ^[5]^
 | 10,000
 | 10,000
 
-| Number of Services per Namespace
+| Number of services per namespace
 | 5,000
 | 5,000
 
-| Number of Back-ends per Service
+| Number of back-ends per service
 | 5,000
 | 5,000
 
-| Number of Deployments per Namespace ^[4]^
+| Number of deployments per namespace ^[4]^
 | 2,000
 | 2,000
 
@@ -60,8 +60,8 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 [.small]
 --
 1. The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.
-2. This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `maxPods` set to `500` using a custom KubeletConfig. If you need 500 user pods, you need a `hostPrefix` of `22` because there are 10-15 system pods already running on the node. The maximum number of pods with attached Persistent Volume Claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only OpenShift Container Storage v4 (OCS v4) was able to satisfy the number of pods per node discussed in this document.
+2. This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `maxPods` set to `500` using a custom kubelet config. If you need 500 user pods, you need a `hostPrefix` of `22` because there are 10-15 system pods already running on the node. The maximum number of pods with attached persistent volume claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only OpenShift Container Storage v4 (OCS v4) was able to satisfy the number of pods per node discussed in this document.
 3. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.
 4. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
-5. Each Service port and each Service back-end has a corresponding entry in iptables. The number of back-ends of a given Service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
+5. Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
 --

--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -5,8 +5,7 @@
 [id="recommended-configurable-storage-technology_{context}"]
 = Recommended configurable storage technology
 
-The following table summarizes the recommended and configurable storage
-technologies for the given {product-title} cluster application.
+The following table summarizes the recommended and configurable storage technologies for the given {product-title} cluster application.
 
 .Recommended and configurable storage technology
 [options="header,footer"]
@@ -41,41 +40,34 @@ technologies for the given {product-title} cluster application.
 | Not configurable^7^
 
 8+a|
-^1^ ReadOnlyMany
+^1^ `ReadOnlyMany`
 
-^2^ ReadWriteMany.
+^2^ `ReadWriteMany`
 
 ^3^ Prometheus is the underlying technology used for metrics.
 
 ^4^ This does not apply to physical disk, VM physical disk, VMDK, loopback over NFS, AWS EBS, and Azure Disk.
 
-^5^ For metrics, using file storage with the ReadWriteMany (RWX) access mode is unreliable. If you use file storage, do not configure the RWX access mode on any PersistentVolumeClaims that are configured for use with metrics.
+^5^ For metrics, using file storage with the `ReadWriteMany` (RWX) access mode is unreliable. If you use file storage, do not configure the RWX access mode on any persistent volume claims (PVCs) that are configured for use with metrics.
 
-^6^ For logging, using any shared
-storage would be an anti-pattern. One volume per elasticsearch is required.
+^6^ For logging, using any shared storage would be an anti-pattern. One volume per elasticsearch is required.
 
-^7^ Object storage is not consumed through {product-title}'s PVs/persistent volume claims (PVCs). Apps must integrate with the object storage REST API.
+^7^ Object storage is not consumed through {product-title}'s PVs or PVCs. Apps must integrate with the object storage REST API.
 
 |===
 
 [NOTE]
 ====
-A scaled registry is an {product-title} registry where two or more Pod replicas are running.
+A scaled registry is an {product-title} registry where two or more pod replicas are running.
 ====
 
 == Specific application storage recommendations
 
 [IMPORTANT]
 ====
-Testing shows issues with using the NFS server on RHEL as storage backend for
-core services. This includes the OpenShift Container Registry and Quay,
-Prometheus for monitoring storage, and Elasticsearch for logging storage.
-Therefore, using RHEL NFS to back PVs used by core services is not recommended.
+Testing shows issues with using the NFS server on {op-system-base-full} as storage backend for core services. This includes the OpenShift Container Registry and Quay, Prometheus for monitoring storage, and Elasticsearch for logging storage. Therefore, using {op-system-base} NFS to back PVs used by core services is not recommended.
 
-Other NFS implementations on the marketplace might not have these issues.
-Contact the individual NFS implementation vendor for more information on any
-testing that was possibly completed against these {product-title} core
-components.
+Other NFS implementations on the marketplace might not have these issues. Contact the individual NFS implementation vendor for more information on any testing that was possibly completed against these {product-title} core components.
 ====
 
 === Registry
@@ -85,23 +77,18 @@ In a non-scaled/high-availability (HA) {product-title} registry cluster deployme
 * The storage technology does not have to support RWX access mode.
 * The storage technology must ensure read-after-write consistency.
 * The preferred storage technology is object storage followed by block storage.
-* File storage is not recommended for {product-title} registry cluster deployment
-with production workloads.
+* File storage is not recommended for {product-title} registry cluster deployment with production workloads.
 
 === Scaled registry
 
 In a scaled/HA {product-title} registry cluster deployment:
 
-* The storage technology must support RWX access mode and must ensure
-read-after-write consistency.
+* The storage technology must support RWX access mode and must ensure read-after-write consistency.
 * The preferred storage technology is object storage.
-* Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft
-Azure Blob Storage, and OpenStack Swift are supported.
+* Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft Azure Blob Storage, and OpenStack Swift are supported.
 * Storage should be S3 or Swift compliant.
-* File storage is not recommended for a scaled/HA {product-title} registry cluster
-deployment with production workloads.
-* For non-cloud platforms, such as vSphere and bare metal installations, the only
-configurable technology is file storage.
+* File storage is not recommended for a scaled/HA {product-title} registry cluster deployment with production workloads.
+* For non-cloud platforms, such as vSphere and bare metal installations, the only configurable technology is file storage.
 * Block storage is not configurable.
 
 === Metrics
@@ -111,11 +98,9 @@ In an {product-title} hosted metrics cluster deployment:
 * The preferred storage technology is block storage.
 * Object storage is not configurable.
 
-
 [IMPORTANT]
 ====
-It is not recommended to use file storage for a hosted metrics cluster
-deployment with production workloads.
+It is not recommended to use file storage for a hosted metrics cluster deployment with production workloads.
 ====
 
 === Logging
@@ -123,38 +108,26 @@ deployment with production workloads.
 In an {product-title} hosted logging cluster deployment:
 
 * The preferred storage technology is block storage.
-* File storage is not recommended for a scaled/HA {product-title} registry cluster
-deployment with production workloads.
+* File storage is not recommended for a scaled/HA {product-title} registry cluster deployment with production workloads.
 * Object storage is not configurable.
 
 [IMPORTANT]
 ====
-Testing shows issues with using the NFS server on RHEL as storage backend for
-core services. This includes Elasticsearch for logging storage. Therefore, using
-RHEL NFS to back PVs used by core services is not recommended.
+Testing shows issues with using the NFS server on {op-system-base} as storage backend for core services. This includes Elasticsearch for logging storage. Therefore, using {op-system-base} NFS to back PVs used by core services is not recommended.
 
-Other NFS implementations on the marketplace might not have these issues.
-Contact the individual NFS implementation vendor for more information on any
-testing that was possibly completed against these {product-title} core
-components.
+Other NFS implementations on the marketplace might not have these issues. Contact the individual NFS implementation vendor for more information on any testing that was possibly completed against these {product-title} core components.
 ====
 
 === Applications
 
 Application use cases vary from application to application, as described in the following examples:
 
-* Storage technologies that support dynamic PV provisioning have low mount time latencies, and are not tied
-to nodes to support a healthy cluster.
-* Application developers are responsible for knowing and understanding the storage
-requirements for their application, and how it works with the provided storage
-to ensure that issues do not occur when an application scales or interacts
-with the storage layer.
+* Storage technologies that support dynamic PV provisioning have low mount time latencies, and are not tied to nodes to support a healthy cluster.
+* Application developers are responsible for knowing and understanding the storage requirements for their application, and how it works with the provided storage to ensure that issues do not occur when an application scales or interacts with the storage layer.
 
 == Other specific application storage recommendations
 
 * {product-title} Internal `etcd`: For the best `etcd` reliability, the lowest consistent latency storage technology is preferable.
-* It is highly recommended that you use `etcd` with storage that handles serial
-writes (fsync) quickly, such as NVMe or SSD. Ceph, NFS, and spinning disks are
-not recommended.
+* It is highly recommended that you use `etcd` with storage that handles serial writes (fsync) quickly, such as NVMe or SSD. Ceph, NFS, and spinning disks are not recommended.
 * {rh-openstack-first} Cinder: {rh-openstack} Cinder tends to be adept in ROX access mode use cases.
 * Databases: Databases (RDBMSs, NoSQL DBs, etc.) tend to perform best with dedicated block storage.

--- a/modules/recommended-scale-practices.adoc
+++ b/modules/recommended-scale-practices.adoc
@@ -9,23 +9,13 @@ When scaling up the cluster to higher node counts:
 
 * Spread nodes across all of the available zones for higher availability.
 * Scale up by no more than 25 to 50 machines at once.
-* Consider creating new MachineSets in each available zone with alternative
-instance types of similar size to help mitigate any periodic provider capacity
-constraints. For example, on AWS, use m5.large and m5d.large.
+* Consider creating new machine sets in each available zone with alternative instance types of similar size to help mitigate any periodic provider capacity constraints. For example, on AWS, use m5.large and m5d.large.
 
 [NOTE]
 ====
-Cloud providers might implement a quota for API services. Therefore, gradually
-scale the cluster.
+Cloud providers might implement a quota for API services. Therefore, gradually scale the cluster.
 ====
 
-The controller might not be able to create the machines if the replicas in the
-MachineSets are set to higher numbers all at one time. The number of requests
-the cloud platform, which {product-title} is deployed on top of, is able to
-handle impacts the process. The controller will start to query more while trying
-to create, check, and update the machines with the status. The cloud platform on
-which {product-title} is deployed has API request limits and excessive queries
-might lead to machine creation failures due to cloud platform limitations.
+The controller might not be able to create the machines if the replicas in the machine sets are set to higher numbers all at one time. The number of requests the cloud platform, which {product-title} is deployed on top of, is able to handle impacts the process. The controller will start to query more while trying to create, check, and update the machines with the status. The cloud platform on which {product-title} is deployed has API request limits and excessive queries might lead to machine creation failures due to cloud platform limitations.
 
-Enable machine health checks when scaling to large node counts. In case of failures, 
-the health checks monitor the condition and automatically repair unhealthy machines.
+Enable machine health checks when scaling to large node counts. In case of failures, the health checks monitor the condition and automatically repair unhealthy machines.

--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -13,27 +13,23 @@
 # oc label node perf-node.example.com cpumanager=true
 ----
 
-. Edit the `MachineConfigPool` of the nodes where CPU Manager should be enabled.
-In this example, all workers have CPU Manager enabled:
+. Edit the `MachineConfigPool` of the nodes where CPU Manager should be enabled. In this example, all workers have CPU Manager enabled:
 +
 ----
 # oc edit machineconfigpool worker
 ----
 
-. Add a label to the worker `MachineConfigPool`:
+. Add a label to the worker machine config pool:
 +
 ----
 metadata:
-  creationTimestamp: 2019-xx-xxx
+  creationTimestamp: 2020-xx-xxx
   generation: 3
   labels:
     custom-kubelet: cpumanager-enabled
 ----
 
-. Create a `KubeletConfig`, `cpumanager-kubeletconfig.yaml`, custom resource (CR).
-Refer to the label created in the previous step to have the correct nodes
-updated with the new `KubeletConfig`. See the `machineConfigPoolSelector`
-section:
+. Create a `KubeletConfig`, `cpumanager-kubeletconfig.yaml`, custom resource (CR). Refer to the label created in the previous step to have the correct nodes updated with the new kubelet config. See the `machineConfigPoolSelector` section:
 +
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -49,17 +45,15 @@ spec:
      cpuManagerReconcilePeriod: 5s
 ----
 
-. Create the dynamic `KubeletConfig`:
+. Create the dynamic kubelet config:
 +
 ----
 # oc create -f cpumanager-kubeletconfig.yaml
 ----
 +
-This adds the CPU Manager feature to the `KubeletConfig` and, if needed, the
-Machine Config Operator (MCO) reboots the node. To enable CPU Manager, a reboot
-is not needed.
+This adds the CPU Manager feature to the kubelet config and, if needed, the Machine Config Operator (MCO) reboots the node. To enable CPU Manager, a reboot is not needed.
 
-. Check for the merged `KubeletConfig`:
+. Check for the merged kubelet config:
 +
 ----
 # oc get machineconfig 99-worker-XXXXXX-XXXXX-XXXX-XXXXX-kubelet -o json | grep ownerReference -A7
@@ -84,9 +78,7 @@ cpuManagerReconcilePeriod: 5s   <1>
 ----
 <1> These settings were defined when you created the `KubeletConfig` CR.
 
-. Create a Pod that requests a core or multiple cores. Both limits and requests
-must have their CPU value set to a whole integer. That is the number of cores
-that will be dedicated to this Pod:
+. Create a pod that requests a core or multiple cores. Both limits and requests must have their CPU value set to a whole integer. That is the number of cores that will be dedicated to this pod:
 +
 ----
 # cat cpumanager-pod.yaml
@@ -109,13 +101,13 @@ spec:
     cpumanager: "true"
 ----
 
-. Create the Pod:
+. Create the pod:
 +
 ----
 # oc create -f cpumanager-pod.yaml
 ----
 
-. Verify that the Pod is scheduled to the node that you labeled:
+. Verify that the pod is scheduled to the node that you labeled:
 +
 ----
 # oc describe pod cpumanager
@@ -136,8 +128,7 @@ QoS Class:       Guaranteed
 Node-Selectors:  cpumanager=true
 ----
 
-. Verify that the `cgroups` are set up correctly. Get the process ID (PID) of the
-`pause` process:
+. Verify that the `cgroups` are set up correctly. Get the process ID (PID) of the `pause` process:
 +
 ----
 # ├─init.scope
@@ -148,9 +139,7 @@ Node-Selectors:  cpumanager=true
   │ └─32706 /pause
 ----
 +
-Pods of quality of service (QoS) tier `Guaranteed` are placed within the
-`kubepods.slice`. Pods of other QoS tiers end up in child `cgroups` of
-`kubepods`:
+Pods of quality of service (QoS) tier `Guaranteed` are placed within the `kubepods.slice`. Pods of other QoS tiers end up in child `cgroups` of `kubepods`:
 +
 ----
 # cd /sys/fs/cgroup/cpuset/kubepods.slice/kubepods-pod69c01f8e_6b74_11e9_ac0f_0a2b62178a22.slice/crio-b5437308f1ad1a7db0574c542bdf08563b865c0345c86e9585f8c0b0a655612c.scope
@@ -166,8 +155,7 @@ tasks 32706
  Cpus_allowed_list:    1
 ----
 
-. Verify that another pod (in this case, the pod in the `burstable` QoS tier) on
-the system cannot run on the core allocated for the `Guaranteed` pod:
+. Verify that another pod (in this case, the pod in the `burstable` QoS tier) on the system cannot run on the core allocated for the `Guaranteed` pod:
 +
 ----
 # cat /sys/fs/cgroup/cpuset/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-podc494a073_6b77_11e9_98c0_06bba5c387ea.slice/crio-c56982f57b75a2420947f0afc6cafe7534c5734efc34157525fa9abbf99e3849.scope/cpuset.cpus
@@ -204,12 +192,7 @@ Allocated resources:
   cpu                         1440m (96%)       1 (66%)
 ----
 +
-This VM has two CPU cores. You set `kube-reserved` to 500 millicores, meaning half
-of one core is subtracted from the total capacity of the node to arrive at the
-`Node Allocatable` amount. You can see that `Allocatable CPU` is 1500 millicores.
-This means you can run one of the CPU Manager pods since each will take one whole
-core. A whole core is equivalent to 1000 millicores. If you try to schedule a
-second pod, the system will accept the pod, but it will never be scheduled:
+This VM has two CPU cores. You set `kube-reserved` to 500 millicores, meaning half of one core is subtracted from the total capacity of the node to arrive at the `Node Allocatable` amount. You can see that `Allocatable CPU` is 1500 millicores. This means you can run one of the CPU Manager pods since each will take one whole core. A whole core is equivalent to 1000 millicores. If you try to schedule a second pod, the system will accept the pod, but it will never be scheduled:
 +
 ----
 NAME                    READY   STATUS    RESTARTS   AGE

--- a/modules/topology-manager-policies.adoc
+++ b/modules/topology-manager-policies.adoc
@@ -30,29 +30,17 @@ This is the default policy and does not perform any topology alignment.
 [id="topology-manager-best-effort-policy_{context}"]
 == best-effort policy
 
-For each container in a Guaranteed Pod with the best-effort topology
-management policy, kublet calls each Hint Provider to discover their resource
-availability. Using this information, the Topology Manager stores the
-preferred NUMA Node affinity for that container. If the affinity is not
-preferred, Topology Manager will store this and admit the pod to the node anyway.
+For each container in a pod with the `best-effort` topology management policy, kubelet calls each Hint Provider to discover their resource
+availability. Using this information, the Topology Manager stores the preferred NUMA Node affinity for that container. If the affinity is not preferred, Topology Manager stores this and admits the pod to the node.
 
 [id="topology-manager-restricted-policy_{context}"]
 == restricted policy
 
-For each container in a Guaranteed Pod with the restricted topology
-management policy, kublet calls each Hint Provider to discover their resource
-availability. Using this information, the Topology Manager stores the
-preferred NUMA Node affinity for that container. If the affinity is not
-preferred, Topology Manager will reject this pod from the node. This will
-result in a pod in a Terminated state with a pod admission failure.
+For each container in a pod with the `restricted` topology management policy, kubelet calls each Hint Provider to discover their resource
+availability. Using this information, the Topology Manager stores the preferred NUMA Node affinity for that container. If the affinity is not
+preferred, Topology Manager rejects this pod from the node, resulting in a pod in a `Terminated` state with a pod admission failure.
 
 [id="topology-manager-single-numa-node_{context}"]
 == single-numa-node
 
-For each container in a Guaranteed Pod with the single-numa-node topology
-management policy, kublet calls each Hint Provider to discover their resource availability.
-Using this information, the Topology Manager determines if a single NUMA Node
-affinity is possible. If it is, the pod will be admitted to the node.
-If this is not possible then the Topology Manager will reject the pod
-from the node. This will result in a pod in a Terminated state with a pod admission
-failure.
+For each container in a pod with the `single-numa-node` topology management policy, kubelet calls each Hint Provider to discover their resource availability. Using this information, the Topology Manager determines if a single NUMA Node affinity is possible. If it is, the pod is admitted to the node. If a single NUMA Node affinity is not possible, the Topology Manager rejects the pod from the node. This results in a pod in a Terminated state with a pod admission failure.

--- a/modules/what-huge-pages-do.adoc
+++ b/modules/what-huge-pages-do.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc

--- a/scalability_and_performance/recommended-cluster-scaling-practices.adoc
+++ b/scalability_and_performance/recommended-cluster-scaling-practices.adoc
@@ -8,13 +8,10 @@ toc::[]
 
 [IMPORTANT]
 ====
-The guidance in this section is only relevant for installations with cloud
-provider integration.
+The guidance in this section is only relevant for installations with cloud provider integration.
 ====
 
-Apply the following best practices to scale the number of worker machines in
-your {product-title} cluster. You scale the worker machines by increasing or
-decreasing the number of replicas that are defined in the worker MachineSet.
+Apply the following best practices to scale the number of worker machines in your {product-title} cluster. You scale the worker machines by increasing or decreasing the number of replicas that are defined in the worker machine set.
 
 include::modules/recommended-scale-practices.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/using-cluster-loader.adoc
+++ b/scalability_and_performance/using-cluster-loader.adoc
@@ -5,10 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Cluster Loader is a tool that deploys large numbers of various objects to a
-cluster, which creates user-defined cluster objects. Build, configure, and run
-Cluster Loader to measure performance metrics of your {product-title} deployment
-at various cluster states.
+Cluster Loader is a tool that deploys large numbers of various objects to a cluster, which creates user-defined cluster objects. Build, configure, and run Cluster Loader to measure performance metrics of your {product-title} deployment at various cluster states.
 
 include::modules/installing-cluster-loader.adoc[leveloffset=+1]
 
@@ -19,12 +16,9 @@ include::modules/configuring-cluster-loader.adoc[leveloffset=+1]
 
 == Known issues
 
-* Cluster Loader fails when called without configuration.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1761925[*BZ#1761925*])
+* Cluster Loader fails when called without configuration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1761925[*BZ#1761925*])
 
-* If the `IDENTIFIER` parameter is not defined in user templates, template
-creation fails with `error: unknown parameter name "IDENTIFIER"`. If you deploy
-templates, add this parameter to your template to avoid this error:
+* If the `IDENTIFIER` parameter is not defined in user templates, template creation fails with `error: unknown parameter name "IDENTIFIER"`. If you deploy templates, add this parameter to your template to avoid this error:
 +
 ----
 {
@@ -34,4 +28,4 @@ templates, add this parameter to your template to avoid this error:
 }
 ----
 +
-If you deploy Pods, adding the parameter is unnecessary.
+If you deploy pods, adding the parameter is unnecessary.


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/27342
Conflicts:
	modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
	modules/cnf-allocating-multiple-huge-page-sizes.adoc
	modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
	modules/cnf-configuring-huge-pages.adoc
	modules/cnf-debugging-low-latency-cnf-tuning-status.adoc
	modules/cnf-installing-the-performance-addon-operator.adoc
	modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
	modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
	modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
	modules/configuring-huge-pages.adoc
	modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
	modules/custom-tuning-specification.adoc
	modules/infrastructure-node-sizing.adoc
	modules/machineset-modifying.adoc
	modules/setting-up-cpu-manager.adoc
	modules/topology-manager-policies.adoc
	modules/what-huge-pages-do.adoc