### PR TITLE
[DRAFT] BZ:1856361 crojob spec and variables

### DIFF
--- a/dev_guide/cron_jobs.adoc
+++ b/dev_guide/cron_jobs.adoc
@@ -20,7 +20,6 @@ link:http://kubernetes.io/docs/user-guide/cron-jobs[Kubernetes] API, which
 can be managed with `oc` commands like other
 xref:../cli_reference/basic_cli_operations.adoc#object-types[object types].
 
-
 ifdef::openshift-online[]
 [IMPORTANT]
 ====
@@ -32,35 +31,16 @@ endif::[]
 
 [WARNING]
 ====
-A cron job creates a job object approximately once per execution time of its
-schedule, but there are circumstances in which it fails to create a job or
-two jobs might be created.  Therefore, jobs must be idempotent and you must
+A cron job creates a job object approximately once for each scheduled time,
+but there are circumstances in which it fails to create a job or
+two jobs might be created. Therefore, jobs must be idempotent and you must
 xref:cleaning-up-after-a-cron-job[configure history limits].
 ====
 
 [[creating-a-cronjob]]
 == Creating a Cron Job
 
-A cron job configuration consists of the following key parts:
-
-* A schedule specified in link:https://en.wikipedia.org/wiki/Cron[cron format].
-* A job template used when creating the next job.
-* An optional deadline (in seconds) for starting the job if it misses its
-scheduled time for any reason. Missed jobs executions will be counted as failed
-ones. If not specified, there is no deadline.
-* `*ConcurrencyPolicy*`: An optional concurrency policy, specifying how to treat
-concurrent jobs within a cron job. Only one of the following concurrent
-policies may be specified. If not specified, this defaults to allowing
-concurrent executions.
-** `Allow` allows Cron Jobs to run concurrently.
-** `Forbid` forbids concurrent runs, skipping the next run if the previous has not
-finished yet.
-** `Replace` cancels the currently running job and replaces
-it with a new one.
-* An optional flag allowing the suspension of a cron job. If set to `true`,
-all subsequent executions will be suspended.
-
-The following is an example of a `*CronJob*` resource:
+The following is an example of a *CronJob* resource:
 
 [source,yaml]
 ----
@@ -69,25 +49,67 @@ kind: CronJob
 metadata:
   name: pi
 spec:
-  schedule: "*/1 * * * *"  <1>
-  jobTemplate:             <2>
+  schedule: "*/1 * * * *"       <1>
+  concurrencyPolicy: "Replace"  <2>
+  startingDeadlineSeconds: 200  <3>
+  suspend: false                <4>
+  successfulJobsHistoryLimit: 3 <5>
+  failedJobsHistoryLimit: 1     <6>
+  jobTemplate:                  <7>
     spec:
       template:
         metadata:
-          labels:          <3>
+          labels:               <8>
             parent: "cronjobpi"
         spec:
           containers:
           - name: pi
             image: perl
             command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
-          restartPolicy: OnFailure <4>
+          restartPolicy: OnFailure <9>
 ----
 
