### PR TITLE
use `systemctl enable --now` shorthand

### DIFF
--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -165,18 +165,10 @@ $ sudo kmods-via-containers build simple-kmod $(uname -r)
 ----
 
 . Enable and start the systemd service:
-.. Enable the service:
 +
 [source,terminal]
 ----
-$ sudo systemctl enable kmods-via-containers@simple-kmod.service
-----
-
-.. Start the service:
-+
-[source,terminal]
-----
-$ sudo systemctl start kmods-via-containers@simple-kmod.service
+$ sudo systemctl enable kmods-via-containers@simple-kmod.service --now
 ----
 
 .. Review the service status:

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -76,7 +76,6 @@ $ sudo firewall-cmd --reload
 +
 [source,terminal]
 ----
-$ sudo systemctl start libvirtd
 $ sudo systemctl enable libvirtd --now
 ----
 


### PR DESCRIPTION
In two more places, use `systemctl enable --now` instead of an
additional `systemctl start` command.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>