### PR TITLE
OSDOCS-1607 update the 'Default monitoring components' table to add monitoring components versions

### DIFF
--- a/modules/monitoring-default-monitoring-components.adoc
+++ b/modules/monitoring-default-monitoring-components.adoc
@@ -11,40 +11,51 @@ By default, the {product-title} {product-version} monitoring stack includes thes
 [options="header"]
 |===
 
-|Component|Description
+|Component|Description|Version
 
 |Cluster Monitoring Operator
 |The Cluster Monitoring Operator (CMO) is a central component of the monitoring stack. It deploys and manages Prometheus instances, the Thanos Querier, the Telemeter Client, and metrics targets and ensures that they are up to date. The CMO is deployed by the Cluster Version Operator (CVO).
+|v4.6.z
 
 |Prometheus Operator
 |The Prometheus Operator (PO) in the `openshift-monitoring` project creates, configures, and manages platform Prometheus instances and Alertmanager instances. It also automatically generates monitoring target configurations based on Kubernetes label queries.
+|v0.42.1
 
 |Prometheus
 |Prometheus is the monitoring system on which the {product-title} monitoring stack is based. Prometheus is a time-series database and a rule evaluation engine for metrics. Prometheus sends alerts to Alertmanager for processing.
+|v2.22.2
 
 |Prometheus Adapter
 |The Prometheus Adapter (PA in the preceding diagram) translates Kubernetes node and pod queries for use in Prometheus. The resource metrics that are translated include CPU and memory utilization metrics. The Prometheus Adapter exposes the cluster resource metrics API for horizontal pod autoscaling. The Prometheus Adapter is also used by the `oc adm top nodes` and `oc adm top pods` commands.
+|v0.7.0
 
 |Alertmanager
 |The Alertmanager service handles alerts received from Prometheus. Alertmanager is also responsible for sending the alerts to external notification systems.
+|v0.21.0
 
 |`kube-state-metrics` agent
 |The `kube-state-metrics` exporter agent (KSM in the preceding diagram) converts Kubernetes objects to metrics that Prometheus can use.
+|v1.9.7
 
 |`openshift-state-metrics` agent
 |The `openshift-state-metrics` exporter (OSM in the preceding diagram) expands upon `kube-state-metrics` by adding metrics for {product-title}-specific resources.
+|v4.6
 
 |`node-exporter` agent
 |The `node-exporter` agent (NE in the preceding diagram) collects metrics about every node in a cluster. The `node-exporter` agent is deployed on every node.
+|v1.0.1
 
 |Thanos Querier
 |The Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface.
+|v0.15.0
 
 |Grafana
 |The Grafana analytics platform provides dashboards for analyzing and visualizing the metrics. The Grafana instance that is provided with the monitoring stack, along with its dashboards, is read-only.
+|v7.2.0
 
 |Telemeter Client
 |The Telemeter Client sends a subsection of the data from platform Prometheus instances to Red Hat to facilitate Remote Health Monitoring for clusters.
+|v4.6.z
 
 |===
 


### PR DESCRIPTION
[OSDOCS-1607](https://issues.redhat.com/browse/OSDOCS-1607) - [Docs] Add monitoring component versions to the Monitoring book

Preview: https://deploy-preview-27602--osdocs.netlify.app/openshift-enterprise/latest/monitoring/understanding-the-monitoring-stack.html#default-monitoring-components_understanding-the-monitoring-stack