### PR TITLE
Avoid referring to RHV on upstream documentation

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -24,6 +24,10 @@ endif::[]
 :cloud-redhat-com: Red Hat OpenShift Cluster Manager
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
+ifdef::openshift-origin[]
+:rh-virtualization-first: oVirt
+:rh-virtualization: oVirt
+endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers


### PR DESCRIPTION
On upstream documentation it make more sense to refer to the
upstream of RHV, oVirt.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>