### PR TITLE
BZ1903547: Update podman req to v1.9.3+

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -27,7 +27,7 @@ to both your network and the Internet.
 
 * Workstation with unrestricted network access
 * `oc` version 4.3.5+
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * If you are working with private registries, set the `REG_CREDS` environment

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -10,7 +10,7 @@ You can create an index image using the `opm` CLI.
 .Prerequisites
 
 * `opm` version 1.12.3+
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 
 .Procedure

--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -17,7 +17,7 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 .Prerequisites
 
 * For Linux, you must provide the following packages:
-** `podman` version 1.4.4+ (version 2.0+ recommended)
+** `podman` version 1.9.3+ (version 2.0+ recommended)
 ** `glibc` version 2.28+
 
 .Procedure

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -32,7 +32,7 @@ For the steps in this procedure, the target registry is an existing mirror regis
 .Prerequisites
 
 * Workstation with unrestricted network access
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:

--- a/modules/olm-mirroring-package-manifest-catalog.adoc
+++ b/modules/olm-mirroring-package-manifest-catalog.adoc
@@ -16,7 +16,7 @@ registry.
 * Workstation with unrestricted network access
 * A custom Operator catalog image based on the Package Manifest Format pushed to a supported registry
 * `oc` version 4.3.5+
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * If you are working with private registries, set the `REG_CREDS` environment

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -39,7 +39,7 @@ endif::[]
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
 endif::[]
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 * `opm` version 1.12.3+
 * Access to a registry that supports

--- a/modules/olm-testing-operator-catalog-image.adoc
+++ b/modules/olm-testing-operator-catalog-image.adoc
@@ -14,7 +14,7 @@ catalog image previously built and pushed to a supported registry.
 .Prerequisites
 
 * A custom Package Manifest Format catalog image pushed to a supported registry
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * `oc` version 4.3.5+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -13,7 +13,7 @@ You can update an existing index image using the `opm index add` commad.
 .Prerequisites
 
 * `opm` version 1.12.3+
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * An index image built and pushed to a registry.
 * An existing CatalogSource referencing the index image.
 

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -26,7 +26,7 @@ image is already configured for use with OperatorHub.
 
 * Workstation with unrestricted network access
 * `oc` version 4.3.5+
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * Access to mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * OperatorHub configured to use custom catalog images

--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -11,7 +11,7 @@ SDK.
 .Prerequisites
 
 * Operator SDK version 0.19.4
-* `podman` version 1.4.4+
+* `podman` version 1.9.3+
 * An Operator project generated using the Operator SDK
 * Access to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -32,7 +32,7 @@ ifdef::openshift-origin[]
 - link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
 ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
 endif::[]
 - OpenShift CLI (`oc`) v{product-version}+ installed
 - Access to a cluster based on Kubernetes v1.12.0+
@@ -184,7 +184,7 @@ ifdef::openshift-origin[]
 - link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
 ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
 endif::[]
 - OpenShift CLI (`oc`) v{product-version}+ installed
 - Access to a cluster based on Kubernetes v1.12.0+
@@ -219,7 +219,7 @@ ifdef::openshift-origin[]
 - link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
 endif::[]
 ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.2.0+, or `buildah` v1.7+
+- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
 endif::[]
 - OpenShift CLI (`oc`) v{product-version}+ installed
 - Access to a cluster based on Kubernetes v1.12.0+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1903547

Bumping for OCP 4.6+ docs per requirement of the `opm index prune` command. I've just bumped all OLM/OSDK-related recommendations at once.

FWIW, it looks like `podman` v2+ is only available in RHEL8 channels. The OCP 4.6 channel itself only goes up to 1.9.3. I'm not sure if that's worth getting into in these OCP docs though, as I believe an OCP subscription should give customers access to that channel too:

https://access.redhat.com/downloads/content/podman/2.0.5-5.module+el8.3.0+8221+97165c3f/x86_64/fd431d51/package