### PR TITLE
multiarch issue 652

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -151,7 +151,7 @@ On your z/VM instance, set up:
 [discrete]
 === Disk storage for the z/VM guest virtual machines
 
-* FICON attached disk storage (DASDs). These can be z/VM minidisks, fullpack minidisks, or dedicated DASDs. To reach the minimum required DASD size for {op-system-first} installations, you need extended address volumes (EAV). If available, use HyperPAV to ensure optimal performance.
+* FICON attached disk storage (DASDs). These can be z/VM minidisks, fullpack minidisks, or dedicated DASDs, all of which must be formatted as CDL, which is the default. To reach the minimum required DASD size for {op-system-first} installations, you need extended address volumes (EAV). If available, use HyperPAV to ensure optimal performance.
 * FCP attached disk storage
 
 [discrete]
@@ -186,7 +186,7 @@ On your z/VM instances, set up:
 [discrete]
 === Disk storage for the z/VM guest virtual machines
 
-* FICON attached disk storage (DASDs). These can be z/VM minidisks, fullpack minidisks, or dedicated DASDs. To reach the minimum required DASD size for {op-system-first} installations, you need extended address volumes (EAV). If available, use HyperPAV and High Performance FICON (zHPF) to ensure optimal performance.
+* FICON attached disk storage (DASDs). These can be z/VM minidisks, fullpack minidisks, or dedicated DASDs, all of which must be formatted as CDL, which is the default. To reach the minimum required DASD size for {op-system-first} installations, you need extended address volumes (EAV). If available, use HyperPAV and High Performance FICON (zHPF) to ensure optimal performance.
 * FCP attached disk storage
 
 [discrete]


### PR DESCRIPTION
Add restriction that DASDS must be CDL format for IBM Z  

https://issues.redhat.com/browse/MULTIARCH-652

This applies to OCP 4.6, 4.5, 4.4, and future versions. 