### PR TITLE
Updating infrastructure components list to include components for monitoring user-defined projects

### DIFF
--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -11,7 +11,7 @@ The following {product-title} components are infrastructure components:
 * Kubernetes and {product-title} control plane services that run on masters
 * The default router
 * The container image registry
-* The cluster metrics collection, or monitoring service
+* The cluster metrics collection, or monitoring service, including components for monitoring user-defined projects
 * Cluster aggregated logging
 * Service brokers
 


### PR DESCRIPTION
Update to wording for [OpenShift Container Platform infrastructure components](https://docs.openshift.com/container-platform/4.6/machine_management/creating-infrastructure-machinesets.html#infrastructure-components_creating-infrastructure-machinesets) to include components for monitoring user-defined projects.