### PR TITLE
Bug 1891614: Update mlx dpdk base on cve-2020-14386

### DIFF
--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -99,7 +99,7 @@ spec:
     image: <DPDK_image> <2>
     securityContext:
      capabilities:
-        add: ["IPC_LOCK"] <3>
+        add: ["IPC_LOCK","NET_RAW"] <3>
     volumeMounts:
     - mountPath: /dev/hugepages <4>
       name: hugepage
@@ -122,7 +122,7 @@ spec:
 ----
 <1> Specify the same `target_namespace` where SriovNetwork CR `mlx-dpdk-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both `Pod` spec and SriovNetowrk CR.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
-<3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container.
+<3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container and `NET_RAW` for the application to access the network interface.
 <4> Mount the hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Optional: Specify the number of DPDK devices allocated to the DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
 <6> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs be allocated from kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.


### PR DESCRIPTION
We need to add the NET_RAW for mlx interfaces after cve-2020-14386
https://access.redhat.com/security/cve/cve-2020-14386

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1891614

Signed-off-by: Sebastian Sch <sebassch@gmail.com>