### PR TITLE
BZ1903672 - fix Storage docs - TP not enabled by default

### DIFF
--- a/modules/persistent-storage-csi-snapshots-operator.adoc
+++ b/modules/persistent-storage-csi-snapshots-operator.adoc
@@ -5,7 +5,7 @@
 [id="persistent-storage-csi-snapshots-operator_{context}"]
 = About the CSI Snapshot Controller Operator
 
-The CSI Snapshot Controller Operator runs in the `openshift-cluster-storage-operator` namespace. It is installed by the Cluster Version Operator (CVO) in all clusters by default.
+The CSI Snapshot Controller Operator runs in the `openshift-cluster-storage-operator` namespace.
 
 The CSI Snapshot Controller Operator installs the CSI snapshot controller, which runs in the `csi-snapshot-controller` namespace.
 
@@ -16,24 +16,24 @@ During {product-title} installation, the CSI Snapshot Controller Operator create
 VolumeSnapshotContent::
 A snapshot taken of a volume in the cluster that has been provisioned by a cluster administrator.
 +
-Similar to the PersistentVolume CRD, the VolumeSnapshotContent CRD is a cluster resource that points to a real snapshot in the storage backend.
+Similar to the `PersistentVolume` CRD, the `VolumeSnapshotContent` CRD is a cluster resource that points to a real snapshot in the storage back end.
 +
 For manually pre-provisioned snapshots, a cluster administrator creates a number of VolumeSnapshotContent objects. These carry the details of the real volume snapshot in the storage system.
 +
-The VolumeSnapshotContent CRD is not namespaced and is for use by a cluster administrator.
+The `VolumeSnapshotContent` CRD is not namespaced and is for use by a cluster administrator.
 
 VolumeSnapshot::
 
-Similar to PersistentVolumeClaim, the VolumeSnapshot CRD defines a developer request for a snapshot. The CSI Snapshot Controller Operator runs the CSI snapshot controller, which handles the binding of a VolumeSnapshot object with an appropriate VolumeSnapshotContent object. The binding is a one-to-one mapping.
+Similar to `PersistentVolumeClaim`, the `VolumeSnapshot` CRD defines a developer request for a snapshot. The CSI Snapshot Controller Operator runs the CSI snapshot controller, which handles the binding of a `VolumeSnapshot` object with an appropriate `VolumeSnapshotContent` object. The binding is a one-to-one mapping.
 +
-The VolumeSnapshot CRD is namespaced. A developer uses the CRD as a distinct request for a snapshot.
+The `VolumeSnapshot` CRD is namespaced. A developer uses the CRD as a distinct request for a snapshot.
 
 VolumeSnapshotClass::
 
-Allows a cluster administrator to specify different attributes belonging to a VolumeSnapshot object. These attributes may differ among snapshots taken of the same volume on the storage system, in which case they would not be expressed by using the same StorageClass of a PersistentVolumeClaim.
+Allows a cluster administrator to specify different attributes belonging to a `VolumeSnapshot` object. These attributes may differ among snapshots taken of the same volume on the storage system, in which case they would not be expressed by using the same storage class of a persistent volume claim.
 +
-The VolumeSnapshotClass CRD defines the parameters for the `csi-external-snapshotter` sidecar to use when creating a snapshot. This allows the storage backend to know what kind of snapshot to dynamically create if multiple options are supported.
+The `VolumeSnapshotClass` CRD defines the parameters for the `csi-external-snapshotter` sidecar to use when creating a snapshot. This allows the storage back end to know what kind of snapshot to dynamically create if multiple options are supported.
 +
-Dynamically provisioned snapshots use the VolumeSnapshotClass to specify storage-provider-specific parameters to use when creating a snapshot.
+Dynamically provisioned snapshots use the volume snapshot class to specify storage-provider-specific parameters to use when creating a snapshot.
 +
-The VolumeSnapshotContentClass CRD is not namespaced and is for use by a cluster administrator to enable global configuration options for their storage backend.
+The `VolumeSnapshotContentClass` CRD is not namespaced and is for use by a cluster administrator to enable global configuration options for their storage back end.

--- a/modules/persistent-storage-csi-snapshots-overview.adoc
+++ b/modules/persistent-storage-csi-snapshots-overview.adoc
@@ -5,9 +5,7 @@
 [id="persistent-storage-csi-snapshots-overview_{context}"]
 = Overview of CSI volume snapshots
 
