### PR TITLE
BZ1875663 - remove  flag

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -92,11 +92,10 @@ that there are no diagnostic errors or warnings.
 xref:../install/prerequisites.adoc#install-config-install-prerequisites[prerequisites].
 If it does not, your upgrade might fail.
 
-* The day before the upgrade, validate {product-title} storage migration to ensure
-potential issues are resolved before the outage window:
+* The day before the upgrade, validate {product-title} storage migration to ensure potential issues are resolved before the outage window. The following command updates the stored version of API objects for etcd storage:
 +
 ----
-$ oc adm migrate storage --include=* --loglevel=2 --confirm --config /etc/origin/master/admin.kubeconfig
+$ oc adm migrate storage --include=* --loglevel=2 --config /etc/origin/master/admin.kubeconfig
 ----
 
 ifdef::openshift-origin[]
@@ -786,7 +785,7 @@ and run the *_openshift-logging/config.yml_* playbook.
 [NOTE]
 ====
 The upgrade can replace your `logging-fluentd` and `logging-curator` ConfigMaps. If you want to retain your current `logging-fluentd` and `logging-curator` ConfigMaps, set the `openshift_logging_fluentd_replace_configmap` and `openshift_logging_curator_replace_configmap` parameters to `no` in the xref:../install/configuring_inventory_file.adoc#configuring-ansible[inventory host file].
-==== 
+====
 
 The EFK upgrade also upgrades Elasticsearch from version 2 to version 5. For important information on changes in Elasticsearch 5, you should review the link:https://www.elastic.co/guide/en/elasticsearch/reference/5.5/breaking-changes-5.0.html[Elasticsearch breaking changes].
 


### PR DESCRIPTION
[BZ1875663](https://bugzilla.redhat.com/show_bug.cgi?id=1875663) - remove `--confirm` flag from `oc adm migrate storage` command.

@jsafrane or @gnufied - Can either of you comment on these questions from the BZ to perhaps give a little more context to this item in the prereqs?

- What does the command check for?
- Why is it important to run it before upgrade?