### PR TITLE
topic_map: use template for RHV/oVirt

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -255,16 +255,16 @@ Topics:
     File: uninstalling-cluster-openstack
   - Name: Uninstalling a cluster on OpenStack from your own infrastructure
     File: uninstalling-openstack-user
-- Name: Installing on RHV
+- Name: Installing on {rh-virtualization}
   Dir: installing_rhv
   Topics:
-  - Name: Installing a cluster quickly on RHV
+  - Name: Installing a cluster quickly on {rh-virtualization}
     File: installing-rhv-default
-  - Name: Installing a cluster on RHV with customizations
+  - Name: Installing a cluster on {rh-virtualization} with customizations
     File: installing-rhv-customizations
-  - Name: Installing a cluster on RHV with user-provisioned infrastructure
+  - Name: Installing a cluster on {rh-virtualization} with user-provisioned infrastructure
     File: installing-rhv-user-infra
-  - Name: Uninstalling a cluster on RHV
+  - Name: Uninstalling a cluster on {rh-virtualization}
     File: uninstalling-cluster-rhv
 - Name: Installing on vSphere
   Dir: installing_vsphere
@@ -2369,7 +2369,7 @@ Topics:
       File: virt-importing-virtual-machine-images-datavolumes
     - Name: Importing virtual machine images to block storage with DataVolumes
       File: virt-importing-virtual-machine-images-datavolumes-block
-    - Name: Importing a Red Hat Virtualization virtual machine
+    - Name: Importing a {rh-virtualization-first} virtual machine
       File: virt-importing-rhv-vm
     - Name: Importing a VMware virtual machine or template
       File: virt-importing-vmware-vm


### PR DESCRIPTION
Use {rh-virtualization} / {rh-virtualization-first}  instead of
the hardcoded name RHV / Red Hat Virtualization within the topic map.
Allows to reference oVirt for OKD instead of RHV.

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>