### PR TITLE
Uninstall cluster-logging from OCP leaves behind cluster-logging operator and elastic-search operator 4.5

### DIFF
--- a/modules/cluster-logging-uninstall.adoc
+++ b/modules/cluster-logging-uninstall.adoc
@@ -29,17 +29,21 @@ To remove cluster logging:
 
 .. Switch to the *Administration* -> *Custom Resource Definitions* page.
 
-.. Click the Options menu {kebab} next to *ClusterLogForwarder* and select *Delete Custom Resource Definition*.
-
 .. Click the Options menu {kebab} next to *ClusterLogging* and select *Delete Custom Resource Definition*.
 
 .. Click the Options menu {kebab} next to *Elasticsearch* and select *Delete Custom Resource Definition*.
+
+.. Click the Options menu {kebab} next to *LogForwarding* and select *Delete Custom Resource Definition*.
 
 . Optional: Remove the Cluster Logging Operator and Elasticsearch Operator:
 
 .. Switch to the *Operators* -> *Installed Operators* page.
 
+.. Select the `openshift-logging` project.
+
 .. Click the Options menu {kebab} next to the Cluster Logging Operator and select *Uninstall Operator*.
+
+.. Select the `openshift-operators-redhat` project.
 
 .. Click the Options menu {kebab} next to the Elasticsearch Operator and select *Uninstall Operator*.
 
@@ -59,10 +63,4 @@ Do not delete the `openshift-operators-redhat` project if other global operators
 ====
 
 .. Confirm the deletion by typing `openshift-operators-redhat` in the dialog box and click *Delete*.
-
-. Optional: Remove any Cluster Logging persistent volume claims (PVC):
-
-.. Switch to the *Storage* -> *Persistent Volume Claims* page.
-
-.. Click the Options menu {kebab} next to each PVC and select *Delete Persistent Volume Claim*.
 


### PR DESCRIPTION
Minor edits to adapt https://github.com/openshift/openshift-docs/pull/26738 for 4.5