### PR TITLE
Separate MachineSet sections into two modules

### DIFF
--- a/machine_management/manually-scaling-machineset.adoc
+++ b/machine_management/manually-scaling-machineset.adoc
@@ -20,3 +20,5 @@ see xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Mo
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machineset-manually-scaling.adoc[leveloffset=+1]
+
+include::modules/machineset-delete-policy.adoc[leveloffset=+1]

--- a/modules/machineset-delete-policy.adoc
+++ b/modules/machineset-delete-policy.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * machine_management/manually-scaling-machineset.adoc
+// * post_installation_configuration/cluster-tasks.adoc
+
+[id="machineset-delete-policy_{context}"]
+= The MachineSet deletion policy
+
+`Random`, `Newest`, and `Oldest` are the three supported deletion options. The default is `Random`, meaning that random machines are chosen and deleted when scaling MachineSets down. The deletion policy can be set according to the use case by modifying the particular MachineSet:
+
+[source,yaml]
+----
+spec:
+  deletePolicy: <delete_policy>
+  replicas: <desired_replica_count>
+----
+
+Specific machines can also be prioritized for deletion by adding the annotation `machine.openshift.io/cluster-api-delete-machine` to the machine of interest, regardless of the deletion policy.
+
+[IMPORTANT]
+====
+By default, the {product-title} router pods are deployed on workers. Because the router is required to access some cluster resources, including the web console, do not scale the worker MachineSet to `0` unless you first relocate the router pods.
+====
+
+[NOTE]
+====
+Custom MachineSets can be used for use cases requiring that services run on specific nodes and that those services are ignored by the controller when the worker MachineSets are scaling down. This prevents service disruption.
+====

--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -45,26 +45,3 @@ $ oc edit machineset <machineset> -n openshift-machine-api
 +
 You can scale the MachineSet up or down. It takes several minutes for the new
 machines to be available.
-
-= The MachineSet delete policy
-
-`Random`, `Newest`, and `Oldest` are the three supported options. The default is `Random`, meaning  that random machines are chosen and deleted when scaling MachineSets down. The delete policy can be set according to the use case by modifying the particular MachineSet:
-
-[source,yaml]
-----
-spec:
-  deletePolicy: <delete policy>
-  replicas: <desired replica count>
-----
-
-Specific machines can also be prioritized for deletion by adding the annotation `machine.openshift.io/cluster-api-delete-machine` to the machine of interest, regardless of the delete policy.
-
-[IMPORTANT]
-====
-By default, the {product-title} router pods are deployed on workers. Because the router is required to access some cluster resources, including the web console, do not scale the worker MachineSet to `0` unless you first relocate the router pods.
-====
-
-[NOTE]
-====
-Custom MachineSets can be used for use cases requiring that services run on specific nodes and that those services are ignored by the controller when the worker MachineSets are scaling down. This prevents service disruption.
-====

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -17,6 +17,8 @@ include::modules/differences-between-machinesets-and-machineconfigpool.adoc[leve
 
 include::modules/machineset-manually-scaling.adoc[leveloffset=+2]
 
+include::modules/machineset-delete-policy.adoc[leveloffset=+2]
+
 [id="post-install-creating-infrastructure-machinesets"]
 == Creating infrastructure MachineSets
 


### PR DESCRIPTION
This breaks up two independent sections that were originally included in one module. No text editing was done here, just restructuring.