### PR TITLE
An egress firewall in ovs-multitenant ignores global projects

### DIFF
--- a/admin_guide/managing_networking.adoc
+++ b/admin_guide/managing_networking.adoc
@@ -257,7 +257,7 @@ ifdef::openshift-dedicated[]
 endif::openshift-dedicated[]
 in order to limit pod access via egress policy.
 
-If you are using the *ovs-networkpolicy* plug-in, egress policy is compatible
+If you are using the *ovs-multitenant* plug-in, egress policy is compatible
 with only one policy per project, and will not work with projects that share a
 network, such as global projects.
 ====


### PR DESCRIPTION
Based on Slack conversation.