### PR TITLE
API terminology and formatting updates for the 4.6 Release Notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -5,57 +5,32 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat {product-title} provides developers and IT organizations with a hybrid
-cloud application platform for deploying both new and existing applications on
-secure, scalable resources with minimal configuration and management overhead.
-{product-title} supports a wide selection of programming languages and
-frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
+Red Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management overhead. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
-Built on Red Hat Enterprise Linux and Kubernetes, {product-title}
-provides a more secure and scalable multi-tenant operating system for today's
-enterprise-class applications, while delivering integrated application runtimes
-and libraries. {product-title} enables organizations to meet security, privacy,
-compliance, and governance requirements.
+Built on Red Hat Enterprise Linux and Kubernetes, {product-title} provides a more secure and scalable multitenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
 [id="ocp-4-6-about-this-release"]
 == About this release
 
 // TODO: Update this link once there is a 1.19-specific URL for the Kubernetes 1.19 release notes (requested in https://github.com/kubernetes/website/issues/23855)
-Red Hat {product-title}
-(link:https://access.redhat.com/errata/RHBA-2020:4196[RHBA-2020:4196]) is now
-available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.19] with CRI-O runtime. New features, changes, and known issues that pertain to
-{product-title} {product-version} are included in this topic.
+Red Hat {product-title} (link:https://access.redhat.com/errata/RHBA-2020:4196[RHBA-2020:4196]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.19] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-Red Hat did not publicly release {product-title} 4.6.0 as the GA version and,
-instead, is releasing {product-title} 4.6.1 as the GA version.
+Red Hat did not publicly release {product-title} 4.6.0 as the GA version and, instead, is releasing {product-title} 4.6.1 as the GA version.
 
-{product-title} {product-version} clusters are available at
-https://cloud.redhat.com/openshift. The {cloud-redhat-com}
-application for {product-title} allows you to deploy OpenShift clusters to
-either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
-{product-title} {product-version} is supported on Red Hat Enterprise Linux 7.7 or
-later, as well as {op-system-first} 4.6.
+{product-title} {product-version} is supported on Red Hat Enterprise Linux 7.7 or later, as well as {op-system-first} 4.6.
 
-You must use {op-system} for the control plane, which are also known as master machines, and
-can use either {op-system} or Red Hat Enterprise Linux 7.7 or later for
-compute machines, which are also known as worker machines.
+You must use {op-system} for the control plane, which are also known as master machines, and can use either {op-system} or Red Hat Enterprise Linux 7.7 or later for compute machines, which are also known as worker machines.
 
 [IMPORTANT]
 ====
-Because only Red Hat Enterprise Linux version 7.7 or later is supported for compute
-machines, you must not upgrade the Red Hat Enterprise Linux compute machines to
-version 8.
+Because only Red Hat Enterprise Linux version 7.7 or later is supported for compute machines, you must not upgrade the Red Hat Enterprise Linux compute machines to version 8.
 ====
 
-{product-title} 4.6 is an Extended Update Support (EUS) release. More
-information on Red Hat OpenShift EUS is available in
-link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle]
-and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-With the release of {product-title} 4.6, version 4.3 is now end of life. For
-more information, see the
-link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+With the release of {product-title} 4.6, version 4.3 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [id="ocp-4-6-new-features-and-enhancements"]
 == New features and enhancements
@@ -68,16 +43,7 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-6-live-env-with-coreos-installer"]
 ==== {op-system} PXE and ISO now live environment
 
-The PXE media and ISO available for {op-system} are now a fully live
-environment. Unlike the previous dedicated PXE media and ISO used for
-{op-system} installation for {product-title} clusters on user-provisioned
-infrastructure, the {op-system} live environment can be configured with Ignition
-and contains all the same packages as the main {op-system} image, such as
-`coreos-installer`, `nmcli`, and `podman`. This allows arbitrary scripting of
-pre- or post-installation workflows. For example, you could run
-`coreos-installer` and then make an HTTP request to signal success to a
-provisioning server. PXE boots use the normal `ignition.config.url`. The ISO can
-be configured with Ignition by using the following command:
+The PXE media and ISO available for {op-system} are now a fully live environment. Unlike the previous dedicated PXE media and ISO used for {op-system} installation for {product-title} clusters on user-provisioned infrastructure, the {op-system} live environment can be configured with Ignition and contains all the same packages as the main {op-system} image, such as `coreos-installer`, `nmcli`, and `podman`. This allows arbitrary scripting of pre- or post-installation workflows. For example, you could run `coreos-installer` and then make an HTTP request to signal success to a provisioning server. PXE boots use the normal `ignition.config.url`. The ISO can be configured with Ignition by using the following command:
 
 [source,terminal]
 ----
@@ -97,18 +63,11 @@ The `coreos-installer` is now rewritten to support more features including:
 [id="ocp-4-6-ignition-spect-updated-v3"]
 ==== Ignition Spec updated to v3
 
-{op-system} now uses Ignition spec v3 as the only supported spec
-version of Ignition. This allows for more complex disk configuration support
-in the future.
+{op-system} now uses Ignition spec v3 as the only supported spec version of Ignition. This allows for more complex disk configuration support in the future.
 
-The change should be mostly transparent for those using installer-provisioned
-infrastructure. For user-provisioned infrastructure installations, you must
-adapt any custom Ignition configurations to use Ignition spec 3. The
-`openshift-install` program now generates Ignition spec 3.
+The change should be mostly transparent for those using installer-provisioned infrastructure. For user-provisioned infrastructure installations, you must adapt any custom Ignition configurations to use Ignition spec 3. The `openshift-install` program now generates Ignition spec 3.
 
-If you are creating Machine Configs for day 1 or day 2 operations that use
-Ignition snippets, they should be created using Ignition spec v3. However, the
-Machine Config Operator (MCO) still supports Ignition spec v2.
+If you are creating machine configs for day 1 or day 2 operations that use Ignition snippets, they should be created using Ignition spec v3. However, the Machine Config Operator (MCO) still supports Ignition spec v2.
 
 [id="ocp-4-6-additional-steps-to-add-nodes-to-clusters"]
 ==== Additional steps to add nodes to existing clusters
@@ -119,29 +78,25 @@ Because of the changes to the Ignition specification, if you want to add more no
 [id="ocp-4-6-extensions-supported-for-rhcos-mco"]
 ==== Extensions now supported for {op-system} and MCO
 
-{op-system} and the MCO now support the following extensions to the default
-{op-system} installation.
+{op-system} and the MCO now support the following extensions to the default {op-system} installation.
 
 * `kernel-devel`
 * `usbguard`
 
 [id="ocp-4-6-4kn-disk-support"]
-==== 4Kn Disks now supported
+==== 4Kn disks now supported
 
 {op-system} now supports installing to disks that use 4K sector sizes.
 
 [id="ocp-4-6-4k-var-partition-support"]
 ==== `/var` partitions now supported
 
-{op-system} now supports `/var` being a separate partition, as well as any other
-subdirectory of `/var`.
+{op-system} now supports `/var` being a separate partition, as well as any other subdirectory of `/var`.
 
 [id="ocp-4-6-static-ip-config-with-ova"]
 ==== Static IP configuration for vSphere using OVA
 
-You can now override default Dynamic Host Configuration Protocol (DHCP)
-networking in vSphere. This requires setting the static IP configuration and
-then setting a `guestinfo` property before booting a VM from an OVA in vSphere.
+You can now override default Dynamic Host Configuration Protocol (DHCP) networking in vSphere. This requires setting the static IP configuration and then setting a `guestinfo` property before booting a VM from an OVA in vSphere.
 
 . Set your static IP:
 +
@@ -156,17 +111,14 @@ $ export IPCFG="ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none nameserver=
 $ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameserver=8.8.8.8"
 ----
 
-. Set the `guestinfo.afterburn.initrd.network-kargs` property before booting a
-VM from an OVA in vSphere:
+. Set the `guestinfo.afterburn.initrd.network-kargs` property before booting a VM from an OVA in vSphere:
 +
 [source,terminal]
 ----
 $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${IPCFG}"
 ----
 
-This lowers the barrier for automatic {op-system-first} deployment in
-environments without DHCP. This enhancement allows for higher-level automation
-to provision an {op-system} OVA in environments with static networking.
+This lowers the barrier for automatic {op-system-first} deployment in environments without DHCP. This enhancement allows for higher-level automation to provision an {op-system} OVA in environments with static networking.
 
 For more information, see
 link:https://bugzilla.redhat.com/show_bug.cgi?id=1785122[*BZ1785122*].
@@ -177,38 +129,28 @@ link:https://bugzilla.redhat.com/show_bug.cgi?id=1785122[*BZ1785122*].
 [id="ocp-4-6-installing-aws-govcloud"]
 ==== Installing a cluster into an AWS GovCloud region
 
-You can now install a cluster on Amazon Web Services (AWS) into a GovCloud
-region. AWS GovCloud is designed for US government agencies, contractors,
-educational institutions, and other US customers that must run sensitive
-workloads.
+You can now install a cluster on Amazon Web Services (AWS) into a GovCloud region. AWS GovCloud is designed for US government agencies, contractors, educational institutions, and other US customers that must run sensitive workloads.
 
-Because GovCloud regions do not have {op-system} AMIs published by Red Hat, you
-must upload a custom AMI that belongs to that region.
+Because GovCloud regions do not have {op-system} AMIs published by Red Hat, you must upload a custom AMI that belongs to that region.
 
 For more information, see xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[Installing a cluster on AWS into a government region].
 
 [id="ocp-4-6-defining-custom-aws-api-endpoints"]
 ==== Defining custom AWS API endpoints
 
-You can now define a `serviceEndpoints` field in the `install-config.yaml`
-file, which lets you specify a list of custom endpoints to override the default
-service endpoints on AWS.
+You can now define a `serviceEndpoints` field in the `install-config.yaml` file, which lets you specify a list of custom endpoints to override the default service endpoints on AWS.
 
 [id="ocp-4-6-installing-azure-gov"]
 ==== Installing a cluster into a Microsoft Azure Government region
 
-You can now install a cluster on Azure into a Microsoft Azure Government (MAG)
-region. Microsoft Azure Government (MAG) is designed for US government agencies
-and their partners that must run sensitive workloads.
+You can now install a cluster on Azure into a Microsoft Azure Government (MAG) region. Microsoft Azure Government (MAG) is designed for US government agencies and their partners that must run sensitive workloads.
 
 For more information, see xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[Installing a cluster on Azure into a government region].
 
 [id="ocp-4-6-udr-for-azure"]
 ==== User-defined outbound routing for clusters running on Azure
 
-You can now choose your own outbound routing for a cluster running on Azure to
-connect to the internet. This allows you to skip the creation of public IP
-addresses and public load balancers.
+You can now choose your own outbound routing for a cluster running on Azure to connect to the internet. This allows you to skip the creation of public IP addresses and public load balancers.
 
 For more information, see xref:../installing/installing_azure/installing-azure-private.adoc#installation-azure-user-defined-routing_installing-azure-private[User-defined outbound routing].
 
@@ -220,18 +162,14 @@ You can now deploy a cluster to VMware vSphere version 7.0. See xref:../installi
 [id="ocp-4-6-bare-metal-ipi"]
 ==== Installing a cluster on bare metal using installer-provisioned infrastructure
 
-{product-title} {product-version} introduces support for installing a cluster on
-bare metal using installer-provisioned infrastructure.
+{product-title} {product-version} introduces support for installing a cluster on bare metal using installer-provisioned infrastructure.
 
 For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installing a cluster on bare metal]
 
 [id="ocp-4-6-handling-credential-requests"]
 ==== Handling credential requests for cloud API access on AWS, Azure, and GCP
 
-There is now a new `credentialsMode` field in the `install-config.yaml` file
-that defines how `CredentialsRequest`s are handled for {product-title}
-components requiring cloud API access on AWS, Azure, and GCP. There are three
-new modes that can be configured:
+There is now a new `credentialsMode` field in the `install-config.yaml` file that defines how `CredentialsRequest` custom resources are handled for {product-title} components requiring cloud API access on AWS, Azure, and GCP. There are three new modes that can be configured:
 
 * Mint
 * Passthrough
@@ -242,20 +180,14 @@ new modes that can be configured:
 Azure and GCP do not support the Manual mode configuration by using the `install-config.yaml` file due to a known issue found in link:https://bugzilla.redhat.com/show_bug.cgi?id=1884691[BZ#1884691].
 ====
 
-If the `credentialsMode` field is set to any of the three modes, the
-installation program does not check the credential for proper permissions prior
-to installing {product-title}. This is useful for when the supplied user
-credentials cannot be properly validated due to limitations in the cloud policy
-simulator.
+If the `credentialsMode` field is set to any of the three modes, the installation program does not check the credential for proper permissions prior to installing {product-title}. This is useful for when the supplied user credentials cannot be properly validated due to limitations in the cloud policy simulator.
 
 For more information on these modes, see xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator].
 
 [id="ocp-4-6-specifying-disk-type-and-size-for-nodes"]
 ==== Specifying disk type and size for control plane and compute nodes
 
-You can now configure the disk type and size on control plane and compute nodes
-for clusters running on Azure and GCP. This can be specified in the
-`install-config.yaml` file with the following fields:
+You can now configure the disk type and size on control plane and compute nodes for clusters running on Azure and GCP. This can be specified in the `install-config.yaml` file with the following fields:
 
 * `osDisk.diskSizeGB`
 * `osDisk.diskType`
@@ -284,8 +216,7 @@ controlPlane:
 [id="ocp-4-6-minimum-disk-size-increase-azure"]
 ==== Minimum disk size for control plane nodes has increased for Azure installations
 
-The minimum disk size requirement for control plane nodes for Azure
-installations has increased from 512 GB to 1024 GB.
+The minimum disk size requirement for control plane nodes for Azure installations has increased from 512 GB to 1024 GB.
 
 [id="ocp-4-6-latest-version-operators-required"]
 ==== Latest version of Operators required before cluster upgrade
@@ -455,7 +386,7 @@ Note the following restrictions for {product-title} on IBM Power Systems:
 * You can use auto-scaling additional of {rh-virtualization} virtual machine worker nodes to improve control of workloads and resources.
 * You can perform disconnected or restricted installations by using a local mirror. This capability is beneficial for financial, public sector, and secure environments.
 * You can xref:../installing/installing_rhv/installing-rhv-user-infra.adoc#installing-rhv-user-infra[install {product-title} on {rh-virtualization} with user-provisioned infrastructure], such as an external load balancer. This process uses a series of Ansible playbooks to enable a more flexible installation.
-* Installing {product-title} on {rh-virtualization} with installer-provisioned infrastructure does not require a static IP address for internal DNS. 
+* Installing {product-title} on {rh-virtualization} with installer-provisioned infrastructure does not require a static IP address for internal DNS.
 * {product-title} version 4.6 requires {rh-virtualization} version 4.4.2 or later.
 +
 [IMPORTANT]
