### PR TITLE
CNV-5260 Modified node maintenance procedure for CLI

### DIFF
--- a/modules/virt-resuming-node-maintenance-cli.adoc
+++ b/modules/virt-resuming-node-maintenance-cli.adoc
@@ -5,43 +5,13 @@
 [id="virt-resuming-node-maintenance-cli_{context}"]
 = Resuming a node from maintenance mode in the CLI
 
-Resume a node from maintenance mode and make it schedulable again by deleting
-the `NodeMaintenance` object for the node.
+Resume a node from maintenance mode by making it schedulable again.
 
 .Procedure
 
-. Find the `NodeMaintenance` object:
+* Mark the node as schedulable. You can then resume scheduling new workloads on the node.
 +
 [source,terminal]
 ----
-$ oc get nodemaintenance
-----
-
-. Optional: Insepct the `NodeMaintenance` object to ensure it is associated with the correct node:
-+
-[source,terminal]
-----
-$ oc describe nodemaintenance <node02-maintenance>
-----
-+
-.Example output
-[source,yaml]
-----
-Name:         node02-maintenance
-Namespace:
-Labels:
-Annotations:
-API Version:  nodemaintenance.kubevirt.io/v1beta1
-Kind:         NodeMaintenance
-...
-Spec:
-  Node Name:  node02
-  Reason:     Replacing node02
-----
-
-. Delete the `NodeMaintenance` object:
-+
-[source,terminal]
-----
-$ oc delete nodemaintenance <node02-maintenance>
+$ oc adm uncordon <node1>
 ----

--- a/modules/virt-setting-node-maintenance-cli.adoc
+++ b/modules/virt-setting-node-maintenance-cli.adoc
@@ -5,34 +5,26 @@
 [id="virt-setting-node-maintenance-cli_{context}"]
 = Setting a node to maintenance mode in the CLI
 
-Set a node to maintenance mode by creating a `NodeMaintenance` custom resource
-(CR) object that references the node name and the reason for setting it to
-maintenance mode.
+Set a node to maintenance mode by marking it as unschedulable and using the `oc adm drain` command to evict or delete pods from the node.
 
 .Procedure
 
-. Create the node maintenance CR configuration. This example uses a CR that is
-called `node02-maintenance.yaml`:
-+
-[source,yaml]
-----
-apiVersion: nodemaintenance.kubevirt.io/v1beta1
-kind: NodeMaintenance
-metadata:
-  name: node02-maintenance
-spec:
-  nodeName: node02
-  reason: "Replacing node02"
-----
-
-. Create the `NodeMaintenance` object in the cluster:
+. Mark the node as unschedulable. The node status changes to `NotReady,SchedulingDisabled`.
 +
 [source,terminal]
 ----
-$ oc apply -f <node02-maintenance.yaml>
+$ oc adm cordon <node1>
 ----
 
-The node live migrates virtual machine instances that have the
-`LiveMigration` eviction strategy, and taint the node so that it is no longer
-schedulable. All other pods and virtual machines on the node are deleted and
-recreated on another node.
+. Drain the node in preparation for maintenance. The node live migrates virtual machine instances that have the `LiveMigratable` condition set to `True` and the `spec:evictionStrategy` field set to `LiveMigrate`. All other pods and virtual machines on the node are deleted and recreated on another node.
++
+[source,terminal]
+----
+$ oc adm drain <node1> --delete-local-data --ignore-daemonsets=true --force
+----
+
+* The `--delete-local-data` flag removes any virtual machine instances on the node that use `emptyDir` volumes. Data in these volumes is ephemeral and is safe to be deleted after termination.
+
+* The `--ignore-daemonsets=true` flag ensures that daemon sets are ignored and pod eviction can continue successfully.
+
+* The `--force` flag is required to delete pods that are not managed by a replica set or daemon set controller.


### PR DESCRIPTION
The changes in this PR address https://issues.redhat.com/browse/CNV-5260

Modified the node maintenance CLI modules. Removed content related to the `NodeMaintenance` CR as it is no longer valid. Added steps to use the `oc adm cordon` and `oc adm drain` commands to evacuate pods before node maintenance.

Preview builds: 
[Setting a node to maintenance mode in the CLI](https://cnv-5260--ocpdocs.netlify.app/openshift-enterprise/latest/virt/node_maintenance/virt-setting-node-maintenance.html#virt-setting-node-maintenance-cli_virt-setting-node-maintenance)
[Resuming a node from maintenance mode in the CLI](https://cnv-5260--ocpdocs.netlify.app/openshift-enterprise/latest/virt/node_maintenance/virt-resuming-node.html#virt-resuming-node-maintenance-cli_virt-resuming-node)

Applies to branch/enterprise-4.7

SME review requested from Stu Gott (tagged in Jira)
QE review requested from Kedar Bidarkar (tagged in Jira)