### PR TITLE
[SRVKS-619] Add TLS cert docs for SM + Serverless

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2722,6 +2722,8 @@ Topics:
     File: serverless-ossm-jwt
   - Name: Using custom domains for Knative services with Service Mesh
     File: serverless-ossm-custom-domains
+  - Name: Configuring TLS for a custom domain using Service Mesh
+    File: serverless-ossm-tls
 # Monitoring
 - Name: Monitoring
   Dir: monitoring

--- a/modules/serverless-ossm-v1x-tls.adoc
+++ b/modules/serverless-ossm-v1x-tls.adoc
@@ -1,0 +1,162 @@
+// Module included in the following assemblies:
+//
+// * serverless/networking/serverless-ossm-tls.adoc
+
+[id="serverless-ossm-v1x-tls_{context}"]
+= Configuring Transport Layer Security for a custom domain using {ProductName} 1.x
+
+You can create a Transport Layer Security (TLS) key and certificates for a custom domain and subdomain using {ProductName}.
+
+.Procedure
+
+. Create a root certificate and private key to sign the certificates for your services:
++
+[source,terminal]
+----
+$ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+    -subj '/O=Example Inc./CN=example.com' \
+    -keyout example.com.key \
+    -out example.com.crt
+----
+. Create a certificate signing request for your domain:
++
+[source,terminal]
+----
+$ openssl req -out custom.example.com.csr -newkey rsa:2048 -nodes \
+    -keyout custom.example.com.key \
+    -subj "/CN=custom-ksvc-domain.example.com/O=Example Inc."
+----
+. Sign the request with your CA:
++
+[source,terminal]
+----
+$ openssl x509 -req -days 365 -set_serial 0 \
+    -CA example.com.crt \
+    -CAkey example.com.key \
+    -in custom.example.com.csr \
+    -out custom.example.com.crt
+----
+. Check that the certificates appear in your directory:
++
+[source,terminal]
+----
+$ ls -1
+----
++
+.Example output
+[source,terminal]
+----
+custom.example.com.crt
+custom.example.com.csr
+custom.example.com.key
+example.com.crt
+example.com.key
+----
+. Create a secret:
++
+[source,terminal]
+----
+$ oc create -n istio-system secret tls custom.example.com \
+    --key=custom.example.com.key \
+    --cert=custom.example.com.crt
+----
+. Attach the secret to the Istio ingress gateway by editing the `ServiceMeshControlPlane` resource.
+.. Edit the `ServiceMeshControlPlane` resource:
++
+[source,terminal]
+----
+$ oc edit -n istio-system ServiceMeshControlPlane <control_plane_name>
+----
+.. Check that the following lines exist in the resource, and if they do not, add them:
++
+[source,yaml]
+----
+spec:
+  istio:
+    gateways:
+      istio-ingressgateway:
+        secretVolumes:
+        - mountPath: /custom.example.com
+          name: custom-example-com
+          secretName: custom.example.com
+----
+. Update the Istio ingress gateway to use your secret.
+.. Edit the `default-gateway` resource:
++
+[source,terminal]
+----
+$ oc edit gateway default-gateway
+----
+.. Check that the following lines exist in the resource, and if they do not, add them:
++
+[source,yaml]
+----
+- hosts:
+  - custom-ksvc-domain.example.com
+  port:
+    name: https
+    number: 443
+    protocol: HTTPS
+  tls:
+    mode: SIMPLE
+    privateKey: /custom.example.com/tls.key
+    serverCertificate: /custom.example.com/tls.crt
+----
+. Update the route to use pass-through TLS and `8443` as the `spec.port.targetPort`.
+.. Edit the route:
++
+[source,terminal]
+----
+$ oc edit route -n istio-system hello
+----
+.. Add the following configuration to the route:
++
+[source,yaml]
+----
+spec:
+  host: custom-ksvc-domain.example.com
+  port:
+    targetPort: 8443
+  tls:
+    insecureEdgeTerminationPolicy: None
+    termination: passthrough
+  to:
+    kind: Service
+    name: istio-ingressgateway
+    weight: 100
+  wildcardPolicy: None
+----
+
+.Verification steps
+
+* Access your serverless application by a secure connection that is now trusted by the CA:
++
+[source,terminal]
+----
+$ curl --cacert example.com.crt \
+    --header "Host: custom-ksvc-domain.example.com" \
+    --resolve "custom-ksvc-domain.example.com:443:<ingress_router_IP>" \
+     https://custom-ksvc-domain.example.com:443
+----
++
+[NOTE]
+====
+You must substitute your own value for `<ingress_router_IP>`.
+Steps for finding this IP or host name value vary depending on your {product-title} provider platform.
+
+.Example command to find the ingress IP
+
+This command is valid for GCP and Azure provider platforms:
+
+[source,terminal]
+----
+$ oc get svc -n openshift-ingress router-default \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+----
+====
++
+.Example output
+[source,terminal]
+----
+Hello OpenShift!
+----

