### PR TITLE
OSSMDOC-166 removed duplicate publication of upstream/downstream diff…

### DIFF
--- a/service_mesh/v1x/ossm-architecture.adoc
+++ b/service_mesh/v1x/ossm-architecture.adoc
@@ -10,8 +10,6 @@ include::modules/ossm-understanding-service-mesh.adoc[leveloffset=+1]
 
 include::modules/ossm-architecture-1x.adoc[leveloffset=+1]
 
-include::modules/ossm-vs-istio-1x.adoc[leveloffset=+1]
-
 = Understanding Kiali
 
 Kiali provides visibility into your service mesh by showing you the microservices in your service mesh, and how they are connected.

--- a/service_mesh/v2x/ossm-architecture.adoc
+++ b/service_mesh/v2x/ossm-architecture.adoc
@@ -10,8 +10,6 @@ include::modules/ossm-understanding-service-mesh.adoc[leveloffset=+1]
 
 include::modules/ossm-architecture.adoc[leveloffset=+1]
 
-include::modules/ossm-vs-istio.adoc[leveloffset=+1]
-
 == Understanding Kiali
 
 Kiali provides visibility into your service mesh by showing you the microservices in your service mesh, and how they are connected.


### PR DESCRIPTION
…erences.

When we reorganized the docs for branching, somehow we ended up publishing the upstream vs product topic twice.  This PR fixes that in both the v1x and v2x docs.