### PR TITLE
BZ 1898042: disclaimers about VMs getting OOM killed

### DIFF
--- a/modules/virt-configuring-guest-memory-overcommitment.adoc
+++ b/modules/virt-configuring-guest-memory-overcommitment.adoc
@@ -5,27 +5,22 @@
 [id="virt-configuring-guest-memory-overcommitment_{context}"]
 = Configuring guest memory overcommitment
 
-If your virtual workload requires more memory than available, you can
-use memory overcommitment to allocate all or most of the host’s memory
-to your virtual machine instances. Enabling memory overcommitment means
-you can maximize resources that are normally reserved for the host.
+If your virtual workload requires more memory than available, you can use memory overcommitment to allocate all or most of the host’s memory to your virtual machine instances (VMIs). Enabling memory overcommitment means that you can maximize resources that are normally reserved for the host.
 
-For example, if the host has 32 GB RAM, you can use memory
-overcommitment to fit 8 virtual machines with 4 GB RAM each. This allocation works under the
-assumption that the virtual machines will not use all of their memory at the same
-time.
+For example, if the host has 32 GB RAM, you can use memory overcommitment to fit 8 virtual machines (VMs) with 4 GB RAM each. This allocation works under the assumption that the virtual machines will not use all of their memory at the same time.
+
+[IMPORTANT]
+====
+Memory overcommitment increases the potential for virtual machine processes to be killed due to memory pressure (OOM killed).
+
+The potential for a VM to be OOM killed varies based on your specific configuration, node memory, available swap space, virtual machine memory consumption, the use of kernel same-page merging (KSM), and other factors.
+====
 
 .Procedure
 
-. To explicitly tell the virtual machine instance that it has more memory available than
-was requested from the cluster, edit the virtual machine configuration file and
-set `spec.domain.memory.guest` to a higher value than
-`spec.domain.resources.requests.memory`. This process is called memory
-overcommitment.
+. To explicitly tell the virtual machine instance that it has more memory available than was requested from the cluster, edit the virtual machine configuration file and set `spec.domain.memory.guest` to a higher value than `spec.domain.resources.requests.memory`. This process is called memory overcommitment.
 +
-In this example, `1024M` is requested from the cluster, but the virtual machine instance is
-told that it has `2048M` available. As long as there is enough free memory
-available on the node, the virtual machine instance will consume up to 2048M.
+In this example, `1024M` is requested from the cluster, but the virtual machine instance is told that it has `2048M` available. As long as there is enough free memory available on the node, the virtual machine instance will consume up to 2048M.
 +
 
 [source,yaml]
@@ -43,8 +38,7 @@ spec:
 +
 [NOTE]
 ====
-The same eviction rules as those for pods apply to the virtual machine instance if
-the node is under memory pressure.
+The same eviction rules as those for pods apply to the virtual machine instance if the node is under memory pressure.
 ====
 
 . Create the virtual machine:
@@ -52,5 +46,5 @@ the node is under memory pressure.
 
 [source,terminal]
 ----
-$ oc create -f <file name>.yaml
+$ oc create -f <file_name>.yaml
 ----

--- a/modules/virt-disabling-guest-memory-overhead-accounting.adoc
+++ b/modules/virt-disabling-guest-memory-overhead-accounting.adoc
@@ -5,25 +5,20 @@
 [id="virt-disabling-guest-memory-overhead-accounting_{context}"]
 = Disabling guest memory overhead accounting
 
-[WARNING]
+A small amount of memory is requested by each virtual machine instance in addition to the amount that you request. This additional memory is used for the infrastructure that wraps each `VirtualMachineInstance` process.
+
+Though it is not usually advisable, it is possible to increase the virtual machine instance density on the node by disabling guest memory overhead accounting.
+
+[IMPORTANT]
 ====
-This procedure is only useful in certain use-cases and must
-only be attempted by advanced users.
+Disabling guest memory overhead accounting increases the potential for virtual machine processes to be killed due to memory pressure (OOM killed).
+
+The potential for a VM to be OOM killed varies based on your specific configuration, node memory, available swap space, virtual machine memory consumption, the use of kernel same-page merging (KSM), and other factors.
 ====
-
-A small amount of memory is requested by each virtual machine instance in
-addition to the amount that you request. This additional memory is used for
-the infrastructure that wraps each `VirtualMachineInstance` process.
-
-Though it is not usually advisable, it is possible to increase the virtual machine instance
-density on the node by disabling guest memory overhead accounting.
-
 
 .Procedure
 
-. To disable guest memory overhead accounting, edit the YAML configuration
-file and set the `overcommitGuestOverhead` value to `true`. This parameter is
-disabled by default.
+. To disable guest memory overhead accounting, edit the YAML configuration file and set the `overcommitGuestOverhead` value to `true`. This parameter is disabled by default.
 +
 [source,yaml]
 ----
@@ -39,8 +34,7 @@ spec:
 +
 [NOTE]
 ====
-If `overcommitGuestOverhead` is enabled, it adds the guest overhead
-to memory limits, if present.
+If `overcommitGuestOverhead` is enabled, it adds the guest overhead to memory limits, if present.
 ====
 
 . Create the virtual machine:

--- a/virt/virtual_machines/advanced_vm_management/virt-managing-guest-memory.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-managing-guest-memory.adoc
@@ -4,13 +4,12 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-managing-guest-memory
 toc::[]
 
-If you want to adjust guest memory settings to suit a specific use case, you can
-do so by editing the guest's YAML configuration file. {VirtProductName} allows you
-to configure guest memory overcommitment and disable guest memory overhead
-accounting.
+If you want to adjust guest memory settings to suit a specific use case, you can do so by editing the guest's YAML configuration file. {VirtProductName} allows you to configure guest memory overcommitment and disable guest memory overhead accounting.
 
-Both of these procedures carry some degree of risk. Proceed only if you are
-an experienced administrator.
+[WARNING]
+====
+The following procedures increase the chance that virtual machine processes will be killed due to memory pressure. Proceed only if you understand the risks.
+====
 
 include::modules/virt-configuring-guest-memory-overcommitment.adoc[leveloffset=+1]
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1898042
Preview build: https://oomkill-warning--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-managing-guest-memory.html

Adding more explicit warnings about the risks of two advanced memory management procedures. Also unwrapped a few lines.

4.6, 4.7 (and maybe 4.5)

@fabiand, can you please review? Thanks!