--- a/modules/serverless-ossm-v2x-tls.adoc
+++ b/modules/serverless-ossm-v2x-tls.adoc
@@ -1,0 +1,164 @@
+// Module included in the following assemblies:
+//
+// * serverless/networking/serverless-ossm-tls.adoc
+
+[id="serverless-ossm-v2x-tls_{context}"]
+= Configuring Transport Layer Security for a custom domain using {ProductName} 2.x
+
+You can create a Transport Layer Security (TLS) key and certificates for a custom domain and subdomain using {ProductName}.
+
+.Procedure
+
+. Create a root certificate and private key to sign the certificates for your services:
++
+[source,terminal]
+----
+$ openssl req -x509 -sha256 -nodes -days 365 -newkey rsa:2048 \
+    -subj '/O=Example Inc./CN=example.com' \
+    -keyout example.com.key \
+    -out example.com.crt
+----
+. Create a certificate signing request for your domain:
++
+[source,terminal]
+----
+$ openssl req -out custom.example.com.csr -newkey rsa:2048 -nodes \
+    -keyout custom.example.com.key \
+    -subj "/CN=custom-ksvc-domain.example.com/O=Example Inc."
+----
+. Sign the request with your CA:
++
+[source,terminal]
+----
+$ openssl x509 -req -days 365 -set_serial 0 \
+    -CA example.com.crt \
+    -CAkey example.com.key \
+    -in custom.example.com.csr \
+    -out custom.example.com.crt
+----
+. Check that the certificates appear in your directory:
++
+[source,terminal]
+----
+$ ls -1
+----
++
+.Example output
+[source,terminal]
+----
+custom.example.com.crt
+custom.example.com.csr
+custom.example.com.key
+example.com.crt
+example.com.key
+----
+. Create a secret:
++
+[source,terminal]
+----
+$ oc create -n istio-system secret tls custom.example.com \
+    --key=custom.example.com.key \
+    --cert=custom.example.com.crt
+----
+. Attach the secret to the Istio ingress gateway by editing the `ServiceMeshControlPlane` resource.
+.. Edit the `ServiceMeshControlPlane` resource:
++
+[source,terminal]
+----
+$ oc edit -n istio-system ServiceMeshControlPlane <control-plane-name>
+----
+.. Check that the following lines exist in the resource, and if they do not, add them:
++
+[source,yaml]
+----
+spec:
+  gateways:
+    ingress:
+      volumes:
+      - volume:
+          secret:
+            secretName: custom.example.com
+        volumeMount:
+          name: custom-example-com
+          mountPath: /custom.example.com
+----
+. Update the Istio ingress gateway to use your secret.
+.. Edit the `default-gateway` resource:
++
+[source,terminal]
+----
+$ oc edit gateway default-gateway
+----
+.. Check that the following lines exist in the resource, and if they do not, add them:
++
+[source,yaml]
+----
+- hosts:
+  - custom-ksvc-domain.example.com
+  port:
+    name: https
+    number: 443
+    protocol: HTTPS
+  tls:
+    mode: SIMPLE
+    privateKey: /custom.example.com/tls.key
+    serverCertificate: /custom.example.com/tls.crt
+----
+. Update the route to use pass-through TLS and `8443` as the `spec.port.targetPort`.
+.. Edit the route:
++
+[source,terminal]
+----
+$ oc edit route -n istio-system hello
+----
+.. Add the following configuration to the route:
++
+[source,yaml]
+----
+spec:
+  host: custom-ksvc-domain.example.com
+  port:
+    targetPort: 8443
+  tls:
+    insecureEdgeTerminationPolicy: None
+    termination: passthrough
+  to:
+    kind: Service
+    name: istio-ingressgateway
+    weight: 100
+  wildcardPolicy: None
+----
+
+.Verification steps
+
+* Access your serverless application by a secure connection that is now trusted by the CA:
++
+[source,terminal]
+----
+$ curl --cacert example.com.crt \
+    --header "Host: custom-ksvc-domain.example.com" \
+    --resolve "custom-ksvc-domain.example.com:443:<ingress_router_IP>" \
+     https://custom-ksvc-domain.example.com:443
+----
++
+[NOTE]
+====
+You must substitute your own value for `<ingress_router_IP>`.
+Steps for finding this IP or host name value vary depending on your {product-title} provider platform.
+
+.Example command to find the ingress IP
+
+This command is valid for GCP and Azure provider platforms:
+
+[source,terminal]
+----
+$ oc get svc -n openshift-ingress router-default \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+----
+====
++
+.Example output
+[source,terminal]
+----
+Hello OpenShift!
+----

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -21,5 +21,5 @@ You can enable JSON Web Token (JWT) authentication for Knative services.
 Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
 
