### PR TITLE
Remove TP note in CSI snapshots

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
@@ -7,10 +7,6 @@ toc::[]
 
 This document describes how to use volume snapshots with supported Container Storage Interface (CSI) drivers to help protect against data loss in {product-title}. Familiarity with xref:../../storage/understanding-persistent-storage.adoc#persistent-volumes_understanding-persistent-storage[persistent volumes] is suggested.
 
-:FeatureName: CSI volume snapshot
-
-include::modules/technology-preview.adoc[leveloffset=+0]
-
 include::modules/persistent-storage-csi-snapshots-overview.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-snapshots-controller-sidecar.adoc[leveloffset=+1]


### PR DESCRIPTION
Beginning in OCP 4.7, CSI volume snapshots is moving from Tech Preview to GA. This PR removes the TP note. In a related PR, I will be updating the TP tracker table and adding a note about this move in the 4.7 Release Notes.
[OSDOCS-1720](https://issues.redhat.com/browse/OSDOCS-1720)