### PR TITLE
Fix #27618: Add commands for cleaning up

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -89,6 +89,41 @@ sshKey: '<ssh_pub_key>'
 [kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
+ifeval::[{release} >= 4.7]
+. Remove old bootstrap resources if any are left over from a previous deployment attempt.
++
+[source,terminal]
+----
+for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
+do
+  sudo virsh destroy $i;
+  sudo virsh undefine $i;
+  sudo virsh vol-delete $i --pool $i;
+  sudo virsh vol-delete $i.ign --pool $i;
+  sudo virsh pool-destroy $i;
+  sudo virsh pool-undefine $i;
+done
+----
+
+endif::[]
+ifeval::[{release} == 4.6]
+. Remove old bootstrap resources if any are left over from a previous deployment attempt.
++
+[source,terminal]
+----
+for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
+do
+  sudo virsh destroy $i;
+  sudo virsh undefine $i;
+  sudo virsh vol-delete $i --pool $i;
+  sudo virsh vol-delete $i.ign --pool default;
+  sudo virsh pool-destroy $i;
+  sudo virsh pool-undefine $i;
+done
+----
+
+endif::[]
+ifeval::[{release} < 4.6]
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.
 +
 [source,terminal]
@@ -101,3 +136,5 @@ do
   sudo virsh vol-delete $i.ign --pool default;
 done
 ----
+
+endif::[]

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -89,7 +89,7 @@ sshKey: '<ssh_pub_key>'
 [kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{release} >= 4.7]
+ifeval::[{release} >= 4.6]
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.
 +
 [source,terminal]
@@ -100,23 +100,6 @@ do
   sudo virsh undefine $i;
   sudo virsh vol-delete $i --pool $i;
   sudo virsh vol-delete $i.ign --pool $i;
-  sudo virsh pool-destroy $i;
-  sudo virsh pool-undefine $i;
-done
-----
-
-endif::[]
-ifeval::[{release} == 4.6]
-. Remove old bootstrap resources if any are left over from a previous deployment attempt.
-+
-[source,terminal]
-----
-for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
-do
-  sudo virsh destroy $i;
-  sudo virsh undefine $i;
-  sudo virsh vol-delete $i --pool $i;
-  sudo virsh vol-delete $i.ign --pool default;
   sudo virsh pool-destroy $i;
   sudo virsh pool-undefine $i;
 done

--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -15,6 +15,41 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 [kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
+ifeval::[{release} >= 4.7]
+. Remove all old bootstrap resources if any are left over from a previous deployment attempt:
++
+[source,bash]
+----
+for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
+do
+  sudo virsh destroy $i;
+  sudo virsh undefine $i;
+  sudo virsh vol-delete $i --pool $i;
+  sudo virsh vol-delete $i.ign --pool $i;
+  sudo virsh pool-destroy $i;
+  sudo virsh pool-undefine $i;
+done
+----
+
+endif::[]
+ifeval::[{release} == 4.6]
+. Remove all old bootstrap resources if any are left over from a previous deployment attempt:
++
+[source,bash]
+----
+for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
+do
+  sudo virsh destroy $i;
+  sudo virsh undefine $i;
+  sudo virsh vol-delete $i --pool $i;
+  sudo virsh vol-delete $i.ign --pool default;
+  sudo virsh pool-destroy $i;
+  sudo virsh pool-undefine $i;
+done
+----
+
+endif::[]
+ifeval::[{release} < 4.6]
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
 +
 [source,bash]
@@ -27,6 +62,7 @@ do
   sudo virsh vol-delete $i.ign --pool default;
 done
 ----
+endif::[]
 
 . Remove the following from the `clusterconfigs` directory to prevent Terraform from failing:
 +

--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -15,7 +15,7 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 [kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{release} >= 4.7]
+ifeval::[{release} >= 4.6]
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
 +
 [source,bash]
@@ -26,23 +26,6 @@ do
   sudo virsh undefine $i;
   sudo virsh vol-delete $i --pool $i;
   sudo virsh vol-delete $i.ign --pool $i;
-  sudo virsh pool-destroy $i;
-  sudo virsh pool-undefine $i;
-done
-----
-
-endif::[]
-ifeval::[{release} == 4.6]
-. Remove all old bootstrap resources if any are left over from a previous deployment attempt:
-+
-[source,bash]
-----
-for i in $(sudo virsh list | tail -n +3 | grep bootstrap | awk {'print $2'});
-do
-  sudo virsh destroy $i;
-  sudo virsh undefine $i;
-  sudo virsh vol-delete $i --pool $i;
-  sudo virsh vol-delete $i.ign --pool default;
   sudo virsh pool-destroy $i;
   sudo virsh pool-undefine $i;
 done


### PR DESCRIPTION
Change the pool name which the volume exists and add commands to delete pools.

At least in **4.6**, this fix seems to be necessary. I have no idea if it is necessary in 4.5 or 4.7.