@@ -499,13 +430,7 @@ If you are upgrading your cluster to {product-title} 4.6, old tokens from {produ
 [id="ocp-4-6-file-integrity-operator"]
 ==== File Integrity Operator is now available
 
-The
-xref:../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[File
-Integrity Operator], an {product-title} Operator that continually runs file
-integrity checks on the cluster nodes, is now available. It deploys a daemon set
-that initializes and runs privileged advanced intrusion detection environment
-(AIDE) containers on each node, providing a status object with a log of files
-that are modified during the initial run of the daemon set Pods.
+The xref:../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[File Integrity Operator], an {product-title} Operator that continually runs file integrity checks on the cluster nodes, is now available. It deploys a daemon set that initializes and runs privileged advanced intrusion detection environment (AIDE) containers on each node, providing a status object with a log of files that are modified during the initial run of the daemon set pods.
 
 [id="ocp-4-6-cluster-scripts-updated"]
 ==== Cluster scripts updated for cluster restore failures
@@ -523,16 +448,14 @@ The Machine API now supports multiple block device mappings for machines running
 [id="ocp-4-6-default-validation-providerspec-apis"]
 ==== Defaults and validation for the Machine API `providerSpec`
 
-Defaults and validation are now enabled on a particular cloud provider API before input from the `providerSpec` is persisted to etcd. Validation is run against machines and MachineSets when they are created. Feedback is returned when the configuration is known to prevent machines from being created by the cloud provider. For example, a MachineSet is rejected if location information is required but is not provided.
+Defaults and validation are now enabled on a particular cloud provider API before input from the `providerSpec` is persisted to etcd. Validation is run against machines and machine sets when they are created. Feedback is returned when the configuration is known to prevent machines from being created by the cloud provider. For example, a machine set is rejected if location information is required but is not provided.
 
 [id="ocp-4-6-azure-machinesets-support-spot-vms"]
-==== MachineSets running on Azure support Spot VMs
+==== Machine sets running on Azure support Spot VMs
 
-MachineSets running on Azure now support Spot VMs. You can create a MachineSet
-that deploys machines as Spot VMs to save on costs compared to
-standard VM prices. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[MachineSets that deploy machines as Spot VMs].
+Machine sets running on Azure now support Spot VMs. You can create a machine set that deploys machines as Spot VMs to save on costs compared to standard VM prices. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#machineset-non-guaranteed-instance_creating-machineset-azure[Machine sets that deploy machines as Spot VMs].
 
-Configure Spot VMs by adding `spotVMOptions` under the `providerSpec` field in the MachineSet YAML file:
+Configure Spot VMs by adding `spotVMOptions` under the `providerSpec` field in the machine set YAML file:
 
 [source,yaml]
 ----
@@ -542,13 +465,11 @@ providerSpec:
 ----
 
 [id="ocp-4-6-gcp-machinesets-support-preemptible-vm-instances"]
-==== MachineSets running on GCP support preemptible VM instances
+==== Machine sets running on GCP support preemptible VM instances
 
-MachineSets running on GCP now support preemptible VM instances. You can create a MachineSet
-that deploys machines as preemptible VM instances to save on costs compared to
-normal instance prices. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[MachineSets that deploy machines as preemptible VM instances].
+Machine sets running on GCP now support preemptible VM instances. You can create a machine set that deploys machines as preemptible VM instances to save on costs compared to normal instance prices. For more information, see xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-non-guaranteed-instance_creating-machineset-gcp[Machine sets that deploy machines as preemptible VM instances].
 
-Configure preemptible VM instances by adding `preemptible` under the `providerSpec` field in the MachineSet YAML file:
+Configure preemptible VM instances by adding `preemptible` under the `providerSpec` field in the machine set YAML file:
 
 [source,yaml]
 ----
@@ -566,69 +487,42 @@ providerSpec:
 * Administrators are now better informed about the differences between the upgrade channels by helpful text and links in the web console.
 * A link to the list of bug fixes and enhancements is now included for each minor or patch release.
 * There is now a visual representation of the different upgrade paths.
-* Alerts now inform administrators when new patch releases, new minor releases, and news channels become available.
+* Alerts now inform administrators when new patch releases, new minor releases, and new channels become available.
 
 [id="ocp-4-6-web-console-improved-operator-installation-workflow"]
 ==== Improved Operator installation workflow with OperatorHub
 
-When administrators install Operators with OperatorHub, they now get immediate
-feedback to ensure that the Operator is installing properly.
+When administrators install Operators with OperatorHub, they now get immediate feedback to ensure that the Operator is installing properly.
 
 [id="ocp-4-6-web-console-improved-operand-details-view"]
 ==== Improved operand details view
 
-You can now see the schema grouping of `specDescriptor` fields and the status of
-your Operands on the operand's details view, so that you can easily see the
-status and configure the `spec` of the operand instance.
+You can now see the schema grouping of `specDescriptor` fields and the status of your Operands on the operand's details view, so that you can easily see the status and configure the `spec` of the operand instance.
 
 [id="ocp-4-6-web-console-view-operators-related-objects"]
 ==== View related objects for cluster Operators
 
-Previously, when viewing a cluster Operator, it was not clear what resources the
-Operator was associated with. When troubleshooting a cluster Operator, it could
-be challenging to locate the logs for all the resources that the Operator
-managed, which might be needed for troubleshooting. Now, with {product-title}
-{product-version}, you can expose a list of related objects of a cluster
-Operator and easily review one of the related objects' details or YAML code for
-troubleshooting.
+Previously, when viewing a cluster Operator, it was not clear what resources the Operator was associated with. When troubleshooting a cluster Operator, it could be challenging to locate the logs for all the resources that the Operator managed, which might be needed for troubleshooting. Now, with {product-title} {product-version}, you can expose a list of related objects of a cluster Operator and easily review one of the related objects' details or YAML code for troubleshooting.
 
 [id="ocp-4-6-web-console-warning-messages-when-editing-managed-resources"]
 ==== Warning messages when editing managed resources
 
-Some resources are managed, such an Operator managed by a deployment, route,
-service, or ConfigMap. Users are discouraged from editing these resources.
-Instead, users should edit the custom resources for the Operator and its
-operand, and expect the Operator to update its related resources. With this
-update:
+Some resources are managed, such an Operator managed by a deployment, route, service, or config map. Users are discouraged from editing these resources. Instead, users should edit the custom resources for the Operator and its operand, and expect the Operator to update its related resources. With this update:
 
-* A *Managed by* label now appears below the resource name with a clickable
-resource link for the managing resource.
-* When the resource is modified or deleted, a message appears warning the user
-that their changes might be reverted.
+* A *Managed by* label now appears below the resource name with a clickable resource link for the managing resource.
+* When the resource is modified or deleted, a message appears warning the user that their changes might be reverted.
 
 [id="ocp-4-6-web-console-specDescriptor-supports-CRD-instance"]
-====  The `k8sResourcePrefix` specDescriptor supports CRD instance
+====  The `k8sResourcePrefix` `specDescriptor` field supports CRD instance
 
-Operator authors, maintainers, and providers can now specify the
-`k8sResourcePrefix` specDescriptor with `Group/Version/Kind` for assigning a CRD
-resource type besides Kubernetes core API.
+Operator authors, maintainers, and providers can now specify the `k8sResourcePrefix` `specDescriptor` field with `Group/Version/Kind` for assigning a CRD resource type besides Kubernetes core API.
 
-For more information, see
-link:https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md[OLM
-Descriptor Reference].
+For more information, see link:https://github.com/openshift/console/blob/master/frontend/packages/operator-lifecycle-manager/src/components/descriptors/reference/reference.md[OLM Descriptor Reference].
 
 [id="ocp-4-6-web-console-column-management"]
 ==== Column management on resources page
 
-A *Manage columns* icon image:manage-columns.png[title="Manage Columns icon"] is
-now added to some resources pages, for example the Pods page. When you click on
-the icon, default column names are listed with check boxes on the left side of
-the modal and additional column names are listed on the right. Deselecting a
-check box will remove that column from the table view. Selecting a check box
-will add that column to the table view. A maximum combination of nine columns
-from both sides of the modal are available for display at one time. Clicking
-*Save* will save the changes that you make. Clicking *Restore Default Columns*
-will restore the default settings of the columns.
+A *Manage columns* icon image:manage-columns.png[title="Manage Columns icon"] is now added to some resources pages, for example the *Pods* page. When you click on the icon, default column names are listed with check boxes on the left side of the modal and additional column names are listed on the right. Deselecting a check box will remove that column from the table view. Selecting a check box will add that column to the table view. A maximum combination of nine columns from both sides of the modal are available for display at one time. Clicking *Save* will save the changes that you make. Clicking *Restore Default Columns* will restore the default settings of the columns.
 
 //[id="ocp-4-6-web-console-administrator-perspective"]
 //==== Administrator Perspective
@@ -636,7 +530,7 @@ will restore the default settings of the columns.
 //* The *Pipelines* section in the navigation bar was updated to provide subsections for Pipelines, Tasks, and Triggers. The Triggers subsection now provides tabs for event listeners, trigger templates, trigger bindings, and cluster trigger bindings.
 
 [id="ocp-4-6-web-console-developer-perspective"]
-==== Developer Perspective
+==== Developer perspective
 
 * Based on user access roles or privileges, the user is now directed to either the *Administrator* or *Developer*  perspective.
 * An interactive getting started tour of the functionalities in the *Developer* perspective is now provided when a user logs in.
@@ -679,7 +573,7 @@ The xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-l
 
 In addition to the features provided in the previous pre-releases, this version includes the following:
 
-* CPU load balancing can be enabled per Pod.
+* CPU load balancing can be enabled per pod.
 * Multiple huge page sizes can be specified at the same time.
 * Improvements to supportability, such as integration gathering and better status reporting.
 * A method for in-field emergency configuration overrides was devised and documented.
@@ -720,8 +614,7 @@ The node service port range is expandable beyond the default range of `30000-327
 [id="ocp-4-6-sr-iov-infiniband-devices"]
 ==== SR-IOV Network Operator InfiniBand device support
 
-The Single Root I/O Virtualization (SR-IOV) Network Operator now supports InfiniBand (IB) network devices.
-For more information on configuring an IB network device for your cluster, refer to xref:../networking/hardware_networks/configuring-sriov-ib-attach.adoc#configuring-sriov-ib-attach[Configuring an SR-IOV InfiniBand network attachment].
+The Single Root I/O Virtualization (SR-IOV) Network Operator now supports InfiniBand (IB) network devices. For more information on configuring an IB network device for your cluster, refer to xref:../networking/hardware_networks/configuring-sriov-ib-attach.adoc#configuring-sriov-ib-attach[Configuring an SR-IOV InfiniBand network attachment].
 
 [id="ocp-4-6-dhcp-range-increased"]
 ==== DHCP range increased for provisioning network
@@ -731,7 +624,7 @@ To better support large deployments, the default DHCP range for the provisioning
 [id="ocp-4-6-pod-network-connectivity-checks"]
 ==== Pod network connectivity checks
 
-Operators can now configure `PodNetworkConnectivityCheck` resources to check each network connection from the Pods that are managed by the Operator. This allows you to more easily identify and troubleshoot issues with important network connections in your cluster.
+Operators can now configure `PodNetworkConnectivityCheck` resources to check each network connection from the pods that are managed by the Operator. This allows you to more easily identify and troubleshoot issues with important network connections in your cluster.
 
 This resource keeps track of the latest reachable condition, the last 10 successes, the last 10 failures, and details about detected outages. The results are also logged and events are created when outages are detected and resolved.
 
@@ -762,7 +655,7 @@ The kubelet is already publishing a set of network-observable related metrics. T
 * Pod namespace
 * Interface name, such as eth0
 
-This works well until new interfaces are added to the Pod, for example via Multus, as it will not be clear what the interface names refer to. The interface label refers to the interface name, but it is not clear what that interface is meant for. In case of many different interfaces, it would be impossible to understand what network the metrics we are monitoring refer to. This is addressed by introducing the new `pod_network_name_info` metric, which can be used to build queries containing both the values exposed by the kubelet and the name of the network attachment definition the metrics relates to, which identifies the type of network.
+This works well until new interfaces are added to the pod, for example via Multus, as it will not be clear what the interface names refer to. The interface label refers to the interface name, but it is not clear what that interface is meant for. In case of many different interfaces, it would be impossible to understand what network the metrics we are monitoring refer to. This is addressed by introducing the new `pod_network_name_info` metric, which can be used to build queries containing both the values exposed by the kubelet and the name of the network attachment definition the metrics relates to, which identifies the type of network.
 
 See xref:../networking/associating-secondary-interfaces-metrics-to-network-attachments.adoc#associating-secondary-interfaces-metrics-to-network-attachments[Associating secondary interfaces metrics to network attachments] for more information.
 
@@ -771,9 +664,9 @@ See xref:../networking/associating-secondary-interfaces-metrics-to-network-attac
 
 There is an optional mode where the Cloud-native Network Functions (CNF) tests try to look for configurations on the cluster instead of applying the new ones. The CNF tests image is a containerized version of the CNF conformance test suite. It is intended to be run against a CNF-enabled {product-title} cluster where all the components required for running CNF workloads are installed.
 
-The tests must perform an environment configuration every time they are executed. This involves items such as creating SR-IOV Node Policies, Performance Profiles, or PtpProfiles. Allowing the tests to configure an already configured cluster might affect the functionality of the cluster. Also, changes to configuration items such as SR-IOV Node Policy might result in the environment being temporarily unavailable until the configuration change is processed.
+The tests need to perform an environment configuration every time they are executed. This involves items such as creating SRI-OV node policies, performance profiles, or PTP profiles. Allowing the tests to configure an already configured cluster might affect the functionality of the cluster. Also, changes to configuration items such as SR-IOV node policy might result in the environment being temporarily unavailable until the configuration change is processed.
 
-xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#discovery-mode_cnf-master[Discovery mode] validates the functionality of a cluster without altering its configuration. Existing environment configurations are used for the tests. The tests attempt to find the configuration items needed and use those items to execute the tests. If resources needed to run a specific test are not found, the test is skipped, providing an appropriate message to the user. After the tests are finished, no cleanup of the pre-configured configuration items is done, and the test environment can be used immediately for another test run.
+xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#discovery-mode_cnf-master[Discovery mode] validates the functionality of a cluster without altering its configuration. Existing environment configurations are used for the tests. The tests attempt to find the configuration items needed and use those items to execute the tests. If resources needed to run a specific test are not found, the test is skipped, providing an appropriate message to the user. After the tests are finished, no cleanup of the preconfigured configuration items is done, and the test environment can be used immediately for another test run.
 
 [id="ocp-4-6-haproxy-version-bump"]
 ==== HAProxy version upgrade
@@ -913,9 +806,9 @@ See xref:../operators/understanding/olm/olm-understanding-dependency-resolution.
 
 The Operator Bundle Format now supports the following additional Kubernetes objects:
 
-* PodDisruptionBudget
-* PriorityClass
-* VerticalPodAutoScaler
+* `PodDisruptionBudget`
+* `PriorityClass`
+* `VerticalPodAutoScaler`
 
 See xref:../operators/understanding/olm-packaging-format.adoc#olm-bundle-format-manifests-optional_olm-packaging-format[Operator Framework packaging formats] for more information.
 
@@ -936,9 +829,9 @@ See xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-defining-csv-we
 [id="ocp-4-6-operator-api"]
 ==== Operator API now supported
 
-The Operator API introduced in {product-title} 4.5 as a Technology Preview feature is now supported and enabled by default. Installing Operators using Operator Lifecycle Manager (OLM) has required cluster administrators to be aware of multiple APIs, including CatalogSources, Subscriptions, ClusterServiceVersions, and InstallPlans. This single Operator API resource is a first step towards a more simplified experience discovering and managing the lifecycle of Operators in a {product-title} cluster.
+The Operator API introduced in {product-title} 4.5 as a Technology Preview feature is now supported and enabled by default. Installing Operators using Operator Lifecycle Manager (OLM) has required cluster administrators to be aware of multiple API objects, including `CatalogSource`, `Subscription`, `ClusterServiceVersion`, and `InstallPlan` resources. This single Operator API resource is a first step towards a more simplified experience discovering and managing the lifecycle of Operators in a {product-title} cluster.
 
-Relevant resources are now automatically labeled accordingly for the new Operator API for any Operators where the CSV is installed using a Subscription. Cluster administrators can use the CLI with this single API to interact with installed Operators. For example:
+Relevant resources are now automatically labeled accordingly for the new Operator API for any Operators where the CSV is installed using a `Subscription` resource. Cluster administrators can use the CLI with this single API to interact with installed Operators. For example:
 
 [source,terminal]
 ----
@@ -1028,7 +921,7 @@ $ oc delete crd operators.operators.coreos.com
 
 . Remove the `OperatorLifecycleManagerV2=true` feature gate from the OLM Operator.
 
-.. Edit the Deployment for the OLM Operator:
+.. Edit the `Deployment` object for the OLM Operator:
 +
 [source,terminal]
 ----
@@ -1036,7 +929,7 @@ $ oc -n openshift-operator-lifecycle-manager \
     edit deployment olm-operator
 ----
 
-.. Remove the following flags from the `args` section in the Deployment:
+.. Remove the following flags from the `args` section in the `Deployment` object:
 +
 [source,terminal]
 ----
@@ -1112,27 +1005,27 @@ Builds now support Git clones behind an HTTPS proxy.
 [id="ocp-4-6-cloud-credential-operator-mode-support"]
 ==== Support for Cloud Credential Operator modes
 
-In addition to the existing default mode of operation, the xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator (CCO)] can now be explicitly configured to operate in the following modes: `Mint`, `Passthrough`, and `Manual`. This feature provides transparency and flexibility in how the CCO uses cloud credentials to process `CredentialRequests` in the cluster for installation and other tasks.
+In addition to the existing default mode of operation, the xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator (CCO)] can now be explicitly configured to operate in the following modes: `Mint`, `Passthrough`, and `Manual`. This feature provides transparency and flexibility in how the CCO uses cloud credentials to process `CredentialsRequest` custom resources in the cluster for installation and other tasks.
 
 [id="ocp-4-6-samples-operator-power-z"]
 ==== Cluster Samples Operator on Power and Z
 
-Imagestreams and templates for Power and Z architectures are now available and installed by the Cluster Samples Operator by default.
+Image streams and templates for Power and Z architectures are now available and installed by the Cluster Samples Operator by default.
 
 [id="ocp-4-6-samples-operator-alert"]
-==== Cluster Samples Operator Alerts
+==== Cluster Samples Operator alerts
 
 If samples do not import, the Cluster Samples Operator now notifies you with an alert instead of moving to a degraded status.
 
-See xref:../openshift_images/samples-operator-alt-registry.adoc#installation-restricted-network-samples_samples-operator-alt-registry[Using Cluster Samples Operator imagestreams with alternate or mirrored registries] for more information.
+See xref:../openshift_images/samples-operator-alt-registry.adoc#installation-restricted-network-samples_samples-operator-alt-registry[Using Cluster Samples Operator image streams with alternate or mirrored registries] for more information.
 
 [id="ocp-4-6-metering"]
 === Metering
 
 [id="ocp-4-6-metering-operator"]
-==== Configuring a retention period of metering Reports
+==== Configuring a retention period of metering `Report` custom resources
 
-You can now set a retention period on a metering Report. The metering Report custom resource has a new `expiration` field. If the `expiration` duration value is set on a Report, and no other Reports or ReportQueries depend on the expiring Report, the Metering Operator removes the Report from your cluster at the end of its retention period. For more information, see metering Reports xref:../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[expiration].
+You can now set a retention period on a metering `Report` custom resources (CRs). The metering `Report` CR has a new `expiration` field. If the `expiration` duration value is set on a `Report` CR, and no other `Report` or `ReportQuery` CRs depend on the expiring `Report` CR, the Metering Operator removes the `Report` CR from your cluster at the end of its retention period. For more information, see metering `Report` CRs xref:../metering/reports/metering-about-reports.adoc#metering-expiration_metering-about-reports[expiration].
 
 [id="ocp-4-6-nodes"]
 === Nodes
@@ -1173,12 +1066,11 @@ The `RemoveDuplicates` strategy now provides an optional parameter, `ExcludeOwne
 See xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler-strategies_nodes-descheduler[Descheduler strategies] for more information.
 
 [id="ocp-4-6-imagecontentsourcepolicy-scoped-to-registry"]
-==== Generate ImageContentSourcePolicy scoped to a registry
+==== Generate `ImageContentSourcePolicy` object scoped to a registry
 
-The `oc adm catalog mirror` command generates an `ImageContentSourcePolicy` (ICSP) that maps the original container image repository to a new location where it will be mirrored, typically inside a disconnected environment. When a new or modified ICSP is applied to a cluster, it is converted to a config file for CRI-O and placed onto each node. The process of placing the config file on a node includes rebooting that node.
+The `oc adm catalog mirror` command generates an `ImageContentSourcePolicy` (ICSP) object that maps the original container image repository to a new location where it will be mirrored, typically inside a disconnected environment. When a new or modified ICSP is applied to a cluster, it is converted to a config file for CRI-O and placed onto each node. The process of placing the config file on a node includes rebooting that node.
 
-This enhancement adds  the `--icsp-scope` flag to `oc adm catalog mirror`. Scopes can be registry or repository. By default, the `oc adm catalog mirror` command generates an ICSP where each entry is specific to a repository. For example, it would map `registry.redhat.io/cloud/test-db` to `mirror.internal.customer.com/cloud/test-db`.  Widening the mirror to registry scope in the ICSP file minimizes the number of times the cluster must
-reboot its nodes. Using the same example, `registry.redhat.io` would map to `mirror.internal.customer.com`.
+This enhancement adds  the `--icsp-scope` flag to `oc adm catalog mirror`. Scopes can be registry or repository. By default, the `oc adm catalog mirror` command generates an ICSP where each entry is specific to a repository. For example, it would map `registry.redhat.io/cloud/test-db` to `mirror.internal.customer.com/cloud/test-db`.  Widening the mirror to registry scope in the ICSP file minimizes the number of times the cluster must reboot its nodes. Using the same example, `registry.redhat.io` would map to `mirror.internal.customer.com`.
 
 Having a widely scoped ICSP reduces the number of times the ICSP might need to change in the future and, thus, reduces the number of times a cluster must reboot all of its nodes.
 
@@ -1233,7 +1125,7 @@ With this new feature, you can perform the following tasks:
 
 * Enable and configure monitoring for user-defined projects
 * Create recording and alerting rules that use metrics from your own pods and services
-* Access metrics and information about alerts through a single, multi-tenant interface
+* Access metrics and information about alerts through a single, multitenant interface
 * Cross-correlate the metrics for user-defined projects with platform metrics
 
 For more information, see xref:../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Understanding the monitoring stack].
