### PR TITLE
API terminology and formatting updates for the 4.7 Release Notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -5,56 +5,32 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat {product-title} provides developers and IT organizations with a hybrid
-cloud application platform for deploying both new and existing applications on
-secure, scalable resources with minimal configuration and management overhead.
-{product-title} supports a wide selection of programming languages and
-frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
+Red Hat {product-title} provides developers and IT organizations with a hybrid cloud application platform for deploying both new and existing applications on secure, scalable resources with minimal configuration and management overhead. {product-title} supports a wide selection of programming languages and frameworks, such as Java, JavaScript, Python, Ruby, and PHP.
 
-Built on Red Hat Enterprise Linux and Kubernetes, {product-title}
-provides a more secure and scalable multi-tenant operating system for today's
-enterprise-class applications, while delivering integrated application runtimes
-and libraries. {product-title} enables organizations to meet security, privacy,
-compliance, and governance requirements.
+Built on {op-system-base-full} and Kubernetes, {product-title} provides a more secure and scalable multi-tenant operating system for today's enterprise-class applications, while delivering integrated application runtimes and libraries. {product-title} enables organizations to meet security, privacy, compliance, and governance requirements.
 
 [id="ocp-4-7-about-this-release"]
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-(link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234]) is now
-available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.19] with CRI-O runtime. New features, changes, and known issues that pertain to
-{product-title} {product-version} are included in this topic.
+(link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.19] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-//Red Hat did not publicly release {product-title} 4.6.0 as the GA version and,
-//instead, is releasing {product-title} 4.6.1 as the GA version.
+//Red Hat did not publicly release {product-title} 4.6.0 as the GA version and, instead, is releasing {product-title} 4.6.1 as the GA version.
 
-{product-title} {product-version} clusters are available at
-https://cloud.redhat.com/openshift. The {cloud-redhat-com}
-application for {product-title} allows you to deploy OpenShift clusters to
-either on-premise or cloud environments.
+{product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
-{product-title} {product-version} is supported on Red Hat Enterprise Linux 7.7 or
-later, as well as {op-system-first} 4.6.
+{product-title} {product-version} is supported on {op-system-base-full} 7.7 or later, as well as {op-system-first} 4.6.
 
-You must use {op-system} machines for the control plane, which are also known as master machines, and
-you can use either {op-system} or Red Hat Enterprise Linux 7.7 or later for
-compute machines, which are also known as worker machines.
+You must use {op-system} machines for the control plane, which are also known as master machines, and you can use either {op-system} or {op-system-base-full} 7.7 or later for compute machines, which are also known as worker machines.
 
 [IMPORTANT]
 ====
-Because only Red Hat Enterprise Linux version 7.7 or later is supported for compute
-machines, you must not upgrade the Red Hat Enterprise Linux compute machines to
-version 8.
+Because only {op-system-base-full} version 7.7 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to version 8.
 ====
 
-//{product-title} 4.6 is an Extended Update Support (EUS) release. More
-//information on Red Hat OpenShift EUS is available in
-//link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle]
-//and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
+//{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-With the release of {product-title} 4.7, version 4.4 is now end of life. For
-more information, see the
-link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+With the release of {product-title} 4.7, version 4.4 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [id="ocp-4-7-new-features-and-enhancements"]
 == New features and enhancements
@@ -143,12 +119,7 @@ For more information, see xref:../nodes/pods/nodes-pods-priority.html#non-preemp
 
 Some features available in previous releases have been deprecated or removed.
 
-Deprecated functionality is still included in {product-title} and continues to
-be supported; however, it will be removed in a future release of this product
-and is not recommended for new deployments. For the most recent list of major
-functionality deprecated and removed within {product-title} {product-version},
-refer to the table below. Additional details for more fine-grained functionality
-that has been deprecated and removed are listed after the table.
+Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {product-title} {product-version}, refer to the table below. Additional details for more fine-grained functionality that has been deprecated and removed are listed after the table.
 
 In the table, features are marked with the following statuses:
 
@@ -161,7 +132,7 @@ In the table, features are marked with the following statuses:
 |====
 |Feature |OCP 4.5 |OCP 4.6 |OCP 4.7
 
-|OperatorSources
+|`OperatorSource` objects
 |DEP
 |REM
 |REM
@@ -211,12 +182,9 @@ In the table, features are marked with the following statuses:
 [id="ocp-4-7-technology-preview"]
 == Technology Preview features
 
-Some features in this release are currently in Technology Preview. These
-experimental features are not intended for production use. Note the
-following scope of support on the Red Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
 
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview
-Features Support Scope]
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
 In the table below, features are marked with the following statuses:
 
@@ -361,7 +329,7 @@ If you are a cluster administrator for a cluster that has been upgraded from {pr
 +
 [WARNING]
 ====
-If you have applications that rely on unauthenticated access, they might receive HTTP 403 errors if you revoke unauthenticated access.
+If you have applications that rely on unauthenticated access, they might receive HTTP `403` errors if you revoke unauthenticated access.
 ====
 +
 Use the following script to revoke unauthenticated access to discovery endpoints:
@@ -393,37 +361,20 @@ This script removes unauthenticated subjects from the following cluster role bin
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} 4.7 are released
-as asynchronous errata through the Red Hat Network. All {product-title} 4.7
-errata is https://access.redhat.com/downloads/content/290/[available on the Red
-Hat Customer Portal]. See the
-https://access.redhat.com/support/policy/updates/openshift[{product-title}
-Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} 4.7 are released as asynchronous errata through the Red Hat Network. All {product-title} 4.7 errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
-Red Hat Customer Portal users can enable errata notifications in the account
-settings for Red Hat Subscription Management (RHSM). When errata notifications
-are enabled, users are notified via email whenever new errata relevant to their
-registered systems are released.
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
 
 [NOTE]
 ====
-Red Hat Customer Portal user accounts must have systems registered and consuming
-{product-title} entitlements for {product-title} errata notification
-emails to generate.
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
-This section will continue to be updated over time to provide notes on
-enhancements and bug fixes for future asynchronous errata releases of
-{product-title} 4.7. Versioned asynchronous releases, for example with the form
-{product-title} 4.7.z, will be detailed in subsections. In addition, releases
-in which the errata text cannot fit in the space provided by the advisory will
-be detailed in subsections that follow.
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} 4.7. Versioned asynchronous releases, for example with the form {product-title} 4.7.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
 
 [IMPORTANT]
 ====
-For any {product-title} release, always review the instructions on
-xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster]
-properly.
+For any {product-title} release, always review the instructions on xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster] properly.
 ====
 
 [id="ocp-4-7-0-ga"]
@@ -431,14 +382,8 @@ properly.
 
 Issued: 2021-xx-xx
 
-{product-title} release 4.7 is now available. The list of container images and
-bug fixes includes in the update are documented in the
-link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234] advisory.
-The RPM packages included in the update are provided by the
-link:https://access.redhat.com/errata/RHBA-2020:5678[RHBA-2020:5678] advisory.
+{product-title} release 4.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:5678[RHBA-2020:5678] advisory.
 
-Space precluded documenting all of the container images for this release in the
-advisory. See the following article for notes on the container images in this
-release:
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/<ARTICLE_ID>[{product-title} 4.7.0 container image list]


### PR DESCRIPTION
API terminology and formatting updates for the 4.7 Release Notes. Not many API concerns, but undid hard wraps and also replaced some instances of "Red Hat Enterprise Linux" and "RHEL" with their respective attributes.

Preview: https://terms-form-update-rns-4_7--ocpdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html