### PR TITLE
[enterprise-4.4] update instructions for using PXE to install RHCOS

### DIFF
--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -40,12 +40,10 @@ endif::only-pxe[]
 
 * Obtain the Ignition config files for your cluster.
 ifndef::only-pxe[]
-* Configure suitable PXE or iPXE infrastructure.
+* Familiarity configuring the necessary DHCP, TFTP, and HTTP services for providing PXE or iPXE infrastructure.
 endif::only-pxe[]
-ifdef::only-pxe[]
-* Configure suitable PXE infrastructure.
-endif::only-pxe[]
-* Have access to an HTTP server that you can access from your computer.
+* Have access to an HTTP server and TFTP server that you can access from your computer.
+
 
 .Procedure
 
@@ -58,6 +56,7 @@ If you plan to add more compute machines to your cluster after you finish
 installation, do not delete these files.
 ====
 
+ifndef::openshift-origin[]
 . Obtain the compressed metal RAW image, `kernel`
 and `initramfs` files from the
 link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
@@ -86,12 +85,21 @@ Only use RAW images for this procedure.
 The file names contain the {product-title} version number.
 They resemble the following examples:
 
-** Compressed metal RAW image: `rhcos-<version>metal.<architecture>.raw.gz`
-** `kernel`: `rhcos-<version>-installer-kernel-<architecture>`
-** `initramfs`: `rhcos-<version>-installer-initramfs.<architecture>.img`
+** Compressed metal RAW image: `rhcos-<version>-<architecture>-metal.<architecture>.raw.gz`
+** `kernel`: `rhcos-<version>-<architecture>-installer-kernel-<architecture>`
+** `initramfs`: `rhcos-<version>-<architecture>-installer-initramfs.<architecture>.img`
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+. Obtain the {op-system} images from the
+link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
+endif::openshift-origin[]
 
-. Upload the compressed metal RAW image and the `kernel` and `initramfs` files
-to your HTTP server.
+. Upload the RAW image to your HTTP server.
+
+. Upload the additional files that are required for your booting method:
+* For traditional PXE, upload the `kernel` and `initramfs` files to your TFTP server.
+* For iPXE, upload the `kernel` and `initramfs` files to your HTTP server.
+
 +
 [IMPORTANT]
 ====
@@ -119,38 +127,73 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL http://<HTTP_server>/rhcos-<version>-installer-kernel-<architecture> <1>
-    APPEND ip=dhcp rd.neednet=1 initrd=http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-metal.<architecture>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <2> <3>
+    KERNEL rhcos-<version>-<architecture>-installer-kernel-<architecture> <1>
+    APPEND ip=dhcp rd.neednet=1 initrd=rhcos-<version>-<architecture>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal.<architecture>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <2> <3>
 ----
-<1> Specify the location of the `kernel` file that you uploaded to your HTTP
-server.
+<1> Specify the location of the `kernel` file available on your TFTP server.
 <2> If you use multiple NICs, specify a single interface in the `ip` option.
 For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 <3> Specify locations of the {op-system} files that you uploaded to your
-HTTP server. The `initrd` parameter value is the location of the `initramfs` file,
-the `coreos.inst.image_url` parameter value is the location of the compressed
-metal RAW image, and the `coreos.inst.ignition_url` parameter value is the
-location of the bootstrap Ignition config file.
+HTTP or TFTP server. The `initrd` parameter value is the location of the `initramfs`
+file on your TFTP server. The `coreos.inst.image_url` parameter value is the
+location of the compressed metal RAW image on your HTTP server, and the
+`coreos.inst.ignition_url` parameter value is the location of the bootstrap
+Ignition config file on your HTTP server.
 
 ifndef::only-pxe[]
 ** For iPXE:
 +
 ----