@@ -1262,12 +1154,12 @@ Red Hat does not guarantee backward compatibility for metrics, recording rules, 
 [id="ocp-4-6-monitoring-prometheus-rule-validation"]
 ==== Prometheus rule validation
 
-{product-title} 4.6 introduces validation of Prometheus rules through a webhook that calls the validating admission plug-in. With this enhancement, PrometheusRule custom resources in all projects are checked against the Prometheus Operator rule validation API.
+{product-title} 4.6 introduces validation of Prometheus rules through a webhook that calls the validating admission plug-in. With this enhancement, `PrometheusRule` custom resources in all projects are checked against the Prometheus Operator rule validation API.
 
 [id="ocp-4-6-monitoring-metrics-and-alerting-rules-added-for-thanos-querier"]
 ==== Metrics and alerting rules added for the Thanos Querier
 
-The Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multi-tenant interface. In {product-title} 4.6, a service monitor and alerting rules are now deployed for the Thanos Querier, which enables monitoring of the Thanos Querier by the monitoring stack.
+The Thanos Querier aggregates and optionally deduplicates core {product-title} metrics and metrics for user-defined projects under a single, multitenant interface. In {product-title} 4.6, a service monitor and alerting rules are now deployed for the Thanos Querier, which enables monitoring of the Thanos Querier by the monitoring stack.
 
 [id="ocp-4-6-vm-pending-alert"]
 ==== Virtual Machine `Pending Changes` alert updates
@@ -1287,11 +1179,11 @@ In {product-title} 4.6, the Insights Operator collects the following additional 
 * The latest pod logs from pods that are not healthy
 * Data about running Red Hat images, including the number of containers using an image and the age of the corresponding pods
 * JSON dumps for pods that have crash looping containers
-* The MachineSet resource configuration
-* The anonymized HostSubnet resource configuration
-* The MachineConfigPools configuration
-* The InstallPlans for `default` and `openshift-&#42;` projects and their count
-* ServiceAccounts statistics from Openshift namespaces
+* The `MachineSet` resource configuration
+* The anonymized `HostSubnet` resource configuration
+* The `MachineConfigPool` resource configuration
+* The `InstallPlan` resource for `default` and `openshift-&#42;` projects and their count
+* `ServiceAccount` resource statistics from Openshift namespaces
 
 Additionally, with this release the Insights Operator collects information about all cluster nodes, while previous versions only collected information about unhealthy nodes.
 
@@ -1335,15 +1227,13 @@ link:https://access.redhat.com/articles/5423161[]
 [id="ocp-4-6-default-cni-np-uses-ovs-on-cluster-nodes"]
 ==== CNI network provider now uses OVS installed on cluster nodes
 
-Both the OpenShift SDN and OVN-Kubernetes Container Network Interface (CNI) cluster networking providers now use the Open vSwitch (OVS) version installed on the cluster nodes. Previously, OVS ran in a container on each node, managed by a DaemonSet. Using the host OVS eliminates any possible downtime from upgrading the containerized version of OVS.
+Both the OpenShift SDN and OVN-Kubernetes Container Network Interface (CNI) cluster networking providers now use the Open vSwitch (OVS) version installed on the cluster nodes. Previously, OVS ran in a container on each node, managed by a daemon set. Using the host OVS eliminates any possible downtime from upgrading the containerized version of OVS.
 
 [discrete]
 [id="ocp-4-6-warnings-when-using-deprecated-apis"]
 ==== Warnings when using deprecated APIs
 
-Warnings are now visible in `client-go` and `oc` on every invocation against a
-deprecated API. Calling a deprecated API returns a warning message containing
-the target Kubernetes removal release and replacement API, if applicable.
+Warnings are now visible in `client-go` and `oc` on every invocation against a deprecated API. Calling a deprecated API returns a warning message containing the target Kubernetes removal release and replacement API, if applicable.
 
 For example:
 
@@ -1364,11 +1254,9 @@ The performance of `COPY` and `ADD` instructions in {product-title} builds are i
 [id="ocp-4-6-operator-sdk-v-0-19-4"]
 ==== Operator SDK v0.19.4
 
-{product-title} supports Operator SDK v0.19.4, which introduces the following
-notable technical changes:
+{product-title} supports Operator SDK v0.19.4, which introduces the following notable technical changes:
 
-* Operator SDK now aligns with the {product-title}-wide switch to using UBI-8
-and Python 3. Downstream base images now use UBI-8 and include Python 3.
+* Operator SDK now aligns with the {product-title}-wide switch to using UBI-8 and Python 3. Downstream base images now use UBI-8 and include Python 3.
 * The command `run --local` is deprecated in favor of `run local`.
 * The commands `run --olm` and `--kubeconfig` are deprecated in favor of `run packagemanifests`.
 * The default CRD version changed from `apiextensions.k8s.io/v1beta1` to `apiextensions.k8s.io/v1` for commands that create or generate CRDs.
@@ -1389,8 +1277,7 @@ Helm-based Operator enhancements include:
 [id="ocp-4-6-ubi-8-all-images"]
 ==== UBI 8 used for all images in {product-title}
 
-All images in {product-title} now use universal base image (UBI) version 8 by
-default.
+All images in {product-title} now use universal base image (UBI) version 8 by default.
 
 [discrete]
 [id="ocp-4-6-jenkins-node-js-12"]
@@ -1422,12 +1309,7 @@ The renamed binary file allows for GPG to correctly verify `sha256sum.txt`, whic
 
 Some features available in previous releases have been deprecated or removed.
 
-Deprecated functionality is still included in {product-title} and continues to
-be supported; however, it will be removed in a future release of this product
-and is not recommended for new deployments. For the most recent list of major
-functionality deprecated and removed within {product-title} {product-version},
-refer to the table below. Additional details for more fine-grained functionality
-that has been deprecated and removed are listed after the table.
+Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {product-title} {product-version}, refer to the table below. Additional details for more fine-grained functionality that has been deprecated and removed are listed after the table.
 
 In the table, features are marked with the following statuses:
 
@@ -1450,12 +1332,12 @@ In the table, features are marked with the following statuses:
 |REM
 |REM
 
-|OperatorSources
+|`OperatorSource` resources
 |DEP
 |DEP
 |REM
 
-|CatalogSourceConfigs
+|`CatalogSourceConfig` resources
 |DEP
 |REM
 |REM
@@ -1488,9 +1370,7 @@ In the table, features are marked with the following statuses:
 [id="ocp-4-6-byo-rhel-7-deprecated"]
 ==== Bring your own {op-system-base} 7 compute machines
 
-The strategy to bring your own (BYO) {op-system-base-full} 7 compute machines is
-now deprecated. Support for using {op-system-base} 7 compute machines is planned
-for removal in a future release of OpenShift 4.
+The strategy to bring your own (BYO) {op-system-base-full} 7 compute machines is now deprecated. Support for using {op-system-base} 7 compute machines is planned for removal in a future release of OpenShift 4.
 
 [id="ocp-4-6-tls-common-name"]
 ==== TLS verification falling back to the Common Name field
@@ -1506,14 +1386,9 @@ The Metering Operator is deprecated and will be removed in a future release.
 === Removed features
 
 [id="ocp-4-6-operatorsources-removed"]
-==== OperatorSources removed
+==== OperatorSource resource removed
 
-The OperatorSources resource, part of the Marketplace API for the Operator
-Framework, has been deprecated for several {product-title} releases and is now
-removed. In {product-title} 4.6, the default catalogs for OperatorHub in the
-`openshift-marketplace` namespace now only use CatalogSources with the `polling`
-feature enabled. The default catalogs poll for new updates in their referenced
-index images every 15 minutes.
+The `OperatorSource` resource, part of the Marketplace API for the Operator Framework, has been deprecated for several {product-title} releases and is now removed. In {product-title} 4.6, the default catalogs for OperatorHub in the `openshift-marketplace` namespace now only use `CatalogSource` resources with the `polling` feature enabled. The default catalogs poll for new updates in their referenced index images every 15 minutes.
 
 [id="ocp-4-6-mongodb-removed"]
 ==== MongoDB templates removed
@@ -1525,21 +1400,22 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 *apiserver-auth*
 