-1. Schedule for the job. In this example, the job will run every minute.
-2. Job template. This is similar to the xref:../dev_guide/jobs.adoc#creating-a-job[job example].
-3. Sets a label for jobs spawned by this cron job.
-4. The restart policy of the pod. This does not apply to the job controller. See xref:../dev_guide/jobs.adoc#creating-a-job-known-issues[Known Issues and Limitations] for details.
+<1> The schedule field for the job is specified in 
+link:https://en.wikipedia.org/wiki/Cron[cron format]. In this example, the
+job runs every minute.
+<2> Optional: The concurrency policy specifies how the job controller treats
+concurrent jobs within a cron job. Only one of the following policies can be
+specified:
+* `Allow` allows multiple instances of the job to run concurrently. `Allow`
+is the default value.
+* `Forbid` prevents multiple instances of the job from running concurrently.
+Scheduled runs are skipped if the previous run has not finished.
+* `Replace` cancels a currently running instance of the job and replaces
+the job with a new instance.
+<3> Optional: The starting deadline specifies a deadline (in seconds) for starting the job
+if a scheduled run is missed for any reason. After the deadline, the cron job
+does not start the job. Missed job runs are counted as failed jobs. By
+default, jobs have no deadline. Be aware that when this field is set, the cron job
+controller counts the number of missed jobs that occur in the interval between
+the value for the deadline and the current moment. For example, if
+`startingDeadlineSeconds` is set to `200`, the controller counts the number
+of missed jobs in the last 200 seconds. For more information, see the limitations
+for link:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/[cron jobs]
+in the Kubernetes documentation for cron job concepts.
+<4> Optional: The suspend field is used to prevent subsequent runs of the cron job.
+If set to `true`, then all subsequent runs are prevented from starting.
+By default, the value is `false`, and jobs are run.
+<5> Optional: The successful jobs history limit specifies the number of finished jobs to
+retain. By default, three jobs are retained.
+<6> Optional: The failed jobs history limit specifies the number of failed jobs to retain.
+By default, one job is retained.
+<7> The job template specifies the job to run. The field is similar to the
+xref:../dev_guide/jobs.adoc#creating-a-job[job example].
+<8> Optional: The labels field specifies a label to set for jobs that are started by
+the cron job. In this example, jobs receive the label `parent=cronjobpi`.
+<9> Optional: The link:https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#restart-policy[restart policy] for pods that are started to run the job. The policy can
+be set to `Always`, `OnFailure`, or `Never`. By default, containers are always
+restarted. Be aware that this field does not apply to the job controller.
+See xref:../dev_guide/jobs.adoc#creating-a-job-known-issues[Known Limitations] for details.
+
+For more information about the `CronJob` specification, see the Kubernetes
+documentation for
+link:https://kubernetes.io/docs/tasks/job/automated-tasks-with-cron-jobs/#writing-a-cron-job-spec[writing a cron job specification].
 
 [NOTE]
 ====
@@ -96,6 +118,7 @@ All cron job `schedule` times are based on the timezone of the master where the 
 
 You can also create and launch a cron job from a single command using `oc run`. The following command creates and launches the same cron job as specified in the previous example:
 
+[source,terminal]
 ----
 $ oc run pi --image=perl --schedule='*/1 * * * *' \
     --restart=OnFailure --labels parent="cronjobpi" \
@@ -105,31 +128,35 @@ $ oc run pi --image=perl --schedule='*/1 * * * *' \
 With `oc run`, the `--schedule` option accepts schedules in link:https://en.wikipedia.org/wiki/Cron[cron format].
 
 [NOTE]
-=====
+====
 When creating a cron job,  `oc run` only supports the `Never` or `OnFailure` restart policies (`--restart`).
-=====
+====
 
 [TIP]
-=====
+====
 Delete cron jobs that you no longer need:
+
+[source,terminal]
 ----
 $ oc delete cronjob/<cron_job_name>
 ----
+
 Doing this prevents them from generating unnecessary artifacts.
-=====
+====
 
 [[cleaning-up-after-a-cron-job]]
 == Cleaning Up After a Cron Job
 
 The `.spec.successfulJobsHistoryLimit` and `.spec.failedJobsHistoryLimit` fields are optional.
-These fields specify how many completed and failed jobs should be kept.  By default, they are
-set to `3` and `1` respectively.  Setting a limit to `0` corresponds to keeping none of the corresponding
+These fields specify how many completed and failed jobs are kept. By default, they are
+set to `3` and `1` respectively. Setting a limit to `0` corresponds to keeping none of the corresponding
 kind of jobs after they finish.
 
-Cron jobs can leave behind artifact resources such as jobs or pods.  As a user it is important
-to configure history limits so that old jobs and their pods are properly cleaned.  Currently,
+Cron jobs can leave behind artifact resources such as jobs and pods. As a user, it is important
+to configure history limits so that old jobs and their pods are properly cleaned. Currently,
 there are two fields within cron job's spec responsible for that:
 
+[source,yaml]
 ----
 apiVersion: batch/v1beta1
 kind: CronJob
@@ -144,5 +171,5 @@ spec:
   ...
 ----
 
-<1> The number of successful finished jobs to retain (defaults to 3).
-<2> The number of failed finished jobs to retain (defaults to 1).
+<1> The number of successful finished jobs to retain. The default value is `3`.
+<2> The number of failed finished jobs to retain. The default value is `1`.


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1856361

Applies to 3.11.  Updates to 4.x can be done in a separate PR.

* Mostly backported info from 4.6.
* Light verification in a 3.11 lab.
* _Better_ parallelism in the callout list.  I couldn't help myself.
* Set suspend to false in the example to reduce head scratching.