### PR TITLE
WIP: Non-preempting PriorityClass

### DIFF
--- a/modules/nodes-pods-priority-configuring.adoc
+++ b/modules/nodes-pods-priority-configuring.adoc
@@ -16,13 +16,15 @@ kind: PriorityClass
 metadata:
   name: high-priority <1>
 value: 1000000 <2>
-globalDefault: false <3>
-description: "This priority class should be used for XYZ service pods only." <4>
+preemptionPolicy: PreemptLowerPriority <3>
+globalDefault: false <4>
+description: "This priority class should be used for XYZ service pods only." <5>
 ----
 <1> The name of the priority class object.
 <2> The priority value of the object.
-<3> Optional field that indicates whether this priority class should be used for pods without a priority class name specified. This field is `false` by default. Only one priority class with `globalDefault` set to `true` can exist in the cluster. If there is no priority class with `globalDefault:true`, the priority of pods with no priority class name is zero. Adding a priority class with `globalDefault:true` affects only pods created after the priority class is added and does not change the priorities of existing pods.
-<4> Optional arbitrary text string that describes which pods developers should use with this priority class.
+<3> Optional field that indicates whether this priority class is preempting or non-preempting. PreemptionPolicy defaults to `PreemptLowerPriority`, which will allow pods of that PriorityClass to preempt lower-priority pods (as is existing default behavior). If PreemptionPolicy is set to `Never`, pods in that PriorityClass will be non-preempting.
+<4> Optional field that indicates whether this priority class should be used for pods without a priority class name specified. This field is `false` by default. Only one priority class with `globalDefault` set to `true` can exist in the cluster. If there is no priority class with `globalDefault:true`, the priority of pods with no priority class name is zero. Adding a priority class with `globalDefault:true` affects only pods created after the priority class is added and does not change the priorities of existing pods.
+<5> Optional arbitrary text string that describes which pods developers should use with this priority class.
 
 .Procedure
 

--- a/modules/nodes-pods-priority-preempt-about.adoc
+++ b/modules/nodes-pods-priority-preempt-about.adoc
@@ -17,6 +17,13 @@ Preemption does not necessarily remove all lower-priority pods from a node. The 
 
 The scheduler considers a node for pod preemption only if the pending pod can be scheduled on the node.
 
+[id="non-preempting-priority-class_{context}"]
+== Non-preempting priority class ==
+
+Pods with PreemptionPolicy: Never will be placed in the scheduling queue ahead of lower-priority pods, but they cannot preempt other pods. A non-preempting pod waiting to be scheduled will stay in the scheduling queue, until sufficient resources are free, and it can be scheduled. Non-preempting pods, like other pods, are subject to scheduler back-off. This means that if the scheduler tries these pods and they cannot be scheduled, they will be retried with lower frequency, allowing other pods with lower priority to be scheduled before them.
+
+Non-preempting pods may still be preempted by other, high-priority pods.
+
 [id="priority-preemption-other_{context}"]
 == Pod preemption and other scheduler settings
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1654 / https://issues.redhat.com/browse/WRKLDS-195

https://kubernetes.io/docs/concepts/configuration/pod-priority-preemption/#priorityclass

Tested with:
```
---
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: high-priority
value: 100000
globalDefault: false
description: "This priority class should be used for XYZ service pods only."
# immutable field
preemptionPolicy: Never
---
apiVersion: scheduling.k8s.io/v1
kind: PriorityClass
metadata:
  name: low-priority
value: 50000
globalDefault: false
description: "This priority class should be used for XYZ service pods only."
---
apiVersion: v1
kind: ReplicationController
metadata:
  name: rc1
spec:
  replicas: 3
  selector:
    app: rc1
  template:
    metadata:
      name: rc1
      labels:
        app: rc1
    spec:
      priorityClassName: high-priority
      containers:
      - name: nginx
        image: nginx
        ports:
        - containerPort: 80
        resources:
          requests:
            memory: "500Mi"
            cpu: "500m"
          limits:
            memory: "500Mi"
            cpu: "500m"
---
apiVersion: v1
kind: ReplicationController
metadata:
  name: rc2
spec:
  replicas: 3
  selector:
    app: rc2
  template:
    metadata:
      name: rc2
      labels:
        app: rc2
    spec:
      priorityClassName: low-priority
      containers:
      - name: nginx
        image: nginx
        ports:
        - containerPort: 80
        resources:
          requests:
            memory: "500Mi"
            cpu: "500m"
          limits:
            memory: "500Mi"
            cpu: "500m"
```