### PR TITLE
BZ1846458 - Remove note that ES scaling is not supported

### DIFF
--- a/logging/config/cluster-logging-log-store.adoc
+++ b/logging/config/cluster-logging-log-store.adoc
@@ -11,22 +11,16 @@ You can make modifications to your log store, including:
 
 * storage for your Elasticsearch cluster
 * shard replication across data nodes in the cluster, from full replication to no replication
-* external access to Elasticsearch data 
-
-[NOTE]
-====
-Scaling down Elasticsearch nodes is not supported. When scaling down, Elasticsearch pods can be accidentally deleted,  
-possibly resulting in shards not being allocated and replica shards being lost.
-====
+* external access to Elasticsearch data
 
 //Following paragraph also in modules/cluster-logging-deploy-storage-considerations.adoc
 
-Elasticsearch is a memory-intensive application. Each Elasticsearch node needs 16G of memory for both memory requests and limits, 
-unless you specify otherwise in the `ClusterLogging` custom resource. The initial set of {product-title} nodes might not be large enough 
+Elasticsearch is a memory-intensive application. Each Elasticsearch node needs 16G of memory for both memory requests and limits,
+unless you specify otherwise in the `ClusterLogging` custom resource. The initial set of {product-title} nodes might not be large enough
 to support the Elasticsearch cluster. You must add additional nodes to the {product-title} cluster to run with the recommended
-or higher memory. 
+or higher memory.
 
-Each Elasticsearch node can operate with a lower memory setting though this is not recommended for production environments.
+Each Elasticsearch node can operate with a lower memory setting, though this is not recommended for production environments.
 
 
 // The following include statements pull in the module files that comprise
@@ -55,4 +49,3 @@ include::modules/cluster-logging-elasticsearch-persistent-storage-empty.adoc[lev
 include::modules/cluster-logging-manual-rollout-rolling.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-elasticsearch-exposing.adoc[leveloffset=+1]
-

--- a/modules/cluster-logging-elasticsearch-scaledown.adoc
+++ b/modules/cluster-logging-elasticsearch-scaledown.adoc
@@ -5,12 +5,11 @@
 [id="cluster-logging-elasticsearch-scaledown_{context}"]
 = Scaling down Elasticsearch pods
 
-Reducing the number of Elasticsearch pod in your cluster can result in data loss or Elasticsearch performance degradation. 
+Reducing the number of Elasticsearch pods in your cluster can result in data loss or Elasticsearch performance degradation. 
 
-If you scale down, you should scale down by one pod at a time and allow the cluster to re-balance the shards and replicas. After the Elasticsearch health status returns to `green`, you can scale down by another pod. 
+If you scale down, you should scale down by one pod at a time and allow the cluster to re-balance the shards and replicas. After the Elasticsearch health status returns to `green`, you can scale down by another pod.
 
 [NOTE]
 ====
-If your Elasticsearch cluster is set to `ZeroRedundancy`, you should not scale down your Elasticsearch pods. 
+If your Elasticsearch cluster is set to `ZeroRedundancy`, you should not scale down your Elasticsearch pods.
 ====
- 


### PR DESCRIPTION
[BZ1846458](https://bugzilla.redhat.com/show_bug.cgi?id=1846458)
As of OCP 4.5, the note about scaling ES nodes being unsupported is no longer relevant. There is now a section added in docs on scaling down ES one node/pod at a time: https://github.com/openshift/openshift-docs/pull/27404/files#diff-133e6e62a5aac180545525ba042091c8662a66b3a160b188dfead122e1445ff9

**PREVIEW LINK:**
https://bz1846458--ocpdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-log-store.html