### PR TITLE
[enterprise-4.5] Update Operator modules for API object & unwrap changes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -881,7 +881,7 @@ Topics:
       File: olm-workflow
     - Name: Dependency resolution
       File: olm-understanding-dependency-resolution
-    - Name: OperatorGroups
+    - Name: Operator groups
       File: olm-understanding-operatorgroups
     - Name: Metrics
       File: olm-understanding-metrics
@@ -946,7 +946,7 @@ Topics:
     File: osdk-ansible
   - Name: Creating Helm-based Operators
     File: osdk-helm
-  - Name: Generating a ClusterServiceVersion (CSV)
+  - Name: Generating a cluster service version (CSV)
     File: osdk-generating-csvs
   - Name: Working with bundle images
     File: osdk-working-bundle-images

--- a/modules/building-memcached-operator-using-osdk.adoc
+++ b/modules/building-memcached-operator-using-osdk.adoc
@@ -5,14 +5,9 @@
 [id="building-memcached-operator-using-osdk_{context}"]
 = Building a Go-based Operator using the Operator SDK
 
-The Operator SDK makes it easier to build Kubernetes native applications, a
-process that can require deep, application-specific operational knowledge. The
-SDK not only lowers that barrier, but it also helps reduce the amount of
-boilerplate code needed for many common management capabilities, such as
-metering or monitoring.
+The Operator SDK makes it easier to build Kubernetes native applications, a process that can require deep, application-specific operational knowledge. The SDK not only lowers that barrier, but it also helps reduce the amount of boilerplate code needed for many common management capabilities, such as metering or monitoring.
 
-This procedure walks through an example of building a simple Memcached Operator
-using tools and libraries provided by the SDK.
+This procedure walks through an example of building a simple Memcached Operator using tools and libraries provided by the SDK.
 
 .Prerequisites
 
@@ -48,10 +43,9 @@ $ operator-sdk new memcached-operator
 $ cd memcached-operator
 ----
 
-. *Add a new Custom Resource Definition (CRD).*
+. *Add a new custom resource definition (CRD).*
 
-.. Use the CLI to add a new CRD API called `Memcached`, with `APIVersion` set to
-`cache.example.com/v1apha1` and `Kind` set to `Memcached`:
+.. Use the CLI to add a new CRD API called `Memcached`, with `APIVersion` set to `cache.example.com/v1apha1` and `Kind` set to `Memcached`:
 +
 [source,terminal]
 ----
@@ -62,8 +56,7 @@ $ operator-sdk add api \
 +
 This scaffolds the Memcached resource API under `pkg/apis/cache/v1alpha1/`.
 
-.. Modify the spec and status of the `Memcached` Custom Resource (CR) at the
-`pkg/apis/cache/v1alpha1/memcached_types.go` file:
+.. Modify the spec and status of the `Memcached` custom resource (CR) at the `pkg/apis/cache/v1alpha1/memcached_types.go` file:
 +
 [source,go]
 ----
@@ -77,8 +70,7 @@ type MemcachedStatus struct {
 }
 ----
 
-.. After modifying the `*_types.go` file, always run the following command to
-update the generated code for that resource type:
+.. After modifying the `*_types.go` file, always run the following command to update the generated code for that resource type:
 +
 [source,terminal]
 ----
@@ -87,21 +79,11 @@ $ operator-sdk generate k8s
 
 . *Optional: Add custom validation to your CRD.*
 +
-OpenAPI v3.0 schemas are added to CRD manifests in the `spec.validation` block when
-the manifests are generated. This validation block allows Kubernetes to validate
-the properties in a Memcached CR when it is created or updated.
+OpenAPI v3.0 schemas are added to CRD manifests in the `spec.validation` block when the manifests are generated. This validation block allows Kubernetes to validate the properties in a Memcached CR when it is created or updated.
 +
-Additionally, a `pkg/apis/<group>/<version>/zz_generated.openapi.go` file is
-generated. This file contains the Go representation of this validation block if
-the `+k8s:openapi-gen=true annotation` is present above the `Kind` type
-declaration, which is present by default. This auto-generated code is your Go
-`Kind` type's OpenAPI model, from which you can create a full OpenAPI
-Specification and generate a client.
+Additionally, a `pkg/apis/<group>/<version>/zz_generated.openapi.go` file is generated. This file contains the Go representation of this validation block if the `+k8s:openapi-gen=true annotation` is present above the `Kind` type declaration, which is present by default. This auto-generated code is the OpenAPI model of your Go `Kind` type, from which you can create a full OpenAPI Specification and generate a client.
 +
-As an Operator author, you can use Kubebuilder markers (annotations) to
-configure custom validations for your API. These markers must always have a
-`+kubebuilder:validation` prefix. For example, adding an enum-type specification
-can be done by adding the following marker:
+As an Operator author, you can use Kubebuilder markers (annotations) to configure custom validations for your API. These markers must always have a `+kubebuilder:validation` prefix. For example, adding an enum-type specification can be done by adding the following marker:
 +
 [source,go]
 ----
@@ -109,17 +91,9 @@ can be done by adding the following marker:
 type Alias string
 ----
 +
-Usage of markers in API code is discussed in the Kubebuilder
-link:https://book.kubebuilder.io/reference/generating-crd.html[Generating CRDs]
-and link:https://book.kubebuilder.io/reference/markers.html[Markers for Config/Code Generation]
-documentation. A full list of OpenAPIv3 validation markers is also available in
-the Kubebuilder
-link:https://book.kubebuilder.io/reference/markers/crd-validation.html[CRD Validation]
-documentation.
+Usage of markers in API code is discussed in the Kubebuilder link:https://book.kubebuilder.io/reference/generating-crd.html[Generating CRDs] and link:https://book.kubebuilder.io/reference/markers.html[Markers for Config/Code Generation] documentation. A full list of OpenAPIv3 validation markers is also available in the Kubebuilder link:https://book.kubebuilder.io/reference/markers/crd-validation.html[CRD Validation] documentation.
 +
-If you add any custom validations, run the following command to update the
-OpenAPI validation section in the CRD's
-`deploy/crds/cache.example.com_memcacheds_crd.yaml` file:
+If you add any custom validations, run the following command to update the OpenAPI validation section in the `deploy/crds/cache.example.com_memcacheds_crd.yaml` file for the CRD:
 +
 [source,terminal]
 ----
@@ -140,10 +114,9 @@ spec:
               type: integer
 ----
 
-. *Add a new Controller.*
+. *Add a new controller.*
 
-.. Add a new Controller to the project to watch and reconcile the Memcached
-resource:
+.. Add a new controller to the project to watch and reconcile the `Memcached` resource:
 +
 [source,terminal]
 ----
@@ -152,33 +125,23 @@ $ operator-sdk add controller \
     --kind=Memcached
 ----
 +
-This scaffolds a new Controller implementation under
-`pkg/controller/memcached/`.
+This scaffolds a new controller implementation under `pkg/controller/memcached/`.
 
-.. For this example, replace the generated controller file
-`pkg/controller/memcached/memcached_controller.go` with the
-link:https://github.com/operator-framework/operator-sdk/blob/master/example/memcached-operator/memcached_controller.go.tmpl[example implementation].
+.. For this example, replace the generated controller file `pkg/controller/memcached/memcached_controller.go` with the link:https://github.com/operator-framework/operator-sdk/blob/master/example/memcached-operator/memcached_controller.go.tmpl[example implementation].
 +
-The example controller executes the following reconciliation logic for each
-`Memcached` CR:
+The example controller executes the following reconciliation logic for each `Memcached` resource:
 +
 --
-* Create a Memcached Deployment if it does not exist.
+* Create a Memcached deployment if it does not exist.
 * Ensure that the Deployment size is the same as specified by the `Memcached` CR spec.
-* Update the `Memcached` CR status with the names of the Memcached pods.
+* Update the `Memcached` resource status with the names of the Memcached pods.
 --
 +
-The next two sub-steps inspect how the Controller watches resources and how the
-reconcile loop is triggered. You can skip these steps
-to go directly to building and running the Operator.
+The next two sub-steps inspect how the controller watches resources and how the reconcile loop is triggered. You can skip these steps to go directly to building and running the Operator.
 
-.. Inspect the Controller implementation at the
-`pkg/controller/memcached/memcached_controller.go` file to see how the
-Controller watches resources.
+.. Inspect the controller implementation at the `pkg/controller/memcached/memcached_controller.go` file to see how the controller watches resources.
 +
-The first watch is for the Memcached type as the primary resource. For each Add,
-Update, or Delete event, the reconcile loop is sent a reconcile `Request` (a
-`<namespace>:<name>` key) for that Memcached object:
+The first watch is for the `Memcached` type as the primary resource. For each add, update, or delete event, the reconcile loop is sent a reconcile `Request` (a `<namespace>:<name>` key) for that `Memcached` object:
 +
 [source,go]
 ----
@@ -186,10 +149,7 @@ err := c.Watch(
   &source.Kind{Type: &cachev1alpha1.Memcached{}}, &handler.EnqueueRequestForObject{})
 ----
 +
-The next watch is for Deployments, but the event handler maps each event to a
-reconcile `Request` for the owner of the Deployment. In this case, this is the
-Memcached object for which the Deployment was created. This allows the
-controller to watch Deployments as a secondary resource:
+The next watch is for `Deployment` objects, but the event handler maps each event to a reconcile `Request` for the owner of the deployment. In this case, this is the `Memcached` object for which the deployment was created. This allows the controller to watch deployments as a secondary resource:
 +
 [source,go]
 ----
@@ -199,10 +159,7 @@ err := c.Watch(&source.Kind{Type: &appsv1.Deployment{}}, &handler.EnqueueRequest
 	})
 ----
 
-.. Every Controller has a Reconciler object with a `Reconcile()` method that
-implements the reconcile loop. The reconcile loop is passed the `Request`
-argument which is a `<namespace>:<name>` key used to lookup the primary resource
-object, Memcached, from the cache:
+.. Every controller has a `Reconciler` object with a `Reconcile()` method that implements the reconcile loop. The reconcile loop is passed the `Request` argument which is a `<namespace>:<name>` key used to lookup the primary resource object, `Memcached`, from the cache:
 +
 [source,go]
 ----
@@ -214,8 +171,7 @@ func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Res
 }
 ----
 +
-Based on the return value of `Reconcile()` the reconcile `Request` may be
-requeued and the loop may be triggered again:
+Based on the return value of the `Reconcile()` function, the reconcile `Request` might be requeued, and the loop might be triggered again:
 +
 [source,go]
 ----
@@ -230,8 +186,7 @@ return reconcile.Result{Requeue: true}, nil
 
 . *Build and run the Operator.*
 
-.. Before running the Operator, the CRD must be registered with the Kubernetes API
-server:
+.. Before running the Operator, the CRD must be registered with the Kubernetes API server:
 +
 [source,terminal]
 ----
@@ -248,7 +203,7 @@ $ oc create \
 +
 Choose one of the following methods.
 
-... _Option A:_ Running as a Deployment inside the cluster.
+... _Option A:_ Running as a deployment inside the cluster.
 
 .... Build the `memcached-operator` image and push it to a registry:
 +
@@ -257,18 +212,14 @@ Choose one of the following methods.
 $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
 ----
 
-.... The Deployment manifest is generated at `deploy/operator.yaml`. Update the
-Deployment image as follows since the default is just a placeholder:
+.... The deployment manifest is generated at `deploy/operator.yaml`. Update the deployment image as follows since the default is just a placeholder:
 +
 [source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
-.... Ensure you have an account on link:https://quay.io[Quay.io] for the next step,
-or substitute your preferred container registry. On the registry,
-link:https://quay.io/new/[create a new public image] repository named
-`memcached-operator`.
+.... Ensure you have an account on link:https://quay.io[Quay.io] for the next step, or substitute your preferred container registry. On the registry, link:https://quay.io/new/[create a new public image] repository named `memcached-operator`.
 
 .... Push the image to the registry:
 +
@@ -277,7 +228,7 @@ link:https://quay.io/new/[create a new public image] repository named
 $ podman push quay.io/example/memcached-operator:v0.0.1
 ----
 
-.... Setup RBAC and deploy `memcached-operator`:
+.... Set up RBAC and create the `memcached-operator` manifests:
 +
 [source,terminal]
 ----
@@ -299,7 +250,7 @@ $ oc create -f deploy/service_account.yaml
 $ oc create -f deploy/operator.yaml
 ----
 
-.... Verify that `memcached-operator` is up and running:
+.... Verify that the `memcached-operator` deploy is up and running:
 +
 [source,terminal]
 ----
@@ -317,22 +268,18 @@ memcached-operator       1         1         1            1           1m
 +
 This method is preferred during development cycle to deploy and test faster.
 +
-Run the Operator locally with the default Kubernetes configuration file present
-at `$HOME/.kube/config`:
+Run the Operator locally with the default Kubernetes configuration file present at `$HOME/.kube/config`:
 +
 [source,terminal]
 ----
 $ operator-sdk run --local --namespace=default
 ----
 +
-You can use a specific `kubeconfig` using the flag
-`--kubeconfig=<path/to/kubeconfig>`.
+You can use a specific `kubeconfig` using the flag `--kubeconfig=<path/to/kubeconfig>`.
 
-. *Verify that the Operator can deploy a Memcached application* by creating a
-Memcached CR.
+. *Verify that the Operator can deploy a Memcached application* by creating a `Memcached` CR.
 
-.. Create the example `Memcached` CR that was generated at
-`deploy/crds/cache_v1alpha1_memcached_cr.yaml`.
+.. Create the example `Memcached` CR that was generated at `deploy/crds/cache_v1alpha1_memcached_cr.yaml`.
 
 .. View the file:
 +
@@ -359,7 +306,7 @@ spec:
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
-.. Ensure that `memcached-operator` creates the Deployment for the CR:
+.. Ensure that `memcached-operator` creates the deployment for the CR:
 +
 [source,terminal]
 ----
@@ -374,8 +321,7 @@ memcached-operator       1         1         1            1           2m
 example-memcached        3         3         3            3           1m
 ----
 
-.. Check the pods and CR status to confirm the status is updated with the
-`memcached` pod names:
+.. Check the pods and CR to confirm the CR status is updated with the pod names:
 +
 [source,terminal]
 ----
@@ -420,8 +366,7 @@ status:
   - example-memcached-6fd7c98d8-m7vn7
 ----
 
-. *Verify that the Operator can manage a deployed Memcached application* by
-updating the size of the deployment.
+. *Verify that the Operator can manage a deployed Memcached application* by updating the size of the deployment.
 
 .. Change the `spec.size` field in the `memcached` CR from `3` to `4`:
 +
@@ -448,7 +393,7 @@ spec:
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
-.. Confirm that the Operator changes the Deployment size:
+.. Confirm that the Operator changes the deployment size:
 +
 [source,terminal]
 ----
@@ -496,5 +441,4 @@ $ oc delete -f deploy/service_account.yaml
 
 .Additional resources
 
-* For more information about OpenAPI v3.0 validation schemas in CRDs, refer to the
-link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema[Kubernetes documentation].
+* For more information about OpenAPI v3.0 validation schemas in CRDs, refer to the link:https://kubernetes.io/docs/tasks/access-kubernetes-api/custom-resources/custom-resource-definitions/#specifying-a-structural-schema[Kubernetes documentation].

--- a/modules/crd-creating-aggregated-cluster-roles.adoc
+++ b/modules/crd-creating-aggregated-cluster-roles.adoc
@@ -3,21 +3,13 @@
 // * operators/understanding/crds/extending-api-with-crds.adoc
 
 [id="crd-creating-aggregated-cluster-role_{context}"]
-= Creating cluster roles for Custom Resource Definitions
+= Creating cluster roles for custom resource definitions
 
-Cluster administrators can grant permissions to existing cluster-scoped Custom
-Resource Definitions (CRDs). If you use the `admin`, `edit`, and `view` default
-cluster roles, take advantage of cluster role aggregation for their rules.
+Cluster administrators can grant permissions to existing cluster-scoped custom resource definitions (CRDs). If you use the `admin`, `edit`, and `view` default cluster roles, you can take advantage of cluster role aggregation for their rules.
 
 [IMPORTANT]
 ====
-You must explicitly assign permissions to each of these roles. The roles with
-more permissions do not inherit rules from roles with fewer permissions. If you
-assign a rule to a role, you must also assign that verb to roles that have more
-permissions. For example, if you grant the `get crontabs` permission to the view
-role, you must also grant it to the `edit` and `admin` roles. The `admin` or
-`edit` role is usually assigned to the user that created a project through the
-project template.
+You must explicitly assign permissions to each of these roles. The roles with more permissions do not inherit rules from roles with fewer permissions. If you assign a rule to a role, you must also assign that verb to roles that have more permissions. For example, if you grant the `get crontabs` permission to the view role, you must also grant it to the `edit` and `admin` roles. The `admin` or `edit` role is usually assigned to the user that created a project through the project template.
 ====
 
 .Prerequisites
@@ -31,10 +23,7 @@ endif::[]
 
 .Procedure
 
-. Create a cluster role definition file for the CRD. The cluster role definition
-is a YAML file that contains the rules that apply to each cluster role. The
-{product-title} controller adds the rules that you specify to the default
-cluster roles.
+. Create a cluster role definition file for the CRD. The cluster role definition is a YAML file that contains the rules that apply to each cluster role. A {product-title} controller adds the rules that you specify to the default cluster roles.
 +
 .Example YAML file for a cluster role definition
 [source,yaml]
@@ -70,9 +59,7 @@ rules:
 <4> Specify this label to grant permissions to the edit default role.
 <5> Specify the group name of the CRD.
 <6> Specify the plural name of the CRD that these rules apply to.
-<7> Specify the verbs that represent the permissions that are granted to the role.
-For example, apply read and write permissions to the `admin` and `edit` roles
-and only read permission to the `view` role.
+<7> Specify the verbs that represent the permissions that are granted to the role. For example, apply read and write permissions to the `admin` and `edit` roles and only read permission to the `view` role.
 <8> Specify this label to grant permissions to the `view` default role.
 <9> Specify this label to grant permissions to the `cluster-reader` default role.
 

--- a/modules/crd-creating-crds.adoc
+++ b/modules/crd-creating-crds.adoc
@@ -3,10 +3,9 @@
 // * operators/understanding/crds/extending-api-with-crds.adoc
 
 [id="crd-creating-custom-resources-definition_{context}"]
-= Creating a Custom Resource Definition
+= Creating a custom resource definition
 
-To create Custom Resource (CR) objects, cluster administrators must first create
-a Custom Resource Definition (CRD).
+To create custom resource (CR) objects, cluster administrators must first create a custom resource definition (CRD).
 
 .Prerequisites
 
@@ -37,11 +36,10 @@ spec:
     - ct <9>
 ----
 <1> Use the `apiextensions.k8s.io/v1beta1` API.
-<2> Specify a name for the definition. This must be in the <plural-name>.<group> format using the values from the `group` and `plural` fields.
-<3> Specify a group name for the API. An API group is a collection of objects that are logically related. For example, all batch objects like `Job` or `ScheduledJob` could be in the batch API Group (such as batch.api.example.com). A good practice is to use a fully-qualified-domain name of your organization.
-<4> Specify a version name to be used in the URL. Each API Group can exist in multiple versions. For example: `v1alpha`, `v1beta`, `v1`.
-<5> Specify whether the custom objects are available to a project (`Namespaced`) or all projects
-in the cluster (`Cluster`).
+<2> Specify a name for the definition. This must be in the `<plural-name>.<group>` format using the values from the `group` and `plural` fields.
+<3> Specify a group name for the API. An API group is a collection of objects that are logically related. For example, all batch objects like `Job` or `ScheduledJob` could be in the batch API group (such as `batch.api.example.com`). A good practice is to use a fully-qualified-domain name (FQDN) of your organization.
+<4> Specify a version name to be used in the URL. Each API group can exist in multiple versions, for example `v1alpha`, `v1beta`, `v1`.
+<5> Specify whether the custom objects are available to a project (`Namespaced`) or all projects in the cluster (`Cluster`).
 <6> Specify the plural name to use in the URL. The `plural` field is the same as a resource in an API URL.
 <7> Specify a singular name to use as an alias on the CLI and for display.
 <8> Specify the kind of objects that can be created. The type can be in CamelCase.
@@ -73,5 +71,4 @@ For example, using the example file, the following endpoint is created:
 /apis/stable.example.com/v1/namespaces/*/crontabs/...
 ----
 +
-You can now use this endpoint URL to create and manage CRs. The object `Kind` is
-based on the `spec.kind` field of the CRD object you created.
+You can now use this endpoint URL to create and manage CRs. The object kind is based on the `spec.kind` field of the CRD object you created.

--- a/modules/crd-creating-custom-resources-from-file.adoc
+++ b/modules/crd-creating-custom-resources-from-file.adoc
@@ -7,11 +7,9 @@
 // * operators/understanding/crds/extending-api-with-crds.adoc
 
 [id="crd-creating-custom-resources-from-file_{context}"]
-= Creating Custom Resources from a file
+= Creating custom resources from a file
 
-After a Custom Resource Definition (CRD) has been added to the cluster, Custom
-Resources (CRs) can be created with the CLI from a file using the CR
-specification.
+After a custom resource definitions (CRD) has been added to the cluster, custom resources (CRs) can be created with the CLI from a file using the CR specification.
 
 .Prerequisites
 
@@ -24,9 +22,7 @@ endif::[]
 
 .Procedure
 
-. Create a YAML file for the CR. In the following example definition, the
-`cronSpec` and `image` custom fields are set in a CR of `Kind: CronTab`. The
-`Kind` comes from the `spec.kind` field of the CRD object.
+. Create a YAML file for the CR. In the following example definition, the `cronSpec` and `image` custom fields are set in a CR of `Kind: CronTab`. The `Kind` comes from the `spec.kind` field of the CRD object:
 +
 .Example YAML file for a CR
 [source,yaml]
@@ -42,13 +38,10 @@ spec: <5>
   image: my-awesome-cron-image
 ----
 +
-<1> Specify the group name and API version (name/version) from the Custom Resource Definition.
+<1> Specify the group name and API version (name/version) from the CRD.
 <2> Specify the type in the CRD.
 <3> Specify a name for the object.
-<4> Specify the
-link:https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#finalizers[finalizers]
-for the object, if any. Finalizers allow controllers to implement conditions
-that must be completed before the object can be deleted.
+<4> Specify the link:https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/#finalizers[finalizers] for the object, if any. Finalizers allow controllers to implement conditions that must be completed before the object can be deleted.
 <5> Specify conditions specific to the type of object.
 
 . After you create the file, create the object:

--- a/modules/crd-custom-resource-definitions.adoc
+++ b/modules/crd-custom-resource-definitions.adoc
@@ -4,45 +4,29 @@
 // * operators/understanding/crds/extending-api-with-crds.adoc
 
 [id="crd-custom-resource-definitions_{context}"]
-= Custom Resource Definitions
+= Custom resource definitions
 
-In the Kubernetes API, a resource is an endpoint that stores a collection of API
-objects of a certain kind. For example, the built-in Pods resource contains a
-collection of Pod objects.
+In the Kubernetes API, a _resource_ is an endpoint that stores a collection of API objects of a certain kind. For example, the built-in `Pods` resource contains a collection of `Pod` objects.
 
-A _Custom Resource Definition_ (CRD) object defines a new, unique object `Kind`
-in the cluster and lets the Kubernetes API server handle its entire lifecycle.
+A _custom resource definition_ (CRD) object defines a new, unique object type, called a _kind_, in the cluster and lets the Kubernetes API server handle its entire lifecycle.
 
-_Custom Resource_ (CR) objects are created from CRDs that have been added to
-the cluster by a cluster administrator, allowing all cluster users to add the
-new resource type into projects.
+_Custom resource_ (CR) objects are created from CRDs that have been added to the cluster by a cluster administrator, allowing all cluster users to add the new resource type into projects.
 
 ifeval::["{context}" == "crd-extending-api-with-crds"]
-When a cluster administrator adds a new CRD to the cluster, the Kubernetes API
-server reacts by creating a new RESTful resource path that can be accessed by
-the entire cluster or a single project (namespace) and begins serving the
-specified CR.
+When a cluster administrator adds a new CRD to the cluster, the Kubernetes API server reacts by creating a new RESTful resource path that can be accessed by the entire cluster or a single project (namespace) and begins serving the specified CR.
 
-Cluster administrators that want to grant access to the CRD to other users can
-use cluster role aggregation to grant access to users with the `admin`, `edit`,
-or `view` default cluster roles. Cluster role aggregation allows the insertion
-of custom policy rules into these cluster roles. This behavior integrates the
-new resource into the cluster's RBAC policy as if it was a built-in resource.
+Cluster administrators that want to grant access to the CRD to other users can use cluster role aggregation to grant access to users with the `admin`, `edit`, or `view` default cluster roles. Cluster role aggregation allows the insertion of custom policy rules into these cluster roles. This behavior integrates the new resource into the RBAC policy of the cluster as if it was a built-in resource.
 endif::[]
 
-Operators in particular make use of CRDs by packaging them with any required
-RBAC policy and other software-specific logic.
+Operators in particular make use of CRDs by packaging them with any required RBAC policy and other software-specific logic.
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-Cluster administrators can also add CRDs manually to the cluster outside of an
-Operator's lifecycle, making them available to all users.
+Cluster administrators can also add CRDs manually to the cluster outside of the lifecycle of an Operator, making them available to all users.
 
 [NOTE]
 ====
-While only cluster administrators can create CRDs, developers can create the CR
-from an existing CRD if they have read and write permission to it.
+While only cluster administrators can create CRDs, developers can create the CR from an existing CRD if they have read and write permission to it.
 ====
 endif::[]
 ifdef::openshift-dedicated[]
-{product-title} cluster administrators can manage RBAC to CRDs that have been
-added to customer project namespaces, making them available to authorized users.
+{product-title} cluster administrators can manage RBAC to CRDs that have been added to customer project namespaces, making them available to authorized users.
 endif::[]

--- a/modules/crd-inspecting-custom-resources.adoc
+++ b/modules/crd-inspecting-custom-resources.adoc
@@ -8,8 +8,7 @@
 [id="crd-inspecting-custom-resources_{context}"]
 = Inspecting custom resources
 
-You can inspect custom resource (CR) objects that exist in your cluster using
-the CLI.
+You can inspect custom resource (CR) objects that exist in your cluster using the CLI.
 
 .Prerequisites
 
@@ -17,7 +16,7 @@ the CLI.
 
 .Procedure
 
-. To get information on a specific `Kind` of a CR, run:
+. To get information on a specific kind of a CR, run:
 +
 [source,terminal]
 ----
@@ -38,8 +37,7 @@ NAME                 KIND
 my-new-cron-object   CronTab.v1.stable.example.com
 ----
 +
-Resource names are not case-sensitive, and you can use either the singular or
-plural forms defined in the CRD, as well as any short name. For example:
+Resource names are not case-sensitive, and you can use either the singular or plural forms defined in the CRD, as well as any short name. For example:
 +
 [source,terminal]
 ----

--- a/modules/managing-memcached-operator-using-olm.adoc
+++ b/modules/managing-memcached-operator-using-olm.adoc
@@ -5,33 +5,22 @@
 [id="managing-memcached-operator-using-olm_{context}"]
 = Managing a Go-based Operator using Operator Lifecycle Manager
 
-The previous section has covered manually running an Operator. In the next
-sections, we will explore using Operator Lifecycle Manager (OLM), which is what
-enables a more robust deployment model for Operators being run in production
-environments.
+The previous section has covered manually running an Operator. The next sections explore using Operator Lifecycle Manager (OLM), which is what enables a more robust deployment model for Operators being run in production environments.
 
-OLM helps you to install, update, and generally manage the lifecycle of all
-of the Operators (and their associated services) on a Kubernetes cluster. It
-runs as an Kubernetes extension and lets you use `oc` for all the lifecycle
-management functions without any additional tools.
+OLM helps you to install, update, and generally manage the lifecycle of all of the Operators and their associated services on a Kubernetes cluster. It runs as an Kubernetes extension and lets you use `oc` for all the lifecycle management functions without any additional tools.
 
 .Prerequisites
 
-- OLM installed on a Kubernetes-based cluster (v1.8 or above to support the
-`apps/v1beta2` API group), for example {product-title} {product-version}
-Preview OLM enabled
+- OLM installed on a Kubernetes-based cluster (v1.8 or above to support the `apps/v1beta2` API group), for example {product-title} {product-version}
 - Memcached Operator built
 
 .Procedure
 
 . *Generate an Operator manifest.*
 +
-An Operator manifest describes how to display, create, and manage the
-application, in this case Memcached, as a whole. It is defined by a
-`ClusterServiceVersion` (CSV) object and is required for OLM to function.
+An Operator manifest describes how to display, create, and manage the application, in this case Memcached, as a whole. It is defined by a `ClusterServiceVersion` (CSV) object and is required for OLM to function.
 +
-From the `memcached-operator/` directory that was created when you built the
-Memcached Operator, generate the CSV manifest:
+From the `memcached-operator/` directory that was created when you built the Memcached Operator, generate the CSV manifest:
 +
 [source,terminal]
 ----
@@ -40,14 +29,10 @@ $ operator-sdk generate csv --csv-version 0.0.1
 +
 [NOTE]
 ====
-See
-link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md[Building a CSV for the Operator Framework]
-for more information on manually defining a manifest file.
+See link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md[Building a CSV for the Operator Framework] for more information on manually defining a manifest file.
 ====
 
-. *Create an OperatorGroup* that specifies the namespaces that the Operator will
-target. Create the following OperatorGroup in the namespace where you will
-create the CSV. In this example, the `default` namespace is used:
+. *Create an Operator group* that specifies the namespaces that the Operator will target. Create the following Operator group in the namespace where you will create the CSV. In this example, the `default` namespace is used:
 +
 [source,yaml]
 ----
@@ -61,22 +46,18 @@ spec:
   - default
 ----
 
-. *Deploy the Operator.* Use the files that were generated into the `deploy/`
-directory by the Operator SDK when you built the Memcached Operator.
+. *Deploy the Operator.* Use the files that were generated into the `deploy/` directory by the Operator SDK when you built the Memcached Operator.
 
-.. Apply the Operator's CSV manifest to the specified namespace in the cluster:
+.. Apply the CSV manifest of the Operator to the specified namespace in the cluster:
 +
 [source,terminal]
 ----
 $ oc apply -f deploy/olm-catalog/memcached-operator/0.0.1/memcached-operator.v0.0.1.clusterserviceversion.yaml
 ----
 +
-When you apply this manifest, the cluster does not immediately update because
-it does not yet meet the requirements specified in the manifest.
+When you apply this manifest, the cluster does not immediately update because it does not yet meet the requirements specified in the manifest.
 
-.. Create the role, role binding, and service account to grant resource
-permissions to the Operator, and the Custom Resource Definition (CRD) to create
-the Memcached type that the Operator manages:
+.. Create the role, role binding, and service account to grant resource permissions to the Operator, and the custom resource definition (CRD) to create the `Memcached` custom resource that the Operator manages:
 +
 [source,terminal]
 ----
@@ -98,22 +79,13 @@ $ oc create -f deploy/role.yaml
 $ oc create -f deploy/role_binding.yaml
 ----
 +
-Because OLM creates Operators in a particular namespace when a manifest is
-applied, administrators can leverage the native Kubernetes RBAC permission model
-to restrict which users are allowed to install Operators.
+Because OLM creates Operators in a particular namespace when a manifest is applied, administrators can leverage the native Kubernetes RBAC permission model to restrict which users are allowed to install Operators.
 
 . *Create an application instance.*
 +
-The Memcached Operator is now running in the `default` namespace. Users
-interact with Operators via instances of `CustomResources`; in this case, the
-resource has the kind `Memcached`. Native Kubernetes RBAC also applies to
-`CustomResources`, providing administrators control over who can interact with
-each Operator.
+The Memcached Operator is now running in the `default` namespace. Users interact with Operators via instances of custom resources; in this case, the resource has the kind `Memcached`. Native Kubernetes RBAC also applies to custom resources, providing administrators control over who can interact with each Operator.
 +
-Creating instances of Memcached in this namespace will now trigger the Memcached
-Operator to instantiate pods running the memcached server that are managed by
-the Operator. The more `CustomResources` you create, the more unique instances
-of Memcached are managed by the Memcached Operator running in this namespace.
+Creating instances of `Memcached` objects in this namespace will now trigger the Memcached Operator to instantiate pods running the `memcached` server that are managed by the Operator. The more custom resources you create, the more unique Memcached application instances are managed by the Memcached Operator running in this namespace.
 +
 [source,terminal]
 ----

--- a/modules/olm-adding-new-crd-version.adoc
+++ b/modules/olm-adding-new-crd-version.adoc
@@ -11,8 +11,7 @@ To add a new version of a CRD:
 
 . Add a new entry in the CRD resource under the `versions` section.
 +
-For example, if the current CRD has one version `v1alpha1` and you want to add a
-new version `v1beta1` and mark it as the new storage version:
+For example, if the current CRD has a version `v1alpha1` and you want to add a new version `v1beta1` and mark it as the new storage version, add a new entry for `v1beta1`:
 +
 [source,yaml]
 ----
@@ -24,10 +23,9 @@ versions:
     served: true
     storage: true
 ----
-<1> Add a new entry for `v1beta1`.
+<1> New entry.
 
-. Ensure the referencing version of the CRD in your CSV's `owned` section is
-updated if the CSV intends to use the new version:
+. Ensure the referencing version of the CRD in the `owned` section of your CSV is updated if the CSV intends to use the new version:
 +
 [source,yaml]
 ----

--- a/modules/olm-approving-pending-upgrade.adoc
+++ b/modules/olm-approving-pending-upgrade.adoc
@@ -5,9 +5,7 @@
 [id="olm-approving-pending-upgrade_{context}"]
 = Manually approving a pending Operator upgrade
 
-If an installed Operator has the approval strategy in its Subscription set to
-*Manual*, when new updates are released in its current update channel, the update must
-be manually approved before installation can begin.
+If an installed Operator has the approval strategy in its subscription set to *Manual*, when new updates are released in its current update channel, the update must be manually approved before installation can begin.
 
 .Prerequisites
 
@@ -15,20 +13,14 @@ be manually approved before installation can begin.
 
 .Procedure
 
-. In the *Administrator* perspective of the {product-title} web console, navigate
-to *Operators -> Installed Operators*.
+. In the *Administrator* perspective of the {product-title} web console, navigate to *Operators -> Installed Operators*.
 
-. Operators that have a pending upgrade display a status with *Upgrade available*.
-Click the name of the Operator you want to upgrade.
+. Operators that have a pending upgrade display a status with *Upgrade available*. Click the name of the Operator you want to upgrade.
 
-. Click the *Subscription* tab. Any upgrades requiring approval are displayed next
-to *Upgrade Status*. For example, it might display *1 requires approval*.
+. Click the *Subscription* tab. Any upgrades requiring approval are displayed next to *Upgrade Status*. For example, it might display *1 requires approval*.
 
 . Click *1 requires approval*, then click *Preview Install Plan*.
 
-. Review the resources that are listed as available for upgrade. When satisfied,
-click *Approve*.
+. Review the resources that are listed as available for upgrade. When satisfied, click *Approve*.
 
-. Navigate back to the *Operators -> Installed Operators* page to monitor the
-progress of the upgrade. When complete, the status changes to *Succeeded* and
-*Up to date*.
+. Navigate back to the *Operators -> Installed Operators* page to monitor the progress of the upgrade. When complete, the status changes to *Succeeded* and *Up to date*.

--- a/modules/olm-arch-catalog-operator.adoc
+++ b/modules/olm-arch-catalog-operator.adoc
@@ -6,22 +6,16 @@
 [id="olm-arch-catalog-operator_{context}"]
 = Catalog Operator
 
-The Catalog Operator is responsible for resolving and installing CSVs and the
-required resources they specify. It is also responsible for watching
-CatalogSources for updates to packages in channels and upgrading them,
-automatically if desired, to the latest available versions.
+The Catalog Operator is responsible for resolving and installing cluster service versions (CSVs) and the required resources they specify. It is also responsible for watching catalog sources for updates to packages in channels and upgrading them, automatically if desired, to the latest available versions.
 
-To track a package in a channel, you can create a Subscription resource
-configuring the desired package, channel, and the CatalogSource you want to pull
-updates from. When updates are found, an appropriate InstallPlan is written into
-the namespace on behalf of the user.
+To track a package in a channel, you can create a `Subscription` object configuring the desired package, channel, and the `CatalogSource` object you want to use for pulling updates. When updates are found, an appropriate `InstallPlan` object is written into the namespace on behalf of the user.
 
 The Catalog Operator uses the following workflow:
 
-. Connect to each CatalogSource in the cluster.
-. Watch for unresolved InstallPlans created by a user, and if found:
+. Connect to each catalog source in the cluster.
+. Watch for unresolved install plans created by a user, and if found:
 .. Find the CSV matching the name requested and add the CSV as a resolved resource.
 .. For each managed or required CRD, add the CRD as a resolved resource.
 .. For each required CRD, find the CSV that manages it.
-. Watch for resolved InstallPlans and create all of the discovered resources for it, if approved by a user or automatically.
-. Watch for CatalogSources and Subscriptions and create InstallPlans based on them.
+. Watch for resolved install plans and create all of the discovered resources for it, if approved by a user or automatically.
+. Watch for catalog sources and subscriptions and create install plans based on them.

--- a/modules/olm-arch-catalog-registry.adoc
+++ b/modules/olm-arch-catalog-registry.adoc
@@ -6,12 +6,6 @@
 [id="olm-arch-catalog-registry_{context}"]
 = Catalog Registry
 
-The Catalog Registry stores CSVs and CRDs for creation in a cluster and stores
-metadata about packages and channels.
+The Catalog Registry stores CSVs and CRDs for creation in a cluster and stores metadata about packages and channels.
 
-A _package manifest_ is an entry in the Catalog Registry that associates a
-package identity with sets of CSVs. Within a package, channels point to a
-particular CSV. Because CSVs explicitly reference the CSV that they replace, a
-package manifest provides the Catalog Operator with all of the information that
-is required to update a CSV to the latest version in a channel, stepping through
-each intermediate version.
+A _package manifest_ is an entry in the Catalog Registry that associates a package identity with sets of CSVs. Within a package, channels point to a particular CSV. Because CSVs explicitly reference the CSV that they replace, a package manifest provides the Catalog Operator with all of the information that is required to update a CSV to the latest version in a channel, stepping through each intermediate version.

--- a/modules/olm-arch-olm-operator.adoc
+++ b/modules/olm-arch-olm-operator.adoc
@@ -6,24 +6,16 @@
 [id="olm-arch-olm-operator_{context}"]
 = OLM Operator
 
-The OLM Operator is responsible for deploying applications defined by CSV
-resources after the required resources specified in the CSV are present in the
-cluster.
+The OLM Operator is responsible for deploying applications defined by CSV resources after the required resources specified in the CSV are present in the cluster.
 
-The OLM Operator is not concerned with the creation of the required resources;
-you can choose to manually create these resources using the CLI or using the
-Catalog Operator. This separation of concern allows users incremental buy-in in
-terms of how much of the OLM framework they choose to leverage for their
-application.
+The OLM Operator is not concerned with the creation of the required resources; you can choose to manually create these resources using the CLI or using the Catalog Operator. This separation of concern allows users incremental buy-in in terms of how much of the OLM framework they choose to leverage for their application.
 
 The OLM Operator uses the following workflow:
 
-. Watch for ClusterServiceVersion (CSVs) in a namespace and check that
-requirements are met.
+. Watch for cluster service versions (CSVs) in a namespace and check that requirements are met.
 . If requirements are met, run the install strategy for the CSV.
 +
 [NOTE]
 ====
-A CSV must be an active member of an OperatorGroup for the install strategy to
-run.
+A CSV must be an active member of an Operator group for the install strategy to run.
 ====

--- a/modules/olm-arch-os-support.adoc
+++ b/modules/olm-arch-os-support.adoc
@@ -5,9 +5,7 @@
 [id="olm-arch-os-support_{context}"]
 = Architecture and operating system support for Operators
 
-The following strings are supported in Operator Lifecycle Manager (OLM) on
-{product-title} when labeling or filtering Operators that support multiple
-architectures and operating systems:
+The following strings are supported in Operator Lifecycle Manager (OLM) on {product-title} when labeling or filtering Operators that support multiple architectures and operating systems:
 
 .Architectures supported on {product-title}
 [options="header"]

--- a/modules/olm-architecture.adoc
+++ b/modules/olm-architecture.adoc
@@ -11,61 +11,56 @@ ifeval::["{context}" == "red-hat-operators"]
 = CRDs
 endif::[]
 
-Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM Operator
-and the Catalog Operator.
+Operator Lifecycle Manager (OLM) is composed of two Operators: the OLM Operator and the Catalog Operator.
 
-Each of these Operators is responsible for managing the Custom Resource
-Definitions (CRDs) that are the basis for the OLM framework:
+Each of these Operators is responsible for managing the custom resource definitions (CRDs) that are the basis for the OLM framework:
 
 .CRDs managed by OLM and Catalog Operators
 [cols="2a,1a,1a,8a",options="header"]
 |===
 |Resource |Short name |Owner |Description
 
-|ClusterServiceVersion
+|`ClusterServiceVersion` (CSV)
 |`csv`
 |OLM
 |Application metadata: name, version, icon, required resources, installation, and so on.
 
-|InstallPlan
+|`InstallPlan`
 |`ip`
 |Catalog
-|Calculated list of resources to be created to automatically install or upgrade
-a CSV.
+|Calculated list of resources to be created to automatically install or upgrade a CSV.
 
-|CatalogSource
+|`CatalogSource`
 |`catsrc`
 |Catalog
 |A repository of CSVs, CRDs, and packages that define an application.
 
-|Subscription
+|`Subscription`
 |`sub`
 |Catalog
 |Used to keep CSVs up to date by tracking a channel in a package.
 
-|OperatorGroup
+|`OperatorGroup`
 |`og`
 |OLM
-|Configures all Operators deployed in the same namespace as the OperatorGroup
-object to watch for their custom resource (CR) in a list of namespaces or
-cluster-wide.
+|Configures all Operators deployed in the same namespace as the `OperatorGroup` object to watch for their custom resource (CR) in a list of namespaces or cluster-wide.
 |===
 
-Each of these Operators is also responsible for creating resources:
+Each of these Operators is also responsible for creating the following resources:
 
 .Resources created by OLM and Catalog Operators
 [options="header"]
 |===
 |Resource |Owner
 
-|Deployments
+|`Deployments`
 .4+.^|OLM
 
-|ServiceAccounts
-|(Cluster)Roles
-|(Cluster)RoleBindings
+|`ServiceAccounts`
+|`(Cluster)Roles`
+|`(Cluster)RoleBindings`
 
-|Custom Resource Definitions (CRDs)
+|`CustomResourceDefinitions` (CRDs)
 .2+.^|Catalog
-|ClusterServiceVersions (CSVs)
+|`ClusterServiceVersions`
 |===

--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -9,23 +9,14 @@
 [id="olm-building-operator-catalog-image_{context}"]
 = Building an Operator catalog image
 
-Cluster administrators can build a custom Operator catalog image to be used by
-Operator Lifecycle Manager (OLM) and push the image to a container image
-registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]. For a
-cluster on a restricted network, this registry can be a registry that the cluster
-has network access to, such as a mirror registry created during a restricted
-network cluster installation.
+Cluster administrators can build a custom Operator catalog image based on the Package Manifest Format to be used by Operator Lifecycle Manager (OLM). The catalog image can be pushed to a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]. For a cluster on a restricted network, this registry can be a registry that the cluster has network access to, such as a mirror registry created during a restricted network cluster installation.
 
 [IMPORTANT]
 ====
-The {product-title} cluster's internal registry cannot be used as the target
-registry because it does not support pushing without a tag, which is required
-during the mirroring process.
+The internal registry of the {product-title} cluste cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
 ====
 
-For this example, the procedure assumes use of a mirror registry that has access
-to both your network and the internet.
+For this example, the procedure assumes use of a mirror registry that has access to both your network and the Internet.
 
 .Prerequisites
 
@@ -33,21 +24,14 @@ to both your network and the internet.
 * Workstation with unrestricted network access
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
-* Access to mirror registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
-* If you are working with private registries, set the `REG_CREDS` environment
-variable to the file path of your registry credentials for use in later steps.
-For example, for the `podman` CLI:
+* Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
-* If you are working with private namespaces that your
-link:https://quay.io[quay.io] account has access to, you must set a Quay
-authentication token. Set the `AUTH_TOKEN` environment variable for use with the
-`--auth-token` flag by making a request against the login API using your
-link:https://quay.io[quay.io] credentials:
+* If you are working with private namespaces that your link:https://quay.io[quay.io] account has access to, you must set a Quay authentication token. Set the `AUTH_TOKEN` environment variable for use with the `--auth-token` flag by making a request against the login API using your link:https://quay.io[quay.io] credentials:
 +
 [source,terminal]
 ----
@@ -63,8 +47,7 @@ $ AUTH_TOKEN=$(curl -sH "Content-Type: application/json" \
 
 .Procedure
 
-. On the workstation with unrestricted network access, authenticate with the
-target mirror registry:
+. On the workstation with unrestricted network access, authenticate with the target mirror registry:
 +
 [source,terminal]
 ----
@@ -79,8 +62,7 @@ during the build:
 $ podman login registry.redhat.io
 ----
 
-. Build a catalog image based on the `redhat-operators` catalog from
-link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
+. Build a catalog image based on the `redhat-operators` catalog from Quay.io, tagging and pushing it to your mirror registry:
 +
 [source,terminal]
 ----
@@ -101,8 +83,7 @@ base image, which must match the target {product-title} cluster. Valid values
 are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 <4> Name your catalog image and include a tag, for example, `v1`.
 <5> Optional: If required, specify the location of your registry credentials file.
-<6> Optional: If you do not want to configure trust for the target registry, add the
-`--insecure` flag.
+<6> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <7> Optional: If other application registry catalogs are used that are not public, specify a Quay authentication token.
 +
 .Example output
@@ -113,8 +94,7 @@ INFO[0013] loading Bundles                               dir=/var/folders/st/9cs
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v1
 ----
 +
-Sometimes invalid manifests are accidentally introduced into Red Hat's catalogs;
-when this happens, you might see some errors:
+Sometimes invalid manifests are accidentally introduced catalogs provided by Red Hat; when this happens, you might see some errors:
 +
 .Example output with errors
 [source,terminal]

--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -5,17 +5,9 @@
 [id="olm-bundle-format_{context}"]
 = Bundle Format
 
-The _Bundle Format_ for Operators is a new packaging format introduced by the
-Operator Framework. To improve scalability and to better enable upstream users
-hosting their own catalogs, the Bundle Format specification simplifies the
-distribution of Operator metadata.
+The _Bundle Format_ for Operators is a new packaging format introduced by the Operator Framework. To improve scalability and to better enable upstream users hosting their own catalogs, the Bundle Format specification simplifies the distribution of Operator metadata.
 
-An Operator bundle represents a single version of an Operator. On-disk _bundle
-manifests_ are containerized and shipped as a _bundle image_, which is a
-non-runnable container image that stores the Kubernetes manifests and Operator
-metadata. Storage and distribution of the bundle image is then managed using
-existing container tools like `podman` and `docker` and container registries
-such as Quay.
+An Operator bundle represents a single version of an Operator. On-disk _bundle manifests_ are containerized and shipped as a _bundle image_, which is a non-runnable container image that stores the Kubernetes manifests and Operator metadata. Storage and distribution of the bundle image is then managed using existing container tools like `podman` and `docker` and container registries such as Quay.
 
 Operator metadata can include:
 
@@ -24,21 +16,18 @@ Operator metadata can include:
 * Required and provided APIs.
 * Related images.
 
-When loading manifests into the Operator Registry database, the following
-requirements are validated:
+When loading manifests into the Operator Registry database, the following requirements are validated:
 
 * The bundle must have at least one channel defined in the annotations.
-* Every bundle has exactly one CSV.
-* If a CSV owns a CRD, that CRD must exist in the bundle.
+* Every bundle has exactly one cluster service version (CSV).
+* If a CSV owns a custom resource definition (CRD), that CRD must exist in the bundle.
 
 [id="olm-bundle-format-manifests_{context}"]
 == Manifests
 
-Bundle manifests refer to a set of Kubernetes manifests that define the
-deployment and RBAC model of the Operator.
+Bundle manifests refer to a set of Kubernetes manifests that define the deployment and RBAC model of the Operator.
 
-A bundle includes one ClusterServiceVersion (CSV) per directory and typically
-the CRDs that define the owned APIs of the CSV in its `/manifests` directory.
+A bundle includes one CSV per directory and typically the CRDs that define the owned APIs of the CSV in its `/manifests` directory.
 
 .Example Bundle Format layout
 [source,terminal]
@@ -58,31 +47,24 @@ etcd
 [id="olm-bundle-format-manifests-optional_{context}"]
 === Optional objects
 
-The following objects can also be optionally included in the `/manifests`
-directory of a bundle:
+The following object types can also be optionally included in the `/manifests` directory of a bundle:
 
 .Supported optional objects
-* Secrets
-* ConfigMaps
+* `Secrets`
+* `ConfigMaps`
 
-When these optional objects are included in a bundle, Operator Lifecycle Manager
-(OLM) can create them from the bundle and manage their lifecycle along with the
-CSV:
+When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
 
 .Lifecycle for optional objects
 * When the CSV is deleted, OLM deletes the optional object.
 * When the CSV is upgraded:
 ** If the name of the optional object is the same, OLM updates it in place.
-** If the name of the optional object has changed between versions, OLM deletes and
-recreates it.
+** If the name of the optional object has changed between versions, OLM deletes and recreates it.
 
 [id="olm-bundle-format-annotations_{context}"]
 == Annotations
 
-A bundle also includes an `annotations.yaml` file in its `/metadata` directory.
-This file defines higher level aggregate data that helps describe the format and
-package information about how the bundle should be added into an index of
-bundles:
+A bundle also includes an `annotations.yaml` file in its `/metadata` directory. This file defines higher level aggregate data that helps describe the format and package information about how the bundle should be added into an index of bundles:
 
 .Example `annotations.yaml`
 [source,yaml]
@@ -95,25 +77,16 @@ annotations:
   operators.operatorframework.io.bundle.channels.v1: "beta,stable" <5>
   operators.operatorframework.io.bundle.channel.default.v1: "stable" <6>
 ----
-<1> The media type or format of the Operator bundle. The `registry+v1` format means
-it contains a CSV and its associated Kubernetes objects.
-<2> The path in the image to the directory that contains the Operator manifests.
-This label is reserved for future use and currently defaults to `manifests/`.
-The value `manifests.v1` implies that the bundle contains Operator manifests.
-<3> The path in the image to the directory that contains metadata files about the
-bundle. This label is reserved for future use and currently defaults to
-`metadata/`. The value `metadata.v1` implies that this bundle has operator metadata.
+<1> The media type or format of the Operator bundle. The `registry+v1` format means it contains a CSV and its associated Kubernetes objects.
+<2> The path in the image to the directory that contains the Operator manifests. This label is reserved for future use and currently defaults to `manifests/`. The value `manifests.v1` implies that the bundle contains Operator manifests.
+<3> The path in the image to the directory that contains metadata files about the bundle. This label is reserved for future use and currently defaults to `metadata/`. The value `metadata.v1` implies that this bundle has Operator metadata.
 <4> The package name of the bundle.
-<5> The list of channels the bundle is subscribing to when added into an Operator
-Registry.
-<6> The default channel an Operator should be subscribed to when installed from a
-registry.
+<5> The list of channels the bundle is subscribing to when added into an Operator Registry.
+<6> The default channel an Operator should be subscribed to when installed from a registry.
 
 [NOTE]
 ====
-In case of a mismatch, the `annotations.yaml` file is authoritative because the
-on-cluster Operator Registry that relies on these annotations only has access to
-this file.
+In case of a mismatch, the `annotations.yaml` file is authoritative because the on-cluster Operator Registry that relies on these annotations only has access to this file.
 ====
 
 [id="olm-bundle-format-dependencies_{context}"]

--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -3,20 +3,19 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
 [id="olm-catalogsource_{context}"]
-= CatalogSource
+= Catalog source
 
-A CatalogSource represents a store of metadata that OLM can query to discover
-and install Operators and their dependencies. The spec of a CatalogSource
-indicates how to construct a pod or how to communicate with a service that
-serves the Operator Registry gRPC API.
+A catalog source represents a store of metadata that OLM can query to discover and install Operators and their dependencies. The spec of a `CatalogSource` object indicates how to construct a pod or how to communicate with a service that serves the Operator Registry gRPC API.
 
-There are three primary `sourceTypes` for a CatalogSource:
+There are three primary `sourceTypes` for a `CatalogSource` object:
 
 * `grpc` with an `image` reference: OLM pulls the image and runs the pod, which is expected to serve a compliant API.
 * `grpc` with an `address` field: OLM attempts to contact the gRPC API at the given address. This should not be used in most cases.
 * `internal` or `configmap`: OLM parses the ConfigMap data and runs a pod that can serve the gRPC API over it.
 
-.Example CatalogSource
+The following example defines a catalog source for OperatorHub.io content:
+
+.Example `CatalogSource` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -31,11 +30,9 @@ spec:
  publisher: OperatorHub.io
 ----
 
-This example defines a CatalogSource for OperatorHub.io content. The name of
-the CatalogSource is used as input to a Subscription, which instructs OLM where
-to look to find a requested Operator:
+The `name` of the `CatalogSource` object is used as input to a subscription, which instructs OLM where to look to find a requested Operator:
 
-.Example Subscription referencing CatalogSource
+.Example `Subscription` object referencing a catalog source
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1

--- a/modules/olm-changing-update-channel.adoc
+++ b/modules/olm-changing-update-channel.adoc
@@ -27,9 +27,7 @@ Installed Operators cannot change to a channel that is older than the current
 channel.
 ====
 
-If the approval strategy in the Subscription is set to *Automatic*, the upgrade
-process initiates immediately. If the approval strategy is set to *Manual*, you
-must manually approve the pending upgrade.
+If the approval strategy in the subscription is set to *Automatic*, the upgrade process initiates as soon as a new Operator version is available in the selected channel. If the approval strategy is set to *Manual*, you must manually approve pending upgrades.
 
 .Prerequisites
 

--- a/modules/olm-crds.adoc
+++ b/modules/olm-crds.adoc
@@ -5,34 +5,30 @@
 [id="olm-resources_{context}"]
 = OLM resources
 
-The following Custom Resource Definitions (CRDs) are defined and managed by
-Operator Lifecycle Manager (OLM):
+The following custom resource definitions (CRDs) are defined and managed by Operator Lifecycle Manager (OLM):
 
 .CRDs managed by OLM and Catalog Operators
 [cols="2a,2a,8a",options="header"]
 |===
 |Resource |Short name |Description
 
-|ClusterServiceVersion
+|`ClusterServiceVersion` (CSV)
 |`csv`
-|Application metadata: name, version, icon, required resources, installation, and so on.
+|Application metadata. For example: name, version, icon, required resources.
 
-|CatalogSource
+|`CatalogSource`
 |`catsrc`
 |A repository of CSVs, CRDs, and packages that define an application.
 
-|Subscription
+|`Subscription`
 |`sub`
 |Keeps CSVs up to date by tracking a channel in a package.
 
-|InstallPlan
+|`InstallPlan`
 |`ip`
-|Calculated list of resources to be created to automatically install or upgrade
-a CSV.
+|Calculated list of resources to be created to automatically install or upgrade a CSV.
 
-|OperatorGroup
+|`OperatorGroup`
 |`og`
-|Configures all Operators deployed in the same namespace as the OperatorGroup
-object to watch for their custom resource (CR) in a list of namespaces or
-cluster-wide.
+|Configures all Operators deployed in the same namespace as the `OperatorGroup` object to watch for their custom resource (CR) in a list of namespaces or cluster-wide.
 |===

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -5,8 +5,7 @@
 [id="olm-creating-catalog-from-index_{context}"]
 = Creating a catalog from an index image
 
-You can create a catalog from an index image and apply it to an {product-title}
-cluster.
+You can create a catalog from an index image and apply it to an {product-title} cluster.
 
 .Prerequisites
 
@@ -14,7 +13,7 @@ cluster.
 
 .Procedure
 
-. Apply a CatalogSource to your cluster that references your index image:
+. Apply a `CatalogSource` object to your cluster that references your index image:
 +
 [source,terminal]
 ----
@@ -35,10 +34,9 @@ spec:
 EOF
 ----
 <1> Specify your index image.
-<2> CatalogSources can automatically check for new versions to keep up to date.
+<2> Catalog sources can automatically check for new versions to keep up to date.
 
-. Verify using the {product-title} web console or CLI that the catalog loaded
-successfully and that packages are available. For example, using the CLI:
+. Verify using the {product-title} web console or CLI that the catalog loaded successfully and that packages are available. For example, using the CLI:
 
 .. Check the pods:
 +
@@ -47,14 +45,14 @@ successfully and that packages are available. For example, using the CLI:
 $ oc get pods -n openshift-marketplace
 ----
 
-.. Check the CatalogSource:
+.. Check the catalog source:
 +
 [source,terminal]
 ----
 $ oc get catalogsource -n openshift-marketplace
 ----
 
-.. Check the PackageManifest:
+.. Check the package manifest:
 +
 [source,terminal]
 ----

--- a/modules/olm-creating-etcd-cluster-from-operator.adoc
+++ b/modules/olm-creating-etcd-cluster-from-operator.adoc
@@ -5,8 +5,7 @@
 [id="olm-creating-etcd-cluster-from-operator_{context}"]
 = Creating an etcd cluster using an Operator
 
-This procedure walks through creating a new etcd cluster using the etcd
-Operator, managed by Operator Lifecycle Manager (OLM).
+This procedure walks through creating a new etcd cluster using the etcd Operator, managed by Operator Lifecycle Manager (OLM).
 
 .Prerequisites
 
@@ -15,13 +14,9 @@ Operator, managed by Operator Lifecycle Manager (OLM).
 
 .Procedure
 
-. Create a new project in the {product-title} web console for this procedure. This
-example uses a project called *my-etcd*.
+. Create a new project in the {product-title} web console for this procedure. This example uses a project called `my-etcd`.
 
-. Navigate to the *Operators -> Installed Operators* page. The Operators that have
-been installed to the cluster by the cluster administrator and are available for
-use are shown here as a list of ClusterServiceVersions (CSVs). CSVs are used to
-launch and manage the software provided by the Operator.
+. Navigate to the *Operators -> Installed Operators* page. The Operators that have been installed to the cluster by the cluster administrator and are available for use are shown here as a list of cluster service versions (CSVs). CSVs are used to launch and manage the software provided by the Operator.
 +
 [TIP]
 ====
@@ -33,41 +28,25 @@ $ oc get csv
 ----
 ====
 
-. On the *Installed Operators* page, click *Copied*, and then click the etcd
-Operator to view more details and available actions.
+. On the *Installed Operators* page, click *Copied*, and then click the etcd Operator to view more details and available actions.
 +
-As shown under *Provided APIs*, this Operator makes available three new resource
-types, including one for an *etcd Cluster* (the `EtcdCluster` resource). These
-objects work similar to the built-in native Kubernetes ones, such as
-`Deployments` or `ReplicaSets`, but contain logic specific to managing etcd.
+As shown under *Provided APIs*, this Operator makes available three new resource types, including one for an *etcd Cluster* (the `EtcdCluster` resource). These objects work similar to the built-in native Kubernetes ones, such as `Deployment` or `ReplicaSet`, but contain logic specific to managing etcd.
 
 . Create a new etcd cluster:
 
 .. In the *etcd Cluster* API box, click *Create New*.
 
-.. The next screen allows you to make any modifications to the minimal starting
-template of an `EtcdCluster` object, such as the size of the cluster. For now,
-click *Create* to finalize. This triggers the Operator to start up the pods,
-Services, and other components of the new etcd cluster.
+.. The next screen allows you to make any modifications to the minimal starting template of an `EtcdCluster` object, such as the size of the cluster. For now, click *Create* to finalize. This triggers the Operator to start up the pods, Services, and other components of the new etcd cluster.
 
-. Click the *Resources* tab to see that your project now contains a number of
-resources created and configured automatically by the Operator.
+. Click the *Resources* tab to see that your project now contains a number of resources created and configured automatically by the Operator.
 +
-Verify that a Kubernetes service has been created that allows you to access the
-database from other pods in your project.
+Verify that a Kubernetes service has been created that allows you to access the database from other pods in your project.
 
-. All users with the `edit` role in a given project can create, manage, and delete
-application instances (an etcd cluster, in this example) managed by Operators
-that have already been created in the project, in a self-service manner, just
-like a cloud service. If you want to enable additional users with this ability,
-project administrators can add the role using the following command:
+. All users with the `edit` role in a given project can create, manage, and delete application instances (an etcd cluster, in this example) managed by Operators that have already been created in the project, in a self-service manner, just like a cloud service. If you want to enable additional users with this ability, project administrators can add the role using the following command:
 +
 [source,terminal]
 ----
 $ oc policy add-role-to-user edit <user> -n <target_project>
 ----
 
-You now have an etcd cluster that will react to failures and rebalance data as
-Pods become unhealthy or are migrated between nodes in the cluster. Most
-importantly, cluster administrators or developers with proper access can now
-easily use the database with their applications.
+You now have an etcd cluster that will react to failures and rebalance data as pods become unhealthy or are migrated between nodes in the cluster. Most importantly, cluster administrators or developers with proper access can now easily use the database with their applications.

--- a/modules/olm-csv.adoc
+++ b/modules/olm-csv.adoc
@@ -3,26 +3,15 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
 [id="olm-csv_{context}"]
-= ClusterServiceVersion
+= Cluster service version
 
-A _ClusterServiceVersion_ (CSV) represents a specific version of a running
-Operator on an {product-title} cluster. It is a YAML manifest created from
-Operator metadata that assists Operator Lifecycle Manager (OLM) in running the
-Operator in the cluster.
+A _cluster service version_ (CSV) represents a specific version of a running Operator on an {product-title} cluster. It is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in the cluster.
 
-OLM requires this metadata about an Operator to ensure that it can be kept
-running safely on a cluster, and to provide information about how updates should
-be applied as new versions of the Operator are published. This is similar to
-packaging software for a traditional operating system; think of the packaging
-step for OLM as the stage at which you make your `rpm`, `dep`, or `apk` bundle.
+OLM requires this metadata about an Operator to ensure that it can be kept running safely on a cluster, and to provide information about how updates should be applied as new versions of the Operator are published. This is similar to packaging software for a traditional operating system; think of the packaging step for OLM as the stage at which you make your `rpm`, `dep`, or `apk` bundle.
 
-A CSV includes the metadata that accompanies an Operator container image, used
-to populate user interfaces with information such as its name, version, description, labels, repository link, and logo.
+A CSV includes the metadata that accompanies an Operator container image, used to populate user interfaces with information such as its name, version, description, labels, repository link, and logo.
 
-A CSV is also a source of technical information required to run the Operator,
-such as which Custom Resources (CRs) it manages or depends on, RBAC rules,
-cluster requirements, and install strategies. This information tells OLM how to
-create required resources and set up the Operator as a Deployment.
+A CSV is also a source of technical information required to run the Operator, such as which custom resources (CRs) it manages or depends on, RBAC rules, cluster requirements, and install strategies. This information tells OLM how to create required resources and set up the Operator as a deployment.
 
 ////
 Metadata::

--- a/modules/olm-defining-csv-webhooks.adoc
+++ b/modules/olm-defining-csv-webhooks.adoc
@@ -5,9 +5,7 @@
 [id="olm-defining-csv-webhook_{context}"]
 = Defining webhooks in a CSV
 
-The ClusterServiceVersion (CSV) resource includes a `webhookdefinitions` section
-to define validating and mutating admission webhooks that ship with an Operator.
-For example:
+The `ClusterServiceVersion` (CSV) resource includes a `webhookdefinitions` section to define validating and mutating admission webhooks that ship with an Operator. For example:
 
 .CSV containing a validating admission webhook
 [source,yaml]
@@ -46,12 +44,9 @@ spec:
 ...
 ----
 
-OLM requires that you define the following:
+Operator Lifecycle Manager (OLM) requires that you define the following:
 
-* The `type` field must be set to either `ValidatingAdmissionWebhook` or
-`MutatingAdmissionWebhook`, or the CSV will be placed in a failed phase. * The
-CSV must contain a Deployment whose name is equivalent to the value supplied in
-the `deploymentName` field of the `webhookdefinition`.
+* The `type` field must be set to either `ValidatingAdmissionWebhook` or `MutatingAdmissionWebhook`, or the CSV will be placed in a failed phase.
+* The CSV must contain a Deployment whose name is equivalent to the value supplied in the `deploymentName` field of the `webhookdefinition`.
 
-When the webhook is created, OLM ensures that the webhook only acts upon
-namespaces that match the OperatorGroup that the Operator is deployed in.
+When the webhook is created, OLM ensures that the webhook only acts upon namespaces that match the Operator group that the Operator is deployed in.

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -5,8 +5,7 @@
 [id="olm-deleting-operator-from-a-cluster-using-cli_{context}"]
 = Deleting Operators from a cluster using the CLI
 
-Cluster administrators can delete installed Operators from a selected namespace
-by using the CLI.
+Cluster administrators can delete installed Operators from a selected namespace by using the CLI.
 
 .Prerequisites
 
@@ -21,8 +20,7 @@ endif::[]
 
 .Procedure
 
-. Check the current version of the subscribed Operator (for example, `jaeger`)
-in the `currentCSV` field:
+. Check the current version of the subscribed Operator (for example, `jaeger`) in the `currentCSV` field:
 +
 [source,terminal]
 ----
@@ -35,7 +33,7 @@ $ oc get subscription jaeger -n openshift-operators -o yaml | grep currentCSV
   currentCSV: jaeger-operator.v1.8.2
 ----
 
-. Delete the Operator's Subscription (for example, `jaeger`):
+. Delete the subscription (for example, `jaeger`):
 +
 [source,terminal]
 ----
@@ -48,8 +46,7 @@ $ oc delete subscription jaeger -n openshift-operators
 subscription.operators.coreos.com "jaeger" deleted
 ----
 
-. Delete the CSV for the Operator in the target namespace using the `currentCSV`
-value from the previous step:
+. Delete the CSV for the Operator in the target namespace using the `currentCSV` value from the previous step:
 +
 [source,terminal]
 ----

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -5,8 +5,7 @@
 [id="olm-deleting-operators-from-a-cluster-using-web-console_{context}"]
 = Deleting Operators from a cluster using the web console
 
-Cluster administrators can delete installed Operators from a selected namespace
-by using the web console.
+Cluster administrators can delete installed Operators from a selected namespace by using the web console.
 
 .Prerequisites
 
@@ -20,26 +19,17 @@ endif::[]
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the Operator you want. Then, click on it.
+. From the *Operators* → *Installed Operators* page, scroll or type a keyword into the *Filter by name* to find the Operator you want. Then, click on it.
 
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
+. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
 +
 An *Uninstall Operator?* dialog box is displayed, reminding you that:
 +
 [.small]
 --
-*Removing the Operator will not remove any of its custom resource definitions or
-managed resources. If your Operator has deployed applications on the cluster or
-configured off-cluster resources, these will continue to run and need to be
-cleaned up manually.*
+*Removing the Operator will not remove any of its custom resource definitions or managed resources. If your Operator has deployed applications on the cluster or configured off-cluster resources, these will continue to run and need to be cleaned up manually.*
 --
 +
-The Operator, any Operator deployments, and pods are removed by this action. Any
-resources managed by the Operator, including CRDs and CRs are not removed. The
-web console enables dashboards and navigation items for some Operators. To
-remove these after uninstalling the Operator, you might need to manually delete
-the Operator CRDs.
+The Operator, any Operator deployments, and pods are removed by this action. Any resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
 
 . Select *Uninstall*. This Operator stops running and no longer receives updates.

--- a/modules/olm-dependency-resolution-about.adoc
+++ b/modules/olm-dependency-resolution-about.adoc
@@ -5,13 +5,9 @@
 [id="olm-dependency-resolution-about_{context}"]
 = About dependency resolution
 
-OLM manages the dependency resolution and upgrade lifecycle of running
-Operators. In many ways, the problems OLM faces are similar to other operating
-system package managers like `yum` and `rpm`.
+OLM manages the dependency resolution and upgrade lifecycle of running Operators. In many ways, the problems OLM faces are similar to other operating system package managers like `yum` and `rpm`.
 
-However, there is one constraint that similar systems do not generally have that
-OLM does: because Operators are always running, OLM attempts to ensure that you
-are never left with a set of Operators that do not work with each other.
+However, there is one constraint that similar systems do not generally have that OLM does: because Operators are always running, OLM attempts to ensure that you are never left with a set of Operators that do not work with each other.
 
 This means that OLM must never:
 

--- a/modules/olm-dependency-resolution-crd-upgrades.adoc
+++ b/modules/olm-dependency-resolution-crd-upgrades.adoc
@@ -3,14 +3,9 @@
 // * operators/olm-understanding-dependency-resolution.adoc
 
 [id="olm-dependency-resolution-crd-upgrades_{context}"]
-= CustomResourceDefinition (CRD) upgrades
+= CRD upgrades
 
-OLM upgrades a CustomResourceDefinition (CRD) immediately if it is owned by a
-singular ClusterServiceVersion (CSV). If a CRD is owned by multiple CSVs, then
-the CRD is upgraded when it has satisfied all of the following backward
-compatible conditions:
+OLM upgrades a custom resource definition (CRD) immediately if it is owned by a singular cluster service version (CSV). If a CRD is owned by multiple CSVs, then the CRD is upgraded when it has satisfied all of the following backward compatible conditions:
 
 - All existing serving versions in the current CRD are present in the new CRD.
-- All existing instances, or custom resources (CRs), that are associated with the
-serving versions of the CRD are valid when validated against the validation
-schema of the new CRD.
+- All existing instances, or custom resources, that are associated with the serving versions of the CRD are valid when validated against the validation schema of the new CRD.

--- a/modules/olm-dependency-resolution-examples.adoc
+++ b/modules/olm-dependency-resolution-examples.adoc
@@ -5,17 +5,16 @@
 [id="olm-dependency-resolution-examples_{context}"]
 = Example dependency resolution scenarios
 
-In the following examples, a _provider_ is an Operator which "owns" a CRD or
-APIService.
+In the following examples, a _provider_ is an Operator which "owns" a CRD or API service.
 
 [discrete]
 === Example: Deprecating dependent APIs
 
-A and B are APIs (e.g., CRDs):
+A and B are APIs (CRDs):
 
-* A's provider depends on B.
-* B’s provider has a Subscription.
-* B’s provider updates to provide C but deprecates B.
+* The provider of A depends on B.
+* The provider of B has a subscription.
+* The provider of B updates to provide C but deprecates B.
 
 This results in:
 
@@ -29,13 +28,11 @@ This is a case OLM prevents with its upgrade strategy.
 
 A and B are APIs:
 
-* A's provider requires B.
-* B's provider requires A.
-* A's provider updates to (provide A2, require B2) and deprecate A.
-* B's provider updates to (provide B2, require A2) and deprecate B.
+* The provider of A requires B.
+* The provider of B requires A.
+* The provider of A updates to (provide A2, require B2) and deprecate A.
+* The provider of B updates to (provide B2, require A2) and deprecate B.
 
-If OLM attempts to update A without simultaneously updating B, or vice-versa, it
-is unable to progress to new versions of the Operators, even though a new
-compatible set can be found.
+If OLM attempts to update A without simultaneously updating B, or vice-versa, it is unable to progress to new versions of the Operators, even though a new compatible set can be found.
 
 This is another case OLM prevents with its upgrade strategy.

--- a/modules/olm-enabling-operator-for-multi-arch.adoc
+++ b/modules/olm-enabling-operator-for-multi-arch.adoc
@@ -5,15 +5,9 @@
 [id="olm-enabling-operator-for-multi-arch_{context}"]
 = Enabling your Operator for multiple architectures and operating systems
 
-Operator Lifecycle Manager (OLM) assumes that all Operators run on Linux hosts.
-However, as an Operator author, you can specify whether your Operator supports
-managing workloads on other architectures, if worker nodes are available in the
-{product-title} cluster.
+Operator Lifecycle Manager (OLM) assumes that all Operators run on Linux hosts. However, as an Operator author, you can specify whether your Operator supports managing workloads on other architectures, if worker nodes are available in the {product-title} cluster.
 
-If your Operator supports variants other than AMD64 and Linux, you can add
-labels to the CSV that provides the Operator to list the supported variants.
-Labels indicating supported architectures and operating systems are defined by
-the following:
+If your Operator supports variants other than AMD64 and Linux, you can add labels to the cluster service version (CSV) that provides the Operator to list the supported variants. Labels indicating supported architectures and operating systems are defined by the following:
 
 [source,yaml]
 ----
@@ -26,14 +20,10 @@ labels:
 
 [NOTE]
 ====
-Only the labels on the channel head of the default channel are considered for
-filtering PackageManifests by label. This means, for example, that providing an
-additional architecture for an Operator in the non-default channel is possible,
-but that architecture is not available for filtering in the PackageManifest API.
+Only the labels on the channel head of the default channel are considered for filtering package manifests by label. This means, for example, that providing an additional architecture for an Operator in the non-default channel is possible, but that architecture is not available for filtering in the `PackageManifest` API.
 ====
 
-If a CSV does not include an `os` label, it is treated as if it has the
-following Linux support label by default:
+If a CSV does not include an `os` label, it is treated as if it has the following Linux support label by default:
 
 [source,yaml]
 ----
@@ -41,8 +31,7 @@ labels:
     operatorframework.io/os.linux: supported
 ----
 
-If a CSV does not include an `arch` label, it is treated as if it has the
-following AMD64 support label by default:
+If a CSV does not include an `arch` label, it is treated as if it has the following AMD64 support label by default:
 
 [source,yaml]
 ----
@@ -50,22 +39,17 @@ labels:
     operatorframework.io/arch.amd64: supported
 ----
 
-If an Operator supports multiple node architectures or operating systems, you
-can add multiple labels, as well.
+If an Operator supports multiple node architectures or operating systems, you can add multiple labels, as well.
 
 .Prerequisites
 
 * An Operator project with a CSV.
-* To support listing multiple architectures and operating systems, your Operator
-image referenced in the CSV must be a manifest list image.
-* For the Operator to work properly in restricted network, or disconnected,
-environments, the image referenced must also be specified using a digest (SHA)
-and not by a tag.
+* To support listing multiple architectures and operating systems, your Operator image referenced in the CSV must be a manifest list image.
+* For the Operator to work properly in restricted network, or disconnected, environments, the image referenced must also be specified using a digest (SHA) and not by a tag.
 
 .Procedure
 
-* Add a label in your CSV's `metadata.labels` for each supported architecture and
-operating system that your Operator supports:
+* Add a label in the `metadata.labels` of your CSV for each supported architecture and operating system that your Operator supports:
 +
 [source,yaml]
 ----
@@ -75,5 +59,4 @@ labels:
   operatorframework.io/os.linux: supported <1>
   operatorframework.io/arch.amd64: supported <1>
 ----
-<1> After you add a new architecture or operating system, you must also now include
-the default `os.linux` and `arch.amd64` variants explicitly.
+<1> After you add a new architecture or operating system, you must also now include the default `os.linux` and `arch.amd64` variants explicitly.

--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -5,11 +5,9 @@
 [id="olm-enabling-operator-for-restricted-network_{context}"]
 = Enabling your Operator for restricted network environments
 
-As an Operator author, your CSV must meet the following additional requirements
-for your Operator to run properly in a restricted network environment:
+As an Operator author, your CSV must meet the following additional requirements for your Operator to run properly in a restricted network environment:
 
-* List any _related images_, or other container images that your Operator might
-require to perform their functions.
+* List any _related images_, or other container images that your Operator might require to perform their functions.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
 You must use SHA references to related images in two places in the Operator's
@@ -32,8 +30,7 @@ spec:
 <2> Specify a unique identifier for the image.
 <3> Specify each image by a digest (SHA), not by an image tag.
 
-* in the `env` section of the Operators Deployments when declaring environment
-variables that inject the image that the Operator should use:
+* in the `env` section of the Operators Deployments when declaring environment variables that inject the image that the Operator should use:
 +
 [source,yaml]
 ----
@@ -85,12 +82,11 @@ spec:
               serviceAccountName: etcd-operator
     strategy: deployment
 ----
-<1> Inject the images referenced by the Operator via environment variables.
+<1> Inject the images referenced by the Operator by using environment variables.
 <2> Specify each image by a digest (SHA), not by an image tag.
 <3> Also reference the Operator container image by a digest (SHA), not by an image tag.
 
-* Look for the `Disconnected` annotation, which indicates that the Operator works
-in a disconnected environment:
+* Look for the `Disconnected` annotation, which indicates that the Operator works in a disconnected environment:
 +
 [source,yaml]
 ----

--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -5,11 +5,7 @@
 [id="olm-inject-custom-ca_{context}"]
 = Injecting a custom CA certificate
 
-When a cluster administrator adds a custom CA certificate to a cluster using a
-ConfigMap, the Cluster Network Operator merges the user-provided certificates
-and system CA certificates into a single bundle. You can inject this merged
-bundle into your Operator running on Operator Lifecycle Manager (OLM), which is
-useful if you have a man-in-the-middle HTTPS proxy.
+When a cluster administrator adds a custom CA certificate to a cluster using a config map, the Cluster Network Operator merges the user-provided certificates and system CA certificates into a single bundle. You can inject this merged bundle into your Operator running on Operator Lifecycle Manager (OLM), which is useful if you have a man-in-the-middle HTTPS proxy.
 
 .Prerequisites
 
@@ -20,13 +16,12 @@ endif::[]
 ifdef::openshift-dedicated[]
 `dedicated-admins-cluster` permissions.
 endif::[]
-- Custom CA certificate added to the cluster using a ConfigMap.
+- Custom CA certificate added to the cluster using a config map.
 - Desired Operator installed and running on OLM.
 
 .Procedure
 
-. Create an empty ConfigMap in the namespace where your Operator's Subscription
-exists and include the following label:
+. Create an empty config map in the namespace where the subscription for your Operator exists and include the following label:
 +
 [source,yaml]
 ----
@@ -37,15 +32,12 @@ metadata:
   labels:
     config.openshift.io/inject-trusted-cabundle: "true" <2>
 ----
-<1> Name of the ConfigMap.
+<1> Name of the config map.
 <2> Requests the Cluster Network Operator to inject the merged bundle.
 +
-After creating this ConfigMap, the ConfigMap is immediately populated with the
-certificate contents of the merged bundle.
+After creating this config map, it is immediately populated with the certificate contents of the merged bundle.
 
-. Update your Operator's Subscription object to include a `spec.config` section
-that mounts the `trusted-ca` ConfigMap as a volume to each container within a
-Pod that requires a custom CA:
+. Update your the `Subscription` object to include a `spec.config` section that mounts the `trusted-ca` config map as a volume to each container within a pod that requires a custom CA:
 +
 [source,yaml]
 ----
@@ -74,6 +66,6 @@ spec:
 <1> Add a `config` section if it does not exist.
 <2> Specify labels to match pods that are owned by the Operator.
 <3> Create a `trusted-ca` volume.
-<4> `ca-bundle.crt` is required as the ConfigMap key.
-<5> `tls-ca-bundle.pem` is required as the ConfigMap path.
+<4> `ca-bundle.crt` is required as the config map key.
+<5> `tls-ca-bundle.pem` is required as the config map path.
 <6> Create a `trusted-ca` volume mount.

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -11,9 +11,7 @@ endif::[]
 [id="olm-installing-operator-from-operatorhub-using-cli_{context}"]
 = Installing from OperatorHub using the CLI
 
-Instead of using the {product-title} web console, you can install an Operator
-from OperatorHub using the CLI. Use the `oc` command to create or update a
-Subscription object.
+Instead of using the {product-title} web console, you can install an Operator from OperatorHub using the CLI. Use the `oc` command to create or update a `Subscription` object.
 
 .Prerequisites
 
@@ -28,8 +26,7 @@ endif::[]
 endif::[]
 
 ifdef::olm-user[]
-- Access to an {product-title} cluster using an account with Operator installation
-permissions.
+- Access to an {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
 - Install the `oc` command to your local system.
@@ -61,39 +58,29 @@ kubefed                            Community Operators   91m
 ...
 ----
 +
-Note the CatalogSource for your desired Operator.
+Note the catalog for your desired Operator.
 
-. Inspect your desired Operator to verify its supported InstallModes and available
-Channels:
+. Inspect your desired Operator to verify its supported install modes and available channels:
 +
 [source,terminal]
 ----
 $ oc describe packagemanifests <operator_name> -n openshift-marketplace
 ----
 
-. An OperatorGroup is an OLM resource that selects target namespaces in which to
-generate required RBAC access for all Operators in the same namespace as the
-OperatorGroup.
+. An Operator group, defined by an `OperatorGroup` object, selects target namespaces in which to generate required RBAC access for all Operators in the same namespace as the Operator group.
 +
-The namespace to which you subscribe the Operator must have an OperatorGroup
-that matches the InstallMode of the Operator, either the `AllNamespaces` or
-`SingleNamespace` mode. If the Operator you intend to install uses the
-`AllNamespaces`, then the `openshift-operators` namespace already has an
-appropriate OperatorGroup in place.
+The namespace to which you subscribe the Operator must have an Operator group that matches the install mode of the Operator, either the `AllNamespaces` or `SingleNamespace` mode. If the Operator you intend to install uses the `AllNamespaces`, then the `openshift-operators` namespace already has an appropriate Operator group in place.
 +
-However, if the Operator uses the `SingleNamespace` mode and you do not already
-have an appropriate OperatorGroup in place, you must create one.
+However, if the Operator uses the `SingleNamespace` mode and you do not already have an appropriate Operator group in place, you must create one.
 +
 [NOTE]
 ====
-The web console version of this procedure handles the creation of the
-OperatorGroup and Subscription objects automatically behind the scenes for you
-when choosing `SingleNamespace` mode.
+The web console version of this procedure handles the creation of the `OperatorGroup` and `Subscription` objects automatically behind the scenes for you when choosing `SingleNamespace` mode.
 ====
 
-.. Create an OperatorGroup object YAML file, for example `operatorgroup.yaml`:
+.. Create an `OperatorGroup` object YAML file, for example `operatorgroup.yaml`:
 +
-.Example OperatorGroup
+.Example `OperatorGroup` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -106,17 +93,16 @@ spec:
   - <namespace>
 ----
 
-.. Create the OperatorGroup object:
+.. Create the `OperatorGroup` object:
 +
 [source,terminal]
 ----
 $ oc apply -f operatorgroup.yaml
 ----
 
-. Create a Subscription object YAML file to subscribe a namespace to an Operator,
-for example `sub.yaml`:
+. Create a `Subscription` object YAML file to subscribe a namespace to an Operator, for example `sub.yaml`:
 +
-.Example Subscription
+.Example `Subscription` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -130,21 +116,16 @@ spec:
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace <4>
 ----
-<1> For `AllNamespaces` InstallMode usage, specify the `openshift-operators`
-namespace. Otherwise, specify the relevant single namespace for
-`SingleNamespace` InstallMode usage.
+<1> For `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Otherwise, specify the relevant single namespace for `SingleNamespace` install mode usage.
 <2> Name of the Operator to subscribe to.
-<3> Name of the CatalogSource that provides the Operator.
-<4> Namespace of the CatalogSource. Use `openshift-marketplace` for the default
-OperatorHub CatalogSources.
+<3> Name of the catalog source that provides the Operator.
+<4> Namespace of the catalog source. Use `openshift-marketplace` for the default OperatorHub catalog sources.
 
-. Create the Subscription object:
+. Create the `Subscription` object:
 +
 [source,terminal]
 ----
 $ oc apply -f sub.yaml
 ----
 +
-At this point, OLM is now aware of the selected Operator. A
-ClusterServiceVersion (CSV) for the Operator should appear in the target
-namespace, and APIs provided by the Operator should be available for creation.
+At this point, OLM is now aware of the selected Operator. A cluster service version (CSV) for the Operator should appear in the target namespace, and APIs provided by the Operator should be available for creation.

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -27,8 +27,7 @@ endif::[]
 [id="olm-installing-from-operatorhub-using-web-console_{context}"]
 = Installing from OperatorHub using the web console
 
-You can install and subscribe to an Operator from OperatorHub using the
-{product-title} web console.
+You can install and subscribe to an Operator from OperatorHub using the {product-title} web console.
 
 .Prerequisites
 
@@ -43,27 +42,22 @@ endif::[]
 endif::[]
 
 ifdef::olm-user[]
-- Access to an {product-title} cluster using an account with Operator installation
-permissions.
+- Access to an {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
 .Procedure
 
 . Navigate in the web console to the *Operators → OperatorHub* page.
 
-. Scroll or type a keyword into the *Filter by keyword* box to find the Operator
-you want. For example, type `{filter-type}` to find the {filter-operator} Operator.
+. Scroll or type a keyword into the *Filter by keyword* box to find the Operator you want. For example, type `{filter-type}` to find the {filter-operator} Operator.
 +
-You can also filter options by *Infrastructure Features*. For example, select
-*Disconnected* if you want to see Operators that work in disconnected
-environments, also known as restricted network environments.
+You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
 . Select the Operator to display additional information.
 +
 [NOTE]
 ====
-Choosing a Community Operator warns that Red Hat does not certify Community
-Operators; you must acknowledge the warning before continuing.
+Choosing a Community Operator warns that Red Hat does not certify Community Operators; you must acknowledge the warning before continuing.
 ====
 
 . Read the information about the Operator and click *Install*.
@@ -72,53 +66,35 @@ Operators; you must acknowledge the warning before continuing.
 
 ifdef::olm-admin[]
 .. Select one of the following:
-*** *All namespaces on the cluster (default)* installs the Operator in the default
-`openshift-operators` namespace to watch and be made available to all namespaces
-in the cluster. This option is not always available.
-*** *A specific namespace on the cluster* allows you to choose a specific, single
-namespace in which to install the Operator. The Operator will only watch and be
-made available for use in this single namespace.
+*** *All namespaces on the cluster (default)* installs the Operator in the default `openshift-operators` namespace to watch and be made available to all namespaces in the cluster. This option is not always available.
+*** *A specific namespace on the cluster* allows you to choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.
 ifdef::openshift-dedicated[]
-If you are installing the Cluster Logging Operator, choose this option to select
-the `openshift-logging` namespace.
+If you are installing the Cluster Logging Operator, choose this option to select the `openshift-logging` namespace.
 endif::[]
 endif::[]
 ifdef::olm-user[]
-.. Choose a specific, single namespace in which to install the Operator. The
-Operator will only watch and be made available for use in this single namespace.
+.. Choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.
 endif::[]
 
 .. Select an *Update Channel* (if more than one is available).
 
 .. Select *Automatic* or *Manual* approval strategy, as described earlier.
 
-. Click *Install* to make the Operator available to the selected namespaces on
-this {product-title} cluster.
+. Click *Install* to make the Operator available to the selected namespaces on this {product-title} cluster.
 
-.. If you selected a Manual approval strategy, the upgrade status of the
-Subscription remains *Upgrading* until you review and approve its Install Plan.
+.. If you selected a *Manual* approval strategy, the upgrade status of the subscription remains *Upgrading* until you review and approve the install plan.
 +
-After approving on the *Install Plan* page, the Subscription upgrade status
-moves to *Up to date*.
+After approving on the *Install Plan* page, the subscription upgrade status moves to *Up to date*.
 
-.. If you selected an Automatic approval strategy, the upgrade status should
-resolve to *Up to date* without intervention.
+.. If you selected an *Automatic* approval strategy, the upgrade status should resolve to *Up to date* without intervention.
 
-. After the upgrade status of the Subscription is *Up to date*, select
-*Operators → Installed Operators* to verify that the ClusterServiceVersion (CSV)
-of the installed Operator eventually shows up. Its *Status* should ultimately
-resolve to *InstallSucceeded* in the relevant namespace.
+. After the upgrade status of the subscription is *Up to date*, select *Operators → Installed Operators* to verify that the cluster service version (CSV) of the installed Operator eventually shows up. The *Status* should ultimately resolve to *InstallSucceeded* in the relevant namespace.
 +
 [NOTE]
 ====
-For the *All namespaces...* Installation Mode, the status resolves to
-*InstallSucceeded* in the `openshift-operators` namespace, but the status is
-*Copied* if you check in other namespaces.
+For the *All namespaces...* installation mode, the status resolves to *InstallSucceeded* in the `openshift-operators` namespace, but the status is *Copied* if you check in other namespaces.
 ====
 +
 If it does not:
 
-.. Check the logs in any pods in the `openshift-operators` project (or other
-relevant namespace if *A specific namespace...* Installation Mode was selected)
-on the *Workloads → Pods* page that are reporting issues to troubleshoot
-further.
+.. Check the logs in any pods in the `openshift-operators` project (or other relevant namespace if *A specific namespace...* installation mode was selected) on the *Workloads → Pods* page that are reporting issues to troubleshoot further.

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -67,10 +67,8 @@ Update Channel:: If an Operator is available through multiple channels, you can
 choose which channel you want to subscribe to. For example, to deploy from the
 *stable* channel, if available, select it from the list.
 
-Approval Strategy:: You can choose Automatic or Manual updates. If you choose
-Automatic updates for an installed Operator, when a new version of that Operator
-is available, Operator Lifecycle Manager (OLM) automatically upgrades the
-running instance of your Operator without human intervention. If you select
-Manual updates, when a newer version of an Operator is available, OLM creates an
-update request. As a cluster administrator, you must then manually approve that
-update request to have the Operator updated to the new version.
+Approval Strategy:: You can choose automatic or manual updates.
++
+If you choose automatic updates for an installed Operator, when a new version of that Operator is available in the selected channel, Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
++
+If you select manual updates, when a newer version of an Operator is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.

--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -14,8 +14,7 @@ You can install the `opm` CLI tool on your workstation.
 .Procedure
 
 ifdef::openshift-enterprise,openshift-webscale[]
-. Set the `REG_CREDS` environment variable to the file path of your registry
-credentials for use in later steps. For example, for the `podman` CLI:
+. Set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
 ----
@@ -30,8 +29,7 @@ $ podman login registry.redhat.io
 ----
 endif::[]
 
-. Extract the `opm` binary from the Operator Registry image and copy it to your
-local file system:
+. Extract the `opm` binary from the Operator Registry image and copy it to your local file system:
 +
 [source,terminal]
 ifdef::openshift-origin[]

--- a/modules/olm-installplan.adoc
+++ b/modules/olm-installplan.adoc
@@ -3,7 +3,6 @@
 // * operators/understanding/olm/olm-understanding-olm.adoc
 
 [id="olm-installplan_{context}"]
-= InstallPlan
+= Install plan
 
-An InstallPlan defines a set of resources to be created to install or upgrade to
-a specific version of a ClusterService defined by a CSV.
+An _install plan_, defined by an `InstallPlan` object, describes a set of resources to be created to install or upgrade to a specific version of an Operator, as defined by a cluster service version (CSV).

--- a/modules/olm-metrics.adoc
+++ b/modules/olm-metrics.adoc
@@ -5,8 +5,7 @@
 [id="olm-metrics_{context}"]
 = Exposed metrics
 
-Operator Lifecycle Manager (OLM) exposes certain OLM-specific resources for use
-by the Prometheus-based {product-title} cluster monitoring stack.
+Operator Lifecycle Manager (OLM) exposes certain OLM-specific resources for use by the Prometheus-based {product-title} cluster monitoring stack.
 
 .Metrics exposed by OLM
 [cols="2a,8a",options="header"]
@@ -14,33 +13,27 @@ by the Prometheus-based {product-title} cluster monitoring stack.
 |Name |Description
 
 |`catalog_source_count`
-|Number of CatalogSources.
+|Number of catalog sources.
 
 |`csv_abnormal`
-|When reconciling a ClusterServiceVersion (CSV), present whenever a CSV version
-is in any state other than `Succeeded`, for example when it is not installed.
-Includes the `name`, `namespace`, `phase`, `reason`, and `version` labels. A
-Prometheus alert is created when this metric is present.
+|When reconciling a cluster service version (CSV), present whenever a CSV version is in any state other than `Succeeded`, for example when it is not installed. Includes the `name`, `namespace`, `phase`, `reason`, and `version` labels. A Prometheus alert is created when this metric is present.
 
 |`csv_count`
 |Number of CSVs successfully registered.
 
 |`csv_succeeded`
-|When reconciling a CSV, represents whether a CSV version is in a `Succeeded`
-state (value `1`) or not (value `0`). Includes the `name`, `namespace`, and
-`version` labels.
+|When reconciling a CSV, represents whether a CSV version is in a `Succeeded` state (value `1`) or not (value `0`). Includes the `name`, `namespace`, and `version` labels.
 
 |`csv_upgrade_count`
 |Monotonic count of CSV upgrades.
 
 |`install_plan_count`
-|Number of InstallPlans.
+|Number of install plans.
 
 |`subscription_count`
-|Number of Subscriptions.
+|Number of subscriptions.
 
 |`subscription_sync_total`
-|Monotonic count of Subscription syncs. Includes the `channel`, `installed` CSV,
-and Subscription `name` labels.
+|Monotonic count of subscription syncs. Includes the `channel`, `installed` CSV, and subscription `name` labels.
 
 |===

--- a/modules/olm-operator-framework.adoc
+++ b/modules/olm-operator-framework.adoc
@@ -5,35 +5,21 @@
 [id="olm-operator-framework_{context}"]
 = Operator Framework
 
-The Operator Framework is a family of tools and capabilities to deliver on the
-customer experience described above. It is not just about writing code; testing,
-delivering, and updating Operators is just as important. The Operator Framework
-components consist of open source tools to tackle these problems:
+The Operator Framework is a family of tools and capabilities to deliver on the customer experience described above. It is not just about writing code; testing, delivering, and updating Operators is just as important. The Operator Framework components consist of open source tools to tackle these problems:
 
 Operator SDK::
-The Operator SDK assists Operator authors in bootstrapping, building, testing,
-and packaging their own Operator based on their expertise without requiring
-knowledge of Kubernetes API complexities.
+The Operator SDK assists Operator authors in bootstrapping, building, testing, and packaging their own Operator based on their expertise without requiring knowledge of Kubernetes API complexities.
 
 Operator Lifecycle Manager::
-Operator Lifecycle Manager (OLM) controls the installation, upgrade, and
-role-based access control (RBAC) of Operators in a cluster. Deployed by default
-in {product-title} {product-version}.
+Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. Deployed by default in {product-title} {product-version}.
 
 Operator Registry::
-The Operator Registry stores ClusterServiceVersions (CSVs) and custom resource
-definitions (CRDs) for creation in a cluster and stores Operator metadata about
-packages and channels. It runs in a Kubernetes or OpenShift cluster to provide
-this Operator catalog data to OLM.
+The Operator Registry stores cluster service versions (CSVs) and custom resource definitions (CRDs) for creation in a cluster and stores Operator metadata about packages and channels. It runs in a Kubernetes or OpenShift cluster to provide this Operator catalog data to OLM.
 
 OperatorHub::
-OperatorHub is a web console for cluster administrators to discover and
-select Operators to install on their cluster. It is deployed by default in
-{product-title}.
+OperatorHub is a web console for cluster administrators to discover and select Operators to install on their cluster. It is deployed by default in {product-title}.
 
 Operator Metering::
-Operator Metering collects operational metrics about Operators on the cluster for
-Day 2 management and aggregating usage metrics.
+Operator Metering collects operational metrics about Operators on the cluster for Day 2 management and aggregating usage metrics.
 
-These tools are designed to be composable, so you can use any that are useful to
-you.
+These tools are designed to be composable, so you can use any that are useful to you.

--- a/modules/olm-operator-maturity-model.adoc
+++ b/modules/olm-operator-maturity-model.adoc
@@ -5,17 +5,12 @@
 [id="olm-maturity-model_{context}"]
 = Operator maturity model
 
-The level of sophistication of the management logic encapsulated within an
-Operator can vary. This logic is also in general highly dependent on the type of
-the service represented by the Operator.
+The level of sophistication of the management logic encapsulated within an Operator can vary. This logic is also in general highly dependent on the type of the service represented by the Operator.
 
-One can however generalize the scale of the maturity of an Operator's
-encapsulated operations for certain set of capabilities that most Operators can
-include. To this end, the following Operator Maturity model defines five phases
-of maturity for generic day two operations of an Operator:
+One can however generalize the scale of the maturity of the encapsulated operations of an Operator for certain set of capabilities that most Operators can include. To this end, the following Operator maturity model defines five phases of maturity for generic day two operations of an Operator:
 
 .Operator maturity model
 image::operator-maturity-model.png[]
 
 The above model also shows how these capabilities can best be developed through
-the Operator SDK's Helm, Go, and Ansible capabilities.
+the Helm, Go, and Ansible capabilities of the Operator SDK.

--- a/modules/olm-operatorgroups-about.adoc
+++ b/modules/olm-operatorgroups-about.adoc
@@ -5,17 +5,12 @@
 
 [id="olm-operatorgroups-about_{context}"]
 ifeval::["{context}" == "olm-understanding-olm"]
-= OperatorGroups
+= Operator groups
 endif::[]
 ifeval::["{context}" != "olm-understanding-olm"]
-= About OperatorGroups
+= About Operator groups
 endif::[]
 
-An _OperatorGroup_ is an OLM resource that provides multitenant configuration to
-OLM-installed Operators. An OperatorGroup selects target namespaces in which to
-generate required RBAC access for its member Operators.
+An _Operator group_, defined by the `OperatorGroup` resource, provides multitenant configuration to OLM-installed Operators. An Operator group selects target namespaces in which to generate required RBAC access for its member Operators.
 
-The set of target namespaces is provided by a comma-delimited string stored in
-the ClusterServiceVersion's (CSV) `olm.targetNamespaces` annotation. This
-annotation is applied to member Operator's CSV instances and is projected into
-their deployments.
+The set of target namespaces is provided by a comma-delimited string stored in the `olm.targetNamespaces` annotation of a cluster service version (CSV). This annotation is applied to the CSV instances of member Operators and is projected into their deployments.

--- a/modules/olm-operatorgroups-copied-csvs.adoc
+++ b/modules/olm-operatorgroups-copied-csvs.adoc
@@ -5,13 +5,8 @@
 [id="olm-operatorgroups-copied-csvs_{context}"]
 = Copied CSVs
 
-OLM creates copies of all active member CSVs of an OperatorGroup in each of that
-OperatorGroup's target namespaces. The purpose of a copied CSV is to tell users
-of a target namespace that a specific Operator is configured to watch resources
-created there. Copied CSVs have a status reason `Copied` and are updated to
-match the status of their source CSV. The `olm.targetNamespaces` annotation is
-stripped from copied CSVs before they are created on the cluster. Omitting the
-target namespace selection avoids the duplication of target namespaces between
-tenants. Copied CSVs are deleted when their source CSV no longer exists or the
-OperatorGroup that their source CSV belongs to no longer targets the copied
-CSV's namespace.
+OLM creates copies of all active member CSVs of an Operator group in each of the target namespaces of that Operator group. The purpose of a copied CSV is to tell users of a target namespace that a specific Operator is configured to watch resources created there.
+
+Copied CSVs have a status reason `Copied` and are updated to match the status of their source CSV. The `olm.targetNamespaces` annotation is stripped from copied CSVs before they are created on the cluster. Omitting the target namespace selection avoids the duplication of target namespaces between tenants.
+
+Copied CSVs are deleted when their source CSV no longer exists or the Operator group that their source CSV belongs to no longer targets the namespace of the copied CSV.

--- a/modules/olm-operatorgroups-csv-annotations.adoc
+++ b/modules/olm-operatorgroups-csv-annotations.adoc
@@ -3,28 +3,25 @@
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
 [id="olm-operatorgroups-csv-annotations_{context}"]
-= OperatorGroup CSV annotations
+= Operator group CSV annotations
 
-Member CSVs of an OperatorGroup have the following annotations:
+Member CSVs of an Operator group have the following annotations:
 
 [cols="1,1",options="header"]
 |===
 |Annotation |Description
 
 |`olm.operatorGroup=<group_name>`
-|Contains the name of the OperatorGroup.
+|Contains the name of the Operator group.
 
 |`olm.operatorGroupNamespace=<group_namespace>`
-|Contains the namespace of the OperatorGroup.
+|Contains the namespace of the Operator group.
 
 |`olm.targetNamespaces=<target_namespaces>`
-|Contains a comma-delimited string that lists the OperatorGroup's target
-namespace selection.
+|Contains a comma-delimited string that lists the target namespace selection of the Operator group.
 |===
 
 [NOTE]
 ====
-All annotations except `olm.targetNamespaces` are included with copied CSVs.
-Omitting the `olm.targetNamespaces` annotation on copied CSVs prevents the
-duplication of target namespaces between tenants.
+All annotations except `olm.targetNamespaces` are included with copied CSVs. Omitting the `olm.targetNamespaces` annotation on copied CSVs prevents the duplication of target namespaces between tenants.
 ====

--- a/modules/olm-operatorgroups-intersections.adoc
+++ b/modules/olm-operatorgroups-intersections.adoc
@@ -3,67 +3,49 @@
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
 [id="olm-operatorgroups-intersection_{context}"]
-= OperatorGroup intersection
+= Operator group intersection
 
-Two OperatorGroups are said to have _intersecting provided APIs_ if the
-intersection of their target namespace sets is not an empty set and the
-intersection of their provided API sets, defined by `olm.providedAPIs`
-annotations, is not an empty set.
+Two Operator groups are said to have _intersecting provided APIs_ if the intersection of their target namespace sets is not an empty set and the intersection of their provided API sets, defined by `olm.providedAPIs` annotations, is not an empty set.
 
-A potential issue is that OperatorGroups with intersecting provided APIs can
-compete for the same resources in the set of intersecting namespaces.
+A potential issue is that Operator groups with intersecting provided APIs can compete for the same resources in the set of intersecting namespaces.
 
 [NOTE]
 ====
-When checking intersection rules, an OperatorGroup's namespace is always
-included as part of its selected target namespaces.
+When checking intersection rules, an Operator group namespace is always included as part of its selected target namespaces.
 ====
 
 [discrete]
 [id="olm-operatorgroups-intersection-rules_{context}"]
 === Rules for intersection
 
-Each time an active member CSV synchronizes, OLM queries the cluster for the set
-of intersecting provided APIs between the CSV's OperatorGroup and all others.
-OLM then checks if that set is an empty set:
+Each time an active member CSV synchronizes, OLM queries the cluster for the set of intersecting provided APIs between the Operator group of the CSV and all others. OLM then checks if that set is an empty set:
 
-* If `true` and the CSV's provided APIs are a subset of the OperatorGroup's:
+* If `true` and the CSV's provided APIs are a subset of the Operator group's:
 ** Continue transitioning.
-* If `true` and the CSV's provided APIs are _not_ a subset of the
-OperatorGroup's:
-** If the OperatorGroup is static:
+* If `true` and the CSV's provided APIs are _not_ a subset of the Operator group's:
+** If the Operator group is static:
 *** Clean up any deployments that belong to the CSV.
 *** Transition the CSV to a failed state with status reason
 `CannotModifyStaticOperatorGroupProvidedAPIs`.
-** If the OperatorGroup is _not_ static:
-*** Replace the OperatorGroup's `olm.providedAPIs` annotation with the union of
-itself and the CSV's provided APIs.
-* If `false` and the CSV's provided APIs are _not_ a subset of the
-OperatorGroup's:
+** If the Operator group is _not_ static:
+*** Replace the Operator group's `olm.providedAPIs` annotation with the union of itself and the CSV's provided APIs.
+* If `false` and the CSV's provided APIs are _not_ a subset of the Operator group's:
 ** Clean up any deployments that belong to the CSV.
-** Transition the CSV to a failed state with status reason
-`InterOperatorGroupOwnerConflict`.
-* If `false` and the CSV's provided APIs are a subset of the OperatorGroup's:
-** If the OperatorGroup is static:
+** Transition the CSV to a failed state with status reason `InterOperatorGroupOwnerConflict`.
+* If `false` and the CSV's provided APIs are a subset of the Operator group's:
+** If the Operator group is static:
 *** Clean up any deployments that belong to the CSV.
-*** Transition the CSV to a failed state with status reason
-`CannotModifyStaticOperatorGroupProvidedAPIs`.
-** If the OperatorGroup is _not_ static:
-*** Replace the OperatorGroup's `olm.providedAPIs` annotation with the
-difference between itself and the CSV's provided APIs.
+*** Transition the CSV to a failed state with status reason `CannotModifyStaticOperatorGroupProvidedAPIs`.
+** If the Operator group is _not_ static:
+*** Replace the Operator group's `olm.providedAPIs` annotation with the difference between itself and the CSV's provided APIs.
 
 [NOTE]
 ====
-Failure states caused by OperatorGroups are non-terminal.
+Failure states caused by Operator groups are non-terminal.
 ====
 
-The following actions are performed each time an OperatorGroup synchronizes:
+The following actions are performed each time an Operator group synchronizes:
 
-* The set of provided APIs from active member CSVs is calculated from the
-cluster. Note that copied CSVs are ignored.
-* The cluster set is compared to `olm.providedAPIs`, and if `olm.providedAPIs`
-contains any extra APIs, then those APIs are pruned.
-* All CSVs that provide the same APIs across all namespaces are requeued. This
-notifies conflicting CSVs in intersecting groups that their conflict has
-possibly been resolved, either through resizing or through deletion of the
-conflicting CSV.
+* The set of provided APIs from active member CSVs is calculated from the cluster. Note that copied CSVs are ignored.
+* The cluster set is compared to `olm.providedAPIs`, and if `olm.providedAPIs` contains any extra APIs, then those APIs are pruned.
+* All CSVs that provide the same APIs across all namespaces are requeued. This notifies conflicting CSVs in intersecting groups that their conflict has possibly been resolved, either through resizing or through deletion of the conflicting CSV.

--- a/modules/olm-operatorgroups-membership.adoc
+++ b/modules/olm-operatorgroups-membership.adoc
@@ -3,43 +3,34 @@
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
 [id="olm-operatorgroups-membership_{context}"]
-= OperatorGroup membership
+= Operator group membership
 
-An Operator is considered a _member_ of an OperatorGroup if the following
-conditions are true:
+An Operator is considered a _member_ of an Operator group if the following conditions are true:
 
-* The Operator's CSV exists in the same namespace as the OperatorGroup.
-* The Operator's CSV's InstallModes support the set of namespaces targeted by
-the OperatorGroup.
+* The CSV of the Operator exists in the same namespace as the Operator group.
+* The install modes in the CSV of the Operator support the set of namespaces targeted by the Operator group.
 
-An InstallMode consists of an `InstallModeType` field and a boolean `Supported`
-field. A CSV's spec can contain a set of InstallModes of four distinct
-`InstallModeTypes`:
+An install mode in a CSV consists of an `InstallModeType` field and a boolean `Supported` field. The spec of a CSV can contain a set of install modes of four distinct `InstallModeTypes`:
 
-.InstallModes and supported OperatorGroups
+.Install modes and supported Operator groups
 [cols="1,2",options="header"]
 |===
 |InstallModeType |Description
 
 |`OwnNamespace`
-|The Operator can be a member of an OperatorGroup that selects its own
- namespace.
+|The Operator can be a member of an Operator group that selects its own namespace.
 
 |`SingleNamespace`
-|The Operator can be a member of an OperatorGroup that selects one namespace.
+|The Operator can be a member of an Operator group that selects one namespace.
 
 |`MultiNamespace`
-|The Operator can be a member of an OperatorGroup that selects more than one
-namespace.
+|The Operator can be a member of an Operator group that selects more than one namespace.
 
 |`AllNamespaces`
-|The Operator can be a member of an OperatorGroup that selects all namespaces
-(target namespace set is the empty string `""`).
+|The Operator can be a member of an Operator group that selects all namespaces (target namespace set is the empty string `""`).
 |===
 
 [NOTE]
 ====
-If a CSV's spec omits an entry of `InstallModeType`, then that type is
-considered unsupported unless support can be inferred by an existing entry that
-implicitly supports it.
+If the spec of a CSV omits an entry of `InstallModeType`, then that type is considered unsupported unless support can be inferred by an existing entry that implicitly supports it.
 ====

--- a/modules/olm-operatorgroups-provided-apis-annotations.adoc
+++ b/modules/olm-operatorgroups-provided-apis-annotations.adoc
@@ -5,14 +5,9 @@
 [id="olm-operatorgroups-provided-apis-annotation_{context}"]
 = Provided APIs annotation
 
-Information about what `GroupVersionKinds` (GVKs) are provided by an
-OperatorGroup are shown in an `olm.providedAPIs` annotation. The annotation's
-value is a string consisting of `<kind>.<version>.<group>` delimited with
-commas. The GVKs of CRDs and APIServices provided by all active member CSVs of
-an OperatorGroup are included.
+A _group/version/kind (GVK)_ is a unique identifier for a Kubernetes API. Information about what GVKs are provided by an Operator group are shown in an `olm.providedAPIs` annotation. The value of the annotation is a string consisting of `<kind>.<version>.<group>` delimited with commas. The GVKs of CRDs and API services provided by all active member CSVs of an Operator group are included.
 
-Review the following example of an OperatorGroup with a single active member CSV
-that provides the PackageManifest resource:
+Review the following example of an `OperatorGroup` object with a single active member CSV that provides the `PackageManifest` resource:
 
 [source,yaml]
 ----

--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -5,13 +5,11 @@
 [id="olm-operatorgroups-rbac_{context}"]
 = Role-based access control
 
-When an OperatorGroup is created, three ClusterRoles are generated. Each
-contains a single AggregationRule with a ClusterRoleSelector set to match a
-label, as shown below:
+When an Operator group is created, three cluster roles are generated. Each contains a single aggregation rule with a cluster role selector set to match a label, as shown below:
 
 [cols="1,1",options="header"]
 |===
-|ClusterRole |Label to match
+|Cluster role |Label to match
 
 |`<operatorgroup_name>-admin`
 |`olm.opgroup.permissions/aggregate-to-admin: <operatorgroup_name>`
@@ -23,17 +21,17 @@ label, as shown below:
 |`olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
 |===
 
-The following RBAC resources are generated when a CSV becomes an active member of an OperatorGroup, as long as the CSV is watching all namespaces with the `AllNamespaces` InstallMode and is not in a failed state with reason `InterOperatorGroupOwnerConflict`.
+The following RBAC resources are generated when a CSV becomes an active member of an Operator group, as long as the CSV is watching all namespaces with the `AllNamespaces` install mode and is not in a failed state with reason `InterOperatorGroupOwnerConflict`:
 
-* ClusterRoles for each API resource from a CRD
-* ClusterRoles for each API resource from an APIService
-* Additional Roles and RoleBindings
+* Cluster roles for each API resource from a CRD
+* Cluster roles for each API resource from an API service
+* Additional roles and role bindings
 
 [id="olm-resources-per-api-resource-crd_{context}"]
-.ClusterRoles generated for each API resource from a CRD
+.Cluster roles generated for each API resource from a CRD
 [cols="1,1a",options="header"]
 |===
-|ClusterRole |Settings
+|Cluster role |Settings
 
 |`<kind>.<group>-<version>-admin`
 |Verbs on `<kind>`:
@@ -83,10 +81,10 @@ Aggregation labels:
 |===
 
 [id="olm-resources-per-api-resource-api_{context}"]
-.ClusterRoles generated for each API resource from an APIService
+.Cluster roles generated for each API resource from an API service
 [cols="1,1a",options="header"]
 |===
-|ClusterRole |Settings
+|Cluster role |Settings
 
 |`<kind>.<group>-<version>-admin`
 |Verbs on `<kind>`:
@@ -126,13 +124,6 @@ Aggregation labels:
 |===
 
 [id="olm-resources-additional-roles-rolebindings_{context}"]
-.Additional Roles and RoleBindings
-* If the CSV defines exactly one target namespace that contains `*`, then a
-ClusterRole and corresponding ClusterRoleBinding are generated for each
-permission defined in the CSV's permissions field. All resources generated are
-given the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>`
-labels.
-* If the CSV does _not_ define exactly one target namespace that contains `*`,
-then all Roles and RoleBindings in the Operator namespace with the
-`olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels are
-copied into the target namespace.
+.Additional roles and role bindings
+* If the CSV defines exactly one target namespace that contains `*`, then a cluster role and corresponding cluster role binding are generated for each permission defined in the `permissions` field of the CSV. All resources generated are given the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels.
+* If the CSV does _not_ define exactly one target namespace that contains `*`, then all roles and role bindings in the Operator namespace with the `olm.owner: <csv_name>` and `olm.owner.namespace: <csv_namespace>` labels are copied into the target namespace.

--- a/modules/olm-operatorgroups-static.adoc
+++ b/modules/olm-operatorgroups-static.adoc
@@ -3,18 +3,11 @@
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
 [id="olm-operatorgroups-static_{context}"]
-= Static OperatorGroups
+= Static Operator groups
 
-An OperatorGroup is _static_ if its `spec.staticProvidedAPIs` field is set to
-`true`. As a result, OLM does not modify the OperatorGroup's `olm.providedAPIs`
-annotation, which means that it can be set in advance. This is useful when a
-user wants to use an OperatorGroup to prevent resource contention in a set of
-namespaces but does not have active member CSVs that provide the APIs for those
-resources.
+An Operator group is _static_ if its `spec.staticProvidedAPIs` field is set to `true`. As a result, OLM does not modify the `olm.providedAPIs` annotation of an Operator group, which means that it can be set in advance. This is useful when a user wants to use an Operator group to prevent resource contention in a set of namespaces but does not have active member CSVs that provide the APIs for those resources.
 
-Below is an example of an OperatorGroup that protects Prometheus resources in
-all namespaces with the `something.cool.io/cluster-monitoring: "true"`
-annotation:
+Below is an example of an Operator group that protects `Prometheus` resources in all namespaces with the `something.cool.io/cluster-monitoring: "true"` annotation:
 
 [source,yaml]
 ----

--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -5,8 +5,7 @@
 [id="olm-operatorgroups-target-namespace_{context}"]
 = Target namespace selection
 
-You can explicitly name the target namespace for an OperatorGroup using the
-`spec.targetNamespaces` parameter:
+You can explicitly name the target namespace for an Operator group using the `spec.targetNamespaces` parameter:
 
 [source,yaml]
 ----
@@ -20,8 +19,7 @@ spec:
   - my-namespace
 ----
 
-You can alternatively specify a namespace using a label selector with the
-`spec.selector` parameter:
+You can alternatively specify a namespace using a label selector with the `spec.selector` parameter:
 
 [source,yaml]
 ----
@@ -37,16 +35,10 @@ metadata:
 
 [IMPORTANT]
 ====
-Listing multiple namespaces via `spec.targetNamespaces` or use of a label
-selector via `spec.selector` is not recommended, as the support for more than
-one target namespace in an OperatorGroup will likely be removed in a future
-release.
+Listing multiple namespaces via `spec.targetNamespaces` or use of a label selector via `spec.selector` is not recommended, as the support for more than one target namespace in an Operator group will likely be removed in a future release.
 ====
 
-If both `spec.targetNamespaces` and `spec.selector` are defined, `spec.selector`
-is ignored. Alternatively, you can omit both `spec.selector` and
-`spec.targetNamespaces` to specify a _global_ OperatorGroup, which selects all
-namespaces:
+If both `spec.targetNamespaces` and `spec.selector` are defined, `spec.selector` is ignored. Alternatively, you can omit both `spec.selector` and `spec.targetNamespaces` to specify a _global_ Operator group, which selects all namespaces:
 
 [source,yaml]
 ----
@@ -57,7 +49,4 @@ metadata:
   namespace: my-namespace
 ----
 
-The resolved set of selected namespaces is shown in an OperatorGroup's
-`status.namespaces` parameter. A global OperatorGroup's `status.namespace` contains
-the empty string (`""`), which signals to a consuming Operator that it should
-watch all namespaces.
+The resolved set of selected namespaces is shown in the `status.namespaces` parameter of an Opeator group. The `status.namespace` of a global Operator group contains the empty string (`""`), which signals to a consuming Operator that it should watch all namespaces.

--- a/modules/olm-operatorgroups-troubleshooting.adoc
+++ b/modules/olm-operatorgroups-troubleshooting.adoc
@@ -3,21 +3,11 @@
 // * operators/understanding/olm/olm-understanding-operatorgroups.adoc
 
 [id="olm-operatorgroups-troubleshooting_{context}"]
-= Troubleshooting OperatorGroups
+= Troubleshooting Operator groups
 
 [discrete]
 [id="olm-operatorgroups-troubleshooting-membership_{context}"]
 === Membership
 
-* If more than one OperatorGroup exists in a single namespace, any CSV created
-in that namespace will transition to a failure state with the reason
-`TooManyOperatorGroups`. CSVs in a failed state for this reason will
-transition to pending once the number of OperatorGroups in their namespaces
-reaches one.
-* If a CSV's InstallModes do not support the target namespace selection of the
-OperatorGroup in its namespace, the CSV will transition to a failure state
-with the reason `UnsupportedOperatorGroup`. CSVs in a failed state for this
-reason will transition to pending once either the OperatorGroup's target
-namespace selection changes to a supported configuration, or the CSV's
-InstallModes are modified to support the OperatorGroup's target namespace
-selection.
+* If more than one Operator group exists in a single namespace, any CSV created in that namespace transitions to a failure state with the reason `TooManyOperatorGroups`. CSVs in a failed state for this reason transition to pending after the number of Operator groups in their namespaces reaches one.
+* If the install modes of a CSV do not support the target namespace selection of the Operator group in its namespace, the CSV transitions to a failure state with the reason `UnsupportedOperatorGroup`. CSVs in a failed state for this reason transition to pending after either the target namespace selection of the Operator group changes to a supported configuration, or the install modes of the CSV are modified to support the target namespace selection.

--- a/modules/olm-operatorhub-architecture.adoc
+++ b/modules/olm-operatorhub-architecture.adoc
@@ -5,28 +5,21 @@
 [id="olm-operatorhub-arch_{context}"]
 = OperatorHub architecture
 
-The OperatorHub UI component is driven by the Marketplace Operator by default on
-{product-title} in the `openshift-marketplace` namespace.
+The OperatorHub UI component is driven by the Marketplace Operator by default on {product-title} in the `openshift-marketplace` namespace.
 
-The Marketplace Operator manages OperatorHub and OperatorSource Custom Resource
-Definitions (CRDs).
+The Marketplace Operator manages `OperatorHub` and `OperatorSource` custom resource definitions (CRDs).
 
 [NOTE]
 ====
-Although some OperatorSource information is exposed through OperatorHub's UI
-interface, it is only used directly by those who are creating their own
-Operators.
+Although some `OperatorSource` object information is exposed through the OperatorHub UI, it is only used directly by those who are creating their own Operators.
 ====
 
 [id="olm-operatorhub-arch-operatorhub_crd_{context}"]
-== OperatorHub CRD
+== `OperatorHub` CRD
 
-You can use the OperatorHub CRD to change the state of the default
-OperatorSources provided with OperatorHub on the cluster between enabled and
-disabled. This capability is useful when configuring {product-title} in
-restricted network environments.
+You can use the `OperatorHub` CRD to change the state of the default `OperatorSource` objects provided with OperatorHub on the cluster between enabled and disabled. This capability is useful when configuring {product-title} in restricted network environments.
 
-.Example OperatorHub Custom Resource
+.Example `OperatorHub` custom resource
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -42,19 +35,15 @@ spec:
     }
   ]
 ----
-<1> `disableAllDefaultSources` is an override that controls availability of all
-default OperatorSources that are configured by default during an {product-title}
-installation.
-<2> Disable default OperatorSources individually by changing the `disabled`
-parameter value per source.
+<1> `disableAllDefaultSources` is an override that controls availability of all default `OperatorSource` objects that are configured by default during an {product-title} installation.
+<2> Disable default the default sources individually by changing the `disabled` parameter value per source.
 
 [id="olm-operatorhub-arch-operatorsource_crd_{context}"]
-== OperatorSource CRD
+== `OperatorSource` CRD
 
-For each Operator, the OperatorSource CRD is used to define the external data
-store used to store Operator bundles.
+For each Operator, the `OperatorSource` CRD is used to define the external data store used to store Operator bundles.
 
-.Example OperatorSource Custom Resource
+.Example `OperatorSource` custom resource
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -70,10 +59,7 @@ spec:
   publisher: "Red Hat" <5>
 ----
 <1> To identify the data store as an application registry, `type` is set to `appregistry`.
-<2> Currently, Quay is the external data store used by OperatorHub, so
-the endpoint is set to `\https://quay.io/cnr` for the Quay.io `appregistry`.
+<2> Currently, Quay is the external data store used by OperatorHub, so the endpoint is set to `\https://quay.io/cnr` for the Quay.io `appregistry`.
 <3> For a Community Operator, `registryNamespace` is set to `community-operator`.
-<4> Optionally, set `displayName` to a name that appears for the Operator in the
-OperatorHub UI.
-<5> Optionally, set `publisher` to the person or organization publishing the
-Operator that appears in the OperatorHub UI.
+<4> Optionally, set `displayName` to a name that appears for the Operator in the OperatorHub UI.
+<5> Optionally, set `publisher` to the person or organization publishing the Operator that appears in the OperatorHub UI.

--- a/modules/olm-operatorhub-overview.adoc
+++ b/modules/olm-operatorhub-overview.adoc
@@ -5,14 +5,9 @@
 [id="olm-operatorhub-overview_{context}"]
 = About OperatorHub
 
-_OperatorHub_ is available via the {product-title} web console and is the
-interface that cluster administrators use to discover and install Operators.
-With one click, an Operator can be pulled from their off-cluster source,
-installed and subscribed on the cluster, and made ready for engineering teams to
-self-service manage the product across deployment environments using the
-Operator Lifecycle Manager (OLM).
+_OperatorHub_ is available via the {product-title} web console and is the interface that cluster administrators use to discover and install Operators. With one click, an Operator can be pulled from their off-cluster source, installed and subscribed on the cluster, and made ready for engineering teams to self-service manage the product across deployment environments using the Operator Lifecycle Manager (OLM).
 
-Cluster administrators can choose from OperatorSources grouped into
+Cluster administrators can choose from Operator sources grouped into
 the following categories:
 
 [cols="2a,8a",options="header"]
@@ -23,18 +18,14 @@ the following categories:
 |Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
 
 |Certified Operators
-|Products from leading independent software vendors (ISVs). Red Hat partners with
-ISVs to package and ship. Supported by the ISV.
+|Products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
 
 |Community Operators
-|Optionally-visible software maintained by relevant representatives in the
-link:https://github.com/operator-framework/community-operators[operator-framework/community-operators]
-GitHub repository. No official support.
+|Optionally-visible software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
 
 |Custom Operators
 |Operators you add to the cluster yourself.
-If you have not added any Custom Operators, the Custom category does not appear in
-the web console on your OperatorHub.
+If you have not added any Custom Operators, the Custom category does not appear in the web console on your OperatorHub.
 |===
 
 [NOTE]
@@ -42,14 +33,6 @@ the web console on your OperatorHub.
 OperatorHub content automatically refreshes every 60 minutes.
 ====
 
-Operators on OperatorHub are packaged to run on OLM. This includes a YAML
-file called a ClusterServiceVersion (CSV) containing all of the CRDs, RBAC
-rules, Deployments, and container images required to install and securely run the
-Operator. It also contains user-visible information like a description of its
-features and supported Kubernetes versions.
+Operators on OperatorHub are packaged to run on OLM. This includes a YAML file called a cluster service version (CSV) containing all of the CRDs, RBAC rules, Deployments, and container images required to install and securely run the Operator. It also contains user-visible information like a description of its features and supported Kubernetes versions.
 
-The Operator SDK can be used to assist developers packaging their Operators for
-use on OLM and OperatorHub. If you have a commercial application that you
-want to make accessible to your customers, get it included using the
-certification workflow provided by Red Hat's ISV partner portal at
-link:https://connect.redhat.com[connect.redhat.com].
+The Operator SDK can be used to assist developers packaging their Operators for use on OLM and OperatorHub. If you have a commercial application that you want to make accessible to your customers, get it included using the certification workflow provided by Red Hat's ISV partner portal at link:https://connect.redhat.com[connect.redhat.com].

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -3,12 +3,9 @@
 // * operators/olm-configuring-proxy-support.adoc
 
 [id="olm-overriding-proxy-settings_{context}"]
-= Overriding an Operator's proxy settings
+= Overriding proxy settings of an Operator
 
-If a cluster-wide egress proxy is configured, applications created from
-Operators using Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy
-settings on their Deployments and pods. Cluster administrators can also override
-these proxy settings by configuring the Operator's Subscription.
+If a cluster-wide egress proxy is configured, applications created from Operators using Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy settings on their deployments and pods. Cluster administrators can also override these proxy settings by configuring the subscription of an Operator.
 
 .Prerequisites
 
@@ -26,9 +23,7 @@ endif::[]
 
 . Select the Operator and click *Install*.
 
-. On the *Install Operator* page, modify the Subscription object's
-YAML to include one or more of the following environment variables in the
-`spec` section:
+. On the *Install Operator* page, modify the `Subscription` object to include one or more of the following environment variables in the `spec` section:
 +
 --
 * `HTTP_PROXY`
@@ -38,7 +33,7 @@ YAML to include one or more of the following environment variables in the
 +
 For example:
 +
-.Subscription object with proxy setting overrides
+.`Subscription` object with proxy setting overrides
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -65,19 +60,14 @@ spec:
 +
 [NOTE]
 ====
-These environment variables can also be unset using an empty value to remove any
-previously set cluster-wide or custom proxy settings.
+These environment variables can also be unset using an empty value to remove any previously set cluster-wide or custom proxy settings.
 ====
 +
-OLM handles these environment variables as a unit; if at least one of them is
-set, all three are considered overridden and the cluster-wide defaults are not
-used for the subscribed Operator's Deployments.
+OLM handles these environment variables as a unit; if at least one of them is set, all three are considered overridden and the cluster-wide defaults are not used for the deployments of the subscribed Operator.
 
 . Click *Install* to make the Operator available to the selected namespaces.
 
-. After the Operator's CSV appears in the relevant namespace, you can verify that
-custom proxy environment variables are set in the Deployment. For example, using
-the CLI:
+. After the CSV for the Operator appears in the relevant namespace, you can verify that custom proxy environment variables are set in the deployment. For example, using the CLI:
 +
 [source,terminal]
 ----

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -11,24 +11,11 @@ ifeval::["{context}" == "red-hat-operators"]
 = Purpose
 endif::[]
 
-
-_Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the
-lifecycle of all Operators and their associated services running across their
-{product-title} clusters. It is part of the
-link:https://operatorframework.io/[Operator Framework], an open source toolkit
-designed to manage Kubernetes native applications (Operators) in an effective,
-automated, and scalable way.
+_Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the lifecycle of Kubernetes native applications (Operators) and their associated services running across their {product-title} clusters. It is part of the link:https://operatorframework.io/[Operator Framework], an open source toolkit designed to manage Operators in an effective, automated, and scalable way.
 
 .Operator Lifecycle Manager workflow
 image::olm-workflow.png[]
 
-OLM runs by default in {product-title} {product-version}, which aids cluster
-administrators in installing, upgrading, and granting access to Operators
-running on their cluster. The {product-title} web console provides management
-screens for cluster administrators to install Operators, as well as grant
-specific projects access to use the catalog of Operators available on the
-cluster.
+OLM runs by default in {product-title} {product-version}, which aids cluster administrators in installing, upgrading, and granting access to Operators running on their cluster. The {product-title} web console provides management screens for cluster administrators to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
 
-For developers, a self-service experience allows provisioning and configuring
-instances of databases, monitoring, and big data services without having to be
-subject matter experts, because the Operator has that knowledge baked into it.
+For developers, a self-service experience allows provisioning and configuring instances of databases, monitoring, and big data services without having to be subject matter experts, because the Operator has that knowledge baked into it.

--- a/modules/olm-package-manifest-format.adoc
+++ b/modules/olm-package-manifest-format.adoc
@@ -5,15 +5,11 @@
 [id="olm-package-manifest-format_{context}"]
 = Package Manifest Format
 
-The _Package Manifest Format_ for Operators is the legacy packaging format
-introduced by the Operator Framework. While this format is deprecated in
-{product-title} 4.5, it is still supported and Operators provided by Red Hat are
-currently shipped using this method.
+The _Package Manifest Format_ for Operators is the legacy packaging format introduced by the Operator Framework. While this format is deprecated in {product-title} 4.5, it is still supported and Operators provided by Red Hat are currently shipped using this method.
 
-In this format, a version of an Operator is represented by a single
-ClusterServiceVersion (CSV) and typically the CustomResourceDefinitions (CRDs)
-that define the owned APIs of the CSV, though additional objects may be
-included. All versions of the Operator are nested in a single directory:
+In this format, a version of an Operator is represented by a single cluster service version (CSV) and typically the custom resource definitions (CRDs) that define the owned APIs of the CSV, though additional objects may be included.
+
+All versions of the Operator are nested in a single directory:
 
 .Example Package Manifest Format layout
 [source,terminal]
@@ -35,8 +31,7 @@ etcd
 └── etcd.package.yaml
 ----
 
-It also includes a `<name>.package.yaml` file that is the _package manifest_
-that defines the package name and channels details:
+It also includes a `<name>.package.yaml` file that is the _package manifest_ that defines the package name and channels details:
 
 .Example package manifest
 [source,yaml]
@@ -52,11 +47,10 @@ channels:
 defaultChannel: alpha
 ----
 
-When loading package manifests into the Operator Registry database, the following
-requirements are validated:
+When loading package manifests into the Operator Registry database, the following requirements are validated:
 
 * Every package has at least one channel.
 * Every CSV pointed to by a channel in a package exists.
 * Every version of an Operator has exactly one CSV.
-* If a CSV owns a CRD, that CRD must exist in the Operator version's directory.
+* If a CSV owns a CRD, that CRD must exist in the directory of the Operator version.
 * If a CSV replaces another, both the old and the new must exist in the package.

--- a/modules/olm-policy-fine-grained-permissions.adoc
+++ b/modules/olm-policy-fine-grained-permissions.adoc
@@ -5,24 +5,21 @@
 [id="olm-policy-fine-grained-permissions_{context}"]
 = Fine-grained permissions
 
-OLM uses the service account specified in OperatorGroup to create or update the
-following resources related to the Operator being installed:
+Operator Lifecycle Manager (OLM) uses the service account specified in an Operator group to create or update the following resources related to the Operator being installed:
 
-* ClusterServiceVersion
-* Subscription
-* Secret
-* ServiceAccount
-* Service
-* ClusterRole and ClusterRoleBinding
-* Role and RoleBinding
+* `ClusterServiceVersion`
+* `Subscription`
+* `Secret`
+* `ServiceAccount`
+* `Service`
+* `ClusterRole` and `ClusterRoleBinding`
+* `Role` and `RoleBinding`
 
-In order to confine Operators to a designated namespace, cluster administrators
-can start by granting the following permissions to the service account:
+In order to confine Operators to a designated namespace, cluster administrators can start by granting the following permissions to the service account:
 
 [NOTE]
 ====
-The following role is a generic example and additional rules might be required
-based on the specific Operator.
+The following role is a generic example and additional rules might be required based on the specific Operator.
 ====
 
 [source,yaml]
@@ -45,11 +42,9 @@ rules:
   resources: ["pods"]
   verbs: ["list", "watch", "get", "create", "update", "patch", "delete"]
 ----
-<1> Add permissions to create other resources, such as Deployments and pods shown
-here.
+<1> Add permissions to create other resources, such as deployments and pods shown here.
 
-In addition, if any Operator specifies a pull secret, the following permissions
-must also be added:
+In addition, if any Operator specifies a pull secret, the following permissions must also be added:
 
 [source,yaml]
 ----

--- a/modules/olm-policy-scenarios.adoc
+++ b/modules/olm-policy-scenarios.adoc
@@ -5,30 +5,16 @@
 [id="olm-policy-scenarios_{context}"]
 = Installation scenarios
 
-When determining whether an Operator can be installed or upgraded on a cluster,
-OLM considers the following scenarios:
+When determining whether an Operator can be installed or upgraded on a cluster, Operator Lifecycle Manager (OLM) considers the following scenarios:
 
-* A cluster administrator creates a new OperatorGroup and specifies a service
-account. All Operator(s) associated with this OperatorGroup are installed and
-run against the privileges granted to the service account.
+* A cluster administrator creates a new Operator group and specifies a service account. All Operator(s) associated with this Operator group are installed and run against the privileges granted to the service account.
 
-* A cluster administrator creates a new OperatorGroup and does not specify any
-service account. {product-title} maintains backward compatibility, so the
-default behavior remains and Operator installs and upgrades are permitted.
+* A cluster administrator creates a new Operator group and does not specify any service account. {product-title} maintains backward compatibility, so the default behavior remains and Operator installs and upgrades are permitted.
 
-* For existing OperatorGroups that do not specify a service account, the default
-behavior remains and Operator installs and upgrades are permitted.
+* For existing Operator groups that do not specify a service account, the default behavior remains and Operator installs and upgrades are permitted.
 
-* A cluster administrator updates an existing OperatorGroup and specifies a
-service account. OLM allows the existing Operator to continue to run with their
-current privileges. When such an existing Operator is going through an upgrade,
-it is reinstalled and run against the privileges granted to the service account
-like any new Operator.
+* A cluster administrator updates an existing Operator group and specifies a service account. OLM allows the existing Operator to continue to run with their current privileges. When such an existing Operator is going through an upgrade, it is reinstalled and run against the privileges granted to the service account like any new Operator.
 
-* A service account specified by an OperatorGroup changes by adding or removing
-permissions, or the existing service account is swapped with a new one. When
-existing Operators go through an upgrade, it is reinstalled and run against the
-privileges granted to the updated service account like any new Operator.
+* A service account specified by an Operator group changes by adding or removing permissions, or the existing service account is swapped with a new one. When existing Operators go through an upgrade, it is reinstalled and run against the privileges granted to the updated service account like any new Operator.
 
-* A cluster administrator removes the service account from an OperatorGroup. The
-default behavior remains and Operator installs and upgrades are permitted.
+* A cluster administrator removes the service account from an Operator group. The default behavior remains and Operator installs and upgrades are permitted.

--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -5,11 +5,9 @@
 [id="olm-policy-scoping-operator-install_{context}"]
 = Scoping Operator installations
 
-To provide scoping rules to Operator installations and upgrades on OLM,
-associate a service account with an OperatorGroup.
+To provide scoping rules to Operator installations and upgrades on Operator Lifecycle Manager (OLM), associate a service account with an Operator group.
 
-Using this example, a cluster administrator can confine a set of Operators to a
-designated namespace.
+Using this example, a cluster administrator can confine a set of Operators to a designated namespace.
 
 .Procedure
 
@@ -25,8 +23,7 @@ metadata:
 EOF
 ----
 
-. Allocate permissions that you want the Operator(s) to be confined to. This
-involves creating a new service account, relevant Role(s), and RoleBinding(s).
+. Allocate permissions that you want the Operator(s) to be confined to. This involves creating a new service account, relevant role(s), and role binding(s).
 +
 [source,terminal]
 ----
@@ -39,9 +36,7 @@ metadata:
 EOF
 ----
 +
-The following example grants the service account permissions to do anything in
-the designated namespace for simplicity. In a production environment, you should
-create a more fine-grained set of permissions:
+The following example grants the service account permissions to do anything in the designated namespace for simplicity. In a production environment, you should create a more fine-grained set of permissions:
 +
 [source,terminal]
 ----
@@ -72,10 +67,9 @@ subjects:
 EOF
 ----
 
-. Create an OperatorGroup in the designated namespace. This OperatorGroup targets
-the designated namespace to ensure that its tenancy is confined to it. In
-addition, OperatorGroups allow a user to specify a service account. Specify the
-ServiceAccount created in the previous step:
+. Create an `OperatorGroup` object in the designated namespace. This Operator group targets the designated namespace to ensure that its tenancy is confined to it.
++
+In addition, Operator groups allow a user to specify a service account. Specify the service account created in the previous step:
 +
 [source,terminal]
 ----
@@ -92,10 +86,9 @@ spec:
 EOF
 ----
 +
-Any Operator installed in the designated namespace is tied to this OperatorGroup
-and therefore to the service account specified.
+Any Operator installed in the designated namespace is tied to this Operator group and therefore to the service account specified.
 
-. Create a Subscription in the designated namespace to install an Operator:
+. Create a `Subscription` object in the designated namespace to install an Operator:
 +
 [source,terminal]
 ----
@@ -112,11 +105,7 @@ spec:
   sourceNamespace: <catalog_source_namespace> <2>
 EOF
 ----
-<1> Specify a CatalogSource that already exists in the designated namespace or one
-that is in the global catalog namespace.
-<2> Specify a CatalogSourceNamespace where the CatalogSource was created.
+<1> Specify a catalog source that already exists in the designated namespace or one that is in the global catalog namespace.
+<2> Specify a namespace where the catalog source was created.
 +
-Any Operator tied to this OperatorGroup is confined to the permissions granted
-to the specified service account. If the Operator requests permissions that are
-outside the scope of the service account, the installation fails with
-appropriate errors.
+Any Operator tied to this Operator group is confined to the permissions granted to the specified service account. If the Operator requests permissions that are outside the scope of the service account, the installation fails with relevant errors.

--- a/modules/olm-policy-troubleshooting.adoc
+++ b/modules/olm-policy-troubleshooting.adoc
@@ -5,14 +5,11 @@
 [id="olm-policy-troubleshooting_{context}"]
 = Troubleshooting permission failures
 
-If an Operator installation fails due to lack of permissions, identify the
-errors using the following procedure.
+If an Operator installation fails due to lack of permissions, identify the errors using the following procedure.
 
 .Procedure
 
-. Review the Subscription object. Its status has an object reference
-`installPlanRef` that points to the InstallPlan object that attempted to create
-the necessary [Cluster]Role[Binding](s) for the Operator:
+. Review the `Subscription` object. Its status has an object reference `installPlanRef` that points to the `InstallPlan` object that attempted to create the necessary `[Cluster]Role[Binding]` object(s) for the Operator:
 +
 [source,yaml]
 ----
@@ -31,7 +28,7 @@ status:
     uid: 2c1df80e-afea-11e9-bce3-5254009c9c23
 ----
 
-. Check the status of the InstallPlan object for any errors:
+. Check the status of the `InstallPlan` object for any errors:
 +
 [source,yaml]
 ----
@@ -52,20 +49,15 @@ status:
 +
 The error message tells you:
 +
-* The type of resource it failed to create, including the API group of the
-resource. In this case, it was `clusterroles` in the `rbac.authorization.k8s.io`
-group.
+* The type of resource it failed to create, including the API group of the resource. In this case, it was `clusterroles` in the `rbac.authorization.k8s.io` group.
 * The name of the resource.
-* The type of error: `is forbidden` tells you that the user does not have enough
-permission to do the operation.
-* The name of the user who attempted to create or update the resource. In this
-case, it refers to the service account specified in the OperatorGroup.
+* The type of error: `is forbidden` tells you that the user does not have enough permission to do the operation.
+* The name of the user who attempted to create or update the resource. In this case, it refers to the service account specified in the Operator group.
 * The scope of the operation: `cluster scope` or not.
 +
 The user can add the missing permission to the service account and then iterate.
 +
 [NOTE]
 ====
-OLM does not currently provide the complete list of errors on the first try,
-but may be added in a future release.
+Operator Lifecycle Manager (OLM) does not currently provide the complete list of errors on the first try.
 ====

--- a/modules/olm-policy-understanding.adoc
+++ b/modules/olm-policy-understanding.adoc
@@ -5,20 +5,10 @@
 [id="olm-policy-understanding_{context}"]
 = Understanding Operator installation policy
 
-Using OLM, cluster administrators can choose to specify a service account for an
-OperatorGroup so that all Operators associated with the OperatorGroup are
-deployed and run against the privileges granted to the service account.
+Using Operator Lifecycle Manager (OLM), cluster administrators can choose to specify a service account for an Operator group so that all Operators associated with the group are deployed and run against the privileges granted to the service account.
 
-`APIService` and `CustomResourceDefinition` resources are always created by OLM
-using the `cluster-admin` role. A service account associated with an
-OperatorGroup should never be granted privileges to write these resources.
+The `APIService` and `CustomResourceDefinition` resources are always created by OLM using the `cluster-admin` role. A service account associated with an Operator group should never be granted privileges to write these resources.
 
-If the specified service account does not have adequate permissions for an
-Operator that is being installed or upgraded, useful and contextual information
-is added to the status of the respective resource(s) so that it is easy for the
-cluster administrator to troubleshoot and resolve the issue.
+If the specified service account does not have adequate permissions for an Operator that is being installed or upgraded, useful and contextual information is added to the status of the respective resource(s) so that it is easy for the cluster administrator to troubleshoot and resolve the issue.
 
-Any Operator tied to this OperatorGroup is now confined to the permissions
-granted to the specified service account. If the Operator asks for permissions
-that are outside the scope of the service account, the install fails with
-appropriate errors.
+Any Operator tied to this Operator group is now confined to the permissions granted to the specified service account. If the Operator asks for permissions that are outside the scope of the service account, the install fails with appropriate errors.

--- a/modules/olm-policy-workflow.adoc
+++ b/modules/olm-policy-workflow.adoc
@@ -5,15 +5,10 @@
 [id="olm-policy-workflow_{context}"]
 = Installation workflow
 
-When an OperatorGroup is tied to a service account and an Operator is installed
-or upgraded, OLM uses the following workflow:
+When an Operator group is tied to a service account and an Operator is installed or upgraded, Operator Lifecycle Manager (OLM) uses the following workflow:
 
-. The given Subscription object is picked up by OLM.
-. OLM fetches the OperatorGroup tied to this Subscription.
-. OLM determines that the OperatorGroup has a service account specified.
-. OLM creates a client scoped to the service account and uses the scoped client to
-install the Operator. This ensures that any permission requested by the Operator
-is always confined to that of the service account in the OperatorGroup.
-. OLM creates a new service account with the set of permissions specified in the
-CSV and assigns it to the Operator. The Operator runs as the assigned service
-account.
+. The given `Subscription` object is picked up by OLM.
+. OLM fetches the Operator group tied to this subscription.
+. OLM determines that the Operator group has a service account specified.
+. OLM creates a client scoped to the service account and uses the scoped client to install the Operator. This ensures that any permission requested by the Operator is always confined to that of the service account in the Operator group.
+. OLM creates a new service account with the set of permissions specified in the CSV and assigns it to the Operator. The Operator runs as the assigned service account.

--- a/modules/olm-removing-crd-version.adoc
+++ b/modules/olm-removing-crd-version.adoc
@@ -5,17 +5,13 @@
 [id="olm-dependency-resolution-removing-crd-version_{context}"]
 = Deprecating or removing a CRD version
 
-OLM does not allow a serving version of a CRD to be removed right away. Instead,
-a deprecated version of the CRD must be first disabled by setting the `served`
-field in the CRD to `false`. Then, the non-serving version can be removed on the
-subsequent CRD upgrade.
+Operator Lifecycle Manager (OLM) does not allow a serving version of a custom resource definition (CRD) to be removed right away. Instead, a deprecated version of the CRD must be first disabled by setting the `served` field in the CRD to `false`. Then, the non-serving version can be removed on the subsequent CRD upgrade.
 
 .Procedure
 
 To deprecate and remove a specific version of a CRD:
 
-. Mark the deprecated version as non-serving to indicate this version is no longer
-in use and may be removed in a subsequent upgrade. For example:
+. Mark the deprecated version as non-serving to indicate this version is no longer in use and may be removed in a subsequent upgrade. For example:
 +
 [source,yaml]
 ----
@@ -26,8 +22,7 @@ versions:
 ----
 <1> Set to `false`.
 
-. Switch the `storage` version to a serving version if the version to be
-deprecated is currently the `storage` version. For example:
+. Switch the `storage` version to a serving version if the version to be deprecated is currently the `storage` version. For example:
 +
 [source,yaml]
 ----
@@ -43,16 +38,12 @@ versions:
 +
 [NOTE]
 ====
-In order to remove a specific version that is or was the `storage` version from
-a CRD, that version must be removed from the `storedVersion` in the CRD's
-status. OLM will attempt to do this for you if it detects a stored version no
-longer exists in the new CRD.
+In order to remove a specific version that is or was the `storage` version from a CRD, that version must be removed from the `storedVersion` in the status of the CRD. OLM will attempt to do this for you if it detects a stored version no longer exists in the new CRD.
 ====
 
 . Upgrade the CRD with the above changes.
 
-. In subsequent upgrade cycles, the non-serving version can be removed completely
-from the CRD. For example:
+. In subsequent upgrade cycles, the non-serving version can be removed completely from the CRD. For example:
 +
 [source,yaml]
 ----
@@ -62,5 +53,4 @@ versions:
     storage: true
 ----
 
-. Ensure the referencing version of the CRD in your CSV’s `owned` section is
-updated accordingly if that version is removed from the CRD.
+. Ensure the referencing CRD version in the `owned` section of your CSV is updated accordingly if that version is removed from the CRD.

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -19,10 +19,7 @@ ifeval::["{context}" != "olm-managing-custom-catalogs"]
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Configuring OperatorHub for restricted networks
 
-Cluster administrators can configure OLM and OperatorHub to use local content in
-a restricted network environment using a custom Operator catalog image. For this
-example, the procedure uses a custom `redhat-operators` catalog image previously
-built and pushed to a supported registry.
+Cluster administrators can configure OLM and OperatorHub to use local content in a restricted network environment using a custom Operator catalog image. For this example, the procedure uses a custom `redhat-operators` catalog image previously built and pushed to a supported registry.
 endif::[]
 
 .Prerequisites
@@ -31,11 +28,8 @@ endif::[]
 * A custom Operator catalog image pushed to a supported registry
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
-* Access to mirror registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
-* If you are working with private registries, set the `REG_CREDS` environment
-variable to the file path of your registry credentials for use in later steps.
-For example, for the `podman` CLI:
+* Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
 ----
@@ -45,8 +39,7 @@ $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 .Procedure
 
 ifeval::["{context}" == "olm-restricted-networks"]
-. Disable the default OperatorSources by adding `disableAllDefaultSources: true`
-to the spec:
+. Disable the default `OperatorSource` objects by adding `disableAllDefaultSources: true` to the spec:
 +
 [source,terminal]
 ----
@@ -54,23 +47,14 @@ $ oc patch OperatorHub cluster --type json \
     -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 ----
 +
-This disables the default OperatorSources that are configured by default during
-an {product-title} installation.
+This disables the default sources that are configured by default during an {product-title} installation.
 endif::[]
 
-. The `oc adm catalog mirror` command extracts the contents of your custom
-Operator catalog image to generate the manifests required for mirroring. You can
-choose to either:
+. The `oc adm catalog mirror` command extracts the contents of your custom Operator catalog image to generate the manifests required for mirroring. You can choose to either:
 +
 --
-* Allow the default behavior of the command to automatically mirror all of the
-image content to your mirror registry after generating manifests, or
-* Add the `--manifests-only` flag to only generate the manifests required for
-mirroring, but do not actually mirror the image content to a registry yet. This
-can be useful for reviewing what will be mirrored, and it allows you to make any
-changes to the mapping list if you only require a subset of the content. You can
-then use that file with the `oc image mirror` command to mirror the modified
-list of images in a later step.
+* Allow the default behavior of the command to automatically mirror all of the image content to your mirror registry after generating manifests, or
+* Add the `--manifests-only` flag to only generate the manifests required for mirroring, but do not actually mirror the image content to a registry yet. This can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you only require a subset of the content. You can then use that file with the `oc image mirror` command to mirror the modified list of images in a later step.
 --
 +
 On your workstation with unrestricted network access, run the following command:
@@ -86,16 +70,10 @@ $ oc adm catalog mirror \
     [--manifests-only] <5>
 ----
 <1> Specify your Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials
-file.
-<3> Optional: If you do not want to configure trust for the target registry, add
-the `--insecure` flag.
-<4> Optional: Because the catalog might reference images that support multiple
-architectures and operating systems, you can filter by architecture and
-operating system to mirror only the images that match. Valid values are
-`linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
-<5> Optional: Only generate the manifests required for mirroring and do not actually
-mirror the image content to a registry.
+<2> Optional: If required, specify the location of your registry credentials file.
+<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<4> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<5> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
 +
 .Example output
 [source,terminal]
@@ -107,32 +85,20 @@ using database at: /tmp/190214037/bundles.db <1>
 ----
 <1> Temporary database generated by the command.
 +
-After running the command, a `<image_name>-manifests/` directory is created in
-the current directory and generates the following files:
+After running the command, a `<image_name>-manifests/` directory is created in the current directory and generates the following files:
 +
 --
-* The `imageContentSourcePolicy.yaml` file defines an ImageContentSourcePolicy
-object that can configure nodes to translate between the image references stored
-in Operator manifests and the mirrored registry.
-* The `mapping.txt` file contains all of the source images and where to map them
-in the target registry. This file is compatible with the `oc image mirror`
-command and can be used to further customize the mirroring configuration.
+* The `imageContentSourcePolicy.yaml` file defines an `ImageContentSourcePolicy` object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
+* The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
 --
 
-. If you used the `--manifests-only` flag in the previous step and want to mirror
-only a subset of the content:
+. If you used the `--manifests-only` flag in the previous step and want to mirror only a subset of the content:
 
-.. Modify the list of images in your `mapping.txt` file to your specifications. If
-you are unsure of the exact names and versions of the subset of images you want
-to mirror, use the following steps to find them:
+.. Modify the list of images in your `mapping.txt` file to your specifications. If you are unsure of the exact names and versions of the subset of images you want to mirror, use the following steps to find them:
 
-... Run the `sqlite3` tool against the temporary database that was generated by the
-`oc adm catalog mirror` command to retrieve a list of images matching a general
-search query. The output helps inform how you will later edit your `mapping.txt`
-file.
+... Run the `sqlite3` tool against the temporary database that was generated by the `oc adm catalog mirror` command to retrieve a list of images matching a general search query. The output helps inform how you will later edit your `mapping.txt` file.
 +
-For example, to retrieve a list of images that are similar to the string
-`clusterlogging.4.3`:
+For example, to retrieve a list of images that are similar to the string `clusterlogging.4.3`:
 +
 [source,terminal]
 ----
@@ -140,8 +106,7 @@ $ echo "select * from related_image \
     where operatorbundle_name like 'clusterlogging.4.3%';" \
     | sqlite3 -line /tmp/190214037/bundles.db <1>
 ----
-<1> Refer to the previous output of the `oc adm catalog mirror` command to find the
-path of the database file.
+<1> Refer to the previous output of the `oc adm catalog mirror` command to find the path of the database file.
 +
 .Example output
 [source,terminal]
@@ -154,11 +119,9 @@ operatorbundle_name = clusterlogging.4.3.33-202008111029.p0
 ...
 ----
 
-... Use the results from the previous step to edit the `mapping.txt` file to only
-include the subset of images you want to mirror.
+... Use the results from the previous step to edit the `mapping.txt` file to only include the subset of images you want to mirror.
 +
-For example, you can use the `image` values from the previous example output to
-find that the following matching lines exist in your `mapping.txt` file:
+For example, you can use the `image` values from the previous example output to find that the following matching lines exist in your `mapping.txt` file:
 +
 .Matching image mappings in `mapping.txt`
 [source,txt]
@@ -167,12 +130,9 @@ registry.redhat.io/openshift4/ose-logging-kibana5@sha256:aa4a8b2a00836d0e28aa649
 registry.redhat.io/openshift4/ose-oauth-proxy@sha256:6b4db07f6e6c962fc96473d86c44532c93b146bbefe311d0c348117bf759c506=<registry_host_name>:<port>/openshift4-ose-oauth-proxy:3754ea2b
 ----
 +
-In this example, if you only want to mirror these images, you would then remove
-all other entries in the `mapping.txt` file and leave only the above two lines.
+In this example, if you only want to mirror these images, you would then remove all other entries in the `mapping.txt` file and leave only the above two lines.
 
-.. Still on your workstation with unrestricted network access, use your modified
-`mapping.txt` file to mirror the images to your registry using the `oc image
-mirror` command:
+.. Still on your workstation with unrestricted network access, use your modified `mapping.txt` file to mirror the images to your registry using the `oc image mirror` command:
 +
 [source,terminal]
 ----
@@ -181,17 +141,16 @@ $ oc image mirror \
     -f ./redhat-operators-manifests/mapping.txt
 ----
 
-. Apply the ImageContentSourcePolicy:
+. Apply the `ImageContentSourcePolicy` object:
 +
 [source,terminal]
 ----
 $ oc apply -f ./redhat-operators-manifests/imageContentSourcePolicy.yaml
 ----
 
-. Create a CatalogSource object that references your catalog image.
+. Create a `CatalogSource` object that references your catalog image.
 
-.. Modify the following to your specifications and save it as a
-`catalogsource.yaml` file:
+.. Modify the following to your specifications and save it as a `catalogsource.yaml` file:
 +
 [source,yaml]
 ----
@@ -208,7 +167,7 @@ spec:
 ----
 <1> Specify your custom Operator catalog image.
 
-.. Use the file to create the CatalogSource object:
+.. Use the file to create the `CatalogSource` object:
 +
 [source,terminal]
 ----
@@ -217,7 +176,7 @@ $ oc create -f catalogsource.yaml
 
 . Verify the following resources are created successfully.
 
-.. Check the Pods:
+.. Check the pods:
 +
 [source,terminal]
 ----
@@ -232,7 +191,7 @@ my-operator-catalog-6njx6               1/1     Running   0         28s
 marketplace-operator-d9f549946-96sgr    1/1     Running   0         26h
 ----
 
-.. Check the CatalogSource:
+.. Check the catalog source:
 +
 [source,terminal]
 ----
@@ -246,7 +205,7 @@ NAME                  DISPLAY               TYPE PUBLISHER  AGE
 my-operator-catalog   My Operator Catalog   grpc            5s
 ----
 
-.. Check the PackageManifest:
+.. Check the package manifest:
 +
 [source,terminal]
 ----
@@ -260,5 +219,4 @@ NAME    CATALOG              AGE
 etcd    My Operator Catalog  34s
 ----
 
-You can now install the Operators from the *OperatorHub* page on your restricted
-network {product-title} cluster web console.
+You can now install the Operators from the *OperatorHub* page on your restricted network {product-title} cluster web console.

--- a/modules/olm-status-conditions.adoc
+++ b/modules/olm-status-conditions.adoc
@@ -4,7 +4,7 @@
 // * support/troubleshooting/troubleshooting-operator-issues.adoc
 
 [id="olm-status-conditions_{context}"]
-= Operator Subscription condition types
+= Operator subscription condition types
 
 Subscriptions can report the following condition types:
 
@@ -14,20 +14,20 @@ Subscriptions can report the following condition types:
 |Condition |Description
 
 |`CatalogSourcesUnhealthy`
-|Some or all of the Catalog Sources to be used in resolution are unhealthy.
+|Some or all of the catalog sources to be used in resolution are unhealthy.
 
 |`InstallPlanMissing`
-|A Subscription's InstallPlan is missing.
+|An install plan for a subscription is missing.
 
 |`InstallPlanPending`
-|A Subscription's InstallPlan is pending installation.
+|An install plan for a subscription is pending installation.
 
 |`InstallPlanFailed`
-|A Subscription's InstallPlan has failed.
+|An install plan for a subscription has failed.
 
 |===
 
 [NOTE]
 ====
-Default {product-title} cluster Operators are managed by the Cluster Version Operator (CVO) and they do not have a Subscription object. Application Operators are managed by Operator Lifecycle Manager (OLM) and they have a Subscription object.
+Default {product-title} cluster Operators are managed by the Cluster Version Operator (CVO) and they do not have a `Subscription` object. Application Operators are managed by Operator Lifecycle Manager (OLM) and they have a `Subscription` object.
 ====

--- a/modules/olm-status-viewing-cli.adoc
+++ b/modules/olm-status-viewing-cli.adoc
@@ -4,9 +4,9 @@
 // * support/troubleshooting/troubleshooting-operator-issues.adoc
 
 [id="olm-status-viewing-cli_{context}"]
-= Viewing Operator Subscription status using the CLI
+= Viewing Operator subscription status using the CLI
 
-You can view Operator Subscription status using the CLI.
+You can view Operator subscription status using the CLI.
 
 .Prerequisites
 
@@ -15,14 +15,14 @@ You can view Operator Subscription status using the CLI.
 
 .Procedure
 
-. List Operator Subscriptions:
+. List Operator subscriptions:
 +
 [source,terminal]
 ----
 $ oc get subs -n <operator_namespace>
 ----
 
-. Use the `oc describe` command to inspect a Subscription resource:
+. Use the `oc describe` command to inspect a `Subscription` resource:
 +
 [source,terminal]
 ----
@@ -44,8 +44,5 @@ Conditions:
 
 [NOTE]
 ====
-Default {product-title} cluster Operators are managed by the Cluster Version
-Operator (CVO) and they do not have a Subscription object. Application Operators
-are managed by Operator Lifecycle Manager (OLM) and they have a Subscription
-object.
+Default {product-title} cluster Operators are managed by the Cluster Version Operator (CVO) and they do not have a `Subscription` object. Application Operators are managed by Operator Lifecycle Manager (OLM) and they have a `Subscription` object.
 ====

--- a/modules/olm-subscription.adoc
+++ b/modules/olm-subscription.adoc
@@ -5,14 +5,11 @@
 [id="olm-subscription_{context}"]
 = Subscription
 
-A Subscription represents an intention to install an Operator. It is the custom
-resource that relates an Operator to a CatalogSource. Subscriptions describe
-which channel of an Operator package to subscribe to, and whether to perform
-updates automatically or manually. If set to automatic, the Subscription ensures
-OLM manages and upgrades the Operator to ensure that the latest version is
-always running in the cluster.
+A subscription, defined by a `Subscription` object, represents an intention to install an Operator. It is the custom resource that relates an Operator to a catalog source.
 
-.Example Subscription
+Subscriptions describe which channel of an Operator package to subscribe to, and whether to perform updates automatically or manually. If set to automatic, the subscription ensures Operator Lifecycle Manager (OLM) manages and upgrades the Operator to ensure that the latest version is always running in the cluster.
+
+.Example `Subscription` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -27,13 +24,6 @@ spec:
   sourceNamespace: operators
 ----
 
-This Subscription object defines the name and namespace of the Operator, as well
-as the catalog from which the Operator data can be found. The channel, such as
-`alpha`, `beta`, or `stable`, helps determine which Operator stream should be
-installed from the CatalogSource.
+This `Subscription` object defines the name and namespace of the Operator, as well as the catalog from which the Operator data can be found. The channel, such as `alpha`, `beta`, or `stable`, helps determine which Operator stream should be installed from the catalog source.
 
-In addition to being easily visible from the {product-title} web console, it is
-possible to identify when there is a newer version of an Operator available by
-inspecting the status of the Operator's Subscription. The value associated with
-the `currentCSV` field is the newest version that is known to OLM, and
-`installedCSV` is the version that is installed on the cluster.
+In addition to being easily visible from the {product-title} web console, it is possible to identify when there is a newer version of an Operator available by inspecting the status of the related subscription. The value associated with the `currentCSV` field is the newest version that is known to OLM, and `installedCSV` is the version that is installed on the cluster.

--- a/modules/olm-terms.adoc
+++ b/modules/olm-terms.adoc
@@ -7,102 +7,70 @@
 
 [id="olm-common-terms-bundle_{context}"]
 == Bundle
-In the Bundle Format, a _bundle_ is a collection of an Operator CSV, manifests,
-and metadata. Together, they form a unique version of an Operator that can be
-installed onto the cluster.
+In the Bundle Format, a _bundle_ is a collection of an Operator CSV, manifests, and metadata. Together, they form a unique version of an Operator that can be installed onto the cluster.
 
 [id="olm-common-terms-bundle-image_{context}"]
 == Bundle image
-In the Bundle Format, a _bundle image_ is a container image that is built from
-Operator manifests and that contains one bundle. Bundle images are stored and
-distributed by Open Container Initiative (OCI) spec container registries, such
-as Quay.io or DockerHub.
+In the Bundle Format, a _bundle image_ is a container image that is built from Operator manifests and that contains one bundle. Bundle images are stored and distributed by Open Container Initiative (OCI) spec container registries, such as Quay.io or DockerHub.
 
 [id="olm-common-terms-catalogsource_{context}"]
-== CatalogSource
-A _CatalogSource_ is a repository of CSVs, CRDs, and packages that define an
-application.
+== Catalog source
+A _catalog source_ is a repository of CSVs, CRDs, and packages that define an application.
 
 [id="olm-common-terms-catalog-image_{context}"]
 == Catalog image
-In the Package Manifest Format, a _catalog image_ is a containerized datastore
-that describes a set of Operator metadata and update metadata that can be
-installed onto a cluster using OLM.
+In the Package Manifest Format, a _catalog image_ is a containerized datastore that describes a set of Operator metadata and update metadata that can be installed onto a cluster using OLM.
 
 [id="olm-common-terms-channel_{context}"]
 == Channel
-A _channel_ defines a stream of updates for an Operator and is used to roll out
-updates for subscribers. The head points to the latest version of that channel.
-For example, a `stable` channel would have all stable versions of an Operator
-arranged from the earliest to the latest.
+A _channel_ defines a stream of updates for an Operator and is used to roll out updates for subscribers. The head points to the latest version of that channel. For example, a `stable` channel would have all stable versions of an Operator arranged from the earliest to the latest.
 
-An Operator can have several channels, and a Subscription binding to a certain
-channel would only look for updates in that channel.
+An Operator can have several channels, and a subscription binding to a certain channel would only look for updates in that channel.
 
 [id="olm-common-terms-channel-head_{context}"]
 == Channel head
 A _channel head_ refers to the latest known update in a particular channel.
 
 [id="olm-common-terms-csv_{context}"]
-== ClusterServiceVersion
-A _ClusterServiceVersion_ (CSV) is a YAML manifest created from Operator
+== Cluster service version
+A _cluster service version (CSV)_ is a YAML manifest created from Operator
 metadata that assists OLM in running the Operator in a cluster. It is the
 metadata that accompanies an Operator container image, used to populate user
-interfaces with information such as its logo, description, and version. It is
-also a source of technical information that is required to run the Operator,
-like the RBAC rules it requires and which custom resources (CRs) it manages or
-depends on.
+interfaces with information such as its logo, description, and version.
+
+It is also a source of technical information that is required to run the Operator, like the RBAC rules it requires and which custom resources (CRs) it manages or depends on.
 
 [id="olm-common-terms-dependency_{context}"]
 == Dependency
-An Operator may have a _dependency_ on another Operator being present in the
-cluster. For example, the Vault Operator has a dependency on the etcd Operator
-for its data persistence layer.
+An Operator may have a _dependency_ on another Operator being present in the cluster. For example, the Vault Operator has a dependency on the etcd Operator for its data persistence layer.
 
-OLM resolves dependencies by ensuring that all specified versions of Operators
-and CRDs are installed on the cluster during the installation phase. This
-dependency is resolved by finding and installing an Operator in a Catalog that
-satisfies the required CRD API, and is not related to packages or bundles.
+OLM resolves dependencies by ensuring that all specified versions of Operators and CRDs are installed on the cluster during the installation phase. This dependency is resolved by finding and installing an Operator in a catalog that satisfies the required CRD API, and is not related to packages or bundles.
 
 [id="olm-common-terms-index-image_{context}"]
 == Index image
-In the Bundle Format, an _index image_ refers to an image of a database (a
-database snapshot) that contains information about Operator bundles including
-CSVs and CRDs of all versions. This index can host a history of Operators on a
-cluster and be maintained by adding or removing Operators using the `opm` CLI
-tool.
+In the Bundle Format, an _index image_ refers to an image of a database (a database snapshot) that contains information about Operator bundles including CSVs and CRDs of all versions. This index can host a history of Operators on a cluster and be maintained by adding or removing Operators using the `opm` CLI tool.
 
 [id="olm-common-terms-installplan_{context}"]
-== InstallPlan
-An _InstallPlan_ is a calculated list of resources to be created to
-automatically install or upgrade a CSV.
+== Install plan
+An _install plan_ is a calculated list of resources to be created to automatically install or upgrade a CSV.
 
 [id="olm-common-terms-operatorgroup_{context}"]
-== OperatorGroup
+== Operator group
 
-An _OperatorGroup_ configures all Operators deployed in the same namespace as
-the OperatorGroup object to watch for their CR in a list of namespaces or
-cluster-wide.
+An _Operator group_ configures all Operators deployed in the same namespace as the `OperatorGroup` object to watch for their CR in a list of namespaces or cluster-wide.
 
 [id="olm-common-terms-package_{context}"]
 == Package
-In the Bundle Format, a _package_ is a directory that encloses all released
-history of an Operator with each version. A released version of an Operator is
-described in a ClusterServiceVersion (CSV) manifest alongside the
-CustomResourceDefinitions (CRDs).
+In the Bundle Format, a _package_ is a directory that encloses all released history of an Operator with each version. A released version of an Operator is described in a CSV manifest alongside the CRDs.
 
 [id="olm-common-terms-registry_{context}"]
 == Registry
-A _registry_ is a database that stores bundle images of Operators, each with all
-of its latest and historical versions in all channels.
+A _registry_ is a database that stores bundle images of Operators, each with all of its latest and historical versions in all channels.
 
 [id="olm-common-terms-subscription_{context}"]
 == Subscription
-A _Subscription_ keeps CSVs up to date by tracking a channel in a package.
+A _subscription_ keeps CSVs up to date by tracking a channel in a package.
 
 [id="olm-common-terms-update-graph_{context}"]
 == Update graph
-An _update graph_ links versions of CSVs together, similar to the update graph
-of any other packaged software. Operators can be installed sequentially, or
-certain versions can be skipped. The update graph is expected to grow only at
-the head with newer versions being added.
+An _update graph_ links versions of CSVs together, similar to the update graph of any other packaged software. Operators can be installed sequentially, or certain versions can be skipped. The update graph is expected to grow only at the head with newer versions being added.

--- a/modules/olm-testing-operator-catalog-image.adoc
+++ b/modules/olm-testing-operator-catalog-image.adoc
@@ -5,19 +5,14 @@
 [id="olm-testing-operator-catalog-image_{context}"]
 = Testing an Operator catalog image
 
-You can validate Operator catalog image content by running it as a container and
-querying its gRPC API. To further test the image, you can then resolve an OLM
-Subscription by referencing the image in a CatalogSource. For this example, the
-procedure uses a custom `redhat-operators` catalog image previously built and
-pushed to a supported registry.
+You can validate Operator catalog image content by running it as a container and querying its gRPC API. To further test the image, you can then resolve an OLM subscription by referencing the image in a `CatalogSource` object. For this example, the procedure uses a custom `redhat-operators` catalog image previously built and pushed to a supported registry.
 
 .Prerequisites
 
 * A custom Operator catalog image pushed to a supported registry
 * `podman` version 1.4.4+
 * `oc` version 4.3.5+
-* Access to mirror registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 
 .Procedure
@@ -90,9 +85,7 @@ $ podman inspect \
 example_registry:5000/olm/redhat-operators@sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3
 ----
 
-. Assuming an OperatorGroup exists in namespace `my-ns` that supports your
-Operator and its dependencies, create a CatalogSource object using the image
-digest. For example:
+. Assuming an Operator group exists in namespace `my-ns` that supports your Operator and its dependencies, create a `CatalogSource` object using the image digest. For example:
 +
 [source,yaml]
 ----
@@ -107,8 +100,7 @@ spec:
   displayName: Red Hat Operators
 ----
 
-. Create a Subscription that resolves the latest available `servicemeshoperator`
-and its dependencies from your catalog image:
+. Create a subscription that resolves the latest available `servicemeshoperator` and its dependencies from your catalog image:
 +
 [source,yaml]
 ----

--- a/modules/olm-understanding-operator-catalog-images.adoc
+++ b/modules/olm-understanding-operator-catalog-images.adoc
@@ -5,10 +5,7 @@
 [id="olm-understanding-operator-catalog-images_{context}"]
 = Understanding Operator catalog images
 
-Operator Lifecycle Manager (OLM) always installs Operators from the latest
-version of an Operator catalog. For {product-title} 4.5, Red Hat-provided
-Operators are distributed via Quay App Registry catalogs from
-link:https://quay.io/[quay.io].
+Operator Lifecycle Manager (OLM) always installs Operators from the latest version of an Operator catalog. For {product-title} 4.5, Red Hat-provided Operators are distributed via Quay App Registry catalogs from link:https://quay.io/[quay.io].
 
 .Red Hat-provided App Registry catalogs
 [cols="3,7",options="header"]
@@ -17,32 +14,22 @@ link:https://quay.io/[quay.io].
 |Description
 
 |`redhat-operators`
-|Public catalog for Red Hat products packaged and shipped by Red Hat. Supported
-by Red Hat.
+|Public catalog for Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
 
 |`certified-operators`
-|Public catalog for products from leading independent software vendors (ISVs).
-Red Hat partners with ISVs to package and ship. Supported by the ISV.
+|Public catalog for products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
 
 |`community-operators`
-|Public catalog for software maintained by relevant representatives in the
-link:https://github.com/operator-framework/community-operators[operator-framework/community-operators]
-GitHub repository. No official support.
+|Public catalog for software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
 
 |===
 
-As catalogs are updated, the latest versions of Operators change, and older
-versions may be removed or altered. This behavior can cause problems maintaining
-reproducible installs over time. In addition, when OLM runs on an
-{product-title} cluster in a restricted network environment, it is unable to
-access the catalogs from link:https://quay.io/[quay.io] directly.
+As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. This behavior can cause problems maintaining reproducible installs over time. In addition, when OLM runs on an {product-title} cluster in a restricted network environment, it is unable to access the catalogs from link:https://quay.io/[quay.io] directly.
 
-Using the `oc adm catalog build` command, cluster administrators can create an
-_Operator catalog image_. An Operator catalog image is:
+Using the `oc adm catalog build` command, cluster administrators can create an _Operator catalog image_. An Operator catalog image is:
 
 - a point-in-time export of an App Registry type catalog's content.
 - the result of converting an App Registry catalog to a container image type catalog.
 - an immutable artifact.
 
-Creating an Operator catalog image provides a simple way to use this content
-without incurring the aforementioned issues.
+Creating an Operator catalog image provides a simple way to use this content without incurring the aforementioned issues.

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -12,7 +12,7 @@ You can update an existing index image using the `opm` CLI.
 * `opm` version 1.12.3+
 * `podman` version 1.4.4+
 * An index image built and pushed to a registry.
-* A CatalogSource created and applied to a cluster.
+* A `CatalogSource` object created and applied to a cluster.
 
 .Procedure
 
@@ -36,8 +36,7 @@ $ opm index add \
 $ podman push quay.io/<namespace>/test-catalog:latest
 ----
 
-. After OLM polls the index image at its regular interval, verify that the new
-packages are successfully added:
+. After Operator Lifecycle Manager (OLM) polls the index image at its regular interval, verify that the new packages are successfully added:
 +
 [source,terminal]
 ----

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -6,37 +6,24 @@
 [id="olm-updating-operator-catalog-image_{context}"]
 = Updating an Operator catalog image
 
-After a cluster administrator has configured OperatorHub to use custom Operator
-catalog images, administrators can keep their {product-title} cluster up to date
-with the latest Operators by capturing updates made to Red Hat’s App Registry
-catalogs. This is done by building and pushing a new Operator catalog image,
-then replacing the existing  CatalogSource’s `spec.image` parameter with the new
-image digest.
+After a cluster administrator has configured OperatorHub to use custom Operator catalog images, administrators can keep their {product-title} cluster up to date with the latest Operators by capturing updates made to App Registry catalogs provided by Red Hat. This is done by building and pushing a new Operator catalog image, then replacing the existing  `spec.image` parameter in the `CatalogSource` object with the new image digest.
 
-For this example, the procedure assumes a custom `redhat-operators` catalog
-image is already configured for use with OperatorHub.
+For this example, the procedure assumes a custom `redhat-operators` catalog image is already configured for use with OperatorHub.
 
 .Prerequisites
 
 * Workstation with unrestricted network access
 * `oc` version 4.3.5+
 * `podman` version 1.4.4+
-* Access to mirror registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * OperatorHub configured to use custom catalog images
-* If you are working with private registries, set the `REG_CREDS` environment
-variable to the file path of your registry credentials for use in later steps.
-For example, for the `podman` CLI:
+* If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
 ----
 $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 ----
-* If you are working with private namespaces that your
-link:https://quay.io[quay.io] account has access to, you must set a Quay
-authentication token. Set the `AUTH_TOKEN` environment variable for use with the
-`--auth-token` flag by making a request against the login API using your
-link:https://quay.io[quay.io] credentials:
+* If you are working with private namespaces that your link:https://quay.io[quay.io] account has access to, you must set a Quay authentication token. Set the `AUTH_TOKEN` environment variable for use with the `--auth-token` flag by making a request against the login API using your link:https://quay.io[quay.io] credentials:
 +
 [source,terminal]
 ----
@@ -52,8 +39,7 @@ $ AUTH_TOKEN=$(curl -sH "Content-Type: application/json" \
 
 .Procedure
 
-. On the workstation with unrestricted network access, authenticate with the
-target mirror registry:
+. On the workstation with unrestricted network access, authenticate with the target mirror registry:
 +
 [source,terminal]
 ----
@@ -68,8 +54,7 @@ during the build:
 $ podman login registry.redhat.io
 ----
 
-. Build a new catalog image based on the `redhat-operators` catalog from
-link:https://quay.io/[quay.io], tagging and pushing it to your mirror registry:
+. Build a new catalog image based on the `redhat-operators` catalog from Quay.io, tagging and pushing it to your mirror registry:
 +
 [source,terminal]
 ----
@@ -83,16 +68,11 @@ $ oc adm catalog build \
     [--auth-token "${AUTH_TOKEN}"] <7>
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
-<2> Set `--from` to the `ose-operator-registry` base image using the tag that
-matches the target {product-title} cluster major and minor version.
-<3> Set `--filter-by-os` to the operating system and architecture to use for the
-base image, which must match the target {product-title} cluster. Valid values
-are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
-<4> Name your catalog image and include a tag, for example, `v2` because it is the
-updated catalog.
+<2> Set `--from` to the `ose-operator-registry` base image using the tag that matches the target {product-title} cluster major and minor version.
+<3> Set `--filter-by-os` to the operating system and architecture to use for the base image, which must match the target {product-title} cluster. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<4> Name your catalog image and include a tag, for example, `v2` because it is the updated catalog.
 <5> Optional: If required, specify the location of your registry credentials file.
-<6> Optional: If you do not want to configure trust for the target registry, add the
-`--insecure` flag.
+<6> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <7> Optional: If other application registry catalogs are used that are not public, specify a Quay authentication token.
 +
 .Example output
@@ -103,10 +83,7 @@ INFO[0013] loading Bundles                               dir=/var/folders/st/9cs
 Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 to example_registry:5000/olm/redhat-operators:v2
 ----
 
-. Mirror the contents of your catalog to your target registry. The following
-`oc adm catalog mirror` command extracts the contents of your custom Operator
-catalog image to generate the manifests required for mirroring and mirrors the
-images to your registry:
+. Mirror the contents of your catalog to your target registry. The following `oc adm catalog mirror` command extracts the contents of your custom Operator catalog image to generate the manifests required for mirroring and mirrors the images to your registry:
 +
 [source,terminal]
 ----
@@ -118,14 +95,9 @@ $ oc adm catalog mirror \
     [--filter-by-os="<os>/<arch>"] <4>
 ----
 <1> Specify your new Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials
-file.
-<3> Optional: If you do not want to configure trust for the target registry, add
-the `--insecure` flag.
-<4> Optional: Because the catalog might reference images that support multiple
-architectures and operating systems, you can filter by architecture and
-operating system to mirror only the images that match. Valid values are
-`linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<2> Optional: If required, specify the location of your registry credentials file.
+<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<4> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 
 . Apply the newly generated manifests:
 +
@@ -136,16 +108,14 @@ $ oc apply -f ./redhat-operators-manifests
 +
 [IMPORTANT]
 ====
-It is possible that you do not need to apply the `imageContentSourcePolicy.yaml`
-manifest. Complete a `diff` of the files to determine if changes are necessary.
+It is possible that you do not need to apply the `imageContentSourcePolicy.yaml` manifest. Complete a `diff` of the files to determine if changes are necessary.
 ====
 
-. Update your CatalogSource object that references your catalog image.
+. Update your `CatalogSource` object that references your catalog image.
 
-.. If you have your original `catalogsource.yaml` file for this CatalogSource:
+.. If you have your original `catalogsource.yaml` file for this `CatalogSource` object:
 
-... Edit your `catalogsource.yaml` file to reference your new catalog image in the
-`spec.image` field:
+... Edit your `catalogsource.yaml` file to reference your new catalog image in the `spec.image` field:
 +
 [source,yaml]
 ----
@@ -162,20 +132,18 @@ spec:
 ----
 <1> Specify your new Operator catalog image.
 
-... Use the updated file to replace the CatalogSource object:
+... Use the updated file to replace the `CatalogSource` object:
 +
 [source,terminal]
 ----
 $ oc replace -f catalogsource.yaml
 ----
 
-.. Alternatively, edit the CatalogSource using the following command and reference
-your new catalog image in the `spec.image` parameter:
+.. Alternatively, edit the catalog source using the following command and reference your new catalog image in the `spec.image` parameter:
 +
 [source,terminal]
 ----
 $ oc edit catalogsource <catalog_source_name> -n openshift-marketplace
 ----
 
-Updated Operators should now be available from the *OperatorHub* page on your
-{product-title} cluster.
+Updated Operators should now be available from the *OperatorHub* page on your {product-title} cluster.

--- a/modules/olm-upgrades.adoc
+++ b/modules/olm-upgrades.adoc
@@ -1,52 +1,36 @@
 // Module included in the following assemblies:
 //
-// * operators/understanding/olm/olm-understanding-olm.adoc
+// * operators/understanding/olm/olm-workflow.adoc
 
 [id="olm-upgrades_{context}"]
 = Operator installation and upgrade workflow in OLM
 
-In the Operator Lifecycle Manager (OLM) ecosystem, the following resources are
-used to resolve Operator installations and upgrades:
+In the Operator Lifecycle Manager (OLM) ecosystem, the following resources are used to resolve Operator installations and upgrades:
 
-* ClusterServiceVersion (CSV)
-* CatalogSource
-* Subscription
+* `ClusterServiceVersion` (CSV)
+* `CatalogSource`
+* `Subscription`
 
-Operator metadata, defined in CSVs, can be stored in a collection called a
-CatalogSource. OLM uses CatalogSources, which use the
-link:https://github.com/operator-framework/operator-registry[Operator Registry API],
-to query for available Operators as well as upgrades for installed Operators.
+Operator metadata, defined in CSVs, can be stored in a collection called a catalog source. OLM uses catalog sources, which use the link:https://github.com/operator-framework/operator-registry[Operator Registry API], to query for available Operators as well as upgrades for installed Operators.
 
-.CatalogSource overview
+.Catalog source overview
 image::olm-catalogsource.png[]
 
-Within a CatalogSource, Operators are organized into _packages_ and streams of
-updates called _channels_, which should be a familiar update pattern from
-{product-title} or other software on a continuous release cycle like web
-browsers.
+Within a catalog source, Operators are organized into _packages_ and streams of updates called _channels_, which should be a familiar update pattern from {product-title} or other software on a continuous release cycle like web browsers.
 
-.Packages and channels in a CatalogSource
+.Packages and channels in a Catalog source
 image::olm-channels.png[]
 
-A user indicates a particular package and channel in a particular CatalogSource
-in a _Subscription_, for example an `etcd` package and its `alpha` channel. If a
-Subscription is made to a package that has not yet been installed in the
-namespace, the latest Operator for that package is installed.
+A user indicates a particular package and channel in a particular catalog source in a _subscription_, for example an `etcd` package and its `alpha` channel. If a subscription is made to a package that has not yet been installed in the namespace, the latest Operator for that package is installed.
 
 [NOTE]
 ====
-OLM deliberately avoids version comparisons, so the "latest" or "newest"
-Operator available from a given _catalog_ -> _channel_ -> _package_ path does not
-necessarily need to be the highest version number. It should be thought of more
-as the _head_ reference of a channel, similar to a Git repository.
+OLM deliberately avoids version comparisons, so the "latest" or "newest" Operator available from a given _catalog_ -> _channel_ -> _package_ path does not necessarily need to be the highest version number. It should be thought of more as the _head_ reference of a channel, similar to a Git repository.
 ====
 
-Each CSV has a `replaces` parameter that indicates which Operator it replaces.
-This builds a graph of CSVs that can be queried by OLM, and updates can be
-shared between channels. Channels can be thought of as entry points into the
-graph of updates:
+Each CSV has a `replaces` parameter that indicates which Operator it replaces. This builds a graph of CSVs that can be queried by OLM, and updates can be shared between channels. Channels can be thought of as entry points into the graph of updates:
 
-.OLM's graph of available channel updates
+.OLM graph of available channel updates
 image::olm-replaces.png[]
 
 .Example channels in a package
@@ -61,56 +45,36 @@ channels:
 defaultChannel: alpha
 ----
 
-For OLM to successfully query for updates, given a CatalogSource, package,
-channel, and CSV, a catalog must be able to return, unambiguously and
-deterministically, a single CSV that `replaces` the input CSV.
+For OLM to successfully query for updates, given a catalog source, package, channel, and CSV, a catalog must be able to return, unambiguously and deterministically, a single CSV that `replaces` the input CSV.
 
 [id="olm-upgrades-example-upgrade-path_{context}"]
 == Example upgrade path
 
-For an example upgrade scenario, consider an installed Operator corresponding to
-CSV version `0.1.1`. OLM queries the CatalogSource and detects an upgrade in the
-subscribed channel with new CSV version `0.1.3` that replaces an older but
-not-installed CSV version `0.1.2`, which in turn replaces the older and
-installed CSV version `0.1.1`.
+For an example upgrade scenario, consider an installed Operator corresponding to CSV version `0.1.1`. OLM queries the catalog source and detects an upgrade in the subscribed channel with new CSV version `0.1.3` that replaces an older but not-installed CSV version `0.1.2`, which in turn replaces the older and installed CSV version `0.1.1`.
 
-OLM walks back from the channel head to previous versions via the `replaces`
-field specified in the CSVs to determine the upgrade path `0.1.3` -> `0.1.2` ->
-`0.1.1`; the direction of the arrow indicates that the former replaces the
-latter. OLM upgrades the Operator one version at the time until it reaches the
-channel head.
+OLM walks back from the channel head to previous versions via the `replaces` field specified in the CSVs to determine the upgrade path `0.1.3` -> `0.1.2` -> `0.1.1`; the direction of the arrow indicates that the former replaces the latter. OLM upgrades the Operator one version at the time until it reaches the channel head.
 
-For this given scenario, OLM installs Operator version `0.1.2` to replace the
-existing Operator version `0.1.1`. Then, it installs Operator version `0.1.3` to
-replace the previously installed Operator version `0.1.2`. At this point, the
-installed operator version `0.1.3` matches the channel head and the upgrade is
-completed.
+For this given scenario, OLM installs Operator version `0.1.2` to replace the existing Operator version `0.1.1`. Then, it installs Operator version `0.1.3` to replace the previously installed Operator version `0.1.2`. At this point, the installed operator version `0.1.3` matches the channel head and the upgrade is completed.
 
 [id="olm-upgrades-skipping_{context}"]
 == Skipping upgrades
 
-OLM's basic path for upgrades is:
+The basic path for upgrades in OLM is:
 
-* A CatalogSource is updated with one or more updates to an Operator.
-* OLM traverses every version of the Operator until reaching the latest version the CatalogSource contains.
+* A catalog source is updated with one or more updates to an Operator.
+* OLM traverses every version of the Operator until reaching the latest version the catalog source contains.
 
-However, sometimes this is not a safe operation to perform. There will be cases
-where a published version of an Operator should never be installed on a cluster
-if it has not already, for example because a version introduces a serious
-vulnerability.
+However, sometimes this is not a safe operation to perform. There will be cases where a published version of an Operator should never be installed on a cluster if it has not already, for example because a version introduces a serious vulnerability.
 
-In those cases, OLM must consider two cluster states and provide an update graph
-that supports both:
+In those cases, OLM must consider two cluster states and provide an update graph that supports both:
 
 * The "bad" intermediate Operator has been seen by the cluster and installed.
 * The "bad" intermediate Operator has not yet been installed onto the cluster.
 
-By shipping a new catalog and adding a _skipped_ release, OLM is ensured that it
-can always get a single unique update regardless of the cluster state and
-whether it has seen the bad update yet.
+By shipping a new catalog and adding a _skipped_ release, OLM is ensured that it can always get a single unique update regardless of the cluster state and whether it has seen the bad update yet.
 
 .Example CSV with skipped release
-[source,yml]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
@@ -126,47 +90,40 @@ spec:
     - etcdoperator.v0.9.1
 ----
 
-Consider the following example Old CatalogSource and New CatalogSource:
+Consider the following example of *Old CatalogSource* and *New CatalogSource*.
 
 .Skipping updates
 image::olm-skipping-updates.png[]
 
 This graph maintains that:
 
-* Any Operator found in Old CatalogSource has a single replacement in New CatalogSource.
-* Any Operator found in New CatalogSource has a single replacement in New CatalogSource.
+* Any Operator found in *Old CatalogSource* has a single replacement in *New CatalogSource*.
+* Any Operator found in *New CatalogSource* has a single replacement in *New CatalogSource*.
 * If the bad update has not yet been installed, it will never be.
 
 [id="olm-upgrades-replacing-multiple_{context}"]
 == Replacing multiple Operators
 
-Creating the New CatalogSource as described requires publishing CSVs that `replace`
-one Operator, but can `skip` several. This can be accomplished using the
-`skipRange` annotation:
+Creating *New CatalogSource* as described requires publishing CSVs that `replace` one Operator, but can `skip` several. This can be accomplished using the `skipRange` annotation:
 
 [source,yaml]
 ----
 olm.skipRange: <semver_range>
 ----
 
-where `<semver_range>` has the version range format supported by the
-link:https://github.com/blang/semver#ranges[semver library].
+where `<semver_range>` has the version range format supported by the link:https://github.com/blang/semver#ranges[semver library].
 
-When searching catalogs for updates, if the head of a channel has a `skipRange`
-annotation and the currently installed Operator has a version field that falls
-in the range, OLM updates to the latest entry in the channel.
+When searching catalogs for updates, if the head of a channel has a `skipRange` annotation and the currently installed Operator has a version field that falls in the range, OLM updates to the latest entry in the channel.
 
 The order of precedence is:
 
-. Channel head in the source specified by `sourceName` on the Subscription, if the
-other criteria for skipping are met.
+. Channel head in the source specified by `sourceName` on the subscription, if the other criteria for skipping are met.
 . The next Operator that replaces the current one, in the source specified by `sourceName`.
-. Channel head in another source that is visible to the Subscription, if the other
-criteria for skipping are met.
+. Channel head in another source that is visible to the subscription, if the other criteria for skipping are met.
 . The next Operator that replaces the current one in any source visible to the
-Subscription.
+subscription.
 
-. Example CSV with `skipRange`
+.Example CSV with `skipRange`
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -181,21 +138,16 @@ metadata:
 [id="olm-upgrades-z-stream_{context}"]
 == Z-stream support
 
-A _z-stream_, or patch release, must replace all previous z-stream releases for
-the same minor version. OLM does not care about major, minor, or patch versions,
-it just needs to build the correct graph in a catalog.
+A _z-stream_, or patch release, must replace all previous z-stream releases for the same minor version. OLM does not consider major, minor, or patch versions, it just needs to build the correct graph in a catalog.
 
-In other words, OLM must be able to take a graph as in Old CatalogSource and, similar
-to before, generate a graph as in New CatalogSource:
+In other words, OLM must be able to take a graph as in *Old CatalogSource* and, similar to before, generate a graph as in *New CatalogSource*:
 
 .Replacing several Operators
 image::olm-z-stream.png[]
 
 This graph maintains that:
 
-* Any Operator found in Old CatalogSource has a single replacement in New CatalogSource.
-* Any Operator found in New CatalogSource has a single replacement in New CatalogSource.
-* Any z-stream release in Old CatalogSource will update to the latest z-stream release in New CatalogSource.
-* Unavailable releases can be considered "virtual" graph nodes; their content does
-not need to exist, the registry just needs to respond as if the graph looks like
-this.
+* Any Operator found in *Old CatalogSource* has a single replacement in *New CatalogSource*.
+* Any Operator found in *New CatalogSource* has a single replacement in *New CatalogSource*.
+* Any z-stream release in *Old CatalogSource* will update to the latest z-stream release in *New CatalogSource*.
+* Unavailable releases can be considered "virtual" graph nodes; their content does not need to exist, the registry just needs to respond as if the graph looks like this.

--- a/modules/olm-webhook-considerations.adoc
+++ b/modules/olm-webhook-considerations.adoc
@@ -5,31 +5,23 @@
 [id="olm-webhook-considerations_{context}"]
 = Webhook considerations
 
-When developing an admission webhook to be managed by OLM, consider the
-following constraints:
+When developing an admission webhook to be managed by Operator Lifecycle Manager (OLM), consider the following constraints:
 
 [discrete]
 [id="olm-webhook-ca_{context}"]
 === Certificate authority constraints
 
-OLM is configured to provide each Deployment with a single certificate authority
-(CA). The logic that generates and mounts the CA into the Deployment was
-originally used by the APIService lifecycle logic. As a result:
+OLM is configured to provide each deployment with a single certificate authority (CA). The logic that generates and mounts the CA into the deployment was originally used by the API service lifecycle logic. As a result:
 
-* The TLS certificate file is mounted to the Deployment at
-`/apiserver.local.config/certificates/apiserver.crt`.
-* The TLS key file is mounted to the Deployment at
-`/apiserver.local.config/certificates/apiserver.key`.
+* The TLS certificate file is mounted to the deployment at `/apiserver.local.config/certificates/apiserver.crt`.
+* The TLS key file is mounted to the deployment at `/apiserver.local.config/certificates/apiserver.key`.
 
 [discrete]
 [id="olm-webhook-rules_{context}"]
 === Admission webhook rules constraints
 
-To prevent an Operator from configuring the cluster into an unrecoverable state,
-OLM places the CSV in the failed phase if the rules defined in an admission
-webhook intercept any of the following requests:
+To prevent an Operator from configuring the cluster into an unrecoverable state, OLM places the CSV in the failed phase if the rules defined in an admission webhook intercept any of the following requests:
 
 * Requests that target all groups
 * Requests that target the `operators.coreos.com` group
-* Requests that target the `ValidatingWebhookConfigurations` or
-`MutatingWebhookConfigurations` resources
+* Requests that target the `ValidatingWebhookConfigurations` or `MutatingWebhookConfigurations` resources

--- a/modules/olm-why-use-operators.adoc
+++ b/modules/olm-why-use-operators.adoc
@@ -11,29 +11,14 @@ Operators provide:
 - Repeatability of installation and upgrade.
 - Constant health checks of every system component.
 - Over-the-air (OTA) updates for OpenShift components and ISV content.
-- A place to encapsulate knowledge from field engineers and spread it to all
-users, not just one or two.
+- A place to encapsulate knowledge from field engineers and spread it to all users, not just one or two.
 --
 
 Why deploy on Kubernetes?::
-Kubernetes (and by extension, {product-title}) contains all of the primitives
-needed to build complex distributed systems – secret handling, load balancing,
-service discovery, autoscaling – that work across on-premise and cloud
-providers.
+Kubernetes (and by extension, {product-title}) contains all of the primitives needed to build complex distributed systems – secret handling, load balancing, service discovery, autoscaling – that work across on-premise and cloud providers.
 
 Why manage your app with Kubernetes APIs and `kubectl` tooling?::
-These APIs are feature rich, have clients for all platforms and plug into the
-cluster’s access control/auditing. An Operator uses the Kubernetes' extension
-mechanism, custom resource definitions (CRDs), so your custom object,
-link:https://marketplace.redhat.com/en-us/products/mongodb-enterprise-advanced-from-ibm[for
-example `MongoDB`], looks and acts just like the built-in, native Kubernetes
-objects.
+These APIs are feature rich, have clients for all platforms and plug into the cluster’s access control/auditing. An Operator uses the Kubernetes extension mechanism, custom resource definitions (CRDs), so your custom object, link:https://marketplace.redhat.com/en-us/products/mongodb-enterprise-advanced-from-ibm[for example `MongoDB`], looks and acts just like the built-in, native Kubernetes objects.
 
-How do Operators compare with Service Brokers?::
-A Service Broker is a step towards programmatic discovery and deployment of an
-app. However, because it is not a long running process, it cannot execute Day 2
-operations like upgrade, failover, or scaling. Customizations and
-parameterization of tunables are provided at install time, versus an Operator
-that is constantly watching your cluster's current state. Off-cluster services
-continue to be a good match for a Service Broker, although Operators exist for
-these as well.
+How do Operators compare with service brokers?::
+A service broker is a step towards programmatic discovery and deployment of an app. However, because it is not a long running process, it cannot execute Day 2 operations like upgrade, failover, or scaling. Customizations and parameterization of tunables are provided at install time, versus an Operator that is constantly watching the current state of your cluster. Off-cluster services are a good match for a service broker, although Operators exist for these as well.

--- a/modules/osdk-about-scorecard-tool.adoc
+++ b/modules/osdk-about-scorecard-tool.adoc
@@ -5,8 +5,4 @@
 [id="osdk-about-scorecard-tool_{context}"]
 = About the scorecard tool
 
-To validate an Operator, the Operator SDK's scorecard tool begins by creating
-all resources required by any related Custom Resources (CRs) and the Operator.
-The scorecard then creates a proxy container in the Operator's Deployment which
-is used to record calls to the API server and run some of the tests. The tests
-performed also examine some of the parameters in the CRs.
+To validate an Operator, the scorecard tool provided by the Operator SDK begins by creating all resources required by any related custom resources (CRs) and the Operator. The scorecard then creates a proxy container in the deployment of the Operator which is used to record calls to the API server and run some of the tests. The tests performed also examine some of the parameters in the CRs.

--- a/modules/osdk-ansible-custom-resource-files.adoc
+++ b/modules/osdk-ansible-custom-resource-files.adoc
@@ -3,16 +3,13 @@
 // * operators/operator_sdk/osdk-ansible.adoc
 
 [id="osdk-ansible-custom-resource-files_{context}"]
-= Custom Resource files
+= Custom resource files
 
-Operators use the Kubernetes' extension mechanism, Custom Resource Definitions
-(CRDs), so your Custom Resource (CR) looks and acts just like the built-in,
-native Kubernetes objects.
+Operators use the Kubernetes extension mechanism, custom resource definitions (CRDs), so your custom resource (CR) looks and acts just like the built-in, native Kubernetes objects.
 
-The CR file format is a Kubernetes resource file. The object has mandatory and
-optional fields:
+The CR file format is a Kubernetes resource file. The object has mandatory and optional fields:
 
-.Custom Resource fields
+.Custom resource fields
 [cols="3,7",options="header"]
 |===
 |Field
@@ -28,14 +25,10 @@ optional fields:
 |Kubernetes-specific metadata to be created.
 
 |`spec` (optional)
-|Key-value list of variables which are passed to Ansible. This field is empty by
-default.
+|Key-value list of variables which are passed to Ansible. This field is empty by default.
 
 |`status`
-|Summarizes the current state of the object. For Ansible-based Operators, the
-link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresource]
-is enabled for CRDs and managed by the `operator_sdk.util.k8s_status` Ansible module by default,
-which includes `condition` information to the CR's `status`.
+|Summarizes the current state of the object. For Ansible-based Operators, the link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresource] is enabled for CRDs and managed by the `operator_sdk.util.k8s_status` Ansible module by default, which includes `condition` information to the CR `status`.
 
 |`annotations`
 |Kubernetes-specific annotations to be appended to the CR.
@@ -50,17 +43,14 @@ The following list of CR annotations modify the behavior of the Operator:
 |Description
 
 |`ansible.operator-sdk/reconcile-period`
-|Specifies the reconciliation interval for the CR. This value is parsed using
-the standard Golang package link:https://golang.org/pkg/time/[`time`].
-Specifically, link:https://golang.org/pkg/time/#ParseDuration[`ParseDuration`]
-is used which applies the default suffix of `s`, giving the value in seconds.
+|Specifies the reconciliation interval for the CR. This value is parsed using the standard Golang package link:https://golang.org/pkg/time/[`time`]. Specifically, link:https://golang.org/pkg/time/#ParseDuration[`ParseDuration`] is used which applies the default suffix of `s`, giving the value in seconds.
 |===
 
 .Example Ansible-based Operator annotation
 [source,yaml]
 ----
-apiVersion: "foo.example.com/v1alpha1"
-kind: "Foo"
+apiVersion: "test1.example.com/v1alpha1"
+kind: "Test1"
 metadata:
   name: "example"
 annotations:

--- a/modules/osdk-ansible-extra-variables.adoc
+++ b/modules/osdk-ansible-extra-variables.adoc
@@ -5,13 +5,9 @@
 [id="osdk-ansible-extra-variables_{context}"]
 = Extra variables sent to Ansible
 
-Extra variables can be sent to Ansible, which are then managed by the Operator.
-The `spec` section of the Custom Resource (CR) passes along the key-value pairs
-as extra variables. This is equivalent to extra variables passed in to the
-`ansible-playbook` command.
+Extra variables can be sent to Ansible, which are then managed by the Operator. The `spec` section of the custom resource (CR) passes along the key-value pairs as extra variables. This is equivalent to extra variables passed in to the `ansible-playbook` command.
 
-The Operator also passes along additional variables under the `meta` field for
-the name of the CR and the namespace of the CR.
+The Operator also passes along additional variables under the `meta` field for the name of the CR and the namespace of the CR.
 
 For the following CR example:
 
@@ -42,10 +38,7 @@ The structure passed to Ansible as extra variables is:
 }
 ----
 
-The `message` and `newParameter` fields are set in the top level as extra
-variables, and `meta` provides the relevant metadata for the CR as defined in
-the Operator. The `meta` fields can be accessed using dot notation in Ansible,
-for example:
+The `message` and `newParameter` fields are set in the top level as extra variables, and `meta` provides the relevant metadata for the CR as defined in the Operator. The `meta` fields can be accessed using dot notation in Ansible, for example:
 
 [source,yaml]
 ----

--- a/modules/osdk-ansible-k8s-module-inside-operator.adoc
+++ b/modules/osdk-ansible-k8s-module-inside-operator.adoc
@@ -5,21 +5,14 @@
 [id="osdk-ansible-k8s-module-inside-operator_{context}"]
 = Testing the k8s Ansible module inside an Operator
 
-After you are familiar using the `k8s` Ansible module locally, you can trigger
-the same Ansible logic inside of an Operator when a Custom Resource (CR)
-changes. This example maps an Ansible role to a specific Kubernetes resource
-that the Operator watches. This mapping is done in the Watches file.
+After you are familiar with using the `k8s` Ansible module locally, you can trigger the same Ansible logic inside of an Operator when a custom resource (CR) changes. This example maps an Ansible role to a specific Kubernetes resource that the Operator watches. This mapping is done in the `watches.yaml` file.
 
 [id="osdk-ansible-k8s-module-inside-operator-testing-local_{context}"]
 == Testing an Ansible-based Operator locally
 
-After getting comfortable testing Ansible workflows locally, you can test the
-logic inside of an Ansible-based Operator running locally.
+After getting comfortable testing Ansible workflows locally, you can test the logic inside of an Ansible-based Operator running locally.
 
-To do so, use the `operator-sdk run --local` command from the top-level directory
-of your Operator project. This command reads from the `./watches.yaml` file and
-uses the `~/.kube/config` file to communicate with a Kubernetes cluster just as
-the `k8s` Ansible module does.
+To do so, use the `operator-sdk run --local` command from the top-level directory of your Operator project. This command reads from the `watches.yaml` file and uses the `~/.kube/config` file to communicate with a Kubernetes cluster just as the `k8s` Ansible module does.
 
 ////
 Possible .Prerequisites list item:
@@ -29,31 +22,26 @@ This section assumes the developer has read the Ansible Operator user guide and 
 
 .Procedure
 
-. Because the `run --local` command reads from the `./watches.yaml` file, there are
-options available to the Operator author. If `role` is left alone (by default,
-`/opt/ansible/roles/<name>`) you must copy the role over to the
-`/opt/ansible/roles/` directory from the Operator directly.
+. Because the `run --local` command reads from the `watches.yaml` file, there are options available to the Operator author. If `role` is left alone (by default, `/opt/ansible/roles/<name>`) you must copy the role over to the `/opt/ansible/roles/` directory from the Operator directly.
 +
-This is cumbersome because changes are not reflected from the current directory.
-Instead, change the `role` field to point to the current directory and comment
-out the existing line:
+This is cumbersome because changes are not reflected from the current directory. Instead, change the `role` field to point to the current directory and comment out the existing line:
 +
 [source,yaml]
 ----
 - version: v1alpha1
-  group: foo.example.com
-  kind: Foo
-  #  role: /opt/ansible/roles/Foo
-  role: /home/user/foo-operator/Foo
+  group: test1.example.com
+  kind: Test1
+  #  role: /opt/ansible/roles/Test1
+  role: /home/user/test1-operator/Test1
 ----
 
-. Create a Custom Resource Definiton (CRD) and proper role-based access control
-(RBAC) definitions for the Custom Resource (CR) `Foo`. The `operator-sdk`
+. Create a custom resource definition (CRD) and proper role-based access control
+(RBAC) definitions for the custom resource (CR) `Test1`. The `operator-sdk`
 command autogenerates these files inside of the `deploy/` directory:
 +
 [source,terminal]
 ----
-$ oc create -f deploy/crds/foo_v1alpha1_foo_crd.yaml
+$ oc create -f deploy/crds/test1_v1alpha1_test1_crd.yaml
 ----
 +
 [source,terminal]
@@ -83,26 +71,22 @@ $ operator-sdk run --local
 ----
 [...]
 INFO[0000] Starting to serve on 127.0.0.1:8888
-INFO[0000] Watching foo.example.com/v1alpha1, Foo, default
+INFO[0000] Watching test1.example.com/v1alpha1, Test1, default
 ----
 
-. Now that the Operator is watching the resource `Foo` for events, the creation
-of a CR triggers your Ansible role to execute. View the `deploy/cr.yaml` file:
+. Now that the Operator is watching the resource `Test1` for events, the creation of a CR triggers your Ansible role to execute. View the `deploy/cr.yaml` file:
 +
 [source,yaml]
 ----
-apiVersion: "foo.example.com/v1alpha1"
-kind: "Foo"
+apiVersion: "test1.example.com/v1alpha1"
+kind: "Test1"
 metadata:
   name: "example"
 ----
 +
-Because the `spec` field is not set, Ansible is invoked with no extra variables.
-The next section covers how extra variables are passed from a CR to Ansible.
-This is why it is important to set sane defaults for the Operator.
+Because the `spec` field is not set, Ansible is invoked with no extra variables. The next section covers how extra variables are passed from a CR to Ansible. This is why it is important to set reasonable defaults for the Operator.
 
-. Create a CR instance of `Foo` with the default variable `state` set to
-`present`:
+. Create a CR instance of `Test1` with the default variable `state` set to `present`:
 +
 [source,terminal]
 ----
@@ -130,8 +114,8 @@ test          Active    3s
 +
 [source,yaml]
 ----
-apiVersion: "foo.example.com/v1alpha1"
-kind: "Foo"
+apiVersion: "test1.example.com/v1alpha1"
+kind: "Test1"
 metadata:
   name: "example"
 spec:
@@ -162,47 +146,41 @@ kube-system   Active    28d
 [id="osdk-ansible-k8s-module-inside-operator-testing-cluster_{context}"]
 == Testing an Ansible-based Operator on a cluster
 
-After getting familiar running Ansible logic inside of an Ansible-based Operator
-locally, you can test the Operator inside of a Pod on a Kubernetes cluster, such
-as {product-title}. Running as a Pod on a cluster is preferred for production
-use.
+After getting familiar running Ansible logic inside of an Ansible-based Operator locally, you can test the Operator inside of a pod on a Kubernetes cluster, such as {product-title}. Running as a pod on a cluster is preferred for production use.
 
 .Procedure
 
-. Build the `foo-operator` image and push it to a registry:
+. Build the `test1-operator` image and push it to a registry:
 +
 [source,terminal]
 ----
-$ operator-sdk build quay.io/example/foo-operator:v0.0.1
+$ operator-sdk build quay.io/example/test1-operator:v0.0.1
 ----
 +
 [source,terminal]
 ----
-$ podman push quay.io/example/foo-operator:v0.0.1
+$ podman push quay.io/example/test1-operator:v0.0.1
 ----
 
-. Deployment manifests are generated in the `deploy/operator.yaml` file. The
-Deployment image in this file must be modified from the placeholder
-`REPLACE_IMAGE` to the previously-built image. To do so, run the following
-command:
+. Deployment manifests are generated in the `deploy/operator.yaml` file. The deployment image in this file must be modified from the placeholder `REPLACE_IMAGE` to the previously-built image. To do so, run the following command:
 +
 [source,terminal]
 ----
-$ sed -i 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
+$ sed -i 's|REPLACE_IMAGE|quay.io/example/test1-operator:v0.0.1|g' deploy/operator.yaml
 ----
 +
-If you are performing these steps on OSX, use the following command instead:
+If you are performing these steps on macOS, use the following command instead:
 +
 [source,terminal]
 ----
-$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/foo-operator:v0.0.1|g' deploy/operator.yaml
+$ sed -i "" 's|REPLACE_IMAGE|quay.io/example/test1-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
-. Deploy the `foo-operator`:
+. Deploy the `test1-operator`:
 +
 [source,terminal]
 ----
-$ oc create -f deploy/crds/foo_v1alpha1_foo_crd.yaml <1>
+$ oc create -f deploy/crds/test1_v1alpha1_test1_crd.yaml <1>
 ----
 <1> Only required if the CRD does not exist already.
 +
@@ -226,7 +204,7 @@ $ oc create -f deploy/role_binding.yaml
 $ oc create -f deploy/operator.yaml
 ----
 
-. Verify that the `foo-operator` is up and running:
+. Verify that the `test1-operator` is up and running:
 +
 [source,terminal]
 ----
@@ -237,12 +215,12 @@ $ oc get deployment
 [source,terminal]
 ----
 NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-foo-operator       1         1         1            1           1m
+test1-operator       1         1         1            1           1m
 ----
 
-. You can now view the Ansible logs for the `foo-operator`:
+. You can now view the Ansible logs for the `test1-operator`:
 +
 [source,terminal]
 ----
-$ oc logs deployment/foo-operator
+$ oc logs deployment/test1-operator
 ----

--- a/modules/osdk-ansible-k8s-module-installing.adoc
+++ b/modules/osdk-ansible-k8s-module-installing.adoc
@@ -16,9 +16,7 @@ To install the `k8s` Ansible module on your local workstation:
 $ sudo yum install ansible
 ----
 
-. Install the
-link:https://github.com/openshift/openshift-restclient-python[OpenShift python client]
-package using `pip`:
+. Install the link:https://github.com/openshift/openshift-restclient-python[OpenShift python client] package using `pip`:
 +
 [source,terminal]
 ----

--- a/modules/osdk-ansible-k8s-module-testing-locally.adoc
+++ b/modules/osdk-ansible-k8s-module-testing-locally.adoc
@@ -5,8 +5,7 @@
 [id="osdk-ansible-k8s-module-testing-locally_{context}"]
 = Testing the k8s Ansible module locally
 
-Sometimes, it is beneficial for a developer to run the Ansible code from their
-local machine as opposed to running and rebuilding the Operator each time.
+Sometimes, it is beneficial for a developer to run the Ansible code from their local machine as opposed to running and rebuilding the Operator each time.
 
 .Procedure
 
@@ -22,36 +21,35 @@ $ ansible-galaxy collection install community.kubernetes
 [source,terminal]
 ----
 $ operator-sdk new --type ansible \
-    --kind Foo \
-    --api-version foo.example.com/v1alpha1 foo-operator
+    --kind Test1 \
+    --api-version test1.example.com/v1alpha1 test1-operator
 ----
 +
 .Example output
 [source,terminal]
 ----
-Create foo-operator/tmp/init/galaxy-init.sh
-Create foo-operator/tmp/build/Dockerfile
-Create foo-operator/tmp/build/test-framework/Dockerfile
-Create foo-operator/tmp/build/go-test.sh
-Rendering Ansible Galaxy role [foo-operator/roles/foo]...
-Cleaning up foo-operator/tmp/init
-Create foo-operator/watches.yaml
-Create foo-operator/deploy/rbac.yaml
-Create foo-operator/deploy/crd.yaml
-Create foo-operator/deploy/cr.yaml
-Create foo-operator/deploy/operator.yaml
+Create test1-operator/tmp/init/galaxy-init.sh
+Create test1-operator/tmp/build/Dockerfile
+Create test1-operator/tmp/build/test-framework/Dockerfile
+Create test1-operator/tmp/build/go-test.sh
+Rendering Ansible Galaxy role [test1-operator/roles/test1]...
+Cleaning up test1-operator/tmp/init
+Create test1-operator/watches.yaml
+Create test1-operator/deploy/rbac.yaml
+Create test1-operator/deploy/crd.yaml
+Create test1-operator/deploy/cr.yaml
+Create test1-operator/deploy/operator.yaml
 Run git init ...
-Initialized empty Git repository in /home/dymurray/go/src/github.com/dymurray/opsdk/foo-operator/.git/
+Initialized empty Git repository in /home/user/go/src/github.com/user/opsdk/test1-operator/.git/
 Run git init done
 ----
 +
 [source,terminal]
 ----
-$ cd foo-operator
+$ cd test1-operator
 ----
 
-. Modify the `roles/foo/tasks/main.yml` file with the desired Ansible logic.
-This example creates and deletes a namespace with the switch of a variable.
+. Modify the `roles/test1/tasks/main.yml` file with the Ansible logic that you want. This example creates and deletes a namespace with the switch of a variable.
 +
 [source,yaml]
 ----
@@ -63,24 +61,22 @@ This example creates and deletes a namespace with the switch of a variable.
     name: test
   ignore_errors: true <1>
 ----
-<1> Setting `ignore_errors: true` ensures that deleting a nonexistent project does
-not fail.
+<1> Setting `ignore_errors: true` ensures that deleting a nonexistent project does not fail.
 
-. Modify the `roles/foo/defaults/main.yml` file to set `state` to `present` by default.
+. Modify the `roles/test1/defaults/main.yml` file to set `state` to `present` by default:
 +
 [source,yaml]
 ----
 state: present
 ----
 
-. Create an Ansible playbook `playbook.yml` in the top-level directory, which
-includes the `foo` role:
+. Create an Ansible playbook `playbook.yml` in the top-level directory, which includes the `test1` role:
 +
 [source,yaml]
 ----
 - hosts: localhost
   roles:
-    - foo
+    - test1
 ----
 
 . Run the playbook:
@@ -100,7 +96,7 @@ PLAY [localhost] ***************************************************************
 PROCEDURE [Gathering Facts] *********************************************************************
 ok: [localhost]
 
-Task [foo : set test namespace to present]
+Task [test1 : set test namespace to present]
 changed: [localhost]
 
 PLAY RECAP *********************************************************************************
@@ -141,7 +137,7 @@ PLAY [localhost] ***************************************************************
 PROCEDURE [Gathering Facts] *********************************************************************
 ok: [localhost]
 
-Task [foo : set test namespace to absent]
+Task [test1 : set test namespace to absent]
 changed: [localhost]
 
 PLAY RECAP *********************************************************************************

--- a/modules/osdk-ansible-managing-cr-status.adoc
+++ b/modules/osdk-ansible-managing-cr-status.adoc
@@ -3,12 +3,9 @@
 // * operators/operator_sdk/osdk-ansible.adoc
 
 [id="osdk-ansible-managing-cr-status_{context}"]
-= Managing Custom Resource status using the `operator_sdk.util` Ansible collection
+= Managing custom resource status using the `operator_sdk.util` Ansible collection
 
-Ansible-based Operators automatically update Custom Resource (CR)
-link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresources]
-with generic information about the previous Ansible run. This includes the
-number of successful and failed tasks and relevant error messages as shown:
+Ansible-based Operators automatically update custom resource (CR) link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#status-subresource[`status` subresources] with generic information about the previous Ansible run. This includes the number of successful and failed tasks and relevant error messages as shown:
 
 [source,yaml]
 ----
@@ -33,48 +30,37 @@ status:
     type: Running
 ----
 
-Ansible-based Operators also allow Operator authors to supply custom status
-values with the `k8s_status` Ansible module, which is included in the
-link:https://galaxy.ansible.com/operator_sdk/util[`operator_sdk.util` collection].
-This allows the author to update the `status` from within Ansible with any
-key-value pair as desired.
+Ansible-based Operators also allow Operator authors to supply custom status values with the `k8s_status` Ansible module, which is included in the link:https://galaxy.ansible.com/operator_sdk/util[`operator_sdk.util` collection]. This allows the author to update the `status` from within Ansible with any key-value pair as desired.
 
-By default, Ansible-based Operators always include the generic Ansible
-run output as shown above. If you would prefer your application did _not_ update
-the status with Ansible output, you can track the status manually
-from your application.
+By default, Ansible-based Operators always include the generic Ansible run output as shown above. If you would prefer your application did _not_ update the status with Ansible output, you can track the status manually from your application.
 
 .Procedure
 
-. To track CR status manually from your application, update the Watches file
-with a `manageStatus` field set to `false`:
+. To track CR status manually from your application, update the `watches.yaml` file with a `manageStatus` field set to `false`:
 +
 [source,yaml]
 ----
 - version: v1
   group: api.example.com
-  kind: Foo
-  role: Foo
+  kind: Test1
+  role: Test1
   manageStatus: false
 ----
 
-. Use the `operator_sdk.util.k8s_status` Ansible module to update the subresource.
-For example, to update with key `foo` and value `bar`, `operator_sdk.util` can
-be used as shown:
+. Use the `operator_sdk.util.k8s_status` Ansible module to update the subresource. For example, to update with key `test1` and value `test2`, `operator_sdk.util` can be used as shown:
 +
 [source,yaml]
 ----
 - operator_sdk.util.k8s_status:
     api_version: app.example.com/v1
-    kind: Foo
+    kind: Test1
     name: "{{ meta.name }}"
     namespace: "{{ meta.namespace }}"
     status:
-      foo: bar
+      test1: test2
 ----
 +
-Collections can also be declared in the `meta/main.yml` for the role, which is
-included for new scaffolded Ansible Operators.
+Collections can also be declared in the `meta/main.yml` for the role, which is included for new scaffolded Ansible Operators:
 +
 [source,yaml]
 ----
@@ -82,19 +68,16 @@ collections:
   - operator_sdk.util
 ----
 +
-Declaring collections in the role meta allows you to invoke the `k8s_status`
-module directly:
+Declaring collections in the role meta allows you to invoke the `k8s_status` module directly:
 +
 [source,yaml]
 ----
 k8s_status:
   <snip>
   status:
-    foo: bar
+    test1: test2
 ----
 
 .Additional resources
 
-- For more details about user-driven status management from Ansible-based
-Operators, see the
-link:https://github.com/operator-framework/operator-sdk/blob/master/proposals/ansible-operator-status.md[Ansible-based Operator Status Proposal for Operator SDK].
+- For more details about user-driven status management from Ansible-based Operators, see the link:https://github.com/operator-framework/operator-sdk/blob/master/proposals/ansible-operator-status.md[Ansible-based Operator Status Proposal for Operator SDK].

--- a/modules/osdk-ansible-runner-directory.adoc
+++ b/modules/osdk-ansible-runner-directory.adoc
@@ -5,11 +5,8 @@
 [id="osdk-ansible-runner-directory_{context}"]
 = Ansible Runner directory
 
-Ansible Runner keeps information about Ansible runs in the container. This
-is located at
-`/tmp/ansible-operator/runner/<group>/<version>/<kind>/<namespace>/<name>`.
+Ansible Runner keeps information about Ansible runs in the container. This is located at `/tmp/ansible-operator/runner/<group>/<version>/<kind>/<namespace>/<name>`.
 
 .Additional resources
 
-- To learn more about the `runner` directory, see the
-link:https://ansible-runner.readthedocs.io/en/latest/index.html[Ansible Runner documentation].
+- To learn more about the `runner` directory, see the link:https://ansible-runner.readthedocs.io/en/latest/index.html[Ansible Runner documentation].

--- a/modules/osdk-ansible-support.adoc
+++ b/modules/osdk-ansible-support.adoc
@@ -5,12 +5,6 @@
 [id="osdk-ansible-support_{context}"]
 = Ansible support in the Operator SDK
 
-The link:https://coreos.com/operators/[Operator Framework] is an open source
-toolkit to manage Kubernetes native applications, called _Operators_, in an
-effective, automated, and scalable way. This framework includes the Operator
-SDK, which assists developers in bootstrapping and building an Operator based on
-their expertise without requiring knowledge of Kubernetes API complexities.
+The link:https://operatorframework.io/[Operator Framework] is an open source toolkit to manage Kubernetes native applications, called _Operators_, in an effective, automated, and scalable way. This framework includes the Operator SDK, which assists developers in bootstrapping and building an Operator based on their expertise without requiring knowledge of Kubernetes API complexities.
 
-One of the Operator SDK's options for generating an Operator project includes
-leveraging existing Ansible playbooks and modules to deploy Kubernetes resources
-as a unified application, without having to write any Go code.
+One of the Operator SDK options for generating an Operator project includes leveraging existing Ansible playbooks and modules to deploy Kubernetes resources as a unified application, without having to write any Go code.

--- a/modules/osdk-ansible-watches-file.adoc
+++ b/modules/osdk-ansible-watches-file.adoc
@@ -3,14 +3,11 @@
 // * operators/operator_sdk/osdk-ansible.adoc
 
 [id="osdk-ansible-watches-file_{context}"]
-= Watches file
+= `watches.yaml` file
 
-The Watches file contains a list of mappings from Custom Resources (CRs),
-identified by its `Group`, `Version`, and `Kind`, to an Ansible role or
-playbook. The Operator expects this mapping file in a predefined location,
-`/opt/ansible/watches.yaml`.
+A _group/version/kind (GVK)_ is a unique identifier for a Kubernetes API. The `watches.yaml` file contains a list of mappings from custom resources (CRs), identified by its GVK, to an Ansible role or playbook. The Operator expects this mapping file in a predefined location at `/opt/ansible/watches.yaml`.
 
-.Watches file mappings
+.`watches.yaml` file mappings
 [cols="3,7",options="header"]
 |===
 |Field
@@ -26,63 +23,50 @@ playbook. The Operator expects this mapping file in a predefined location,
 |Kind of CR to watch
 
 |`role` (default)
-|Path to the Ansible role added to the container. For example, if your `roles`
-directory is at `/opt/ansible/roles/` and your role is named `busybox`, this
-value would be `/opt/ansible/roles/busybox`. This field is mutually exclusive
-with the `playbook` field.
+|Path to the Ansible role added to the container. For example, if your `roles` directory is at `/opt/ansible/roles/` and your role is named `busybox`, this value would be `/opt/ansible/roles/busybox`. This field is mutually exclusive with the `playbook` field.
 
 |`playbook`
-|Path to the Ansible playbook added to the container. This playbook is expected
-to be simply a way to call roles. This field is mutually exclusive with the
-`role` field.
+|Path to the Ansible playbook added to the container. This playbook is expected to be a way to call roles. This field is mutually exclusive with the `role` field.
 
 |`reconcilePeriod` (optional)
-|The reconciliation interval, how often the role or playbook is run, for a given
-CR.
+|The reconciliation interval, how often the role or playbook is run, for a given CR.
 
 |`manageStatus` (optional)
-|When set to `true` (default), the Operator manages the status of the CR
-generically. When set to `false`, the status of the CR is managed elsewhere, by
-the specified role or playbook or in a separate controller.
+|When set to `true` (default), the Operator manages the status of the CR generically. When set to `false`, the status of the CR is managed elsewhere, by the specified role or playbook or in a separate controller.
 |===
 
-.Example Watches file
+.Example `watches.yaml` file
 [source,yaml]
 ----
 - version: v1alpha1 <1>
-  group: foo.example.com
-  kind: Foo
-  role: /opt/ansible/roles/Foo
+  group: test1.example.com
+  kind: Test1
+  role: /opt/ansible/roles/Test1
 
 - version: v1alpha1 <2>
-  group: bar.example.com
-  kind: Bar
+  group: test2.example.com
+  kind: Test2
   playbook: /opt/ansible/playbook.yml
 
 - version: v1alpha1 <3>
-  group: baz.example.com
-  kind: Baz
-  playbook: /opt/ansible/baz.yml
+  group: test3.example.com
+  kind: Test3
+  playbook: /opt/ansible/test3.yml
   reconcilePeriod: 0
   manageStatus: false
 ----
-<1> Simple example mapping `Foo` to the `Foo` role.
-<2> Simple example mapping `Bar` to a playbook.
-<3> More complex example for the `Baz` kind. Disables re-queuing and managing
-the CR status in the playbook.
+<1> Simple example mapping `Test1` to the `test1` role.
+<2> Simple example mapping `Test2` to a playbook.
+<3> More complex example for the `Test3` kind. Disables re-queuing and managing the CR status in the playbook.
 
 [id="osdk-ansible-watches-file-advanced_{context}"]
 == Advanced options
 
-Advanced features can be enabled by adding them to your Watches file per GVK
-(group, version, and kind). They can go below the `group`, `version`, `kind` and
-`playbook` or `role` fields.
+Advanced features can be enabled by adding them to your `watches.yaml` file per GVK. They can go below the `group`, `version`, `kind` and `playbook` or `role` fields.
 
-Some features can be overridden per resource using an annotation on that Custom
-Resource (CR). The options that can be overridden have the annotation specified
-below.
+Some features can be overridden per resource using an annotation on that CR. The options that can be overridden have the annotation specified below.
 
-.Advanced Watches file options
+.Advanced `watches.yaml` file options
 [cols="3,2,4,2,1",options="header"]
 |===
 |Feature
@@ -99,8 +83,7 @@ below.
 
 |Manage status
 |`manageStatus`
-|Allows the Operator to manage the `conditions` section of each CR's `status`
-section.
+|Allows the Operator to manage the `conditions` section of each CR `status` section.
 |
 |`true`
 
@@ -118,15 +101,12 @@ section.
 
 |Max runner artifacts
 |`maxRunnerArtifacts`
-|Manages the number of
-link:https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy[artifact directories]
-that Ansible Runner keeps in the Operator container for each individual
-resource.
+|Manages the number of link:https://ansible-runner.readthedocs.io/en/latest/intro.html#runner-artifacts-directory-hierarchy[artifact directories] that Ansible Runner keeps in the Operator container for each individual resource.
 |`ansible.operator-sdk/max-runner-artifacts`
 |`20`
 |===
 
-.Example Watches file with advanced options
+.Example `watches.yml` file with advanced options
 [source,yaml]
 ----
 - version: v1alpha1

--- a/modules/osdk-apiservices.adoc
+++ b/modules/osdk-apiservices.adoc
@@ -5,67 +5,52 @@
 [id="osdk-apiservices_{context}"]
 = Understanding your API services
 
-As with CRDs, there are two types of APIServices that your Operator may use:
-_owned_ and _required_.
+As with CRDs, there are two types of API services that your Operator may use: _owned_ and _required_.
 
 [id="osdk-apiservices-owned_{context}"]
-== Owned APIServices
+== Owned API services
 
-When a CSV owns an APIService, it is responsible for describing the deployment
-of the extension `api-server` that backs it and the `group-version-kinds` it
-provides.
+When a CSV owns an API service, it is responsible for describing the deployment of the extension `api-server` that backs it and the group/version/kind (GVK) it provides.
 
-An APIService is uniquely identified by the `group-version` it provides and can
-be listed multiple times to denote the different kinds it is expected to
-provide.
+An API service is uniquely identified by the group/version it provides and can be listed multiple times to denote the different kinds it is expected to provide.
 
-.Owned APIService fields
+.Owned API service fields
 [cols="2a,5a,2",options="header"]
 |===
-|Field |Description |Required/Optional
+|Field |Description |Required/optional
 
 |`Group`
-|Group that the APIService provides, for example `database.example.com`.
+|Group that the API service provides, for example `database.example.com`.
 |Required
 
 |`Version`
-|Version of the APIService, for example `v1alpha1`.
+|Version of the API service, for example `v1alpha1`.
 |Required
 
 |`Kind`
-|A kind that the APIService is expected to provide.
+|A kind that the API service is expected to provide.
 |Required
 
 |`Name`
-|The plural name for the APIService provided
+|The plural name for the API service provided.
 |Required
 
 |`DeploymentName`
-|Name of the deployment defined by your CSV that corresponds to your APIService
-(required for owned APIServices). During the CSV pending phase, the OLM Operator
-searches the InstallStrategy of your CSV for a Deployment spec with a matching
-name, and if not found, does not transition the CSV to the install ready phase.
+|Name of the deployment defined by your CSV that corresponds to your API service (required for owned API services). During the CSV pending phase, the OLM Operator searches the `InstallStrategy` of your CSV for a `Deployment` spec with a matching name, and if not found, does not transition the CSV to the "Install Ready" phase.
 |Required
 
 |`DisplayName`
-|A human readable version of your APIService name, for example `MongoDB Standalone`.
+|A human readable version of your API service name, for example `MongoDB Standalone`.
 |Required
 
 |`Description`
-|A short description of how this APIService is used by the Operator or a
-description of the functionality provided by the APIService.
+|A short description of how this API service is used by the Operator or a description of the functionality provided by the API service.
 |Required
 
 |`Resources`
-a|Your APIServices own one or more types of Kubernetes objects. These are listed
-in the resources section to inform your users of the objects they might need to
-troubleshoot or how to connect to the application, such as the Service or
-Ingress rule that exposes a database.
+a|Your API services own one or more types of Kubernetes objects. These are listed in the resources section to inform your users of the objects they might need to troubleshoot or how to connect to the application, such as the service or ingress rule that exposes a database.
 
-It is recommended to only list out the objects that are important to a human,
-not an exhaustive list of everything you orchestrate. For example, ConfigMaps
-that store internal state that should not be modified by a user should not
-appear here.
+It is recommended to only list out the objects that are important to a human, not an exhaustive list of everything you orchestrate. For example, do not list config maps that store internal state that are not meant to be modified by a user.
 |Optional
 
 |`SpecDescriptors`, `StatusDescriptors`, and `ActionDescriptors`
@@ -74,68 +59,50 @@ appear here.
 |===
 
 [id="osdk-apiservices-resource-creation_{context}"]
-=== APIService Resource Creation
+=== API service resource creation
 
-Operator Lifecycle Manager (OLM) is responsible for creating or replacing
-the Service and APIService resources for each unique owned APIService:
+Operator Lifecycle Manager (OLM) is responsible for creating or replacing the service and API service resources for each unique owned API service:
 
-* Service Pod selectors are copied from the CSV deployment matching the
-APIServiceDescription's `DeploymentName`.
+* Service pod selectors are copied from the CSV deployment matching the `DeploymentName` field of the API service description.
 
-* A new CA key/cert pair is generated for each installation and the
-base64-encoded CA bundle is embedded in the respective APIService resource.
+* A new CA key/certificate pair is generated for each installation and the base64-encoded CA bundle is embedded in the respective API service resource.
 
 [id="osdk-apiservices-service-certs_{context}"]
-=== APIService Serving Certs
+=== API service serving certificates
 
-OLM handles generating a serving key/cert pair whenever an owned APIService
-is being installed. The serving certificate has a CN containing the host name of
-the generated Service resource and is signed by the private key of the CA bundle
-embedded in the corresponding APIService resource.
+OLM handles generating a serving key/certificate pair whenever an owned API service is being installed. The serving certificate has a common name (CN) containing the host name of the generated `Service` resource and is signed by the private key of the CA bundle embedded in the corresponding API service resource.
 
-The cert is stored as a type `kubernetes.io/tls` Secret in the deployment
-namespace, and a Volume named `apiservice-cert` is automatically appended to the
-Volumes section of the deployment in the CSV matching the
-APIServiceDescription's `DeploymentName` field.
+The certificate is stored as a type `kubernetes.io/tls` secret in the deployment namespace, and a volume named `apiservice-cert` is automatically appended to the volumes section of the deployment in the CSV matching the `DeploymentName` field of the API service description.
 
-If one does not already exist, a VolumeMount with a matching name is also
-appended to all containers of that deployment. This allows users to define a
-VolumeMount with the expected name to accommodate any custom path requirements.
-The generated VolumeMount's path defaults to
-`/apiserver.local.config/certificates` and any existing VolumeMounts with the
-same path are replaced.
+If one does not already exist, a volume mount with a matching name is also appended to all containers of that deployment. This allows users to define a volume mount with the expected name to accommodate any custom path requirements. The path of the generated volume mount defaults to `/apiserver.local.config/certificates` and any existing volume mounts with the same path are replaced.
 
 [id="osdk-apiservice-required_{context}"]
-== Required APIServices
+== Required API services
 
-OLM ensures all required CSVs have an APIService that is available and all
-expected `group-version-kinds` are discoverable before attempting installation.
-This allows a CSV to rely on specific kinds provided by APIServices it does not
-own.
+OLM ensures all required CSVs have an API service that is available and all expected GVKs are discoverable before attempting installation. This allows a CSV to rely on specific kinds provided by API services it does not own.
 
-.Required APIService fields
+.Required API service fields
 [cols="2a,5a,2",options="header"]
 |===
-|Field |Description |Required/Optional
+|Field |Description |Required/optional
 
 |`Group`
-|Group that the APIService provides, for example `database.example.com`.
+|Group that the API service provides, for example `database.example.com`.
 |Required
 
 |`Version`
-|Version of the APIService, for example `v1alpha1`.
+|Version of the API service, for example `v1alpha1`.
 |Required
 
 |`Kind`
-|A kind that the APIService is expected to provide.
+|A kind that the API service is expected to provide.
 |Required
 
 |`DisplayName`
-|A human readable version of your APIService name, for example `MongoDB Standalone`.
+|A human readable version of your API service name, for example `MongoDB Standalone`.
 |Required
 
 |`Description`
-|A short description of how this APIService is used by the Operator or a
-description of the functionality provided by the APIService.
+|A short description of how this API service is used by the Operator or a description of the functionality provided by the API service.
 |Required
 |===

--- a/modules/osdk-architecture.adoc
+++ b/modules/osdk-architecture.adoc
@@ -5,20 +5,11 @@
 [id="osdk-architecture_{context}"]
 = Architecture of the Operator SDK
 
-The link:https://coreos.com/operators/[Operator Framework] is an open source
-toolkit to manage Kubernetes native applications, called _Operators_, in an
-effective, automated, and scalable way. Operators take advantage of Kubernetes'
-extensibility to deliver the automation advantages of cloud services like
-provisioning, scaling, and backup and restore, while being able to run anywhere
-that Kubernetes can run.
+The link:https://coreos.com/operators/[Operator Framework] is an open source toolkit to manage Kubernetes native applications, called _Operators_, in an effective, automated, and scalable way. Operators take advantage of Kubernetes extensibility to deliver the automation advantages of cloud services like provisioning, scaling, and backup and restore, while being able to run anywhere that Kubernetes can run.
 
-Operators make it easy to manage complex, stateful applications on top of
-Kubernetes. However, writing an Operator today can be difficult because of
-challenges such as using low-level APIs, writing boilerplate, and a lack of
-modularity, which leads to duplication.
+Operators make it easy to manage complex, stateful applications on top of Kubernetes. However, writing an Operator today can be difficult because of challenges such as using low-level APIs, writing boilerplate, and a lack of modularity, which leads to duplication.
 
-The Operator SDK is a framework designed to make writing Operators easier by
-providing:
+The Operator SDK is a framework designed to make writing Operators easier by providing:
 
 - High-level APIs and abstractions to write the operational logic more intuitively
 - Tools for scaffolding and code generation to quickly bootstrap a new project
@@ -30,7 +21,7 @@ providing:
 The Operator SDK provides the following workflow to develop a new Operator:
 
 . Create a new Operator project using the Operator SDK command line interface (CLI).
-. Define new resource APIs by adding Custom Resource Definitions (CRDs).
+. Define new resource APIs by adding custom resource definitions (CRDs).
 . Specify resources to watch using the Operator SDK API.
 . Define the Operator reconciling logic in a designated handler and use the Operator SDK API to interact with resources.
 . Use the Operator SDK CLI to build and generate the Operator deployment manifests.
@@ -38,16 +29,12 @@ The Operator SDK provides the following workflow to develop a new Operator:
 .Operator SDK workflow
 image::osdk-workflow.png[]
 
-At a high level, an Operator using the Operator SDK processes events for watched
-resources in an Operator author-defined handler and takes actions to reconcile
-the state of the application.
+At a high level, an Operator using the Operator SDK processes events for watched resources in an Operator author-defined handler and takes actions to reconcile the state of the application.
 
 [id="osdk-architecture-manager_{context}"]
 == Manager file
 
-The main program for the Operator is the manager file at `cmd/manager/main.go`.
-The manager automatically registers the scheme for all Custom Resources (CRs)
-defined under `pkg/apis/` and runs all controllers under `pkg/controller/`.
+The main program for the Operator is the manager file at `cmd/manager/main.go`. The manager automatically registers the scheme for all custom resources (CRs) defined under `pkg/apis/` and runs all controllers under `pkg/controller/`.
 
 The manager can restrict the namespace that all controllers watch for resources:
 

--- a/modules/osdk-building-ansible-operator.adoc
+++ b/modules/osdk-building-ansible-operator.adoc
@@ -5,15 +5,12 @@
 [id="osdk-building-ansible-operator_{context}"]
 = Building an Ansible-based Operator using the Operator SDK
 
-This procedure walks through an example of building a simple Memcached Operator
-powered by Ansible playbooks and modules using tools and libraries provided by
-the Operator SDK.
+This procedure walks through an example of building a simple Memcached Operator powered by Ansible playbooks and modules using tools and libraries provided by the Operator SDK.
 
 .Prerequisites
 
 - Operator SDK CLI installed on the development workstation
-- Access to a Kubernetes-based cluster v1.11.3+ (for example {product-title} {product-version})
-using an account with `cluster-admin` permissions
+- Access to a Kubernetes-based cluster v1.11.3+ (for example {product-title} {product-version}) using an account with `cluster-admin` permissions
 - OpenShift CLI (`oc`) v{product-version}+ installed
 - link:https://docs.ansible.com/ansible/latest/index.html[`ansible`] v2.9.0+
 - link:https://ansible-runner.readthedocs.io/en/latest/install.html[`ansible-runner`] v1.1.0+
@@ -21,13 +18,9 @@ using an account with `cluster-admin` permissions
 
 .Procedure
 
-. *Create a new Operator project.* A namespace-scoped Operator watches and manages
-resources in a single namespace. Namespace-scoped Operators are preferred
-because of their flexibility. They enable decoupled upgrades, namespace
-isolation for failures and monitoring, and differing API definitions.
+. *Create a new Operator project.* A namespace-scoped Operator watches and manages resources in a single namespace. Namespace-scoped Operators are preferred because of their flexibility. They enable decoupled upgrades, namespace isolation for failures and monitoring, and differing API definitions.
 +
-To create a new Ansible-based, namespace-scoped `memcached-operator` project and
-change to its directory, use the following commands:
+To create a new Ansible-based, namespace-scoped `memcached-operator` project and change to the new directory, use the following commands:
 +
 [source,terminal]
 ----
@@ -42,21 +35,18 @@ $ operator-sdk new memcached-operator \
 $ cd memcached-operator
 ----
 +
-This creates the `memcached-operator` project specifically for watching the
-Memcached resource with APIVersion `example.com/v1apha1` and Kind `Memcached`.
+This creates the `memcached-operator` project specifically for watching the `Memcached` resource with API version `example.com/v1apha1` and kind `Memcached`.
 
 . *Customize the Operator logic.*
 +
-For this example, the `memcached-operator` executes the following reconciliation
-logic for each `Memcached` Custom Resource (CR):
+For this example, the `memcached-operator` executes the following reconciliation logic for each `Memcached` custom resource (CR):
 +
 --
-* Create a `memcached` Deployment if it does not exist.
-* Ensure that the Deployment size is the same as specified by the `Memcached` CR.
+* Create a `memcached` deployment if it does not exist.
+* Ensure that the deployment size is the same as specified by the `Memcached` CR.
 --
 +
-By default, the `memcached-operator` watches `Memcached` resource events as
-shown in the `watches.yaml` file and executes the Ansible role `Memcached`:
+By default, the `memcached-operator` watches `Memcached` resource events as shown in the `watches.yaml` file and executes the Ansible role `Memcached`:
 +
 [source,yaml]
 ----
@@ -67,9 +57,7 @@ shown in the `watches.yaml` file and executes the Ansible role `Memcached`:
 +
 You can optionally customize the following logic in the `watches.yaml` file:
 
-.. Specifying a `role` option configures the Operator to use this specified path
-when launching `ansible-runner` with an Ansible role. By default, the new
-command fills in an absolute path to where your role should go:
+.. Specifying a `role` option configures the Operator to use this specified path when launching `ansible-runner` with an Ansible role. By default, the `operator-sdk new` command fills in an absolute path to where your role should go:
 +
 [source,yaml]
 ----
@@ -79,9 +67,7 @@ command fills in an absolute path to where your role should go:
   role: /opt/ansible/roles/memcached
 ----
 
-.. Specifying a `playbook` option in the `watches.yaml` file configures the
-Operator to use this specified path when launching `ansible-runner` with an
-Ansible playbook:
+.. Specifying a `playbook` option in the `watches.yaml` file configures the Operator to use this specified path when launching `ansible-runner` with an Ansible playbook:
 +
 [source,yaml]
 ----
@@ -93,43 +79,29 @@ Ansible playbook:
 
 . *Build the Memcached Ansible role.*
 +
-Modify the generated Ansible role under the `roles/memcached/` directory. This
-Ansible role controls the logic that is executed when a resource is modified.
+Modify the generated Ansible role under the `roles/memcached/` directory. This Ansible role controls the logic that is executed when a resource is modified.
 
 .. *Define the `Memcached` spec.*
 +
-Defining the spec for an Ansible-based Operator can be done entirely in Ansible.
-The Ansible Operator passes all key-value pairs listed in the CR spec field
-along to Ansible as
-link:https://docs.ansible.com/ansible/2.5/user_guide/playbooks_variables.html#passing-variables-on-the-command-line[variables].
-The names of all variables in the spec field are converted to snake case
-(lowercase with an underscore) by the Operator before running Ansible. For
-example, `serviceAccount` in the spec becomes `service_account` in Ansible.
+Defining the spec for an Ansible-based Operator can be done entirely in Ansible. The Ansible Operator passes all key-value pairs listed in the CR spec field along to Ansible as link:https://docs.ansible.com/ansible/2.5/user_guide/playbooks_variables.html#passing-variables-on-the-command-line[variables]. The names of all variables in the spec field are converted to snake case (lowercase with an underscore) by the Operator before running Ansible. For example, `serviceAccount` in the spec becomes `service_account` in Ansible.
 +
 [TIP]
 ====
-You should perform some type validation in Ansible on the variables to ensure
-that your application is receiving expected input.
+You should perform some type validation in Ansible on the variables to ensure that your application is receiving expected input.
 ====
 +
-In case the user does not set the `spec` field, set a default by modifying the
-`roles/memcached/defaults/main.yml` file:
+In case the user does not set the `spec` field, set a default by modifying the `roles/memcached/defaults/main.yml` file:
 +
 [source,yaml]
 ----
 size: 1
 ----
 
-.. *Define the `Memcached` Deployment.*
+.. *Define the `Memcached` deployment.*
 +
-With the `Memcached` spec now defined, you can define what Ansible is actually
-executed on resource changes. Because this is an Ansible role, the default
-behavior executes the tasks in the `roles/memcached/tasks/main.yml` file.
+With the `Memcached` spec now defined, you can define what Ansible is actually executed on resource changes. Because this is an Ansible role, the default behavior executes the tasks in the `roles/memcached/tasks/main.yml` file.
 +
-The goal is for Ansible to create a Deployment if it does not exist, which runs
-the `memcached:1.4.36-alpine` image. Ansible 2.7+ supports the
-link:https://docs.ansible.com/ansible/2.7/modules/k8s_module.html[k8s Ansible module],
-which this example leverages to control the Deployment definition.
+The goal is for Ansible to create a deployment if it does not exist, which runs the `memcached:1.4.36-alpine` image. Ansible 2.7+ supports the link:https://docs.ansible.com/ansible/2.7/modules/k8s_module.html[k8s Ansible module], which this example leverages to control the deployment definition.
 +
 Modify the `roles/memcached/tasks/main.yml` to match the following:
 +
@@ -168,16 +140,12 @@ Modify the `roles/memcached/tasks/main.yml` to match the following:
 +
 [NOTE]
 ====
-This example used the `size` variable to control the number of replicas of the
-`Memcached` Deployment. This example sets the default to `1`, but any user can
-create a CR that overwrites the default.
+This example used the `size` variable to control the number of replicas of the `Memcached` deployment. This example sets the default to `1`, but any user can create a CR that overwrites the default.
 ====
 
 . *Deploy the CRD.*
 +
-Before running the Operator, Kubernetes needs to know about the new Custom
-Resource Definition (CRD) the Operator will be watching. Deploy the `Memcached`
-CRD:
+Before running the Operator, Kubernetes needs to know about the new custom resource definition (CRD) that the Operator will be watching. Deploy the `Memcached` CRD:
 +
 [source,terminal]
 ----
@@ -189,14 +157,13 @@ $ oc create -f deploy/crds/cache.example.com_memcacheds_crd.yaml
 There are two ways to build and run the Operator:
 +
 --
-* As a Pod inside a Kubernetes cluster.
+* As a pod inside a Kubernetes cluster.
 * As a Go program outside the cluster using the `operator-sdk up` command.
 --
 +
 Choose one of the following methods:
 
-.. *Run as a Pod* inside a Kubernetes cluster. This is the preferred
-method for production use.
+.. *Run as a pod* inside a Kubernetes cluster. This is the preferred method for production use.
 
 ... Build the `memcached-operator` image and push it to a registry:
 +
@@ -210,16 +177,14 @@ $ operator-sdk build quay.io/example/memcached-operator:v0.0.1
 $ podman push quay.io/example/memcached-operator:v0.0.1
 ----
 
-... Deployment manifests are generated in the `deploy/operator.yaml` file. The
-deployment image in this file needs to be modified from the placeholder
-`REPLACE_IMAGE` to the previous built image. To do this, run:
+... Deployment manifests are generated in the `deploy/operator.yaml` file. The deployment image in this file needs to be modified from the placeholder `REPLACE_IMAGE` to the previous built image. To do this, run:
 +
 [source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/memcached-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
-... Deploy the `memcached-operator`:
+... Deploy the `memcached-operator` manifests:
 +
 [source,terminal]
 ----
@@ -241,7 +206,7 @@ $ oc create -f deploy/role_binding.yaml
 $ oc create -f deploy/operator.yaml
 ----
 
-... Verify that the `memcached-operator` is up and running:
+... Verify that the `memcached-operator` deployment is up and running:
 +
 [source,terminal]
 ----
@@ -254,19 +219,13 @@ NAME                     DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 memcached-operator       1         1         1            1           1m
 ----
 
-.. *Run outside the cluster.* This method is preferred during the
-development cycle to speed up deployment and testing.
+.. *Run outside the cluster.* This method is preferred during the development cycle to speed up deployment and testing.
 +
-Ensure that Ansible Runner and Ansible Runner HTTP Plug-in are installed or else
-you will see unexpected errors from Ansible Runner when a CR is created.
+Ensure that Ansible Runner and Ansible Runner HTTP Plug-in are installed or else you will see unexpected errors from Ansible Runner when a CR is created.
 +
-It is also important that the role path referenced in the `watches.yaml` file
-exists on your machine. Because normally a container is used where the role is
-put on disk, the role must be manually copied to the configured Ansible roles
-path (for example `/etc/ansible/roles`).
+It is also important that the role path referenced in the `watches.yaml` file exists on your machine. Because normally a container is used where the role is put on disk, the role must be manually copied to the configured Ansible roles path (for example `/etc/ansible/roles`).
 
-... To run the Operator locally with the default Kubernetes configuration file
-present at `$HOME/.kube/config`:
+... To run the Operator locally with the default Kubernetes configuration file present at `$HOME/.kube/config`:
 +
 [source,terminal]
 ----
@@ -282,8 +241,7 @@ $ operator-sdk run --local --kubeconfig=config
 
 . *Create a `Memcached` CR.*
 
-.. Modify the `deploy/crds/cache_v1alpha1_memcached_cr.yaml` file as shown and
-create a `Memcached` CR:
+.. Modify the `deploy/crds/cache_v1alpha1_memcached_cr.yaml` file as shown and create a `Memcached` CR:
 +
 [source,terminal]
 ----
@@ -306,7 +264,7 @@ spec:
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
-.. Ensure that the `memcached-operator` creates the Deployment for the CR:
+.. Ensure that the `memcached-operator` creates the deployment for the CR:
 +
 [source,terminal]
 ----
@@ -339,8 +297,7 @@ memcached-operator-7cc7cfdf86-vvjqk   1/1       Running   0          2m
 
 . *Update the size.*
 
-.. Change the `spec.size` field in the `memcached` CR from `3` to `4` and apply the
-change:
+.. Change the `spec.size` field in the `memcached` CR from `3` to `4` and apply the change:
 +
 [source,terminal]
 ----
@@ -363,7 +320,7 @@ spec:
 $ oc apply -f deploy/crds/cache_v1alpha1_memcached_cr.yaml
 ----
 
-.. Confirm that the Operator changes the Deployment size:
+.. Confirm that the Operator changes the deployment size:
 +
 [source,terminal]
 ----

--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -5,8 +5,7 @@
 [id="osdk-building-bundle-image_{context}"]
 = Building a bundle image
 
-You can build, push, and validate an Operator bundle image using the Operator
-SDK.
+You can build, push, and validate an Operator bundle image using the Operator SDK.
 
 .Prerequisites
 
@@ -25,14 +24,11 @@ $ operator-sdk bundle create \
     -b podman <2>
 ----
 <1> The image tag that you want the bundle image to have.
-<2> The CLI tool to use for building the container image, either `docker` (default),
-`podman`, or `buildah`. This example uses `podman`.
+<2> The CLI tool to use for building the container image, either `docker` (default), `podman`, or `buildah`. This example uses `podman`.
 +
 [NOTE]
 ====
-If your local manifests are not located in the default
-`<project_root>/deploy/olm-catalog/test-operator/manifests`, specify the
-location with the `--directory` flag.
+If your local manifests are not located in the default `<project_root>/deploy/olm-catalog/test-operator/manifests`, specify the location with the `--directory` flag.
 ====
 
 . Log in to the registry where you want to push the bundle image. For example:

--- a/modules/osdk-building-helm-operator.adoc
+++ b/modules/osdk-building-helm-operator.adoc
@@ -5,33 +5,24 @@
 [id="osdk-building-helm-operator_{context}"]
 = Building a Helm-based Operator using the Operator SDK
 
-This procedure walks through an example of building a simple Nginx Operator
-powered by a Helm chart using tools and libraries provided by the Operator SDK.
+This procedure walks through an example of building a simple Nginx Operator powered by a Helm chart using tools and libraries provided by the Operator SDK.
 
 [TIP]
 ====
-It is best practice to build a new Operator for each chart. This can allow for
-more native-behaving Kubernetes APIs (for example, `oc get Nginx`) and
-flexibility if you ever want to write a fully-fledged Operator in Go, migrating
-away from a Helm-based Operator.
+It is best practice to build a new Operator for each chart. This can allow for more native-behaving Kubernetes APIs (for example, `oc get Nginx`) and flexibility if you ever want to write a fully-fledged Operator in Go, migrating away from a Helm-based Operator.
 ====
 
 .Prerequisites
 
 - Operator SDK CLI installed on the development workstation
-- Access to a Kubernetes-based cluster v1.11.3+ (for example {product-title} {product-version})
-using an account with `cluster-admin` permissions
+- Access to a Kubernetes-based cluster v1.11.3+ (for example {product-title} {product-version}) using an account with `cluster-admin` permissions
 - OpenShift CLI (`oc`) v{product-version}+ installed
 
 .Procedure
 
-. *Create a new Operator project.* A namespace-scoped Operator watches and manages
-resources in a single namespace. Namespace-scoped Operators are preferred
-because of their flexibility. They enable decoupled upgrades, namespace
-isolation for failures and monitoring, and differing API definitions.
+. *Create a new Operator project.* A namespace-scoped Operator watches and manages resources in a single namespace. Namespace-scoped Operators are preferred because of their flexibility. They enable decoupled upgrades, namespace isolation for failures and monitoring, and differing API definitions.
 +
-To create a new Helm-based, namespace-scoped `nginx-operator` project, use the
-following command:
+To create a new Helm-based, namespace-scoped `nginx-operator` project, use the following command:
 +
 [source,terminal]
 ----
@@ -46,25 +37,20 @@ $ operator-sdk new nginx-operator \
 $ cd nginx-operator
 ----
 +
-This creates the `nginx-operator` project specifically for watching the Nginx
-resource with APIVersion `example.com/v1apha1` and Kind `Nginx`.
+This creates the `nginx-operator` project specifically for watching the Nginx resource with API version `example.com/v1apha1` and kind `Nginx`.
 
 . *Customize the Operator logic.*
 +
-For this example, the `nginx-operator` executes the following reconciliation
-logic for each `Nginx` Custom Resource (CR):
+For this example, the `nginx-operator` executes the following reconciliation logic for each `Nginx` custom resource (CR):
 +
 --
-* Create a Nginx Deployment if it does not exist.
-* Create a Nginx Service if it does not exist.
-* Create a Nginx Ingress if it is enabled and does not exist.
-* Ensure that the Deployment, Service, and optional Ingress match the desired
-configuration (for example, replica count, image, service type) as specified by
-the Nginx CR.
+* Create an Nginx deployment if it does not exist.
+* Create an Nginx service if it does not exist.
+* Create an Nginx ingress if it is enabled and does not exist.
+* Ensure that the deployment, service, and optional ingress match the desired configuration (for example, replica count, image, service type) as specified by the Nginx CR.
 --
 +
-By default, the `nginx-operator` watches `Nginx` resource events as shown in the
-`watches.yaml` file and executes Helm releases using the specified chart:
+By default, the `nginx-operator` watches `Nginx` resource events as shown in the `watches.yaml` file and executes Helm releases using the specified chart:
 +
 [source,yaml]
 ----
@@ -78,29 +64,19 @@ By default, the `nginx-operator` watches `Nginx` resource events as shown in the
 +
 When a Helm Operator project is created, the Operator SDK creates an example Helm chart that contains a set of templates for a simple Nginx release.
 +
-For this example, templates are available for Deployment, Service, and Ingress
-resources, along with a `NOTES.txt` template, which Helm chart developers use to
-convey helpful information about a release.
+For this example, templates are available for deployment, service, and ingress resources, along with a `NOTES.txt` template, which Helm chart developers use to convey helpful information about a release.
 +
-If you are not already familiar with Helm Charts, take a moment to review the
-link:https://docs.helm.sh/developing_charts/[Helm Chart developer documentation].
+If you are not already familiar with Helm Charts, review the link:https://docs.helm.sh/developing_charts/[Helm Chart developer documentation].
 
 .. *Understand the Nginx CR spec.*
 +
-Helm uses a concept called
-link:https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing[values]
-to provide customizations to a Helm chart's defaults, which are defined in the
-Helm chart's `values.yaml` file.
+Helm uses a concept called link:https://docs.helm.sh/using_helm/#customizing-the-chart-before-installing[values] to provide customizations to the defaults of a Helm chart, which are defined in the `values.yaml` file.
 +
-Override these defaults by setting the desired values in the CR spec. You can
-use the number of replicas as an example:
+Override these defaults by setting the desired values in the CR spec. You can use the number of replicas as an example:
 
-... First, inspect the `helm-charts/nginx/values.yaml` file to find that the chart
-has a value called `replicaCount` and it is set to `1` by default. To have 2
-Nginx instances in your deployment, your CR spec must contain `replicaCount: 2`.
+... First, inspect the `helm-charts/nginx/values.yaml` file to find that the chart has a value called `replicaCount` and it is set to `1` by default. To have 2 Nginx instances in your deployment, your CR spec must contain `replicaCount: 2`.
 +
-Update the `deploy/crds/example.com_v1alpha1_nginx_cr.yaml` file to look like the
-following:
+Update the `deploy/crds/example.com_v1alpha1_nginx_cr.yaml` file to look like the following:
 +
 [source,yaml]
 ----
@@ -112,9 +88,7 @@ spec:
   replicaCount: 2
 ----
 
-... Similarly, the default service port is set to `80`. To instead use `8080`,
-update the `deploy/crds/example.com_v1alpha1_nginx_cr.yaml` file again by adding the
-service port override:
+... Similarly, the default service port is set to `80`. To instead use `8080`, update the `deploy/crds/example.com_v1alpha1_nginx_cr.yaml` file again by adding the service port override:
 +
 [source,yaml]
 ----
@@ -128,13 +102,11 @@ spec:
     port: 8080
 ----
 +
-The Helm Operator applies the entire spec as if it was the contents of a values
-file, just like the `helm install -f ./overrides.yaml` command works.
+The Helm Operator applies the entire spec as if it was the contents of a values file, just like the `helm install -f ./overrides.yaml` command works.
 
 . *Deploy the CRD.*
 +
-Before running the Operator, Kubernetes needs to know about the new custom
-resource definition (CRD) the operator will be watching. Deploy the following CRD:
+Before running the Operator, Kubernetes must know about the new custom resource definition (CRD) that the Operator will be watching. Deploy the following CRD:
 +
 [source,terminal]
 ----
@@ -146,13 +118,13 @@ $ oc create -f deploy/crds/example_v1alpha1_nginx_crd.yaml
 There are two ways to build and run the Operator:
 +
 --
-* As a Pod inside a Kubernetes cluster.
+* As a pod inside a Kubernetes cluster.
 * As a Go program outside the cluster using the `operator-sdk up` command.
 --
 +
 Choose one of the following methods:
 
-.. *Run as a Pod* inside a Kubernetes cluster. This is the preferred
+.. *Run as a pod* inside a Kubernetes cluster. This is the preferred
 method for production use.
 
 ... Build the `nginx-operator` image and push it to a registry:
@@ -167,16 +139,14 @@ $ operator-sdk build quay.io/example/nginx-operator:v0.0.1
 $ podman push quay.io/example/nginx-operator:v0.0.1
 ----
 
-... Deployment manifests are generated in the `deploy/operator.yaml` file. The
-deployment image in this file needs to be modified from the placeholder
-`REPLACE_IMAGE` to the previous built image. To do this, run:
+... Deployment manifests are generated in the `deploy/operator.yaml` file. The deployment image in this file needs to be modified from the placeholder `REPLACE_IMAGE` to the previous built image. To do this, run:
 +
 [source,terminal]
 ----
 $ sed -i 's|REPLACE_IMAGE|quay.io/example/nginx-operator:v0.0.1|g' deploy/operator.yaml
 ----
 
-... Deploy the `nginx-operator`:
+... Deploy the `nginx-operator` manifests:
 +
 [source,terminal]
 ----
@@ -198,7 +168,7 @@ $ oc create -f deploy/role_binding.yaml
 $ oc create -f deploy/operator.yaml
 ----
 
-... Verify that the `nginx-operator` is up and running:
+... Verify that the `nginx-operator` deployment is up and running:
 +
 [source,terminal]
 ----
@@ -212,16 +182,11 @@ NAME                 DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
 nginx-operator       1         1         1            1           1m
 ----
 
-.. *Run outside the cluster.* This method is preferred during the development
-cycle to speed up deployment and testing.
+.. *Run outside the cluster.* This method is preferred during the development cycle to speed up deployment and testing.
 +
-It is important that the chart path referenced in the `watches.yaml` file exists
-on your machine. By default, the `watches.yaml` file is scaffolded to work with
-an Operator image built with the `operator-sdk build` command. When developing
-and testing your operator with the `operator-sdk run --local` command, the SDK
-looks in your local file system for this path.
+It is important that the chart path referenced in the `watches.yaml` file exists on your machine. By default, the `watches.yaml` file is scaffolded to work with an Operator image built with the `operator-sdk build` command. When developing and testing your Operator with the `operator-sdk run --local` command, the SDK looks in your local file system for this path.
 
-... Create a symlink at this location to point to your Helm chart's path:
+... Create a symlink at this location to point to the path of your Helm chart:
 +
 [source,terminal]
 ----
@@ -233,8 +198,7 @@ $ sudo mkdir -p /opt/helm/helm-charts
 $ sudo ln -s $PWD/helm-charts/nginx /opt/helm/helm-charts/nginx
 ----
 
-... To run the Operator locally with the default Kubernetes configuration file
-present at `$HOME/.kube/config`:
+... To run the Operator locally with the default Kubernetes configuration file present at `$HOME/.kube/config`:
 +
 [source,terminal]
 ----
@@ -257,7 +221,7 @@ Apply the `Nginx` CR that you modified earlier:
 $ oc apply -f deploy/crds/example.com_v1alpha1_nginx_cr.yaml
 ----
 +
-Ensure that the `nginx-operator` creates the Deployment for the CR:
+Ensure that the `nginx-operator` creates the deployment for the CR:
 +
 [source,terminal]
 ----
@@ -286,7 +250,7 @@ example-nginx-b9phnoz9spckcrua7ihrbkrt1-f8f9c875d-fjcr9   1/1       Running   0 
 example-nginx-b9phnoz9spckcrua7ihrbkrt1-f8f9c875d-ljbzl   1/1       Running   0          1m
 ----
 +
-Check that the Service port is set to `8080`:
+Check that the service port is set to `8080`:
 +
 [source,terminal]
 ----
@@ -302,8 +266,7 @@ example-nginx-b9phnoz9spckcrua7ihrbkrt1   ClusterIP   10.96.26.3   <none>       
 
 . *Update the `replicaCount` and remove the port.*
 +
-Change the `spec.replicaCount` field from `2` to `3`, remove the `spec.service`
-field, and apply the change:
+Change the `spec.replicaCount` field from `2` to `3`, remove the `spec.service` field, and apply the change:
 +
 [source,terminal]
 ----
@@ -326,7 +289,7 @@ spec:
 $ oc apply -f deploy/crds/example.com_v1alpha1_nginx_cr.yaml
 ----
 +
-Confirm that the Operator changes the Deployment size:
+Confirm that the Operator changes the deployment size:
 +
 [source,terminal]
 ----
@@ -340,7 +303,7 @@ NAME                                           DESIRED   CURRENT   UP-TO-DATE   
 example-nginx-b9phnoz9spckcrua7ihrbkrt1        3         3         3            3           1m
 ----
 +
-Check that the Service port is set to the default `80`:
+Check that the service port is set to the default `80`:
 +
 [source,terminal]
 ----

--- a/modules/osdk-cli-reference-add.adoc
+++ b/modules/osdk-cli-reference-add.adoc
@@ -1,8 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-add_{context}"]
 = add
 
-The `operator-sdk add` command adds a controller or resource to the project. The
-command must be run from the Operator project root directory.
+The `operator-sdk add` command adds a controller or resource to the project. The command must be run from the Operator project root directory.
 
 .`add` subcommands
 [options="header",cols="1,3"]
@@ -10,27 +13,16 @@ command must be run from the Operator project root directory.
 |Subcommand |Description
 
 |`api`
-|Adds a new API definition for a new Custom Resource (CR) under `pkg/apis` and
-generates the Customer Resource Definition (CRD) and Custom Resource (CR) files
-under `deploy/crds/`. If the API already exists at `pkg/apis/<group>/<version>`,
-then the command does not overwrite and returns an error.
+|Adds a new API definition for a new custom resource (CR) under `pkg/apis` and generates the custom resource definition (CRD) and CR files under `deploy/crds/`. If the API already exists at `pkg/apis/<group>/<version>`, then the command does not overwrite and returns an error.
 
 |`controller`
-|Adds a new controller under `pkg/controller/<kind>/`. The controller expects to
-use the CR type that should already be defined under
-`pkg/apis/<group>/<version>` via the `operator-sdk add api --kind=<kind>
---api-version=<group/version>` command. If the controller package for that
-`Kind` already exists at `pkg/controller/<kind>`, then the command does not
-overwrite and returns an error.
-
+|Adds a new controller under `pkg/controller/<kind>/`. The controller expects to use the CR type that should already be defined under `pkg/apis/<group>/<version>` via the `operator-sdk add api --kind=<kind> --api-version=<group/version>` command. If the controller package for that kind already exists at `pkg/controller/<kind>`, then the command does not overwrite and returns an error.
 
 |`crd`
-a|Adds a CRD and the CR files. The `<project-name>/deploy` path must already
-exist. The `--api-version` and `--kind` flags are required to generate the new
-Operator application.
+a|Adds a CRD and the CR files. The `<project_name>/deploy` path must already exist. The `--api-version` and `--kind` flags are required to generate the new Operator application.
 
-* Generated CRD filename: `<project-name>/deploy/crds/<group>_<version>_<kind>_crd.yaml`
-* Generated CR  filename: `<project-name>/deploy/crds/<group>_<version>_<kind>_cr.yaml`
+* Generated CRD filename: `<project_name>/deploy/crds/<group>_<version>_<kind>_crd.yaml`
+* Generated CR filename: `<project_name>/deploy/crds/<group>_<version>_<kind>_cr.yaml`
 |===
 
 .`add api` flags
@@ -39,8 +31,7 @@ Operator application.
 |Flag |Description
 
 |`--api-version` (string)
-|CRD `APIVersion` in the format `$GROUP_NAME/$VERSION` (e.g.,
-`app.example.com/v1alpha1`).
+|CRD API version in the format `<group_name>/<version>`, for example `app.example.com/v1alpha1`.
 
 |`--kind` (string)
 |CRD `Kind` (e.g., `AppService`).
@@ -50,7 +41,9 @@ For example:
 
 [source,terminal]
 ----
-$ operator-sdk add api --api-version app.example.com/v1alpha1 --kind AppService
+$ operator-sdk add api \
+    --api-version app.example.com/v1alpha1 \
+    --kind AppService
 ----
 
 .Example output
@@ -86,7 +79,9 @@ pkg/apis/
 
 [source,terminal]
 ----
-$ operator-sdk add controller --api-version app.example.com/v1alpha1 --kind AppService
+$ operator-sdk add controller \
+    --api-version app.example.com/v1alpha1 \
+    --kind AppService
 ----
 
 .Example output
@@ -113,7 +108,9 @@ pkg/controller/
 
 [source,terminal]
 ----
-$ operator-sdk add crd --api-version app.example.com/v1alpha1 --kind AppService
+$ operator-sdk add crd \
+    --api-version app.example.com/v1alpha1 \
+    --kind AppService
 ----
 
 .Example output

--- a/modules/osdk-cli-reference-build.adoc
+++ b/modules/osdk-cli-reference-build.adoc
@@ -1,9 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-build_{context}"]
 = build
 
-The `operator-sdk build` command compiles the code and builds the executables.
-After `build` completes, the image is built locally in `docker`. It must then be
-pushed to a remote registry.
+The `operator-sdk build` command compiles the code and builds the executables. After `build` completes, the image is built using a local container engine. It must then be pushed to a remote registry.
 
 .`build` arguments
 [options="header",cols="1,3"]
@@ -11,7 +13,7 @@ pushed to a remote registry.
 |Argument |Description
 
 |`<image>`
-|The container image to be built, e.g., `quay.io/example/operator:v0.0.1`.
+|The container image to be built, for example `quay.io/example/operator:v0.0.1`.
 |===
 
 .`build` flags
@@ -26,15 +28,13 @@ pushed to a remote registry.
 |Path of namespaced resources manifest for tests. Default: `deploy/operator.yaml`.
 
 |`--test-location` (string)
-|Location of tests. Default: `./test/e2e`
+|Location of tests. Default: `./test/e2e`.
 
 |`-h, --help`
 |Usage help output.
 |===
 
-If `--enable-tests` is set, the `build` command also builds the testing binary,
-adds it to the container image, and generates a `deploy/test-pod.yaml` file that
-allows a user to run the tests as a Pod on a cluster.
+If `--enable-tests` is set, the `build` command also builds the testing binary, adds it to the container image, and generates a `deploy/test-pod.yaml` file that allows a user to run the tests as a pod on a cluster.
 
 For example:
 

--- a/modules/osdk-cli-reference-completion.adoc
+++ b/modules/osdk-cli-reference-completion.adoc
@@ -1,8 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-completion_{context}"]
 = completion
 
-The `operator-sdk completion` command generates shell completions to make
-issuing CLI commands quicker and easier.
+The `operator-sdk completion` command generates shell completions to make issuing CLI commands quicker and easier.
 
 .`completion` subcommands
 [options="header",cols="1,3"]

--- a/modules/osdk-cli-reference-generate.adoc
+++ b/modules/osdk-cli-reference-generate.adoc
@@ -5,15 +5,12 @@
 [id="osdk-cli-reference-generate_{context}"]
 = generate
 
-The `operator-sdk generate` command invokes a specific generator to generate
-code as needed.
+The `operator-sdk generate` command invokes a specific generator to generate code as needed.
 
 [id="osdk-cli-reference-generate-crds_{context}"]
 == crds
 
-The `generate crds` subcommand generates CRDs or updates them if they exist, under
-`deploy/crds/__crd.yaml`. OpenAPI V3 validation YAML is generated as a
-`validation` object.
+The `generate crds` subcommand generates custom resource definitions (CRDs) or updates them if they exist, under `deploy/crds/__crd.yaml`. OpenAPI V3 validation YAML is generated as a `validation` object.
 
 .`generate crds` flags
 [options="header",cols="1,3"]
@@ -21,7 +18,7 @@ The `generate crds` subcommand generates CRDs or updates them if they exist, und
 |Flag |Description
 
 |`--crd-version` (string)
-|CRD version to generate (default `v1beta1`)
+|CRD version to generate. Default: `v1beta1`
 
 |`-h`, `--help`
 |Help for `generate crds`
@@ -49,10 +46,7 @@ $ tree deploy/crds
 [id="osdk-cli-reference-generate-csv_{context}"]
 == csv
 
-The `csv` subcommand writes a ClusterServiceVersion (CSV) manifest for use with
-Operator Lifecycle Manager (OLM). It also optionally writes
-CustomResourceDefinition (CRD) files to
-`deploy/olm-catalog/<operator_name>/<csv_version>`.
+The `csv` subcommand writes a cluster service version (CSV) manifest for use with Operator Lifecycle Manager (OLM). It also optionally writes CRD files to `deploy/olm-catalog/<operator_name>/<csv_version>`.
 
 .`generate csv` flags
 [options="header",cols="1,3"]
@@ -70,8 +64,7 @@ CustomResourceDefinition (CRD) files to
 |The semantic version of the CSV manifest. Required.
 
 |`--default-channel`
-|Use the channel passed to `--csv-channel` as the package manifests' default
-channel. Only valid when `--csv-channel` is set.
+|Use the channel passed to `--csv-channel` as the default channel of the package manifests. Only valid when `--csv-channel` is set.
 
 |`--from-version` (string)
 |The semantic version of CSV manifest to use as a base for a new version.
@@ -80,8 +73,7 @@ channel. Only valid when `--csv-channel` is set.
 |The Operator name to use while generating the CSV.
 
 |`--update-crds`
-|Updates CRD manifests in `deploy/<operator_name>/<csv_version>` using the
-latest CRD manifests.
+|Updates CRD manifests in `deploy/<operator_name>/<csv_version>` using the latest CRD manifests.
 
 |===
 
@@ -89,7 +81,9 @@ For example:
 
 [source,terminal]
 ----
-$ operator-sdk generate csv --csv-version 0.1.0 --update-crds
+$ operator-sdk generate csv \
+    --csv-version 0.1.0 \
+		--update-crds
 ----
 
 .Example output
@@ -107,15 +101,11 @@ INFO[0000] Created deploy/olm-catalog/operator-name/0.1.0/operator-name.v0.1.0.c
 [id="osdk-cli-reference-generate-k8s_{context}"]
 == k8s
 
-The `k8s` subcommand runs the Kubernetes
-link:https://github.com/kubernetes/code-generator[code-generators] for all CRD
-APIs under `pkg/apis/`. Currently, `k8s` only runs `deepcopy-gen` to generate
-the required `DeepCopy()` functions for all Custom Resource (CR) types.
+The `k8s` subcommand runs the Kubernetes link:https://github.com/kubernetes/code-generator[code-generators] for all CRD APIs under `pkg/apis/`. Currently, `k8s` only runs `deepcopy-gen` to generate the required `DeepCopy()` functions for all custom resource (CR) types.
 
 [NOTE]
 ====
-This command must be run every time the API (`spec` and `status`) for a custom
-resource type is updated.
+This command must be run every time the API (`spec` and `status`) for a custom resource type is updated.
 ====
 
 For example:

--- a/modules/osdk-cli-reference-new.adoc
+++ b/modules/osdk-cli-reference-new.adoc
@@ -1,9 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-new_{context}"]
 = new
 
-The `operator-sdk new` command creates a new Operator application and generates
-(or _scaffolds_) a default project directory layout based on the input
-`<project_name>`.
+The `operator-sdk new` command creates a new Operator application and generates (or _scaffolds_) a default project directory layout based on the input `<project_name>`.
 
 .`new` arguments
 [options="header",cols="1,3"]
@@ -20,7 +22,7 @@ The `operator-sdk new` command creates a new Operator application and generates
 |Flag |Description
 
 |`--api-version`
-|CRD `APIVersion` in the format `$GROUP_NAME/$VERSION`, for example `app.example.com/v1alpha1`. Used with `ansible` or `helm` types.
+|CRD API version in the format `<group_name>/<version>`, for example `app.example.com/v1alpha1`. Used with `ansible` or `helm` types.
 
 |`--generate-playbook`
 |Generate an Ansible playbook skeleton. Used with `ansible` type.
@@ -29,33 +31,31 @@ The `operator-sdk new` command creates a new Operator application and generates
 |Path to file containing headers for generated Go files. Copied to `hack/boilerplate.go.txt`.
 
 |`--helm-chart <string>`
-|Initialize Helm operator with existing Helm chart: `<url>`, `<repo>/<name>`, or local path.
+|Initialize Helm Operator with existing Helm chart: `<url>`, `<repo>/<name>`, or local path.
 
 |`--helm-chart-repo <string>`
 |Chart repository URL for the requested Helm chart.
 
 |`--helm-chart-version <string>`
-|Specific version of the Helm chart. (Default: latest version)
+|Specific version of the Helm chart. Default: latest version.
 
 |`--help, -h`
 |Usage and help output.
 
 |`--kind <string>`
-|CRD `Kind`, for example `AppService`. Used with `ansible` or `helm` types.
+|CRD kind, for example `AppService`. Used with `ansible` or `helm` types.
 
 | `--skip-git-init`
 |Do not initialize the directory as a Git repository.
 
 |`--type`
-|Type of Operator to initialize: `go`, `ansible` or `helm`. (Default: `go`)
+|Type of Operator to initialize: `go`, `ansible` or `helm`. Default: `go`.
 
 |===
 
 [NOTE]
 ====
-Starting with Operator SDK v0.12.0, the `--dep-manager` flag and support for
-`dep`-based projects have been removed. Go projects are now scaffolded to use Go
-modules.
+Starting with Operator SDK v0.12.0, the `--dep-manager` flag and support for `dep`-based projects have been removed. Go projects are now scaffolded to use Go modules.
 ====
 
 .Example usage for Go project

--- a/modules/osdk-cli-reference-print-deps.adoc
+++ b/modules/osdk-cli-reference-print-deps.adoc
@@ -1,8 +1,11 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-print-deps_{context}"]
 = print-deps
 
-The `operator-sdk print-deps` command prints the most recent Golang packages and
-versions required by Operators. It prints in columnar format by default.
+The `operator-sdk print-deps` command prints the most recent Golang packages and versions required by Operators. It prints in columnar format by default.
 
 .`print-deps` flags
 [options="header",cols="1,3"]

--- a/modules/osdk-cli-reference-run.adoc
+++ b/modules/osdk-cli-reference-run.adoc
@@ -5,8 +5,7 @@
 [id="osdk-cli-reference-run_{context}"]
 = run
 
-The `operator-sdk run` command provides options that can launch the Operator in
-various environments.
+The `operator-sdk run` command provides options that can launch the Operator in various environments.
 
 .`run` arguments
 [options="header",cols="1,3"]
@@ -14,18 +13,16 @@ various environments.
 |Arguments |Description
 
 |`--kubeconfig` (string)
-|The file path to a Kubernetes configuration file. Defaults: `$HOME/.kube/config`
+|The file path to a Kubernetes configuration file. Default: `$HOME/.kube/config`
 
 |`--local`
-|The Operator is run locally by building the Operator binary
-with the ability to access a Kubernetes cluster using a `kubeconfig` file.
+|The Operator is run locally by building the Operator binary with the ability to access a Kubernetes cluster using a `kubeconfig` file.
 
 |`--namespace` (string)
 |The namespace where the Operator watches for changes. Default: `default`
 
 |`--operator-flags`
-|Flags that the local Operator may need. Example: `--flag1 value1 --flag2=value2`.
-For use with the `--local` flag only.
+|Flags that the local Operator might require. Example: `--flag1 value1 --flag2=value2`. For use with the `--local` flag only.
 
 |`-h, --help`
 |Usage help output.
@@ -34,9 +31,7 @@ For use with the `--local` flag only.
 [id="osdk-cli-reference-run-local_{context}"]
 == --local
 
-The `--local` flag launches the Operator on the local machine by building
-the Operator binary with the ability to access a Kubernetes cluster using a
-`kubeconfig` file.
+The `--local` flag launches the Operator on the local machine by building the Operator binary with the ability to access a Kubernetes cluster using a `kubeconfig` file.
 
 For example:
 
@@ -48,26 +43,18 @@ $ operator-sdk run --local \
   --operator-flags "--flag1 value1 --flag2=value2"
 ----
 
-The following example uses the default `kubeconfig`, the default namespace
-environment variable, and passes in flags for the Operator. To use the Operator
-flags, your Operator must know how to handle the option. For example, for an
-Operator that understands the `resync-interval` flag:
+The following example uses the default `kubeconfig`, the default namespace environment variable, and passes in flags for the Operator. To use the Operator flags, your Operator must know how to handle the option. For example, for an Operator that understands the `resync-interval` flag:
 
 [source,terminal]
 ----
 $ operator-sdk run --local --operator-flags "--resync-interval 10"
 ----
 
-If you are planning on using a different namespace than the default, use the
-`--namespace` flag to change where the Operator is watching for Custom Resources
-(CRs) to be created:
+If you are planning on using a different namespace than the default, use the `--namespace` flag to change where the Operator is watching for custom resources (CRs) to be created:
 
 [source,terminal]
 ----
 $ operator-sdk run --local --namespace "testing"
 ----
 
-For this to work, your Operator must handle the `WATCH_NAMESPACE`
-environment variable. This can be accomplished using the
-link:https://github.com/operator-framework/operator-sdk/blob/89bf021063d18b6769bdc551ed08fc37027939d5/pkg/util/k8sutil/k8sutil.go#L140[utility function]
-`k8sutil.GetWatchNamespace` in your Operator.
+For this to work, your Operator must handle the `WATCH_NAMESPACE` environment variable. This can be accomplished using the link:https://github.com/operator-framework/operator-sdk/blob/89bf021063d18b6769bdc551ed08fc37027939d5/pkg/util/k8sutil/k8sutil.go#L140[utility function] `k8sutil.GetWatchNamespace` in your Operator.

--- a/modules/osdk-cli-reference-test.adoc
+++ b/modules/osdk-cli-reference-test.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-cli-reference.adoc
+
 [id="osdk-cli-reference-test_{context}"]
 = test
 
@@ -5,8 +9,7 @@ The `operator-sdk test` command can test the Operator locally.
 
 == local
 
-The `local` subcommand runs Go tests built using the test framework of the
-Operator SDK locally.
+The `local` subcommand runs Go tests built using the test framework of the Operator SDK locally.
 
 .`test local` arguments
 [options="header",cols="1,3"]
@@ -14,7 +17,7 @@ Operator SDK locally.
 |Arguments |Description
 
 |`<test_location>` (string)
-|Location of e2e test files (e.g., `./test/e2e/`).
+|Location of end-to-end (e2e) test files, for example `./test/e2e/`.
 |===
 
 .`test local` flags
@@ -29,26 +32,22 @@ Operator SDK locally.
 |Path to manifest for global resources. Default: `deploy/crd.yaml`.
 
 |`--namespaced-manifest` (string)
-|Path to manifest for per-test, namespaced resources. Default: combines
-`deploy/service_account.yaml`, `deploy/rbac.yaml`, and `deploy/operator.yaml`.
+|Path to manifest for per-test, namespaced resources. Default: combines `deploy/service_account.yaml`, `deploy/rbac.yaml`, and `deploy/operator.yaml`.
 
 |`--namespace` (string)
-|If non-empty, a single namespace to run tests in (e.g., `operator-test`).
-Default: `""`
+|If non-empty, a single namespace to run tests in, for example `operator-test`. Default: `""`.
 
 |`--go-test-flags` (string)
-|Extra arguments to pass to `go test` (e.g., `-f "-v -parallel=2"`).
+|Extra arguments to pass to `go test`, for example `-f "-v -parallel=2"`.
 
 |`--up-local`
-|Enable running the Operator locally with `go run` instead of as an image in the
-cluster.
+|Enable running the Operator locally with `go run` instead of as an image in the cluster.
 
 |`--no-setup`
 |Disable test resource creation.
 
 |`--image` (string)
-|Use a different Operator image from the one specified in the namespaced
-manifest.
+|Use a different Operator image from the one specified in the namespaced manifest.
 
 |`-h, --help`
 |Usage help output.

--- a/modules/osdk-crd-templates.adoc
+++ b/modules/osdk-crd-templates.adoc
@@ -5,17 +5,11 @@
 [id="osdk-crds-templates_{context}"]
 = CRD templates
 
-Users of your Operator will need to be aware of which options are required
-versus optional. You can provide templates for each of your Custom Resource
-Definitions (CRDs) with a minimum set of configuration as an annotation named
-`alm-examples`. Compatible UIs will pre-fill this template for users to further
-customize.
+Users of your Operator must be made aware of which options are required versus optional. You can provide templates for each of your custom resource definitions (CRDs) with a minimum set of configuration as an annotation named `alm-examples`. Compatible UIs will pre-fill this template for users to further customize.
 
-The annotation consists of a list of the `kind`, for example, the CRD name and
-the corresponding `metadata` and `spec` of the Kubernetes object.
+The annotation consists of a list of the kind, for example, the CRD name and the corresponding `metadata` and `spec` of the Kubernetes object.
 
-The following full example provides templates for `EtcdCluster`, `EtcdBackup`
-and `EtcdRestore`:
+The following full example provides templates for `EtcdCluster`, `EtcdBackup` and `EtcdRestore`:
 
 [source,yaml]
 ----

--- a/modules/osdk-crds.adoc
+++ b/modules/osdk-crds.adoc
@@ -3,8 +3,6 @@
 // * operators/operator_sdk/osdk-generating-csvs.adoc
 
 [id="osdk-crds_{context}"]
-= Understanding your Custom Resource Definitions (CRDs)
+= Understanding your custom resource definitions (CRDs)
 
-There are two types of Custom Resource Definitions (CRDs) that your Operator may
-use: ones that are _owned_ by it and ones that it depends on, which are
-_required_.
+There are two types of custom resource definitions (CRDs) that your Operator can use: ones that are _owned_ by it and ones that it depends on, which are _required_.

--- a/modules/osdk-csv-composition-configuration.adoc
+++ b/modules/osdk-csv-composition-configuration.adoc
@@ -5,19 +5,18 @@
 [id="osdk-configuring-csv-composition_{context}"]
 = CSV composition configuration
 
-Operator authors can configure CSV composition by populating several fields in
-the `deploy/olm-catalog/csv-config.yaml` file:
+Operator authors can configure CSV composition by populating several fields in the `deploy/olm-catalog/csv-config.yaml` file:
 
 [cols="2a,8a",options="header"]
 |===
 |Field |Description
 
 |`operator-path` (string)
-|The Operator resource manifest file path. Defaults to `deploy/operator.yaml`.
+|The Operator resource manifest file path. Default: `deploy/operator.yaml`.
 
 |`crd-cr-path-list` (string(, string)*)
-|A list of CRD and CR manifest file paths. Defaults to `[deploy/crds/*_{crd,cr}.yaml]`.
+|A list of CRD and CR manifest file paths. Default: `[deploy/crds/*_{crd,cr}.yaml]`.
 
 |`rbac-path-list` (string(, string)*)
-|A list of RBAC role manifest file paths. Defaults to `[deploy/role.yaml]`.
+|A list of RBAC role manifest file paths. Default: `[deploy/role.yaml]`.
 |===

--- a/modules/osdk-generating-a-csv.adoc
+++ b/modules/osdk-generating-a-csv.adoc
@@ -20,5 +20,4 @@
 $ operator-sdk generate csv --csv-version <version>
 ----
 
-. In the new CSV generated in the `deploy/olm-catalog/` directory, ensure all
-required, manually-defined fields are set appropriately.
+. In the new CSV generated in the `deploy/olm-catalog/` directory, ensure all required, manually-defined fields are set appropriately.

--- a/modules/osdk-helm-chart-support.adoc
+++ b/modules/osdk-helm-chart-support.adoc
@@ -5,29 +5,11 @@
 [id="osdk-helm-chart-support_{context}"]
 = Helm chart support in the Operator SDK
 
-The link:https://coreos.com/operators/[Operator Framework] is an open source
-toolkit to manage Kubernetes native applications, called _Operators_, in an
-effective, automated, and scalable way. This framework includes the Operator
-SDK, which assists developers in bootstrapping and building an Operator based on
-their expertise without requiring knowledge of Kubernetes API complexities.
+The link:https://coreos.com/operators/[Operator Framework] is an open source toolkit to manage Kubernetes native applications, called _Operators_, in an effective, automated, and scalable way. This framework includes the Operator SDK, which assists developers in bootstrapping and building an Operator based on their expertise without requiring knowledge of Kubernetes API complexities.
 
-One of the Operator SDK's options for generating an Operator project includes
-leveraging an existing Helm chart to deploy Kubernetes resources as a unified
-application, without having to write any Go code. Such Helm-based Operators are
-designed to excel at stateless applications that require very little logic when
-rolled out, because changes should be applied to the Kubernetes objects that are
-generated as part of the chart. This may sound limiting, but can be sufficient
-for a surprising amount of use-cases as shown by the proliferation of Helm
-charts built by the Kubernetes community.
+One of the Operator SDK options for generating an Operator project includes leveraging an existing Helm chart to deploy Kubernetes resources as a unified application, without having to write any Go code. Such Helm-based Operators are designed to excel at stateless applications that require very little logic when rolled out, because changes should be applied to the Kubernetes objects that are generated as part of the chart. This may sound limiting, but can be sufficient for a surprising amount of use-cases as shown by the proliferation of Helm charts built by the Kubernetes community.
 
-The main function of an Operator is to read from a custom object that represents
-your application instance and have its desired state match what is running. In
-the case of a Helm-based Operator, the object's spec field is a list of
-configuration options that are typically described in Helm's `values.yaml` file.
-Instead of setting these values with flags using the Helm CLI (for example, `helm install -f values.yaml`),
-you can express them within a Custom Resource (CR), which, as a native
-Kubernetes object, enables the benefits of RBAC applied to it and an audit
-trail.
+The main function of an Operator is to read from a custom object that represents your application instance and have its desired state match what is running. In the case of a Helm-based Operator, the `spec` field of the object is a list of configuration options that are typically described in the Helm `values.yaml` file. Instead of setting these values with flags using the Helm CLI (for example, `helm install -f values.yaml`), you can express them within a custom resource (CR), which, as a native Kubernetes object, enables the benefits of RBAC applied to it and an audit trail.
 
 For an example of a simple CR called `Tomcat`:
 
@@ -41,24 +23,18 @@ spec:
   replicaCount: 2
 ----
 
-The `replicaCount` value, `2` in this case, is propagated into the chart's
-templates where following is used:
+The `replicaCount` value, `2` in this case, is propagated into the template of the chart where the following is used:
 
 [source,yaml]
 ----
 {{ .Values.replicaCount }}
 ----
 
-After an Operator is built and deployed, you can deploy a new instance of an app
-by creating a new instance of a CR, or list the different instances running in
-all environments using the `oc` command:
+After an Operator is built and deployed, you can deploy a new instance of an app by creating a new instance of a CR, or list the different instances running in all environments using the `oc` command:
 
 [source,terminal]
 ----
 $ oc get Tomcats --all-namespaces
 ----
 
-There is no requirement use the Helm CLI or install Tiller; Helm-based Operators
-import code from the Helm project. All you have to do is have an instance of the
-Operator running and register the CR with a Custom Resource Definition (CRD).
-And because it obeys RBAC, you can more easily prevent production changes.
+There is no requirement use the Helm CLI or install Tiller; Helm-based Operators import code from the Helm project. All you have to do is have an instance of the Operator running and register the CR with a custom resource definition (CRD). Because it obeys RBAC, you can more easily prevent production changes.

--- a/modules/osdk-hiding-internal-objects.adoc
+++ b/modules/osdk-hiding-internal-objects.adoc
@@ -5,16 +5,16 @@
 [id="osdk-hiding-internal-objects_{context}"]
 = Hiding internal objects
 
-It is common practice for Operators to use Custom Resource Definitions (CRDs)
-internally to accomplish a task. These objects are not meant for users to
-manipulate and can be confusing to users of the Operator. For example, a
-database Operator might have a Replication CRD that is created whenever a user
-creates a Database object with `replication: true`.
+It is common practice for Operators to use custom resource definitions (CRDs) internally to accomplish a task. These objects are not meant for users to manipulate and can be confusing to users of the Operator. For example, a database Operator might have a `Replication` CRD that is created whenever a user creates a Database object with `replication: true`.
 
-If any CRDs are not meant for manipulation by users, they can be hidden in the
-user interface using the `operators.operatorframework.io/internal-objects`
-annotation in the Operator's ClusterServiceVersion (CSV):
+As an Operator author, you can hide any CRDs in the user interface that are not meant for user manipulation by adding the `operators.operatorframework.io/internal-objects` annotation to the cluster service version (CSV) of your Operator.
 
+.Procedure
+
+. Before marking one of your CRDs as internal, ensure that any debugging information or configuration that might be required to manage the application is reflected on the status or `spec` block of your CR, if applicable to your Operator.
+
+. Add the `operators.operatorframework.io/internal-objects` annotation to the CSV of your Operator to specify any internal objects to hide in the user interface:
++
 .Internal object annotation
 [source,yaml]
 ----
@@ -27,7 +27,3 @@ metadata:
 ...
 ----
 <1> Set any internal CRDs as an array of strings.
-
-Before marking one of your CRDs as internal, make sure that any debugging
-information or configuration that might be required to manage the application is
-reflected on the CR's status or `spec` block, if applicable to your Operator.

--- a/modules/osdk-how-csv-gen-works.adoc
+++ b/modules/osdk-how-csv-gen-works.adoc
@@ -5,9 +5,9 @@
 [id="osdk-how-csv-gen-works_{context}"]
 = How CSV generation works
 
-An Operator project's `deploy/` directory is the standard location for all
-manifests required to deploy an Operator. The Operator SDK can use data from
-manifests in `deploy/` to write a CSV. The following command:
+The `deploy/` directory of an Operator project is the standard location for all manifests required to deploy an Operator. The Operator SDK can use data from manifests in `deploy/` to write a cluster service version (CSV).
+
+The following command:
 
 [source,terminal]
 ----
@@ -22,50 +22,33 @@ Exactly three types of manifests are required to generate a CSV:
 - `*_{crd,cr}.yaml`
 - RBAC role files, for example `role.yaml`
 
-Operator authors may have different versioning requirements for these files and
-can configure which specific files are included in the
-`deploy/olm-catalog/csv-config.yaml` file.
+Operator authors may have different versioning requirements for these files and can configure which specific files are included in the `deploy/olm-catalog/csv-config.yaml` file.
 
 [discrete]
 [id="osdk-how-csv-gen-works-workflow_{context}"]
 == Workflow
 
-Depending on whether an existing CSV is detected, and assuming all configuration
-defaults are used, the `generate csv` subcommand either:
+Depending on whether an existing CSV is detected, and assuming all configuration defaults are used, the `generate csv` subcommand either:
 
-- Creates a new CSV, with the same location and naming convention as exists
-currently, using available data in YAML manifests and source files.
+- Creates a new CSV, with the same location and naming convention as exists currently, using available data in YAML manifests and source files.
 
-.. The update mechanism checks for an existing CSV in `deploy/`. When one is not
-found, it creates a ClusterServiceVersion object, referred to here as a _cache_,
-and populates fields easily derived from Operator metadata, such as Kubernetes
-API `ObjectMeta`.
+.. The update mechanism checks for an existing CSV in `deploy/`. When one is not found, it creates a `ClusterServiceVersion` object, referred to here as a _cache_, and populates fields easily derived from Operator metadata, such as Kubernetes API `ObjectMeta`.
 
-.. The update mechanism searches `deploy/` for manifests that contain data a CSV
-uses, such as a Deployment resource, and sets the appropriate CSV fields in the
-cache with this data.
+.. The update mechanism searches `deploy/` for manifests that contain data a CSV uses, such as a `Deployment` resource, and sets the appropriate CSV fields in the cache with this data.
 
-.. After the search completes, every cache field populated is written back to a
-CSV YAML file.
+.. After the search completes, every cache field populated is written back to a CSV YAML file.
 
 or:
 
-- Updates an existing CSV at the currently pre-defined location, using available
-data in YAML manifests and source files.
+- Updates an existing CSV at the currently pre-defined location, using available data in YAML manifests and source files.
 
-.. The update mechanism checks for an existing CSV in `deploy/`. When one is
-found, the CSV YAML file contents are marshaled into a ClusterServiceVersion
-cache.
+.. The update mechanism checks for an existing CSV in `deploy/`. When one is found, the CSV YAML file contents are marshaled into a CSV cache.
 
-.. The update mechanism searches `deploy/` for manifests that contain data a CSV
-uses, such as a Deployment resource, and sets the appropriate CSV fields in the
-cache with this data.
+.. The update mechanism searches `deploy/` for manifests that contain data a CSV uses, such as a `Deployment` resource, and sets the appropriate CSV fields in the cache with this data.
 
-.. After the search completes, every cache field populated is written back to a
-CSV YAML file.
+.. After the search completes, every cache field populated is written back to a CSV YAML file.
 
 [NOTE]
 ====
-Individual YAML fields are overwritten and not the entire file, as descriptions
-and other non-generated parts of a CSV should be preserved.
+Individual YAML fields are overwritten and not the entire file, as descriptions and other non-generated parts of a CSV should be preserved.
 ====

--- a/modules/osdk-installing-cli.adoc
+++ b/modules/osdk-installing-cli.adoc
@@ -7,23 +7,17 @@
 [id="osdk-installing-cli_{context}"]
 = Installing the Operator SDK CLI
 
-The Operator SDK has a CLI tool that assists developers in creating, building,
-and deploying a new Operator project. You can install the SDK CLI on your
-workstation so you are prepared to start authoring your own Operators.
+The Operator SDK has a CLI tool that assists developers in creating, building, and deploying a new Operator project. You can install the SDK CLI on your workstation so you are prepared to start authoring your own Operators.
 
 [NOTE]
 ====
-This guide uses
-link:https://github.com/kubernetes/minikube#installation[minikube] v0.25.0+ as
-the local Kubernetes cluster and link:https://quay.io/[Quay.io] for the public
-registry.
+This guide uses link:https://github.com/kubernetes/minikube#installation[minikube] v0.25.0+ as the local Kubernetes cluster and link:https://quay.io/[Quay.io] for the public registry.
 ====
 
 [id="osdk-installing-cli-gh-release_{context}"]
 == Installing from GitHub release
 
-You can download and install a pre-built release binary of the SDK CLI from the
-project on GitHub.
+You can download and install a pre-built release binary of the Operator SDK CLI from the project on GitHub.
 
 .Prerequisites
 
@@ -67,7 +61,7 @@ $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download
 
 . Verify the downloaded release binary.
 
-.. Download the provided ASC file.
+.. Download the provided `.asc` file.
 +
 --
 * For Linux:
@@ -85,8 +79,7 @@ $ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download
 ----
 --
 
-.. Place the binary and corresponding ASC file into the same directory and run
-the following command to verify the binary:
+.. Place the binary and corresponding `.asc` file into the same directory and run the following command to verify the binary:
 +
 --
 * For Linux:
@@ -104,8 +97,7 @@ $ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
 ----
 --
 +
-If you do not have the public key of the maintainer on your workstation, you
-will get the following error:
+If you do not have the public key of the maintainer on your workstation, you will get the following error:
 +
 .Example output with error
 [source,terminal]
@@ -117,15 +109,13 @@ $ gpg: Can't check signature: No public key
 ----
 <1> RSA key string.
 +
-To download the key, run the following command, replacing `<key_id>` with the RSA
-key string provided in the output of the previous command:
+To download the key, run the following command, replacing `<key_id>` with the RSA key string provided in the output of the previous command:
 +
 [source,terminal]
 ----
 $ gpg [--keyserver keys.gnupg.net] --recv-key "<key_id>" <1>
 ----
-<1> If you do not have a key server configured, specify one with the
-`--keyserver` option.
+<1> If you do not have a key server configured, specify one with the `--keyserver` option.
 
 . Install the release binary in your `PATH`:
 +

--- a/modules/osdk-leader-election-types.adoc
+++ b/modules/osdk-leader-election-types.adoc
@@ -5,9 +5,7 @@
 [id="osdk-leader-for-life-election_{context}"]
 = Using Leader-for-life election
 
-With the Leader-for-life election implementation, a call to `leader.Become()`
-blocks the Operator as it retries until it can become the leader by creating the
-ConfigMap named `memcached-operator-lock`:
+With the Leader-for-life election implementation, a call to `leader.Become()` blocks the Operator as it retries until it can become the leader by creating the config map named `memcached-operator-lock`:
 
 [source,go]
 ----
@@ -27,16 +25,12 @@ func main() {
 }
 ----
 
-If the Operator is not running inside a cluster, `leader.Become()` simply
-returns without error to skip the leader election since it cannot detect the
-Operator's namespace.
+If the Operator is not running inside a cluster, `leader.Become()` simply returns without error to skip the leader election since it cannot detect the name of the Operator.
 
 [id="osdk-leader-with-lease-election_{context}"]
 = Using Leader-with-lease election
 
-The Leader-with-lease implementation can be enabled using the
-link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager#Options[Manager Options]
-for leader election:
+The Leader-with-lease implementation can be enabled using the link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager#Options[Manager Options] for leader election:
 
 [source,go]
 ----
@@ -57,7 +51,4 @@ func main() {
 }
 ----
 
-When the Operator is not running in a cluster, the Manager returns an error when
-starting since it cannot detect the Operator's namespace in order to create the
-ConfigMap for leader election. You can override this namespace by setting the
-Manager's `LeaderElectionNamespace` option.
+When the Operator is not running in a cluster, the Manager returns an error when starting because it cannot detect the namespace of the Operator in order to create the config map for leader election. You can override this namespace by setting the `LeaderElectionNamespace` option for the Manager.

--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -5,13 +5,9 @@
 [id="osdk-manually-defined-csv-fields_{context}"]
 = Manually-defined CSV fields
 
-Many CSV fields cannot be populated using generated, non-SDK-specific manifests.
-These fields are mostly human-written, English metadata about the Operator and
-various Custom Resource Definitions (CRDs).
+Many CSV fields cannot be populated using generated, generic manifests that are not specific to Operator SDK. These fields are mostly human-written, English metadata about the Operator and various custom resource definitions (CRDs).
 
-Operator authors must directly modify their CSV YAML file, adding personalized
-data to the following required fields. The Operator SDK gives a warning CSV
-generation when a lack of data in any of the required fields is detected.
+Operator authors must directly modify their cluster service version (CSV) YAML file, adding personalized data to the following required fields. The Operator SDK gives a warning during CSV generation when a lack of data in any of the required fields is detected.
 
 .Required
 [cols="2a,8a",options="header"]
@@ -19,28 +15,25 @@ generation when a lack of data in any of the required fields is detected.
 |Field |Description
 
 |`metadata.name`
-|A unique name for this CSV. Operator version should be included in the name to
-ensure uniqueness, for example `app-operator.v0.1.1`.
+|A unique name for this CSV. Operator version should be included in the name to ensure uniqueness, for example `app-operator.v0.1.1`.
 
 |`metadata.capabilities`
-|The Operator's capability level according to the Operator maturity model.
-Options include `Basic Install`, `Seamless Upgrades`, `Full Lifecycle`, `Deep Insights`, and `Auto Pilot`.
+|The capability level according to the Operator maturity model. Options include `Basic Install`, `Seamless Upgrades`, `Full Lifecycle`, `Deep Insights`, and `Auto Pilot`.
 
 |`spec.displayName`
 |A public name to identify the Operator.
 
 |`spec.description`
-|A short description of the Operator's functionality.
+|A short description of the functionality of the Operator.
 
 |`spec.keywords`
-|Keywords describing the operator.
+|Keywords describing the Operator.
 
 |`spec.maintainers`
-|Human or organizational entities maintaining the Operator, with a `name` and
-`email`.
+|Human or organizational entities maintaining the Operator, with a `name` and `email`.
 
 |`spec.provider`
-|The Operators' provider (usually an organization), with a `name`.
+|The provider of the Operator (usually an organization), with a `name`.
 
 |`spec.labels`
 |Key-value pairs to be used by Operator internals.
@@ -49,12 +42,10 @@ Options include `Basic Install`, `Seamless Upgrades`, `Full Lifecycle`, `Deep In
 |Semantic version of the Operator, for example `0.1.1`.
 
 |`spec.customresourcedefinitions`
-|Any CRDs the Operator uses. This field is populated automatically by the
-Operator SDK if any CRD YAML files are present in `deploy/`. However, several
-fields not in the CRD manifest spec require user input:
+|Any CRDs the Operator uses. This field is populated automatically by the Operator SDK if any CRD YAML files are present in `deploy/`. However, several fields not in the CRD manifest spec require user input:
 
 - `description`: description of the CRD.
-- `resources`: any Kubernetes resources leveraged by the CRD, for example pods and StatefulSets.
+- `resources`: any Kubernetes resources leveraged by the CRD, for example `Pod` and `StatefulSet` objects.
 - `specDescriptors`: UI hints for inputs and outputs of the Operator.
 |===
 
@@ -68,28 +59,21 @@ fields not in the CRD manifest spec require user input:
 |The name of the CSV being replaced by this CSV.
 
 |`spec.links`
-|URLs (for example, websites and documentation) pertaining to the Operator or
-application being managed, each with a `name` and `url`.
+|URLs (for example, websites and documentation) pertaining to the Operator or application being managed, each with a `name` and `url`.
 
 |`spec.selector`
 |Selectors by which the Operator can pair resources in a cluster.
 
 |`spec.icon`
-|A base64-encoded icon unique to the Operator, set in a `base64data` field with
-a `mediatype`.
+|A base64-encoded icon unique to the Operator, set in a `base64data` field with a `mediatype`.
 
 |`spec.maturity`
-|The level of maturity the software has achieved at this version. Options include
-`planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`, and
-`deprecated`.
+|The level of maturity the software has achieved at this version. Options include `planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`, and `deprecated`.
 |===
 
-Further details on what data each field above should hold are found in the
-link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md[CSV spec].
+Further details on what data each field above should hold are found in the link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md[CSV spec].
 
 [NOTE]
 ====
-Several YAML fields currently requiring user intervention can potentially be
-parsed from Operator code; such Operator SDK functionality will be addressed in
-a future design document.
+Several YAML fields currently requiring user intervention can potentially be parsed from Operator code.
 ====

--- a/modules/osdk-monitoring-prometheus-metrics-helper-modifying-port.adoc
+++ b/modules/osdk-monitoring-prometheus-metrics-helper-modifying-port.adoc
@@ -14,5 +14,9 @@ Operator authors can modify the port that metrics are exposed on.
 
 .Procedure
 
-* In the generated Operator's `cmd/manager/main.go` file, change the value of `metricsPort` in the line `var
-metricsPort int32 = 8383`.
+* In the `cmd/manager/main.go` file of the generated Operator, change the value of `metricsPort` in the following line:
++
+[source,go]
+----
+var metricsPort int32 = 8383
+----

--- a/modules/osdk-monitoring-prometheus-metrics-helper.adoc
+++ b/modules/osdk-monitoring-prometheus-metrics-helper.adoc
@@ -5,23 +5,18 @@
 [id="osdk-monitoring-prometheus-metrics-helper_{context}"]
 = Metrics helper
 
-In Go-based Operators generated using the Operator SDK, the following
-function exposes general metrics about the running program:
+In Go-based Operators generated using the Operator SDK, the following function exposes general metrics about the running program:
 
 [source,go]
 ----
 func ExposeMetricsPort(ctx context.Context, port int32) (*v1.Service, error)
 ----
 
-These metrics are inherited from the `controller-runtime` library API. By
-default, the metrics are served on `0.0.0.0:8383/metrics`.
+These metrics are inherited from the `controller-runtime` library API. By default, the metrics are served on `0.0.0.0:8383/metrics`.
 
-A Service object is created with the metrics port exposed, which can be then
-accessed by Prometheus. The Service object is garbage collected when the leader
-Pod's root owner is deleted.
+A `Service` object is created with the metrics port exposed, which can be then accessed by Prometheus. The `Service` object is garbage collected when the leader pod's `root` owner is deleted.
 
-The following example is present in the `cmd/manager/main.go` file in all
-Operators generated using the Operator SDK:
+The following example is present in the `cmd/manager/main.go` file in all Operators generated using the Operator SDK:
 
 [source,go]
 ----

--- a/modules/osdk-monitoring-prometheus-operator-support.adoc
+++ b/modules/osdk-monitoring-prometheus-operator-support.adoc
@@ -6,11 +6,6 @@
 [id="osdk-monitoring-prometheus-operator-support_{context}"]
 = Prometheus Operator support
 
-link:https://prometheus.io/[Prometheus] is an open-source systems monitoring and
-alerting toolkit. The Prometheus Operator creates, configures, and manages
-Prometheus clusters running on Kubernetes-based clusters, such as
-{product-title}.
+link:https://prometheus.io/[Prometheus] is an open-source systems monitoring and alerting toolkit. The Prometheus Operator creates, configures, and manages Prometheus clusters running on Kubernetes-based clusters, such as {product-title}.
 
-Helper functions exist in the Operator SDK by default to automatically set up
-metrics in any generated Go-based Operator for use on clusters where the
-Prometheus Operator is deployed.
+Helper functions exist in the Operator SDK by default to automatically set up metrics in any generated Go-based Operator for use on clusters where the Prometheus Operator is deployed.

--- a/modules/osdk-monitoring-prometheus-servicemonitor-creating.adoc
+++ b/modules/osdk-monitoring-prometheus-servicemonitor-creating.adoc
@@ -3,11 +3,9 @@
 // * operators/operator_sdk/osdk-monitoring-prometheus.adoc
 
 [id="osdk-monitoring-prometheus-servicemonitor-creating_{context}"]
-= Creating ServiceMonitor resources
+= Creating service monitors
 
-Operator authors can add Service target discovery of created monitoring Services
-using the `metrics.CreateServiceMonitor()` helper function, which accepts the
-newly created Service.
+Operator authors can add service target discovery of created monitoring services using the `metrics.CreateServiceMonitor()` helper function, which accepts the newly created service.
 
 .Prerequisites
 

--- a/modules/osdk-monitoring-prometheus-servicemonitor.adoc
+++ b/modules/osdk-monitoring-prometheus-servicemonitor.adoc
@@ -3,18 +3,12 @@
 // * operators/operator_sdk/osdk-monitoring-prometheus.adoc
 
 [id="osdk-monitoring-prometheus-servicemonitor_{context}"]
-= ServiceMonitor resources
+= Service monitors
 
-A ServiceMonitor is a Custom Resource Definition (CRD) provided by the
-Prometheus Operator that discovers the `Endpoints` in Service objects and
-configures Prometheus to monitor those pods.
+A `ServiceMonitor` is a custom resource provided by the Prometheus Operator that discovers the `Endpoints` in `Service` objects and configures Prometheus to monitor those pods.
 
-In Go-based Operators generated using the Operator SDK, the
-`GenerateServiceMonitor()` helper function can take a Service object and
-generate a ServiceMonitor Custom Resource (CR) based on it.
+In Go-based Operators generated using the Operator SDK, the `GenerateServiceMonitor()` helper function can take a `Service` object and generate a `ServiceMonitor` object based on it.
 
 .Additional resources
 
-* See the
-link:https://github.com/coreos/prometheus-operator/blob/7a25bf6b6bb2347dacb235659b73bc210117acc7/Documentation/design.md#servicemonitor[Prometheus Operator documentation]
-for more information about the ServiceMonitor CRD.
+* See the link:https://github.com/coreos/prometheus-operator/blob/7a25bf6b6bb2347dacb235659b73bc210117acc7/Documentation/design.md#servicemonitor[Prometheus Operator documentation] for more information about the `ServiceMonitor` custom resource definition (CRD).

--- a/modules/osdk-owned-crds.adoc
+++ b/modules/osdk-owned-crds.adoc
@@ -5,18 +5,14 @@
 [id="osdk-crds-owned_{context}"]
 = Owned CRDs
 
-The CRDs owned by your Operator are the most important part of your CSV. This
-establishes the link between your Operator and the required RBAC rules,
-dependency management, and other Kubernetes concepts.
+The custom resource definitions (CRDs) owned by your Operator are the most important part of your CSV. This establishes the link between your Operator and the required RBAC rules, dependency management, and other Kubernetes concepts.
 
-It is common for your Operator to use multiple CRDs to link together concepts,
-such as top-level database configuration in one object and a representation of
-ReplicaSets in another. Each one should be listed out in the CSV file.
+It is common for your Operator to use multiple CRDs to link together concepts, such as top-level database configuration in one object and a representation of replica sets in another. Each one should be listed out in the CSV file.
 
 .Owned CRD fields
 [cols="2a,5a,2",options="header"]
 |===
-|Field |Description |Required/Optional
+|Field |Description |Required/optional
 
 |`Name`
 |The full name of your CRD.
@@ -35,8 +31,7 @@ ReplicaSets in another. Each one should be listed out in the CSV file.
 |Required
 
 |`Description`
-|A short description of how this CRD is used by the Operator or a description of
-the functionality provided by the CRD.
+|A short description of how this CRD is used by the Operator or a description of the functionality provided by the CRD.
 |Required
 
 |`Group`
@@ -44,19 +39,13 @@ the functionality provided by the CRD.
 |Optional
 
 |`Resources`
-a|Your CRDs own one or more types of Kubernetes objects. These are listed in the resources section to inform your users of the objects they might need to troubleshoot or how to connect to the application, such as the Service or Ingress rule that exposes a database.
+a|Your CRDs own one or more types of Kubernetes objects. These are listed in the `resources` section to inform your users of the objects they might need to troubleshoot or how to connect to the application, such as the service or ingress rule that exposes a database.
 
-It is recommended to only list out the objects that are important to a human,
-not an exhaustive list of everything you orchestrate. For example, ConfigMaps
-that store internal state that should not be modified by a user should not
-appear here.
+It is recommended to only list out the objects that are important to a human, not an exhaustive list of everything you orchestrate. For example, do not list config maps that store internal state that are not meant to be modified by a user.
 |Optional
 
 |`SpecDescriptors`, `StatusDescriptors`, and `ActionDescriptors`
-a|These Descriptors are a way to hint UIs with certain inputs or outputs of your
-Operator that are most important to an end user. If your CRD contains the name
-of a Secret or ConfigMap that the user must provide, you can specify that here.
-These items are linked and highlighted in compatible UIs.
+a|These descriptors are a way to hint UIs with certain inputs or outputs of your Operator that are most important to an end user. If your CRD contains the name of a secret or config map that the user must provide, you can specify that here. These items are linked and highlighted in compatible UIs.
 
 There are three types of descriptors:
 
@@ -64,26 +53,19 @@ There are three types of descriptors:
 * `StatusDescriptors`: A reference to fields in the `status` block of an object.
 * `ActionDescriptors`: A reference to actions that can be performed on an object.
 
-All Descriptors accept the following fields:
+All descriptors accept the following fields:
 
-* `DisplayName`: A human readable name for the Spec, Status, or Action.
-* `Description`: A short description of the Spec, Status, or Action and how it is
-used by the Operator.
+* `DisplayName`: A human readable name for the `Spec`, `Status`, or `Action`.
+* `Description`: A short description of the `Spec`, `Status`, or `Action` and how it is used by the Operator.
 * `Path`: A dot-delimited path of the field on the object that this descriptor describes.
-* `X-Descriptors`: Used to determine which "capabilities" this descriptor has and
-which UI component to use. See the *openshift/console* project for a canonical
-link:https://github.com/openshift/console/tree/release-4.3/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts[list of React UI X-Descriptors] for {product-title}.
+* `X-Descriptors`: Used to determine which "capabilities" this descriptor has and which UI component to use. See the *openshift/console* project for a canonical link:https://github.com/openshift/console/tree/release-4.3/frontend/packages/operator-lifecycle-manager/src/components/descriptors/types.ts[list of React UI X-Descriptors] for {product-title}.
 
-Also see the *openshift/console* project for more information on
-link:https://github.com/openshift/console/tree/release-4.3/frontend/packages/operator-lifecycle-manager/src/components/descriptors[Descriptors]
-in general.
+Also see the *openshift/console* project for more information on link:https://github.com/openshift/console/tree/release-4.3/frontend/packages/operator-lifecycle-manager/src/components/descriptors[Descriptors] in general.
 |Optional
 
 |===
 
-The following example depicts a `MongoDB Standalone` CRD that requires some user
-input in the form of a Secret and ConfigMap, and orchestrates Services,
-StatefulSets, pods and ConfigMaps:
+The following example depicts a `MongoDB Standalone` CRD that requires some user input in the form of a secret and config map, and orchestrates services, stateful sets, pods and config maps:
 
 [id="osdk-crds-owned-example_{context}"]
 .Example owned CRD

--- a/modules/osdk-project-staffolding-layout.adoc
+++ b/modules/osdk-project-staffolding-layout.adoc
@@ -5,15 +5,12 @@
 [id="osdk-project-scaffolding-layout_{context}"]
 = Operator project scaffolding layout
 
-The `operator-sdk` CLI generates a number of packages for each Operator project.
-The following sections describes a basic rundown of each generated file and
-directory.
+The `operator-sdk` CLI generates a number of packages for each Operator project. The following sections describes a basic rundown of each generated file and directory.
 
 [id="osdk-project-scaffolding-layout-go_{context}"]
 == Go-based projects
 
-Go-based Operator projects (the default type) generated using the `operator-sdk new`
-command contain the following directories and files:
+Go-based Operator projects (the default type) generated using the `operator-sdk new` command contain the following directories and files:
 
 [options="header",cols="1,2"]
 |===
@@ -21,48 +18,33 @@ command contain the following directories and files:
 |File/folders |Purpose
 
 |`cmd/`
-|Contains `manager/main.go` file, which is the main program of the Operator. This
-instantiates a new manager which registers all Custom Resource Definitions under
-`pkg/apis/` and starts all controllers under `pkg/controllers/`.
+|Contains `manager/main.go` file, which is the main program of the Operator. This instantiates a new manager which registers all custom resource defintitions (CRDs) under `pkg/apis/` and starts all controllers under `pkg/controllers/`.
 
 |`pkg/apis/`
-|Contains the directory tree that defines the APIs of the Custom Resource
-Definitions (CRDs). Users are expected to edit the
-`pkg/apis/<group>/<version>/<kind>_types.go` files to define the API for each
-resource type and import these packages in their controllers to watch for these
-resource types.
+|Contains the directory tree that defines the APIs of the CRDs. Users are expected to edit the `pkg/apis/<group>/<version>/<kind>_types.go` files to define the API for each resource type and import these packages in their controllers to watch for these resource types.
 
 |`pkg/controller`
-|This `pkg` contains the controller implementations. Users are expected to edit
-the `pkg/controller/<kind>/<kind>_controller.go` files to define the
-controller's reconcile logic for handling a resource type of the specified
-`kind`.
+|This `pkg` contains the controller implementations. Users are expected to edit the `pkg/controller/<kind>/<kind>_controller.go` files to define the reconcile logic of the controller for handling a resource type of the specified kind.
 
 |`build/`
-|Contains the `Dockerfile` and build scripts used to build the Operator.
+|Contains the Dockerfile and build scripts used to build the Operator.
 
 |`deploy/`
-|Contains various YAML manifests for registering CRDs, setting up RBAC,
-and deploying the Operator as a Deployment.
+|Contains various YAML manifests for registering CRDs, setting up RBAC, and deploying the Operator as a deployment.
 
 a|`Gopkg.toml` +
 `Gopkg.lock`
-|The link:https://github.com/golang/dep[Go Dep] manifests that describe the
-external dependencies of this Operator.
+|The link:https://github.com/golang/dep[Go Dep] manifests that describe the external dependencies of this Operator.
 
 |`vendor/`
-|The golang link:https://golang.org/cmd/go/#hdr-Vendor_Directories[vendor] folder
-that contains the local copies of the external dependencies that satisfy the
-imports of this project. link:https://github.com/golang/dep[Go Dep] manages the
-vendor directly.
+|The Golang link:https://golang.org/cmd/go/#hdr-Vendor_Directories[vendor] folder that contains the local copies of the external dependencies that satisfy the imports of this project. link:https://github.com/golang/dep[Go Dep] manages the vendor directly.
 
 |===
 
 [id="osdk-project-scaffolding-layout-helm_{context}"]
 == Helm-based projects
 
-Helm-based Operator projects generated using the `operator-sdk new --type helm`
-command contain the following directories and files:
+Helm-based Operator projects generated using the `operator-sdk new --type helm` command contain the following directories and files:
 
 [options="header",cols="1,2"]
 |===
@@ -70,17 +52,15 @@ command contain the following directories and files:
 |File/folders |Purpose
 
 |`deploy/`
-|Contains various YAML manifests for registering CRDs, setting up RBAC,
-and deploying the Operator as a Deployment.
+|Contains various YAML manifests for registering CRDs, setting up RBAC, and deploying the Operator as a Deployment.
 
 |`helm-charts/<kind>`
-|Contains a Helm chart initialized using the equivalent of the
-link:https://docs.helm.sh/helm/#helm-create[`helm create`] command.
+|Contains a Helm chart initialized using the equivalent of the `helm create` command.
 
 |`build/`
-|Contains the `Dockerfile` and build scripts used to build the Operator.
+|Contains the Dockerfile and build scripts used to build the Operator.
 
 |`watches.yaml`
-|Contains `Group`, `Version`, `Kind`, and Helm chart location.
+|Contains group/version/kind (GVK) and Helm chart location.
 
 |===

--- a/modules/osdk-required-crds.adoc
+++ b/modules/osdk-required-crds.adoc
@@ -5,24 +5,16 @@
 [id="osdk-crds-required_{context}"]
 = Required CRDs
 
-Relying on other required CRDs is completely optional and only exists to reduce
-the scope of individual Operators and provide a way to compose multiple
-Operators together to solve an end-to-end use case.
+Relying on other required CRDs is completely optional and only exists to reduce the scope of individual Operators and provide a way to compose multiple Operators together to solve an end-to-end use case.
 
-An example of this is an Operator that might set up an application and install
-an etcd cluster (from an etcd Operator) to use for distributed locking and a
-Postgres database (from a Postgres Operator) for data storage.
+An example of this is an Operator that might set up an application and install an etcd cluster (from an etcd Operator) to use for distributed locking and a Postgres database (from a Postgres Operator) for data storage.
 
-Operator Lifecycle Manager (OLM) checks against the available CRDs and
-Operators in the cluster to fulfill these requirements. If suitable versions are
-found, the Operators are started within the desired namespace and a Service
-Account created for each Operator to create, watch, and modify the Kubernetes
-resources required.
+Operator Lifecycle Manager (OLM) checks against the available CRDs and Operators in the cluster to fulfill these requirements. If suitable versions are found, the Operators are started within the desired namespace and a service account created for each Operator to create, watch, and modify the Kubernetes resources required.
 
 .Required CRD fields
 [cols="2a,5a,2",options="header"]
 |===
-|Field |Description |Required/Optional
+|Field |Description |Required/optional
 
 |`Name`
 |The full name of the CRD you require.

--- a/modules/osdk-running-scorecard.adoc
+++ b/modules/osdk-running-scorecard.adoc
@@ -7,25 +7,16 @@
 
 .Prerequisites
 
-The following prerequisites for the Operator project are checked by the
-scorecard tool:
+The following prerequisites for the Operator project are checked by the scorecard tool:
 
 * Access to a cluster running Kubernetes 1.11.3 or later.
-* If you want to use the scorecard to check the integration of your Operator
-project with Operator Lifecycle Manager (OLM), then a ClusterServiceVersion
-(CSV) file is also required. This is a requirement when the `olm-deployed`
-option is used.
-* For Operators that were not generated using the Operator SDK (non-SDK
-Operators):
-** Resource manifests for installing and configuring the Operator and CRs.
+* If you want to use the scorecard to check the integration of your Operator project with Operator Lifecycle Manager (OLM), then a cluster service version (CSV) file is also required. This is a requirement when the `olm-deployed` option is used.
+* For Operators that were not generated using the Operator SDK (non-SDK Operators):
+** Resource manifests for installing and configuring the Operator and custom resources (CRs).
 ifdef::openshift-origin[]
-See the
-link:https://github.com/operator-framework/operator-sdk/blob/v0.15.0/doc/test-framework/writing-e2e-tests.md[Writing E2E Tests]
-guide for more information on the global and namespaced manifests.
+See the link:https://github.com/operator-framework/operator-sdk/blob/v0.15.0/doc/test-framework/writing-e2e-tests.md[Writing E2E Tests] guide for more information on the global and namespaced manifests.
 endif::[]
-** Configuration getter that supports reading from the `KUBECONFIG` environment
-variable, such as the `clientcmd` or `controller-runtime` configuration getters.
-This is required for the scorecard proxy to work correctly.
+** Configuration getter that supports reading from the `KUBECONFIG` environment variable, such as the `clientcmd` or `controller-runtime` configuration getters. This is required for the scorecard proxy to work correctly.
 
 .Procedure
 
@@ -38,5 +29,4 @@ This is required for the scorecard proxy to work correctly.
 $ operator-sdk scorecard
 ----
 +
-The scorecard return code is `1` if any of the executed texts did not pass and
-`0` if all selected tests passed.
+The scorecard return code is `1` if any of the executed texts did not pass and `0` if all selected tests passed.

--- a/modules/osdk-scorecard-config.adoc
+++ b/modules/osdk-scorecard-config.adoc
@@ -5,15 +5,12 @@
 [id="osdk-scorecard-config_{context}"]
 = Scorecard configuration
 
-The scorecard tool uses a configuration file that allows you to configure
-internal plug-ins, as well as several global configuration options.
+The scorecard tool uses a configuration file that allows you to configure internal plug-ins, as well as several global configuration options.
 
 [id="osdk-scorecard-config-file_{context}"]
 == Configuration file
 
-The default location for the scorecard tool's configuration is the
-`<project_dir>/.osdk-scorecard.*`. The following is an example of a
-YAML-formatted configuration file:
+The default location for the scorecard tool configuration is the `<project_dir>/.osdk-scorecard.*`. The following is an example of a YAML-formatted configuration file:
 
 .Scorecard configuration file
 [source,yaml]
@@ -31,32 +28,27 @@ scorecard:
           - "deploy/crds/cache.example.com_v1alpha1_memcachedrs_cr.yaml"
         csv-path: "deploy/olm-catalog/memcached-operator/0.0.3/memcached-operator.v0.0.3.clusterserviceversion.yaml"
 ----
-<1> `basic` tests configured to test two CRs.
+<1> `basic` tests configured to test two custom resources (CRs).
 <2> `olm` tests configured to test two CRs.
 
-Configuration methods for global options take the following priority, highest to
-lowest:
+Configuration methods for global options take the following priority, highest to lowest:
 
 Command arguments (if available) -> configuration file -> default
 
-The configuration file must be in YAML format. As the configuration file might
-be extended to allow configuration of all `operator-sdk` subcommands in the
-future, the scorecard's configuration must be under a `scorecard` subsection.
+The configuration file must be in YAML format. As the configuration file might be extended to allow configuration of all `operator-sdk` subcommands in the future, the scorecard configuration must be under a `scorecard` subsection.
 
 [NOTE]
 ====
-Configuration file support is provided by the `viper` package. For more info
-on how viper configuration works, see the `viper` package
-link:https://github.com/spf13/viper/blob/master/README.md[README].
+Configuration file support is provided by the `viper` package. For more info on how `viper` configuration works, see the link:https://github.com/spf13/viper/blob/master/README.md[README].
 ====
 
 [id="osdk-scorecard-config-args_{context}"]
 == Command arguments
 
-While most of the scorecard tool's configuration is done using a configuration
-file, you can also use the following arguments:
+While most of the scorecard tool configuration is done using a configuration file, you can also use the following arguments:
 
 .Scorecard tool arguments
+[cols="25%,20%,55%",options="header"]
 |===
 |Flag |Type |Description
 
@@ -66,26 +58,19 @@ file, you can also use the following arguments:
 
 |`--config`
 |string
-|The path to the scorecard configuration file. The default is
-`<project_dir>/.osdk-scorecard`. The file type and extension must be `.yaml`. If
-a configuration file is not provided or found at the default location, the
-scorecard exits with an error.
+|The path to the scorecard configuration file. The default is `<project_dir>/.osdk-scorecard`. The file type and extension must be `.yaml`. If a configuration file is not provided or found at the default location, the scorecard exits with an error.
 
 |`--output`, `-o`
 |string
-|Output format. Valid options are `text` and `json`. The default format is
-`text`, which is designed to be a human readable format. The `json` format uses
-the JSON schema output format used for plug-ins defined later.
+|Output format. Valid options are `text` and `json`. The default format is `text`, which is designed to be a human readable format. The `json` format uses the JSON schema output format used for plug-ins defined later.
 
 |`--kubeconfig`, `-o`
 |string
-|The path to the `kubeconfig` file. It sets the `kubeconfig` for internal
-plug-ins.
+|The path to the `kubeconfig` file. It sets the `kubeconfig` for internal plug-ins.
 
 |`--version`
 |string
-|The version of scorecard to run. The default and only valid option is
-`v1alpha2`.
+|The version of scorecard to run. The default and only valid option is `v1alpha2`.
 
 |`--selector`, `-l`
 |string
@@ -93,8 +78,7 @@ plug-ins.
 
 |`--list`, `-L`
 |bool
-|If `true`, only print the test names that would be run based on selector
-filtering.
+|If `true`, only print the test names that would be run based on selector filtering.
 |===
 
 [id="osdk-scorecard-config-file-options_{context}"]
@@ -103,23 +87,21 @@ filtering.
 The scorecard configuration file provides the following options:
 
 .Scorecard configuration file options
+[cols="25%,20%,55%",options="header"]
 |===
 |Option |Type |Description
 
 |`bundle`
 |string
-|Equivalent of the `--bundle` flag. OLM bundle directory path, when specified,
-runs bundle validation.
+|Equivalent of the `--bundle` flag. Operator Lifecycle Manager (OLM) bundle directory path, when specified, runs bundle validation.
 
 |`output`
 |string
-|Equivalent of the `--output` flag. If this option is defined by both the
-configuration file and the flag, the flag's value takes priority.
+|Equivalent of the `--output` flag. If this option is defined by both the configuration file and the flag, the flag value takes priority.
 
 |`kubeconfig`
 |string
-|Equivalent of the `--kubeconfig` flag. If this option is defined by both the
-configuration file and the flag, the flag's value takes priority.
+|Equivalent of the `--kubeconfig` flag. If this option is defined by both the configuration file and the flag, the flag value takes priority.
 
 |`plugins`
 |array
@@ -129,10 +111,10 @@ configuration file and the flag, the flag's value takes priority.
 [id="osdk-scorecard-config-plugins_{context}"]
 === Basic and OLM plug-ins
 
-The scorecard supports the internal `basic` and `olm` plug-ins, which are
-configured by a `plugins` section in the configuration file.
+The scorecard supports the internal `basic` and `olm` plug-ins, which are configured by a `plugins` section in the configuration file.
 
 .Plug-in options
+[cols="25%,20%,55%",options="header"]
 |===
 |Option |Type |Description
 
@@ -142,23 +124,19 @@ configured by a `plugins` section in the configuration file.
 
 |`csv-path`
 |string
-|The path to the CSV for the Operator. Required for OLM tests or if
-`olm-deployed` is set to `true`.
+|The path to the cluster service version (CSV) for the Operator. Required for OLM tests or if `olm-deployed` is set to `true`.
 
 |`olm-deployed`
 |bool
-|Indicates that the CSV and relevant CRDs have been deployed onto the cluster by
-OLM.
+|Indicates that the CSV and relevant CRDs have been deployed onto the cluster by OLM.
 
 |`kubeconfig`
 |string
-|The path to the `kubeconfig` file. If both the global `kubeconfig` and this
-field are set, this field is used for the plug-in.
+|The path to the `kubeconfig` file. If both the global `kubeconfig` and this field are set, this field is used for the plug-in.
 
 |`namespace`
 |string
-|The namespace to run the plug-ins in. If unset, the default specified by the
-`kubeconfig` file is used.
+|The namespace to run the plug-ins in. If unset, the default specified by the `kubeconfig` file is used.
 
 |`init-timeout`
 |int
@@ -170,22 +148,14 @@ field are set, this field is used for the plug-in.
 
 |`namespaced-manifest`
 |string
-|The manifest file with all resources that run within a namespace. By default,
-the scorecard combines the `service_account.yaml`, `role.yaml`,
-`role_binding.yaml`, and `operator.yaml` files from the `deploy` directory into
-a temporary manifest to use as the namespaced manifest.
+|The manifest file with all resources that run within a namespace. By default, the scorecard combines the `service_account.yaml`, `role.yaml`, `role_binding.yaml`, and `operator.yaml` files from the `deploy` directory into a temporary manifest to use as the namespaced manifest.
 
 |`global-manifest`
 |string
-|The manifest containing required resources that run globally (not namespaced).
-By default, the scorecard combines all CRDs in the `crds-dir` directory into a
-temporary manifest to use as the global manifest.
+|The manifest containing required resources that run globally (not namespaced). By default, the scorecard combines all CRDs in the `crds-dir` directory into a temporary manifest to use as the global manifest.
 |===
 
 [NOTE]
 ====
-Currently, using the scorecard with a CSV does not permit multiple CR manifests
-to be set through the CLI, configuration file, or CSV annotations. You must tear
-down your Operator in the cluster, re-deploy, and re-run the scorecard for each
-CR that is tested.
+Currently, using the scorecard with a CSV does not permit multiple CR manifests to be set through the CLI, configuration file, or CSV annotations. You must tear down your Operator in the cluster, re-deploy, and re-run the scorecard for each CR that is tested.
 ====

--- a/modules/osdk-scorecard-olm.adoc
+++ b/modules/osdk-scorecard-olm.adoc
@@ -5,24 +5,20 @@
 [id="osdk-scorecard-olm_{context}"]
 = Running the scorecard with an OLM-managed Operator
 
-The scorecard can be run using a ClusterServiceVersion (CSV), providing a way to
-test cluster-ready and non-SDK Operators.
+The scorecard can be run using a cluster service version (CSV), providing a way to test cluster-ready and non-Operator SDK Operators.
 
 .Procedure
 
-. The scorecard requires a proxy container in the Operator's `Deployment` Pod to
-read Operator logs. A few modifications to your CSV and creation of one extra
-object are required to run the proxy _before_ deploying your Operator with OLM.
+. The scorecard requires a proxy container in the deployment pod of the Operator to read Operator logs. A few modifications to your CSV and creation of one extra object are required to run the proxy _before_ deploying your Operator with Operator Lifecycle Manager (OLM).
 +
-This step can be performed manually or automated using bash functions. Choose
-one of the following methods.
+This step can be performed manually or automated using bash functions. Choose one of the following methods.
 +
 --
 * *Manual method:*
 
-..  Create a proxy server Secret containing a local Kubeconfig.
+..  Create a proxy server secret containing a local `kubeconfig` file`.
 
-... Generate a user name using the scorecard proxy's namespaced owner reference.
+... Generate a user name using the namespaced owner reference of the scorecard proxy.
 +
 [source,terminal]
 ----
@@ -30,9 +26,7 @@ $ echo '{"apiVersion":"","kind":"","name":"scorecard","uid":"","Namespace":"'<na
 ----
 <1> Replace `<namespace>` with the namespace your Operator will deploy in.
 
-... Write a `Config` manifest `scorecard-config.yaml` using the following template,
-replacing `<username>` with the base64 user name generated in the previous
-step:
+... Write a `Config` manifest `scorecard-config.yaml` using the following template, replacing `<username>` with the base64 user name generated in the previous step:
 +
 [source,yaml]
 ----
@@ -64,7 +58,7 @@ users:
 $ cat scorecard-config.yaml | base64 -w 0
 ----
 
-... Create a Secret manifest `scorecard-secret.yaml`:
+... Create a `Secret` manifest `scorecard-secret.yaml`:
 +
 [source,yaml]
 ----
@@ -79,14 +73,14 @@ data:
 <1> Replace `<namespace>` with the namespace your Operator will deploy in.
 <2> Replace `<kubeconfig_base64>` with the `Config` encoded as base64.
 
-... Apply the Secret:
+... Apply the secret:
 +
 [source,terminal]
 ----
 $ oc apply -f scorecard-secret.yaml
 ----
 
-... Insert a volume referring to the Secret into the Deployment for the Operator:
+... Insert a volume referring to the secret into the deployment for the Operator:
 +
 [source,yaml]
 ----
@@ -112,8 +106,7 @@ spec:
 ----
 <1> Scorecard `kubeconfig` volume.
 
-.. Insert a volume mount and `KUBECONFIG` environment variable into each container
-in your Operator's Deployment:
+.. Insert a volume mount and `KUBECONFIG` environment variable into each container in the deployment of your Operator:
 +
 [source,yaml]
 ----
@@ -143,7 +136,7 @@ spec:
 <2> Scorecard `kubeconfig` environment variable.
 <3> Repeat the same for this and all other containers.
 
-.. Insert the scorecard proxy container into the Operator's Deployment:
+.. Insert the scorecard proxy container into the deployment of your Operator:
 +
 [source,yaml]
 ----
@@ -178,10 +171,7 @@ spec:
 
 * *Automated method:*
 +
-The
-link:https://github.com/operator-framework/community-operators[`community-operators`]
-repository has several bash functions that can perform the previous steps in the
-procedure for you.
+The link:https://github.com/operator-framework/community-operators[`community-operators`] repository has several bash functions that can perform the previous steps in the procedure for you.
 
 .. Run the following `curl` command:
 +
@@ -198,7 +188,7 @@ $ curl -Lo csv-manifest-modifiers.sh \
 $ . ./csv-manifest-modifiers.sh
 ----
 
-.. Create the Kubeconfig Secret file:
+.. Create the `kubeconfig` secret file:
 +
 [source,terminal]
 ----
@@ -206,22 +196,22 @@ $ create_kubeconfig_secret_file scorecard-secret.yaml "<namespace>" <1>
 ----
 <1> Replace `<namespace>` with the namespace your Operator will deploy in.
 
-.. Apply the Secret:
+.. Apply the secret:
 +
 [source,terminal]
 ----
 $ oc apply -f scorecard-secret.yaml
 ----
 
-.. Insert the Kubeconfig volume:
+.. Insert the `kubeconfig` volume:
 +
 [source,terminal]
 ----
 $ insert_kubeconfig_volume "<csv_file>" <1>
 ----
-<1> Replace `<csv_file>` with the path to your Operator's CSV manifest.
+<1> Replace `<csv_file>` with the path to your CSV manifest.
 
-.. Insert the Kubeconfig Secret mount:
+.. Insert the `kubeconfig` secret mount:
 +
 [source,terminal]
 ----
@@ -236,16 +226,11 @@ $ insert_proxy_container "<csv_file>" "quay.io/operator-framework/scorecard-prox
 ----
 --
 
-. After inserting the proxy container, follow the steps in the _Getting started with the Operator SDK_
-guide to bundle your CSV and CRDs and deploy your Operator on OLM.
+. After inserting the proxy container, follow the steps in the _Getting started with the Operator SDK_ guide to bundle your CSV and custom resource definitions (CRDs) and deploy your Operator on OLM.
 
-. After your Operator has been deployed on OLM, define a `.osdk-scorecard.yaml`
-configuration file in your Operator project and ensure both the `csv-path: <csv_manifest_path>`
-and `olm-deployed` options are set.
+. After your Operator has been deployed on OLM, define a `.osdk-scorecard.yaml` configuration file in your Operator project and ensure both the `csv-path: <csv_manifest_path>` and `olm-deployed` options are set.
 
-. Run the scorecard with both the
-`csv-path: <csv_manifest_path>` and `olm-deployed` options set in your scorecard
-configuration file:
+. Run the scorecard with both the `csv-path: <csv_manifest_path>` and `olm-deployed` options set in your scorecard configuration file:
 +
 [source,terminal]
 ----

--- a/modules/osdk-scorecard-tests.adoc
+++ b/modules/osdk-scorecard-tests.adoc
@@ -5,13 +5,9 @@
 [id="osdk-scorecard-tests_{context}"]
 = Tests performed
 
-By default, the scorecard tool has eight internal tests it can run available
-across two internal plug-ins. If multiple CRs are specified for a plug-in, the
-test environment is fully cleaned up after each CR so that each CR gets a clean
-testing environment.
+By default, the scorecard tool has a set of internal tests it can run available across two internal plug-ins. If multiple CRs are specified for a plug-in, the test environment is fully cleaned up after each CR so that each CR gets a clean testing environment.
 
-Each test has a short name that uniquely identifies the test. This is useful
-when selecting a specific test or tests to run. For example:
+Each test has a short name that uniquely identifies the test. This is useful when selecting a specific test or tests to run. For example:
 
 [source,terminal]
 ----
@@ -29,67 +25,50 @@ $ operator-sdk scorecard -o text --selector='test in (checkspectest,checkstatust
 The following basic Operator tests are available from the `basic` plug-in:
 
 .`basic` plug-in tests
+[cols="25%,55%,20%",options="header"]
 |===
 |Test |Description |Short name
 
 |Spec Block Exists
-|This test checks the Custom Resource(s) created in the cluster to make sure that
-all CRs have a `spec` block. This test has a maximum score of `1`.
+|This test checks the custom resources (CRs) created in the cluster to make sure that all CRs have a `spec` block. This test has a maximum score of `1`.
 |`checkspectest`
 
 |Status Block Exists
-|This test checks the Custom Resource(s) created in the cluster to make sure that
-all CRs have a `status` block. This test has a maximum score of `1`.
+|This test checks the CRs created in the cluster to make sure that all CRs have a `status` block. This test has a maximum score of `1`.
 |`checkstatustest`
 
 |Writing Into CRs Has An Effect
-|This test reads the scorecard proxy's logs to verify that the Operator is making
-`PUT` or `POST`, or both, requests to the API server, indicating that it is
-modifying resources. This test has a maximum score of `1`.
+|This test reads the scorecard proxy logs to verify that the Operator is making `PUT` or `POST`, or both, requests to the API server, indicating that it is modifying resources. This test has a maximum score of `1`.
 |`writingintocrshaseffecttest`
 |===
 
 [id="osdk-scorecard-tests-olm_{context}"]
 == OLM plug-in
 
-The following OLM integration tests are available from the `olm` plug-in:
+The following Operator Lifecycle Manager (OLM) integration tests are available from the `olm` plug-in:
 
+.`olm` plug-in tests
+[cols="25%,55%,20%",options="header"]
 |===
 |Test |Description |Short name
 
 |OLM Bundle Validation
-|This test validates the OLM bundle manifests found in the bundle directory as
-specified by the bundle flag. If the bundle contents contain errors, then the
-test result output includes the validator log as well as error messages from
-the validation library.
+|This test validates the OLM bundle manifests found in the bundle directory as specified by the bundle flag. If the bundle contents contain errors, then the test result output includes the validator log as well as error messages from the validation library.
 |`bundlevalidationtest`
 
 |Provided APIs Have Validation
-|This test verifies that the CRDs for the provided CRs contain a validation
-section and that there is validation for each `spec` and `status` field detected
-in the CR. This test has a maximum score equal to the number of CRs provided
-by the `cr-manifest` option.
+|This test verifies that the CRDs for the provided CRs contain a validation section and that there is validation for each `spec` and `status` field detected in the CR. This test has a maximum score equal to the number of CRs provided by the `cr-manifest` option.
 |`crdshavevalidationtest`
 
 |Owned CRDs Have Resources Listed
-|This test makes sure that the CRDs for each CR provided by the `cr-manifest`
-option have a `resources` subsection in the `owned` CRDs section of the CSV. If
-the test detects used resources that are not listed in the `resources` section,
-it lists them in the suggestions at the end of the test. This test has a maximum
-score equal to the number of CRs provided by the `cr-manifest` option.
+|This test makes sure that the CRDs for each CR provided by the `cr-manifest` option have a `resources` subsection in the `owned` CRDs section of the CSV. If the test detects used resources that are not listed in the `resources` section, it lists them in the suggestions at the end of the test. This test has a maximum score equal to the number of CRs provided by the `cr-manifest` option.
 |`crdshaveresourcestest`
 
 |Spec Fields With Descriptors
-|This test verifies that every field in the Custom Resources' `spec` sections
-have a corresponding descriptor listed in the CSV. This test has a maximum score
-equal to the total number of fields in the `spec` sections of each custom resource
-passed in by the `cr-manifest` option.
+|This test verifies that every field in the `spec` sections of custom resources have a corresponding descriptor listed in the CSV. This test has a maximum score equal to the total number of fields in the `spec` sections of each custom resource passed in by the `cr-manifest` option.
 |`specdescriptorstest`
 
 |Status Fields With Descriptors
-|This test verifies that every field in the Custom Resources' `status` sections
-have a corresponding descriptor listed in the CSV. This test has a maximum score
-equal to the total number of fields in the `status` sections of each custom
-resource passed in by the `cr-manifest` option.
+|This test verifies that every field in the `status` sections of custom resources have a corresponding descriptor listed in the CSV. This test has a maximum score equal to the total number of fields in the `status` sections of each custom resource passed in by the `cr-manifest` option.
 |`statusdescriptorstest`
 |===

--- a/modules/osdk-suggested-namespace.adoc
+++ b/modules/osdk-suggested-namespace.adoc
@@ -5,21 +5,13 @@
 [id="osdk-suggested-namespace_{context}"]
 = Setting a suggested namespace
 
-Some Operators must be deployed in a specific namespace, or with ancillary
-resources in specific namespaces, in order to work properly. If resolved from a
-Subscription, OLM defaults the namespaced resources of an Operator to the
-namespace of its Subscription.
+Some Operators must be deployed in a specific namespace, or with ancillary resources in specific namespaces, in order to work properly. If resolved from a subscription, Operator Lifecycle Manager (OLM) defaults the namespaced resources of an Operator to the namespace of its subscription.
 
-As an Operator author, you can instead express a desired target namespace as
-part of your CSV to maintain control over the final namespaces of the resources
-installed for their Operators. When adding the Operator to a cluster using
-OperatorHub, this enables the web console to autopopulate the suggested
-namespace for the cluster administrator during the installation process.
+As an Operator author, you can instead express a desired target namespace as part of your cluster service version (CSV) to maintain control over the final namespaces of the resources installed for their Operators. When adding the Operator to a cluster using OperatorHub, this enables the web console to autopopulate the suggested namespace for the cluster administrator during the installation process.
 
 .Procedure
 
-* In your CSV, set the `operatorframework.io/suggested-namespace` annotation to
-your suggested namespace:
+* In your CSV, set the `operatorframework.io/suggested-namespace` annotation to your suggested namespace:
 +
 [source,yaml]
 ----

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide walks cluster administrators through installing Operators to an
-{product-title} cluster and subscribing Operators to namespaces.
+This guide walks cluster administrators through installing Operators to an {product-title} cluster and subscribing Operators to namespaces.
 
 include::modules/olm-installing-operators-from-operatorhub.adoc[leveloffset=+1]
 include::modules/olm-installing-from-operatorhub-using-web-console.adoc[leveloffset=+2]
@@ -14,5 +13,5 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+2]
 .Additional resources
 
-* xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About OperatorGroups]
+* xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About Operator groups]
 endif::[]

--- a/operators/admin/olm-configuring-proxy-support.adoc
+++ b/operators/admin/olm-configuring-proxy-support.adoc
@@ -5,10 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-If a global proxy is configured on the {product-title} cluster, Operator
-Lifecycle Manager automatically configures Operators that it manages with the
-cluster-wide proxy. However, you can also configure installed Operators to
-override the global proxy or inject a custom CA certificate.
+If a global proxy is configured on the {product-title} cluster, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. However, you can also configure installed Operators to override the global proxy or inject a custom CA certificate.
 
 .Additional resources
 

--- a/operators/admin/olm-creating-policy.adoc
+++ b/operators/admin/olm-creating-policy.adoc
@@ -5,29 +5,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Operators can require wide privileges to run, and the required privileges can
-change between versions. Operator Lifecycle Manager (OLM) runs with
-`cluster-admin` privileges. By default, Operator authors can specify any set of
-permissions in the ClusterServiceVersion (CSV) and OLM will consequently grant
-it to the Operator.
+Operators can require wide privileges to run, and the required privileges can change between versions. Operator Lifecycle Manager (OLM) runs with `cluster-admin` privileges. By default, Operator authors can specify any set of permissions in the cluster service version (CSV) and OLM will consequently grant it to the Operator.
 
-Cluster administrators should take measures to ensure that an Operator cannot
-achieve cluster-scoped privileges and that users cannot escalate privileges
-using OLM. One method for locking this down requires cluster administrators
-auditing Operators before they are added to the cluster. Cluster administrators
-are also provided tools for determining and constraining which actions are
-allowed during an Operator installation or upgrade using service accounts.
+Cluster administrators should take measures to ensure that an Operator cannot achieve cluster-scoped privileges and that users cannot escalate privileges using OLM. One method for locking this down requires cluster administrators auditing Operators before they are added to the cluster. Cluster administrators are also provided tools for determining and constraining which actions are allowed during an Operator installation or upgrade using service accounts.
 
-By associating an OperatorGroup with a service account that has a set of
-privileges granted to it, cluster administrators can set policy on Operators to
-ensure they operate only within predetermined boundaries using RBAC rules. The
-Operator is unable to do anything that is not explicitly permitted by those
-rules.
+By associating an _Operator group_ with a service account that has a set of privileges granted to it, cluster administrators can set policy on Operators to ensure they operate only within predetermined boundaries using RBAC rules. The Operator is unable to do anything that is not explicitly permitted by those rules.
 
-This self-sufficient, limited scope installation of Operators by non-cluster
-administrators means that more of the Operator Framework tools can safely be
-made available to more users, providing a richer experience for building
-applications with Operators.
+This self-sufficient, limited scope installation of Operators by non-cluster administrators means that more of the Operator Framework tools can safely be made available to more users, providing a richer experience for building applications with Operators.
 
 include::modules/olm-policy-understanding.adoc[leveloffset=+1]
 include::modules/olm-policy-scenarios.adoc[leveloffset=+2]

--- a/operators/admin/olm-deleting-operators-from-cluster.adoc
+++ b/operators/admin/olm-deleting-operators-from-cluster.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The following describes how to delete Operators from a cluster using either the
-web console or the CLI.
+The following describes how to delete Operators that were previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
 
 include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
 include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -21,7 +21,7 @@ After enabling OLM in a restricted network, you can continue to use your unrestr
 ====
 While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a restricted network still depends on the Operator itself. The Operator must:
 
-* List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its ClusterServiceVersion (CSV) object.
+* List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its `ClusterServiceVersion` (CSV) object.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
 See the following Red Hat Knowledgebase Article for a list of Red Hat Operators that support running in disconnected mode:

--- a/operators/admin/olm-status.adoc
+++ b/operators/admin/olm-status.adoc
@@ -5,11 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Understanding the state of the system in Operator Lifecycle Manager (OLM) is
-important for making decisions about and debugging problems with installed
-Operators. OLM provides insight into Subscriptions and related Catalog Source
-resources regarding their state and actions performed. This helps users better
-understand the healthiness of their Operators.
+Understanding the state of the system in Operator Lifecycle Manager (OLM) is important for making decisions about and debugging problems with installed Operators. OLM provides insight into subscriptions and related catalog sources regarding their state and actions performed. This helps users better understand the healthiness of their Operators.
 
 include::modules/olm-status-conditions.adoc[leveloffset=+1]
 include::modules/olm-status-viewing-cli.adoc[leveloffset=+1]

--- a/operators/admin/olm-upgrading-operators.adoc
+++ b/operators/admin/olm-upgrading-operators.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can upgrade Operators that have been previously
-installed using Operator Lifecycle Manager (OLM) on your {product-title}
-cluster.
+As a cluster administrator, you can upgrade Operators that have been previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
 
 include::modules/olm-changing-update-channel.adoc[leveloffset=+1]
 include::modules/olm-approving-pending-upgrade.adoc[leveloffset=+1]

--- a/operators/operator_sdk/osdk-ansible.adoc
+++ b/operators/operator_sdk/osdk-ansible.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines Ansible support in the Operator SDK and walks Operator
-authors through examples building and running Ansible-based Operators with the
-`operator-sdk` CLI tool that use Ansible playbooks and modules.
+This guide outlines Ansible support in the Operator SDK and walks Operator authors through examples building and running Ansible-based Operators with the `operator-sdk` CLI tool that use Ansible playbooks and modules.
 
 include::modules/osdk-ansible-support.adoc[leveloffset=+1]
 include::modules/osdk-ansible-custom-resource-files.adoc[leveloffset=+2]
@@ -21,19 +19,11 @@ include::modules/osdk-building-ansible-operator.adoc[leveloffset=+1]
 [id="osdk-ansible-k8s-module"]
 == Managing application lifecycle using the k8s Ansible module
 
-To manage the lifecycle of your application on Kubernetes using Ansible, you
-can use the link:https://docs.ansible.com/ansible/2.7/modules/k8s_module.html[`k8s` Ansible module].
-This Ansible module allows a developer to either leverage their existing
-Kubernetes resource files (written in YAML) or express the lifecycle management
-in native Ansible.
+To manage the lifecycle of your application on Kubernetes using Ansible, you can use the link:https://docs.ansible.com/ansible/2.7/modules/k8s_module.html[`k8s` Ansible module]. This Ansible module allows a developer to either leverage their existing Kubernetes resource files (written in YAML) or express the lifecycle management in native Ansible.
 
-One of the biggest benefits of using Ansible in conjunction with existing
-Kubernetes resource files is the ability to use Jinja templating so that you can
-customize resources with the simplicity of a few variables in Ansible.
+One of the biggest benefits of using Ansible in conjunction with existing Kubernetes resource files is the ability to use Jinja templating so that you can customize resources with the simplicity of a few variables in Ansible.
 
-This section goes into detail on usage of the `k8s` Ansible module. To get
-started, install the module on your local workstation and test it using a
-playbook before moving on to using it within an Operator.
+This section goes into detail on usage of the `k8s` Ansible module. To get started, install the module on your local workstation and test it using a playbook before moving on to using it within an Operator.
 
 include::modules/osdk-ansible-k8s-module-installing.adoc[leveloffset=+2]
 include::modules/osdk-ansible-k8s-module-testing-locally.adoc[leveloffset=+2]
@@ -44,9 +34,7 @@ include::modules/osdk-ansible-managing-cr-status.adoc[leveloffset=+1]
 [id="osdk-ansible-addtl-resources"]
 == Additional resources
 
-- See
-xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices]
-to learn about the project directory structures created by the Operator SDK.
+- See xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices] to learn about the project directory structures created by the Operator SDK.
 - link:https://blog.openshift.com/reaching-for-the-stars-with-ansible-operator/[Reaching for the Stars with Ansible Operator] - Red Hat OpenShift Blog
 
 - link:https://operators.gitbook.io/operator-developer-guide-for-red-hat-partners/[Operator Development Guide for Red Hat Partners]

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -1,44 +1,24 @@
 [id="osdk-generating-csvs"]
-= Generating a ClusterServiceVersion (CSV)
+= Generating a cluster service version (CSV)
 include::modules/common-attributes.adoc[]
 :context: osdk-generating-csvs
 
 toc::[]
 
-A _ClusterServiceVersion_ (CSV) is a YAML manifest created from Operator
-metadata that assists Operator Lifecycle Manager (OLM) in running the Operator
-in a cluster. It is the metadata that accompanies an Operator container image,
-used to populate user interfaces with information such as its logo, description,
-and version. It is also a source of technical information that is required to
-run the Operator, like the RBAC rules it requires and which Custom Resources
-(CRs) it manages or depends on.
+A _cluster service version_ (CSV), defined by a `ClusterServiceVersion` object, is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in a cluster. It is the metadata that accompanies an Operator container image, used to populate user interfaces with information such as its logo, description, and version. It is also a source of technical information that is required to run the Operator, like the RBAC rules it requires and which custom resources (CRs) it manages or depends on.
 
-The Operator SDK includes the `generate csv` subcommand to generate a
-_ClusterServiceVersion_ (CSV) for the current Operator project customized using
-information contained in manually-defined YAML manifests and Operator source
-files.
+The Operator SDK includes the `generate csv` subcommand to generate a CSV for the current Operator project customized using information contained in manually-defined YAML manifests and Operator source files.
 
-A CSV-generating command removes the responsibility of Operator authors having
-in-depth OLM knowledge in order for their Operator to interact with OLM or
-publish metadata to the Catalog Registry. Further, because the CSV spec will
-likely change over time as new Kubernetes and OLM features are implemented, the
-Operator SDK is equipped to easily extend its update system to handle new CSV
-features going forward.
+A CSV-generating command removes the responsibility of Operator authors having in-depth OLM knowledge in order for their Operator to interact with OLM or publish metadata to the Catalog Registry. Further, because the CSV spec will likely change over time as new Kubernetes and OLM features are implemented, the Operator SDK is equipped to easily extend its update system to handle new CSV features going forward.
 
-The CSV version is the same as the Operator's, and a new CSV is generated when
-upgrading Operator versions. Operator authors can use the `--csv-version` flag
-to have their Operators' state encapsulated in a CSV with the supplied semantic version:
+The CSV version is the same as the Operator version, and a new CSV is generated when upgrading Operator versions. Operator authors can use the `--csv-version` flag to have their Operator state encapsulated in a CSV with the supplied semantic version:
 
 [source,terminal]
 ----
 $ operator-sdk generate csv --csv-version <version>
 ----
 
-This action is idempotent and only updates the CSV file when a new version is
-supplied, or a YAML manifest or source file is changed. Operator authors should
-not have to directly modify most fields in a CSV manifest. Those that require
-modification are defined in this guide. For example, the CSV version must be
-included in `metadata.name`.
+This action is idempotent and only updates the CSV file when a new version is supplied, or a YAML manifest or source file is changed. Operator authors should not have to directly modify most fields in a CSV manifest. Those that require modification are defined in this guide. For example, the CSV version must be included in `metadata.name`.
 
 include::modules/osdk-how-csv-gen-works.adoc[leveloffset=+1]
 include::modules/osdk-csv-composition-configuration.adoc[leveloffset=+1]
@@ -52,8 +32,7 @@ include::modules/olm-enabling-operator-restricted-network.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]
 .Additional resources
 
-- See the link:https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list[Image Manifest V 2, Schema 2]
-specification for more information on manifest lists.
+- See the link:https://docs.docker.com/registry/spec/manifest-v2-2/#manifest-list[Image Manifest V 2, Schema 2] specification for more information on manifest lists.
 
 include::modules/olm-arch-os-support.adoc[leveloffset=+2]
 

--- a/operators/operator_sdk/osdk-getting-started.adoc
+++ b/operators/operator_sdk/osdk-getting-started.adoc
@@ -5,14 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the basics of the Operator SDK and walks Operator authors
-with cluster administrator access to a Kubernetes-based cluster (such as
-{product-title}) through an example of building a simple Go-based Memcached
-Operator and managing its lifecycle from installation to upgrade.
+This guide outlines the basics of the Operator SDK and walks Operator authors with cluster administrator access to a Kubernetes-based cluster (such as {product-title}) through an example of building a simple Go-based Memcached Operator and managing its lifecycle from installation to upgrade.
 
-This is accomplished using two centerpieces of the Operator Framework:
-Operator SDK (the `operator-sdk` CLI tool and `controller-runtime` library API)
-and Operator Lifecycle Manager (OLM).
+This is accomplished using two centerpieces of the Operator Framework: Operator SDK (the `operator-sdk` CLI tool and `controller-runtime` library API) and Operator Lifecycle Manager (OLM).
 
 [NOTE]
 ====
@@ -29,9 +24,7 @@ include::modules/managing-memcached-operator-using-olm.adoc[leveloffset=+1]
 [id="osdk-getting-started-addtl-resources"]
 == Additional resources
 
-- See
-xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices]
-to learn about the project directory structures created by the Operator SDK.
+- See xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices] to learn about the project directory structures created by the Operator SDK.
 
 - link:https://operators.gitbook.io/operator-developer-guide-for-red-hat-partners/[Operator Development Guide for Red Hat Partners]
 
@@ -39,14 +32,9 @@ ifdef::openshift-origin[]
 [id="osdk-getting-started-getting-involved"]
 == Getting involved
 
-This guide provides an effective demonstration of the value of the Operator
-Framework for building and managing Operators, but this is much more left out in
-the interest of brevity. The Operator Framework and its components are open
-source, so visit each project individually and learn what else you can do:
+This guide provides an effective demonstration of the value of the Operator Framework for building and managing Operators, but this is much more left out in the interest of brevity. The Operator Framework and its components are open source, so visit each project individually and learn what else you can do:
 
 link:https://github.com/operator-framework[*github.com/operator-framework*]
 
-If you want to discuss your experience, have questions, or want to get involved,
-join the
-link:https://groups.google.com/forum/#!forum/operator-framework[Operator Framework mailing list].
+If you want to discuss your experience, have questions, or want to get involved, join the link:https://groups.google.com/forum/#!forum/operator-framework[Operator Framework mailing list].
 endif::[]

--- a/operators/operator_sdk/osdk-helm.adoc
+++ b/operators/operator_sdk/osdk-helm.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines Helm chart support in the Operator SDK and walks Operator
-authors through an example of building and running an Nginx Operator with the
-`operator-sdk` CLI tool that uses an existing Helm chart.
+This guide outlines Helm chart support in the Operator SDK and walks Operator authors through an example of building and running an Nginx Operator with the `operator-sdk` CLI tool that uses an existing Helm chart.
 
 include::modules/osdk-helm-chart-support.adoc[leveloffset=+1]
 include::modules/osdk-installing-cli.adoc[leveloffset=+1]
@@ -16,8 +14,6 @@ include::modules/osdk-building-helm-operator.adoc[leveloffset=+1]
 [id="osdk-helm-addtl-resources"]
 == Additional resources
 
-- See
-xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices]
-to learn about the project directory structures created by the Operator SDK.
+- See xref:../../operators/operator_sdk/osdk-appendices.adoc#osdk-project-scaffolding-layout_operator-appendices[Appendices] to learn about the project directory structures created by the Operator SDK.
 
 - link:https://operators.gitbook.io/operator-developer-guide-for-red-hat-partners/[Operator Development Guide for Red Hat Partners]

--- a/operators/operator_sdk/osdk-leader-election.adoc
+++ b/operators/operator_sdk/osdk-leader-election.adoc
@@ -5,36 +5,15 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-During the lifecycle of an Operator, it is possible that there may be more than
-one instance running at any given time, for example when rolling out an upgrade
-for the Operator. In such a scenario, it is necessary to avoid contention
-between multiple Operator instances using leader election. This ensures only one
-leader instance handles the reconciliation while the other instances are
-inactive but ready to take over when the leader steps down.
+During the lifecycle of an Operator, it is possible that there may be more than one instance running at any given time, for example when rolling out an upgrade for the Operator. In such a scenario, it is necessary to avoid contention between multiple Operator instances using leader election. This ensures only one leader instance handles the reconciliation while the other instances are inactive but ready to take over when the leader steps down.
 
-There are two different leader election implementations to choose from, each
-with its own trade-off:
+There are two different leader election implementations to choose from, each with its own trade-off:
 
-* _Leader-for-life_: The leader Pod only gives up leadership (using garbage
-collection) when it is deleted. This implementation precludes the possibility of
-two instances mistakenly running as leaders (split brain). However, this method
-can be subject to a delay in electing a new leader. For example, when the leader
-Pod is on an unresponsive or partitioned node, the
-link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options[`pod-eviction-timeout`]
-dictates how it takes for the leader Pod to be deleted from the node and step
-down (default `5m`). See the link:https://godoc.org/github.com/operator-framework/operator-sdk/pkg/leader[Leader-for-life] Go documentation for more.
+Leader-for-life:: The leader pod only gives up leadership, using garbage collection, when it is deleted. This implementation precludes the possibility of two instances mistakenly running as leaders, a state also known as split brain. However, this method can be subject to a delay in electing a new leader. For example, when the leader pod is on an unresponsive or partitioned node, the link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-controller-manager/#options[`pod-eviction-timeout`] dictates long how it takes for the leader pod to be deleted from the node and step down, with a default of `5m`. See the link:https://godoc.org/github.com/operator-framework/operator-sdk/pkg/leader[Leader-for-life] Go documentation for more.
 
-* _Leader-with-lease_: The leader Pod periodically renews the leader lease and
-gives up leadership when it cannot renew the lease. This implementation allows
-for a faster transition to a new leader when the existing leader is isolated,
-but there is a possibility of split brain in
-link:https://github.com/kubernetes/client-go/blob/30b06a83d67458700a5378239df6b96948cb9160/tools/leaderelection/leaderelection.go#L21-L24[certain situations]. See the
-link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/leaderelection[Leader-with-lease]
-Go documentation for more.
+Leader-with-lease:: The leader pod periodically renews the leader lease and gives up leadership when it cannot renew the lease. This implementation allows for a faster transition to a new leader when the existing leader is isolated, but there is a possibility of split brain in link:https://github.com/kubernetes/client-go/blob/30b06a83d67458700a5378239df6b96948cb9160/tools/leaderelection/leaderelection.go#L21-L24[certain situations]. See the link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/leaderelection[Leader-with-lease] Go documentation for more.
 
-By default, the Operator SDK enables the Leader-for-life implementation. Consult
-the related Go documentation for both approaches to consider the trade-offs that make
-sense for your use case,
+By default, the Operator SDK enables the Leader-for-life implementation. Consult the related Go documentation for both approaches to consider the trade-offs that make sense for your use case.
 
 The following examples illustrate how to use the two options.
 

--- a/operators/operator_sdk/osdk-migrating-to-v0-1-0.adoc
+++ b/operators/operator_sdk/osdk-migrating-to-v0-1-0.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide describes how to migrate an Operator project built using Operator SDK
-v0.0.x to the project structure required by
-link:https://github.com/operator-framework/operator-sdk/releases[Operator SDK v0.1.0].
+This guide describes how to migrate an Operator project built using Operator SDK v0.0.x to the project structure required by link:https://github.com/operator-framework/operator-sdk/releases[Operator SDK v0.1.0].
 
 The recommended method for migrating your project is to:
 
@@ -15,13 +13,7 @@ The recommended method for migrating your project is to:
 . Copy your code into the new project.
 . Modify the new project as described for v0.1.0.
 
-This guide uses the `memcached-operator`, the example project
-from xref:osdk-getting-started.adoc#osdk-getting-started[Getting started with the Operator SDK],
-to illustrate the migration steps. See the
-link:https://github.com/operator-framework/operator-sdk-samples/tree/aa15bd278eec0959595e0a0a7282a26055d7f9d6/memcached-operator[v0.0.7 memcached-operator]
-and
-link:https://github.com/operator-framework/operator-sdk-samples/tree/4c6934448684a6953ece4d3d9f3f77494b1c125e/memcached-operator[v0.1.0 memcached-operator]
-project structures for pre- and post-migration examples, respectively.
+This guide uses the `memcached-operator`, the example project from xref:osdk-getting-started.adoc#osdk-getting-started[Getting started with the Operator SDK], to illustrate the migration steps. See the link:https://github.com/operator-framework/operator-sdk-samples/tree/aa15bd278eec0959595e0a0a7282a26055d7f9d6/memcached-operator[v0.0.7 memcached-operator] and link:https://github.com/operator-framework/operator-sdk-samples/tree/4c6934448684a6953ece4d3d9f3f77494b1c125e/memcached-operator[v0.1.0 memcached-operator] project structures for pre- and post-migration examples, respectively.
 
 include::modules/creating-new-osdk-v0-1-0-project.adoc[leveloffset=+1]
 include::modules/migrating-custom-types-pkg-apis.adoc[leveloffset=+1]

--- a/operators/operator_sdk/osdk-monitoring-prometheus.adoc
+++ b/operators/operator_sdk/osdk-monitoring-prometheus.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide describes the built-in monitoring support provided by the Operator
-SDK using the Prometheus Operator and details usage for Operator authors.
+This guide describes the built-in monitoring support provided by the Operator SDK using the Prometheus Operator and details usage for Operator authors.
 
 include::modules/osdk-monitoring-prometheus-operator-support.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/osdk-scorecard.adoc
+++ b/operators/operator_sdk/osdk-scorecard.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Operator authors should validate that their Operator is packaged correctly and
-free of syntax errors. As an Operator author, you can use the Operator SDK's
-scorecard tool to validate your Operator packaging and run tests.
+Operator authors should validate that their Operator is packaged correctly and free of syntax errors. As an Operator author, you can use the Operator SDK scorecard tool to validate your Operator packaging and run tests.
 
 [NOTE]
 ====
@@ -18,10 +16,7 @@ include::modules/osdk-about-scorecard-tool.adoc[leveloffset=+1]
 include::modules/osdk-scorecard-config.adoc[leveloffset=+1]
 .Additional resources
 
-* You can either set `cr-manifest` or your CSV's
-`metadata.annotations['alm-examples']` to provide CRs to the scorecard, but not
-both. See xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-crds-templates_osdk-generating-csvs[CRD templates]
-for details.
+* You can either set `cr-manifest` or your CSV `metadata.annotations['alm-examples']` to provide CRs to the scorecard, but not both. See xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-crds-templates_osdk-generating-csvs[CRD templates] for details.
 
 include::modules/osdk-scorecard-tests.adoc[leveloffset=+1]
 .Additional resources

--- a/operators/operator_sdk/osdk-working-bundle-images.adoc
+++ b/operators/operator_sdk/osdk-working-bundle-images.adoc
@@ -12,5 +12,4 @@ include::modules/osdk-building-bundle-image.adoc[leveloffset=+1]
 [id="osdk-working-bundle-images-additional-resources"]
 == Additional resources
 
-* See xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Operator Framework packaging formats]
-for more details on the Bundle Format.
+* See xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Operator Framework packaging formats] for more details on the Bundle Format.

--- a/operators/understanding/crds/crd-extending-api-with-crds.adoc
+++ b/operators/understanding/crds/crd-extending-api-with-crds.adoc
@@ -1,12 +1,11 @@
 [id="crd-extending-api-with-crds"]
-= Extending the Kubernetes API with Custom Resource Definitions
+= Extending the Kubernetes API with custom resource definitions
 include::modules/common-attributes.adoc[]
 :context: crd-extending-api-with-crds
 
 toc::[]
 
-This guide describes how cluster administrators can extend their {product-title}
-cluster by creating and managing Custom Resource Definitions (CRDs).
+This guide describes how cluster administrators can extend their {product-title} cluster by creating and managing custom resource definitions (CRDs).
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 include::modules/crd-creating-crds.adoc[leveloffset=+1]

--- a/operators/understanding/crds/crd-managing-resources-from-crds.adoc
+++ b/operators/understanding/crds/crd-managing-resources-from-crds.adoc
@@ -1,12 +1,11 @@
 [id="crd-managing-resources-from-crds"]
-= Managing resources from Custom Resource Definitions
+= Managing resources from custom resource definitions
 include::modules/common-attributes.adoc[]
 :context: crd-managing-resources-from-crds
 
 toc::[]
 
-This guide describes how developers can manage Custom Resources (CRs) that come
-from Custom Resource Definitions (CRDs).
+This guide describes how developers can manage custom resources (CRs) that come from custom resource definitions (CRDs).
 
 include::modules/crd-custom-resource-definitions.adoc[leveloffset=+1]
 include::modules/crd-creating-custom-resources-from-file.adoc[leveloffset=+1]

--- a/operators/understanding/olm-common-terms.adoc
+++ b/operators/understanding/olm-common-terms.adoc
@@ -5,8 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This topic provides a glossary of common terms related to the Operator
-Framework, including Operator Lifecycle Manager (OLM) and the Operator SDK, for
-both packaging formats: Package Manifest Format and Bundle Format.
+This topic provides a glossary of common terms related to the Operator Framework, including Operator Lifecycle Manager (OLM) and the Operator SDK, for both packaging formats: Package Manifest Format and Bundle Format.
 
 include::modules/olm-terms.adoc[leveloffset=+1]

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the packaging formats for Operators supported by Operator
-Lifecycle Manager (OLM) in {product-title}.
+This guide outlines the packaging formats for Operators supported by Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-package-manifest-format.adoc[leveloffset=+1]
 include::modules/olm-bundle-format.adoc[leveloffset=+1]
@@ -16,13 +15,12 @@ ifdef::openshift-origin[]
 [id="olm-packaging-format-addtl-resources"]
 == Additional resources
 
-See the upstream `operator-framework/operator-registry` project repository for
-more information on the Operator Bundle Format:
+See the upstream `operator-framework/operator-registry` project repository for more information on the Operator Bundle Format:
 
 - link:https://github.com/operator-framework/operator-registry/blob/master/docs/design/operator-bundle.md[Operator Bundle Overview]
 - link:https://github.com/operator-framework/operator-registry/blob/master/README.md[Operator Registry README]
 
-See the project's *Releases* page for `opm` CLI downloads:
+See the project *Releases* page for `opm` CLI downloads:
 
 - link:https://github.com/operator-framework/operator-registry/releases[Releases]
 endif::[]

--- a/operators/understanding/olm-understanding-operatorhub.adoc
+++ b/operators/understanding/olm-understanding-operatorhub.adoc
@@ -13,6 +13,7 @@ include::modules/olm-operatorhub-architecture.adoc[leveloffset=+1]
 [id="olm-understanding-operatorhub-resources"]
 == Additional resources
 
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[Catalog source]
 * xref:../../operators/operator_sdk/osdk-getting-started.adoc#osdk-getting-started[Getting started with the Operator SDK]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-generating-csvs[Generating a ClusterServiceVersion (CSV)]
 * xref:../../operators/understanding/olm/olm-workflow.adoc#olm-upgrades_olm-workflow[Operator installation and upgrade workflow in OLM]

--- a/operators/understanding/olm-what-operators-are.adoc
+++ b/operators/understanding/olm-what-operators-are.adoc
@@ -5,25 +5,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Conceptually, _Operators_ take human operational knowledge and encode it into
-software that is more easily shared with consumers.
+Conceptually, _Operators_ take human operational knowledge and encode it into software that is more easily shared with consumers.
 
-Operators are pieces of software that ease the operational complexity of running
-another piece of software. They act like an extension of the software vendor's
-engineering team, watching over a Kubernetes environment (such as
-{product-title}) and using its current state to make decisions in real time.
-Advanced Operators are designed to handle upgrades seamlessly, react to failures
-automatically, and not take shortcuts, like skipping a software backup process
-to save time.
+Operators are pieces of software that ease the operational complexity of running another piece of software. They act like an extension of the software vendor's engineering team, watching over a Kubernetes environment (such as {product-title}) and using its current state to make decisions in real time. Advanced Operators are designed to handle upgrades seamlessly, react to failures automatically, and not take shortcuts, like skipping a software backup process to save time.
 
-More technically, _Operators_ are a method of packaging, deploying, and managing a
-Kubernetes application.
+More technically, Operators are a method of packaging, deploying, and managing a Kubernetes application.
 
-A Kubernetes application is an app that is both deployed on Kubernetes and
-managed using the Kubernetes APIs and `kubectl` or `oc` tooling. To be able to
-make the most of Kubernetes, you require a set of cohesive APIs to extend in order
-to service and manage your apps that run on Kubernetes. Think of
-Operators as the runtime that manages this type of app on Kubernetes.
+A Kubernetes application is an app that is both deployed on Kubernetes and managed using the Kubernetes APIs and `kubectl` or `oc` tooling. To be able to make the most of Kubernetes, you require a set of cohesive APIs to extend in order to service and manage your apps that run on Kubernetes. Think of Operators as the runtime that manages this type of app on Kubernetes.
 
 include::modules/olm-why-use-operators.adoc[leveloffset=+1]
 include::modules/olm-operator-framework.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-arch.adoc
+++ b/operators/understanding/olm/olm-arch.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the component architecture of Operator Lifecycle Manager
-(OLM) in {product-title}.
+This guide outlines the component architecture of Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-architecture.adoc[leveloffset=+1]
 include::modules/olm-arch-olm-operator.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-understanding-dependency-resolution.adoc
+++ b/operators/understanding/olm/olm-understanding-dependency-resolution.adoc
@@ -5,9 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines dependency resolution and Custom Resource Definition (CRD)
-upgrade lifecycles with Operator Lifecycle Manager (OLM) in
-{product-title}.
+This guide outlines dependency resolution and custom resource definition (CRD) upgrade lifecycles with Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-dependency-resolution-about.adoc[leveloffset=+1]
 include::modules/olm-dependency-resolution-crd-upgrades.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-understanding-olm.adoc
+++ b/operators/understanding/olm/olm-understanding-olm.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide provides an overview of the concepts that drive Operator Lifecycle
-Manager (OLM) in {product-title}.
+This guide provides an overview of the concepts that drive Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-overview.adoc[leveloffset=+1]
 include::modules/olm-crds.adoc[leveloffset=+1]
@@ -16,5 +15,4 @@ include::modules/olm-subscription.adoc[leveloffset=+2]
 include::modules/olm-installplan.adoc[leveloffset=+2]
 include::modules/olm-operatorgroups-about.adoc[leveloffset=+2]
 
-For more information, see the xref:../../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-understanding-operatorgroups[OperatorGroups]
-guide.
+For more information, see the xref:../../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-understanding-operatorgroups[Operator groups] guide.

--- a/operators/understanding/olm/olm-understanding-operatorgroups.adoc
+++ b/operators/understanding/olm/olm-understanding-operatorgroups.adoc
@@ -1,12 +1,11 @@
 [id="olm-understanding-operatorgroups"]
-= OperatorGroups
+= Operator groups
 include::modules/common-attributes.adoc[]
 :context: olm-understanding-operatorgroups
 
 toc::[]
 
-This guide outlines the use of OperatorGroups with Operator Lifecycle
-Manager (OLM) in {product-title}.
+This guide outlines the use of Operator groups with Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-operatorgroups-about.adoc[leveloffset=+1]
 include::modules/olm-operatorgroups-membership.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-workflow.adoc
+++ b/operators/understanding/olm/olm-workflow.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide outlines the workflow of Operator Lifecycle Manager (OLM) in
-{product-title}.
+This guide outlines the workflow of Operator Lifecycle Manager (OLM) in {product-title}.
 
 include::modules/olm-upgrades.adoc[leveloffset=+1]

--- a/operators/user/olm-creating-apps-from-installed-operators.adoc
+++ b/operators/user/olm-creating-apps-from-installed-operators.adoc
@@ -5,7 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-This guide walks developers through an example of creating applications from an
-installed Operator using the {product-title} web console.
+This guide walks developers through an example of creating applications from an installed Operator using the {product-title} web console.
 
 include::modules/olm-creating-etcd-cluster-from-operator.adoc[leveloffset=+1]

--- a/operators/user/olm-installing-operators-in-namespace.adoc
+++ b/operators/user/olm-installing-operators-in-namespace.adoc
@@ -5,17 +5,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-If a cluster administrator has delegated Operator installation permissions to
-your account, you can install and subscribe an Operator to your namespace in a
-self-service manner.
+If a cluster administrator has delegated Operator installation permissions to your account, you can install and subscribe an Operator to your namespace in a self-service manner.
 
 [id="olm-installing-operators-in-namespace-prereqs"]
 == Prerequisites
 
-A cluster administrator must add certain permissions to your {product-title}
-user account to allow self-service Operator installation to a namespace. See
-xref:../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
-for details.
+A cluster administrator must add certain permissions to your {product-title} user account to allow self-service Operator installation to a namespace. See xref:../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators] for details.
 
 include::modules/olm-installing-operators-from-operatorhub.adoc[leveloffset=+1]
 include::modules/olm-installing-from-operatorhub-using-web-console.adoc[leveloffset=+2]
@@ -23,5 +18,5 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+2]
 .Additional resources
 
-* xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About OperatorGroups]
+* xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About Operator groups]
 endif::[]

--- a/operators/user/olm-webhooks.adoc
+++ b/operators/user/olm-webhooks.adoc
@@ -5,11 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Validating and mutating admission webhooks allow Operator authors to intercept,
-modify, and accept or reject resources before they are saved to the object store
-and handled by the Operator controller. Operator Lifecycle Manager (OLM) can
-manage the lifecycle of these webhooks when they are shipped alongside your
-Operator.
+Validating and mutating admission webhooks allow Operator authors to intercept, modify, and accept or reject resources before they are saved to the object store and handled by the Operator controller. Operator Lifecycle Manager (OLM) can manage the lifecycle of these webhooks when they are shipped alongside your Operator.
 
 include::modules/olm-defining-csv-webhooks.adoc[leveloffset=+1]
 include::modules/olm-webhook-considerations.adoc[leveloffset=+1]


### PR DESCRIPTION
Manual cp of https://github.com/openshift/openshift-docs/pull/27667, which had a lot of conflicts to resolve due to changes between 4.5 and 4.6.

Preview (internal): http://file.rdu.redhat.com/~adellape/121120/op_ref_api_45/operators/understanding/olm-what-operators-are.html