### PR TITLE
Rel Notes doc text for 4.5.22 release

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -5,48 +5,29 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat {product-title} provides developers and IT organizations with a hybrid
-cloud application platform for deploying both new and existing applications on
-secure, scalable resources with minimal configuration and management overhead.
-{product-title} supports a wide selection of programming languages and
-frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
+Red Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management overhead. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
-Built on Red Hat Enterprise Linux (RHEL) and Kubernetes, {product-title}
-provides a more secure and scalable multi-tenant operating system for today's
-enterprise-class applications, while delivering integrated application runtimes
-and libraries. {product-title} enables organizations to meet security, privacy,
-compliance, and governance requirements.
+Built on Red Hat Enterprise Linux (RHEL) and Kubernetes, {product-title} provides a more secure and scalable multi-tenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
 [id="ocp-4-5-about-this-release"]
 == About this release
 
-Red Hat {product-title}
-(link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409]) is now
-available. This release uses link:https://v1-18.docs.kubernetes.io/docs/setup/release/notes/[Kubernetes 1.18] with CRI-O runtime. New features, changes, and known issues that pertain to
-{product-title} {product-version} are included in this topic.
+Red Hat {product-title} (link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409]) is now available. This release uses link:https://v1-18.docs.kubernetes.io/docs/setup/release/notes/[Kubernetes 1.18] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-Red Hat did not publicly release {product-title} 4.5.0 as the GA version and,
-instead, is releasing {product-title} 4.5.1 as the GA version.
+Red Hat did not publicly release {product-title} 4.5.0 as the GA version and, instead, is releasing {product-title} 4.5.1 as the GA version.
 
-{product-title} {product-version} clusters are available at
-https://cloud.redhat.com/openshift. The {cloud-redhat-com}
-application for {product-title} allows you to deploy OpenShift clusters to
-either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
 {product-title} {product-version} is supported on RHEL 7, version 7.7 or later, as well as {op-system-first} 4.5.
 
-You must use {op-system} for the control plane, which are also known as master machines, and
-can use either {op-system} or RHEL 7, version 7.7 or later, for
-compute machines, which are also known as worker machines.
+You must use {op-system} for the control plane, which are also known as master machines, and can use either {op-system} or RHEL 7, version 7.7 or later, for compute machines, which are also known as worker machines.
 
 [IMPORTANT]
 ====
 Because only RHEL 7, version 7.7 or later, is supported for compute machines, you must not upgrade the RHEL compute machines to version 8.
 ====
 
-With the release of {product-title} 4.5, version 4.2 is now end of life. For
-more information, see the
-link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+With the release of {product-title} 4.5, version 4.2 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [id="ocp-4-5-new-features-and-enhancements"]
 == New features and enhancements
@@ -59,42 +40,32 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-5-installing-cluster-on-vsphere-using-installer-provisioned-infra"]
 ==== Installing a cluster on vSphere using installer-provisioned infrastructure
 
-{product-title} 4.5 introduces support for installing a cluster on vSphere using
-installer-provisioned infrastructure.
+{product-title} 4.5 introduces support for installing a cluster on vSphere using installer-provisioned infrastructure.
 
 // For more information, see ../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[Installing a cluster on vSphere]
 
 [id="ocp-4-5-installing-cluster-on-gcp-using-user-provisioned-infra-and-shared-vpc"]
 ==== Installing a cluster on GCP using user-provisioned infrastructure and a shared VPC
 
-{product-title} 4.5 introduces support for installing a cluster on Google Cloud
-Platform (GCP) using user-provisioned infrastructure and a shared VPC.
+{product-title} 4.5 introduces support for installing a cluster on Google Cloud Platform (GCP) using user-provisioned infrastructure and a shared VPC.
 
 // For more information, see ../installing//installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[Installing a cluster on GCP using Deployment Manager templates and a shared VPC].
 
 [id="ocp-4-5-three-node-bare-metal-deployments"]
 ==== Three-node bare metal deployments
 
-You can install and run three-node clusters in {product-title} with no workers.
-This provides smaller, more resource efficient clusters for deployment,
-development, and testing.
+You can install and run three-node clusters in {product-title} with no workers. This provides smaller, more resource efficient clusters for deployment, development, and testing.
 
-Previously in Technology Preview, this feature is now fully supported in
-{product-title} 4.5.
+Previously in Technology Preview, this feature is now fully supported in {product-title} 4.5.
 
-For more information, see
-xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installation-three-node-cluster_installing-bare-metal[Running a three-node cluster].
+For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installation-three-node-cluster_installing-bare-metal[Running a three-node cluster].
 
 [id="ocp-4-5-restricted-network-cluster-upgrade-improvements"]
 ==== Restricted network cluster upgrade improvements
 
-The Cluster Version Operator (CVO) can now verify the release images if the
-image signature is available as a config map in the cluster during the upgrade
-process for a restricted network cluster. This removes the need for using the
-`--force` flag during upgrades in a restricted network environment.
+The Cluster Version Operator (CVO) can now verify the release images if the image signature is available as a config map in the cluster during the upgrade process for a restricted network cluster. This removes the need for using the `--force` flag during upgrades in a restricted network environment.
 
-This improved upgrade workflow is completed by running the enhanced
-`oc adm release mirror` command. The following actions are performed:
+This improved upgrade workflow is completed by running the enhanced `oc adm release mirror` command. The following actions are performed:
 
 * Pulls the image signature from the release during the mirroring process.
 * Applies the signature config map directly to the connected cluster.
@@ -105,11 +76,7 @@ This improved upgrade workflow is completed by running the enhanced
 [id="ocp-4-5-migrate-azure-private-dns-zones"]
 ==== Migrating Azure private DNS zones
 
-There is now a new `openshift-install migrate` command available for migrating
-Azure private DNS zones. If you installed an {product-title} version 4.2 or 4.3
-cluster on Azure that uses installer-provisioned infrastructure, your cluster
-might use a legacy private DNS zone. If it does, you must migrate it to the new
-type of private DNS zone.
+There is now a new `openshift-install migrate` command available for migrating Azure private DNS zones. If you installed an {product-title} version 4.2 or 4.3 cluster on Azure that uses installer-provisioned infrastructure, your cluster might use a legacy private DNS zone. If it does, you must migrate it to the new type of private DNS zone.
 
 // For more information on this new command and migrating Azure private DNS
 // zones, see ../installing/installing_azure/migrating-azure-dns-zones.adoc#migrating-azure-dns-zones[Migrating legacy Azure DNS zones].
@@ -117,20 +84,12 @@ type of private DNS zone.
 [id="ocp-4-5-built-in-help-for-installconfig-supported-fields"]
 ==== Built-in help for `install-config.yaml` supported fields
 
-There is a new `openshift-install explain` command available that lists all the
-fields for supported `install-config.yaml` file versions including a short
-description explaining each resource. It also provides details on which fields
-are mandatory and specifies their default value. Using the `explain` command
-reduces the need to continually look up configuration options when creating or
-customizing the `install-config.yaml` file.
+There is a new `openshift-install explain` command available that lists all the fields for supported `install-config.yaml` file versions including a short description explaining each resource. It also provides details on which fields are mandatory and specifies their default value. Using the `explain` command reduces the need to continually look up configuration options when creating or customizing the `install-config.yaml` file.
 
 [id="ocp-4-5-encrypt-ebs-instance-volumes-with-kms-key"]
 ==== Encrypt EBS instance volumes with a KMS key
 
-You can now define a KMS key to encrypt EBS instance volumes. This is useful if
-you have explicit compliance and security guidelines when deploying to AWS. The
-KMS key can be configured in the `install-config.yaml` file by setting the
-optional `kmsKeyARN` field. For example:
+You can now define a KMS key to encrypt EBS instance volumes. This is useful if you have explicit compliance and security guidelines when deploying to AWS. The KMS key can be configured in the `install-config.yaml` file by setting the optional `kmsKeyARN` field. For example:
 
 [source,yaml]
 ----
@@ -147,45 +106,32 @@ compute:
 ...
 ----
 
-If no key is specified, the account's default KMS key for that particular region
-is used.
+If no key is specified, the account's default KMS key for that particular region is used.
 
 [id="ocp-4-5-install-to-pre-existing-vpc-with-multiple-cidrs-on-aws"]
 ==== Install to pre-existing VPC with multiple CIDRs on AWS
 
-You can now install {product-title} to a VPC with more than one CIDR on AWS.
-This lets you select secondary CIDRs for the machine network. When the VPC is
-provisioned by the installer, it does not create multiple CIDRs or configure the
-routing between subnets. Installing to a pre-existing VPC with multiple CIDRs is
-supported for both user-provisioned and installer-provisioned infrastructure
-installation workflows.
+You can now install {product-title} to a VPC with more than one CIDR on AWS. This lets you select secondary CIDRs for the machine network. When the VPC is provisioned by the installer, it does not create multiple CIDRs or configure the routing between subnets. Installing to a pre-existing VPC with multiple CIDRs is supported for both user-provisioned and installer-provisioned infrastructure installation workflows.
 
 [id="ocp-4-5-adding-custom-domain-names-to-aws-vpc-dhcp-options"]
 ==== Adding custom domain names to AWS Virtual Private Cloud (VPC) DHCP option sets
 
-Custom domain names can now be added to AWS Virtual Private Cloud (VPC) DHCP
-option sets. This enables certificate signing request (CSR) approval of new
-nodes when custom DHCP options are used.
+Custom domain names can now be added to AWS Virtual Private Cloud (VPC) DHCP option sets. This enables certificate signing request (CSR) approval of new nodes when custom DHCP options are used.
 
 [id="ocp-4-5-provisioning-ipv6-in-ironic"]
 ==== Provisioning bare metal hosts using IPv6 with Ironic
 
-Binaries required for IPv6 provisioning using the UEFI networking stack have now
-been introduced in Ironic. You can now provision bare metal hosts using IPv6
-with Ironic. The `snpnoly.efi` bootloader executable and compatible iPXE
-binaries are now included in the `tftpboot` directory.
+Binaries required for IPv6 provisioning using the UEFI networking stack have now been introduced in Ironic. You can now provision bare metal hosts using IPv6 with Ironic. The `snpnoly.efi` bootloader executable and compatible iPXE binaries are now included in the `tftpboot` directory.
 
 [id="ocp-4-5-openstack-custom-networking"]
 ==== Custom networks and subnets for clusters on {rh-openstack}
 
-{product-title} {product-version} introduces support for installing clusters on {rh-openstack-first}
- that rely on preexisting networks and subnets.
+{product-title} {product-version} introduces support for installing clusters on {rh-openstack-first} that rely on preexisting networks and subnets.
 
 [id="ocp-4-5-openstack-additional-networks"]
 ==== Additional networks for clusters on {rh-openstack}
 
-{product-title} {product-version} introduces support for multiple networks in clusters that run on {rh-openstack}.
-You can specify these networks for both control plane and compute machines during installation.
+{product-title} {product-version} introduces support for multiple networks in clusters that run on {rh-openstack}. You can specify these networks for both control plane and compute machines during installation.
 
 [id="ocp-4-5-openstack-kuryr-octavia"]
 ==== Improved {rh-openstack} load balancer upgrade experience for clusters that use Kuryr
@@ -217,13 +163,7 @@ Master nodes can now be named as any valid hostname. See link:https://bugzilla.r
 [id="ocp-4-5-octavia-supports-listeners-on-same-port"]
 ==== Octavia OVN provider driver supports listeners on same port
 
-The `ovn-octavia` driver now supports listeners on the same port for different
-protocols. This was not supported previously on the `ovn-octavia` driver, but
-now it is supported and there is no need to block it. This means that it is
-possible to have, for instance, the DNS service expose port 53 in both TCP
-and UDP protocols when using `ovn-octavia`. See
-link:https://bugzilla.redhat.com/show_bug.cgi?id=1846452[*BZ#1846452*] for more
-information.
+The `ovn-octavia` driver now supports listeners on the same port for different protocols. This was not supported previously on the `ovn-octavia` driver, but now it is supported and there is no need to block it. This means that it is possible to have, for instance, the DNS service expose port 53 in both TCP and UDP protocols when using `ovn-octavia`. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1846452[*BZ#1846452*] for more information.
 
 [id="ocp-4-5-security"]
 === Security
@@ -231,8 +171,7 @@ information.
 [id="ocp-4-5-security-oauth-proxy-imagestream-restricted-network"]
 ==== Using the `oauth-proxy` image stream in restricted network installations
 
-The `oauth-proxy` image can now be consumed by external components in restricted
-network installations by using the `oauth-proxy` image stream.
+The `oauth-proxy` image can now be consumed by external components in restricted network installations by using the `oauth-proxy` image stream.
 
 [id="ocp-4-5-images"]
 === Images
@@ -240,15 +179,12 @@ network installations by using the `oauth-proxy` image stream.
 [id="ocp-4-5-images-mirroring-files"]
 ==== Mirroring release images to and from files
 
-You can now mirror release images from a registry to a file and from a file to a
-registry.
+You can now mirror release images from a registry to a file and from a file to a registry.
 
 [id="ocp-4-5-images-mirror-release-image-signatures"]
 ==== Mirroring release image signatures
 
-The `oc adm release mirror` command was extended to also create and apply
-config map manifests that contain the release image signature, which the Cluster
-Version Operator can use to verify the mirrored release.
+The `oc adm release mirror` command was extended to also create and apply config map manifests that contain the release image signature, which the Cluster Version Operator can use to verify the mirrored release.
 
 [id="ocp-4-5-machine-api"]
 === Machine API
@@ -256,10 +192,7 @@ Version Operator can use to verify the mirrored release.
 [id="ocp-4-5-aws-machinesets-support-spot-instances"]
 ==== AWS machine sets support spot instances
 
-AWS machine sets now support spot instances. This lets you create a machine set
-that deploys machines as spot instances so you can save costs compared to
-on-demand instance prices. You can configure spot instances by adding the
-following line under the `providerSpec` field in the machine set YAML file:
+AWS machine sets now support spot instances. This lets you create a machine set that deploys machines as spot instances so you can save costs compared to on-demand instance prices. You can configure spot instances by adding the following line under the `providerSpec` field in the machine set YAML file:
 
 [source,yaml]
 ----
@@ -271,30 +204,21 @@ providerSpec:
 [id="ocp-4-5-autoscaling-the-minimum-number-of-machines"]
 ==== Autoscaling the minimum number of machines to 0
 
-You can now set the minimum number of replicas for a machine autoscaler to `0`.
-This allows the autoscaler to be more cost-effective by scaling between zero
-machines and the machine count necessary based on the resources your workloads
-require.
+You can now set the minimum number of replicas for a machine autoscaler to `0`. This allows the autoscaler to be more cost-effective by scaling between zero machines and the machine count necessary based on the resources your workloads require.
 
-For more information, see the
-xref:../machine_management/applying-autoscaling.adoc#machine-autoscaler-cr_applying-autoscaling[`MachineAutoscaler` resource definition].
+For more information, see the xref:../machine_management/applying-autoscaling.adoc#machine-autoscaler-cr_applying-autoscaling[`MachineAutoscaler` resource definition].
 
 [id="ocp-4-5-machinehealthcheck-with-empty-selector-monitors-all-machines"]
 ==== `MachineHealthCheck` resource with empty selector monitors all machines
 
-A `MachineHealthCheck` resource that contains an empty `selector` field now
-monitors all machines.
+A `MachineHealthCheck` resource that contains an empty `selector` field now monitors all machines.
 
-For more information on the `selector` field in the `MachineHealthCheck` resource,
-see the
-xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-resource_deploying-machine-health-checks[Sample `MachineHealthCheck` resource].
+For more information on the `selector` field in the `MachineHealthCheck` resource, see the xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-resource_deploying-machine-health-checks[Sample `MachineHealthCheck` resource].
 
 [id="ocp-4-5-describing-machine-and-machineset-fields-using-oc-explain"]
 ==== Describing machine and machine set fields by using `oc explain`
 
-A full OpenAPI schema is now provided for machine and machine set Custom
-Resources. The `oc explain` command now provides descriptions for fields included in machine
-and machine set API resources.
+A full OpenAPI schema is now provided for machine and machine set Custom Resources. The `oc explain` command now provides descriptions for fields included in machine and machine set API resources.
 
 [id="ocp-4-5-nodes"]
 === Nodes
@@ -304,8 +228,7 @@ and machine set API resources.
 
 The descheduler now allows you to configure the `RemovePodsHavingTooManyRestarts` strategy. This strategy ensures that pods that have been restarted too many times are removed from nodes. Likewise, the Descheduler Operator now supports full upstream descheduler strategy names, allowing for more one-to-one configuration.
 
-See xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler-strategies_nodes-descheduler[Descheduler strategies]
-for more information.
+See xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler-strategies_nodes-descheduler[Descheduler strategies] for more information.
 
 [id="ocp-4-5-vertical-pod-autoscaler-tp"]
 ==== Vertical Pod Autoscaler Operator (Technology Preview)
@@ -323,15 +246,12 @@ If separate physical hosts are available on an {rh-openstack} deployment, contro
 [id="ocp-4-5-monitor-your-own-services-tp"]
 ==== Monitor your own services (Technology Preview)
 
-The following improvements are now available to further enhance monitoring your
-own services:
+The following improvements are now available to further enhance monitoring your own services:
 
 * Allow cross-correlation of the metrics of your own service with cluster metrics.
-* Allow using metrics of services in user namespaces in recording and
-alerting rules.
+* Allow using metrics of services in user namespaces in recording and alerting rules.
 * Add multi-tenancy support for the Alertmanager API.
-* Add the ability to deploy user recording and alerting rules with higher
-availability.
+* Add the ability to deploy user recording and alerting rules with higher availability.
 * Add the ability to introspect Thanos Stores using the Thanos Querier.
 * Access metrics of all services together in the web console from a single view.
 
@@ -372,9 +292,7 @@ The link to launch Kibana has been moved from the *Monitoring* menu to the *Appl
 [id="ocp-4-5-new-attribute-filters"]
 ====  New Infrastructure Features filters for Operators in OperatorHub
 
-You can now filter Operators by *Infrastructure Features* in OperatorHub. For
-example, select *Disconnected* to see Operators that work in
-disconnected environments.
+You can now filter Operators by *Infrastructure Features* in OperatorHub. For example, select *Disconnected* to see Operators that work in disconnected environments.
 
 [id="ocp-4-5-developer-perspective"]
 ==== Developer Perspective
@@ -400,12 +318,9 @@ For `AlertManagerReceiversNotConfigured` alerts that display on the cluster dash
 [id="ocp-4-5-scale-cluster-maximums"]
 ==== Cluster maximums
 
-Updated guidance around
-xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[Cluster
-maximums] for {product-title} {product-version} is now available.
+Updated guidance around xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[Cluster maximums] for {product-title} {product-version} is now available.
 
-Use the link:https://access.redhat.com/labs/ocplimitscalculator/[{product-title}
-Limit Calculator] to estimate cluster limits for your environment.
+Use the link:https://access.redhat.com/labs/ocplimitscalculator/[{product-title} Limit Calculator] to estimate cluster limits for your environment.
 
 [id="ocp-4-5-networking"]
 === Networking
