### PR TITLE
nodes can only be a member of a single machineconfigpool

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -11,6 +11,11 @@ The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet,
 * A machine config can make a specific change to a file or service on the operating system of each system representing a pool of {product-title} nodes.
 
 * MCO applies changes to operating systems in pools of machines. All {product-title} clusters start with worker and master node pools. By adding more role labels, you can configure custom pools of nodes. For example, you can set up a custom pool of worker nodes that includes particular hardware features needed by an application. However, examples in this section focus on changes to the default pool types.
++
+[IMPORTANT]
+====
+A node can have multiple labels applied that indicate its type, such as `master` or `worker`, however it can be a member of only a *single* machine config pool.
+====
 
 * Some machine configuration must be in place before {product-title} is installed to disk. In most cases, this can be accomplished by creating
 a machine config that is injected directly into the {product-title} installer process, instead of running as a post-installation machine config. In other cases, you might need to do bare metal installation where you pass kernel arguments at {product-title} installer start-up, to do such things as setting per-node individual IP addresses or advanced disk partitioning.


### PR DESCRIPTION
This came up in a question on Slack, so let's explicitly call it out.