### PR TITLE
Removing OKE abbreviation as it is not allowed

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -386,7 +386,7 @@ h|
 | X
 | X
 
-| OpenShift Container Storage Sub Compatibility (not included in OCP or OKE)
+| OpenShift Container Storage Sub Compatibility (not included in OCP or {oke})
 | X
 | X
 
@@ -411,7 +411,7 @@ h|
 | X
 | X
 
-| ISV or Partner Operator and Container Compatibility (not included in OCP or OKE)
+| ISV or Partner Operator and Container Compatibility (not included in OCP or {oke})
 | X
 | X
 


### PR DESCRIPTION
According to a recent word nerds meeting recap, OKE is not an allowed abbreviation for OpenShift Kubernetes Engine.