-kernel  http://<HTTP_server>/rhcos-<version>-installer-kernel-<architecture> ip=dhcp rd.neednet=1 initrd=http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-metal.<arhcitectutre>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
-initrd http://<HTTP_server>/rhcos-<version>-installer-initramfs.<architecture>.img <3>
+kernel  http://<HTTP_server>/rhcos-<version>-<architecture>-installer-kernel-<architecture> ip=dhcp rd.neednet=1 initrd=rhcos-<version>-<architecture>-installer-initramfs.<architecture>.img console=tty0 console=ttyS0 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal.<architecture>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
+initrd http://<HTTP_server>/rhcos-<version>-<architecture>-installer-initramfs.<architecture>.img <3>
 boot
 ----
 <1> Specify locations of the {op-system} files that you uploaded to your
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
-the `initrd` parameter value is the location of the `initramfs` file,
-the `coreos.inst.image_url` parameter value is the location of the compressed
-metal RAW image, and the `coreos.inst.ignition_url` parameter value is the
-location of the bootstrap Ignition config file.
+the `initrd` parameter value references the name of the `initramfs` file that is
+supplied on the following `initrd` line, the `coreos.inst.image_url` parameter value
+is the location of the compressed metal RAW image, and the `coreos.inst.ignition_url`
+parameter value is the location of the bootstrap Ignition config file.
 <2> If you use multiple NICs, specify a single interface in the `ip` option.
 For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 <3> Specify the location of the `initramfs` file that you uploaded to your HTTP
 server.
 endif::only-pxe[]
+
+. If you use UEFI, perform the following actions:
+.. Provide the EFI binaries and `grub.cfg` file that are required for booting the system. You need the `shim.efi` binary and the `grubx64.efi` binary.
+
+** Extract the necessary EFI binaries by mounting the {op-system} ISO on
+your host and then mounting the `images/efiboot.img` file to your host.
+From the `efiboot.img` mount point, you then copy the `EFI/redhat/shimx64.efi` and
+`EFI/redhat/grubx64.efi` files to your TFTP server.
++
+----
+# mkdir -p /mnt/{iso,efiboot}
+# mount -o loop rhcos-installer.x86_64.iso /mnt/iso
+# mount -o loop,ro /mnt/iso/images/efiboot.img /mnt/efiboot
+# cp /mnt/efiboot/EFI/redhat/{shimx64.efi,grubx64.efi} .
+# umount /mnt/{efiboot,iso}
+----
+
+.. Copy the `EFI/redhat/grub.cfg` file that is included in the {op-system} ISO to your TFTP server.
+
+.. Edit the `grub.cfg` file to include the following arguments:
++
+----
+menuentry 'Install Red Hat Enterprise Linux CoreOS' --class fedora --class gnu-linux --class gnu --class os {
+	linux rhcos-<version>-<architecture>-installer-kernel-<architecture> nomodeset rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=sda coreos.inst.image_url=http://<HTTP_server>/rhcos-<version>-<architecture>-metal.<architecture>.raw.gz coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1>
+	initrd rhcos-<version>-<architecture>-installer-initramfs.<architecture>.img <2>
+}
+----
+<1> The first argument to the `linux` line item is the location of the `kernel`
+file that you uploaded to your TFTP server. For the `coreos.inst.image_url` parameter
+value, specify the location of the compressed metal RAW image that you uploaded
+to your HTTP server. For the `coreos.inst.ignition_url` paramter, specify the location of the
+bootstrap Ignition config file that you uploaded to your HTTP server.
+<2> Specify the location of the `initramfs` file that you uploaded to your TFTP
+server.
+
 
 . Continue to create the machines for your cluster.
 +


### PR DESCRIPTION
In BZ#1853443 it was noted that the docs were missing a step for
configuring `grub.cfg` when using UEFI hosts. This change effectively
brings back that section (removed in
d5a3e2bd824c712f88ad95da2528512f43bc6abf) and provides updates for
correctly configuring PXE and iPXE use cases.

Additionally, a number of the artifact names were updates to match the
format that can be found on mirror.openshift.com and access.redhat.com

From https://github.com/openshift/openshift-docs/pull/27120