### PR TITLE
Update "Red Hat Operators reference" modules for API object & unwrap changes

### DIFF
--- a/modules/cloud-credential-operator.adoc
+++ b/modules/cloud-credential-operator.adoc
@@ -8,83 +8,43 @@
 [discrete]
 == Purpose
 
-The Cloud Credential Operator (CCO) manages cloud provider credentials as
-Kubernetes custom resource definitions (CRDs). The CCO syncs on
-`credentialsRequest` custom resources (CRs) to allow {product-title} components
-to request cloud provider credentials with the specific permissions that are
-required for the cluster to run.
+The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubernetes custom resource definitions (CRDs). The CCO syncs on `credentialsRequest` custom resources (CRs) to allow {product-title} components to request cloud provider credentials with the specific permissions that are required for the cluster to run.
 
-By setting different values for the `credentialsMode` parameter in the
-`install-config.yaml` file, the CCO can be configured to operate in several
-different modes. If no mode is specified, or the `credentialsMode` parameter is
-set to an empty string (`""`), the CCO operates in its default mode.
+By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in several different modes. If no mode is specified, or the `credentialsMode` parameter is set to an empty string (`""`), the CCO operates in its default mode.
 
 [discrete]
 === Default behavior
-For platforms where multiple modes are supported (AWS, Azure, and GCP), when the CCO operates in its default mode, it checks the provided credentials
-dynamically to determine for which mode they are sufficient to process `credentialsRequest` CRs.
+For platforms where multiple modes are supported (AWS, Azure, and GCP), when the CCO operates in its default mode, it checks the provided credentials dynamically to determine for which mode they are sufficient to process `credentialsRequest` CRs.
 
-By default, the CCO determines whether the credentials are sufficient for mint
-mode, which is the preferred mode of operation, and uses those credentials to
-create appropriate credentials for components in the cluster. If the credentials
-are not sufficient for mint mode, it determines whether they are sufficient for
-passthrough mode. If the credentials are not sufficient for passthrough mode,
-the CCO cannot adequately process `credentialsRequest` CRs.
+By default, the CCO determines whether the credentials are sufficient for mint mode, which is the preferred mode of operation, and uses those credentials to create appropriate credentials for components in the cluster. If the credentials are not sufficient for mint mode, it determines whether they are sufficient for passthrough mode. If the credentials are not sufficient for passthrough mode, the CCO cannot adequately process `credentialsRequest` CRs.
 
 [NOTE]
 ====
 The CCO cannot verify whether Azure credentials are sufficient for passthrough mode. If Azure credentials are insufficient for mint mode, the CCO operates with the assumption that the credentials are sufficient for passthrough mode.
 ====
 
-If the provided credentials are determined to be insufficient during
-installation, the installation fails. For AWS, the installer fails early in the
-process and indicates which required permissions are missing. Other providers
-might not provide specific information about the cause of the error until errors are encountered.
+If the provided credentials are determined to be insufficient during installation, the installation fails. For AWS, the installer fails early in the process and indicates which required permissions are missing. Other providers might not provide specific information about the cause of the error until errors are encountered.
 
-If the credentials are changed after a successful installation and the CCO
-determines that the new credentials are insufficient, the CCO puts conditions on
-any new `credentialsRequest` CRs to indicate that it cannot process them because
-of the insufficient credentials.
+If the credentials are changed after a successful installation and the CCO determines that the new credentials are insufficient, the CCO puts conditions on any new `credentialsRequest` CRs to indicate that it cannot process them because of the insufficient credentials.
 
-To resolve insufficient credentials issues, provide a credential with sufficient
-permissions. If an error occurred during installation, try installing again. For
-issues with new `credentialsRequest` CRs, wait for the CCO to try to process the
-CR again. As an alternative, you can manually create IAM for AWS, Azure, or GCP. For details, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
+To resolve insufficient credentials issues, provide a credential with sufficient permissions. If an error occurred during installation, try installing again. For issues with new `credentialsRequest` CRs, wait for the CCO to try to process the CR again. As an alternative, you can manually create IAM for AWS, Azure, or GCP. For details, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
 
 [discrete]
 === Modes
 
-By setting different values for the `credentialsMode` parameter in the
-`install-config.yaml` file, the CCO can be configured to operate in _mint_,
-_passthrough_, or _manual_ mode. These options provide transparency and
-flexibility in how the CCO uses cloud credentials to process
-`credentialsRequest` CRs in the cluster, and allow the CCO to be configured to
-suit the security requirements of your organization. Not all CCO modes are
-supported for all cloud providers.
+By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in _mint_, _passthrough_, or _manual_ mode. These options provide transparency and flexibility in how the CCO uses cloud credentials to process `credentialsRequest` CRs in the cluster, and allow the CCO to be configured to suit the security requirements of your organization. Not all CCO modes are supported for all cloud providers.
 
 [discrete]
 ==== Mint mode
 Mint mode is supported for AWS, Azure, and GCP.
 
