### PR TITLE
Monitoring term style updates for 4.4

### DIFF
--- a/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
+++ b/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
@@ -20,8 +20,14 @@ The Alertmanager UI accessed in this procedure is the old interface for Alertman
 
 . Run:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get routes
+----
++
+.Example output
+[source,terminal]
+----
 NAME                HOST/PORT                                                     ...
 alertmanager-main   alertmanager-main-openshift-monitoring.apps._url_.openshift.com ...
 grafana             grafana-openshift-monitoring.apps._url_.openshift.com           ...
@@ -32,9 +38,9 @@ prometheus-k8s      prometheus-k8s-openshift-monitoring.apps._url_.openshift.com
 +
 For example, this is the resulting URL for Alertmanager:
 +
+[source,text]
 ----
 https://alertmanager-main-openshift-monitoring.apps._url_.openshift.com
 ----
 
 . Navigate to the address using a web browser and authenticate.
-

--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -15,6 +15,7 @@ You can overwrite the default Alertmanager configuration by editing the `alertma
 
 . Print the currently active Alertmanager configuration into file `alertmanager.yaml`:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .data "alertmanager.yaml" }}' |base64 -d > alertmanager.yaml
 ----
@@ -85,6 +86,7 @@ With this configuration, alerts of `critical` severity fired by the `example-app
 +
 . Apply the new configuration in the file:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file=alertmanager.yaml --dry-run -o=yaml |  oc -n openshift-monitoring replace secret --filename=-
 ----

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -15,8 +15,9 @@ You can assign tolerations to any of the monitoring stack components to enable m
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-configurable-monitoring-components.adoc
+++ b/modules/monitoring-configurable-monitoring-components.adoc
@@ -5,7 +5,7 @@
 [id="configurable-monitoring-components_{context}"]
 = Configurable monitoring components
 
-This table shows the monitoring components you can configure and the keys used to specify the components in the ConfigMap:
+This table shows the monitoring components you can configure and the keys used to specify the components in the config map:
 
 .Configurable monitoring components
 [options="header"]
@@ -22,4 +22,3 @@ This table shows the monitoring components you can configure and the keys used t
 |====
 
 From this list, only Prometheus and Alertmanager have extensive configuration options. All other components usually provide only the `nodeSelector` field for being deployed on a specified node.
-

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -15,8 +15,9 @@ For the Prometheus or Alertmanager to use a persistent volume (PV), you first mu
 
 .Procedure
 
-. Edit the `cluster-monitoring-config` ConfigMap:
+. Edit the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
@@ -5,18 +5,19 @@
 [id="configuring-the-cluster-monitoring-stack_{context}"]
 = Configuring the cluster monitoring stack
 
-You can configure the Prometheus Cluster Monitoring stack using ConfigMaps. ConfigMaps configure the Cluster Monitoring Operator, which in turn configures components of the stack.
+You can configure the Prometheus Cluster Monitoring stack using config maps. Config maps configure the Cluster Monitoring Operator, which in turn configures components of the stack.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the OpenShift CLI (oc).
-* You have created the `cluster-monitoring-config` ConfigMap object.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
@@ -38,7 +39,7 @@ data:
 +
 Substitute `<component>` and `<configuration_for_the_component>` accordingly.
 +
-For example, create this ConfigMap to configure a Persistent Volume Claim (PVC) for Prometheus:
+For example, create this `ConfigMap` object to configure a Persistent Volume Claim (PVC) for Prometheus:
 +
 [source,yaml,subs=quotes]
 ----
@@ -62,4 +63,3 @@ data:
 Here, *prometheusK8s* defines the Prometheus component and the following lines define its configuration.
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically.
-

--- a/modules/monitoring-creating-a-role-for-setting-up-metrics-collection.adoc
+++ b/modules/monitoring-creating-a-role-for-setting-up-metrics-collection.adoc
@@ -29,6 +29,7 @@ This role enables a user to set up metrics collection for services.
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f custom-metrics-role.yaml
 ----

--- a/modules/monitoring-creating-alerting-rules.adoc
+++ b/modules/monitoring-creating-alerting-rules.adoc
@@ -42,6 +42,7 @@ This configuration creates an alerting rule named `example-alert`, which fires a
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f example-app-alerting-rule.yaml
 ----

--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -3,9 +3,9 @@
 // * monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
 
 [id="creating-cluster-monitoring-configmap_{context}"]
-= Creating a cluster monitoring ConfigMap
+= Creating a cluster monitoring config map
 