-* Previously, certain conditions caused the Ingress Operator to not push the CA certificate to its `router-certs` secret, so the Cluster Authentication Operator could not construct a trust chain to the certificate in its health checks, causing it to go Degraded and prevent an upgrade. The CA is now always included from the `default-ingress-cert` ConfigMap during the default router CA check, so the Cluster Authentication Operator no longer blocks upgrades. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866818[*BZ#1866818*])
+* Previously, certain conditions caused the Ingress Operator to not push the CA certificate to its `router-certs` secret, so the Cluster Authentication Operator could not construct a trust chain to the certificate in its health checks, causing it to go `Degraded` and prevent an upgrade. The CA is now always included from the `default-ingress-cert` config map during the default router CA check, so the Cluster Authentication Operator no longer blocks upgrades. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866818[*BZ#1866818*])
 
 * Previously, the Cluster Authentication Operator failed to parse HTML pages that were returned from OIDC servers that ignore `Accept: application/json` when a login flow that they do not support is requested, because the Operator was expecting a JSON response. As a result, the Operator failed to honor the IDP configuration. The Cluster Authentication Operator no longer fails with an error when an HTML page is returned from an OIDC server because it does not support the requested flow. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877803[*BZ#1877803*])
 
-* Previously, ConfigMaps and secrets were not properly validated by the Cluster Authentication Operator, which could cause a new deployment of the OAuth server to roll out with invalid or missing files, causing the pods to crash. ConfigMaps and secrets are now properly validated by the Cluster Authentication Operator, so a new deployment should not roll out when the ConfigMaps or secrets referenced contain invalid data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1777137[*BZ#1777137*])
+* Previously, config maps and secrets were not properly validated by the Cluster Authentication Operator, which could cause a new deployment of the OAuth server to roll out with invalid or missing files, causing the pods to crash. Config maps and secrets are now properly validated by the Cluster Authentication Operator, so a new deployment should not roll out when the config maps or secrets referenced contain invalid data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1777137[*BZ#1777137*])
 
 *Bare Metal Hardware Provisioning*
 
-* Previously, the ironic-image container configuration was missing the setting to enable the idrac-redfish-virtual-media boot driver. Because of this, users were unable to select the idrac-virtual-media boot URL for Metal3. The missing ironic-image container configuration is now included, so users are able to select the idrac-virtual-media URL for Metal3. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1858019[*BZ#1858019*])
+* Previously, the `ironic-image` container configuration was missing the setting to enable the `idrac-redfish-virtual-media` boot driver. Because of this, users were unable to select the `idrac-virtual-media` boot URL for Metal3. The missing `ironic-image` container configuration is now included, so users are able to select the `idrac-virtual-media` URL for Metal3. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1858019[*BZ#1858019*])
 
 * Previously, certain Dell firmware versions dropped support for configuring persistent boot using Redfish. Updating Dell iDRAC firmware to version 4.20.20.20 resolves the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1828885[*BZ#1828885*])
 
 * In this release, an issue that resulted in inspection timeouts if many nodes were inspected at the same time has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1830256[*BZ#1830256*])
 
 * Previously, the `ironic-image` container configuration was missing the setting to enable the `idrac-redfish-virtual-media` boot driver. Because of this, users were unable to select the `idrac-virtual-media` boot URL for Metal3. The missing `ironic-image` container configuration is now included, so users are able to select the `idrac-virtual-media` URL for Metal3. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853302[*BZ#1853302*])
+//This appears to be the wrong description for this bug. Flagging to revisit.
 
 * Previously, the HTTPd container in the `metal3` pod in the `openshift-machine-api` namespace that is used for serving bare metal ironic images allowed directory listings. With this release, directory listings are no longer allowed in this container.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859334[*BZ#1859334*])"
@@ -1548,45 +1424,45 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * Errors in `buildah` libraries could ignore certain HTTP errors. Builds could fail to push images due to temporary issues with the target registry. This bug fix updates `buildah` to respect these errors when pushing image blobs. As a result, `buildah` now fails to push an image if the upstream registry is temporarily unavailable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1816578[*BZ#1816578*])
 
-* Previously, the container image signature policy used in OpenShift Container Platform builds did not contain any configuration for local images. When only allowing images from specific registries, postCommit scripts in builds failed because it was not allowed to use local images. The container image signature policy has been updated to always allow images that reference local storage layers directly. Now builds can successfully complete if they contain a postCommit hook. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1838372[*BZ#1838372*])
+* Previously, the container image signature policy used in OpenShift Container Platform builds did not contain any configuration for local images. When only allowing images from specific registries, postCommit scripts in builds failed because it was not allowed to use local images. The container image signature policy has been updated to always allow images that reference local storage layers directly. Now, builds can successfully complete if they contain a postCommit hook. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1838372[*BZ#1838372*])
 
-* Previously, if a Dockerfile used in Docker strategy builds used the ARG instruction to define build arguments before the first FROM instruction occurred in the Dockerfile, that instruction was dropped when the Dockerfile was preprocessed to incorporate any overrides that were specified in the Build or BuildConfig. References to those arguments were subsequently not resolved properly while building an image using the preprocessed Dockerfile. The preprocessing logic has been modified to preserve ARG instructions which are encountered before the first FROM instruction when generating the updated Dockerfile contents, so this problem no longer occurs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842982[*BZ#1842982*])
+* Previously, if a `Dockerfile` used in Docker strategy builds used the `ARG` instruction to define build arguments before the first `FROM` instruction occurred in the `Dockerfile`, that instruction was dropped when the `Dockerfile` was preprocessed to incorporate any overrides that were specified in the `Build` or `BuildConfig` resource. References to those arguments were subsequently not resolved properly while building an image using the preprocessed Dockerfile. The preprocessing logic has been modified to preserve `ARG` instructions which are encountered before the first `FROM` instruction when generating the updated `Dockerfile` contents, so this problem no longer occurs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842982[*BZ#1842982*])
 
 * Previously, Buildah erased image architecture and OS fields on images. This caused common container tools to fail because the resulting images could not identify their architecture and OS. This bug fix prevents Buildah from overwriting the image and architecture unless there are explicit overrides. This ensures that images always have architecture and OS fields, and the image mismatch warning does not appear. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1858779[*BZ#1858779*])
 
-* Previously, Dockerfile builds failed because they did not expand build arguments correctly in some situations. This update fixes the Dockerfile build argument processing, and thus Dockerfile builds now succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1839683[*BZ#1839683*])
+* Previously, `Dockerfile` builds failed because they did not expand build arguments correctly in some situations. This update fixes the `Dockerfile` build argument processing, and thus `Dockerfile` builds now succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1839683[*BZ#1839683*])
 
 * Previously, Buildah made an extraneous call to read an image from its blob cache, which caused Source-to-Image (S2I) builds to fail. This issue was fixed in Buildah v1.14.11, which was vendored into {product-title} builds in {product-version}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844469[*BZ#1844469*])
 
-* Previously, buildah could not reference images in `COPY –from` Dockerfile instructions. As a result, multistage Dockerfile builds that contained `COPY –from=<image>` failed. Buildah has been updated to a version that supports `COPY –from` instructions. Builds that contain these instructions can now succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844596[*BZ#1844596*])
+* Previously, Buildah could not reference images in `COPY –from` `Dockerfile` instructions. As a result, multistage `Dockerfile` builds that contained `COPY –from=<image>` failed. Buildah has been updated to a version that supports `COPY –from` instructions. Builds that contain these instructions can now succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844596[*BZ#1844596*])
 
 *Cloud Compute*
 
-* Previously, if the *replicas* field on a MachineSet was set to a nil value, the autoscaler could not determine the current number of replicas within the MachineSet and therefore could not perform scaling operations. With this release, the autoscaler uses the last number of observed replicas in the MachineSet as reported by the *replicas* field in the status if a nil value is set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852061[*BZ#1852061*])
+* Previously, if the *replicas* field on a machine set was set to a nil value, the autoscaler could not determine the current number of replicas within the machine set and therefore could not perform scaling operations. With this release, the autoscaler uses the last number of observed replicas in the machine set as reported by the *replicas* field in the status if a nil value is set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852061[*BZ#1852061*])
 
 * Previously, the autoscaler did not balance workloads across different failure domains if a memory discrepancy of more than 128 MB existed between nodes of the same type. With this release, the maximum memory discrepancy is increased to 256 MB. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824215[*BZ#1824215*])
 
-* Previously, the MachineSet replicas field did not have a default value. As a result, if the field were not present, the MachineSet controller failed silently. The replicas field now has a default value. A default of one replica is used if the replicas field is not set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844596[*BZ#1844596*])
+* Previously, the machine set replicas field did not have a default value. As a result, if the field were not present, the machine set controller failed silently. The replicas field now has a default value. A default of one replica is used if the replicas field is not set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844596[*BZ#1844596*])
 
-* Previously, the MachineHealthCheck controller did not check if a machine had been deleted previously before it attempted to delete it. As a result, the controller could send multiple deletion requests, resulting in spurious logging and event reports. The MachineHealthCheck controller now checks if a machine has been deleted before attempting to delete it. As a result, duplicate logs and events are reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844986[*BZ#1844986*])
+* Previously, the machine health check controller did not check if a machine had been deleted previously before it attempted to delete it. As a result, the controller could send multiple deletion requests, resulting in spurious logging and event reports. The machine health check controller now checks if a machine has been deleted before attempting to delete it. As a result, duplicate logs and events are reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844986[*BZ#1844986*])
 
-* Previously, the machine API Operator updated the cluster operator machine API when it was in a stable state. As a result, the resource cycled rapidly between states. The resource’s status now changes only after changes are rolled out. The status remains stable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855839[*BZ#1855839*])
+* Previously, the machine API Operator updated the cluster Operator machine API when it was in a stable state. As a result, the resource cycled rapidly between states. The resource’s status now changes only after changes are rolled out. The status remains stable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855839[*BZ#1855839*])
 
-* Previously, setting the ClusterAutoscaler resource values of `balanceSimilarNodeGroups`, `ignoreDaemonSetsUtilization`, or `skipNodesWithLocalStorage` to `false` did not register when the cluster autoscaler was deployed. These values are now read properly when the cluster autoscaler is deployed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854907[*BZ#1854907*])
+* Previously, setting the `ClusterAutoscaler` resource values of `balanceSimilarNodeGroups`, `ignoreDaemonSetsUtilization`, or `skipNodesWithLocalStorage` to `false` did not register when the cluster autoscaler was deployed. These values are now read properly when the cluster autoscaler is deployed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854907[*BZ#1854907*])
 
 * Rarely, duplicate machine API controller instances could be deployed. As a result, clusters could leak machines that would become inaccessible. Leader election mechanisms are now added to all machine API components to ensure that duplicate instances are not created. Machine API controllers only run the prescribed number of instances. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861896[*BZ#1861896*])
 
-* On {rh-virtualization-first} clusters, manual machine scaling could fail. Scaling machines from the Console or CLI now works. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1817853[*BZ#1817853*])
+* On {rh-virtualization-first} clusters, manual machine scaling could fail. Scaling machines from the web console or CLI now works. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1817853[*BZ#1817853*])
 
-* Previously, must-gather did not collect BareMetalHost records. As a result, debugging information could be incomplete. BareMetalHost records are now collected by must-gather. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841886[*BZ#1841886*])
+* Previously, must-gather did not collect `BareMetalHost` records. As a result, debugging information could be incomplete. `BareMetalHost` records are now collected by must-gather. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841886[*BZ#1841886*])
 
-* Previously, on clusters that run on Azure, compute machines converted into a “Failed” stage at installation. As a result, VMs were not recognized after being created. Attempts to contact the machines flooded logs with errors, and VMs could fail after starting correctly. As a fix, machines in the `Creating` state are identified as being created already. Logs contain fewer errors, and machines are less likely to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1836141[*BZ#1836141*])
+* Previously, on clusters that run on Azure, compute machines converted into a `Failed` stage at installation. As a result, VMs were not recognized after being created. Attempts to contact the machines flooded logs with errors, and VMs could fail after starting correctly. As a fix, machines in the `Creating` state are identified as being created already. Logs contain fewer errors, and machines are less likely to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1836141[*BZ#1836141*])
 
-* Previously, MachineHealthCheck could accept negative values for `spec.maxUnhealthy`. As a result, at negative values, numerous events were produced for each reconciliation attempt. Negative values for `spec.maxUnhealthy`. Are now treated as `0`, which reduces spurious log messages. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862556[*BZ#1862556*])
+* Previously, machine health check could accept negative values for `spec.maxUnhealthy`. As a result, at negative values, numerous events were produced for each reconciliation attempt. Negative values for `spec.maxUnhealthy`. Are now treated as `0`, which reduces spurious log messages. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862556[*BZ#1862556*])
 
 *Cloud Credential Operator*
 
-* Previously, when upgrading from OpenShift Container Platform version 4.5 to version 4.6, some fields were updated to the 4.6 default values. This affected the ability to downgrade from 4.6 to 4.5 because the 4.5 field values were not preserved. Rather than leaving the fields unspecified in 4.5, this bug fix explicitly preserves the 4.5 values so they can be specified as default values again on a downgrade attempt. Now downgrading from 4.6 to 4.5 can succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868376[*BZ#1868376*])
+* Previously, when upgrading from OpenShift Container Platform version 4.5 to version 4.6, some fields were updated to the 4.6 default values. This affected the ability to downgrade from 4.6 to 4.5 because the 4.5 field values were not preserved. Rather than leaving the fields unspecified in 4.5, this bug fix explicitly preserves the 4.5 values so they can be specified as default values again on a downgrade attempt. Now, downgrading from 4.6 to 4.5 can succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868376[*BZ#1868376*])
 
 * Previously, the Cloud Credential Operator leader election used the default values from `controller-runtime` and as a result, wrote to `etcd` every two seconds. This release implements custom leader election, which now writes only every 90 seconds and releases the lock immediately on normal shutdown. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1858403[*BZ#1858403*])
 
@@ -1594,78 +1470,78 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * The Cluster Version Operator served metrics using HTTP instead of HTTPS, and was subject to man-in-the-middle attacks as a result of unencrypted data. Now, The Cluster Version Operator serves metrics using HTTPS and data is encrypted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809195[*BZ#1809195*])
 
-* When cluster administrators had configured ClusterVersion overrides, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until an administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])
+* When cluster administrators had configured cluster version overrides, the upgrade process would get stuck. Now, the upgrades are blocked when the override is set. Upgrades will not begin until an administrator removes the overrides. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822844[*BZ#1822844*])
 
-* The Cluster Version Operator used to load trusted CAs from the ConfigMap referenced by the Proxy configuration's `trustedCA` property. The referenced ConfigMag is user-maintained, and a user setting corrupted certificates would interrupt the Operator's access to the Proxy. Now, the Operator loads the trustedCAs from the `openshift-config-managed/trusted-ca-bundle`, which the Network Operator populates when the Proxy configuration's referenced `trustedCA` ConfigMap is valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1797123[*BZ#1797123*])
+* The Cluster Version Operator used to load trusted CAs from the config map referenced by the proxy configuration's `trustedCA` property. The referenced config map is user-maintained, and a user setting corrupted certificates would interrupt the Operator's access to the Proxy. Now, the Operator loads the `trustedCA` configuration from the `openshift-config-managed/trusted-ca-bundle`, which the Network Operator populates when the proxy configuration's referenced `trustedCA` config map is valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1797123[*BZ#1797123*])
 
-* HTTPS signatures retrieved serialized stores, causing potential time outs before the Cluster Version Operator could complete the tasks. Now, external HTTPS signature retrieval is parallel and all stores will be attempted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840343[*BZ#1840343*])
+* HTTPS signatures retrieved serialized stores, causing potential timeouts before the Cluster Version Operator could complete the tasks. Now, external HTTPS signature retrieval is parallel and all stores will be attempted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840343[*BZ#1840343*])
 
-* Previously, during z-stream cluster upgrades using the option `--to-image`, for example `oc adm upgrade --to-image`, the Cluster Version Operator was using the cluster version being upgraded to, rather than the current cluster version for validation purposes. This caused z-stream upgrades to fail. Now z-stream cluster upgrades using the option `--to-image` are allowed even when Cluster Version Operator has `Upgradeable=false`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822513[*BZ#1822513*])
+* Previously, during z-stream cluster upgrades using the option `--to-image`, for example `oc adm upgrade --to-image`, the Cluster Version Operator was using the cluster version being upgraded to, rather than the current cluster version for validation purposes. This caused z-stream upgrades to fail. Now, z-stream cluster upgrades using the option `--to-image` are allowed even when Cluster Version Operator has `Upgradeable=false`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822513[*BZ#1822513*])
 
-* Previously, the Cluster Version Operator (CVO) was not syncing the shareProcessNamespace parameter in the Pod spec, which caused the Registry Operator to not update the shareProcessNamespace setting. The CVO now syncs shareProcessNamespace, DNSPolicy, and TerminationGracePeriodSeconds, fixing the Registry Operator update issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866554[*BZ#1866554*])
+* Previously, the Cluster Version Operator (CVO) was not syncing the `shareProcessNamespace` parameter in the pod spec, which caused the Registry Operator to not update the `shareProcessNamespace` setting. The CVO now syncs the `shareProcessNamespace`, `DNSPolicy`, and `TerminationGracePeriodSeconds` parameters, fixing the Registry Operator update issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866554[*BZ#1866554*])
 
 *Console Kubevirt Plugin*
 
-* Previously, NICs that had the same NIC profile could not be imported successfully, or the wrong network was chosen. The UI now forces users to select the same network, which is not the pod network, for such NICs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852473[*BZ#1852473*])
+* Previously, NICs that had the same NIC profile could not be imported successfully, or the wrong network was chosen. The web console now forces users to select the same network, which is not the pod network, for such NICs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852473[*BZ#1852473*])
 
 * Virtual machines were not displayed when logged in as a non-administrative user, due to the VM list waiting for the `virtualmachineimports` data to render. Now, the VM list is rendered correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843780[*BZ#1843780*])
 
-* The Create VM Wizard Edit Disk Modal did not respect cloned PVC namespaces. it was not possible to edit edit `datavolume` disks from a different namespace. Now, the disk modal properly registers the correct namespace of `datavolume` disks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859518[*BZ#1859518*])
+* The *Create VM* wizard *Edit Disk* modal did not respect cloned PVC namespaces. It was not possible to edit `datavolume` disks from a different namespace. Now, the disk modal properly registers the correct namespace of `datavolume` disks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859518[*BZ#1859518*])
 
-* Virtual machines and templates could not have the same name when referring to a URL source because the `datavolume` name was hard coded. Now, an auto generated unique string is added to the `datavolume` name and new virtual machines and templates can have the same name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860936[*BZ#1860936*])
+* Virtual machines and templates could not have the same name when referring to a URL source because the `datavolume` name was hard-coded. Now, an automatically generated unique string is added to the `datavolume` name and new virtual machines and templates can have the same name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860936[*BZ#1860936*])
 
 * Network utilization data would show `Not Available` due to an empty array of data. Now, a check has been implemented and empty arrays are interpreted as no data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1850438[*BZ#1850438*])
 
-* With this release, the Import VM function is removed from the Developer perspective of the web console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1876377[*BZ#1876377*])
+* With this release, the *Import VM* function is removed from the *Developer* perspective of the web console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1876377[*BZ#1876377*])
 
 *Console Metal3 Plugin*
 
-* The user interface did not detect older Node maintenance CRDs because the EI was searching for the latest version. As a result, the Node Maintenance action would miss the older NodeMaintenance CR if present. Now, the UI observes both NodeMaintenance CRs.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1837156[*BZ#1837156*])
+* The user interface did not detect older node maintenance CRDs because the EI was searching for the latest version. As a result, the Node Maintenance action would miss the older `NodeMaintenance` CR if present. Now, the web console observes both `NodeMaintenance` CRs.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1837156[*BZ#1837156*])
 
 * The user interface did not correctly evaluate graceful shutdowns, causing incorrect warnings to appear when shutting down the console. Now, the interface waits for the node pods to load and the correct warnings are displayed upon shutdown. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1872893[*BZ#1872893*])
 
 *Containers*
 
-* Previously, the logic that handled COPY or ADD instructions for copying content from the build context did not efficiently filter when a `.dockerignore` file was present. COPY and ADD would be noticeably slowed by the cumulative overhead of evaluating whether each item in the source location needed to be copied to the destination. This bug fix rewrote the logic and the presence of a `.dockerignore` file will no longer noticeably slow the speed at which COPY and ADD instructions are handled during a build. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1828119[*BZ#1828119*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1813258[*BZ#1813258*])
+* Previously, the logic that handled `COPY` or `ADD` instructions for copying content from the build context did not efficiently filter when a `.dockerignore` file was present. `COPY` and `ADD` would be noticeably slowed by the cumulative overhead of evaluating whether each item in the source location needed to be copied to the destination. This bug fix rewrote the logic and the presence of a `.dockerignore` file will no longer noticeably slow the speed at which `COPY` and `ADD` instructions are handled during a build. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1828119[*BZ#1828119*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1813258[*BZ#1813258*])
 
-* Previously, Image builds and pushes would fail with the 'error reading blob from source' error because the builder logic would compute the contents of new layers twice. The logic, which cached layer contents, depended on the products of those calculations remaining consistent. If a new layer's contents changed between the two computations, the cache was unable to supply the layers contents when they were needed. The contents of new layers are no longer computed twice and image builds and pushes will no longer fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1720730[*BZ#1720730*])
+* Previously, image builds and pushes would fail with the `error reading blob from source` error message because the builder logic would compute the contents of new layers twice. The logic, which cached layer contents, depended on the products of those calculations remaining consistent. If a new layer's contents changed between the two computations, the cache was unable to supply the layers contents when they were needed. The contents of new layers are no longer computed twice and image builds and pushes will no longer fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1720730[*BZ#1720730*])
 
 *Web console (Developer perspective)*
 
 * Previously, when you tried to delete a Knative application through the *Topology* view, a false positive error about a non-existing *Knative route* was reported. This issue is now fixed and the error is no longer displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866214[*BZ#1866214*])
 
-* Previously, the Developer Console did not allow images from insecure registries to be imported. This bug fix adds a checkbox that allows users to use the insecure registries in the *Deploy image* form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826740[*BZ#1826740*])
+* Previously, the *Developer* perspective of the web console did not allow images from insecure registries to be imported. This bug fix adds a checkbox that allows users to use the insecure registries in the *Deploy image* form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1826740[*BZ#1826740*])
 
 * When a user selected the *From Catalog* option to create an application, the *Developer Catalog* displayed a blank page instead of a list of templates to create an application. This was caused when the 1.18.0 Jaeger Operator was installed. This issue has now been fixed and the templates are displayed as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845279[*BZ#1845279*])
 
-* When deleting a parallel task in a Pipeline through the *Pipeline Builder* in the Developer Console, the interface was rearranging the tasks connected to the parallel task incorrectly, creating orphan tasks. With this fix, the tasks connected to the deleted parallel task are reconnected with the original Pipeline. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1856155[*BZ#1856155*])
+* When deleting a parallel task in a Pipeline through the *Pipeline Builder* in the *Developer* perspective of the web console, the interface was rearranging the tasks connected to the parallel task incorrectly, creating orphan tasks. With this fix, the tasks connected to the deleted parallel task are reconnected with the original Pipeline. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1856155[*BZ#1856155*])
 
 * The web console was crashing with a JavaScript exception when the user canceled the creation of a Pipeline through the web console with a side panel opened at the same time. This was fixed by improving the internal state handling. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1856267[*BZ#1856267*])
 
-* A user with the required permissions was unable to retrieve and deploy an image from another project. The required RoleBindings have now been created to fix this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843222[*BZ#1843222*])
+* A user with the required permissions was unable to retrieve and deploy an image from another project. The required role bindings have now been created to fix this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843222[*BZ#1843222*])
 
-* When you tried to deploy an application from a Git repository with the *Import from Git* function, the Developer Console reported a false positive error `Git repository is not reachable` for private repositories reachable by the cluster. This was fixed by adding information on making the private repository available to the cluster in the error message. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877739[*BZ#1877739*])
+* When you tried to deploy an application from a Git repository with the *Import from Git* function, the *Developer* perspective of the web console reported a false positive error `Git repository is not reachable` for private repositories reachable by the cluster. This was fixed by adding information on making the private repository available to the cluster in the error message. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877739[*BZ#1877739*])
 
-* When a Go application was created through the Developer Console, a route to the application was not created. This was caused by a bug in `build-tools` and incorrectly configured ports. The issue has been fixed by picking either the user-provided port or the default port 8080 as the target port. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874817[*BZ#1874817*])
+* When a Go application was created through the *Developer* perspective of the web console, a route to the application was not created. This was caused by a bug in `build-tools` and incorrectly configured ports. The issue has been fixed by picking either the user-provided port or the default port 8080 as the target port. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874817[*BZ#1874817*])
 
 * When you created an application with the *Import from Git* function, a subsequent change of the application's Git repository from the web console was not possible. This was caused by changing the application name in subsequent editing of the Git repository URL. This was fixed by making the application name read-only when editing the application Git repository URL. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1873095[*BZ#1873095*])
 
 * Previously, a user without administrative or project listing privileges could not see the metrics of any projects. This bug fix removes the checks for user privileges when accessing the cluster metrics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842875[*BZ#1842875*])
 
-* Users with the `@` character in their user names, like `user@example.com`, could not start a Pipeline from the Developer Console. This was caused by a limitation in Kubernetes labels. The issue was fixed by moving the "Started by" metadata from a Kubernetes label to a Kubernetes annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868653[*BZ#1868653*])
+* Users with the `@` character in their user names, like `user@example.com`, could not start a Pipeline from the *Developer* perspective of the web console. This was caused by a limitation in Kubernetes labels. The issue was fixed by moving the `Started by` metadata from a Kubernetes label to a Kubernetes annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868653[*BZ#1868653*])
 
 * Previously, when a user selected a metric the QueryEditor would show the query. However, if the user deleted or modified the query and selected the same metric again, the QueryEditor would not update. With this fix, if a query is cleared by the user and they tried to select the same query again, the query input text area will show the query. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843387[*BZ#1843387*])
 
-* The che-workspace-operator removed support for the Workspace resource and replaced it with the DevWorkspace CRD. As a result, the command line terminal was not enabled with the latest che-workspace-operator. With this fix, the OpenShift command line terminal was moved to use the DevWorkspace resource. The command line terminal will now be enabled in the OpenShift Console when the che-workspace-operator is installed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844938[*BZ#1844938*])
+* The Che Workspace Operator removed support for the `Workspace` resource and replaced it with the `DevWorkspace` CRD. As a result, the command line terminal was not enabled with the latest Che Workspace Operator. With this fix, the OpenShift command line terminal was moved to use the `DevWorkspace` resource. The command line terminal will now be enabled in the OpenShift Console when the Che Workspace Operator is installed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844938[*BZ#1844938*])
 
 * Previously, the route decorator for Knative services redirected users to a revision specific route if traffic was distributed across multiple revisions. The route decorator has been updated to always point to the Knative base service route.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860768[*BZ#1860768*])"
 
 *DNS*
 
-* Previously, intermittent invalid memory address or nil pointer dereference errors occurred and were followed by timeouts for Kube API access when running CoreDNS 1.6.6. This is now fixed by correctly handling errors with Endpoint Tombstones. Now CoreDNS behaves as intended without intermittent panics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868315[*BZ#1868315*])
+* Previously, intermittent invalid memory address or nil pointer dereference errors occurred and were followed by timeouts for Kube API access when running CoreDNS 1.6.6. This is now fixed by correctly handling errors with Endpoint Tombstones. Now, CoreDNS behaves as intended without intermittent panics. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868315[*BZ#1868315*])
 
-* Previously, the DNS Operator repeatedly attempted to update DNS and Service objects in response to default values that were set by the API. With this update, the DNS Operator now considers values that are left unspecified by the DNS Operator to be equal to values in DNS and Service objects. Thus, the DNS Operator no longer updates a DNS or Service object in response to API default values. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842741[*BZ#1842741*])
+* Previously, the DNS Operator repeatedly attempted to update `DNS` and `Service` objects in response to default values that were set by the API. With this update, the DNS Operator now considers values that are left unspecified by the DNS Operator to be equal to values in `DNS` and `Service` objects. Thus, the DNS Operator no longer updates a `DNS` or `Service` object in response to API default values. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842741[*BZ#1842741*])
 
 *etcd*
 
@@ -1685,23 +1561,23 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * Registry Operator type assertions were made twice for a variable and the second time the result was not checked. This caused false assertions and created panic conditions. Now, checked  type assertions are used and the Operator does not panic. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879426[*BZ#1879426*])
 
-* Previously, the Operator bootstrap `storageManaged` setting was set to true, causing conflicts if the user manually updated the configuration file. Now, an additional configuration field, `spec.storage.storageManagementState` has been created. Users can indicate `Managed` or `Unmanaged` and the Operator will respect the setting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1833109[*BZ#1833109*])
+* Previously, the Operator bootstrap `storageManaged` setting was set to `true`, causing conflicts if the user manually updated the configuration file. Now, an additional configuration field, `spec.storage.storageManagementState` has been created. Users can indicate `Managed` or `Unmanaged` and the Operator will respect the setting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1833109[*BZ#1833109*])
 
-* Removing the Image Registry on OpenStack when content was written to storage resulted in storage for the Image Registry not being removed and a 409 HTTP return code error being logged. This bug fix removes the storage content before removing the storage. Now when the Image Registry Operator is removed, its storage is also removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835770[*BZ#1835770*])
+* Removing the Image Registry on OpenStack when content was written to storage resulted in storage for the Image Registry not being removed and a `409` HTTP return code error being logged. This bug fix removes the storage content before removing the storage. Now, when the Image Registry Operator is removed, its storage is also removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835770[*BZ#1835770*])
 
-* During installation on OpenStack, if there was a failure to access Swift storage during the Image Registry Operator bootstrap process, it caused an incomplete bootstrap. This resulted in a failure to create the Image Registry configuration resource, which blocked fixes or changes its configuration. This bug fix prevents failure during bootstrap in case of a problem when accessing Swift storage. If there is an error, it is logged allowing the bootstrap to finish and configuration resources to be created. Now the Image Registry Operator is now more flexible, and if it cannot access Swift storage, it bootstraps the internal Image Registry using a PVC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846263[*BZ#1846263*])
+* During installation on OpenStack, if there was a failure to access Swift storage during the Image Registry Operator bootstrap process, it caused an incomplete bootstrap. This resulted in a failure to create the Image Registry configuration resource, which blocked fixes or changes its configuration. This bug fix prevents failure during bootstrap in case of a problem when accessing Swift storage. If there is an error, it is logged allowing the bootstrap to finish and configuration resources to be created. Now, the Image Registry Operator is now more flexible, and if it cannot access Swift storage, it bootstraps the internal Image Registry using a PVC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846263[*BZ#1846263*])
 
 * The Image Registry Operator avoids calling Azure endpoints too many times, because Azure enforces quotas and previously the Operator was constantly querying for storage account keys. This bug fix caches the keys locally for a set period of time to avoid going remotely to get the keys every time they are needed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853734[*BZ#1853734*])
 
-* Previously, the operator interpreted a running job as successful when reporting on the operator status, even though the job could potentially result in a failed state. Now the running jobs are ignored when reporting the operator status. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857684[*BZ#1857684*])
+* Previously, the Operator interpreted a running job as successful when reporting on the Operator status, even though the job could potentially result in a failed state. Now, the running jobs are ignored when reporting the Operator status. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857684[*BZ#1857684*])
 
-* The image registry purging process failed when running over s3 storage because it was listing directories twice. Now, directorues are listed once and the image purging process completes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861304[*BZ#1861304*])
+* The image registry purging process failed when running over s3 storage because it was listing directories twice. Now, directories are listed once and the image purging process completes successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861304[*BZ#1861304*])
 
-* Previously, if the Image Registry operator was removed, the pruner job failed because it could not reach a non-existent registry. Now, the pruner job removes etcd objects only and does not attempt to ping the registry if it is removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867792[*BZ#1867792*])
+* Previously, if the Image Registry Operator was removed, the pruner job failed because it could not reach a non-existent registry. Now, the pruner job removes etcd objects only and does not attempt to ping the registry if it is removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867792[*BZ#1867792*])
 
-* If a user manually added a bucket name, the operator did not create the bucket. Now, the operator creates a bucket successfully based on the user-provided name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1870513[*BZ31875013*])
+* If a user manually added a bucket name, the Operator did not create the bucket. Now, the Operator creates a bucket successfully based on the user-provided name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1870513[*BZ31875013*])
 
-* Previously, the Image Registry Operator could not get events from the cluster when it encountered "Too large resource version" errors. With this release, the `client-go` library is updated to fix the reflector so that the Operator can recover from "Too large resource version" errors.
+* Previously, the Image Registry Operator could not get events from the cluster when it encountered `Too large resource version` error messages. With this release, the `client-go` library is updated to fix the reflector so that the Operator can recover from `Too large resource version` error messages.
  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880354[*BZ#1880354*])
 
 * Previously, the value provided for `spec.requests.read/write.maxWaitInQueue` in the Image Registry Operator configuration file was not validated. If the provided value was a string that could not be parsed as a duration, the change was not applied, and a message informing about the incorrect value was repeatedly logged. This release adds validation so that a user cannot provide invalid values for this field. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1833245[*BZ#1833245*])
@@ -1713,28 +1589,27 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * Previously, when a machine tried to get the `resourcePoolPath`, it found multiple resource pools and was unable to resolve the correct one. With this release, a property added to the machine sets with the `resourcePoolPath` information helps resolve the correct one. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852545[*BZ#1852545*])
 
-* Previously, a hardcoded value was set when calculating the end of the DHCP allocation pool when provisioning the nodes subnet. This caused an error when deploying on an OpenShift Container Platform cluster on OpenStack with a machine CIDR smaller than 18. This bug fix removes hardcoding the number of nodes and, instead, dynamically calculates the end of the DHCP allocation pool. Now it is possible to deploy a cluster on OpenStack with a machine CIDR of any length, provided it is large enough for all required nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871048[*BZ#1871048*])
+* Previously, a hard-coded value was set when calculating the end of the DHCP allocation pool when provisioning the nodes subnet. This caused an error when deploying on an OpenShift Container Platform cluster on OpenStack with a machine CIDR smaller than 18. This bug fix removes hard-coding the number of nodes and, instead, dynamically calculates the end of the DHCP allocation pool. Now, it is possible to deploy a cluster on OpenStack with a machine CIDR of any length, provided it is large enough for all required nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871048[*BZ#1871048*])
 
 * Previously, some available networks were not shown during cluster installation because of an `ovirt-engine-sdk-go` API error that affected oVirt network parsing. The issue is now resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1838559[*BZ#1838559*])
 
-* Previously, in the vSphere console wizard, only networks of type `Network` and `DistributedVirtualPortgroup` were displayed even though `OpaqueNetwork` is also a valid option. `OpaqueNetwork` is now an option in the wizard, so that type of network can be selected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844103[*BZ#1844103*])
+* Previously, in the *vSphere* web console wizard, only networks of type `Network` and `DistributedVirtualPortgroup` were displayed even though `OpaqueNetwork` is also a valid option. `OpaqueNetwork` is now an option in the wizard, so that type of network can be selected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844103[*BZ#1844103*])
 
 * Previously, the Manila Operator did not support custom self-signed certificates, so the Manila Operator failed to deploy Manila CSI driver on some environments that used self-signed certificates. Now, the Operator fetches the user-provided CA certificate from the system config map, mounts it to the driver's containers, and update the driver's configuration. As a result, the Manila Operator can deploy and manage the Manila CSI driver on environments with self-signed certificates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1839226[*BZ#1839226*])
 
-* Previously, configuring the `platform.aws.userTags` parameter to add `name` or `kubernetes.io/cluster/` tags to resources that the installation program creates caused the machine-api to fail to identify existing control plane machines and create another set of control plane hosts, which created problems with etcd cluster membership. Now you can no longer set error-prone tags in the `platform.aws.userTags` parameter, and your cluster is less likely to have extra control plane hosts and broken etcd clusters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862209[*BZ#1862209*])
+* Previously, configuring the `platform.aws.userTags` parameter to add `name` or `kubernetes.io/cluster/` tags to resources that the installation program creates caused the machine API to fail to identify existing control plane machines and create another set of control plane hosts, which created problems with etcd cluster membership. Now, you can no longer set error-prone tags in the `platform.aws.userTags` parameter, and your cluster is less likely to have extra control plane hosts and broken etcd clusters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862209[*BZ#1862209*])
 
-* Previously, healthcheck probes were not defined on load balancers deployed in Azure clusters on user-provisioned infrastructure. Because the load balancers were not defined, they did not detect when an API endpoints were no longer available and still directed traffic to them, which caused client failures. Now, the healthcheck probes are used on the load balancers, and they correctly detect when API endpoints are not available and stop routing traffic to offline nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1836016[*BZ#1836016*])
+* Previously, health check probes were not defined on load balancers deployed in Azure clusters on user-provisioned infrastructure. Because the load balancers were not defined, they did not detect when an API endpoints were no longer available and still directed traffic to them, which caused client failures. Now, the health check probes are used on the load balancers, and they correctly detect when API endpoints are not available and stop routing traffic to offline nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1836016[*BZ#1836016*])
 
 * Previously, the installation program did not accept `\*` as a valid value for the `proxy.noProxy` field, so you could not create a cluster with no proxy set to `*` during installation. Now, the installation program accepts `\*` as a valid value for that parameter, so you can set no proxy to `*` during installation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877486[*BZ#1877486*])
 
-* Previously when you installed a cluster in GCP, `US` was always used as the location, and it was not possible to install a cluster in some regions outside of US. Now, the installation program sets the right location for the region that you specify, and installations succeed in other locations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871030[*BZ#1871030*])
+* Previously, when you installed a cluster in GCP, `US` was always used as the location, and it was not possible to install a cluster in some regions outside of US. Now, the installation program sets the right location for the region that you specify, and installations succeed in other locations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871030[*BZ#1871030*])
 
-* Previously when you installed a cluster on vSphere with installer-provisioned infrastructure, it was possible to assign the same IP address to ingress and the API, which caused the bootstrap machine and one of the master machines to have the same IP address. Now, the installation program validates that the IP addresses are different, and the master and bootstrap machines have unique IP addresses. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853859[*BZ#1853859*])
+* Previously, when you installed a cluster on vSphere with installer-provisioned infrastructure, it was possible to assign the same IP address to ingress and the API, which caused the bootstrap machine and one of the control plane machines to have the same IP address. Now, the installation program validates that the IP addresses are different, and the control plane and bootstrap machines have unique IP addresses. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853859[*BZ#1853859*])
 
-* Previously, when an interface obtained a new dhcp4 or dhcp6 lease, the `local-dns-prepender` did not update the `resolv.conf` file to include all the required resolvers for the cluster. Now, the `dhcp4-change` and `dhcp6-change` action types always make the `local-dns-prepender` start updates.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1866534[*BZ#1866534*])
+* Previously, when an interface obtained a new DHCP4 or DHCP6 lease, the `local-dns-prepender` did not update the `resolv.conf` file to include all the required resolvers for the cluster. Now, the `dhcp4-change` and `dhcp6-change` action types always make the `local-dns-prepender` start updates.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1866534[*BZ#1866534*])
 
-* Previously, you could not deploy clusters to the following GCP regions: `asia-northeast3`, `asia-southeast-2`, `us-west3`, and `us-west4`. You can now use these regions.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1847549[*BZ#1847549*])
+* Previously, you could not deploy clusters to the following GCP regions: `asia-northeast3`, `asia-southeast-2`, `us-west3`, and `us-west4`. You can now use these regions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847549[*BZ#1847549*])
 
 * Previously, the OpenStack installation program used inconsistent output format for the `InstanceID()` function. It obtained the instance ID from either metadata or by sending requests to the server. In the latter case, the result always had '/' prefix, which is the correct format. If the instance ID came from the metadata, the system failed to verify its node existence and failed because of the error. Because, the metadata format now also contains the '/' prefix there, the ID format is always correct, and the system can always successfully verify node existence. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1850149[*BZ#1850149*])
 
@@ -1744,15 +1619,15 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * Previously, installation failed when a certificate was followed by two end-of-line character sequences. This update fixes the certificate authority (CA) certificate trust bundle parser, which now ignores invisible characters. Thus, the CA certificate trust bundle can now feature an arbitrary number of end-of-line character sequences before, between, and after certificates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1813354[*BZ#1813354*])
 
-* Previously, when the interactive installer prompt requested the `ExternalNetwork` for the cluster, all possible network choices were listed, which included invalid options. With this update, the interactive installer now filters the possible options and lists only external networks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881532[*BZ#1881532*])
+* Previously, when the interactive installer prompt requested the `ExternalNetwork` resource for the cluster, all possible network choices were listed, which included invalid options. With this update, the interactive installer now filters the possible options and lists only external networks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881532[*BZ#1881532*])
 
-* Previously, the bare metal `kube-apiserver` health check probe used a hardcoded IPv4 address to communicate with the load balancer. This update fixes the health check to use `localhost`, which covers both IPv4 and IPv6 cases. Additionally, the `readyz` endpoint for the API server is checked rather than `healthz`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847082[*BZ#1847082*])
+* Previously, the bare metal `kube-apiserver` health check probe used a hard-coded IPv4 address to communicate with the load balancer. This update fixes the health check to use `localhost`, which covers both IPv4 and IPv6 cases. Additionally, the `readyz` endpoint for the API server is checked rather than `healthz`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847082[*BZ#1847082*])
 
-* Due to a Terraform step that did not list all of its dependent steps, clusters on {rh-openstack-first} experienced a race condition that sometimes caused the Terraform job to fail with a "Resource not found" error. The step is now listed as `depends_on` to avoid the race condition. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1734460[*BZ#1734460*])
+* Due to a Terraform step that did not list all of its dependent steps, clusters on {rh-openstack-first} experienced a race condition that sometimes caused the Terraform job to fail with a `Resource not found` error message. The step is now listed as `depends_on` to avoid the race condition. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1734460[*BZ#1734460*])
 
 * Previously, the cluster API did not validate {rh-openstack} flavors before updating machines. As a result, machines that had invalid flavors failed to boot. Flavors are now validated before updating machines, and machines that have invalid flavors return errors immediately. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1820421[*BZ#1820421*])
 
-* Previously, clusters on {rh-openstack} that had periods in their names failed at the bootstrap phase in installation. Periods are no longer allowed in the names of clusters on {rh-openstack}. If a cluster name contains a period, an error message is generated early in the installation process. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857158[*BZ#1857158*])
+* Previously, clusters on {rh-openstack} that had periods (`.`) in their names failed at the bootstrap phase in installation. Periods are no longer allowed in the names of clusters on {rh-openstack}. If a cluster name contains a period, an error message is generated early in the installation process. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857158[*BZ#1857158*])
 
 * Previously, health check probes were not defined for load balancers in user-provisioned infrastructure deployed clusters on AWS. The load balancers did not detect when API endpoints became unavailable, which caused client failures. In this update, health check probes have been added and the load balancers do not route traffic to offline nodes.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1836018[*BZ#1836018*])
@@ -1769,17 +1644,17 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 *kube-controller-manager*
 
-* Previously, the DaemonSet controller did not clear expectations when recreating a daemon set. As a result, the daemon set might get stuck for five minutes until the expectations expired. Now the DaemonSet controller correctly clears the expectations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843319[*BZ#1843319*])
+* Previously, the daemon set controller did not clear expectations when recreating a daemon set. As a result, the daemon set might get stuck for five minutes until the expectations expired. Now, the daemon set controller correctly clears the expectations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843319[*BZ#1843319*])
 
 * UID range allocation is not updated when a project is removed, and thus the UID range can be exhausted on a cluster that has high namespace creation and removal turnover. To resolve the issue, the `kube-controller-manager` pod is periodically restarted, which triggers the repair procedure and clears the UID range. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1808588[*BZ#1808588*])
 
 * Previously, the endpoints controller sent large quantities of API requests at every informer resync interval, which caused degradation in large clusters with many endpoints. Various inconsistencies in storage and the comparison of endpoints caused the endpoints controller to incorrectly assume that there were many additional updates that needed to be made to a cluster than were actually necessary. This fix updates storage and comparison functions for endpoints so that they are more consistent. Thus, the endpoints controller now only sends updates when necessary. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854434[*BZ#1854434*])
 
-* Previously, NotFound errors were mishandled by controller logic. This caused controllers such as Deployment, DaemonSet, and ReplicaSet controllers to not be aware of missing pods. This fix updates controllers to correctly react to a pod NotFound event, which indicates that the pod was previously removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843187[*BZ#1843187*])
+* Previously, `NotFound` errors were mishandled by controller logic. This caused controllers such as deployment, daemon set, and replica set controllers to not be aware of missing pods. This fix updates controllers to correctly react to a pod `NotFound` event, which indicates that the pod was previously removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843187[*BZ#1843187*])
 
 *kube-scheduler*
 
-* Previously, when evicting a pod in dry run mode, certain descheduler strategies logged the eviction twice. Now only a single log entry is created for the eviction. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841187[*BZ#1841187*])
+* Previously, when evicting a pod in dry run mode, certain descheduler strategies logged the eviction twice. Now, only a single log entry is created for the eviction. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841187[*BZ#1841187*])
 
 *Logging*
 
@@ -1789,7 +1664,7 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 * Because the Elasticsearch Operator was not updating the secret hash for the Kibana deployment, Kibana pods would not be restarted if the secret gets updated. The code was changed to correctly update the hash for the deployment, which triggers a the pods to redeploy, as expected.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1834576[*BZ#1834576*])
 
-* Because of the introduction of Fluentd init containers, Fluentd could not be deployed in a cluster without deploying the Elasticsearch Operator (EO). The code was changed to alllow Fluentd without the EO being present. As a result, in a cluster without Elasticsearch, Fluentd works as expexted.
+* Because of the introduction of Fluentd init containers, Fluentd could not be deployed in a cluster without deploying the Elasticsearch Operator (EO). The code was changed to allow Fluentd without the EO being present. As a result, in a cluster without Elasticsearch, Fluentd works as expected.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849188[*BZ#1849188*])
 
 * Because the ability to open Kibana in an iframe was not expressly denied, it opened Kibana to the possibility of attack, such as clickjacking. The code was changed to explicitly set `x-frame-options:deny`, which blocks the use of iframes.
@@ -1797,25 +1672,25 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 *Machine Config Operator*
 
-* In bare metal environments, an `infra-dns` container runs on each host to support node name resolutions and other internal DNS records. A NetworkManager script also updates the `/etc/resolv.conf` on the host to point to the `infra-dns` container. Additionally, when pods are created, they receive their DNS configuration file (the `/etc/resolv.conf` file) from their hosts.
+* In bare metal environments, an `infra-dns` container runs on each host to support node name resolutions and other internal DNS records. A `NetworkManager` script also updates the `/etc/resolv.conf` on the host to point to the `infra-dns` container. Additionally, when pods are created, they receive their DNS configuration file (the `/etc/resolv.conf` file) from their hosts.
 +
-If an HAProxy pod was created before NetworkManager scripts update the `/etc/resolv.conf` file on the host, the pod can repeatedly fail because the `api-int` internal DNS record is not resolvable. This bug fix updates the Machine Config Operator (MCO) to now verify that the `/etc/resolv.conf` file of the HAProxy pod is identical to the host `/etc/resolv.conf` file. As a result, the HAProxy pod no longer experiences these errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849432[*BZ#1849432*])
+If an HAProxy pod was created before `NetworkManager` scripts update the `/etc/resolv.conf` file on the host, the pod can repeatedly fail because the `api-int` internal DNS record is not resolvable. This bug fix updates the Machine Config Operator (MCO) to now verify that the `/etc/resolv.conf` file of the HAProxy pod is identical to the host `/etc/resolv.conf` file. As a result, the HAProxy pod no longer experiences these errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849432[*BZ#1849432*])
 
-* Keepalived is used to provide high availability (HA) for both the API and default router. The Keepalived instance in each node monitors local health by curling the health endpoint of the local entity, for example the local `kube-apiserver`. Previously, the `curl` command failed only when the TCP connection failed, and not on HTTP non-200 errors. This caused Keepalived to sometimes not failover to another healthy node, even when the local entity was unhealthy, which lead to errors in API requests.
+* Keepalived is used to provide high availability (HA) for both the API and default router. The Keepalived instance in each node monitors local health by curling the health endpoint of the local entity, for example the local `kube-apiserver`. Previously, the `curl` command failed only when the TCP connection failed, and not on HTTP non-200 errors. This caused Keepalived to sometimes not fail over to another healthy node, even when the local entity was unhealthy, which lead to errors in API requests.
 +
-This bug fix updates the Machine Config Operator (MCO) to modify the `curl` command to now also fail when the server replies with a non-200 retcode. As a result, the API and Ingress router now correctly failover to a healthy node in case of failure in a local entity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844387[*BZ#1844387*])
+This bug fix updates the Machine Config Operator (MCO) to modify the `curl` command to now also fail when the server replies with a non-200 return code. As a result, the API and Ingress router now correctly failover to a healthy node in case of failure in a local entity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844387[*BZ#1844387*])
 
 * In bare metal environments, some DNS records were hard-coded for IPv4. This caused some records to not be served correctly in IPv6 environments, which might necessitate creating those records in an external DNS server. This bug fix updates the Machine Config Operator (MCO) so that DNS records are now populated correctly based on the Internet Protocol version in use. As a result, internal records are now served correctly in both IPv4 and IPv6. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1820785[*BZ#1820785*])
 
-* Previously, kernel arguments specified in MachineConfigs needed to be split out into individual argument strings in the array. These arguments were not validated before being concatenated into an `rpm-ostree` command. Multiple kernel arguments concatenated using a space, as allowed in a single line in the kernel command line, would create an invalid `rpm-ostree` command. This bug fix updates the MachineConfigController to parse each `kernelArgument` item in a similar manner as the kernel. As a result, users can supply multiple arguments concatenated using a space without errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1812649[*BZ#1812649*])
+* Previously, kernel arguments specified in machine configs needed to be split out into individual argument strings in the array. These arguments were not validated before being concatenated into an `rpm-ostree` command. Multiple kernel arguments concatenated using a space, as allowed in a single line in the kernel command line, would create an invalid `rpm-ostree` command. This bug fix updates the machine config controller to parse each `kernelArgument` item in a similar manner as the kernel. As a result, users can supply multiple arguments concatenated using a space without errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1812649[*BZ#1812649*])
 
 * Previously, the control plane would always be schedulable for user workloads in bare metal environments. This bug fix updates the Machine Config Operator (MCO) so that control plane nodes are now correctly configured as `NoSchedule` in a typical deployment with workers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1828250[*BZ#1828250*])
 
-* Previously with the Machine Config Operator (MCO), unnecessary API VIP moves could cause client connection errors. This bug fix updates API VIP health checks to limit the number of times it moves. As a result, there are now fewer errors caused by API VIP moves. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1823950[*BZ#1823950*])
+* Previously, with the Machine Config Operator (MCO), unnecessary API VIP moves could cause client connection errors. This bug fix updates API VIP health checks to limit the number of times it moves. As a result, there are now fewer errors caused by API VIP moves. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1823950[*BZ#1823950*])
 
 *Web console (Administrator perspective)*
 
-* The Operand's tab for Operand list view was missing. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842965[*BZ#1842965*])
+* The operand's tab for operand list view was missing. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842965[*BZ#1842965*])
 
 * When IPv6 was disabled, the downloads pod socket could not bind and the downloads pod crashed. If IPv6 is not enabled, IPv4 is now used for the socket. The downloads pod now works regardless of enabling IPv4 and IPv6. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846922[*BZ#1846922*])
 
@@ -1829,9 +1704,9 @@ This bug fix updates the Machine Config Operator (MCO) to modify the `curl` comm
 
 * The *create role binding* links were inconsistently namespaced or used cluster links, so the *create role binding* page was incorrect. This bug fix updates the links to use the namespace, where available, and the cluster in other cases. The correct page is now used. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*])
 
-* Previously, the web console did not support Grafana `valueMaps` for singlestat panels, so singlestat panels were unable to display Grafana valueMaps. Support is now added and singlestat panels can display Grafana `valueMaps`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866928[*BZ#1866928*])
+* Previously, the web console did not support Grafana value maps for singlestat panels, so singlestat panels were unable to display Grafana value maps. Support is now added and singlestat panels can display Grafana value maps. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1866928[*BZ#1866928*])
 
-* `oc debug` was updated with link:https://bugzilla.redhat.com/show_bug.cgi?id=1812813[BZ#1812813] to create a new debug project with an empty node selector in order to work around a problem where `oc debug` only works against worker nodes. The web console avoided this problem by asking users to choose a namespace when visiting the *Node > Terminal* page before the terminal is opened, resulting in inconsistency in the user experience compared to `oc`. The web console now creates a new debug project with an empty node selector upon visiting the *Node > Terminal* page. The behavior of the web console *Node > Terminal* page now aligns with the behavior of `oc debug`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881953[*BZ#1881953*])
+* `oc debug` was updated with link:https://bugzilla.redhat.com/show_bug.cgi?id=1812813[BZ#1812813] to create a new debug project with an empty node selector in order to work around a problem where `oc debug` only works against worker nodes. The web console avoided this problem by asking users to choose a namespace when visiting the *Node* -> *Terminal* page before the terminal is opened, resulting in inconsistency in the user experience compared to `oc`. The web console now creates a new debug project with an empty node selector upon visiting the *Node* -> *Terminal* page. The behavior of the web console *Node* -> *Terminal* page now aligns with the behavior of `oc debug`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881953[*BZ#1881953*])
 
 * When all receivers were deleted, the web console would experience a runtime error and the user was presented with a blank screen. Null checks are now added in the code and users ate presented with a *No Receivers* empty state screen instead. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1849556[*BZ#1849556*])
 
@@ -1843,39 +1718,39 @@ This bug fix updates the Machine Config Operator (MCO) to modify the `curl` comm
 
 * There was a missing keyword field in the API and users were unable to search by keyword in OperatorHub. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840786[*BZ#1840786*])
 
-* Previously, the Operator Hub in the web console sometimes showed the incorrect icon for an Operator. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844125[*BZ#1844125*])
+* Previously, the OperatorHub in the web console sometimes showed the incorrect icon for an Operator. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844125[*BZ#1844125*])
 
 * In this release, a broken link to the cluster monitoring documentation from the web console OperatorHub install page is corrected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1856803[*BZ#1856803*])
 
-* Previously, clicking Create EtcdRestore on the EtcdRestores page caused the web console to stop responding. With this release, the Create EtcdRestore form view workflow loads correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845815[*BZ#1845815*])
+* Previously, clicking *Create EtcdRestore* on the *EtcdRestores* page caused the web console to stop responding. With this release, the *Create EtcdRestore* form view workflow loads correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845815[*BZ#1845815*])
 
-* Previously, the Operand form array and object fields did not have logic to retrieve and show field descriptions on the form. As a result, descriptions were not rendered for array or object type fields. This bug fix adds logic to now display array and object field descriptions on the Operand creation form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854198[*BZ#1854198*])
+* Previously, the operand form array and object fields did not have logic to retrieve and show field descriptions on the form. As a result, descriptions were not rendered for array or object type fields. This bug fix adds logic to now display array and object field descriptions on the operand creation form. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854198[*BZ#1854198*])
 
-* Previously, the Deployment Configuration Overview page sometimes crashed with the error `e is undefined` when a new Pod was starting up. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853705[*BZ#1853705*])
+* Previously, the *Deployment Configuration Overview* page sometimes crashed with the error `e is undefined` when a new pod was starting up. The issue has been resolved in this release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1853705[*BZ#1853705*])
 
 * Previously, the cluster upgrade interface in the web console was visible on OpenShift Dedicated, even though OpenShift Dedicated users cannot perform cluster upgrades. The cluster upgrade interface is now hidden for OpenShift Dedicated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874257[*BZ#1874257*])
 
 * Previously, empty objects in an operand template were pruned when submitting the form or switching between the form and YAML view. With this release, template data is used as a mask when pruning empty structures from the form data, and only values that are not defined in the template are pruned. Empty values that are defined in a template remain. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1847921[*BZ#1847921*])
 
-* The tooltip details were sometimes truncated when hovering over the Cluster Logging donut chart. This bug fix enables the entire tooltip description to display for this chart. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842408[*BZ#1842408*])
+* The tooltip details were sometimes truncated when hovering over the *Cluster Logging* donut chart. This bug fix enables the entire tooltip description to display for this chart. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842408[*BZ#1842408*])
 
-* For the Registry field on the Create Instance page, some of the text in the schema property descriptions matched the format used to create fuzzy hyperlinks in Linkify. This resulted in unintended hyperlinks. This bug fix disables the fuzzy link feature in Linkify. Now, only URL strings using a proper protocol scheme are rendered as hyperlinks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841025[*BZ#1841025*])
+* For the *Registry* field on the *Create Instance* page, some of the text in the schema property descriptions matched the format used to create fuzzy hyperlinks in Linkify. This resulted in unintended hyperlinks. This bug fix disables the fuzzy link feature in Linkify. Now, only URL strings using a proper protocol scheme are rendered as hyperlinks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1841025[*BZ#1841025*])
 
-* The AWS Secret field always displayed the Loading icon even when the ListDropdown component was not in a loading state. This bug fixes the component logic so that the Loading icon only displays when the drop-down list is in a loading state. A placeholder displays if the drop-down list is not in a loading state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845817[*BZ#1845817*])
+* The AWS `Secret` field always displayed the loading icon even when the `ListDropdown` component was not in a loading state. This bug fixes the component logic so that the loading icon only displays when the drop-down list is in a loading state. A placeholder displays if the drop-down list is not in a loading state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845817[*BZ#1845817*])
 
-* Previously, Resource Log pages in the web console became slow or unresponsive when the logs contained long lines. This bug fixes the performance issues by limiting the number of characters per log line that displays on the Resource Log page and providing an alternate method to view the full log content. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874558[*BZ#1874558*])
+* Previously, *Resource Log* pages in the web console became slow or unresponsive when the logs contained long lines. This bug fixes the performance issues by limiting the number of characters per log line that displays on the *Resource Log* page and providing an alternate method to view the full log content. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874558[*BZ#1874558*])
 
-* Previously, the node file system calculations for Used and Total were incorrect due to an incorrect query. Now, the query is updated and calculates the data correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874028[*BZ31874028*])
+* Previously, the node file system calculations for *Used* and *Total* were incorrect due to an incorrect query. Now, the query is updated and calculates the data correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874028[*BZ31874028*])
 
-* The Overview page in the web console incorrectly included the container level usage metric to display network utilization data. This bug fix replaces the incorrect metric with the node level usage metric to accurately display network utilization data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855556[*BZ#1855556*])
+* The *Overview* page in the web console incorrectly included the container level usage metric to display network utilization data. This bug fix replaces the incorrect metric with the node level usage metric to accurately display network utilization data. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855556[*BZ#1855556*])
 
-* Previously, the Created At timestamp format for operators did not require a specific format, resulting in the timestamp displaying inconsistently on the web console. Now, if the Created At timestamp value is entered as a valid date for an operator, the timestamp displays in a consistent manner with other timestamps in the console. If the value is not entered using a valid date format, the Created At timestamp displays as an invalid string. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855378[*BZ#1855378*])
+* Previously, the *Created At* timestamp format for Operators did not require a specific format, resulting in the timestamp displaying inconsistently on the web console. Now, if the *Created At* timestamp value is entered as a valid date for an Operator, the timestamp displays in a consistent manner with other timestamps in the console. If the value is not entered using a valid date format, the *Created At* timestamp displays as an invalid string. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855378[*BZ#1855378*])
 
 * The web console displayed an old logo for OperatorHub. This bug fix replaces the old logo with the current logo. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1810046[*BZ#1810046*])
 
-* Previously, the operator resource field names displayed inconsistently in the web console as either camelCase or Start Case. Now, the operand form generation logic labels the form fields using Start Case by default. The default can be overridden by CSV or CRD objects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854196[*BZ#1854196*])
+* Previously, the Operator resource field names displayed inconsistently in the web console as either camelCase or Start Case. Now, the operand form generation logic labels the form fields using Start Case by default. The default can be overridden by CSV or CRD objects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854196[*BZ#1854196*])
 
-* Previously, the Resource Log view did not show single line logs and did not show the last line of a pod log if it was missing a newline control character (/n). Now, the log view has been updated to show the entire pod log content for single line logs and final lines that are not terminated with a newline character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1876853[*BZ#1876853*])
+* Previously, the *Resource Log* view did not show single line logs and did not show the last line of a pod log if it was missing a newline control character (`/n`). Now, the log view has been updated to show the entire pod log content for single line logs and final lines that are not terminated with a newline character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1876853[*BZ#1876853*])
 
 * Previously, the {product-title} web console YAML editor allowed `metadata.namespace` entries for all resources. An error was returned when `namespace: <namespace>` was added for resources that did not take a namespace value. `metadata.namespace` entries are now removed when a configuration is saved, if a resource does not take a namespace value.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846894[*BZ#1846894*])
@@ -1888,31 +1763,31 @@ This bug fix updates the Machine Config Operator (MCO) to modify the `curl` comm
 
 * Previously, the configuration reload for Prometheus was sometimes triggered while the configuration was not fully generated, which triggered the `PrometheusNotIngestingSamples` and `PrometheusNotConnectedToAlertmanagers` alerts because there were no scrape or alerting targets. The configuration reload process now ensures that the configuration on disk is valid before reloading Prometheus, and the alerts are not fired. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845561[*BZ#1845561*])
 
-* Previously the `AlertmanagerConfigInconsistent` alert could fire during an upgrade because some of the Alertmanager pods were temporarily not running due to a rolling update of the stateful set. Even though the alert resolved itself, this could cause confusion for cluster administrators. The `AlertmanagerConfigInconsistent` no longer considers the number of running Alertmanager pods, so it no longer fires during upgrades when some of the Alertmanager pods are in a not-running, transient state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846397[*BZ#1846397*])
+* Previously, the `AlertmanagerConfigInconsistent` alert could fire during an upgrade because some of the Alertmanager pods were temporarily not running due to a rolling update of the stateful set. Even though the alert resolved itself, this could cause confusion for cluster administrators. The `AlertmanagerConfigInconsistent` no longer considers the number of running Alertmanager pods, so it no longer fires during upgrades when some of the Alertmanager pods are in a not-running, transient state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846397[*BZ#1846397*])
 
 * Previously, some alerts did not have the correct severity set or were incorrect, which caused upgrade issues. The severity level for many alerts were changed from critical to warning, the `KubeStatefulSetUpdateNotRolledOut` and `KubeDaemonSetRolloutStuck` alerts were adjusted, and the `KubeAPILatencyHigh` and `KubeAPIErrorsHigh` alerts were removed. These alerts are now correct and should not cause upgrade issues. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824988[*BZ#1824988*])
 
 * Previously, `KubeTooManyPods` alert used the `kubelet_running_pod_count`, which includes completed pods, so was incorrect for the `KubeTooManyPods` alert. Now, `container_memory_rss` is leveraged to find the actual number of pods running on a node for the `KubeTooManyPods` alert. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846805[*BZ#1846805*])
 
-* Previously, the `node_exporter` daemon set defaulted to a `maxUnavailable` of `1`, so the rollout was entirely serialized and slow on large clusters. Since the `node_exporter` daemon set does not affect workload availability, the `maxUnavailable` now scales with the cluster size, which allows for a faster rollout. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867603[*BZ#1867603*])
+* Previously, the `node_exporter` daemon set defaulted to a `maxUnavailable` value of `1`, so the rollout was entirely serialized and slow on large clusters. Since the `node_exporter` daemon set does not affect workload availability, the `maxUnavailable` value now scales with the cluster size, which allows for a faster rollout. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867603[*BZ#1867603*])
 
 *Networking*
 
-* With this release, Kuryr-Kubernetes now attempts to detect the bridge interface for Pod subports on the Container Network Interface (CNI) level, instead of using a value set in `kuryr.conf`. This approach supports cases when VMs call the interface without using a value set in `kuryr.conf`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1829517[*BZ#1829517*])
+* With this release, Kuryr-Kubernetes now attempts to detect the bridge interface for pod subports on the Container Network Interface (CNI) level, instead of using a value set in `kuryr.conf`. This approach supports cases when VMs call the interface without using a value set in `kuryr.conf`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1829517[*BZ#1829517*])
 
-* Previously, OpenShift SDN exposed metrics unencrypted over HTTP. Now OpenShift SDN exposes metrics over TLS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809205[*BZ#1809205*])
+* Previously, OpenShift SDN exposed metrics unencrypted over HTTP. Now, OpenShift SDN exposes metrics over TLS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1809205[*BZ#1809205*])
 
-* Previously, when idling a service OpenShift SDN did not always delete a service and its endpoints in the correct order. As a result, sometimes the node port for a service was not deleted. When the service scaled up again, it was therefore unreachable. Now OpenShift SDN ensures that the node port is always deleted correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857743[*BZ#1857743*])
+* Previously, when idling a service, OpenShift SDN did not always delete a service and its endpoints in the correct order. As a result, sometimes the node port for a service was not deleted. When the service scaled up again, it was therefore unreachable. Now, OpenShift SDN ensures that the node port is always deleted correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857743[*BZ#1857743*])
 
-* Previously, an egress router pod failed to initialize because of a missing dependency on legacy iptables binaries. Now an egress router pod successfully initializes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822945[*BZ#1822945*])
+* Previously, an egress router pod failed to initialize because of a missing dependency on legacy iptables binaries. Now, an egress router pod successfully initializes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822945[*BZ#1822945*])
 
-* Previously, when deleting network policies on a cluster that is using the OVN-Kubernetes cluster networking provider, a race condition prevented network policies from being reliably deleted when deleting the associated namespace. Now network policy objects are always correctly deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859682[*BZ#1859682*])
+* Previously, when deleting network policies on a cluster that is using the OVN-Kubernetes cluster networking provider, a race condition prevented network policies from being reliably deleted when deleting the associated namespace. Now, network policy objects are always correctly deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1859682[*BZ#1859682*])
 
-* Previously, when using the OpenShift SDN pod network provider in multitenant isolation mode, pods were unable to reach services configured with `externalIPs` set. Now pods can reach services with a service external IP address configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1762580[*BZ#1762580*])
+* Previously, when using the OpenShift SDN pod network provider in multitenant isolation mode, pods were unable to reach services configured with `externalIPs` set. Now, pods can reach services with a service external IP address configured. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1762580[*BZ#1762580*])
 
-* Previously, OVN-Kubernetes exposed metrics unencrypted over HTTP. Now OVN-Kubernetes exposes metrics over TLS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822720[*BZ#1822720*])
+* Previously, OVN-Kubernetes exposed metrics unencrypted over HTTP. Now, OVN-Kubernetes exposes metrics over TLS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1822720[*BZ#1822720*])
 
-* Previously, on {product-title} on Red Hat OpenStack Platform, when using the OVN-Octavia driver, it was not possible to attach listeners to different protocols on the same port. Now it is possible to expose several protocols on the same port. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846396[*BZ#1846396*])
+* Previously, on {product-title} on Red Hat OpenStack Platform, when using the OVN-Octavia driver, it was not possible to attach listeners to different protocols on the same port. Now, it is possible to expose several protocols on the same port. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1846396[*BZ#1846396*])
 
 *Node*
 
@@ -1926,7 +1801,7 @@ This bug fix updates the Machine Config Operator (MCO) to modify the `curl` comm
 
 *oauth-apiserver*
 
-* Previously, when the Authentication Operator receives an HTML payload from an OpenID Connect Authentication (OIDC) server that ignores the `Accept: application/json` header, the Operator logged an error about the payload. Now the Operator includes the URL of the page that it requested to aid in troubleshooting the OIDC server response. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861789[*BZ#1861789*])
+* Previously, when the Authentication Operator received an HTML payload from an OpenID Connect Authentication (OIDC) server that ignores the `Accept: application/json` header, the Operator logged an error about the payload. Now, the Operator includes the URL of the page that it requested to aid in troubleshooting the OIDC server response. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861789[*BZ#1861789*])
 
 *oc*
 
@@ -1938,13 +1813,13 @@ This bug fix updates the Machine Config Operator (MCO) to modify the `curl` comm
 
 *OLM*
 
-* Operator Lifecycle Manager (OLM) exposes the `subscription.spec.config.nodeSelector` field in the subscription CRD, but previously did not apply `nodeSelectors` labels to the deployments defined in the ClusterServiceVersion (CSV). This made users unable to set `nodeSelectors` on their CSV deployments. This bug fix updates OLM to now propagate `nodeSelector` labels defined in the `subscription.spec.config.nodeSelector` field to deployments in the CSV. As a result, the field now works as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860035[*BZ#1860035*])
+* Operator Lifecycle Manager (OLM) exposes the `subscription.spec.config.nodeSelector` field in the subscription CRD, but previously did not apply `nodeSelectors` labels to the deployments defined in the `ClusterServiceVersion` object (CSV). This made users unable to set `nodeSelectors` on their CSV deployments. This bug fix updates OLM to now propagate `nodeSelector` labels defined in the `subscription.spec.config.nodeSelector` field to deployments in the CSV. As a result, the field now works as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860035[*BZ#1860035*])
 
-* Previously, Operator Lifecycle Manager (OLM) did not reuse existing valid CA certificates when installing a ClusterServiceVersion (CSV) that entered the `installing` phase multiple times. OLM applied a new webhook hash to the deployment, causing a new replica set to be created. The running Operator then redeployed, possibly many times during an installation. This bug fix updates OLM to now check if the CA already exists and reuses it if valid. As a result, if OLM detects existing valid CAs, OLM now reuses the CAs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868712[*BZ#1868712*])
+* Previously, Operator Lifecycle Manager (OLM) did not reuse existing valid CA certificates when installing a `ClusterServiceVersion` object (CSV) that entered the `installing` phase multiple times. OLM applied a new webhook hash to the deployment, causing a new replica set to be created. The running Operator then redeployed, possibly many times during an installation. This bug fix updates OLM to now check if the CA already exists and reuses it if valid. As a result, if OLM detects existing valid CAs, OLM now reuses the CAs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868712[*BZ#1868712*])
 
 * Operator Lifecycle Manager (OLM) appends `OwnerReferences` metadata to service resources installed for Operators that provide API services. Previously, whenever an Operator of this class was redeployed by OLM, for example during a certificate rotation, a duplicate `OwnerReference` was appended to the related service, causing the number of `OwnerReferences` to grow unbounded. With this bug fix, when adding `OwnerReferences`, OLM now updates an existing `OwnerReference` if found. As a result, the number of `OwnerReferences` appended to a service by OLM is bounded. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842399[*BZ#1842399*])
 
-* Operator Lifecycle Manager (OLM) previously did not pull bundle images before attempting to unpack them, causing the `opm alpha bundle validate` command to fail with "image not found" or similar errors. This bug fix updates OLM to now pull bundle images before attempting to unpack in the bundle validator. As a result, the `opm alpha bundle validate` command successfully pulls and unpacks images before performing validation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857502[*BZ#1857502*])
+* Operator Lifecycle Manager (OLM) previously did not pull bundle images before attempting to unpack them, causing the `opm alpha bundle validate` command to fail with `image not found` or similar error messages. This bug fix updates OLM to now pull bundle images before attempting to unpack in the bundle validator. As a result, the `opm alpha bundle validate` command successfully pulls and unpacks images before performing validation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857502[*BZ#1857502*])
 
 * Previously, the web console would choose Operator icons to display in OperatorHub by returning the icon from the first channel declared in the package. This sometimes caused the displayed icon to be different than the latest icon published to the package. This has been fixed by choosing the icon from the default channel, which ensures the latest icon is displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1843652[*BZ#1843652*])
 
@@ -1979,42 +1854,39 @@ $ coreos-installer install ... ＼
 
 * Previously, the HAProxy router 503 page was not compliant with the standards used by some web application firewalls. The 503 page has been updated to resolve this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1852728[*BZ#1852728*])
 
-* When the Ingress Operator reconciles an IngressController object configured for the NodePortService endpoint publishing strategy type, the Operator gets the ingresscontroller's NodePort service from the API to determine whether the operator needs to create or update the service. If the service does not exist, the operator creates it, with an empty value for the `spec.sessionAffinity` field. If the service does exist, the operator compares it with what the Ingress Operator expects in order to determine whether an update is needed for that service.  In this comparison, if the API has set the default value, `None`, for the service `spec.sessionAffinity` field, the Operator detects the update and tries to set the `spec.sessionAffinity` field back to the empty value.
+* When the Ingress Operator reconciles an `IngressController` object configured for the `NodePortService` endpoint publishing strategy type, the Operator gets the ingress controller's `NodePort` service from the API to determine whether the Operator needs to create or update the service. If the service does not exist, the Operator creates it, with an empty value for the `spec.sessionAffinity` field. If the service does exist, the Operator compares it with what the Ingress Operator expects in order to determine whether an update is needed for that service.  In this comparison, if the API has set the default value, `None`, for the service `spec.sessionAffinity` field, the Operator detects the update and tries to set the `spec.sessionAffinity` field back to the empty value.
 +
-As a result, the Ingress Operator repeatedly attempts to update the NodePort Services in response to the blank.
-The Ingress Operator was changed to consider unspecified values and default values to be equal when comparing NodePort service. The operator no longer updates an IngressController NodePort service in response to API defaulting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842742[*BZ#1842742*])
+As a result, the Ingress Operator repeatedly attempts to update the `NodePort` services in response to the blank. The Ingress Operator was changed to consider unspecified values and default values to be equal when comparing `NodePort` service. The Operator no longer updates an Ingress Controller `NodePort` service in response to API defaulting. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842742[*BZ#1842742*])
 
-* Previously, if you updated a cluster with improper routes, HAProxy would initialize into a defunct state. However, the update would not trigger any alerts and the cluster would incorrectly report the Ingress Controller as available. HAProxy initial sync logic was fixed so that upgrades with broken routes fail.  As a result, upgrading a cluster with improper routes is not successful and the HAProxyReloadFail or HAProxyDown alerts are reported.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1861455[*BZ#1861455*])
+* Previously, if you updated a cluster with improper routes, HAProxy would initialize into a defunct state. However, the update would not trigger any alerts and the cluster would incorrectly report the Ingress Controller as available. HAProxy initial sync logic was fixed so that upgrades with broken routes fail.  As a result, upgrading a cluster with improper routes is not successful and the `HAProxyReloadFail` or `HAProxyDown` alerts are reported. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1861455[*BZ#1861455*])
 
-* Because of the risk of connection re-use/coalescing when using HTTP/2 ALPN, a warning message was added to the output of the Ingress Controller in the CLI to use to enable HTTP/2 ALPN only on a route that uses custom (non-wildcard) certificate. As a result, routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1827364[*BZ#1827364*])
+* Because of the risk of connection re-use/coalescing when using HTTP/2 ALPN, a warning message was added to the output of the Ingress Controller in the CLI to use to enable HTTP/2 ALPN only on a route that uses custom (non-wildcard) certificate. As a result, routes that do not have their own custom certificate will not be HTTP/2 ALPN-enabled on either the frontend or the backend. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1827364[*BZ#1827364*])
 
 * Previously, when HAProxy was reloaded, HAProxy Prometheus counter metrics would decrease in value, which explicitly violates the definition of a counter metric. The router code was fixed to note the time of the last metrics scrape. This prevents scraping beyond the preserved counter values during a reload. As a result the counter metrics do not show a sudden increase followed by a decrease when the router is reloading. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1752814[*BZ#1752814*])
 
 *Samples*
 
-* Previously, an alert rule for the Samples Operator misspelled the registry.redhat.io host name. The rule now uses the correct host name in the alert message. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1863014[*BZ#1863014*])
+* Previously, an alert rule for the Samples Operator misspelled the `registry.redhat.io` host name. The rule now uses the correct host name in the alert message. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1863014[*BZ#1863014*])
 
-* Previously, when upgrading {product-title} the Samples Operator might block the upgrade if the API server is intermittently unavailable. Now the Operator handles intermittent connectivity gracefully and upgrades are no longer blocked. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854857[*BZ#1854857*])
+* Previously, when upgrading {product-title}, the Samples Operator might block the upgrade if the API server is intermittently unavailable. Now, the Operator handles intermittent connectivity gracefully and upgrades are no longer blocked. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1854857[*BZ#1854857*])
 
 *Storage*
 
-* Error message content for Local Storage Operator logging was too generic to help with debugging. Additional details are now provided when a LocalVolume object is created and the specified device is either not found or invalid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840127[*BZ#1840127*])
+* Error message content for Local Storage Operator logging was too generic to help with debugging. Additional details are now provided when a `LocalVolume` object is created and the specified device is either not found or invalid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1840127[*BZ#1840127*])
 
 * Storage Operator stopped reconciling when `Upgradable=False` on v1alpha1 CRDs. As a result, the Cluster Storage Operator could not perform z-stream upgrades when these CRDs were detected on the cluster. This fix changed the order of the reconciliation loop. Now, z-stream upgrades complete successfully and v1alpha1 CRDs are detected without errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1873299[*BZ#1873299*])
 
-* Manila volumes could not be unmounted after the NFS driver pod restarted because the restart process assigned a new IP address to the pod. Now the pod uses the host network and host IP address to mount and unmount volumes, even after restarting the driver pod. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867152[*BZ#1867152*])
+* Manila volumes could not be unmounted after the NFS driver pod restarted because the restart process assigned a new IP address to the pod. Now, the pod uses the host network and host IP address to mount and unmount volumes, even after restarting the driver pod. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1867152[*BZ#1867152*])
 
 * This bug fix reduces log noise when changing fsGroup of a small volume. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877001[*BZ#1877001*])
 
-* A condition in the vSphere cloud provider could cause failures in persistent volume provisioning in rare cicumstances due to a heavy load. This bug fixes the condition and allows vSphere volumes to provision reliably. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1806034[*BZ#1806034*])
+* A condition in the vSphere cloud provider could cause failures in persistent volume provisioning in rare circumstances due to a heavy load. This bug fixes the condition and allows vSphere volumes to provision reliably. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1806034[*BZ#1806034*])
 
-* Upgrades from OCP 4.3.z to 4.4.0 fail when clusters have installed v1alpha1 VolumeSnapshot CRDs manually or by an independent CSI driver. OpenShift Container Platform 4.4 introduced v1beta1 VolumeSnapshot CRDs, which are not compatible with v1alpha1 VolumeSnapshot CRDs. Now, the Cluster Storage Operator checks for the presence of v1alpha1 VolumeSnapshot CRDs. If detected, a message displays stating that the v1alpha1 VolumeSnapshot CRDs must be removed for the upgrade to proceed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835869[*BZ#1835869*])
+* Upgrades from OCP 4.3.z to 4.4.0 fail when clusters have installed v1alpha1 `VolumeSnapshot` CRDs manually or by an independent CSI driver. OpenShift Container Platform 4.4 introduced v1beta1 `VolumeSnapshot` CRDs, which are not compatible with v1alpha1 `VolumeSnapshot` CRDs. Now, the Cluster Storage Operator checks for the presence of v1alpha1 `VolumeSnapshot` CRDs. If detected, a message displays stating that the v1alpha1 `VolumeSnapshot` CRDs must be removed for the upgrade to proceed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1835869[*BZ#1835869*])
 
-* When VolumeSnapshotContent deletion policies were modified, the VolumeSnapshot instances could not be deleted because the finalizers associated with those instances were not updated. This bug fix removes the finalizers when the VolumeSnapshotContent deletion policies are modified, and allows the VolumeSnapshot instances to be deleted after the associated resource objects are removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842964[*BZ#1842964*])
+* When `VolumeSnapshotContent` object deletion policies were modified, the `VolumeSnapshot` resource instances could not be deleted because the finalizers associated with those instances were not updated. This bug fix removes the finalizers when the `VolumeSnapshotContent` object deletion policies are modified, and allows the `VolumeSnapshot` resource instances to be deleted after the associated resource objects are removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842964[*BZ#1842964*])
 
-* Previously, the default OpenShift RBAC rules did not allow regular users to access or create VolumeSnapshot and VolumeSnapshotClass instances. Now, the default OpenShift RBAC rules allow basic-users to read/write VolumeSnapshots and read VolumeSnapshotClasses. Additionally, storage-admins can read/write VolumeSnapshotContents by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842408[*BZ#1842408*])
+* Previously, the default OpenShift RBAC rules did not allow regular users to access or create `VolumeSnapshot` and `VolumeSnapshotClass` resource instances. Now, the default OpenShift RBAC rules allow basic-users to read/write `VolumeSnapshot` resources and read `VolumeSnapshotClass` resources. Additionally, storage-admins can read/write `VolumeSnapshotContent` objects by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1842408[*BZ#1842408*])
 
 * Previously, there was no validation to prevent the Local Storage Operator from creating one device to multiple PVs. This release adds validation for this scenario so that trying to create a PV on a block device where one is already provisioned by the Local Storage Operator will fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1744385[*BZ#1744385*])
 
@@ -2026,12 +1898,9 @@ The Ingress Operator was changed to consider unspecified values and default valu
 [id="ocp-4-6-technology-preview"]
 == Technology Preview features
 
-Some features in this release are currently in Technology Preview. These
-experimental features are not intended for production use. Note the
-following scope of support on the Red Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
 
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview
-Features Support Scope]
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
 In the table below, features are marked with the following statuses:
 
@@ -2202,19 +2071,17 @@ In the table below, features are marked with the following statuses:
 
 * Currently, when scaling to greater than 75 nodes in a cluster, the OVN-Kubernetes cluster networking provider database might become corrupt, leaving the cluster in an unusable state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887585[*BZ#1887585*])
 
-* Currently, scaling up {op-system-base-full} worker nodes on a cluster with the OVN-Kubernetes cluster networking provider will not work. This will be resolved in a future {op-system-base} 7.8.z and {op-system-base} 7.9.z release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1884323[*BZ#1884323*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1871935[*BZ#1871935*])
+* Currently, scaling up {op-system-base-full} worker nodes on a cluster with the OVN-Kubernetes cluster networking provider will not work. This will be resolved in a future {op-system-base} 7.8.z and {op-system-base} 7.9.z release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1884323[*BZ#1884323*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1871935[*BZ#1871935*])
 
 * Currently, when scaling up a worker node that is running on {op-system-base-full} 7.8, the OVN-Kubernetes cluster networking provider fails to initialize on the new node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1884323[*BZ#1884323*])
 
-* Downgrading from {product-title} {product-version} to 4.5 will be fixed in a future 4.5.z release.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1882394[*BZ#1882394*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1886148[*BZ#1886148*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1886127[*BZ#1886127*])
+* Downgrading from {product-title} {product-version} to 4.5 will be fixed in a future 4.5.z release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1882394[*BZ#1882394*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1886148[*BZ#1886148*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1886127[*BZ#1886127*])
 
 * Currently, upgrading from {product-title} 4.5 to {product-version} with {op-system-base-full} worker nodes does not work. This will be resolved in a future 4.6.z release. First, upgrade {op-system-base}, then upgrade the cluster, and then run the normal {op-system-base} upgrade playbook again. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887607[*BZ#1887607*])
 
 * {product-title} 4.5 to {product-version} upgrade fails when an external network is configured on a bond device; the `ovs-configuration` service fails and nodes becomes unreachable. This will be resolved in a future 4.6.z release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887545[*BZ#1887545*])
 
-* Currently, HugePages are not detected properly when requested in several Non-Uniform Memory Access (NUMA) nodes. This is caused by the cnf-tests suite reporting errors when clusters contain several NUMA nodes because the tests compare the number of HugePages on one NUMA with the total number of HugePages on the entire node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1889633[*BZ#1889633*])
+* Currently, huge pages are not detected properly when requested in several Non-Uniform Memory Access (NUMA) nodes. This is caused by the cnf-tests suite reporting errors when clusters contain several NUMA nodes because the tests compare the number of huge pages on one NUMA with the total number of huge pages on the entire node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1889633[*BZ#1889633*])
 
 * The Data Plane Development Kit (DPDK) test used to check packet forwarding and receiving always fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1889631[*BZ#1889631*])
 
@@ -2262,13 +2129,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821771[*BZ#1821771*])
 
-* Running the `operator-sdk new` or `operator-sdk create api` commands without the
-`--helm-chart` flag builds a Helm-based Operator that uses the default
-boilerplate Nginx chart. While this example chart works correctly on upstream
-Kubernetes, it fails to deploy successfully on {product-title}.
+* Running the `operator-sdk new` or `operator-sdk create api` commands without the `--helm-chart` flag builds a Helm-based Operator that uses the default boilerplate Nginx chart. While this example chart works correctly on upstream Kubernetes, it fails to deploy successfully on {product-title}.
 +
-To work around this issue, use the `--helm-chart` flag to provide a Helm chart
-that deploys successfully on {product-title}. For example:
+To work around this issue, use the `--helm-chart` flag to provide a Helm chart that deploys successfully on {product-title}. For example:
 +
 [source,terminal]
 ----
@@ -2278,28 +2141,15 @@ $ operator-sdk new <operator_name> --type=helm \
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874754[*BZ#1874754*])
 
-* When installing {product-title} on bare metal nodes with the Redfish Virtual
-Media feature, a failure occurs when the Baseboard Management Controller (BMC)
-attempts to load the virtual media image from the provisioning network. This
-happens if the BMC is not using the provisioning network, or its network does
-not have routing set up to the provisioning network. As a workaround, when using
-virtual media, the provisioning network must be turned off, or the BMCs must be
-routed to the provisioning network as a prerequisite.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1872787[*BZ#1872787*])
+* When installing {product-title} on bare metal nodes with the Redfish Virtual Media feature, a failure occurs when the Baseboard Management Controller (BMC) attempts to load the virtual media image from the provisioning network. This happens if the BMC is not using the provisioning network, or its network does not have routing set up to the provisioning network. As a workaround, when using virtual media, the provisioning network must be turned off, or the BMCs must be routed to the provisioning network as a prerequisite. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1872787[*BZ#1872787*])
 
-* The {product-title} installation program does not support the Manual mode configuration by using the `install-config.yaml` file on GCP and Azure due to a known issue. Instead, you must manually insert a ConfigMap into the manifest directory during the manifest generation stage of the cluster installation process as documented in xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Manually creating IAM for Azure] and xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[Manually creating IAM for GCP]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1884691[*BZ#1884691*])
+* The {product-title} installation program does not support the Manual mode configuration by using the `install-config.yaml` file on GCP and Azure due to a known issue. Instead, you must manually insert a config map into the manifest directory during the manifest generation stage of the cluster installation process as documented in xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Manually creating IAM for Azure] and xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[Manually creating IAM for GCP]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1884691[*BZ#1884691*])
 
-* On a power environment, when a pod is created using the FC persistent volume claim and the targetWWN as a parameter, the FC volume attach fails with “no fc disk found” error and the pod remains in `ContainerCreating state`.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1887026[*BZ#1887026*])
+* On a power environment, when a pod is created using the FC persistent volume claim and the targetWWN as a parameter, the FC volume attach fails with `no fc disk found` error message and the pod remains in `ContainerCreating state`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887026[*BZ#1887026*])
 
-* When a node providing an egress IP is shut down, the pods hosted on that node
-are not moved to another node providing an egress IP. This causes the outgoing
-traffic of the pods to always fail when a node providing an egress IP is shut
-down.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1877273[*BZ#1877273*])
+* When a node providing an egress IP is shut down, the pods hosted on that node are not moved to another node providing an egress IP. This causes the outgoing traffic of the pods to always fail when a node providing an egress IP is shut down. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1877273[*BZ#1877273*])
 
-* Private, disconnected cluster installations are not supported for AWS GovCloud when installing in the `us-gov-east-1` region due to a known issue.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1881262[*BZ#1881262*]).
+* Private, disconnected cluster installations are not supported for AWS GovCloud when installing in the `us-gov-east-1` region due to a known issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881262[*BZ#1881262*]).
 
 * Firewall rules used by machines not prefixed with the infrastructure ID are preserved when destroying a cluster running on Google Cloud Platform (GCP) with installer-provisioned infrastructure. This causes the destroy process of the installation program to fail. As a workaround, you must manually delete the firewall rule of the machine in the GCP web console:
 +
@@ -2308,8 +2158,7 @@ down.
 $ gcloud compute firewall-rules delete <firewall_rule_name>
 ----
 +
-Once the firewall rule of the machine with the missing infrastructure ID is removed, the cluster can be destroyed.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1801968[*BZ#1801968*])
+Once the firewall rule of the machine with the missing infrastructure ID is removed, the cluster can be destroyed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1801968[*BZ#1801968*])
 
 * The `opm alpha bundle build` command fails on Windows 10. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883773[*BZ#1883773*])
 
@@ -2321,11 +2170,9 @@ controller.go:114] loading OpenAPI spec for "v1beta1.metrics.k8s.io" failed with
 controller.go:127] OpenAPI AggregationController: action for item v1beta1.metrics.k8s.io: Rate Limited Requeue.
 ----
 +
-In some cases, these errors might cause the `KubeAPIErrorsHigh` alert to fire, but the underlying issue is not known to degrade {product-title} functionality.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1819053[*BZ#1819053*])
+In some cases, these errors might cause the `KubeAPIErrorsHigh` alert to fire, but the underlying issue is not known to degrade {product-title} functionality. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1819053[*BZ#1819053*])
 
-* Rules API back-ends are sometimes not detected if Store API stores are discovered before Rules API stores. When this occurs, a store reference is created without a Rules API client, and the Rules API endpoint from Thanos Querier does not return any rules.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1870287[*BZ#1870287*])
+* Rules API back-ends are sometimes not detected if Store API stores are discovered before Rules API stores. When this occurs, a store reference is created without a Rules API client, and the Rules API endpoint from Thanos Querier does not return any rules. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1870287[*BZ#1870287*])
 
 * If an AWS account is configured to use AWS Organizations service control policies (SCPs) that use a global condition to deny all actions or require a specific permission, the AWS policy simulator API that validates permissions produces a false negative. When the permissions cannot be validated, {product-title} AWS installations fail, even if the provided credentials have the required permissions for installation.
 +
@@ -2349,18 +2196,13 @@ When bypassing this check, ensure that the credentials you provide have the xref
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1829101[*BZ#1829101*])
 
-* Clusters that run on {rh-openstack} and use Kuryr create unnecessary Neutron ports
-for each `hostNetworking` pod. You can delete these ports safely.
-Automatic port deletion is planned for a future release of
-{product-title}.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1888318[*BZ#1888318*])
+* Clusters that run on {rh-openstack} and use Kuryr create unnecessary Neutron ports for each `hostNetworking` pod. You can delete these ports safely. Automatic port deletion is planned for a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1888318[*BZ#1888318*])
 
-* Deployments on {rh-openstack} configured with Kuryr might experience kuryr-cni pods going into a CrashLoop, which reports a `NetlinkError: (17, 'File exists')` error. As a workaround, you must reboot the node. A fix is planned to resolve this issue in a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1869606[*BZ#1869606*])
+* Deployments on {rh-openstack} configured with Kuryr might experience kuryr-cni pods going into a crash loop, which reports a `NetlinkError: (17, 'File exists')` error message. As a workaround, you must reboot the node. A fix is planned to resolve this issue in a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1869606[*BZ#1869606*])
 
 * When deploying an egress router pod in DNS proxy mode, the pod fails to initialize. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1888024[*BZ#1888024*])
 
-* {op-system} real time (RT) kernels are currently only supported on compute nodes, not control plane nodes. Compact clusters are not supported with RT kernels in {product-title} 4.6.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1887007[*BZ#1887007*])
+* {op-system} real time (RT) kernels are currently only supported on compute nodes, not control plane nodes. Compact clusters are not supported with RT kernels in {product-title} 4.6. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887007[*BZ#1887007*])
 
 * To increase security, the `NET_RAW` and `SYS_CHROOT` capabilities are no longer available in the default list of CRI-O capabilities.
 +
@@ -2373,17 +2215,12 @@ The `NET_RAW` and `SYS_CHROOT` capabilities were removed as default capabilities
 +
 After upgrading, it is recommended to disable the `NET_RAW` and `SYS_CHROOT` capabilities, and then test your workloads. When you are ready to remove these capabilities, delete the `99-worker-generated-crio-capabilities` and `99-master-generated-crio-capabilities` machine configs.
 +
-*Important*: If you are upgrading from an earlier release, upgrade to 4.5.16 before you upgrade to 4.6.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1874671[*BZ#1874671*]).
+*Important*: If you are upgrading from an earlier release, upgrade to 4.5.16 before you upgrade to 4.6. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874671[*BZ#1874671*]).
 
-* The {product-title} Machine API bare metal actuator currently deletes Machine objects when the underlying bare metal host is deleted. This behavior does not align with other cloud provider actuators, which move a Machine object to the failed phase rather than removing it altogether if the underlying cloud provider resource is deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868104[*BZ#1868104*])
+* The {product-title} Machine API bare metal actuator currently deletes Machine objects when the underlying bare metal host is deleted. This behavior does not align with other cloud provider actuators, which move a `Machine` object to the failed phase rather than removing it altogether if the underlying cloud provider resource is deleted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1868104[*BZ#1868104*])
 
 * When upgrading a cluster from version 4.5 to 4.6 that was installed with
-installer-provisioned infrastructure on vSphere, the upgrade fails if the
-control plane node IP addresses change during the upgrade. As a workaround, you must
-reserve the control plane node IP addresses before upgrading to version 4.6. Review
-your DHCP server's documentation for the configuration of reservations.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1883521[*BZ#1883521*])
+installer-provisioned infrastructure on vSphere, the upgrade fails if the control plane node IP addresses change during the upgrade. As a workaround, you must reserve the control plane node IP addresses before upgrading to version 4.6. Review your DHCP server's documentation for the configuration of reservations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883521[*BZ#1883521*])
 
 * For `oc` commands that require TLS verification, if the certificates do not set a Subject Alternative Name, verification does not fall back to the Common Name field and the command fails with the following error:
 +
@@ -2407,9 +2244,9 @@ A future 4.6 z-stream might return a warning instead of an error, to allow more 
 
 * The *Application Details* page, in the *Application Stages* view, provides inaccurate links for the projects in the application environment. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1889348[*BZ#1889348*])
 
-* Under the condition of heavy Pod creation, creation fails with `error reserving pod name ...: name is reserved`. CRI-O's context for the CNI executable ends and it kills the process. Pod creation succeeds eventually, but it takes a lot of time. Therefore, the kubelet thinks that CRI-O did not create the Pod. The kubelet sends the request again and a name conflict occurs. This issue is currently under investigation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1785399[*BZ#1785399*])
+* Under the condition of heavy pod creation, creation fails with the message `error reserving pod name ...: name is reserved`. CRI-O's context for the CNI executable ends and it kills the process. Pod creation succeeds eventually, but it takes a lot of time. Therefore, the kubelet thinks that CRI-O did not create the pod. The kubelet sends the request again and a name conflict occurs. This issue is currently under investigation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1785399[*BZ#1785399*])
 
-* If the cluster networking provider is OVN-Kubernetes, when using a Service external IP address that is not assigned to any node in the cluster, network traffic to the external IP address is not routable. As a workaround, ensure that a Service external IP address is always assigned to a node in the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1890270[*BZ#1890270*])
+* If the cluster networking provider is OVN-Kubernetes, when using a service external IP address that is not assigned to any node in the cluster, network traffic to the external IP address is not routable. As a workaround, ensure that a service external IP address is always assigned to a node in the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1890270[*BZ#1890270*])
 
 [discrete]
 [id="ocp-4-6-known-issues-olm-mirror"]
@@ -2443,37 +2280,20 @@ For {product-title} on IBM Power Systems on PowerVM, the following requirements 
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} 4.6 are released
-as asynchronous errata through the Red Hat Network. All {product-title} 4.6
-errata is https://access.redhat.com/downloads/content/290/[available on the Red
-Hat Customer Portal]. See the
-https://access.redhat.com/support/policy/updates/openshift[{product-title}
-Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} 4.6 are released as asynchronous errata through the Red Hat Network. All {product-title} 4.6 errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
-Red Hat Customer Portal users can enable errata notifications in the account
-settings for Red Hat Subscription Management (RHSM). When errata notifications
-are enabled, users are notified via email whenever new errata relevant to their
-registered systems are released.
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming
-{product-title} entitlements for {product-title} errata notification
-emails to generate.
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
-This section will continue to be updated over time to provide notes on
-enhancements and bug fixes for future asynchronous errata releases of
-{product-title} 4.6. Versioned asynchronous releases, for example with the form
-{product-title} 4.6.z, will be detailed in subsections. In addition, releases
-in which the errata text cannot fit in the space provided by the advisory will
-be detailed in subsections that follow.
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} 4.6. Versioned asynchronous releases, for example with the form {product-title} 4.6.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
 
 [IMPORTANT]
 ====
-For any {product-title} release, always review the instructions on
-xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster]
-properly.
+For any {product-title} release, always review the instructions on xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster] properly.
 ====
 
 [id="ocp-4-6-1-ga"]


### PR DESCRIPTION
API terminology and formatting updates for the 4.6 Release Notes. Also replaced hard wraps and some other minor standards edits.
Preview: https://terms-form-update-rns-4_6--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html