### PR TITLE
MIG-466: MTC version and image names for 1.4.0

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -33,5 +33,5 @@ endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
-:mtc-version: 1.3
-:mtc-version-z: 1.3.2
+:mtc-version: 1.4
+:mtc-version-z: 1.4.0


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-466

MTC 1.4.0 GA date is Feb. 10
CP to 4.5, 4.6, 4.7