### PR TITLE
Fix #27584: Fix invalid argument for curl

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -87,8 +87,8 @@ $ export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubuserconte
 +
 [source,terminal]
 ----
-$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache
-$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache
+$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI}
+$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache/${RHCOS_OPENSTACK_URI}
 ----
 
 . Confirm SELinux type is of `httpd_sys_content_t` for the newly created files.


### PR DESCRIPTION
Add filename to `-o` option because `-o` have to be file path instead of directory path.