### PR TITLE
Fix #27579: Add escape for each double-quotes

### DIFF
--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -100,23 +100,23 @@ This step can also be run from the web console.
 ----
 [kni@provisioner ~]$ export PUB_CONN=<baremetal_nic_name>
 [kni@provisioner ~]$ export PROV_CONN=<prov_nic_name>
-[kni@provisioner ~]$ sudo nohup bash -c '
-    nmcli con down "$PROV_CONN"
-    nmcli con down "$PUB_CONN"
-    nmcli con delete "$PROV_CONN"
-    nmcli con delete "$PUB_CONN"
-    # RHEL 8.1 appends the word "System" in front of the connection, delete in case it exists
-    nmcli con down "System $PUB_CONN"
-    nmcli con delete "System $PUB_CONN"
+[kni@provisioner ~]$ sudo nohup bash -c "
+    nmcli con down \"$PROV_CONN\"
+    nmcli con down \"$PUB_CONN\"
+    nmcli con delete \"$PROV_CONN\"
+    nmcli con delete \"$PUB_CONN\"
+    # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
+    nmcli con down \"System $PUB_CONN\"
+    nmcli con delete \"System $PUB_CONN\"
     nmcli connection add ifname provisioning type bridge con-name provisioning
-    nmcli con add type bridge-slave ifname "$PROV_CONN" master provisioning
+    nmcli con add type bridge-slave ifname \"$PROV_CONN\" master provisioning
     nmcli connection add ifname baremetal type bridge con-name baremetal
-    nmcli con add type bridge-slave ifname "$PUB_CONN" master baremetal
-    nmcli con down "$PUB_CONN";pkill dhclient;dhclient baremetal
+    nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
+    pkill dhclient;dhclient baremetal
     nmcli connection modify provisioning ipv6.addresses fd00:1101::1/64 ipv6.method manual
     nmcli con down provisioning
     nmcli con up provisioning
-'
+"
 ----
 +
 [NOTE]


### PR DESCRIPTION
* Add escape for every double-quotes
  * We don't need any quotes unless the name of the interface contains spaces, but it seems someone added them just in case in the past. So I keep all double-quotes and escape them.
  * There was also an idea to add `-E` to `sudo` command, but it's safer to expand all variables before `sudo` has invoked than to pass all the environment variables to root.
* Remove the second `nmcli con down "$PUB_CONN"` command.
  * Since the connection with this name doesn't exist at this stage, the command will be never succeeded.