### PR TITLE
CNV - version bump and upgrade note

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,8 +14,8 @@
 :ProductVersion:
 :VirtVersion: 2.5
 :KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.0
-:LastHCOVersion: 2.4.3
+:HCOVersion: 2.5.1
+// :LastHCOVersion: 2.4.4
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -35,8 +35,8 @@ $ oc get csv
 [source,terminal,subs="attributes+"]
 ----
 VERSION  REPLACES                                        PHASE
-{HCOVersion}    kubevirt-hyperconverged-operator.v{LastHCOVersion}         Installing
-{LastHCOVersion}                                                    Replacing
+2.5.0    kubevirt-hyperconverged-operator.v2.4.3         Installing
+2.4.3                                                    Replacing
 ----
 
 . Optional: Monitor the aggregated status of all {VirtProductName} component

--- a/modules/virt-upgrade-pathways.adoc
+++ b/modules/virt-upgrade-pathways.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * virt/upgrading-virt.adoc
+
+[id="virt-upgrade-pathways_{context}"]
+= Upgrade pathways for minor releases
+
+The upgrade pathway is different depending on the 2.4.z version of {VirtProductName} that you have installed.
+
+[id="virt-upgrade-pathways-2.4.3_{context}"]
+== Upgrading from 2.4.3 to 2.5.1
+
+You must first upgrade to 2.5.0 before you can upgrade the z-stream. You can then upgrade from 2.5.0 to 2.5.1.
+
+If your *Approval Strategy* is *Automatic*, which is the default, {VirtProductName} upgrades the z-stream automatically once you have upgraded to 2.5.0.
+
+[id="virt-upgrade-pathways-2.4.4_{context}"]
+== Upgrading from 2.4.4 to 2.5.1
+
+You cannot currently upgrade from 2.4.4 to 2.5.0 or 2.5.1.
+
+// This needs to be updated when 2.5.2 is released

--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -9,6 +9,8 @@ monitor the status of an update by using the web console.
 
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
+include::modules/virt-upgrade-pathways.adoc[leveloffset=+1]
+
 include::modules/virt-upgrading-virt.adoc[leveloffset=+1]
 
 include::modules/virt-monitoring-upgrade-status.adoc[leveloffset=+1]


### PR DESCRIPTION
1. Bumped the LastHCOVersion variable to 2.4.4 (only appears in the monitoring upgrade module)
2. Bumped the HCOVersion variable to 2.5.1
3. Where the HCOVersion variable was used in the monitoring upgrade module, have hard-coded to 2.5.0
4. Added Module to Upgrading OpenShift Virt assembly to describe upgrade pathways of 2.4.3 -> 2.5.0 -> 2.5.1 or 2.4.4 -> 2.5.2 (not yet released) as plainly as possible

New content for upgrade pathway:
https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-upgrade-pathways_upgrading-virt

Hardcoded minor upgrade (2.4.3 to 2.5.0):
https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-monitoring-upgrade-status_upgrading-virt

HCOVariable rendered as 2.5.1 in the following sections:
https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data.html#virt-about-collecting-virt-data_virt-collecting-virt-data

https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data.html#gathering-data-specific-features_virt-collecting-virt-data

https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt-cli.html#virt-deleting-virt-cli_uninstalling-virt-cli

https://cnv-zstream-bump--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html#virt-subscribing-cli_installing-virt-cli