### PR TITLE
[enterprise-4.4]Style updates to the Support section

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -17,6 +17,6 @@ The `oc adm must-gather` CLI command collects the information from your cluster 
 
 You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product.
 
-When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that Pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
+When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
 
 // todo: table or ref module listing available images?

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -13,10 +13,7 @@ endif::[]
 [id="gathering-data-specific-features_{context}"]
 = Gathering data about specific features
 
-You can gather debugging information about specific features by using the
-`oc adm must-gather` CLI command with the `--image` or `--image-stream` argument.
-The `must-gather` tool supports multiple images, so you can gather data about
-more than one feature by running a single command.
+You can gather debugging information about specific features by using the `oc adm must-gather` CLI command with the `--image` or `--image-stream` argument. The `must-gather` tool supports multiple images, so you can gather data about more than one feature by running a single command.
 
 ifdef::from-main-support-section[]
 
@@ -77,7 +74,7 @@ endif::from-main-support-section[]
 
 [NOTE]
 ====
-To collect the default must-gather data in addition to specific feature data, add the `--image-stream=openshift/must-gather` argument.
+To collect the default `must-gather` data in addition to specific feature data, add the `--image-stream=openshift/must-gather` argument.
 ====
 
 .Prerequisites
@@ -91,38 +88,33 @@ To collect the default must-gather data in addition to specific feature data, ad
 
 ifndef::openshift-origin[]
 
-. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream`
-arguments. For example, the following command gathers both the default cluster
-data and information specific to {CNVProductName}:
+. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to {VirtProductName}:
 +
 ----
 $ oc adm must-gather \
  --image-stream=openshift/must-gather \ <1>
  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8 <2>
 ----
-<1> The default {product-title} must-gather image
-<2> The must-gather image for {CNVProductName}
+<1> The default {product-title} `must-gather` image
+<2> The must-gather image for {VirtProductName}
 
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
 
-. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream`
-arguments. For example, the following command gathers both the default cluster
-data and information specific to KubeVirt:
+. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to KubeVirt:
 +
 ----
 $ oc adm must-gather \
  --image-stream=openshift/must-gather \ <1>
  --image=quay.io/kubevirt/must-gather <2>
 ----
-<1> The default {product-title} must-gather image
+<1> The default {product-title} `must-gather` image
 <2> The must-gather image for KubeVirt
 
 endif::openshift-origin[]
 
-. Create a compressed file from the `must-gather` directory that was just created
-in your working directory. For example, on a computer that uses a Linux
+. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux
 operating system, run the following command:
 +
 ----
@@ -131,8 +123,7 @@ $ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
 <1> Make sure to replace `must-gather-local.5421342344627712289/` with the
 actual directory name.
 
-. Attach the compressed file to your support case on the
-link:https://access.redhat.com[Red Hat Customer Portal].
+. Attach the compressed file to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
 
 ifeval::["{context}" == "gathering-cluster-data"]
 :!from-main-support-section:

--- a/modules/insights-operator-showing-data-collected-from-the-cluster.adoc
+++ b/modules/insights-operator-showing-data-collected-from-the-cluster.adoc
@@ -13,7 +13,7 @@ You can review the data that is collected by the Insights Operator.
 
 .Procedure
 
-. Find the name of the currently running Pod for the Insights Operator:
+. Find the name of the currently running pod for the Insights Operator:
 +
 ----
 $ INSIGHTS_OPERATOR_POD=$(oc get pods --namespace=openshift-insights -o custom-columns=:metadata.name --no-headers  --field-selector=status.phase=Running)

--- a/modules/support-gather-data.adoc
+++ b/modules/support-gather-data.adoc
@@ -5,8 +5,7 @@
 [id="support_gathering_data_{context}"]
 = Gathering data about your cluster for Red Hat Support
 
-You can gather debugging information about your cluster by using the
-`oc adm must-gather` CLI command.
+You can gather debugging information about your cluster by using the `oc adm must-gather` CLI command.
 
 .Prerequisites
 
@@ -25,7 +24,7 @@ $ oc adm must-gather
 +
 [NOTE]
 ====
-If this command fails, for example if you cannot schedule a Pod on your cluster, then use the `oc adm inspect` command to gather information for particular resources. Contact Red Hat Support for the recommended resources to gather.
+If this command fails, for example if you cannot schedule a pod on your cluster, then use the `oc adm inspect` command to gather information for particular resources. Contact Red Hat Support for the recommended resources to gather.
 ====
 +
 [NOTE]
@@ -37,15 +36,13 @@ $ oc import-image is/must-gather -n openshift
 ----
 ====
 
-. Create a compressed file from the `must-gather` directory that was just created
-in your working directory. For example, on a computer that uses a Linux
+. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux
 operating system, run the following command:
 +
 ----
 $ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
 ----
-<1> Make sure to replace `must-gather-local.5421342344627712289/` with the
-actual directory name.
+<1> Make sure to replace `must-gather-local.5421342344627712289/` with the actual directory name.
 
 . Attach the compressed file to your support case on the
 link:https://access.redhat.com[Red Hat Customer Portal].


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/27369
Conflicts:
	_topic_map.yml
	modules/copying-files-pods-and-containers.adoc
	modules/gathering-data-specific-features.adoc
	modules/investigating-master-node-installation-issues.adoc
	modules/investigating-worker-node-installation-issues.adoc
	modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
	modules/querying-operator-status-after-installation.adoc
	modules/storage-multi-attach-error.adoc
	modules/support-collecting-network-trace.adoc
	modules/support-gather-data.adoc
	modules/support-generating-a-sosreport-archive.adoc
	modules/support-providing-diagnostic-data-to-red-hat.adoc
	modules/troubleshooting-disabling-autoreboot-mco.adoc
	modules/understanding-pod-error-states.adoc
	modules/upi-installation-considerations.adoc
	support/troubleshooting/investigating-monitoring-issues.adoc
	support/troubleshooting/investigating-pod-issues.adoc
	support/troubleshooting/troubleshooting-operator-issues.adoc