### PR TITLE
modules/encrypt-disk: update encryption to use Ignition-created LUKS

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -6,6 +6,11 @@
 = Enabling Tang disk encryption
 Use this procedure to enable Tang mode disk encryption during {product-title} deployment.
 
+[NOTE]
+====
+On previous versions of {op-system}, disk encryption was configured by specifying `/etc/clevis.json` in the Ignition config. That file is not supported in clusters created with {product-title} 4.7 or above, and the LUKS device should be configured directly via the Ignition `luks` section.
+====
+
 .Procedure
 
 . Access a Red Hat Enterprise Linux server from which you can configure the encryption
@@ -57,19 +62,6 @@ PLjNyRdGw03zlRoGjQYMahSZGu9
 ----
 eyJhbmc3SlRyMXpPenc3ajhEQ01tZVJiTi1oM...
 ----
-
-. Create a Base64 encoded file, replacing the URL of the Tang server (`url`) and thumbprint (`thp`) you just generated:
-+
-[source,terminal]
-----
-$ (cat <<EOM
-{
- "url": "https://tang.example.com",
- "thp": "PLjNyRdGw03zlRoGjQYMahSZGu9"
-}
-EOM
-) | base64 -w0
-----
 +
 .Example output
 [source,terminal]
@@ -93,15 +85,20 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
-      files:
-      - contents:
-          source: data:text/plain;base64,e30K
-          source: data:text/plain;base64,ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3psVExHYlhuUWFoUzBHdTAiCn0K
-        mode: 420
-        overwrite: true
-        path: /etc/clevis.json
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tang:
+              - url: https://tang.example.com
+                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
 EOF
 ----
 
@@ -119,15 +116,20 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
-      files:
-      - contents:
-          source: data:text/plain;base64,e30K
-          source: data:text/plain;base64,ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3psVExHYlhuUWFoUzBHdTAiCn0K
-        mode: 420
-        overwrite: true
-        path: /etc/clevis.json
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tang:
+              - url: https://tang.example.com
+                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
 EOF
 ----
 
@@ -142,7 +144,7 @@ EOF
   spec:
     config:
       ignition:
-        version: 3.1.0
+        version: 3.2.0
     kernelArguments:
       - rd.neednet=1 <.>
 ----

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -6,6 +6,11 @@
 = Enabling TPM v2 disk encryption
 Use this procedure to enable TPM v2 mode disk encryption during {product-title} deployment.
 
+[NOTE]
+====
+On previous versions of {op-system}, disk encryption was configured by specifying `/etc/clevis.json` in the Ignition config. That file is not supported in clusters created with {product-title} 4.7 or above, and the LUKS device should be configured directly via the Ignition `luks` section.
+====
+
 .Procedure
 
 . Check to see if TPM v2 encryption needs to be enabled in the BIOS on each node.
@@ -34,14 +39,18 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
-      files:
-      - contents:
-          source: data:text/plain;base64,e30K
-        mode: 420
-        overwrite: true
-        path: /etc/clevis.json
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tpm2: true
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
 EOF
 ----
 ** To create a master file, run the following command:
@@ -58,14 +67,18 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
-      files:
-      - contents:
-          source: data:text/plain;base64,e30K
-        mode: 420
-        overwrite: true
-        path: /etc/clevis.json
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tpm2: true
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
 EOF
 ----
 


### PR DESCRIPTION
Updates the `installation-special-config-encrypt-disk-*` docs to use Ignition created LUKS for OCP 4.7+