### PR TITLE
BZ#1721567: overlay2 driver reqs XFS

### DIFF
--- a/install/host_preparation.adoc
+++ b/install/host_preparation.adoc
@@ -444,11 +444,14 @@ management in RHEL Atomic Host.
 [[configuring-docker-overlayfs]]
 === Configuring OverlayFS
 
-OverlayFS is a type of union file system. It allows you to overlay one file system on top of another.
+OverlayFS is a type of union file system. OverlayFS enables you to overlay one file system on top of another.
 Changes are recorded in the upper file system, while the lower file system remains unmodified.
 
 xref:../scaling_performance/optimizing_storage.adoc#comparing-overlay-graph-drivers[Comparing the Overlay Versus Overlay2 Graph Drivers]
 has more information about the *overlay* and *overlay2* drivers.
+
+To use the *overlay2* driver, the lower layer must use the XFS file system. The
+lower-layer file system is the file system that remains unmodified.
 
 For information about enabling the OverlayFS storage driver for the Docker service, see the
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html-single/managing_containers/#using_the_overlay_graph_driver[Red Hat Enterprise Linux Atomic Host documentation].

--- a/scaling_performance/optimizing_storage.adoc
+++ b/scaling_performance/optimizing_storage.adoc
@@ -455,14 +455,6 @@ significant overlap in image content.
 Page cache sharing is not possible with DeviceMapper because thin-provisioned
 devices are allocated on a per-container basis.
 
-[NOTE]
-====
-DeviceMapper is the default Docker storage configuration on Red Hat Enterprise Linux.
-The use of OverlayFS as the container storage
-technology is under evaluation and moving Red Hat Enterprise Linux to OverlayFS as
-the default in future releases is under consideration.
-====
-
 [[comparing-overlay-graph-drivers]]
 === Comparing the Overlay and Overlay2 graph drivers
 


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1721567.

* The Prepare Hosts > Configuring OverlayFS seems to be the
  most tactical place to position the information about XFS.

* Somewhat related to this bz, the Scaling and Perf > Optimizing
  Storage page had a TIP that RHEL might use overlayFS instead of
  Device Mapper as a future consideration. I removed the TIP
  because the future is now.