### PR TITLE
Updating glossary link in API object reference guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -963,7 +963,7 @@ You must have at least one secret, config map, or service account.
 The total number of persistent volume claims in a project.
 ....
 
-Note that if an object uses an acronym or other special capitalization, then its general reference should honor that. For example, general references to `APIService` should be written as "API service", not "api service". Any other exceptions or special guidance are noted in the xref:../../contributing_to_docs/term_glossary.adoc[glossary].
+Note that if an object uses an acronym or other special capitalization, then its general reference should honor that. For example, general references to `APIService` should be written as "API service", not "api service". Any other exceptions or special guidance are noted in the xref:../contributing_to_docs/term_glossary.adoc[glossary].
 
 [id="api-object-object-references"]
 === Object references


### PR DESCRIPTION
I think this relates to master only.

This PR updates the glossary link in the API object formatting guidelines. At present the link seems broken for me:

  https://github.com/openshift/openshift-docs/blob/contributing_to_docs/term_glossary.adoc

I think the link should go to:

  https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/term_glossary.adoc

I couldn't work out how to test the updated link in my PR, because contributing_to_docs/doc_guidelines.html does not build in my local `asciibinder build` since it is not in the topic_map.adoc file. Please can you advise as to how I can test this?