@@ -413,11 +328,9 @@ Limit Calculator] to estimate cluster limits for your environment.
 [id="ocp-4-5-mirgating-from-sdn-to-default-cni-tp"]
 ==== Migrating from the OpenShift SDN default CNI network provider (Technology Preview)
 
-You can now migrate to the OVN-Kubernetes default Container Network Interface
-(CNI) network provider from the OpenShift SDN default CNI network provider.
+You can now migrate to the OVN-Kubernetes default Container Network Interface (CNI) network provider from the OpenShift SDN default CNI network provider.
 
-For more information, see
-xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrate from the OpenShift SDN default CNI network provider].
+For more information, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrate from the OpenShift SDN default CNI network provider].
 
 [id="ocp-4-5-ingress-enhancements"]
 ==== Ingress Controller enhancements
@@ -430,9 +343,7 @@ There are two noteworthy Ingress Controller enhancements introduced in {product-
 [id="ocp-4-5-haproxy-upgraded"]
 ==== HAProxy upgraded to version 2.0.14
 
-The HAProxy used for the Ingress Controller has been upgraded from version 2.0.13 to 2.0.14.
-This upgrade provides a router reload performance improvement. The router reload
-optimization is most beneficial for clusters with thousands of routes.
+The HAProxy used for the Ingress Controller has been upgraded from version 2.0.13 to 2.0.14. This upgrade provides a router reload performance improvement. The router reload optimization is most beneficial for clusters with thousands of routes.
 
 [id="ocp-4-5-http-2-ingress-support"]
 ==== HTTP/2 Ingress support
@@ -441,18 +352,9 @@ You can now enable transparent end-to-end HTTP/2 connectivity in HAProxy. This f
 
 You can enable HTTP/2 connectivity in HAProxy for an individual Ingress Controller or for the entire cluster. For more information, see xref:../networking/ingress-operator.adoc#nw-http2-haproxy_ingress-operator[HTTP/2 Ingress connectivity].
 
-To enable the use of HTTP/2 for the connection from the client to HAProxy, a
-route must specify a custom certificate. A route that uses the default
-certificate cannot use HTTP/2. This restriction is necessary to avoid problems
-from connection coalescing, where the client re-uses a connection for different
-routes that use the same certificate.
+To enable the use of HTTP/2 for the connection from the client to HAProxy, a route must specify a custom certificate. A route that uses the default certificate cannot use HTTP/2. This restriction is necessary to avoid problems from connection coalescing, where the client re-uses a connection for different routes that use the same certificate.
 
-The connection from HAProxy to the application pod can use HTTP/2 only for
-re-encrypt routes and not for edge-terminated or insecure routes. This
-restriction comes from the fact that HAProxy uses Application-Level Protocol
-Negotiation (ALPN), which is a TLS extension, to negotiate the use of HTTP/2
-with the back-end. The implication is that end-to-end HTTP/2 is possible with
-passthrough and re-encrypt and not with insecure or edge-terminated routes.
+The connection from HAProxy to the application pod can use HTTP/2 only for re-encrypt routes and not for edge-terminated or insecure routes. This restriction comes from the fact that HAProxy uses Application-Level Protocol Negotiation (ALPN), which is a TLS extension, to negotiate the use of HTTP/2 with the back-end. The implication is that end-to-end HTTP/2 is possible with passthrough and re-encrypt and not with insecure or edge-terminated routes.
 
 [IMPORTANT]
 ====
@@ -465,17 +367,12 @@ A connection that uses the HTTP/2 protocol cannot be upgraded to the WebSocket p
 [id="ocp-4-5-oc-new-app-deployment-resources"]
 ==== oc new-app now produces `Deployment` resources
 
-The `oc new-app` command now produces `Deployment` resources instead of
-`DeploymentConfig` resources by default. If you prefer to create `DeploymentConfig`
-resources, you can pass the `--as-deployment-config` flag when invoking `oc new-app`. For more information, see
-xref:../applications/deployments/what-deployments-are.adoc#what-deployments-are[Understanding `Deployments` and `DeploymentConfigs`].
+The `oc new-app` command now produces `Deployment` resources instead of `DeploymentConfig` resources by default. If you prefer to create `DeploymentConfig` resources, you can pass the `--as-deployment-config` flag when invoking `oc new-app`. For more information, see xref:../applications/deployments/what-deployments-are.adoc#what-deployments-are[Understanding `Deployments` and `DeploymentConfigs`].
 
 [id="ocp-4-5-support-nodeaffinity-scheduler-in-image-registry-crd"]
 ==== Support node affinity scheduler in image registry CRD
 
-The node affinity scheduler is now supported to ensure image registry
-deployments complete even when an infrastructure node does not exist. The node
-affinity scheduler must be manually configured.
+The node affinity scheduler is now supported to ensure image registry deployments complete even when an infrastructure node does not exist. The node affinity scheduler must be manually configured.
 
 See xref:../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity rules]
 for more information.
@@ -539,56 +436,29 @@ Volume cloning using CSI, previously in Technology Preview, is now fully support
 [id="ocp-4-5-bundle-format-opm"]
 ==== Bundle Format for packaging Operators and `opm` CLI tool
 
-The Bundle Format for Operators is a new packaging format introduced by the
-Operator Framework that is supported starting with {product-title} 4.5. To
-improve scalability and better enable upstream users hosting their own catalogs,
-the Bundle Format specification simplifies the distribution of Operator
-metadata.
+The Bundle Format for Operators is a new packaging format introduced by the Operator Framework that is supported starting with {product-title} 4.5. To improve scalability and better enable upstream users hosting their own catalogs, the Bundle Format specification simplifies the distribution of Operator metadata.
 
 [NOTE]
 ====
-While the legacy Package Manifest Format is deprecated in {product-title} 4.5,
-it is still supported and Operators provided by Red Hat are currently shipped
-using the Package Manifest Format.
+While the legacy Package Manifest Format is deprecated in {product-title} 4.5, it is still supported and Operators provided by Red Hat are currently shipped using the Package Manifest Format.
 ====
 
-An Operator bundle represents a single version of an Operator and can be
-scaffolded with the Operator SDK. On-disk _bundle manifests_ are containerized
-and shipped as a _bundle image_, a non-runnable container image that stores the
-Kubernetes manifests and Operator metadata. Storage and distribution of the
-bundle image is then managed using existing container tools like `podman` and
-`docker` and container registries like Quay.
+An Operator bundle represents a single version of an Operator and can be scaffolded with the Operator SDK. On-disk _bundle manifests_ are containerized and shipped as a _bundle image_, a non-runnable container image that stores the Kubernetes manifests and Operator metadata. Storage and distribution of the bundle image is then managed using existing container tools like `podman` and `docker` and container registries like Quay.
 
-See
-xref:../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Packaging formats]
-for more details on the Bundle Format.
+See xref:../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Packaging formats] for more details on the Bundle Format.
 
-The new `opm` CLI tool is also introduced alongside the Bundle Format. The `opm`
-CLI allows you to create and maintain catalogs of Operators from a list of
-bundles, called an index, that are equivalent to a "repository". The result is a
-container image, called an _index image_, which can be stored in a container
-registry and then installed on a cluster.
+The new `opm` CLI tool is also introduced alongside the Bundle Format. The `opm` CLI allows you to create and maintain catalogs of Operators from a list of bundles, called an index, that are equivalent to a "repository". The result is a container image, called an _index image_, which can be stored in a container registry and then installed on a cluster.
 
-An index contains a database of pointers to Operator manifest content that can
-be queried via an included API that is served when the container image is run.
-On {product-title}, OLM can use the index image as a catalog by referencing it
-in a `CatalogSource` object, which polls the image at regular intervals to enable
-frequent updates to installed Operators on the cluster.
+An index contains a database of pointers to Operator manifest content that can be queried via an included API that is served when the container image is run. On {product-title}, OLM can use the index image as a catalog by referencing it in a `CatalogSource` object, which polls the image at regular intervals to enable frequent updates to installed Operators on the cluster.
 
-See xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-bundle-format[Managing custom catalogs]
-for more details on `opm` usage.
+See xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-bundle-format[Managing custom catalogs] for more details on `opm` usage.
 
 [id="ocp-4-5-olm-v1-crd"]
 ==== v1 CRD support in Operator Lifecycle Manager
 
-Operator Lifecycle Manager (OLM) now supports Operators using v1
-custom resource definitions (CRDs) when loading Operators into catalogs and
-deploying them on cluster. Previously, OLM only supported v1beta1 CRDs; OLM now
-manages both v1 and v1beta1 CRDs in the same way.
+Operator Lifecycle Manager (OLM) now supports Operators using v1 custom resource definitions (CRDs) when loading Operators into catalogs and deploying them on cluster. Previously, OLM only supported v1beta1 CRDs; OLM now manages both v1 and v1beta1 CRDs in the same way.
 
-To support this feature, OLM now enforces CRD upgrades are safer by ensuring
-existing CRD storage versions are not missing in the upgraded CRD, avoiding
-potential data loss.
+To support this feature, OLM now enforces CRD upgrades are safer by ensuring existing CRD storage versions are not missing in the upgraded CRD, avoiding potential data loss.
 
 [id="ocp-4-5-report-etcd-member-status-conditions"]
 ==== Report etcd member status conditions
@@ -598,14 +468,9 @@ The etcd cluster Operator now reports etcd member status conditions.
 [id="ocp-4-5-olm-webhooks"]
 ==== Admission webhook support in OLM
 
-Validating and mutating admission webhooks allow Operator authors to intercept,
-modify, and accept or reject resources before they are saved to the object store
-and handled by the Operator controller. Operator Lifecycle Manager (OLM) can
-manage the lifecycle of these webhooks when they are shipped alongside your
-Operator.
+Validating and mutating admission webhooks allow Operator authors to intercept, modify, and accept or reject resources before they are saved to the object store and handled by the Operator controller. Operator Lifecycle Manager (OLM) can manage the lifecycle of these webhooks when they are shipped alongside your Operator.
 
-See xref:../operators/user/olm-webhooks.adoc#olm-webhooks[Managing admission webhooks in Operator Lifecycle Manager]
-for more details.
+See xref:../operators/user/olm-webhooks.adoc#olm-webhooks[Managing admission webhooks in Operator Lifecycle Manager] for more details.
 
 [id="ocp-4-5-configmap-configs-added-from-openshift-config-namespace"]
 ==== Config map configurations added from `openshift-config` namespace
@@ -615,18 +480,9 @@ Config map configurations are now added from the `openshift-config` namespace us
 [id="ocp-4-5-operator-api"]
 ==== Read-only Operator API (Technology Preview)
 
-The new Operator API is now available as a Technology Preview feature in
-read-only mode. Previously, installing Operators using Operator Lifecycle
-Manager (OLM) required cluster administrators to be aware of multiple APIs,
-including `CatalogSource`, `Subscription`, `ClusterServiceVersion`, and
-`InstallPlan` objects. This single Operator API resource is a first step towards a more
-simplified experience discovering and managing the lifecycle of Operators in a
-{product-title} cluster.
+The new Operator API is now available as a Technology Preview feature in read-only mode. Previously, installing Operators using Operator Lifecycle Manager (OLM) required cluster administrators to be aware of multiple APIs, including `CatalogSource`, `Subscription`, `ClusterServiceVersion`, and `InstallPlan` objects. This single Operator API resource is a first step towards a more simplified experience discovering and managing the lifecycle of Operators in a {product-title} cluster.
 
-Currently only available using the CLI and requiring a few manual steps to
-enable, this feature previews interacting with Operators as a first-class API
-object. Cluster administrators can discover previously installed Operators using
-this API in read-only mode, for example using the `oc get operators` command.
+Currently only available using the CLI and requiring a few manual steps to enable, this feature previews interacting with Operators as a first-class API object. Cluster administrators can discover previously installed Operators using this API in read-only mode, for example using the `oc get operators` command.
 
 To enable this Technology Preview feature:
 
@@ -678,8 +534,7 @@ $ oc -n openshift-operator-lifecycle-manager \
 
 .. Save your changes.
 
-. Install an Operator using the normal OperatorHub method if you have not already;
-this example uses an etcd Operator installed in the project `test-project`.
+. Install an Operator using the normal OperatorHub method if you have not already; this example uses an etcd Operator installed in the project `test-project`.
 
 . Create a new Operator resource for the installed etcd Operator.
 
@@ -701,9 +556,7 @@ metadata:
 $ oc create -f etcd-test-op.yaml
 ----
 
-. To have the installed Operator opt in to the new API, apply the
-`operators.coreos.com/etcd-test` label to the following objects related to your
-Operator:
+. To have the installed Operator opt in to the new API, apply the `operators.coreos.com/etcd-test` label to the following objects related to your Operator:
 +
 --
 * `Subscription`
@@ -714,8 +567,7 @@ Operator:
 +
 [NOTE]
 ====
-In a future release, these objects will be automatically labeled for any
-Operators where the CSV was installed using a `Subscription` object.
+In a future release, these objects will be automatically labeled for any Operators where the CSV was installed using a `Subscription` object.
 ====
 +
 For example:
@@ -742,8 +594,7 @@ NAME        AGE
 etcd-test   17m
 ----
 
-.. Inspect your Operator's details and note that the objects you labeled are
-represented:
+.. Inspect your Operator's details and note that the objects you labeled are represented:
 +
 [source,terminal]
 ----
@@ -830,10 +681,7 @@ With this update, support for respecting a cluster-wide proxy configuration is a
 [id="ocp-4-5-virtualization-ga"]
 ==== OpenShift Virtualization support on {product-title} 4.5
 
-Red Hat OpenShift Virtualization is supported to run on {product-title} 4.5. Previously known as container-native
-virtualization, OpenShift Virtualization enables you to bring traditional
-virtual machines (VMs) into {product-title} where they run alongside containers,
-and are managed as native Kubernetes objects.
+Red Hat OpenShift Virtualization is supported to run on {product-title} 4.5. Previously known as container-native virtualization, OpenShift Virtualization enables you to bring traditional virtual machines (VMs) into {product-title} where they run alongside containers, and are managed as native Kubernetes objects.
 
 [id="ocp-4-5-notable-technical-changes"]
 == Notable technical changes
@@ -844,12 +692,9 @@ and are managed as native Kubernetes objects.
 [id="ocp-4-5-osdk-v0-17-1"]
 ==== Operator SDK v0.17.2
 
-{product-title} 4.5 supports Operator SDK v0.17.2, which introduces the
-following notable technical changes:
+{product-title} 4.5 supports Operator SDK v0.17.2, which introduces the following notable technical changes:
 
-* The `--crd-version` flag was added to the `new`, `add api`, `add crd`, and
-`generate crds` commands so that users can opt in to `v1` CRDs. The default setting
-is `v1beta1`.
+* The `--crd-version` flag was added to the `new`, `add api`, `add crd`, and `generate crds` commands so that users can opt in to `v1` CRDs. The default setting is `v1beta1`.
 
 Ansible-based Operator enhancements include:
 
@@ -864,32 +709,17 @@ Helm-based Operator enhancements include:
 [id="ocp-4-5-termination-grace-period-support"]
 ==== terminationGracePeriod parameter support
 
-{product-title} now properly supports the `terminationGracePeriodSeconds`
-parameter with the CRI-O container runtime.
+{product-title} now properly supports the `terminationGracePeriodSeconds` parameter with the CRI-O container runtime.
 
 [discrete]
 [id="ocp-4-5-readyz-config"]
 ==== `/readyz` configuration for API server health probe
 
-All {product-title} 4.5 clusters using user-provisioned infrastructure must be
-configured to use the `/readyz` endpoint for API server health checking to
-remain supported. Any clusters using user-provisioned infrastructure installed
-on versions prior to {product-title} 4.5 must be reconfigured to use `/readyz`.
+All {product-title} 4.5 clusters using user-provisioned infrastructure must be configured to use the `/readyz` endpoint for API server health checking to remain supported. Any clusters using user-provisioned infrastructure installed on versions prior to {product-title} 4.5 must be reconfigured to use `/readyz`.
 
-Clusters using user-provisioned infrastructure without `/readyz` configured can
-suffer from API outages when the API server restarts. The API server can restart
-after events such as configuration changes, certificate updates, or control
-plane machine reboots. The load balancer must be configured to take a maximum of
-30 seconds from the time the API server turns off the `/readyz` endpoint to the
-removal of the API server instance from the pool. Within the time frame, the
-`/readyz` endpoint must be removed or added, depending on whether it returned an
-error or became healthy. The readiness check is recommended to probe every five or
-10 seconds, with two consecutive successful requests to become healthy and
-three consecutive failed requests to become unhealthy.
+Clusters using user-provisioned infrastructure without `/readyz` configured can suffer from API outages when the API server restarts. The API server can restart after events such as configuration changes, certificate updates, or control plane machine reboots. The load balancer must be configured to take a maximum of 30 seconds from the time the API server turns off the `/readyz` endpoint to the removal of the API server instance from the pool. Within the time frame, the `/readyz` endpoint must be removed or added, depending on whether it returned an error or became healthy. The readiness check is recommended to probe every five or 10 seconds, with two consecutive successful requests to become healthy and three consecutive failed requests to become unhealthy.
 
-For more information, see the network topology requirements in the
-user-provisioned infrastructure installation documentation for your cloud
-provider.
+For more information, see the network topology requirements in the user-provisioned infrastructure installation documentation for your cloud provider.
 
 [discrete]
 [id="ocp-4-5-binary-sha256sum-txt-renamed-for-ocp-releases"]
@@ -904,12 +734,7 @@ The renamed binary file allows for GPG to correctly verify `sha256sum.txt`, whic
 
 Some features available in previous releases have been deprecated or removed.
 
-Deprecated functionality is still included in {product-title} and continues to
-be supported; however, it will be removed in a future release of this product
-and is not recommended for new deployments. For the most recent list of major
-functionality deprecated and removed within {product-title} {product-version},
-refer to the table below. Additional details for more fine-grained functionality
-that has been deprecated and removed are listed after the table.
+Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {product-title} {product-version}, refer to the table below. Additional details for more fine-grained functionality that has been deprecated and removed are listed after the table.
 
 In the table, features are marked with the following statuses:
 
@@ -965,64 +790,40 @@ In the table, features are marked with the following statuses:
 [id="ocp-4-5-jenkins-pipeline-build-strategy"]
 ==== Jenkins Pipeline build strategy
 
-The Jenkins Pipeline build strategy is now deprecated. You should use
-Jenkinsfiles directly on Jenkins or OpenShift Pipelines instead.
+The Jenkins Pipeline build strategy is now deprecated. You should use Jenkinsfiles directly on Jenkins or OpenShift Pipelines instead.
 
 [id="ocp-4-5-deprecated-v1beta1-crds"]
 ==== v1beta1 CRDs
 
-The `apiextensions.k8s.io/v1beta1` API version for custom resource definitions
-(CRDs) is now deprecated. It will be removed in a future release of
-{product-title}.
+The `apiextensions.k8s.io/v1beta1` API version for custom resource definitions (CRDs) is now deprecated. It will be removed in a future release of {product-title}.
 
 See xref:ocp-4-5-olm-v1-crd[v1 CRD support in Operator Lifecycle Manager] for related details.
 
 [id="ocp-4-5-custom-label-no-longer-in-use"]
 ==== Custom label no longer in use
 
-The `flavor.template.kubevirt.io/Custom` label is no longer used to identify
-Custom flavors.
+The `flavor.template.kubevirt.io/Custom` label is no longer used to identify Custom flavors.
 
 [id="ocp-4-5-deprecation-of-operatorsources"]
 ==== `OperatorSource` and `CatalogSourceConfig` objects block cluster upgrades
 
-The `OperatorSource` and `CatalogSourceConfig` objects have been deprecated for several
-{product-title} releases. Starting in {product-title} 4.4, if there are any
-custom `OperatorSource` or `CatalogSourceConfig` objects present on the cluster,
-the `marketplace` cluster Operator sets an `Upgradeable=false` condition and
-issues a *Warning* alert. This means that upgrades to {product-title} 4.5 are
-blocked if the objects are still installed.
+The `OperatorSource` and `CatalogSourceConfig` objects have been deprecated for several {product-title} releases. Starting in {product-title} 4.4, if there are any custom `OperatorSource` or `CatalogSourceConfig` objects present on the cluster, the `marketplace` cluster Operator sets an `Upgradeable=false` condition and issues a *Warning* alert. This means that upgrades to {product-title} 4.5 are blocked if the objects are still installed.
 
 [NOTE]
 ====
-Upgrades to {product-title} 4.4 z-stream releases are still permitted in this
-state.
+Upgrades to {product-title} 4.4 z-stream releases are still permitted in this state.
 ====
 
-In {product-title} 4.5, `OperatorSource` objects are still deprecated and only exist for
-the use of the default `OperatorSource` objects. `CatalogSourceConfig` objects, however, are now
-removed.
+In {product-title} 4.5, `OperatorSource` objects are still deprecated and only exist for the use of the default `OperatorSource` objects. `CatalogSourceConfig` objects, however, are now removed.
 
-See the
-link:https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated[{product-title} 4.4 release notes]
-for how to convert `OperatorSource` and `CatalogSourceConfig` objects to use
-`CatalogSource` objects directly, which clears the alert and enables cluster upgrades to
-{product-title} 4.5.
+See the link:https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated[{product-title} 4.4 release notes] for how to convert `OperatorSource` and `CatalogSourceConfig` objects to use `CatalogSource` objects directly, which clears the alert and enables cluster upgrades to {product-title} 4.5.
 
 [id="ocp-4-5-ignition-config-spec-v2"]
 ==== Ignition config spec v2
 
-The v2 Ignition config spec is now deprecated for use when deploying new nodes
-as part of a fresh {product-title} 4.6 installation. The v2 Ignition config spec
-is still supported for machine configurations.
+The v2 Ignition config spec is now deprecated for use when deploying new nodes as part of a fresh {product-title} 4.6 installation. The v2 Ignition config spec is still supported for machine configurations.
 
-If you have created custom Ignition v2 spec configurations to deploy new
-clusters, you must convert these to spec v3 when installing new {product-title}
-4.6 clusters. You should use the
-link:https://github.com/coreos/ign-converter[Ignition Config Converter tool] to
-complete the conversion process. In general, v2 can be directly translated to
-v3. In certain edge cases, you might need to modify the output to make explicit
-configuration details that were assumed by spec v2.
+If you have created custom Ignition v2 spec configurations to deploy new clusters, you must convert these to spec v3 when installing new {product-title} 4.6 clusters. You should use the link:https://github.com/coreos/ign-converter[Ignition Config Converter tool] to complete the conversion process. In general, v2 can be directly translated to v3. In certain edge cases, you might need to modify the output to make explicit configuration details that were assumed by spec v2.
 
 [id="ocp-4-5-removed-features"]
 === Removed features
@@ -1032,32 +833,19 @@ configuration details that were assumed by spec v2.
 
 The following `oc` commands and flags are affected:
 
-* The `oc policy can-i` command was deprecated in {product-title} 3.9 and has
-been removed. You must use `oc auth can-i` instead.
+* The `oc policy can-i` command was deprecated in {product-title} 3.9 and has been removed. You must use `oc auth can-i` instead.
 
-* The `--image` flag previously used for the `oc new-app` and `oc new-build`
-commands was deprecated in {product-title} 3.2 and has been removed. You must
-use the `--image-stream` flag with these commands instead.
+* The `--image` flag previously used for the `oc new-app` and `oc new-build` commands was deprecated in {product-title} 3.2 and has been removed. You must use the `--image-stream` flag with these commands instead.
 
-* The `--list` flag previously used in the `oc set volumes` command was
-deprecated in {product-title} 3.3 and has been removed. The `oc set volumes`
-lists volumes without a flag.
+* The `--list` flag previously used in the `oc set volumes` command was deprecated in {product-title} 3.3 and has been removed. The `oc set volumes` lists volumes without a flag.
 
-* The `-t` flag previously used in the `oc process` command was deprecated in
-{product-title} 3.11 and has been removed. You must use the `--template` flag
-with this command instead.
+* The `-t` flag previously used in the `oc process` command was deprecated in {product-title} 3.11 and has been removed. You must use the `--template` flag with this command instead.
 
-* The `--output-version` flag previously used in the `oc process` command was
-deprecated in {product-title} 3.11 and has been removed. This flag was already
-ignored.
+* The `--output-version` flag previously used in the `oc process` command was deprecated in {product-title} 3.11 and has been removed. This flag was already ignored.
 
-* The `-v` flag previously used in the `oc set deployment-hook` command was
-deprecated in {product-title} 3.11 and has been removed. You must use the
-`--volumes` flag with this command instead.
+* The `-v` flag previously used in the `oc set deployment-hook` command was deprecated in {product-title} 3.11 and has been removed. You must use the `--volumes` flag with this command instead.
 
-* The `-v` and `--verbose` flags previously used in the `oc status` command were
-deprecated in {product-title} 3.11 and have been removed. You must use the
-`--suggest` flag with this command instead.
+* The `-v` and `--verbose` flags previously used in the `oc status` command were deprecated in {product-title} 3.11 and have been removed. You must use the `--suggest` flag with this command instead.
 
 [id="ocp-4-5-oc-run-pod"]
 ==== The `oc run` OpenShift CLI command now only creates pods
@@ -1069,53 +857,29 @@ The `oc run` command can now only be used to create pods. Use the `oc create` co
 
 [IMPORTANT]
 ====
-Service Catalog is not installed by default in {product-title} 4; however, it
-now blocks upgrades to {product-title} 4.5 if installed.
+Service Catalog is not installed by default in {product-title} 4; however, it now blocks upgrades to {product-title} 4.5 if installed.
 ====
 
-Service Catalog, Template Service Broker, Ansible Service Broker, and their
-associated Operators were deprecated starting in {product-title} 4.2. Ansible
-Service Broker, including Ansible Service Broker Operator and related APIs and
-APBs, were removed in {product-title} 4.4.
+Service Catalog, Template Service Broker, Ansible Service Broker, and their associated Operators were deprecated starting in {product-title} 4.2. Ansible Service Broker, including Ansible Service Broker Operator and related APIs and APBs, were removed in {product-title} 4.4.
 
-Service Catalog, Template Service Broker, and their associated Operators are now
-removed in {product-title} 4.5, including the related
-`.servicecatalog.k8s.io/v1beta1` API.
+Service Catalog, Template Service Broker, and their associated Operators are now removed in {product-title} 4.5, including the related `.servicecatalog.k8s.io/v1beta1` API.
 
 [NOTE]
 ====
-Templates are still available in {product-title} 4.5, but they are no longer
-handled by Template Service Broker. By default, the Samples Operator handles Red
-Hat Enterprise Linux (RHEL)-based {product-title} image streams and templates.
-See
-xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Samples Operator]
-for details.
+Templates are still available in {product-title} 4.5, but they are no longer handled by Template Service Broker. By default, the Samples Operator handles Red Hat Enterprise Linux (RHEL)-based {product-title} image streams and templates. See xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Samples Operator] for details.
 ====
 
-The `service-catalog-controller-manager` and `service-catalog-apiserver` cluster
-Operators were set to `Upgradeable=false` in 4.4. This means that they block
-cluster upgrades to the next minor version, 4.5 in this case, if they are still
-installed at that time. Upgrades to z-stream releases such as 4.4.z, however,
-are still permitted in this state.
+The `service-catalog-controller-manager` and `service-catalog-apiserver` cluster Operators were set to `Upgradeable=false` in 4.4. This means that they block cluster upgrades to the next minor version, 4.5 in this case, if they are still installed at that time. Upgrades to z-stream releases such as 4.4.z, however, are still permitted in this state.
 
-If Service Catalog and Template Service Broker are enabled in 4.4, specifically
-if their management state is set to `Managed`, the web console warns cluster
-administrators that these features are still enabled. The following alerts can
-be viewed from the *Monitoring* -> *Alerting* page on a 4.4 cluster and have a
-*Warning* severity:
+If Service Catalog and Template Service Broker are enabled in 4.4, specifically if their management state is set to `Managed`, the web console warns cluster administrators that these features are still enabled. The following alerts can be viewed from the *Monitoring* -> *Alerting* page on a 4.4 cluster and have a *Warning* severity:
 
 * `ServiceCatalogAPIServerEnabled`
 * `ServiceCatalogControllerManagerEnabled`
 * `TemplateServiceBrokerEnabled`
 
-If they are still enabled on a 4.4 cluster, cluster administrators can see
-link:https://docs.openshift.com/container-platform/4.4/applications/service_brokers/uninstalling-service-catalog.html#sb-uninstalling-service-catalog[Uninstalling Service Catalog] and link:https://docs.openshift.com/container-platform/4.4/applications/service_brokers/uninstalling-template-service-broker.html#sb-uninstalling-template-service-broker[Uninstalling Template Service Broker]
-in the {product-title} 4.4 documentation to uninstall it, which permits cluster
-upgrades to 4.5.
+If they are still enabled on a 4.4 cluster, cluster administrators can see link:https://docs.openshift.com/container-platform/4.4/applications/service_brokers/uninstalling-service-catalog.html#sb-uninstalling-service-catalog[Uninstalling Service Catalog] and link:https://docs.openshift.com/container-platform/4.4/applications/service_brokers/uninstalling-template-service-broker.html#sb-uninstalling-template-service-broker[Uninstalling Template Service Broker] in the {product-title} 4.4 documentation to uninstall it, which permits cluster upgrades to 4.5.
 
