### PR TITLE
Updating persistent-storage-vsphere-backup module included in assemblies

### DIFF
--- a/modules/persistent-storage-vsphere-backup.adoc
+++ b/modules/persistent-storage-vsphere-backup.adoc
@@ -1,6 +1,12 @@
 // Module included in the following assemblies:
 //
 // * storage/persistent_storage/persistent-storage-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
 
 [id="vsphere-pv-backup_{context}"]
 = Backing up VMware vSphere volumes


### PR DESCRIPTION
Updating "Module included in the following assemblies:" section of this module. This new module was added to the vSphere installing assemblies in [PR-26960](https://github.com/openshift/openshift-docs/pull/26960), but I forgot to comment that it is included in the vSphere installing assemblies.