### PR TITLE
CNV-BZ-1895007 Modified SriovNetwork object to include more supported parameters

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -126,6 +126,12 @@ spec:
   networkNamespace: <target_namespace> <4>
   vlan: <vlan> <5>
   spoofChk: "<spoof_check>" <6>
+  linkState: <link_state> <7>
+  maxTxRate: <max_tx_rate> <8>
+  minTxRate: <min_rx_rate> <9>
+  vlanQoS: <vlan_qos> <10>
+  trust: "<trust_vf>" <11>
+  capabilities: <capabilities> <12>
 ifdef::ocp-sriov-net[]
   ipam: {} <7>
   linkState: <link_state> <8>
@@ -147,24 +153,25 @@ endif::ocp-sriov-net[]
 ====
 You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
 ====
-ifdef::ocp-sriov-net[]
-<7> A configuration object for the IPAM CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
-<8> Optional: Replace `<link_state>` with the link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
-<9> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
-<10> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.
+<7> Optional: Replace `<link_state>` with the link state of virtual function (VF). Allowed value are `enable`, `disable` and `auto`.
+<8> Optional: Replace `<max_tx_rate>` with a maximum transmission rate, in Mbps, for the VF.
+<9> Optional: Replace `<min_tx_rate>` with a minimum transmission rate, in Mbps, for the VF. This value should always be less than or equal to Maximum transmission rate.
 +
 [NOTE]
 ====
 Intel NICs do not support the `minTxRate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[BZ#1772847].
 ====
-<11> Optional: Replace `<vlan_qos>` with an IEEE 802.1p priority level for the VF. The default value is `0`.
-<12> Optional: Replace `<trust_vf>` with the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
+<10> Optional: Replace `<vlan_qos>` with an IEEE 802.1p priority level for the VF. The default value is `0`.
+<11> Optional: Replace `<trust_vf>` with the trust mode of the VF. The allowed values are the strings `"on"` and `"off"`.
 +
 [IMPORTANT]
 ====
 You must enclose the value you specify in quotes or the CR is rejected by the SR-IOV Network Operator.
 ====
-<13> Optional: Replace `<capabilities>` with the capabilities to configure for this network. You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+<12> Optional: Replace `<capabilities>` with the capabilities to configure for this network.
+ifdef::ocp-sriov-net[]
+You can specify `"{ "ips": true }"` to enable IP address support or `"{ "mac": true }"` to enable MAC address support.
+<13> A configuration object for the IPAM CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
 endif::ocp-sriov-net[]
 
 [start=2]


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1895007

Changed the conditional statements to expose the `SriovNetwork` object parameters that are supported for VMs.

Preview build: https://bz1895007--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.html#nw-sriov-network-attachment_virt-defining-an-sriov-network

Labels branch/enterprise-4.7, branch/enterprise-4.6, branch/enterprise-4.5.