### PR TITLE
CNV-8834 - 2.4.4 upgrade pathway and HCO version bump for 2.5.2

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.5
 :KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.1
+:HCOVersion: 2.5.2
 // :LastHCOVersion: 2.4.4
 :product-build:
 :DownloadURL: registry.access.redhat.com

--- a/modules/virt-upgrade-pathways.adoc
+++ b/modules/virt-upgrade-pathways.adoc
@@ -7,16 +7,20 @@
 
 The upgrade pathway is different depending on the 2.4.z version of {VirtProductName} that you have installed.
 
-[id="virt-upgrade-pathways-2.4.3_{context}"]
-== Upgrading from 2.4.3 to 2.5.1
+[IMPORTANT]
+====
+You must upgrade your {product-title} to 4.6 before upgrading the minor release of {VirtProductName}.
+====
 
-You must first upgrade to 2.5.0 before you can upgrade the z-stream. You can then upgrade from 2.5.0 to 2.5.1.
+[id="virt-upgrade-pathways-2.4.3_{context}"]
+== Upgrading from 2.4.3 to 2.5.2
+
+You must first upgrade to 2.5.0 before you can upgrade the z-stream. You can then upgrade from 2.5.0 to 2.5.1 and then to 2.5.2.
 
 If your *Approval Strategy* is *Automatic*, which is the default, {VirtProductName} upgrades the z-stream automatically once you have upgraded to 2.5.0.
 
 [id="virt-upgrade-pathways-2.4.4_{context}"]
-== Upgrading from 2.4.4 to 2.5.1
+== Upgrading from 2.4.4 to 2.5.2
 
-You cannot currently upgrade from 2.4.4 to 2.5.0 or 2.5.1.
+You can upgrade from 2.4.4 directly to 2.5.2.
 
-// This needs to be updated when 2.5.2 is released


### PR DESCRIPTION
HCOVersion bump and adding 2.4.4 upgrade pathway to 2.5.2

[CNV-8834](https://issues.redhat.com/browse/CNV-8834)

Preview: https://cnv-252-upgrade--ocpdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-upgrade-pathways_upgrading-virt