-In 4.5, a pair of jobs are created in a new `openshift-service-catalog-removed`
-namespace to run during the cluster upgrade process. Their behavior depends on
-the management state of Service Catalog:
+In 4.5, a pair of jobs are created in a new `openshift-service-catalog-removed` namespace to run during the cluster upgrade process. Their behavior depends on the management state of Service Catalog:
 
 * `Removed`: The Jobs remove the following Service Catalog items:
 ** Operators
@@ -1126,26 +890,19 @@ the management state of Service Catalog:
 
 * `Unmanaged`: The jobs skip removal and do nothing.
 
-* `Managed`: The jobs report an error in logs. This state is unlikely to occur because
-upgrades would have been blocked. The jobs take no other actions.
+* `Managed`: The jobs report an error in logs. This state is unlikely to occur because upgrades would have been blocked. The jobs take no other actions.
 
-The jobs and `openshift-service-catalog-removed` namespace will be removed in a
-future {product-title} release.
+The jobs and `openshift-service-catalog-removed` namespace will be removed in a future {product-title} release.
 
 [NOTE]
 ====
-As of {product-title} 4.5, all Red Hat-provided service brokers have been
-removed. Any other broker installed by users is not removed by the upgrade
-process. This is to avoid removing any services that might have been deployed
-using the brokers. Users must remove these brokers manually.
+As of {product-title} 4.5, all Red Hat-provided service brokers have been removed. Any other broker installed by users is not removed by the upgrade process. This is to avoid removing any services that might have been deployed using the brokers. Users must remove these brokers manually.
 ====
 
 [id="ocp-4-5-csc-removed"]
 ==== `CatalogSourceConfig` objects removed
 
-`CatalogSourceConfig` objects are now removed. See
-xref:ocp-4-5-deprecation-of-operatorsources[`OperatorSource` and `CatalogSourceConfig` objects block cluster upgrades]
-for more details.
+`CatalogSourceConfig` objects are now removed. See xref:ocp-4-5-deprecation-of-operatorsources[`OperatorSource` and `CatalogSourceConfig` objects block cluster upgrades] for more details.
 
 [id="ocp-4-5-bug-fixes"]
 == Bug fixes
@@ -1164,17 +921,9 @@ for more details.
 
 *Bare Metal Hardware Provisioning*
 
