### PR TITLE
Update exposing service with port-forward section

### DIFF
--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -46,18 +46,17 @@ route "mysql-80-rhel7" exposed
 ----
 
 . Use a tool, such as cURL, to make sure you can reach the service using the
-cluster IP address for the service:
+cluster IP address for the service. First, port-forward the service:
 +
 [source,terminal]
 ----
-$ curl <pod_ip>:<port>
+$ oc port-forward service/mysql-80-rhel7 <port>:3306
 ----
-+
-For example:
+. Then in another terminal window verify that you can access the service:
 +
 [source,terminal]
 ----
-$ curl 172.30.131.89:3306
+$ curl localhost:<port>
 ----
 +
 The examples in this section use a MySQL service, which requires a client
@@ -68,7 +67,7 @@ If you have a MySQL client, log in with the standard CLI command:
 +
 [source,terminal]
 ----
-$ mysql -h 172.30.131.89 -u admin -p
+$ mysql -h 127.0.0.1 -P <port> -u admin -p
 ----
 +
 .Example output


### PR DESCRIPTION
The current documentation is misleading. In step 4 in https://docs.openshift.com/aro/4/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#nw-exposing-service_configuring-ingress-cluster-traffic-ingress-controller it instructs the user to curl pod ip. It is not possible to access pod IP from outside the cluster - user must either port forward the pod (or service) or they need to be inside the cluster (e.g. rsh or oc debug). This PR adds this step. 