### PR TITLE
GH27762: RHV IPI doesn't need static IP for internal DNS

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -455,6 +455,7 @@ Note the following restrictions for {product-title} on IBM Power Systems:
 * You can use auto-scaling additional of {rh-virtualization} virtual machine worker nodes to improve control of workloads and resources.
 * You can perform disconnected or restricted installations by using a local mirror. This capability is beneficial for financial, public sector, and secure environments.
 * You can xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[install {product-title} on {rh-virtualization} with user-provisioned infrastructure], such as an external load balancer. This process uses a series of Ansible playbooks to enable a more flexible installation.
+* Installing {product-title} on {rh-virtualization} with installer-provisioned infrastructure does not require a static IP address for internal DNS. 
 * {product-title} version 4.6 requires {rh-virtualization} version 4.4.2 or later.
 +
 [IMPORTANT]


### PR DESCRIPTION
For https://github.com/openshift/openshift-docs/issues/27762: "It would be worth to mention RHV IPI won't require static ip for internal DNS."

Preview: https://gh27762--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-enhancements-to-rhv-installer