### PR TITLE
BZ1893600 - clarify disk and partitions in "separate /var partitioning"

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -68,6 +68,8 @@ include::modules/installation-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
+include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
+
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -59,7 +59,7 @@ include::modules/installation-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
+include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -57,6 +57,8 @@ include::modules/installation-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
+include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
+
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * installing-vsphere.adoc
+// * installing-vsphere-network-customizations.adoc
+// * installing-restricted-networks-vsphere.adoc
+
+// This content was sourced from the bare metal RHCOS assembly file `modules/installation-user-infra-machines-advanced.adoc` under the `== Disk partitioning` subheader. "Disk partioning" content in the bare metal assembly is not modularized, so anything in this vsphere module should be checked against that file for consistency until such time that the large bare metal assembly can be modularized.
+
+[id="installation-disk-partitioning_{context}"]
+= Disk partitioning
+
+In most cases, data partitions are originally created by installing {op-system}, rather than by installing another operating system. In such cases, the {product-title} installer should be allowed to configure your disk partitions.
+
+However, there are two cases where you might want to intervene to override the default partitioning when installing an
+{product-title} node:
+
+* Create separate partitions: For greenfield installations on an empty
+disk, you might want to add separate storage to a partition. This is
+officially supported for making `/var` or a subdirectory of `/var`, such as `/var/lib/etcd`, a separate partition, but not both.
++
+[IMPORTANT]
+====
+Kubernetes supports only two filesystem partitions. If you add more than one partition to the original configuration, Kubernetes cannot monitor all of them.
+====
+* Retain existing partitions: For a brownfield installation where you are reinstalling {product-title} on an existing node and want to retain data partitions installed from your previous operating system, there are both boot arguments and options to `coreos-installer` that allow you to retain existing data partitions.
+
+[discrete]
+= Creating a separate `/var` partition
+In general, disk partitioning for {product-title} should be left to the
+installer. However, there are cases where you might want to create separate partitions in a part of the filesystem that you expect to grow.
+
+{product-title} supports the addition of a single partition to attach
+storage to either the `/var` partition or a subdirectory of `/var`.
+For example:
+
+* `/var/lib/containers`: Holds container-related content that can grow
+as more images and containers are added to a system.
+* `/var/lib/etcd`: Holds data that you might want to keep separate for purposes such as performance optimization of etcd storage.
+* `/var`: Holds data that you might want to keep separate for purposes such as auditing.
+
+Storing the contents of a `/var` directory separately makes it easier to grow storage for those areas as needed and reinstall {product-title} at a later date and keep that data intact. With this method, you will not have to pull all your containers again, nor will you have to copy massive log files when you update systems.
+
+Because `/var` must be in place before a fresh installation of
+{op-system-first}, the following procedure sets up the separate `/var` partition
+by creating a machine config that is inserted during the `openshift-install`
+preparation phases of an {product-title} installation.
+
+.Procedure
+
+. Create a directory to hold the {product-title} installation files:
++
+[source,terminal]
+----
+$ mkdir $HOME/clusterconfig
+----
+
+. Run `openshift-install` to create a set of files in the `manifest` and
+`openshift` subdirectories. Answer the system questions as you are prompted:
++
+[source,terminal]
+----
+$ openshift-install create manifests --dir $HOME/clusterconfig
+? SSH Public Key ...
+$ ls $HOME/clusterconfig/openshift/
+99_kubeadmin-password-secret.yaml
+99_openshift-cluster-api_master-machines-0.yaml
+99_openshift-cluster-api_master-machines-1.yaml
+99_openshift-cluster-api_master-machines-2.yaml
+...
+----
+
+. Create a `MachineConfig` object and add it to a file in the `openshift` directory.
+For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This attaches storage to a separate `/var`
+directory.
+
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 98-var-partition
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      disks:
+      - device: /dev/<device_name> <1>
+        partitions:
+        - sizeMiB: <partition_size>
+          startMiB: <partition_start_offset> <2>
+          label: var
+      filesystems:
+        - path: /var
+          device: /dev/disk/by-partlabel/var
+          format: xfs
+    systemd:
+      units:
+        - name: var.mount
+          enabled: true
+          contents: |
+            [Unit]
+            Before=local-fs.target
+            [Mount]
+            Where=/var
+            What=/dev/disk/by-partlabel/var
+            [Install]
+            WantedBy=local-fs.target
+----
++
+<1> The storage device name of the disk that you want to partition.
+<2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+
+. Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
++
+[source,terminal]
+----
+$ openshift-install create ignition-configs --dir $HOME/clusterconfig
+$ ls $HOME/clusterconfig/
+auth  bootstrap.ign  master.ign  metadata.json  worker.ign
+----
+
+Now you can use the Ignition config files as input to the vSphere installation procedures to install {op-system-first} systems.

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -55,24 +55,28 @@ $ coreos-installer install --copy-network \
 
 [id="installation-user-infra-machines-advanced_disk_{context}"]
 == Disk partitioning
