### PR TITLE
[enterprise-4.5] Update extract path for opm install

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -37,7 +37,7 @@ local file system:
 ifdef::openshift-origin[]
 ----
 $ oc image extract quay.io/openshift/origin-operator-registry:4.5.0 \
-    --path /usr/bin/opm:. \
+    --path /usr/bin/registry/opm:. \
     --confirm
 ----
 endif::[]
@@ -45,7 +45,7 @@ ifdef::openshift-enterprise,openshift-webscale[]
 ----
 $ oc image extract registry.redhat.io/openshift4/ose-operator-registry:v4.5 \
     -a ${REG_CREDS} \//<1>
-    --path /usr/bin/opm:. \
+    --path /usr/bin/registry/opm:. \
     --confirm
 ----
 <1> Specify the location of your registry credentials file.


### PR DESCRIPTION
Modified version of https://github.com/openshift/openshift-docs/pull/27942 for 4.5 (which didn't have macOS/Windows steps).