### PR TITLE
Various tweaks related to RHCOS ISO/PXE installation

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -48,14 +48,15 @@ The rootfs image is the same for FCP and DASD.
 ... The network interface name. Omit this value to let {op-system} decide.
 ... If you use static IP addresses, an empty string.
 ** For `coreos.inst.ignition_url=`, specify the Ignition file for the machine role. Use `bootstrap.ign`, `master.ign`, or `worker.ign`. Only HTTP and HTTPS protocols are supported.
+** For `coreos.live.rootfs_url=`, specify the matching rootfs artifact for the kernel and initramfs you are booting. Only HTTP and HTTPS protocols are supported.
 ** All other parameters can stay as they are.
 +
 Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 +
 ----
-rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=ftp://
+rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
 cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=ftp://cl1.provide.example.com:8080/ignition/bootstrap.ign
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
 rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
 !condev rd.dasd=0.0.3490

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -182,7 +182,7 @@ metal installation procedures to install {op-system-first} systems.
 === Retaining existing partitions
 For an ISO installation, you can add options to the `coreos-installer` command line
 that causes the installer to maintain one or more existing partitions.
-For a PXE installation, you can `APPEND` `coreos.inst` options to preserve partitions.
+For a PXE installation, you can `APPEND` `coreos.inst.*` options to preserve partitions.
 
 Saved partitions might be partitions from an existing {product-title}
 system that has data partitions that you want to keep. Here are a few tips:
@@ -261,7 +261,8 @@ It is not recommended to modify these files.
 For PXE installations, you pass the Ignition configs on the `APPEND` line using the
 `coreos.inst.ignition_url=` option. For ISO installations, after the ISO boots to
 the shell prompt, you identify the Ignition config on the `coreos-installer`
-command line with the `--ignition-url=` option.
+command line with the `--ignition-url=` option. In both cases, only HTTP and HTTPS
+protocols are supported.
 +
 
 * **Live install Ignition config**: This type must be created manually and should be avoided if possible, as it is not supported by Red Hat. With this method, the Ignition config passes to the live install medium, runs immediately upon booting, and performs setup tasks before and/or after the {op-system} system installs to disk. This method should only be used for performing tasks that must be performed once and not applied again later, such as with advanced partitioning that cannot be done using a machine config.

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -141,6 +141,8 @@ a|Optional: Download and install the specified {op-system} image.
 
 * If you are using `coreos.inst.image_url`, you must also use `coreos.inst.insecure`. This is because the bare-metal media are not GPG-signed for {product-title}.
 
+* Only HTTP and HTTPS protocols are supported.
+
 a|`coreos.inst.skip_reboot`
 
 a|Optional: The system will not reboot after installing. Once the install finishes, you will receive a prompt that allows you to inspect what is happening during installation. This argument should not be used in production environments and is intended for debugging purposes only.

--- a/modules/machine-user-infra-machines-iso.adoc
+++ b/modules/machine-user-infra-machines-iso.adoc
@@ -10,7 +10,6 @@ You can create more compute machines for your bare metal cluster by using an ISO
 .Prerequisites
 
 * Obtain the URL of the Ignition config file for the compute machines for your cluster. You uploaded this file to your HTTP server during installation.
-* Obtain the URL of the BIOS or UEFI {op-system} image file that you uploaded to your HTTP server during cluster installation.
 
 .Procedure
 
@@ -23,14 +22,11 @@ You can create more compute machines for your bare metal cluster by using an ISO
 +
 [source,terminal]
 ----
-coreos.inst=yes
 coreos.inst.install_dev=sda <1>
-coreos.inst.image_url=<bare_metal_image_URL> <2>
-coreos.inst.ignition_url=http://example.com/worker.ign <3>
+coreos.inst.ignition_url=http://example.com/worker.ign <2>
 ----
 <1> Specify the block device of the system to install to.
-<2> Specify the URL of the UEFI or BIOS image that you uploaded to your server.
-<3> Specify the URL of the compute Ignition config file. Only HTTP and HTTPS protocols are supported.
+<2> Specify the URL of the compute Ignition config file. Only HTTP and HTTPS protocols are supported.
 
 . Press `Enter` to complete the installation. After {op-system} installs, the system reboots. After the system reboots, it applies the Ignition config file that you specified.
 


### PR DESCRIPTION
- Don't use ftp:// in the example config (rhbz#1901802).
- Mention where missing that URLs to various artifacts only support HTTP
  and HTTPS.
- Drop unnecessary `coreos.inst=yes` and `coreos.inst.image_url` kargs.
- Various other minor tweaks I noticed as I was passing through.