-include::modules/serverless-ossm-v1x-jwt.adoc[leveloffset=+1]
 include::modules/serverless-ossm-v2x-jwt.adoc[leveloffset=+1]
+include::modules/serverless-ossm-v1x-jwt.adoc[leveloffset=+1]

--- a/serverless/networking/serverless-ossm-tls.adoc
+++ b/serverless/networking/serverless-ossm-tls.adoc
@@ -1,0 +1,37 @@
+include::modules/serverless-document-attributes.adoc[]
+include::modules/ossm-document-attributes.adoc[]
+[id="serverless-ossm-tls"]
+= Configuring Transport Layer Security for a custom domain using {ProductName}
+:context: serverless-ossm-tls
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+You can create a Transport Layer Security (TLS) key and certificates for a custom domain and subdomain using {ProductName}.
+
+[NOTE]
+====
+{ServerlessProductName} is compatible only with full implementations of either {ProductName} 1.x or 2.x. {ServerlessProductName} does not support custom usage of some 1.x resources and some 2.x resources in the same deployment. For example, upgrading to 2.x while still using the control plane `maistra.io/v1` spec is not supported.
+====
+
+[id="serverless-ossm-tls-prereqs"]
+== Prerequisites
+
+* Install xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessProductName}].
+* Install {ProductName} xref:../../service_mesh/v1x/installing-ossm.adoc#installing-ossm-v1x[1.x] or xref:../../service_mesh/v2x/installing-ossm.adoc#installing-ossm-v2x[2.x].
+* Complete the configuration steps in xref:../../serverless/networking/serverless-ossm.adoc#serverless-ossm[Using Service Mesh with OpenShift Serverless].
+* Configure a custom domain. See xref:../../serverless/networking/serverless-ossm-custom-domains.adoc#serverless-ossm-custom-domains[Using custom domains for Knative services with Service Mesh].
+* In this example, `openssl` is used to generate certificates, but you can use any certificate generation tool to create these.
+
+[IMPORTANT]
+====
+This example uses the `example.com` domain.
+The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
+
+To complete and verify this procedure in your deployment, you need either a certificate signed by a widely trusted public CA, or a CA provided by your organization.
+
+Example commands must be adjusted according to your domain, subdomain and CA.
+====
+
+include::modules/serverless-ossm-v2x-tls.adoc[leveloffset=+1]
+include::modules/serverless-ossm-v1x-tls.adoc[leveloffset=+1]


### PR DESCRIPTION
@nak3 @cardil this PR is to finally add the content that was previously in the PR we closed due to not being able to verify this procedure.

Please review what is here and add suggestions if there's anything else we need to do or if you have any issues with verification.

If there are still steps required that can't be done without having documented steps for the underlying OpenShift part, we should discuss it with @sjstout as part of the core docs IMO, instead of trying to add it as a workaround in just this procedure.

Applies for OCP 4.6, 4.7