-A _snapshot_ represents the state of the storage volume in a cluster at a particular point in time. VolumeSnapshots can be used to provision a new volume.
-
-{product-title} supports CSI volume snapshots by default. However, a specific CSI driver is required.
+A _snapshot_ represents the state of the storage volume in a cluster at a particular point in time. Volume snapshots can be used to provision a new volume. A specific CSI driver is required.
 
 With CSI volume snapshots, a cluster administrator can:
 
@@ -23,10 +21,9 @@ With CSI volume snapshots, an app developer can:
 * Rapidly rollback to a previous development version.
 * Use storage more efficiently by not having to make a full copy each time.
 
-Be aware of the following when using VolumeSnapshot:
+Be aware of the following when using volume snapshots:
 
 * Support is only available for CSI drivers. In-tree and FlexVolumes are not supported.
 * {product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
 link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
-* CSI drivers may or may not have implemented the volume snapshot functionality. CSI drivers that have provided support for VolumeSnapshots will likely use the `csi-external-snapshotter` sidecar. See documentation provided by the CSI driver for details.
-* {product-title} {product-version} supports version 1.1.0 of the link:https://github.com/container-storage-interface/spec[CSI specification].
+* CSI drivers may or may not have implemented the volume snapshot functionality. CSI drivers that have provided support for volume snapshots will likely use the `csi-external-snapshotter` sidecar. See documentation provided by the CSI driver for details.

--- a/modules/storage-expanding-add-volume-expansion.adoc
+++ b/modules/storage-expanding-add-volume-expansion.adoc
@@ -5,14 +5,14 @@
 [id="add-volume-expansion_{context}"]
 = Enabling volume expansion support
 
-Before you can expand persistent volumes, the StorageClass must
+Before you can expand persistent volumes, the storage class must
 have the `allowVolumeExpansion` field set to `true`.
 
 .Procedure
 
-* Edit the StorageClass and add the `allowVolumeExpansion` attribute.
+* Edit the storage class and add the `allowVolumeExpansion` attribute.
 The following example demonstrates adding this line at the bottom
-of the StorageClass's configuration.
+of the storage class configuration.
 +
 [source,yaml]
 ----

--- a/modules/storage-expanding-csi-volumes.adoc
+++ b/modules/storage-expanding-csi-volumes.adoc
@@ -5,12 +5,7 @@
 [id="expanding-csi-volumes_{context}"]
 = Expanding CSI volumes
 
-You can use the Container Storage Interface (CSI) to expand storage volumes after they have already been created.
-
-{product-title} supports CSI volume expansion by default. However, a specific CSI driver is required.
+You can use the Container Storage Interface (CSI) to expand storage volumes after they have already been created. A specific CSI driver is required.
 
 {product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
 link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
-
-{product-title} {product-version} supports version 1.1.0 of the
-link:https://github.com/container-storage-interface/spec[CSI specification].

--- a/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
@@ -14,9 +14,9 @@ include::modules/technology-preview.adoc[leveloffset=+1]
 
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a Container Storage Interface (CSI) Operator and driver.
 
-To create CSI-provisioned PVs that mount to AWS EBS storage assets, {product-title} installs the AWS EBS CSI Driver Operator and the AWS EBS CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
+To create CSI-provisioned PVs that mount to AWS EBS storage assets, the AWS EBS CSI Driver Operator and the AWS EBS CSI driver use the `openshift-cluster-csi-drivers` namespace.
 
-* The _AWS EBS CSI Driver Operator_ provides a StorageClass by default that you can use to create PVCs. You also have the option to create the AWS EBS StorageClass as described in xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent Storage Using AWS Elastic Block Store].
+* The _AWS EBS CSI Driver Operator_ provides a storage class by default that you can use to create PVCs. You also have the option to create the AWS EBS storage class as described in xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent Storage Using AWS Elastic Block Store].
 
 * The _AWS EBS CSI driver_ enables you to create and mount AWS EBS PVs.
 


### PR DESCRIPTION
[BZ1903672](https://bugzilla.redhat.com/show_bug.cgi?id=1903672) - as described in [this doc](https://docs.google.com/document/d/1dkfqbGfi__Cs9UZMZrv1zGaJwXoHxO84YQkMlvrfAo4/edit#), Tech Preview features are opt-in and therefore not enabled by default. This PR fixes wording in Storage docs where we had previously described certain TP features as enabled by default. It also updates a few style guide formatting instances.

@openshift/sig-storage PTAL, thanks!