-Mint mode is the default and recommended best practice setting for the CCO
-to use. In this mode, the CCO uses the provided admin-level cloud credential to
-run the cluster.
+Mint mode is the default and recommended best practice setting for the CCO to use. In this mode, the CCO uses the provided admin-level cloud credential to run the cluster.
 
-If the credential is not removed after installation, it is stored and used by
-the CCO to process `credentialsRequest` CRs for components in the cluster and
-create new credentials for each with only the specific permissions that are
-required. The continuous reconciliation of cloud credentials in mint mode allows
-actions that require additional credentials or permissions, such as upgrading,
-to proceed.
+If the credential is not removed after installation, it is stored and used by the CCO to process `credentialsRequest` CRs for components in the cluster and create new credentials for each with only the specific permissions that are required. The continuous reconciliation of cloud credentials in mint mode allows actions that require additional credentials or permissions, such as upgrading, to proceed.
 
-The requirement that mint mode stores the admin-level credential in the cluster
-`kube-system` namespace might not suit the security requirements of every
-organization.
+The requirement that mint mode stores the admin-level credential in the cluster `kube-system` namespace might not suit the security requirements of every organization.
 
-When using the CCO in mint mode, ensure that the credential you provide meets
-the requirements of the cloud on which you are running or installing
-{product-title}. If the provided credentials are not sufficient for mint mode,
-the CCO cannot create an IAM user.
+When using the CCO in mint mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials are not sufficient for mint mode, the CCO cannot create an IAM user.
 
 .Mint mode credential requirements
 [cols="1,9a"]
@@ -123,45 +83,25 @@ the CCO cannot create an IAM user.
 
 [discrete]
 ===== Mint mode with removal or rotation of the admin-level credential
-Mint mode with removal or rotation of the admin-level credential is supported
-for AWS in {product-title} version 4.4 and later.
+Mint mode with removal or rotation of the admin-level credential is supported for AWS in {product-title} version 4.4 and later.
 
-This option requires the presence of the admin-level credential during
-installation, but the credential is not stored in the cluster permanently and
-does not need to be long-lived.
+This option requires the presence of the admin-level credential during installation, but the credential is not stored in the cluster permanently and does not need to be long-lived.
 
-After installing {product-title} in mint mode, you can remove the admin-level
-credential Secret from the cluster. If you remove the Secret, the CCO uses a
-previously minted read-only credential that allows it to verify whether all
-`credentialsRequest` CRs have their required permissions. Once removed, the
-associated credential can be destroyed on the underlying cloud if desired.
+After installing {product-title} in mint mode, you can remove the admin-level credential Secret from the cluster. If you remove the Secret, the CCO uses a previously minted read-only credential that allows it to verify whether all `credentialsRequest` CRs have their required permissions. Once removed, the associated credential can be destroyed on the underlying cloud if desired.
 
-The admin-level credential is not required unless something that requires an
-admin-level credential needs to be changed, for instance during an upgrade.
-Prior to each upgrade, you must reinstate the credential Secret with the
-admin-level credential. If the credential is not present, the upgrade might be
-blocked.
+The admin-level credential is not required unless something that requires an admin-level credential needs to be changed, for instance during an upgrade. Prior to each upgrade, you must reinstate the credential Secret with the admin-level credential. If the credential is not present, the upgrade might be blocked.
 
 [discrete]
 ==== Passthrough mode
-Passthrough mode is supported for AWS, Azure, GCP, {rh-openstack-first},
-{rh-virtualization-first}, and VMware vSphere.
+Passthrough mode is supported for AWS, Azure, GCP, {rh-openstack-first}, {rh-virtualization-first}, and VMware vSphere.
 
 In passthrough mode, the CCO passes the provided cloud credential to the components that request cloud credentials. The credential must have permissions to perform the installation and complete the operations that are required by components in the cluster, but does not need to be able to create new credentials. The CCO does not attempt to create additional limited-scoped credentials in passthrough mode.
 
 [discrete]
 ===== Passthrough mode permissions requirements
-When using the CCO in passthrough mode, ensure that the credential you provide
-meets the requirements of the cloud on which you are running or installing
-{product-title}. If the provided credentials the CCO passes to a component
-that creates a `credentialsRequest` CR are not sufficient, that component will
-report an error when it tries to call an API that it does not have permissions
-for.
+When using the CCO in passthrough mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials the CCO passes to a component that creates a `credentialsRequest` CR are not sufficient, that component will report an error when it tries to call an API that it does not have permissions for.
 
