### PR TITLE
BZ-1874289 Adding content for backing up VMware vSphere persistent volumes

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -84,6 +84,7 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 == Next steps
 

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -75,6 +75,7 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 == Next steps
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -79,6 +79,7 @@ For instructions about configuring registry storage so that it references the co
 
 include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 == Next steps
 

--- a/modules/persistent-storage-vsphere-backup.adoc
+++ b/modules/persistent-storage-vsphere-backup.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
+
+[id="vsphere-pv-backup_{context}"]
+= Backing up VMware vSphere volumes
+
+{product-title} provisions new volumes as independent persistent disks to freely attach and detach the volume on any node in the cluster. As a consequence, it is not possible to back up volumes that use snapshots, or to restore volumes from snapshots. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html[Snapshot Limitations] for more information.
+
+.Procedure
+
+To create a backup of persistent volumes:
+
+.  Stop the application that is using the persistent volume.
+.  Clone the persistent volume.
+.  Restart the application.
+.  Create a backup of the cloned volume.
+.  Delete the cloned volume.

--- a/storage/persistent_storage/persistent-storage-vsphere.adoc
+++ b/storage/persistent_storage/persistent-storage-vsphere.adoc
@@ -38,3 +38,5 @@ include::modules/persistent-storage-vsphere-dynamic-provisioning-cli.adoc[levelo
 include::modules/persistent-storage-vsphere-static-provisioning.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-vsphere-formatting.adoc[leveloffset=+2]
+
+include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]


### PR DESCRIPTION
BZ-1874289 https://bugzilla.redhat.com/show_bug.cgi?id=1874289 (see comment # 20)

Adding information regarding backing up VMware vSphere volumes. This info was in 3.11 docs, but was not included in 4.x.

**NOTE:** Content was reviewed in this [PR-26960](https://github.com/openshift/openshift-docs/pull/26960). Some of the assemblies in the `master` branch (and 4.5+) are not in the `4.4` branch. I created this separate PR to add this new module to `4.4` and the appropriate vSphere install assemblies.