### PR TITLE
Add recommendation around service name impacting the pods

### DIFF
--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -167,3 +167,20 @@ links in the deployment's service specification file to overcome this:
     labels:
       template: deploymentConfigTemplate
 ----
+
+The number of application pods that can run in a namespace is dependent on the number of services and the
+length of the service name when the environment variables are used for service discovery. `ARG_MAX` on the system 
+defines the maximum argument length for a new process and it is set to `2097152 KiB` by default. The Kubelet injects 
+environment variables in to each pod scheduled to run in the namespace including:
+
+* `<SERVICE_NAME>_SERVICE_HOST=<IP>`
+* `<SERVICE_NAME>_SERVICE_PORT=<PORT>`
+* `<SERVICE_NAME>_PORT=tcp://<IP>:<PORT>`
+* `<SERVICE_NAME>_PORT_<PORT>_TCP=tcp://<IP>:<PORT>`
+* `<SERVICE_NAME>_PORT_<PORT>_TCP_PROTO=tcp`
+* `<SERVICE_NAME>_PORT_<PORT>_TCP_PORT=<PORT>`
+* `<SERVICE_NAME>_PORT_<PORT>_TCP_ADDR=<ADDR>`
+
+The pods in the namespace will start to fail if the argument length exceeds the allowed value and the number of 
+characters in a service name impacts it. For example, in a namespace with 5000 services, the limit on the service name 
+is 33 characters, which enables you to run 5000 pods in the namespace.


### PR DESCRIPTION
This length of the service name impacts the number of pods that can run
in a namespace with maximum number of services tested deployed - 5000.
This commit adds a recommendation for the user to be able to plan their
applications accordingly.