### PR TITLE
Remove topic from ARO doc set

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -507,7 +507,7 @@ Topics:
     File: about-openshift-sdn
   - Name: Configuring egress IPs for a project
     File: assigning-egress-ips
-    Distros: openshift-origin,openshift-enterprise,openshift-webscale,openshift-aro
+    Distros: openshift-origin,openshift-enterprise,openshift-webscale
   - Name: Configuring an egress firewall for a project
     File: configuring-egress-firewall
   - Name: Editing an egress firewall for a project


### PR DESCRIPTION
Removing this topic from the ARO doc set as it is not pertinent for ARO. Merge to [enterprise-4](https://issues.redhat.com/browse/enterprise-4).3 branch ONLY. No QE needed.