-The credential you provide for passthrough mode in AWS, Azure, or GCP must have
-all the requested permissions for all `credentialsRequest` CRs that are required
-by the version of {product-title} you are running or installing. To locate the
-`credentialsRequest` CRs that are required for your cloud provider, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
+The credential you provide for passthrough mode in AWS, Azure, or GCP must have all the requested permissions for all `credentialsRequest` CRs that are required by the version of {product-title} you are running or installing. To locate the `credentialsRequest` CRs that are required for your cloud provider, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
 
 To install an {product-title} cluster on {rh-openstack-first}, the CCO requires a credential with the permissions of a `member` user role.
 
@@ -209,42 +149,22 @@ To install an {product-title} cluster on VMware vSphere, the CCO requires a cred
 
 [discrete]
 ===== Passthrough mode credential maintenance
-If `credentialsRequest` CRs change over time as the cluster is upgraded, you
-must manually update the passthrough mode credential to meet the requirements.
-To avoid credentials issues during an upgrade, check the `credentialsRequest`
-CRs in the release image for the new version of {product-title} before
-upgrading. To locate the `credentialsRequest` CRs that are required for your
-cloud provider, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
-
+If `credentialsRequest` CRs change over time as the cluster is upgraded, you must manually update the passthrough mode credential to meet the requirements. To avoid credentials issues during an upgrade, check the `credentialsRequest` CRs in the release image for the new version of {product-title} before upgrading. To locate the `credentialsRequest` CRs that are required for your cloud provider, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
 [discrete]
 ===== Reducing permissions after installation
-When using passthrough mode, each component has the same permissions used by all
-other components. If you do not reduce the permissions after installing, all
-components have the broad permissions that are required to run the installer.
+When using passthrough mode, each component has the same permissions used by all other components. If you do not reduce the permissions after installing, all components have the broad permissions that are required to run the installer.
 
-After installation, you can reduce the permissions on your credential to only
-those that are required to run the cluster, as defined by the
-`credentialsRequest` CRs in the release image for the version of
-{product-title} that you are using.
+After installation, you can reduce the permissions on your credential to only those that are required to run the cluster, as defined by the `credentialsRequest` CRs in the release image for the version of {product-title} that you are using.
 
-To locate the `credentialsRequest` CRs that are required for AWS, Azure, or GCP
-and learn how to change the permissions the CCO uses, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
+To locate the `credentialsRequest` CRs that are required for AWS, Azure, or GCP and learn how to change the permissions the CCO uses, see the _Manually creating IAM_ section of the installation content for AWS, Azure, or GCP.
 
 [discrete]
 ==== Manual mode
 Manual mode is supported for AWS.
 
