### PR TITLE
Add Kuryr docs about limitation of service without selector

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -11,15 +11,13 @@ Using {product-title} with Kuryr SDN has several known limitations.
 [id="openstack-general-limitations_{context}"]
 == {rh-openstack} general limitations
 
-{product-title} with Kuryr SDN does not support `Service` objects with type `NodePort`.
+Using {product-title} with Kuryr SDN has several limitations that apply to all versions and environments:
 
-{product-title} with Kuryr SDN and OVN Octavia provider supports `Service` objects
-without specifying `.spec.selector` only when the `Endpoints` object `.subsets.addresses`
-are either on the Nodes or Pods subnet.
+* `Service` objects with the `NodePort` type are not supported.
 
-If the machines subnet is not connected to a router, or if the
-subnet is connected, but the router has no external gateway set,
-Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
+* Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `EndPoints` object includes the nodes' or pods' subnet. 
+
+* If the machines subnet is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
 
 [discrete]
 [id="openstack-version-limitations_{context}"]

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -15,7 +15,7 @@ Using {product-title} with Kuryr SDN has several limitations that apply to all v
 
 * `Service` objects with the `NodePort` type are not supported.
 
-* Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `Endpoints` object includes the nodes' or pods' subnet. 
+* Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `Endpoints` object includes the subnet of the nodes or pods. 
 
 * If the machines subnet is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
 

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -13,6 +13,10 @@ Using {product-title} with Kuryr SDN has several known limitations.
 
 {product-title} with Kuryr SDN does not support `Service` objects with type `NodePort`.
 
+{product-title} with Kuryr SDN and OVN Octavia provider supports `Service` objects
+without specifying `.spec.selector` only when the `Endpoints` object `.subsets.addresses`
+are either on the Nodes or Pods subnet.
+
 If the machines subnet is not connected to a router, or if the
 subnet is connected, but the router has no external gateway set,
 Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -17,7 +17,7 @@ Using {product-title} with Kuryr SDN has several limitations that apply to all v
 
 * Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `Endpoints` object includes the subnet of the nodes or pods. 
 
-* If the machines subnet is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
+* If the subnet on which machines are created is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
 
 [discrete]
 [id="openstack-version-limitations_{context}"]

--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -15,7 +15,7 @@ Using {product-title} with Kuryr SDN has several limitations that apply to all v
 
 * `Service` objects with the `NodePort` type are not supported.
 
-* Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `EndPoints` object includes the nodes' or pods' subnet. 
+* Clusters that use the OVN Octavia provider driver support `Service` objects for which the `.spec.selector` property is unspecified only if the `.subsets.addresses` property of the `Endpoints` object includes the nodes' or pods' subnet. 
 
 * If the machines subnet is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
 


### PR DESCRIPTION
When using services without selectors with Kuryr and OVN octavia
provider the Endpoints address should be either on the Nodes or Pods
subnet. This commit includes this restriction to the docs.