### PR TITLE
[enterprise-4.4] Uninstall cluster-logging from OCP leaves behind cluster-logging operator and elastic-search operator

### DIFF
--- a/modules/cluster-logging-uninstall.adoc
+++ b/modules/cluster-logging-uninstall.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-uninstall_{context}"]
 = Uninstalling cluster logging from {product-title}
 
-You can remove cluster logging from your cluster.
+You can stop log aggregation by deleting the Cluster Logging custom resource (CR). However, after deleting the CR there are other cluster logging components that remain, which you can optionally remove. 
 
 .Prerequisites
 
@@ -15,15 +15,52 @@ You can remove cluster logging from your cluster.
 
 To remove cluster logging:
 
-. Use the following command to remove everything generated during the deployment.
-+
-----
-$ oc delete clusterlogging instance -n openshift-logging
-----
+. Use the {product-title} web console to remove the Cluster Logging CR:
 
-. Use the following command to remove the Persistent Volume Claims that remain
-after the Operator instances are deleted:
+.. Switch to the *Administration* -> *Custom Resource Definitions* page.
+
+.. On the *Custom Resource Definitions* page, click *ClusterLogging*.
+
+.. On the *Custom Resource Definition Details* page, click *Instances*.
+
+.. Click the Options menu {kebab} next to the instance and select *Delete ClusterLogging*.
+
+. Optional: Delete the custom resource definitions (CRD):
+
+.. Switch to the *Administration* -> *Custom Resource Definitions* page.
+
+.. Click the Options menu {kebab} next to *ClusterLogging* and select *Delete Custom Resource Definition*.
+
+.. Click the Options menu {kebab} next to *Elasticsearch* and select *Delete Custom Resource Definition*.
+
+.. Click the Options menu {kebab} next to *LogForwarding* and select *Delete Custom Resource Definition*.
+
+. Optional: Remove the Cluster Logging Operator and Elasticsearch Operator:
+
+.. Switch to the *Operators* -> *Installed Operators* page.
+
+.. Select the `openshift-logging` project.
+
+.. Click the Options menu {kebab} next to the Cluster Logging Operator and select *Uninstall Operator*.
+
+.. Select the `openshift-operators-redhat` project.
+
+.. Click the Options menu {kebab} next to the Elasticsearch Operator and select *Uninstall Operator*.
+
+. Optional: Remove the Cluster Logging and Elasticsearch projects. 
+
+.. Switch to the *Home* -> *Projects* page.
+
+.. Click the Options menu {kebab} next to the *openshift-logging* project and select *Delete Project*.
+
+.. Confirm the deletion by typing `openshift-logging` in the dialog box and click *Delete*.
+
+.. Click the Options menu {kebab} next to the *openshift-operators-redhat* project and select *Delete Project*.
 +
-----
-$ oc delete pvc --all -n openshift-logging
-----
+[IMPORTANT]
+====
+Do not delete the `openshift-operators-redhat` project if other global operators are installed in this namespace.
+====
+
+.. Confirm the deletion by typing `openshift-operators-redhat` in the dialog box and click *Delete*.
+


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/26738/