### PR TITLE
virt-installing-qemu-guest-agent: drop non-prerequisite

### DIFF
--- a/virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
+++ b/virt/virtual_machines/virt-installing-qemu-guest-agent.adoc
@@ -6,15 +6,6 @@ toc::[]
 
 The xref:../../virt/virtual_machines/virt-viewing-qemu-guest-agent-web.adoc#virt-viewing-qemu-guest-agent-web[QEMU guest agent] is a daemon that runs on the virtual machine and passes information to the host about the virtual machine, users, file systems, and secondary networks.
 
-== Prerequisites
-
-* Verify that the guest agent is installed and running by entering the following command:
-+
-----
-$ systemctl status qemu-guest-agent
-----
-+
-
 include::modules/virt-installing-qemu-guest-agent-on-linux-vm.adoc[leveloffset=+1]
 
 You can also install and start the QEMU guest agent by using the


### PR DESCRIPTION
The dropped text is not a prerequisite for starting the installation
procedures, it is the expected *outcome* of the Linux procedure.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>