### PR TITLE
Require --filter-by-os='.*' for OLM mirroring

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -81,14 +81,14 @@ $ oc adm catalog mirror \
     <mirror_registry>:<port> \//<2>
     [-a ${REG_CREDS}] \//<3>
     [--insecure] \//<4>
-    [--filter-by-os="<os>/<arch>"] \//<5>
+    --filter-by-os='.*' \//<5>
     [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
 <2> Specify the target registry to mirror the Operator content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<5> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<5> This flag is currently required due to a known issue with multiple architecture support. If unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
 <6> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
 +
 .Example output


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1890951.

Preview (internal):

Step 3 - http://file.rdu.redhat.com/~adellape/120320/filterbyos_all/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks