### PR TITLE
Removed the viewing pod logs topics from cluster logging

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1685,8 +1685,6 @@ Topics:
     File: cluster-logging-curator
   - Name: Maintenance and support
     File: cluster-logging-maintenance-support
-- Name: Viewing cluster logs
-  File: cluster-logging-viewing
 - Name: Viewing cluster logs in Kibana
   File: cluster-logging-visualizer
   Distros: openshift-enterprise,openshift-origin


### PR DESCRIPTION
In researching https://bugzilla.redhat.com/show_bug.cgi?id=1878944 we determined that the modules to view cluster logs are both incorrect in that they are not related to aggregated cluster logging and not appropriate for the cluster logging docs. 
I added a new topic for viewing logs in Kibana in a separate PR:
Preview: https://logging-access-logs--ocpdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-visualizer.html#cluster-logging-visualizer-kibana_cluster-logging-visualizer
