### PR TITLE
Fix #27583: Add cp for openshift-baremetal-install

### DIFF
--- a/modules/ipi-install-extracting-the-openshift-installer.adoc
+++ b/modules/ipi-install-extracting-the-openshift-installer.adoc
@@ -31,4 +31,5 @@ After retrieving the installer, the next step is to extract it.
 ----
 [kni@provisioner ~]$ sudo cp oc /usr/local/bin
 [kni@provisioner ~]$ oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${RELEASE_IMAGE}
+[kni@provisioner ~]$ sudo cp openshift-baremetal-install /usr/local/bin
 ----


### PR DESCRIPTION
Add `cp` for `openshift-baremetal-install` to be able to use the command for later procedure.