### PR TITLE
OSDOCS-1654: Release notes for non-preempting priority class option

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -108,6 +108,12 @@ The xref:../support/remote_health_monitoring/using-insights-to-identify-issues-w
 [id="ocp-4-7-nodes"]
 === Nodes
 
+[id="ocp-4-7-nodes-non-preempting-priority-classes"]
+==== Non-preempting option for priority classes (Technology Preview)
+
+You can now configure a priority class to be non-preempting by setting the `preemptionPolicy` field to `Never`. Pods with this priority class setting are placed in the scheduling queue ahead of lower priority pods, but do not preempt other pods.
+
+For more information, see xref:../nodes/pods/nodes-pods-priority.html#non-preempting-priority-class_nodes-pods-priority[Non-preempting priority classes].
 
 [id="ocp-4-7-logging"]
 === Cluster logging


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1654

Preview: https://osdocs-1654-rn--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-nodes-non-preempting-priority-classes