### PR TITLE
Updating the limiting scrape samples section

### DIFF
--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -6,19 +6,21 @@
 [id="determining-why-prometheus-is-consuming-disk-space_{context}"]
 = Determining why Prometheus is consuming a lot of disk space
 
-Labels are used to define attributes for metrics in the form of key-value pairs. A unique time series is created for every key-value pair. Adding many values to labels can result in an exponential increase in the number of time series created. This can impact Prometheus performance and can consume a lot of disk space.
+Developers can create labels to define attributes for metrics in the form of key-value pairs. The number of potential key-value pairs corresponds to the number of possible values for an attribute. An attribute that has an unlimited number of potential values is called an unbound attribute. For example, a `customer_id` attribute is unbound because it has an infinite number of possible values.
 
-When Prometheus consumes a lot of disk:
+Every assigned key-value pair has a unique time series. The use of many unbound attributes in labels can result in an exponential increase in the number of time series created. This can impact Prometheus performance and can consume a lot of disk space.
 
-* You can *check the number of scrape samples* that are being collected
-* You can *reduce the number of unique time series that are created* by reducing the number of unbound attributes that are assigned to user-defined metrics
+You can use the following measures when Prometheus consumes a lot of disk:
+
+* *Check the number of scrape samples* that are being collected.
+* *Reduce the number of unique time series that are created* by reducing the number of unbound attributes that are assigned to user-defined metrics.
 +
 [NOTE]
 ====
-Unbound attributes are those that can contain any possible value. Using attributes that are bound to a limited set of possible values reduces the number of potential key-value pair combinations.
+Using attributes that are bound to a limited set of possible values reduces the number of potential key-value pair combinations.
 ====
 +
-* Cluster administrators can *enforce limits on the number of samples that can be scraped* across user-defined projects
+* *Enforce limits on the number of samples that can be scraped* across user-defined projects. This requires cluster administrator privileges.
 
 .Prerequisites
 

--- a/modules/monitoring-limiting-scrape-samples-in-user-defined-projects.adoc
+++ b/modules/monitoring-limiting-scrape-samples-in-user-defined-projects.adoc
@@ -1,15 +1,20 @@
 // Module included in the following assemblies:
 //
-// * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+// * monitoring/configuring-the-monitoring-stack.adoc
 
-[id="limiting-scrape-samples-in-user-defined-projects_{context}"]
-= Limiting scrape samples in user-defined projects
+[id="controlling-the-impact-of-unbound-attributes-in-user-defined-projects_{context}"]
+= Controlling the impact of unbound metrics attributes in user-defined projects
 
-Labels are used to define attributes for metrics in the form of key-value pairs. A unique time series is created for every key-value pair. Adding many values to labels can result in an exponential increase in the number of time series created. This can impact Prometheus performance and can consume a lot of disk space.
+Developers can create labels to define attributes for metrics in the form of key-value pairs. The number of potential key-value pairs corresponds to the number of possible values for an attribute. An attribute that has an unlimited number of potential values is called an unbound attribute. For example, a `customer_id` attribute is unbound because it has an infinite number of possible values.
 
-You can prevent this by limiting the number of samples that can be accepted per target scrape in user-defined projects. You should also create alerts that fire when the target cannot be scraped or when a scrape sample threshold is reached.
+Every assigned key-value pair has a unique time series. The use of many unbound attributes in labels can result in an exponential increase in the number of time series created. This can impact Prometheus performance and can consume a lot of disk space.
+
+Cluster administrators can use the following measures to control the impact of unbound metrics attributes in user-defined projects:
+
+* *Limit the number of samples that can be accepted* per target scrape in user-defined projects
+* *Create alerts* that fire when a scrape sample threshold is reached or when the target cannot be scraped
 
 [NOTE]
 ====
-Limiting scrape samples can help prevent the issues caused by adding many unbound attributes to labels. However, you should also prevent the underlying cause by limiting the number of unbound attributes that you define for your metrics. Unbound attributes are those that can contain any possible value. Using attributes that are bound to a limited set of possible values reduces the number of potential key-value pair combinations.
+Limiting scrape samples can help prevent the issues caused by adding many unbound attributes to labels. Developers can also prevent the underlying cause by limiting the number of unbound attributes that they define for metrics. Using attributes that are bound to a limited set of possible values reduces the number of potential key-value pair combinations.
 ====


### PR DESCRIPTION
This applies to master, branch/enterprise-4.6 and branch/enterprise-4.7.

This PR more clearly describes the problems that can occur by using unbound attributes when defining metrics labels and how to address them.

The preview assemblies are [here](https://limiting-scrape-samples-update--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#limiting-scrape-samples-in-user-defined-projects_configuring-the-monitoring-stack) and [here](https://limiting-scrape-samples-update--ocpdocs.netlify.app/openshift-enterprise/latest/monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues).