### PR TITLE
CNV BZ#1902217 - Highlight enabling of KubeMacPool

### DIFF
--- a/virt/install/installing-virt-cli.adoc
+++ b/virt/install/installing-virt-cli.adoc
@@ -16,3 +16,12 @@ using the command line to apply manifests to your cluster.
 include::modules/virt-subscribing-cli.adoc[leveloffset=+1]
 
 include::modules/virt-deploying-operator-cli.adoc[leveloffset=+1]
+
+== Next steps
+
+You might want to additionally configure the following components:
+
+* The _KubeMacPool_ component provides a MAC address pool service for virtual machine NICs in designated namespaces. xref:../../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-about-kubemacpool_virt-using-mac-address-pool-for-vms[Enable a MAC address pool in a namespace] by applying the KubeMacPool label to that namespace.
+
+* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
+

--- a/virt/install/installing-virt-web.adoc
+++ b/virt/install/installing-virt-web.adoc
@@ -18,3 +18,11 @@ to subscribe to and deploy the {VirtProductName} Operators.
 include::modules/virt-subscribing-to-the-catalog.adoc[leveloffset=+1]
 
 include::modules/virt-deploying-virt.adoc[leveloffset=+1]
+
+== Next steps
+
+You might want to additionally configure the following components:
+
+* The _KubeMacPool_ component provides a MAC address pool service for virtual machine NICs in designated namespaces. xref:../../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-about-kubemacpool_virt-using-mac-address-pool-for-vms[Enable a MAC address pool in a namespace] by applying the KubeMacPool label to that namespace.
+
+* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -12,6 +12,11 @@ configure a PXE network so that you can boot machines over the network.
 To get started, a network administrator configures a bridge network attachment definition
 for a namespace in the web console or CLI. Users can then create a NIC to attach pods and virtual machines in that namespace to the bridge network.
 
+[NOTE]
+====
+The _KubeMacPool_ component provides a MAC address pool service for virtual machine NICs in designated namespaces. It is not enabled by default. xref:../../../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-about-kubemacpool_virt-using-mac-address-pool-for-vms[Enable a MAC address pool in a namespace] by applying the KubeMacPool label to that namespace.
+====
+
 include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 
 == Creating a network attachment definition

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -9,9 +9,11 @@ you must use the `masquerade` binding method. It is the only recommended
 binding method for use with the default pod network. Do not use
 `masquerade` mode with non-default networks.
 
+xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[For secondary networks], use the `bridge` binding method.
+
 [NOTE]
 ====
-For secondary networks, use the `bridge` binding method.
+The _KubeMacPool_ component provides a MAC address pool service for virtual machine NICs in designated namespaces. It is not enabled by default. xref:../../../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-about-kubemacpool_virt-using-mac-address-pool-for-vms[Enable a MAC address pool in a namespace] by applying the KubeMacPool label to that namespace.
 ====
 
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Adding Next Steps info to the two Install assemblies. This highlights optional additional configuration for KubeMacPool and HPP. 
This also adds Notes to relevant VM network assemblies, informing users that they may need to enable KubeMacPool, and xrefs to the relevant content.

https://bugzilla.redhat.com/show_bug.cgi?id=1902217

Preview links:
Install web: https://cnv-bz1902217-mac--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-web.html#next-steps 
Install cli: https://cnv-bz1902217-mac--ocpdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html#next-steps

Using the default pod network: https://cnv-bz1902217-mac--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html
Attaching VM to multiple networks: https://cnv-bz1902217-mac--ocpdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html