### PR TITLE
Including the RVM command within the preceding note

### DIFF
--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -83,11 +83,15 @@ live content editing on a Fedora Linux system.
 
 1. Install the _RubyGems_ package with `yum install rubygems`
 
-NOTE: On certain systems, `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
+[NOTE]
+====
+On certain systems, `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:
 
+[source,terminal]
 ----
 $ curl -sSL https://get.rvm.io | bash -s stable --ruby
 ----
+====
 
 2. Install _Ruby_ development packages with `yum install ruby-devel`
 3. Install _gcc_ with `yum install gcc-c++`


### PR DESCRIPTION
This applies to master only.

This relates to https://github.com/openshift/openshift-docs/pull/27685. I noticed after that PR was merged that the command should be embedded in the note. This PR applies that change.