### PR TITLE
BZ-1886892: Adding note to set 'GODEBUG=x509ignoreCN=0'

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -21,6 +21,13 @@ ifdef::openshift-origin[]
 * You have created a pull secret for your mirror repository.
 endif::[]
 
+* If you use self-signed certificates that do not set a Subject Alternative Name, you must precede the `oc` commands in this procedure with `GODEBUG=x509ignoreCN=0`. If you do not set this variable, the `oc` commands will fail with the following error:
++
+[source,terminal]
+----
+x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
+----
+
 .Procedure
 
 Complete the following steps on the mirror host:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1886892

Preview: https://bz-1886892-update--ocpdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations.html#installation-mirror-repository_installing-restricted-networks-preparations