-In most cases, the {product-title} installer should be allowed to configure
-your disk partitions. However, there are two cases where you might want to
-intervene to override the default partitioning when installing an
+
+// This content is not modularized, so any updates to this "Disk partitioning" section should be checked against the module created for vSphere UPI parity in the module file named `installation-disk-partitioning.adoc` for consistency until such time as this large assembly can be modularized.
+
+In most cases, data partitions are originally created by installing {op-system}, rather than by installing another operating system. In such cases, the {product-title} installer should be allowed to configure your disk partitions.
+
+However, there are two cases where you might want to intervene to override the default partitioning when installing an
 {product-title} node:
 
 * Create separate partitions: For greenfield installations on an empty
-disk, you might want to add separate storage to a partition. This is only
-officially supported for making `/var` or a subdirectory of `/var` a separate
-partition, but not both. If you create more than one partition, Kubernetes
-will not be able to monitor them both.
-
-* Retain existing partitions: For a brownfield installation, where you are reinstalling on an existing {product-title} node and want to retain data partitions from your previous operating system, there are both boot arguments and options to `coreos-installer` that allow you to retain existing data partitions.
+disk, you might want to add separate storage to a partition. This is
+officially supported for making `/var` or a subdirectory of `/var`, such as `/var/lib/etcd`, a separate partition, but not both.
++
+[IMPORTANT]
+====
+Kubernetes supports only two filesystem partitions. If you add more than one partition to the original configuration, Kubernetes cannot monitor all of them.
+====
+* Retain existing partitions: For a brownfield installation where you are reinstalling {product-title} on an existing node and want to retain data partitions installed from your previous operating system, there are both boot arguments and options to `coreos-installer` that allow you to retain existing data partitions.
 
 [id="installation-user-infra-machines-advanced_vardisk_{context}"]
 === Creating a separate `/var` partition
 In general, disk partitioning for {product-title} should be left to the
-installer. However, there are cases where you might want to create a
-separate partition in a part of the file system that you expect to grow.
+installer. However, there are cases where you might want to create separate partitions in a part of the filesystem that you expect to grow.
 
 {product-title} supports the addition of a single partition to attach
 storage to either the `/var` partition or a subdirectory of `/var`.
@@ -80,8 +84,8 @@ For example:
 
 * `/var/lib/containers`: Holds container-related content that can grow
 as more images and containers are added to a system.
-* `/var`: Holds data that you might want to keep separate for purposes such as
-auditing.
+* `/var/lib/etcd`: Holds data that you might want to keep separate for purposes such as performance optimization of etcd storage.
+* `/var`: Holds data that you might want to keep separate for purposes such as auditing.
 
 Storing the contents of a `/var` directory separately makes it easier to grow storage for those areas as needed and reinstall {product-title} at a later date and keep that data intact. With this method, you will not have to pull all your containers again, nor will you have to copy massive log files when you update systems.
 
@@ -116,7 +120,7 @@ $ ls $HOME/clusterconfig/openshift/
 
 . Create a `MachineConfig` object and add it to a file in the `openshift` directory.
 For example, name the file `98-var-partition.yaml`,
-change the device name to the name of the storage device on the `worker` systems,
+change the disk device name to the name of the storage device on the `worker` systems,
 and set the storage size as appropriate. This attaches storage to a separate `/var`
 directory.
 


### PR DESCRIPTION
[BZ1893600](https://bugzilla.redhat.com/show_bug.cgi?id=1893600)
Since the time that this bug was reported, we have begun addressing the most critical aspect of this bug in regards to documenting the Static IP config details in the vSphere docs and not just the release notes. This work is in final review and should be merged soon via https://github.com/openshift/openshift-docs/pull/27394.

Here in this separate PR, I have sought to clarify partitions/nodes where I thought it might help. I'm uncertain whether OCP supports adding more than one disk/partition to RHCOS with separate /var partitioning, so see my question inline.

Lastly, the BZ asks:
> Why do you put a general disk topic (separate /var) ONLY into the bare metal chapter? This applies to ALL platforms!

But is this ^^ true? My very amateur and writer-ly understanding is that separating /var partitions is recommended only for bare metal installs.

See also: [BZ1898275](https://bugzilla.redhat.com/show_bug.cgi?id=1898275)