### PR TITLE
Rosaupdate

### DIFF
--- a/modules/rosa-installing-prerequisites.adoc
+++ b/modules/rosa-installing-prerequisites.adoc
@@ -70,7 +70,7 @@ $ aws ec2 describe-regions
 ----
 +
 . Install `rosa`, the {product-title} Command-line Interface (CLI).
-.. Download the link:https://github.com/openshift/rosa/releases/latest[latest release] of `rosa` for your operating system.
+.. Download the link:https://github.com/openshift/moactl/releases[latest release] of `rosa` for your operating system.
 .. Optional: Rename the executable file you downloaded to `rosa`. This documentation uses `rosa` to refer to the executable file.
 .. Optional: Add `rosa` to your path.
 .. Verify your installation by running the following command:


### PR DESCRIPTION
Fixing a broken link in the ROSA private-preview docs. No QE needed. Only applicable to 4.5 branch.