-To configure the {product-title} monitoring stack, you must create the cluster monitoring ConfigMap.
+To configure the {product-title} monitoring stack, you must create the cluster monitoring `ConfigMap` object.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ To configure the {product-title} monitoring stack, you must create the cluster m
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
-. If the ConfigMap does not exist:
+. If the `ConfigMap` object does not exist:
 .. Create the following YAML manifest. In this example the file is called `cluster-monitoring-config.yaml`:
 +
 [source,yaml]
@@ -35,7 +35,7 @@ data:
   config.yaml: |
 ----
 +
-.. Apply the configuration to create the ConfigMap:
+.. Apply the configuration to create the `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-deploying-a-sample-service.adoc
+++ b/modules/monitoring-deploying-a-sample-service.adoc
@@ -64,6 +64,7 @@ This configuration deploys a service named `prometheus-example-app` in the `ns1`
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f prometheus-example-app.yaml
 ----
@@ -72,8 +73,14 @@ It will take some time to deploy the service.
 
 . You can check that the service is running:
 +
+[source,terminal]
 ----
 $ oc -n ns1 get pod
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                      READY     STATUS    RESTARTS   AGE
 prometheus-example-app-7857545cb7-sbgwq   1/1       Running   0          81m
 ----

--- a/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
+++ b/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
@@ -5,24 +5,26 @@
 [id="enabling-monitoring-of-your-own-services_{context}"]
 = Enabling monitoring of your own services
 
-You can enable monitoring your own services by setting the `techPreviewUserWorkload/enabled` flag in the cluster monitoring ConfigMap.
+You can enable monitoring your own services by setting the `techPreviewUserWorkload/enabled` flag in the cluster monitoring config map.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the OpenShift CLI (oc).
-* You have created the `cluster-monitoring-config` ConfigMap object.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----
 
 . Set the `techPreviewUserWorkload` setting to `true` under `data/config.yaml`:
 +
+[source,yaml]
 ----
 apiVersion: v1
 kind: ConfigMap
@@ -39,8 +41,14 @@ data:
 
 . Optional: You can check that the `prometheus-user-workload` pods were created:
 +
+[source,terminal]
 ----
 $ oc -n openshift-user-workload-monitoring get pod
+----
++
+.Example output
+[source,terminal]
+----
 NAME                                   READY   STATUS    RESTARTS   AGE
 prometheus-operator-85bbb7b64d-7jwjd   1/1     Running   0          3m24s
 prometheus-user-workload-0             5/5     Running   1          3m13s

--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -176,6 +176,7 @@ spec:
 
 . Show the Prometheus Adapter image to use:
 +
+[source,terminal]
 ----
 $ kubectl get -n openshift-monitoring deploy/prometheus-adapter -o jsonpath="{..image}"
 quay.io/openshift-release-dev/ocp-v4.3-art-dev@sha256:76db3c86554ad7f581ba33844d6a6ebc891236f7db64f2d290c3135ba81c264c
@@ -241,6 +242,7 @@ spec:
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f deploy.yaml
 ----

--- a/modules/monitoring-giving-view-access-to-a-user.adoc
+++ b/modules/monitoring-giving-view-access-to-a-user.adoc
@@ -14,14 +14,16 @@ By default, only cluster administrator users and developers have access to metri
 
 .Procedure
 
-* Run this command to give <user> access to all metrics of your services in <namespace>:
+* Run this command to give a user access to all metrics of your services in a defined namespace:
 +
+[source,terminal]
 ----
 $ oc policy add-role-to-user view <user> -n <namespace>
 ----
 +
 For example, to give view access to the `ns1` namespace to user `bobwilliams`, run:
 +
+[source,terminal]
 ----
 $ oc policy add-role-to-user view bobwilliams -n ns1
 ----

--- a/modules/monitoring-listing-acting-alerting-rules.adoc
+++ b/modules/monitoring-listing-acting-alerting-rules.adoc
@@ -11,14 +11,21 @@ You can list the alerting rules that currently apply to the cluster.
 
 . Configure the necessary port forwarding:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring port-forward svc/prometheus-operated 9090
 ----
 
 . Fetch the JSON object containing acting alerting rules and their properties:
 +
+[source,terminal]
 ----
 $ curl -s http://localhost:9090/api/v1/rules | jq '[.data.groups[].rules[] | select(.type=="alerting")]'
+----
++
+.Example output
+[source,terminal]
+----
 [
   {
     "name": "ClusterOperatorDown",

--- a/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
@@ -15,8 +15,9 @@ By default, the Prometheus Cluster Monitoring stack configures the retention tim
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -15,8 +15,9 @@ You can move any of the monitoring stack components to specific nodes.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
+[source,terminal]
 ----
 $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 ----

--- a/modules/monitoring-setting-up-metrics-collection.adoc
+++ b/modules/monitoring-setting-up-metrics-collection.adoc
@@ -5,9 +5,9 @@
 [id="setting-up-metrics-collection_{context}"]
 = Setting up metrics collection
 
-To use the metrics exposed by your service, you need to configure OpenShift Monitoring to scrape metrics from the `/metrics` endpoint. You can do this using a ServiceMonitor, a custom resource definition (CRD) that specifies how a service should be monitored, or a PodMonitor, a CRD that specifies how a pod should be monitored. The former requires a Service object, while the latter does not, allowing Prometheus to directly scrape metrics from the metrics endpoint exposed by a Pod.
+To use the metrics exposed by your service, you need to configure OpenShift Monitoring to scrape metrics from the `/metrics` endpoint. You can do this using a `ServiceMonitor` custom resource definition (CRD) that specifies how a service should be monitored, or a `PodMonitor` CRD that specifies how a pod should be monitored. The former requires a `Service` object, while the latter does not, allowing Prometheus to directly scrape metrics from the metrics endpoint exposed by a Pod.
 
-This procedure shows how to create a ServiceMonitor for the service.
+This procedure shows how to create a `ServiceMonitor` resource for the service.
 
 .Prerequisites
 
@@ -15,9 +15,9 @@ This procedure shows how to create a ServiceMonitor for the service.
 
 .Procedure
 
-. Create a YAML file for the ServiceMonitor configuration. In this example, the file is called `example-app-service-monitor.yaml`.
+. Create a YAML file for the `ServiceMonitor` resource configuration. In this example, the file is called `example-app-service-monitor.yaml`.
 
-. Fill the file with the configuration for creating the ServiceMonitor:
+. Fill the file with the configuration for creating the `ServiceMonitor` resource:
 +
 [source,yaml]
 ----
@@ -42,20 +42,27 @@ This configuration makes OpenShift Monitoring scrape the metrics exposed by the 
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f example-app-service-monitor.yaml
 ----
 +
-It will take some time to deploy the ServiceMonitor.
+It will take some time to deploy the `ServiceMonitor` resource.
 
-. You can check that the ServiceMonitor is running:
+. You can check that the `ServiceMonitor` resource is running:
 +
+[source,terminal]
 ----
 $ oc -n ns1 get servicemonitor
+----
++
+.Example output
+[source,terminal]
+----
 NAME                         AGE
 prometheus-example-monitor   81m
 ----
 
 .Additional resources
 
-See the link:https://github.com/openshift/prometheus-operator/blob/release-4.3/Documentation/api.md[Prometheus Operator API documentation] for more information on ServiceMonitors and PodMonitors.
+See the link:https://github.com/openshift/prometheus-operator/blob/release-4.3/Documentation/api.md[Prometheus Operator API documentation] for more information on `ServiceMonitor` and `PodMonitor` resources.

--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -21,14 +21,14 @@ include::modules/monitoring-configuring-the-cluster-monitoring-stack.adoc[levelo
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 
 include::modules/monitoring-configurable-monitoring-components.adoc[leveloffset=+1]
 include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * See xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors] for more information about using node selectors.
 * See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint.
 
@@ -36,7 +36,7 @@ include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * See the xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[{product-title} documentation] on taints and tolerations.
 * See the link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes documentation] on taints and tolerations.
 
@@ -62,7 +62,7 @@ include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 * xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 

--- a/monitoring/monitoring-your-own-services.adoc
+++ b/monitoring/monitoring-your-own-services.adoc
@@ -20,7 +20,7 @@ include::modules/monitoring-enabling-monitoring-of-your-own-services.adoc[levelo
 
 .Additional resources
 
-* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 
 include::modules/monitoring-deploying-a-sample-service.adoc[leveloffset=+1]
 include::modules/monitoring-creating-a-role-for-setting-up-metrics-collection.adoc[leveloffset=+1]


### PR DESCRIPTION
Style updates to terminology in the Monitoring book for 4.4.
I also added `[source,terminal]` and `.Example output` in some places because the book was a mixed bag.

Updates to 4.5 will be handled in a separate PR. Updates to 4.6 and 4.7 were made in a separate [PR](https://github.com/openshift/openshift-docs/pull/27662) as there was a major overhaul of the Monitoring book in 4.6.