### PR TITLE
cluster capacity: add missing rbac rules

### DIFF
--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -28,12 +28,21 @@ $ cat << EOF| oc create -f -
 [source,terminal]
 ----
 kind: ClusterRole
-apiVersion: v1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: cluster-capacity-role
 rules:
 - apiGroups: [""]
-  resources: ["pods", "nodes", "persistentvolumeclaims", "persistentvolumes", "services"]
+  resources: ["pods", "nodes", "persistentvolumeclaims", "persistentvolumes", "services", "replicationcontrollers"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["apps"]
+  resources: ["replicasets", "statefulsets"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["policy"]
+  resources: ["poddisruptionbudgets"]
+  verbs: ["get", "watch", "list"]
+- apiGroups: ["storage.k8s.io"]
+  resources: ["storageclasses"]
   verbs: ["get", "watch", "list"]
 EOF
 ----


### PR DESCRIPTION
Syncing with https://github.com/kubernetes-sigs/cluster-capacity/blob/master/config/rbac.yaml

4.6 bug: https://bugzilla.redhat.com/show_bug.cgi?id=1901127