-* Because the UEFI boot process was using the `ipxe.efi` binary when using IPv4
-networks, the boot process reported that there were no network devices found.
-As a result, the Preboot eXecution Environment (PXE) boots the machines with
-*No network devices*. The `dnsmasq.conf` file has been updated to use the
-`snponly.efi` binary for IPv4 networks. The machines booting with PXE utilize
-the UEFI network drivers and are able to deploy as they have network
-connectivity.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1830161[*BZ#1830161*])
+* Because the UEFI boot process was using the `ipxe.efi` binary when using IPv4 networks, the boot process reported that there were no network devices found. As a result, the Preboot eXecution Environment (PXE) boots the machines with *No network devices*. The `dnsmasq.conf` file has been updated to use the `snponly.efi` binary for IPv4 networks. The machines booting with PXE utilize the UEFI network drivers and are able to deploy as they have network connectivity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1830161[*BZ#1830161*])
 
-* If a cluster has networking issues during install (for example a slow image download) the install could fail. To address this problem, the PXE boot has been changed to include retries and the networking maximum number of retries has been increased for communication between the bare metal provisioner and the nodes being provisioned. The installer will now handle slow network conditions.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1822763[*BZ#1822763*])
+* If a cluster has networking issues during install (for example a slow image download) the install could fail. To address this problem, the PXE boot has been changed to include retries and the networking maximum number of retries has been increased for communication between the bare metal provisioner and the nodes being provisioned. The installer will now handle slow network conditions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822763[*BZ#1822763*])
 
 *Build*
 
@@ -1283,15 +1032,13 @@ default interface for the operating system is selected based on common template 
 
 * *Time Range* and *Refresh Interval* drop menus have been added in the *Monitoring* dashboard tab in *Developer* Perspective. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1807210[*BZ#1807210*])
 
-* No Pipeline Resources were created in the namespace although the *Start Pipeline* modal required one. The user would see a disabled and empty dropdown above fields, losing some context of what the fields were for. With this bug fix, *Create Pipeline Resource* gives the user context of what they were doing inline in the *Start Pipeline* modal. The user now has a better experience starting a Pipeline from the start modal when there are no Pipeline Resources created in the namespace.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1826526[*BZ#1826526*])
+* No Pipeline Resources were created in the namespace although the *Start Pipeline* modal required one. The user would see a disabled and empty dropdown above fields, losing some context of what the fields were for. With this bug fix, *Create Pipeline Resource* gives the user context of what they were doing inline in the *Start Pipeline* modal. The user now has a better experience starting a Pipeline from the start modal when there are no Pipeline Resources created in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826526[*BZ#1826526*])
 
 * Layout padding was missing, which allowed the title to flow over the *Close* button. If text was over the *Close* button, it made it difficult to click. The layout is now fixed to prevent the title from overlapping the *Close* button and the button is now always accessible via mouse click. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1796516[*BZ#1796516*])
 
 * Pipeline Builder incorrectly interpreted a default value of an empty string (`''`) as having no default. Some Operator-provided tasks needed this to be the default and, therefore, had issues working without it. Check for a default property and do not assume the validity of the value. Now, any values that the OpenShift Pipeline Operator deems as a valid default value are respected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1829567[*BZ#1829567*])
 
-* The Pipeline Builder reads `Task`/`ClusterTask` definitions and incorrectly assumed that all parameters were of type `string`.
-When a `Task` parameter of type `array` was encountered, it would cast the array to a string and represent it, losing the type; it would produce a value to the `Task` parameter as `string`, thus breaking the contract with the `Task` object. The `array` type is now supported in the web console and the type is properly retrained. Managing both types allows the Pipeline Builder to work the way it was intended. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1813707[*BZ#1813707*])
+* The Pipeline Builder reads `Task`/`ClusterTask` definitions and incorrectly assumed that all parameters were of type `string`. When a `Task` parameter of type `array` was encountered, it would cast the array to a string and represent it, losing the type; it would produce a value to the `Task` parameter as `string`, thus breaking the contract with the `Task` object. The `array` type is now supported in the web console and the type is properly retrained. Managing both types allows the Pipeline Builder to work the way it was intended. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1813707[*BZ#1813707*])
 
 * The Pipeline page was inconsistent with other pages. The *Create Pipeline* button was always enabled and did not take into consideration when no projects were available. The *Create Pipeline* button is now removed when the Getting Started guide is enabled. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1792693[*BZ#1792693*])
 
@@ -1347,29 +1094,23 @@ When a `Task` parameter of type `array` was encountered, it would cast the array
 
 * The Azure infrastructure name is used for generated Azure containers and storage accounts. Therefore, if the Azure infrastructure name contained uppercase letters, the container would successfully be created, but the storage account creation would fail. This bug fix adjusts the container name creation logic to discard invalid characters, allowing the image registry to deploy on an infrastructure that contains invalid characters in its name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1827807[*BZ#1827807*])
 
-* When deleting a non-empty image registry with GCP storage, the image registry hostname was not being removed from the image configuration file. This prevented you from creating a new image registry. The code has been changed to remove the image registry hostname from the image configuration file when you delete an image registry. As a result, you can delete and create image registries as expected.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1827075[*BZ#1827075*])
+* When deleting a non-empty image registry with GCP storage, the image registry hostname was not being removed from the image configuration file. This prevented you from creating a new image registry. The code has been changed to remove the image registry hostname from the image configuration file when you delete an image registry. As a result, you can delete and create image registries as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1827075[*BZ#1827075*])
 
-* Because the image registry was not removing objects from a bucket before it removes the bucket, you could not delete a bucket with images. The code has been changed to remove images before removing a bucket. You can delete non-empty buckets as expected.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1827075[*BZ#1827075*])
+* Because the image registry was not removing objects from a bucket before it removes the bucket, you could not delete a bucket with images. The code has been changed to remove images before removing a bucket. You can delete non-empty buckets as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1827075[*BZ#1827075*])
 
 * Because images in the image registry were not clearing their yum cache, the image sizes can get large. The image registry `Dockerfile` was changed to include a `yum clean all` command. The size of the images are smaller. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1804493[*BZ#1804493*])
 
 * The `keepYoungerThan` parameter in an image pruning custom resource uses nanoseconds and cannot be configured to use a larger period of time. Nanoseconds are not an appropriate period to use in an image pruner. A new parameter has been added to the image pruning custom resource, `keepYoungerThanDuration` that replaces and overrides the `keepYoungerThan` parameter. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835004[*BZ#1835004*])
 
-* The Image Registry Operator did not properly clean up the storage status when the user changed the Operator to `Removed` state. As a result, when the user changed the Operator back to `Managed`, the Operator could not create a new storage pod. The Operator was changed to properly clean up the storage status and the Operator can create a new storage pod.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1785534[*BZ#1785534*])
+* The Image Registry Operator did not properly clean up the storage status when the user changed the Operator to `Removed` state. As a result, when the user changed the Operator back to `Managed`, the Operator could not create a new storage pod. The Operator was changed to properly clean up the storage status and the Operator can create a new storage pod. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1785534[*BZ#1785534*])
 
-* Because the Image Registry Operator was not cleaning logs, you could see improper messages in the logs. The code has been changed to clean the logs to remove these improper messages. The logs now display proper information.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1797840[*BZ#1797840*])
+* Because the Image Registry Operator was not cleaning logs, you could see improper messages in the logs. The code has been changed to clean the logs to remove these improper messages. The logs now display proper information. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1797840[*BZ#1797840*])
 
 * Because the default Image Registry Operator was configured with zero replicas, problems could result unless the value is manually changed. The Operator was updated to install with one. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1811846[*BZ#1811846*])
 
-* Registry credentials used during the cluster install were not available to specific namespaces, the user needed to create new credentials. The code was changed so that if the credentials for a registry were provided during the install, users can import images using those credentials.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1816534[*BZ#1816534*])
+* Registry credentials used during the cluster install were not available to specific namespaces, the user needed to create new credentials. The code was changed so that if the credentials for a registry were provided during the install, users can import images using those credentials. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1816534[*BZ#1816534*])
 
-* Because the Image Registry Operator was being installed with only one pod, it did not meet requirements. The Operator is now installed with two pods for high availability.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1810317[*BZ#1810317*])
+* Because the Image Registry Operator was being installed with only one pod, it did not meet requirements. The Operator is now installed with two pods for high avaijk:https://bugzilla.redhat.com/show_bug.cgi?id=1810317[*BZ#1810317*])
 
 *Installer*
 
@@ -1435,8 +1176,7 @@ Now, the installation program uses different AWS Terraform provider code, which 
 
 * {rh-openstack} resources that share names cannot be removed. Previously, if security groups that shared a name existed, cluster destruction using Ansible playbooks failed on {rh-openstack} clouds. Now, the `down-security-groups.yaml` playbook uses group IDs instead of names when destroying clusters. All security groups are deleted if the playbook finishes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841072[*BZ#1841072*])
 
-* Some {rh-openstack} environments might enforce a policy that disallows VMs from booting with ephemeral disks. As a result, cluster installations failed when bootstrap machines attempted to boot from ephemeral disks. Now, bootstrap machines follow `rootVolume` settings from the control plane machine pool, allowing cluster installations to succeed in environments that disallow VMs from booting with ephemeral disks.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1820434[*BZ#1820434*])
+* Some {rh-openstack} environments might enforce a policy that disallows VMs from booting with ephemeral disks. As a result, cluster installations failed when bootstrap machines attempted to boot from ephemeral disks. Now, bootstrap machines follow `rootVolume` settings from the control plane machine pool, allowing cluster installations to succeed in environments that disallow VMs from booting with ephemeral disks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1820434[*BZ#1820434*])
 
 * Previously, a prerequisite Terraform step did not always happen before floating IP address (FIP) association on clusters that ran on {rh-openstack}. As a result, a race condition could occur that would cause installations to fail. The Terraform step now always occurs before FIP association. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846297[*BZ#1846297*])
 
@@ -1464,11 +1204,9 @@ Now, the installation program uses different AWS Terraform provider code, which 
 
 * In an IPv6 bare metal deployment, Elasticsearch was binding on the IPv4 loopback address instead of the cluster IPv6 address. As a result, the Elasticsearch cluster failed to start. The downward API was changed to set the binding and publish host for Elasticsearch. Elasticsearch is able to bind to the network interface and starts as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1811867[*BZ#1811867*])
 
-* Because the cluster logging cluster service version (CSV) was using incorrect paths to obtain the status of some cluster logging components, the status was not being reported. As a result, cluster logging was not functioning properly. The paths have been corrected and cluster logging is working as expected.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1840888[*BZ#1840888*])
+* Because the cluster logging cluster service version (CSV) was using incorrect paths to obtain the status of some cluster logging components, the status was not being reported. As a result, cluster logging was not functioning properly. The paths have been corrected and cluster logging is working as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840888[*BZ#1840888*])
 
-* Because the Elasticsearch Operator create a second deployment when more than three Elasticsearch nodes are configured, the Cluster Logging Operator was not reading the correct number of Elasticsearch nodes. As a result, the Cluster Logging Custom Resource always reported the number of nodes associated with one deployment. The Cluster Logging Operator was changed to correctly compute the number of Elasticsearch nodes.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1732698[*BZ#1732698*])
+* Because the Elasticsearch Operator create a second deployment when more than three Elasticsearch nodes are configured, the Cluster Logging Operator was not reading the correct number of Elasticsearch nodes. As a result, the Cluster Logging Custom Resource always reported the number of nodes associated with one deployment. The Cluster Logging Operator was changed to correctly compute the number of Elasticsearch nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1732698[*BZ#1732698*])
 
 *Machine Config Operator*
 
@@ -1484,8 +1222,7 @@ Now, the installation program uses different AWS Terraform provider code, which 
 
 * Previously, when the interface that keepalived uses was bridged, it was possible for users to dynamically put interfaces in bonds or bridges, and doing so could prevent keepalived from resuming operation, disrupting Virtual IP management. With this fix, the monitor interface now changes and reloads keepalived so that it reads the new configuration and virtual IP management can operate with minimal disruption. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1751978[*BZ#1751978*])
 
-* Because some routes contained the `expires` field, IPv6 (`non_virtual_ip` script) could not process the route. As a result, services that need to be configured with a `non_virtual_ip` fail. The `non_virtual_ip` script has been updated. Routes are parsed and services are configured correctly.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1817236[*BZ#1817236*]
+* Because some routes contained the `expires` field, IPv6 (`non_virtual_ip` script) could not process the route. As a result, services that need to be configured with a `non_virtual_ip` fail. The `non_virtual_ip` script has been updated. Routes are parsed and services are configured correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1817236[*BZ#1817236*]
 
 *Web console (Administrator perspective)*
 
@@ -1541,23 +1278,17 @@ Now, the installation program uses different AWS Terraform provider code, which 
 
 * Previously, in the administration perspective, when viewing the *Workloads* tab with a side panel visible, the notification drawer when expanded is hidden beneath the side panel. This bug fix adjusts the CSS `z-index` so that the notification drawer is visible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1813052[*BZ#1813052*])
 
-* Previously, the OperatorHub was visible in the web console to only cluster administrators. With this update, the web console now shows the OperatorHub to users who are assigned the `aggregate-olm-view` and `aggregate-olm-edit` cluster role bindings.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1819938[*BZ#1819938*])
+* Previously, the OperatorHub was visible in the web console to only cluster administrators. With this update, the web console now shows the OperatorHub to users who are assigned the `aggregate-olm-view` and `aggregate-olm-edit` cluster role bindings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1819938[*BZ#1819938*])
 
-* Previously on the *Home* -> *Events* page from the *Administrator* perspective of the web console, the node name did not show for several node events. With this update, all events now correctly link to the corresponding node.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1809813[*BZ#1809813*])
+* Previously on the *Home* -> *Events* page from the *Administrator* perspective of the web console, the node name did not show for several node events. With this update, all events now correctly link to the corresponding node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809813[*BZ#1809813*])
 
-* Previously, the *Home* -> *Overview* menu item from the *Administrator* perspective of the web console was hidden from users who could not list namespaces, but otherwise have permissions to see cluster metrics. With this update, the *Overview* navigation item is now visible for all users who have authority to view cluster metrics.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1811757[*BZ#1811757*])
+* Previously, the *Home* -> *Overview* menu item from the *Administrator* perspective of the web console was hidden from users who could not list namespaces, but otherwise have permissions to see cluster metrics. With this update, the *Overview* navigation item is now visible for all users who have authority to view cluster metrics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1811757[*BZ#1811757*])
 
-* Previously in the OperatorHub on the *Installed Operators* page, the link to view more APIs for an installed Operator did not open the correct tab. With this update, the *View x more* link under *Provided APIs* goes to the *Details* tab for the installed Operator.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1824254[*BZ#1824254*])
+* Previously in the OperatorHub on the *Installed Operators* page, the link to view more APIs for an installed Operator did not open the correct tab. With this update, the *View x more* link under *Provided APIs* goes to the *Details* tab for the installed Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824254[*BZ#1824254*])
 
-* Previously in the OperatorHub, overflow of a container background was not hidden in mobile view. This update fixes the gray background and hides the overflow.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1809812[*BZ#1809812*])
+* Previously in the OperatorHub, overflow of a container background was not hidden in mobile view. This update fixes the gray background and hides the overflow. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809812[*BZ#1809812*])
 
-* Previously, the `fieldDependency` `specDescriptor` did not work as expected. As a result, the Control Field did not control the visibility of the Dependent Field. The visibility of the Dependent Field is now correctly enabled or disabled by the Control Field.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1826074[*BZ#1826074*])
+* Previously, the `fieldDependency` `specDescriptor` did not work as expected. As a result, the Control Field did not control the visibility of the Dependent Field. The visibility of the Dependent Field is now correctly enabled or disabled by the Control Field. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826074[*BZ#1826074*])
 
 * Previously, the default CA certificate was being used inside the console pod. This bug fix configures the console to use the `default-ingress-cert` config map if that config map exists; if it does not exist, the console configures the default CA certificate instead. This allows the default Ingress certificate to be used, if available, to verify access to the routes the Ingress controller creates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824934[*BZ#1824934*])
 
@@ -1573,26 +1304,15 @@ Now, the installation program uses different AWS Terraform provider code, which 
 
 * Previously, `oc` was not listed first on the CLI downloads page because the CLI downloads were listed alphabetically. Because `oc` is the primary CLI for {product-title}, it is now listed at the top of the CLI downloads page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824934[*BZ#1824934*])
 
-* Previously, the *Explorer* view presented *Access Review* tabs to users who lacked the required permissions to view these tabs. Users without this authorization saw an error message and instructions to try reloading the tab, but retrying would not change the result. With this release, the *Access Review* tabs are hidden from users who do not have permission to view the contents of the tabs.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1786251[*BZ#1786251*])
+* Previously, the *Explorer* view presented *Access Review* tabs to users who lacked the required permissions to view these tabs. Users without this authorization saw an error message and instructions to try reloading the tab, but retrying would not change the result. With this release, the *Access Review* tabs are hidden from users who do not have permission to view the contents of the tabs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1786251[*BZ#1786251*])
 
-* Previously, memory consumption data in the *Cluster Utilization* card view and the top consumers popover view was inconsistent because these two views used different methods to calculate memory usage. With this release, the two views use the same method to calculate memory usage so that the data they provide is consistent.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1812096[*BZ#1812096*])
+* Previously, memory consumption data in the *Cluster Utilization* card view and the top consumers popover view was inconsistent because these two views used different methods to calculate memory usage. With this release, the two views use the same method to calculate memory usage so that the data they provide is consistent. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1812096[*BZ#1812096*])
 
-* Previously, users were able to create two routing labels for a single alert receiver. When two routing labels had the same key, the list page only showed the latest created one. However, exactly if one of the routing labels used regular expressions, the details page separated them as two distinct routing labels. With this release, users can no longer create two routing labels for a single alert receiver.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1804049[*BZ#1804049*])
+* Previously, users were able to create two routing labels for a single alert receiver. When two routing labels had the same key, the list page only showed the latest created one. However, exactly if one of the routing labels used regular expressions, the details page separated them as two distinct routing labels. With this release, users can no longer create two routing labels for a single alert receiver. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1804049[*BZ#1804049*])
 
-* With this release, an update to a library that is used by the web console resolved performance and display issues on some views.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1796658[*BZ#1796658*])
+* With this release, an update to a library that is used by the web console resolvjtps://bugzilla.redhat.com/show_bug.cgi?id=1796658[*BZ#1796658*])
 
-* Select links in the mast head had an href value of `\#` with an OnClick
-handler containing the target destination. As a result, those links have the
-option to open in a new tab, however the `#` resolved to the dashboard instead
-of the intended target destination. Now, any links with an href of `#` are
-updated to a button element so the *Open Link In New Tab* option is not
-available. Links that have the *Open Link In New Tab* option show the correct
-URL.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1703757[*BZ#1703757*])
+* Select links in the mast head had an href value of `\#` with an OnClick handler containing the target destination. As a result, those links have the option to open in a new tab, however the `#` resolved to the dashboard instead of the intended target destination. Now, any links with an href of `#` are updated to a button element so the *Open Link In New Tab* option is not available. Links that have the *Open Link In New Tab* option show the correct URL. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1703757[*BZ#1703757*])
 
 *Monitoring*
 
@@ -1708,34 +1428,25 @@ This caused certain Operators to fail to upgrade to new versions. This bug fix u
 
 * Previously, service load balancers could not include Azure master nodes, which broke ingress on compact clusters where worker nodes are also master nodes. Azure only allows a node's network interface card (NIC) to be associated with a single load balancer at any point in time. With this update, the installer was changed to create a unified load balancer and network security group that are used for both the API and services of type `LoadBalancer`. Now, service load balancers can include master nodes on Azure and ingress works on compact clusters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1794839[*BZ#1794839*])
 
-* Previously, the openshift-router did not establish a watch of default certificate secret contents if the secret was invalid. Upon starting, the openshift-router failed to read the invalid secret, which must exist for the router pod to start. As a result, the user had to update the invalid secret and delete the current router pods. With this update, the router now watches for any changes in the default certificate secret without deleting the router pods. If the secret is invalid, the router uses and serves the default router certificate. If the secret is valid, the router serves the default certificate from that secret.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1820400[*BZ#1820400*])
+* Previously, the openshift-router did not establish a watch of default certificate secret contents if the secret was invalid. Upon starting, the openshift-router failed to read the invalid secret, which must exist for the router pod to start. As a result, the user had to update the invalid secret and delete the current router pods. With this update, the router now watches for any changes in the default certificate secret without deleting the router pods. If the secret is invalid, the router uses and serves the default router certificate. If the secret is valid, the router serves the default certificate from that secret. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1820400[*BZ#1820400*])
 
 * Previously, the Ingress Operator failed to configure DNS when running in AWS China regions. With this update, the Ingress Operator now detects when it is running in AWS China regions and can configure DNS in Route 53 API endpoint. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1805224[*BZ#1805224*])
 
-* Previously, the Ingress Operator continuously upserted DNS records that it managed on Azure and Google Cloud Provider (GCP). With this update, the Ingress Operator avoids upserting a DNS record if the record is already published and neither the record nor the DNS zone configuration has changed since the controller last upserted the record. The Ingress Operator now makes fewer calls to the cloud provider API, which might prevent *cloud provider rate limited* events in the `openshift-ingress` namespace. Additionally, the Ingress Operator logs now show fewer `upserted DNS record` log messages.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1809354[*BZ#1809354*])
+* Previously, the Ingress Operator continuously upserted DNS records that it managed on Azure and Google Cloud Provider (GCP). With this update, the Ingress Operator avoids upserting a DNS record if the record is already published and neither the record nor the DNS zone configuration has changed since the controller last upserted the record. The Ingress Operator now makes fewer calls to the cloud provider API, which might prevent *cloud provider rate limited* events in the `openshift-ingress` namespace. Additionally, the Ingress Operator logs now show fewer `upserted DNS record` log messages. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809354[*BZ#1809354*])
 
-* Previously, the ingress-to-route controller used the ingresses resource from the `extensions/v1beta1` API group, which was deprecated in Kubernetes 1.18. With this update, the ingress-to-route controller now uses the ingresses resource from the `networking.k8s.io/v1beta1` API group.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1801415[*BZ#1801415*])
+* Previously, the ingress-to-route controller used the ingresses resource from the `extensions/v1beta1` API group, which was deprecated in Kubernetes 1.18. With this update, the ingress-to-route controller now uses the ingresses resource from the `networking.k8s.io/v1beta1` API group. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1801415[*BZ#1801415*])
 
-* Previously, the router was not promoting inactive routes when a conflicting route was deleted. Now when a route is deleted, the router reprocesses all inactive routes and activates routes that no longer conflict with the deleted route.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1821095[*BZ#1821095*])
+* Previously, the router was not promoting inactive routes when a conflicting route was deleted. Now when a route is deleted, the router reprocesses all inactive routes and activates routes that no longer conflict with the deleted route. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821095[*BZ#1821095*])
 
-* Previously, when a service with type `LoadBalancer` or an Ingress Controller with the `LoadBalancerService` endpoint publishing strategy type was deleted, the service remained present and in a `pending` state. The service controller was changed in {product-title} 3.10 to prevent unnecessary `GetLoadBalancer` cloud-provider API calls when non-`LoadBalancer` services were created or deleted. A subsequent change in Kubernetes 1.15 prevented these unnecessary API calls in a different way. As a result, interaction between these two changes broke the service controller's clean-up logic for services with type `LoadBalancer`. With this update, the change added in {product-title} 3.10 was removed. Deletion of services with a type `LoadBalancer` and Ingress Controllers with a `LoadBalancerService` type can now complete.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1798282[*BZ#1798282*])
+* Previously, when a service with type `LoadBalancer` or an Ingress Controller with the `LoadBalancerService` endpoint publishing strategy type was deleted, the service remained present and in a `pending` state. The service controller was changed in {product-title} 3.10 to prevent unnecessary `GetLoadBalancer` cloud-provider API calls when non-`LoadBalancer` services were created or deleted. A subsequent change in Kubernetes 1.15 prevented these unnecessary API calls in a different way. As a result, interaction between these two changes broke the service controller's clean-up logic for services with type `LoadBalancer`. With this update, the change added in {product-title} 3.10 was removed. Deletion of services with a type `LoadBalancer` and Ingress Controllers with a `LoadBalancerService` type can now complete. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1798282[*BZ#1798282*])
 
-* Previously, a confusing `LoadBalancerManager` status condition reason was set by the Ingress Operator when the endpoint publishing strategy did not include managing a load balancer. When an `IngressController` resource is configured to use an endpoint publishing strategy type other than `LoadBalancerService`, the Ingress Operator does not manage a load balancer for that Ingress Controller. With this update, the `LoadBalancerManager` status condition more clearly states why the Operator is not managing a load balancer for the Ingress Controller. The message now does not use phrases such as *unsupported* or *does not support*.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1826113[*BZ#1826113*])
+* Previously, a confusing `LoadBalancerManager` status condition reason was set by the Ingress Operator when the endpoint publishing strategy did not include managing a load balancer. When an `IngressController` resource is configured to use an endpoint publishing strategy type other than `LoadBalancerService`, the Ingress Operator does not manage a load balancer for that Ingress Controller. With this update, the `LoadBalancerManager` status condition more clearly states why the Operator is not managing a load balancer for the Ingress Controller. The message now does not use phrases such as *unsupported* or *does not support*. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826113[*BZ#1826113*])
 
-* Previously, a Forwarded HTTP header with a non-standard `proto-version` parameter was added when the Ingress Controller forwarded an HTTP request to an application. As a result, the Forwarded header was not standards-compliant and might have caused problems when applications tried to parse the header value. With this update, the Forwarded header is now standards-compliant and the Ingress Controller does not specify a `proto-version` parameter in the Forwarded header.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1803001[*BZ#1803001*])
+* Previously, a Forwarded HTTP header with a non-standard `proto-version` parameter was added when the Ingress Controller forwarded an HTTP request to an application. As a result, the Forwarded header was not standards-compliant and might have caused problems when applications tried to parse the header value. With this update, the Forwarded header is now standards-compliant and the Ingress Controller does not specify a `proto-version` parameter in the Forwarded header. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1803001[*BZ#1803001*])
 
-* Previously, Prometheus counters that show the number of active sessions were preserved across router restarts and increased indefinitely. With this update, `haproxy_frontend_current_session` and `haproxy_server_current_session` now accurately depict the number of active sessions. The value of these counters are now reset upon router restart.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1832539[*BZ#1832539*])
+* Previously, Prometheus counters that show the number of active sessions were preserved across router restarts and increased indefinitely. With this update, `haproxy_frontend_current_session` and `haproxy_server_current_session` now accurately depict the number of active sessions. The value of these counters are now reset upon router restart. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1832539[*BZ#1832539*])
 
-* If the backing pods of a service exposed via a route are unavailable (e.g., crashlooping, deleted), the router responds with a `503` error. Previously, the `haproxy_server_http_responses_total` metric for that route was no longer available, thus monitoring on the route was no longer possible. With this update, all backend metrics are now reported and users can track when no pods are up.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1835845[*BZ#1835845*])
+* If the backing pods of a service exposed via a route are unavailable (e.g., crashlooping, deleted), the router responds with a `503` error. Previously, the `haproxy_server_http_responses_total` metric for that route was no longer available, thus monitoring on the route was no longer possible. With this update, all backend metrics are now reported and users can track when no pods are up. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835845[*BZ#1835845*])
 
 *Samples*
 
@@ -1766,9 +1477,7 @@ This caused certain Operators to fail to upgrade to new versions. This bug fix u
 [id="ocp-4-5-technology-preview"]
 == Technology Preview features
 
-Some features in this release are currently in Technology Preview. These
-experimental features are not intended for production use. Note the
-following scope of support on the Red Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
@@ -1946,18 +1655,9 @@ In the table below, features are marked with the following statuses:
 
 * When upgrading to a new {product-title} release with the default CNI network provider set to OVN-Kubernetes, the upgrade fails and the cluster is left in an unusable state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854175[*BZ#1854175*])
 
-* Because the `ImageContentSourcePolicy` for image registry pull-through is not
-yet supported, the deployment pod cannot mirror images by using a digest ID if
-the image stream has the pull-through policy enabled. In this case, an
-`ImagePullBackOff` error displays.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1787112[*BZ#1787112*])
+* Because the `ImageContentSourcePolicy` for image registry pull-through is not yet supported, the deployment pod cannot mirror images by using a digest ID if the image stream has the pull-through policy enabled. In this case, an `ImagePullBackOff` error displays. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1787112[*BZ#1787112*])
 
-* If you scale up with a RHEL worker while running a cluster on {rh-openstack}
-that uses user-provisioned infrastructure, all routes are inaccessible if the
-Ingress port VIP is on the RHEL worker. As a workaround, you must reschedule the
-router pod to an {op-system} node and make the Ingress VIP migrate to the
-{op-system} node. To do this, add the `node.openshift.io/os_id: rhcos` label to
-the Ingress Controller before upgrade:
+* If you scale up with a RHEL worker while running a cluster on {rh-openstack} that uses user-provisioned infrastructure, all routes are inaccessible if the Ingress port VIP is on the RHEL worker. As a workaround, you must reschedule the router pod to an {op-system} node and make the Ingress VIP migrate to the {op-system} node. To do this, add the `node.openshift.io/os_id: rhcos` label to the Ingress Controller before upgrade:
 +
 ----
 $ oc -n openshift-ingress-operator edit ingresscontroller/default -o yaml
@@ -1978,75 +1678,35 @@ spec:
 
 * In the *Topology* view, when you right-click a Knative service, the *Edit Application Grouping* option is displayed twice in the context menu. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849107[*BZ#1849107*])
 
-* The Special Resources Operator (SRO) cannot be deployed successfully on
-{product-title} 4.5. This prevents the deployment of NVIDIA drivers, which
-are required by the cluster to run workloads requiring GPU resources. Also, the
-Topology Manager feature could not be tested with GPU resources as a result of
-this known issue.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1847805[*BZ#1847805*])
+* The Special Resources Operator (SRO) cannot be deployed successfully on {product-title} 4.5. This prevents the deployment of NVIDIA drivers, which are required by the cluster to run workloads requiring GPU resources. Also, the Topology Manager feature could not be tested with GPU resources as a result of this known issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847805[*BZ#1847805*])
 
-* The web console includes the option to create VM vNICS with a SLIRP binding,
-but this is not supported. Attempting to use this option will cause the VM to
-fail to boot. Do not select this option.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1828744[*BZ#1828744*])
+* The web console includes the option to create VM vNICS with a SLIRP binding, but this is not supported. Attempting to use this option will cause the VM to fail to boot. Do not select this option. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1828744[*BZ#1828744*])
 
-* There is an issue where pods that use the OpenShift SDN default CNI network
-provider in a node can lose network communication, causing the pods to crash.
-This can sometimes happen when upgrading a cluster. As a workaround, you can
-delete and re-create the pods.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1855118[*BZ#1855118*])
+* There is an issue where pods that use the OpenShift SDN default CNI network provider in a node can lose network communication, causing the pods to crash. This can sometimes happen when upgrading a cluster. As a workaround, you can delete and re-create the pods. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855118[*BZ#1855118*])
 
-* There is a known issue where the custom pool is not supported on the master node. The command `oc label node` applies the new custom role to the target master node, but the Machine Config Operator does not apply changes specific to the custom pool. This results in an error, which can be seen in the Machine Config Controller pod logs. As a suggested workaround to ensure that control plane nodes remain stable, it is recommended to not apply multiple roles on master.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1797687[*BZ#1797687*])
+* There is a known issue where the custom pool is not supported on the master node. The command `oc label node` applies the new custom role to the target master node, but the Machine Config Operator does not apply changes specific to the custom pool. This results in an error, which can be seen in the Machine Config Controller pod logs. As a suggested workaround to ensure that control plane nodes remain stable, it is recommended to not apply multiple roles on master. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1797687[*BZ#1797687*])
 
-* The logging performance for clusters is degraded compared to past versions of
-{product-title}. This is being actively investigated and will be updated in a
-future release of {product-title}.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1833486[*BZ#1833486*])
+* The logging performance for clusters is degraded compared to past versions of {product-title}. This is being actively investigated and will be updated in a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1833486[*BZ#1833486*])
 
-* You might receive a message that the system is unable to mount a volume when the volume contains a large number of files. This can happen when a pod mounts a volume that is set with `FSGroup SecurityContext` because the GID ownership of the files must be recursively updated for all files on the volume. Users should expect that pods using volumes with a large number of files and the `FSGroup SecurityContext` setting can take considerable time to start.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1515907[*BZ#1515907*])
+* You might receive a message that the system is unable to mount a volume when the volume contains a large number of files. This can happen when a pod mounts a volume that is set with `FSGroup SecurityContext` because the GID ownership of the files must be recursively updated for all files on the volume. Users should expect that pods using volumes with a large number of files and the `FSGroup SecurityContext` setting can take considerable time to start. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1515907[*BZ#1515907*])
 
-* Running pods with frequent probes can cause the number of conmon processes to
-grow quickly. A conmon process is a program that detaches from its parent,
-CRI-O, and is used to exec the container runtime. If the probes happen
-frequently enough, systemd has trouble reaping all of its new children, and some
-conmon processes can become zombies.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1852064[*BZ#1852064*])
+* Running pods with frequent probes can cause the number of conmon processes to grow quickly. A conmon process is a program that detaches from its parent, CRI-O, and is used to exec the container runtime. If the probes happen frequently enough, systemd has trouble reaping all of its new children, and some conmon processes can become zombies. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852064[*BZ#1852064*])
 
 * On Microsoft Azure when upgrading from 4.4 to 4.5, the Ingress Operator can fail to ensure a DNSRecord due to errors refreshing the token. Restarting the Ingress Operator fixes the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854383[*BZ#1854383*])
 
-* When running {product-title} on Azure with installer-provisioned
-infrastructure, there is a known issue where `oc` commands fail
-intermittently with TLS handshake timeout errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1851549[*BZ#1851549*])
+* When running {product-title} on Azure with installer-provisioned infrastructure, there is a known issue where `oc` commands fail intermittently with TLS handshake timeout errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1851549[*BZ#1851549*])
 
-* For clusters on VMware vSphere instances using installer-provisioned
-infrastructure, bootstrap workers fail. The default resource pool resolves to
-multiple instances.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1852545[*BZ#1852545*])
+* For clusters on VMware vSphere instances using installer-provisioned infrastructure, bootstrap workers fail. The default resource pool resolves to multiple instances. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852545[*BZ#1852545*])
 
-* There is an issue where the Machine Config Operator (MCO) becomes degraded
-during the installation of an {product-title} cluster. This is caused by a
-machine config ordering problem during the bootstrap process. As a workaround, you
-must prefix any custom machine config file with a differing priority of `98-`
-instead of `99-`.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1826150[*BZ#1826150*])
+* There is an issue where the Machine Config Operator (MCO) becomes degraded during the installation of an {product-title} cluster. This is caused by a machine config ordering problem during the bootstrap process. As a workaround, you must prefix any custom machine config file with a differing priority of `98-` instead of `99-`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826150[*BZ#1826150*])
 
-* Git clone operations that go through an HTTPS proxy fail. Non-TLS (HTTP)
-proxies can be used successfully.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1750650[*BZ#1750650*])
+* Git clone operations that go through an HTTPS proxy fail. Non-TLS (HTTP) proxies can be used successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1750650[*BZ#1750650*])
 
-* Git clone operations fail in builds running behind a proxy if the source URIs
-use the `git://` or `ssh://` scheme.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1751738[*BZ#1751738*])
+* Git clone operations fail in builds running behind a proxy if the source URIs use the `git://` or `ssh://` scheme. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1751738[*BZ#1751738*])
 
-* An issue has been found for the s390x and ppc64le architectures that renders
-nodes unavailable for workloads after a forced reboot or power down. Do not
-force reboot or power down nodes.
+* An issue has been found for the s390x and ppc64le architectures that renders nodes unavailable for workloads after a forced reboot or power down. Do not force reboot or power down nodes.
 +
-If a forced reboot or power down is unavoidable and a node that comes back up is
-unavailable for workloads:
+If a forced reboot or power down is unavoidable and a node that comes back up is unavailable for workloads:
 +
 . SSH into the node.
 . Stop the CRI-O and kubelet services.
@@ -2055,14 +1715,9 @@ unavailable for workloads:
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1858411[*BZ#1858411*])
 
-* If an AWS account is configured to use AWS Organizations service control
-policies (SCPs) that use a global condition to deny all actions or require a
-specific permission, {product-title} AWS installations fail, even if the
-provided credentials have the required permissions for installation.
+* If an AWS account is configured to use AWS Organizations service control policies (SCPs) that use a global condition to deny all actions or require a specific permission, {product-title} AWS installations fail, even if the provided credentials have the required permissions for installation.
 +
-A xref:ocp-4-5-8-added-credentialsmode-parameter-for-aws-install-workaround[workaround for this issue]
-is introduced in {product-title} 4.5.8.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1829101[*BZ#1829101*])
+A xref:ocp-4-5-8-added-credentialsmode-parameter-for-aws-install-workaround[workaround for this issue] is introduced in {product-title} 4.5.8. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1829101[*BZ#1829101*])
 
 * In {product-title} 4.1, anonymous users could access discovery endpoints. Later releases revoked this access to reduce the possible attack surface for security exploits because some discovery endpoints are forwarded to aggregated API servers. However, unauthenticated access is preserved in upgraded clusters so that existing use cases are not broken.
 +
@@ -2102,35 +1757,20 @@ This script removes unauthenticated subjects from the following cluster role bin
 [id="ocp-4-5-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} 4.5 are released
-as asynchronous errata through the Red Hat Network. All {product-title} 4.5
-errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the
-https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} 4.5 are released as asynchronous errata through the Red Hat Network. All {product-title} 4.5 errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
-Red Hat Customer Portal users can enable errata notifications in the account
-settings for Red Hat Subscription Management (RHSM). When errata notifications
-are enabled, users are notified via email whenever new errata relevant to their
-registered systems are released.
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming
-{product-title} entitlements for {product-title} errata notification
-emails to generate.
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
-This section will continue to be updated over time to provide notes on
-enhancements and bug fixes for future asynchronous errata releases of
-{product-title} 4.5. Versioned asynchronous releases, for example with the form
-{product-title} 4.5.z, will be detailed in subsections. In addition, releases
-in which the errata text cannot fit in the space provided by the advisory will
-be detailed in subsections that follow.
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} 4.5. Versioned asynchronous releases, for example with the form {product-title} 4.5.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
 
 [IMPORTANT]
 ====
-For any {product-title} release, always review the instructions on
-xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster]
-properly.
+For any {product-title} release, always review the instructions on xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster] properly.
 ====
 
 [id="RHBA-2020-2409"]
@@ -2138,14 +1778,9 @@ properly.
 
 Issued: 2020-07-13
 
-{product-title} release 4.5 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409]
-advisory. The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:2408[RHBA-2020:2408] advisory.
+{product-title} release 4.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:2409[RHBA-2020:2409] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:2408[RHBA-2020:2408] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5184131[{product-title} 4.5.1 container image list]
 
@@ -2154,97 +1789,59 @@ link:https://access.redhat.com/solutions/5184131[{product-title} 4.5.1 container
 
 Issued: 2020-07-13
 
-Container image updates are now available for {product-title} 4.5. Details of
-the updates are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:2412[RHSA-2020:2412] advisory.
+Container image updates are now available for {product-title} 4.5. Details of the updates are documented in the link:https://access.redhat.com/errata/RHSA-2020:2412[RHSA-2020:2412] advisory.
 
 [id="RHSA-2020-2413"]
 === RHSA-2020:2413 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-07-13
 
-A package update is now available for {product-title} 4.5. Details of the update
-are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:2413[RHSA-2020:2413] advisory.
+A package update is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:2413[RHSA-2020:2413] advisory.
 
 [id="RHBA-2020-2909"]
 === RHBA-2020:2909 - {product-title} 4.5.2 bug fix update
 
 Issued: 2020-07-16
 
-{product-title} release 4.5.2 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:2909[RHBA-2020:2909] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:2908[RHBA-2020:2908] advisory.
+{product-title} release 4.5.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:2909[RHBA-2020:2909] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:2908[RHBA-2020:2908] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5225291[{product-title} 4.5.2 container image list]
 
 [id="RHBA-2020-2909-bug-fixes"]
 ==== Bug Fixes
 
-* Upgrades to {product-title} 4.5.1 failed on nodes with Secure Boot configured.
-For clusters configured with Secure Boot, one node from both the control plane
-and compute machine config pools failed to reboot, which caused the Machine
-Config Operator (MCO) to be degraded. The cluster subsequently failed to
-upgrade. The issue is not present in this release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1856501[*BZ#1856501*])
+* Upgrades to {product-title} 4.5.1 failed on nodes with Secure Boot configured. For clusters configured with Secure Boot, one node from both the control plane and compute machine config pools failed to reboot, which caused the Machine Config Operator (MCO) to be degraded. The cluster subsequently failed to upgrade. The issue is not present in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1856501[*BZ#1856501*])
 
 [id="ocp-4-5-3"]
 === RHBA-2020:2956 - {product-title} 4.5.3 bug fix update
 
 Issued: 2020-07-22
 
-{product-title} release 4.5.3 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:2956[RHBA-2020:2956] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:2955[RHBA-2020:2955] advisory.
+{product-title} release 4.5.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:2956[RHBA-2020:2956] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:2955[RHBA-2020:2955] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5239171[{product-title} 4.5.3 container image list]
 
 [id="ocp-4-5-3-bug-fixes"]
 ==== Bug Fixes
 
-* Previously, an issue caused nodes to become unavailable for workloads after a
-forced reboot or power down. This has been fixed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1857224[*BZ#1857224*])
+* Previously, an issue caused nodes to become unavailable for workloads after a forced reboot or power down. This has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857224[*BZ#1857224*])
 
-* Previously, the web console would choose Operator icons to display in
-OperatorHub by returning the icon from the first channel declared in the
-package. This sometimes caused the displayed icon to be different than
-the latest icon published to the package. This has been fixed by choosing the
-icon from the default channel, which ensures the latest icon is displayed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1844588[*BZ#1844588*])
+* Previously, the web console would choose Operator icons to display in OperatorHub by returning the icon from the first channel declared in the package. This sometimes caused the displayed icon to be different than the latest icon published to the package. This has been fixed by choosing the icon from the default channel, which ensures the latest icon is displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844588[*BZ#1844588*])
 
-* Previously, the container image signature policy used in {product-title}
-builds did not contain any configuration for local images. When only allowing
-images from specific registries, `postCommit` scripts in builds failed because it
-was not allowed to use local images. The container image signature policy has
-been updated to always allow images that reference local storage layers
-directly. Now builds can successfully complete if they contain a `postCommit`
-hook. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849173[*BZ#1849173*])
+* Previously, the container image signature policy used in {product-title} builds did not contain any configuration for local images. When only allowing images from specific registries, `postCommit` scripts in builds failed because it was not allowed to use local images. The container image signature policy has been updated to always allow images that reference local storage layers directly. Now builds can successfully complete if they contain a `postCommit` hook. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849173[*BZ#1849173*])
 
 [id="ocp-4-5-4"]
 === RHBA-2020:3028 - {product-title} 4.5.4 bug fix update
 
 Issued: 2020-07-30
 
-{product-title} release 4.5.4 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3028[RHBA-2020:3028] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3027[RHBA-2020:3027] and
-link:https://access.redhat.com/errata/RHEA-2020:3208[RHEA-2020:3208] advisories.
+{product-title} release 4.5.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3028[RHBA-2020:3028] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3027[RHBA-2020:3027] and link:https://access.redhat.com/errata/RHEA-2020:3208[RHEA-2020:3208] advisories.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5267451[{product-title} 4.5.4 container image list]
 
@@ -2254,8 +1851,7 @@ link:https://access.redhat.com/solutions/5267451[{product-title} 4.5.4 container
 [id="ocp-4-5-4-ibm-z"]
 ===== IBM Z and LinuxONE
 
-With this release, IBM Z and LinuxONE is now compatible with {product-title} {product-version}.
-See xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z_installing-ibm-z[Installing a cluster on IBM Z and LinuxONE] for installation instructions.
+With this release, IBM Z and LinuxONE is now compatible with {product-title} {product-version}. See xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z_installing-ibm-z[Installing a cluster on IBM Z and LinuxONE] for installation instructions.
 
 [discrete]
 ====== Restrictions
@@ -2288,8 +1884,7 @@ Note the following restrictions for {product-title} on IBM Z and LinuxONE:
 
 * Worker nodes must run {op-system-first}.
 * Persistent shared storage must be of type Filesystem: NFS.
-* These features are available for {product-title} on IBM Z for
-{product-version}, but not for {product-title} {product-version} on x86:
+* These features are available for {product-title} on IBM Z for {product-version}, but not for {product-title} {product-version} on x86:
 ** HyperPAV enabled on IBM System Z for the virtual machine for FICON attached ECKD storage.
 
 
@@ -2331,159 +1926,107 @@ Note the following restrictions for {product-title} on IBM Power:
 [id="ocp-4-5-4-bug-fixes"]
 ==== Bug Fixes
 
-* Previously, the action menu for an operand on the operand list could close
-immediately after opening. This behavior was observed when clicking the tab for
-an Operator-provided API on the *Installed Operators* -> *Operator Details* page.
-The menu now functions correctly and does not close without user interaction.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1842717[*BZ#1842717*])
+* Previously, the action menu for an operand on the operand list could close immediately after opening. This behavior was observed when clicking the tab for an Operator-provided API on the *Installed Operators* -> *Operator Details* page. The menu now functions correctly and does not close without user interaction. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842717[*BZ#1842717*])
 
-* Previously, when filtering the OperatorHub catalog in the web console, some
-Operator icons did not appear until the user scrolled down on the page. With
-this release, the icons appear immediately when filtered.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1844503[*BZ#1844503*])
+* Previously, when filtering the OperatorHub catalog in the web console, some Operator icons did not appear until the user scrolled down on the page. With this release, the icons appear immediately when filtered. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844503[*BZ#1844503*])
 
-* Previously, the quota gauge charts on the *Resource Quota Details* page of the
-web console rendered with a width of zero and were not visible. The issue has
-been resolved in this release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1845125[*BZ#1845125*])
+* Previously, the quota gauge charts on the *Resource Quota Details* page of the web console rendered with a width of zero and were not visible. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845125[*BZ#1845125*])
 
-* Previously, clicking *Create EtcdRestore* on the *EtcdRestores* page caused
-the web console to stop responding. With this release, the *Create EtcdRestore*
-form view workflow loads correctly.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1847277[*BZ#1847277*])
+* Previously, clicking *Create EtcdRestore* on the *EtcdRestores* page caused the web console to stop responding. With this release, the *Create EtcdRestore* form view workflow loads correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847277[*BZ#1847277*])
 
-* Previously, in the *Create Knative Serving* form view workflow for the
-OpenShift Serverless Operator, some fields that should only accept numeric
-characters accepted non-numeric characters. The issue has been resolved in this
-release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1847283[*BZ#1847283*])
+* Previously, in the *Create Knative Serving* form view workflow for the OpenShift Serverless Operator, some fields that should only accept numeric characters accepted non-numeric characters. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847283[*BZ#1847283*])
 
-* Previously, clicking *Create* on the *Create ManilaDriver* form view workflow
-for the Manila CSI Driver Operator did not create a `ManilaDriver` instance or any
-response in the web console. The issue has been resolved in this release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1853274[*BZ#1853274*])
+* Previously, clicking *Create* on the *Create ManilaDriver* form view workflow for the Manila CSI Driver Operator did not create a `ManilaDriver` instance or any response in the web console. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853274[*BZ#1853274*])
 
 [id="ocp-4-5-4-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3207"]
 === RHSA-2020:3207 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-07-30
 
-An update for `jenkins-2-plugins` is now available for {product-title} 4.5.
-Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3207[RHSA-2020:3207] advisory.
+An update for `jenkins-2-plugins` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3207[RHSA-2020:3207] advisory.
 
 [id="ocp-4-5-5"]
 === RHBA-2020:3188 - {product-title} 4.5.5 bug fix update
 
 Issued: 2020-08-10
 
-{product-title} release 4.5.5 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3188[RHBA-2020:3188] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3189[RHBA-2020:3189] advisory.
+{product-title} release 4.5.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3188[RHBA-2020:3188] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3189[RHBA-2020:3189] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5304951[{product-title} 4.5.5 container image list]
 
 [id="ocp-4-5-5-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="ocp-4-5-6"]
 === RHBA-2020:3330 - {product-title} 4.5.6 bug fix update
 
 Issued: 2020-08-17
 
-{product-title} release 4.5.6 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3330[RHBA-2020:3330] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3331[RHBA-2020:3331] advisory.
+{product-title} release 4.5.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3330[RHBA-2020:3330] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3331[RHBA-2020:3331] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5317761[{product-title} 4.5.6 container image list]
 
 [id="ocp-4-5-6-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3453"]
 === RHSA-2020:3453 - Important: {product-title} 4.5 security update
 
 Issued: 2020-08-17
 
-An update for `jenkins-2-plugins` and `python-rsa` is now available for {product-title} 4.5.
-Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3453[RHSA-2020:3453] advisory.
+An update for `jenkins-2-plugins` and `python-rsa` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3453[RHSA-2020:3453] advisory.
 
 [id="ocp-4-5-7"]
 === RHBA-2020:3436 - {product-title} 4.5.7 bug fix update
 
 Issued: 2020-08-24
 
-{product-title} release 4.5.7 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3436[RHBA-2020:3436] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3437[RHBA-2020:3437] advisory.
+{product-title} release 4.5.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3436[RHBA-2020:3436] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3437[RHBA-2020:3437] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5331611[{product-title} 4.5.7 container image list]
 
 [id="ocp-4-5-7-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3519"]
 === RHSA-2020:3519 - Important: {product-title} 4.5 security update
 
 Issued: 2020-08-24
 
-An update for `jenkins` and `openshift` is now available for {product-title}
-4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3519[RHSA-2020:3519] advisory.
+An update for `jenkins` and `openshift` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3519[RHSA-2020:3519] advisory.
 
 [id="RHSA-2020-3520"]
 === RHSA-2020:3520 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-08-24
 
-An update for `openshift-enterprise-hyperkube-container` is now available for
-{product-title} 4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3520[RHSA-2020:3520] advisory.
+An update for `openshift-enterprise-hyperkube-container` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3520[RHSA-2020:3520] advisory.
 
 [id="ocp-4-5-8"]
 === RHBA-2020:3510 - {product-title} 4.5.8 bug fix update
 
 Issued: 2020-09-08
 
-{product-title} release 4.5.8 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3510[RHBA-2020:3510] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3511[RHBA-2020:3511] advisory.
+{product-title} release 4.5.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3510[RHBA-2020:3510] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3511[RHBA-2020:3511] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5357141[{product-title} 4.5.8 container image list]
 
@@ -2493,9 +2036,7 @@ link:https://access.redhat.com/solutions/5357141[{product-title} 4.5.8 container
 [id="ocp-4-5-8-added-projectid-for-network-interfaces"]
 ===== Added `projectID` field for network interfaces
 
-The new `projectID` field is now available to configure in a `MachineSet` custom
-resource under `.spec.template.spec.providerSpec.networkInterfaces`. This field
-allows machines to be booted in shared VPCs.
+The new `projectID` field is now available to configure in a `MachineSet` custom resource under `.spec.template.spec.providerSpec.networkInterfaces`. This field allows machines to be booted in shared VPCs.
 
 [source,yaml]
 ----
@@ -2514,20 +2055,9 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=18687
 [id="ocp-4-5-8-added-credentialsmode-parameter-for-aws-install-workaround"]
 ===== Added `credentialsMode` parameter to bypass inaccurate AWS permissions validation
 
-For AWS installations, {product-title} depends on an AWS policy simulator API to
-validate permissions. If an AWS account is configured to use AWS Organizations
-service control policies (SCPs), permissions are checked against the policies
-that are set in the SCPs. When SCPs include policies that use a global condition
-to deny all actions or require a specific permission, the policy simulator API
-does not correctly validate permissions. For example, policies with conditions
-such as for all regions except `us-east-1` and `us-west-2`, or for all roles
-except `role-xyz`, cause the AWS API to return false negatives. When the permissions
-cannot be validated, {product-title} AWS installations fail, even if the
-provided credentials have the required permissions to install {product-title}.
+For AWS installations, {product-title} depends on an AWS policy simulator API to validate permissions. If an AWS account is configured to use AWS Organizations service control policies (SCPs), permissions are checked against the policies that are set in the SCPs. When SCPs include policies that use a global condition to deny all actions or require a specific permission, the policy simulator API does not correctly validate permissions. For example, policies with conditions such as for all regions except `us-east-1` and `us-west-2`, or for all roles except `role-xyz`, cause the AWS API to return false negatives. When the permissions cannot be validated, {product-title} AWS installations fail, even if the provided credentials have the required permissions to install {product-title}.
 
-With this release, you can bypass the policy simulator permissions check by
-setting a value for the `credentialsMode` parameter in the `install-config.yaml`
-configuration file.
+With this release, you can bypass the policy simulator permissions check by setting a value for the `credentialsMode` parameter in the `install-config.yaml` configuration file.
 
 .Example `install-config.yaml` configuration file
 
@@ -2543,300 +2073,189 @@ compute:
 ----
 <1> This line is added to set the `credentialsMode` parameter to `Mint`.
 
-Setting a value for `credentialsMode` bypasses the permissions check for AWS
-accounts configured to use SCPs and allows the installation to proceed. When
-bypassing this check, ensure that the credentials you provide have the
-permissions that are required for the specified mode.
+Setting a value for `credentialsMode` bypasses the permissions check for AWS accounts configured to use SCPs and allows the installation to proceed. When bypassing this check, ensure that the credentials you provide have the permissions that are required for the specified mode.
 
-The value of `credentialsMode` changes the behavior of the Cloud Credential
-Operator (CCO) as follows:
+The value of `credentialsMode` changes the behavior of the Cloud Credential Operator (CCO) as follows:
 
-* `Mint` - The CCO uses the provided admin-level cloud credential to run the
-installer. If the credential is not removed after installation, it is stored and
-used by the CCO to process `CredentialsRequest` custom resources in the cluster and create new
-users for each with specific required permissions.
-* `Passthrough` - The CCO uses the provided non-admin cloud credential that has
-enough permissions to perform the installation to run the installer. For more
-information about locating the permissions specified in the `CredentialsRequest` custom resources
-for the version of {product-title} being installed, see
-xref:../installing/installing_aws/manually-creating-iam.adoc[Manually creating IAM for AWS].
+* `Mint` - The CCO uses the provided admin-level cloud credential to run the installer. If the credential is not removed after installation, it is stored and used by the CCO to process `CredentialsRequest` custom resources in the cluster and create new users for each with specific required permissions.
+* `Passthrough` - The CCO uses the provided non-admin cloud credential that has enough permissions to perform the installation to run the installer. For more information about locating the permissions specified in the `CredentialsRequest` custom resources for the version of {product-title} being installed, see xref:../installing/installing_aws/manually-creating-iam.adoc[Manually creating IAM for AWS].
 
 [id="ocp-4-5-8-bug-fixes"]
 ==== Bug fixes
 
-* Previously, intermittent API server errors were reported for the
-`ImageChangesInProgress` condition instead of the `SamplesExists` condition of
-the Samples Operator config object. When the API server reported that all
-samples were installed, the Samples Operator failed to switch the `Progressing`
-condition to `false` because there was unexpected data in its
-`ImageChangesInProgress` condition. This incorrectly caused upgrades to be
-marked as incomplete. This bug fix updates the `SamplesExists` condition to
-report errors on the API server, so upgrades are no longer blocked if
-intermittent API server errors occur while the Samples Operator is upgrading.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1857201[BZ#1857201])
+* Previously, intermittent API server errors were reported for the `ImageChangesInProgress` condition instead of the `SamplesExists` condition of the Samples Operator config object. When the API server reported that all samples were installed, the Samples Operator failed to switch the `Progressing` condition to `false` because there was unexpected data in its `ImageChangesInProgress` condition. This incorrectly caused upgrades to be marked as incomplete. This bug fix updates the `SamplesExists` condition to report errors on the API server, so upgrades are no longer blocked if intermittent API server errors occur while the Samples Operator is upgrading. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857201[BZ#1857201])
 
-* Previously, the `ironic-image` container configuration was missing the setting
-to enable the `idrac-redfish-virtual-media` boot driver. Because of this, users
-were unable to select the `idrac-virtual-media` boot URL for Metal3. The missing
-`ironic-image` container configuration is now included, so users are able to
-select the `idrac-virtual-media` URL for Metal3.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1859488[BZ#1859488])
+* Previously, the `ironic-image` container configuration was missing the setting to enable the `idrac-redfish-virtual-media` boot driver. Because of this, users were unable to select the `idrac-virtual-media` boot URL for Metal3. The missing `ironic-image` container configuration is now included, so users are able to select the `idrac-virtual-media` URL for Metal3. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859488[BZ#1859488])
 
-* Previously, the Operand form array and object fields did not have logic to
-retrieve and show field descriptions on the form. As a result, descriptions
-were not rendered for array or object type fields. This bug fix adds logic to now
-display array and object field descriptions on the Operand creation form.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1861433[BZ#1861433])
+* Previously, the Operand form array and object fields did not have logic to retrieve and show field descriptions on the form. As a result, descriptions were not rendered for array or object type fields. This bug fix adds logic to now display array and object field descriptions on the Operand creation form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861433[BZ#1861433])
 
-* Previously, Buildah erased image architecture and OS fields on images. This
-caused common container tools to fail because the resulting images could not
-identify their architecture and OS. This bug fix prevents Buildah from overwriting
-the image and architecture unless there are explicit overrides. This ensures that
-images always have architecture and OS fields, and the image mismatch warning
-does not appear.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1868401[BZ#1868401])
+* Previously, Buildah erased image architecture and OS fields on images. This caused common container tools to fail because the resulting images could not identify their architecture and OS. This bug fix prevents Buildah from overwriting the image and architecture unless there are explicit overrides. This ensures that images always have architecture and OS fields, and the image mismatch warning does not appear. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868401[BZ#1868401])
 
-* Previously, intermittent invalid memory address or nil pointer dereference
-errors occurred and were followed by timeouts for Kube API access when running CoreDNS
-1.6.6. This is now fixed by correctly handling errors with Endpoint Tombstones.
-Now CoreDNS behaves as intended without intermittent panics.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1869309[BZ#1869309])
+* Previously, intermittent invalid memory address or nil pointer dereference errors occurred and were followed by timeouts for Kube API access when running CoreDNS 1.6.6. This is now fixed by correctly handling errors with Endpoint Tombstones. Now CoreDNS behaves as intended without intermittent panics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1869309[BZ#1869309])
 
-* Previously, the controller for `BareMetalHost` objects mirrored status data to
-an annotation, including a timestamp of the latest status update. This was not
-needed by the cluster. This could result in the `BareMetalHost` object entering a state
-of continuous flux where affected `BareMetalHost` objects would be subject to longer
-back-offs between reconciliation to prevent the controller from overwhelming the
-Kubernetes API. The annotation causing the problem is no longer written, which fixes
-the issue.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1851531[BZ#1851531])
+* Previously, the controller for `BareMetalHost` objects mirrored status data to an annotation, including a timestamp of the latest status update. This was not needed by the cluster. This could result in the `BareMetalHost` object entering a state of continuous flux where affected `BareMetalHost` objects would be subject to longer back-offs between reconciliation to prevent the controller from overwhelming the Kubernetes API. The annotation causing the problem is no longer written, which fixes the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1851531[BZ#1851531])
 
-* Previously, the Cluster Version Operator (CVO) was not syncing the
-`shareProcessNamespace` parameter in the pod spec, which caused the Registry
-Operator to not update the `shareProcessNamespace` setting. The CVO now syncs
-`shareProcessNamespace`, `DNSPolicy`, and `TerminationGracePeriodSeconds`,
-fixing the Registry Operator update issues.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1868478[BZ#1868478])
+* Previously, the Cluster Version Operator (CVO) was not syncing the `shareProcessNamespace` parameter in the pod spec, which caused the Registry Operator to not update the `shareProcessNamespace` setting. The CVO now syncs `shareProcessNamespace`, `DNSPolicy`, and `TerminationGracePeriodSeconds`, fixing the Registry Operator update issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868478[BZ#1868478])
 
 [id="ocp-4-5-8-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3578"]
 === RHSA-2020:3578 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-09-08
 
-An update for `cluster-network-operator-container`, `cluster-version-operator-container`,
-`elasticsearch-operator-container`, `logging-kibana6-container`, and
-`ose-cluster-svcat-controller-manager-operator-container` is now available for
-{product-title} 4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3578[RHSA-2020:3578] advisory.
+An update for `cluster-network-operator-container`, `cluster-version-operator-container`, `elasticsearch-operator-container`, `logging-kibana6-container`, and `ose-cluster-svcat-controller-manager-operator-container` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3578[RHSA-2020:3578] advisory.
 
 [id="ocp-4-5-9"]
 === RHBA-2020:3618 - {product-title} 4.5.9 bug fix update
 
 Issued: 2020-09-14
 
-{product-title} release 4.5.9 is now available. The list of bug fixes that are included in the update is documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3618[RHBA-2020:3618] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3619[RHBA-2020:3619] advisory.
+{product-title} release 4.5.9 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3618[RHBA-2020:3618] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3619[RHBA-2020:3619] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5393001[{product-title} 4.5.9 container image list]
 
 [id="ocp-4-5-9-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="ocp-4-5-11"]
 === RHBA-2020:3719 - {product-title} 4.5.11 bug fix update
 
 Issued: 2020-09-21
 
-{product-title} release 4.5.11 is now available. The list of container images
-and bug fixes included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3719[RHBA-2020:3719] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3720[RHBA-2020:3720] advisory.
+{product-title} release 4.5.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3719[RHBA-2020:3719] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3720[RHBA-2020:3720] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5410611[{product-title} 4.5.11 container image list]
 
 [id="ocp-4-5-11-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3780"]
 === RHSA-2020:3780 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-09-21
 
-An update for `ose-cluster-svcat-apiserver-operator-container` is now available
-for {product-title} 4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3780[RHSA-2020:3780] advisory.
+An update for `ose-cluster-svcat-apiserver-operator-container` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3780[RHSA-2020:3780] advisory.
 
 [id="ocp-4-5-13"]
 === RHBA-2020:3760 - {product-title} 4.5.13 bug fix update
 
 Issued: 2020-09-30
 
-{product-title} release 4.5.13 is now available. The list of container images
-and bug fixes included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3760[RHBA-2020:3760] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3761[RHBA-2020:3761] advisory.
+{product-title} release 4.5.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3760[RHBA-2020:3760] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3761[RHBA-2020:3761] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5436311[{product-title} 4.5.13 container image list]
 
 [id="ocp-4-5-13-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="RHSA-2020-3841"]
 === RHSA-2020:3841 - Important: {product-title} 4.5 security update
 
 Issued: 2020-09-30
 
-An update for `jenkins` is now available
-for {product-title} 4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3841[RHSA-2020:3841] advisory.
+An update for `jenkins` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3841[RHSA-2020:3841] advisory.
 
 [id="RHSA-2020-3842"]
 === RHSA-2020:3842 - Moderate: {product-title} 4.5 security update
 
 Issued: 2020-09-30
 
-An update for `openshift-enterprise-console-container` is now available
-for {product-title} 4.5. Details of the update are documented in the
-link:https://access.redhat.com/errata/RHSA-2020:3842[RHSA-2020:3842] advisory.
+An update for `openshift-enterprise-console-container` is now available for {product-title} 4.5. Details of the update are documented in the link:https://access.redhat.com/errata/RHSA-2020:3842[RHSA-2020:3842] advisory.
 
 [id="ocp-4-5-14"]
 === RHBA-2020:3843 - {product-title} 4.5.14 bug fix update
 
 Issued: 2020-10-12
 
-{product-title} release 4.5.14 is now available. The list of container images
-and bug fixes included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:3843[RHBA-2020:3843] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:3844[RHBA-2020:3844] advisory.
+{product-title} release 4.5.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:3843[RHBA-2020:3843] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:3844[RHBA-2020:3844] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5479921[{product-title} 4.5.14 container image list]
 
 [id="ocp-4-5-14-bug-fixes"]
 ==== Bug fixes
 
-* With this release, the value of each logging level is documented in the logging field of the `imageregistry` API.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1843244[BZ#1843244])
+* With this release, the value of each logging level is documented in the logging field of the `imageregistry` API. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843244[BZ#1843244])
 
-* Previously, a mismatch between the version and the database sometimes caused problems when restoring a pod from the most recent image. With this release, the configuration YAML file for the pod is copied with the backup to avoid causing a mismatch.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1877930[BZ#1877930])
+* Previously, a mismatch between the version and the database sometimes caused problems when restoring a pod from the most recent image. With this release, the configuration YAML file for the pod is copied with the backup to avoid causing a mismatch. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877930[BZ#1877930])
 
-* Previously, if a pod referred to an invalid image reference, the pruner job caused the Image Registry Operator to enter a degraded state, which blocked upgrades. To be able to upgrade, users had to remove the pods that caused the issue and wait for the next pruning occurrence, or suspend the pruner job. With this release, a metric and alert have been added to indicate when the pruner job fails, and the pruner status no longer impacts the Operator status.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1879176[BZ#1879176])
+* Previously, if a pod referred to an invalid image reference, the pruner job caused the Image Registry Operator to enter a degraded state, which blocked upgrades. To be able to upgrade, users had to remove the pods that caused the issue and wait for the next pruning occurrence, or suspend the pruner job. With this release, a metric and alert have been added to indicate when the pruner job fails, and the pruner status no longer impacts the Operator status. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879176[BZ#1879176])
 
-* Previously, Kubernetes dependencies for the Cluster DNS Operator in the {product-title} 4.5 branch were out of date. With this release, the Cluster DNS Operator dependencies are updated from Kubernetes 0.18.0-rc2 to v0.18.9.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1880311[BZ#1880311])
+* Previously, Kubernetes dependencies for the Cluster DNS Operator in the {product-title} 4.5 branch were out of date. With this release, the Cluster DNS Operator dependencies are updated from Kubernetes 0.18.0-rc2 to v0.18.9. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880311[BZ#1880311])
 
-* Previously, Kubernetes dependencies for the Cluster Ingress Operator in the {product-title} 4.5 branch were out of date. With this release, the Cluster Ingress Operator dependencies are updated from Kubernetes 0.18.3 to v0.18.9.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1880315[BZ#1880315])
+* Previously, Kubernetes dependencies for the Cluster Ingress Operator in the {product-title} 4.5 branch were out of date. With this release, the Cluster Ingress Operator dependencies are updated from Kubernetes 0.18.3 to v0.18.9. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880315[BZ#1880315])
 
 * Previously, a watch cache in the Kubernetes API was initialized from the global revision (`etcd`) and could remain for an undefined period if no changes were made. This behavior sometimes led to a situation in which a client got a resource version (RV) from a server that had observed a newer RV, disconnected from it due to a network error, and reconnected to a server that was behind, resulting in "Too large resource version" errors. With this release, the reflector is fixed so that it can recover from these errors, and Operators that use the `client-go` library for getting notifications from the server can recover and make progress upon receiving the errors.
++
 This issue is resolved for:
 ** `cluster-kube-apiserver-operator` (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880322[BZ#1880322])
 ** `cluster-kube-storage-version-migrator-operator` (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880327[BZ#1880327])
 ** `cluster-openshift-apiserver-operator` (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880353[BZ#1880353])
 
-* Previously, new pipeline triggers could not be created because the web console was not compatible with the latest OpenShift Pipelines Operator 1.1. This release supports the latest version and allows the creation of pipeline triggers.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1880376[BZ#1880376])
+* Previously, new pipeline triggers could not be created because the web console was not compatible with the latest OpenShift Pipelines Operator 1.1. This release supports the latest version and allows the creation of pipeline triggers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880376[BZ#1880376])
 
-* Previously, a Kubernetes bug prevented the API client from recovering quickly after recovery from a TCP reset. Client logs could be flooded with "Timeout: Too large resource version" errors when a lost connection was reestablished. This could cause an issue with controllers or Operators that maintain client connections to the API server. With this release, the fix for the Kubernetes bug has been applied to the Samples Operator, and the Operator is no longer susceptible to this error message loop.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1881068[BZ#1881068])
+* Previously, a Kubernetes bug prevented the API client from recovering quickly after recovery from a TCP reset. Client logs could be flooded with "Timeout: Too large resource version" errors when a lost connection was reestablished. This could cause an issue with controllers or Operators that maintain client connections to the API server. With this release, the fix for the Kubernetes bug has been applied to the Samples Operator, and the Operator is no longer susceptible to this error message loop. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881068[BZ#1881068])
 
-* Previously, unnecessary API VIP moves caused client connection errors. With this release, the API VIP health check limits the number of times it moves, resulting in fewer errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1881147[BZ#1881147])
+* Previously, unnecessary API VIP moves caused client connection errors. With this release, the API VIP health check limits the number of times it moves, resulting in fewer errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881147[BZ#1881147])
 
 [id="ocp-4-5-14-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="ocp-4-5-15"]
 === RHBA-2020:4228 - {product-title} 4.5.15 bug fix update
 
 Issued: 2020-10-19
 
-{product-title} release 4.5.15 is now available. The list of container images
-and bug fixes included in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:4228[RHBA-2020:4228] advisory.
-The RPM packages that are included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:4229[RHBA-2020:4229] advisory.
+{product-title} release 4.5.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:4228[RHBA-2020:4228] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:4229[RHBA-2020:4229] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/5493561[{product-title} 4.5.15 container image list]
 
 [id="ocp-4-5-15-bug-fixes"]
 ==== Bug fixes
 
-* A new API version for CSR was introduced in a future version of {product-title}, and as a consequence, older versions could not approve or deny certificates during upgrade. With this release, versions of CSR in older versions of `oc` are tolerated so that it is possible to deny or approve certificates with `oc` 4.5 against future versions.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1860789[*BZ#1860789*])
+* A new API version for CSR was introduced in a future version of {product-title}, and as a consequence, older versions could not approve or deny certificates during upgrade. With this release, versions of CSR in older versions of `oc` are tolerated so that it is possible to deny or approve certificates with `oc` 4.5 against future versions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860789[*BZ#1860789*])
 
 * In bare metal environments, an `infra-dns` container runs on each host to support node name resolutions and other internal DNS records. A `NetworkManager` script also updates the `/etc/resolv.conf` on the host to point to the `infra-dns` container. Additionally, when pods are created, they receive their DNS configuration file (the `/etc/resolv.conf` file) from their hosts.
 +
-If an HAProxy pod was created before `NetworkManager` scripts update the `/etc/resolv.conf` file on the host, the pod can repeatedly fail because the `api-int` internal DNS record is not resolvable. This bug fix updates the Machine Config Operator (MCO) to now verify that the `/etc/resolv.conf` file of the HAProxy pod is identical to the host `/etc/resolv.conf` file. As a result, the HAProxy pod no longer experiences these errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1862874[*BZ#1862874*])
+If an HAProxy pod was created before `NetworkManager` scripts update the `/etc/resolv.conf` file on the host, the pod can repeatedly fail because the `api-int` internal DNS record is not resolvable. This bug fix updates the Machine Config Operator (MCO) to now verify that the `/etc/resolv.conf` file of the HAProxy pod is identical to the host `/etc/resolv.conf` file. As a result, the HAProxy pod no longer experiences these errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862874[*BZ#1862874*])
 
-* Previously, if a control plane kubelet could not be reached, but pods were still running, Machine API pods that were running on that node were rescheduled to another. This created multiple Machine API pods that competed to control Machine API resources in the cluster. This could result in an excess number of instances being created, as well as the possibility for the Machine API controllers to leak instances, requiring manual intervention. With this release, leader election has been added to all Machine API controllers, ensuring that only a single instance of a controller is allowed to manage Machine API resources. With only a single leader for each controller, excess instances are no longer created or leaked.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1864352[*BZ#1864352*])
+* Previously, if a control plane kubelet could not be reached, but pods were still running, Machine API pods that were running on that node were rescheduled to another. This created multiple Machine API pods that competed to control Machine API resources in the cluster. This could result in an excess number of instances being created, as well as the possibility for the Machine API controllers to leak instances, requiring manual intervention. With this release, leader election has been added to all Machine API controllers, ensuring that only a single instance of a controller is allowed to manage Machine API resources. With only a single leader for each controller, excess instances are no longer created or leaked. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1864352[*BZ#1864352*])
 
-* Previously, resource names were getting updated in the edit flow and the edit application user was unable to change the Git repository or update the application. With this fix, the application name is no longer updated while in the edit flow, and the edit flow user is able to change the Git repository and update the application.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1877290[*BZ#1877290*])
+* Previously, resource names were getting updated in the edit flow and the edit application user was unable to change the Git repository or update the application. With this fix, the application name is no longer updated while in the edit flow, and the edit flow user is able to change the Git repository and update the application. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877290[*BZ#1877290*])
 
-* Previously, a watch cache in the Kubernetes API was initialized from the global revision (`etcd`) and could remain for an undefined period if no changes were made. This behavior could lead to a situation in which a client gets a resource version (RV) from a server that has observed a newer RV, disconnects from it due to a network error, and reconnects to a server that is behind, resulting in "Too large resource version" errors. With this release, the reflector is fixed so that it can recover from "Too large resource version" errors and Operators that use the `client-go` library for getting notifications from the server can recover and make progress upon receiving "Too large resource version" errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1877346[*BZ#1877346*])
+* Previously, a watch cache in the Kubernetes API was initialized from the global revision (`etcd`) and could remain for an undefined period if no changes were made. This behavior could lead to a situation in which a client gets a resource version (RV) from a server that has observed a newer RV, disconnects from it due to a network error, and reconnects to a server that is behind, resulting in "Too large resource version" errors. With this release, the reflector is fixed so that it can recover from "Too large resource version" errors and Operators that use the `client-go` library for getting notifications from the server can recover and make progress upon receiving "Too large resource version" errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877346[*BZ#1877346*])
 
-* Previously, when the Authentication Operator received an HTML payload from an OpenID Connect Authentication (OIDC) server that ignored the `Accept: application/json` header, the OIDC servers could respond with an HTML page that states that the authentication Operator failed to parse because it was expecting JSON. Now, the Operator ignores the error and does not allow CLI login for OIDC servers that ignore the header.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1879417[*BZ#1879417*])
+* Previously, when the Authentication Operator received an HTML payload from an OpenID Connect Authentication (OIDC) server that ignored the `Accept: application/json` header, the OIDC servers could respond with an HTML page that states that the authentication Operator failed to parse because it was expecting JSON. Now, the Operator ignores the error and does not allow CLI login for OIDC servers that ignore the header. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879417[*BZ#1879417*])
 
-* Previously, the Image Registry Operator could not get events from the cluster when it encountered "Too large resource version" errors. With this release, the `client-go` library is updated to fix the reflector so that the Operator can recover from "Too large resource version" errors.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1880314[*BZ#1880314*])
+* Previously, the Image Registry Operator could not get events from the cluster when it encountered "Too large resource version" errors. With this release, the `client-go` library is updated to fix the reflector so that the Operator can recover from "Too large resource version" errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880314[*BZ#1880314*])
 
-* The Kubernetes network proxy does not support multiple cluster CIDRs to detect local traffic. When multiple CIDRs are configured in OpenShift SDN, the Cluster Network Operator (CNO) sets the `KubeProxyConfiguration.clusterCIDR` field to an empty string. In {product-title} 4.4 and earlier, the empty value was ignored, but in 4.5 and later, passing an empty value causes an error. As a result, after upgrading from 4.4 to 4.5, if the `sdn-config ConfigMap` has an empty string in the `clusterCIDR` field, the configuration cannot be parsed and the SDN pods enter a crash loop. With this release, the empty value is ignored and SDN pods no longer crash when multiple CIDRs are configured.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1881830[*BZ#1881830*])
+* The Kubernetes network proxy does not support multiple cluster CIDRs to detect local traffic. When multiple CIDRs are configured in OpenShift SDN, the Cluster Network Operator (CNO) sets the `KubeProxyConfiguration.clusterCIDR` field to an empty string. In {product-title} 4.4 and earlier, the empty value was ignored, but in 4.5 and later, passing an empty value causes an error. As a result, after upgrading from 4.4 to 4.5, if the `sdn-config ConfigMap` has an empty string in the `clusterCIDR` field, the configuration cannot be parsed and the SDN pods enter a crash loop. With this release, the empty value is ignored and SDN pods no longer crash when multiple CIDRs are configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881830[*BZ#1881830*])
 
 [id="ocp-4-5-15-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.5 cluster to this latest release, see
-xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="ocp-4-5-16"]
 === RHBA-2020:4268 - {product-title} 4.5.16 bug fix update
@@ -2937,6 +2356,22 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/5608671[{product-title} 4.5.21 container image list]
 
 [id="ocp-4-5-21-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+
+[id="ocp-4-5-22"]
+=== RHBA-2020:5051 - {product-title} 4.5.22 bug fix update
+
+Issued: 2020-12-08
+
+{product-title} release 4.5.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:5250[RHBA-2020:5250] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:5251[RHBA-2020:5251] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/5628431[{product-title} 4.5.22 container image list]
+
+[id="ocp-4-5-22-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]


### PR DESCRIPTION
Release Notes text for 4.5.22, scheduled for 8 December. Also went ahead and replaced hard wraps in this PR.
Preview: https://rns-4_5_22--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-5-release-notes.html