-In manual mode, a user manages cloud credentials instead of the CCO. To use this
-mode, you must examine the `credentialsRequest` CRs in the release image for the
-version of {product-title} that you are running or installing, create
-corresponding credentials in the underlying cloud provider, and create
-Kubernetes Secrets in the correct namespaces to satisfy all `credentialsRequest`
-CRs for the cluster's cloud provider.
+In manual mode, a user manages cloud credentials instead of the CCO. To use this mode, you must examine the `credentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `credentialsRequest` CRs for the cluster's cloud provider.
 
-Using manual mode allows each cluster component to have only the permissions it
-requires, without storing an admin-level credential in the cluster. This mode
-also does not require connectivity to the AWS public IAM endpoint. However, you
-must manually reconcile permissions with new release images for every upgrade.
+Using manual mode allows each cluster component to have only the permissions it requires, without storing an admin-level credential in the cluster. This mode also does not require connectivity to the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade.
 
 //later include upgrade info from manually-maintained-credentials-upgrade
 
@@ -254,10 +174,7 @@ For information about configuring AWS to use manual mode, see _Manually creating
 ==== Disabled CCO
 Disabled CCO is supported for Azure and GCP.
 
-To manually manage credentials for Azure or GCP, you must disable the CCO.
-Disabling the CCO has many of the same configuration and maintenance
-requirements as running the CCO in manual mode, but is accomplished by a
-different process. For more information, see the _Manually creating IAM_ section of the installation content for Azure or GCP.
+To manually manage credentials for Azure or GCP, you must disable the CCO. Disabling the CCO has many of the same configuration and maintenance requirements as running the CCO in manual mode, but is accomplished by a different process. For more information, see the _Manually creating IAM_ section of the installation content for Azure or GCP.
 
 [discrete]
 == Project
@@ -267,9 +184,9 @@ link:https://github.com/openshift/cloud-credential-operator[openshift-cloud-cred
 [discrete]
 == CRDs
 
-* credentialsrequests.cloudcredential.openshift.io
+* `credentialsrequests.cloudcredential.openshift.io`
 ** Scope: Namespaced
-** CR: credentialsrequest
+** CR: `credentialsrequest`
 ** Validation: Yes
 
 [discrete]

--- a/modules/cluster-authentication-operator.adoc
+++ b/modules/cluster-authentication-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Cluster Authentication Operator installs and maintains the Authentication
-Custom Resource in a cluster and can be viewed with:
+The Cluster Authentication Operator installs and maintains the `Authentication` custom resource in a cluster and can be viewed with:
 
 [source,terminal]
 ----

--- a/modules/cluster-autoscaler-operator.adoc
+++ b/modules/cluster-autoscaler-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Cluster Autoscaler Operator manages deployments of the OpenShift Cluster
-Autoscaler using the cluster-api provider.
+The Cluster Autoscaler Operator manages deployments of the OpenShift Cluster Autoscaler using the `cluster-api` provider.
 
 [discrete]
 == Project
@@ -19,10 +18,5 @@ link:https://github.com/openshift/cluster-autoscaler-operator[cluster-autoscaler
 [discrete]
 == CRDs
 
-* `ClusterAutoscaler`: This is a singleton resource, which controls the configuration
-of the cluster's autoscaler instance. The Operator will only respond to the
-`ClusterAutoscaler` resource named `default` in the managed namespace, the
-value of the `WATCH_NAMESPACE` environment variable.
-* `MachineAutoscaler`: This resource targets a node group and manages the
-annotations to enable and configure autoscaling for that group, the `min` and
-`max` size. Currently only `MachineSet` objects can be targeted.
+* `ClusterAutoscaler`: This is a singleton resource, which controls the configuration autoscaler instance for the cluster. The Operator only responds to the `ClusterAutoscaler` resource named `default` in the managed namespace, the value of the `WATCH_NAMESPACE` environment variable.
+* `MachineAutoscaler`: This resource targets a node group and manages the annotations to enable and configure autoscaling for that group, the `min` and `max` size. Currently only `MachineSet` objects can be targeted.

--- a/modules/cluster-dns-operator.adoc
+++ b/modules/cluster-dns-operator.adoc
@@ -8,17 +8,14 @@
 [discrete]
 == Purpose
 
-The DNS Operator deploys and manages CoreDNS to provide a name resolution
-service to pods that enables DNS-based Kubernetes Service discovery in
-{product-title}.
+The DNS Operator deploys and manages CoreDNS to provide a name resolution service to pods that enables DNS-based Kubernetes Service discovery in {product-title}.
 
 The Operator creates a working default deployment based on the cluster's configuration.
 
 * The default cluster domain is `cluster.local`.
 * Configuration of the CoreDNS Corefile or Kubernetes plug-in is not yet supported.
 
-The DNS Operator manages CoreDNS as a Kubernetes daemon set exposed as a service
-with a static IP. CoreDNS runs on all nodes in the cluster.
+The DNS Operator manages CoreDNS as a Kubernetes daemon set exposed as a service with a static IP. CoreDNS runs on all nodes in the cluster.
 
 [discrete]
 == Project

--- a/modules/cluster-image-registry-operator.adoc
+++ b/modules/cluster-image-registry-operator.adoc
@@ -8,21 +8,13 @@
 [discrete]
 == Purpose
 
-The Cluster Image Registry Operator manages a singleton instance of the
-{product-title} registry. It manages all configuration of the registry,
-including creating storage.
+The Cluster Image Registry Operator manages a singleton instance of the {product-title} registry. It manages all configuration of the registry, including creating storage.
 
-On initial start up, the Operator creates a default `image-registry` resource
-instance based on the configuration detected in the cluster. This indicates
-what cloud storage type to use based on the cloud provider.
+On initial start up, the Operator creates a default `image-registry` resource instance based on the configuration detected in the cluster. This indicates what cloud storage type to use based on the cloud provider.
 
-If insufficient information is available to define a complete `image-registry`
-resource, then an incomplete resource is defined and the Operator updates the
-resource status with information about what is missing.
+If insufficient information is available to define a complete `image-registry` resource, then an incomplete resource is defined and the Operator updates the resource status with information about what is missing.
 
-The Cluster Image Registry Operator runs in the `openshift-image-registry`
-namespace and it also manages the registry instance in that location. All
-configuration and workload resources for the registry reside in that namespace.
+The Cluster Image Registry Operator runs in the `openshift-image-registry` namespace and it also manages the registry instance in that location. All configuration and workload resources for the registry reside in that namespace.
 
 [discrete]
 == Project

--- a/modules/cluster-kube-scheduler-operator.adoc
+++ b/modules/cluster-kube-scheduler-operator.adoc
@@ -8,9 +8,7 @@
 [discrete]
 == Purpose
 
-The Kubernetes Scheduler Operator manages and updates the Kubernetes Scheduler
-deployed on top of {product-title}. The operator is based on the {product-title} library-go
-framework and it is installed with the Cluster Version Operator (CVO).
+The Kubernetes Scheduler Operator manages and updates the Kubernetes Scheduler deployed on top of {product-title}. The Operator is based on the {product-title} `library-go` framework and it is installed with the Cluster Version Operator (CVO).
 
 The Kubernetes Scheduler Operator contains the following components:
 
@@ -34,5 +32,4 @@ The configuration for the Kubernetes Scheduler is the result of merging:
 * a default configuration.
 * an observed configuration from the spec `schedulers.config.openshift.io`.
 
-All of these are sparse configurations, invalidated JSON snippets which are
-merged in order to form a valid configuration at the end.
+All of these are sparse configurations, invalidated JSON snippets which are merged in order to form a valid configuration at the end.

--- a/modules/cluster-monitoring-operator.adoc
+++ b/modules/cluster-monitoring-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Cluster Monitoring Operator manages and updates the Prometheus-based cluster
-monitoring stack deployed on top of {product-title}.
+The Cluster Monitoring Operator manages and updates the Prometheus-based cluster monitoring stack deployed on top of {product-title}.
 
 [discrete]
 == Project
@@ -19,21 +18,21 @@ link:https://github.com/openshift/cluster-monitoring-operator[openshift-monitori
 [discrete]
 == CRDs
 
-* alertmanagers.monitoring.coreos.com
+* `alertmanagers.monitoring.coreos.com`
 ** Scope: Namespaced
-** CR: alertmanager
+** CR: `alertmanager`
 ** Validation: Yes
-* prometheuses.monitoring.coreos.com
+* `prometheuses.monitoring.coreos.com`
 ** Scope: Namespaced
-** CR: prometheus
+** CR: `prometheus`
 ** Validation: Yes
-* prometheusrules.monitoring.coreos.com
+* `prometheusrules.monitoring.coreos.com`
 ** Scope: Namespaced
-** CR: prometheusrule
+** CR: `prometheusrule`
 ** Validation: Yes
-* servicemonitors.monitoring.coreos.com
+* `servicemonitors.monitoring.coreos.com`
 ** Scope: Namespaced
-** CR: servicemonitor
+** CR: `servicemonitor`
 ** Validation: Yes
 
 [discrete]

--- a/modules/cluster-network-operator.adoc
+++ b/modules/cluster-network-operator.adoc
@@ -8,5 +8,4 @@
 [discrete]
 == Purpose
 
-The Cluster Network Operator installs and upgrades the networking components on
-an OpenShift Kubernetes cluster.
+The Cluster Network Operator installs and upgrades the networking components on an {product-title} cluster.

--- a/modules/cluster-openshift-controller-manager-operators.adoc
+++ b/modules/cluster-openshift-controller-manager-operators.adoc
@@ -8,15 +8,14 @@
 [discrete]
 == Purpose
 
-The OpenShift Controller Manager Operator installs and maintains the `OpenShiftControllerManager` Custom Resource in a cluster and can be viewed with:
+The OpenShift Controller Manager Operator installs and maintains the `OpenShiftControllerManager` custom resource in a cluster and can be viewed with:
 
 [source,terminal]
 ----
 $ oc get clusteroperator openshift-controller-manager -o yaml
 ----
 
-The Custom Resource Definition `openshiftcontrollermanagers.operator.openshift.io`
-can be viewed in a cluster with:
+The custom resource definitino (CRD) `openshiftcontrollermanagers.operator.openshift.io` can be viewed in a cluster with:
 
 [source,terminal]
 ----

--- a/modules/cluster-samples-operator.adoc
+++ b/modules/cluster-samples-operator.adoc
@@ -8,20 +8,21 @@
 [discrete]
 == Purpose
 
-The Cluster Samples Operator manages the sample imagestreams and templates stored in the `openshift` namespace.
+The Cluster Samples Operator manages the sample image streams and templates stored in the `openshift` namespace.
 
-On initial start up, the Operator creates the default samples configuration resource to initiate the creation of the imagestreams and templates. The configuration object
-is a cluster scoped object with the key `cluster` and type `configs.samples`.
+On initial start up, the Operator creates the default samples configuration resource to initiate the creation of the image streams and templates. The configuration object is a cluster scoped object with the key `cluster` and type `configs.samples`.
 
-The imagestreams are the {op-system-first}-based {product-title} imagestreams pointing to images on `registry.redhat.io`. Similarly, the templates are those categorized as {product-title} templates.
+The image streams are the {op-system-first}-based {product-title} image streams pointing to images on `registry.redhat.io`. Similarly, the templates are those categorized as {product-title} templates.
 
-The Cluster Samples Operator deployment is contained within the `openshift-cluster-samples-operator` namespace. On start up, the install pull secret is used by the imagestream import logic in the internal registry and API server to authenticate with `registry.redhat.io`. An administrator can create any additional secrets in the `openshift` namespace if they change the registry used for the sample imagestreams. If created, those secrets contain the content of a Docker `config.json` needed to facilitate image import.
+The Cluster Samples Operator deployment is contained within the `openshift-cluster-samples-operator` namespace. On start up, the install pull secret is used by the image stream import logic in the internal registry and API server to authenticate with `registry.redhat.io`. An administrator can create any additional secrets in the `openshift` namespace if they change the registry used for the sample image streams. If created, those secrets contain the content of a `config.json` for `docker` needed to facilitate image import.
 
-The image for the Cluster Samples Operator contains imagestream and template definitions for the associated {product-title} release. After the Cluster Samples Operator creates a sample, it adds an annotation that denotes the {product-title} version that it is compatible with. The Operator uses this annotation to ensure that each sample matches it's release version. Samples outside of its inventory are ignored, as are skipped samples. Modifications to any samples that are managed by the Operator are allowed as long as the version annotation is not modified or deleted.  However, on an upgrade, as the version annotation will change, those modifications can get replaced as the sample will be updated with the newer version. The Jenkins images are part of the image payload from the installation and are tagged into the imagestreams directly.
+The image for the Cluster Samples Operator contains image stream and template definitions for the associated {product-title} release. After the Cluster Samples Operator creates a sample, it adds an annotation that denotes the {product-title} version that it is compatible with. The Operator uses this annotation to ensure that each sample matches the compatible release version. Samples outside of its inventory are ignored, as are skipped samples.
+
+Modifications to any samples that are managed by the Operator are allowed as long as the version annotation is not modified or deleted. However, on an upgrade, as the version annotation will change, those modifications can get replaced as the sample will be updated with the newer version. The Jenkins images are part of the image payload from the installation and are tagged into the image streams directly.
 
 The samples resource includes a finalizer, which cleans up the following upon its deletion:
 
-* Operator-managed imagestreams
+* Operator-managed image streams
 * Operator-managed templates
 * Operator-generated configuration resources
 * Cluster status resources

--- a/modules/cluster-storage-operator.adoc
+++ b/modules/cluster-storage-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Cluster Storage Operator sets {product-title} cluster-wide storage defaults.
-It ensures a default storage class exists for {product-title} clusters.
+The Cluster Storage Operator sets {product-title} cluster-wide storage defaults. It ensures a default storage class exists for {product-title} clusters.
 
 [discrete]
 == Project
@@ -25,5 +24,4 @@ No configuration is required.
 == Notes
 
 * The Cluster Storage Operator supports Amazon Web Services (AWS) and {rh-openstack-first}.
-* The created storage class can be made non-default by editing its annotation, but
-the storage class cannot be deleted as long as the Operator runs.
+* The created storage class can be made non-default by editing its annotation, but the storage class cannot be deleted as long as the Operator runs.

--- a/modules/etcd-operator.adoc
+++ b/modules/etcd-operator.adoc
@@ -9,7 +9,6 @@
 == Purpose
 
 The etcd cluster Operator automates etcd cluster scaling, enables etcd monitoring and metrics, and simplifies disaster recovery procedures.
-
 [discrete]
 == Project
 
@@ -18,14 +17,15 @@ link:https://github.com/openshift/cluster-etcd-operator/[cluster-etcd-operator]
 [discrete]
 == CRDs
 
-* etcds.operator.openshift.io
+* `etcds.operator.openshift.io`
 ** Scope: Cluster
-** CR: etcd
+** CR: `etcd`
 ** Validation: Yes
 
 [discrete]
 == Configuration objects
 
+[source,terminal]
 ----
 $ oc edit etcd cluster
 ----

--- a/modules/ingress-operator.adoc
+++ b/modules/ingress-operator.adoc
@@ -18,17 +18,17 @@ link:https://github.com/openshift/cluster-ingress-operator[openshift-ingress-ope
 [discrete]
 == CRDs
 
-* clusteringresses.ingress.openshift.io
+* `clusteringresses.ingress.openshift.io`
 ** Scope: Namespaced
-** CR: clusteringresses
+** CR: `clusteringresses`
 ** Validation: No
 
 [discrete]
 == Configuration objects
 
 * Cluster config
-** Type Name: clusteringresses.ingress.openshift.io
-** Instance Name: default
+** Type Name: `clusteringresses.ingress.openshift.io`
+** Instance Name: `default`
 ** View Command:
 +
 [source,terminal]
@@ -39,21 +39,16 @@ $ oc get clusteringresses.ingress.openshift.io -n openshift-ingress-operator def
 [discrete]
 == Notes
 
-The Ingress Operator sets up the router in the `openshift-ingress` project and
-creates the deployment for the router:
+The Ingress Operator sets up the router in the `openshift-ingress` project and creates the deployment for the router:
 
 [source,terminal]
 ----
 $ oc get deployment -n openshift-ingress
 ----
 
-The Ingress Operator uses the `clusterNetwork[].cidr` from the network/cluster
-status to determine what mode (IPv4, IPv6, or dual stack) the managed ingress
-controller (router) should operate in. For example, if `clusterNetwork` contains
-only a v6 `cidr`, then the ingress controller will operate in v6-only mode. In
-the following example, ingress controllers managed by the Ingress Operator will
-run in v4-only mode because only one cluster network exists and the network is a
-v4 `cidr`:
+The Ingress Operator uses the `clusterNetwork[].cidr` from the `network/cluster` status to determine what mode (IPv4, IPv6, or dual stack) the managed ingress controller (router) should operate in. For example, if `clusterNetwork` contains only a v6 `cidr`, then the ingress controller operate in IPv6-only mode.
+
+In the following example, ingress controllers managed by the Ingress Operator will run in IPv4-only mode because only one cluster network exists and the network is an IPv4 `cidr`:
 
 [source,terminal]
 ----

--- a/modules/kube-apiserver-operator.adoc
+++ b/modules/kube-apiserver-operator.adoc
@@ -8,10 +8,7 @@
 [discrete]
 == Purpose
 
-The Kubernetes API Server Operator manages and updates the Kubernetes API server
-deployed on top of {product-title}. The Operator is based on the OpenShift
-library-go framework and it is installed using the Cluster Version Operator
-(CVO).
+The Kubernetes API Server Operator manages and updates the Kubernetes API server deployed on top of {product-title}. The Operator is based on the OpenShift library-go framework and it is installed using the Cluster Version Operator (CVO).
 
 [discrete]
 == Project
@@ -21,9 +18,9 @@ link:https://github.com/openshift/cluster-kube-apiserver-operator[openshift-kube
 [discrete]
 == CRDs
 
-* kubeapiservers.operator.openshift.io
+* `kubeapiservers.operator.openshift.io`
 ** Scope: Cluser
-** CR: kubeapiserver
+** CR: `kubeapiserver`
 ** Validation: Yes
 
 [discrete]

--- a/modules/kube-controller-manager-operator.adoc
+++ b/modules/kube-controller-manager-operator.adoc
@@ -8,10 +8,7 @@
 [discrete]
 == Purpose
 
-The Kubernetes Controller Manager Operator manages and updates the Kubernetes
-Controller Manager deployed on top of {product-title}. The Operator is based on
-OpenShift library-go framework and it is installed via the Cluster Version
-Operator (CVO).
+The Kubernetes Controller Manager Operator manages and updates the Kubernetes Controller Manager deployed on top of {product-title}. The Operator is based on OpenShift `library-go` framework and it is installed via the Cluster Version Operator (CVO).
 
 It contains the following components:
 
@@ -20,7 +17,7 @@ It contains the following components:
 * Installer based on static pods
 * Configuration observer
 
-By default, the Operator exposes Prometheus metrics through the metrics service.
+By default, the Operator exposes Prometheus metrics through the `metrics` service.
 
 [discrete]
 == Project

--- a/modules/machine-api-operator.adoc
+++ b/modules/machine-api-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Machine API Operator manages the lifecycle of specific purpose CRDs,
-controllers, and RBAC objects that extend the Kubernetes API. This declares the desired state of machines in a cluster.
+The Machine API Operator manages the lifecycle of specific purpose custom resource definitions (CRD), controllers, and RBAC objects that extend the Kubernetes API. This declares the desired state of machines in a cluster.
 
 [discrete]
 == Project

--- a/modules/machine-config-operator.adoc
+++ b/modules/machine-config-operator.adoc
@@ -9,21 +9,14 @@
 [discrete]
 == Purpose
 
-The Machine Config Operator manages and applies configuration and updates of the
-base operating system and container runtime, including everything between the
-kernel and kubelet.
+The Machine Config Operator manages and applies configuration and updates of the base operating system and container runtime, including everything between the kernel and kubelet.
 
 There are four components:
 
-* machine-config-server: Provides Ignition configuration to new machines joining the cluster.
-* machine-config-controller: Coordinates the upgrade of machines to the desired
-configurations defined by a `MachineConfig` object. Options are provided to
-control the upgrade for sets of machines individually.
-* machine-config-daemon: Applies new machine configuration during update.
-Validates and verifies the machine's state to the requested machine
-configuration.
-* machine-config: Provides a complete source of machine configuration at
-installation, first start up, and updates for a machine.
+* `machine-config-server`: Provides Ignition configuration to new machines joining the cluster.
+* `machine-config-controller`: Coordinates the upgrade of machines to the desired configurations defined by a `MachineConfig` object. Options are provided to control the upgrade for sets of machines individually.
+* `machine-config-daemon`: Applies new machine configuration during update. Validates and verifies the state of the machine to the requested machine configuration.
+* `machine-config`: Provides a complete source of machine configuration at installation, first start up, and updates for a machine.
 
 [discrete]
 == Project

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -22,22 +22,13 @@ ifdef::operators[]
 [discrete]
 == Purpose
 endif::operators[]
-The Node Tuning Operator helps you manage node-level tuning by orchestrating the
-Tuned daemon. The majority of high-performance applications require some level
-of kernel tuning. The Node Tuning Operator provides a unified management
-interface to users of node-level sysctls and more flexibility to add custom
-tuning specified by user needs. The Operator manages the containerized Tuned
-daemon for {product-title} as a Kubernetes daemon set. It ensures the custom
-tuning specification is passed to all containerized Tuned daemons running in the
-cluster in the format that the daemons understand. The daemons run on all nodes
-in the cluster, one per node.
+The Node Tuning Operator helps you manage node-level tuning by orchestrating the Tuned daemon. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
 
-Node-level settings applied by the containerized Tuned daemon are rolled back on
-an event that triggers a profile change or when the containerized Tuned daemon
-is terminated gracefully by receiving and handling a termination signal.
+The Operator manages the containerized Tuned daemon for {product-title} as a Kubernetes daemon set. It ensures the custom tuning specification is passed to all containerized Tuned daemons running in the cluster in the format that the daemons understand. The daemons run on all nodes in the cluster, one per node.
 
-The Node Tuning Operator is part of a standard {product-title} installation in
-version 4.1 and later.
+Node-level settings applied by the containerized Tuned daemon are rolled back on an event that triggers a profile change or when the containerized Tuned daemon is terminated gracefully by receiving and handling a termination signal.
+
+The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
 ifdef::operators[]
 [discrete]
 == Project

--- a/modules/openshift-apiserver-operator.adoc
+++ b/modules/openshift-apiserver-operator.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The OpenShift API Server Operator installs and maintains the
-`openshift-apiserver` on a cluster.
+The OpenShift API Server Operator installs and maintains the `openshift-apiserver` on a cluster.
 
 [discrete]
 == Project
@@ -19,7 +18,7 @@ link:https://github.com/openshift/cluster-openshift-apiserver-operator[openshift
 [discrete]
 == CRDs
 
-* openshiftapiservers.operator.openshift.io
+* `openshiftapiservers.operator.openshift.io`
 ** Scope: Cluster
-** CR: openshiftapiserver
+** CR: `openshiftapiserver`
 ** Validation: Yes

--- a/modules/operator-marketplace.adoc
+++ b/modules/operator-marketplace.adoc
@@ -8,8 +8,7 @@
 [discrete]
 == Purpose
 
-The Marketplace Operator is a conduit to bring off-cluster Operators to your
-cluster.
+The Marketplace Operator is a conduit to bring off-cluster Operators to your cluster.
 
 [discrete]
 == Project

--- a/modules/prometheus-operator.adoc
+++ b/modules/prometheus-operator.adoc
@@ -8,20 +8,15 @@
 [discrete]
 == Purpose
 
-The Prometheus Operator for Kubernetes provides easy monitoring definitions for
-Kubernetes services and deployment and management of Prometheus instances.
+The Prometheus Operator for Kubernetes provides easy monitoring definitions for Kubernetes services and deployment and management of Prometheus instances.
 
 Once installed, the Prometheus Operator provides the following features:
 
-* Create and Destroy: Easily launch a Prometheus instance for your Kubernetes
-namespace, a specific application or team easily using the Operator.
+* Create and Destroy: Easily launch a Prometheus instance for your Kubernetes namespace, a specific application or team easily using the Operator.
 
-* Simple Configuration: Configure the fundamentals of Prometheus like versions,
-persistence, retention policies, and replicas from a native Kubernetes resource.
+* Simple Configuration: Configure the fundamentals of Prometheus like versions, persistence, retention policies, and replicas from a native Kubernetes resource.
 
-* Target Services via Labels: Automatically generate monitoring target
-configurations based on familiar Kubernetes label queries; no need to learn a
-Prometheus specific configuration language.
+* Target Services via Labels: Automatically generate monitoring target configurations based on familiar Kubernetes label queries; no need to learn a Prometheus specific configuration language.
 
 [discrete]
 == Project


### PR DESCRIPTION
Completes the work started in https://github.com/openshift/openshift-docs/pull/27667.

Preview (internal): http://file.rdu.redhat.com/~adellape/121020/op_ref_api/operators/operator-reference.html