### PR TITLE
BZ 1906890 - Documentation refers to append-bootstrap.ign but the example of that file has been removed from the documentation

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -12,7 +12,6 @@ Before you install a cluster that contains user-provisioned infrastructure on VM
 .Prerequisites
 
 * Obtain the Ignition config files for your cluster.
-* Have access to an HTTP server that you can access from your computer and that the machines that you create can access.
 * Create a link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.vcenterhost.doc/GUID-B1018F28-3F14-4DFE-9B4B-F48BBDB72C10.html[vSphere cluster].
 
 .Procedure
@@ -34,7 +33,7 @@ $ base64 -w0 <installation_directory>/worker.ign > <installation_directory>/work
 +
 [source,terminal]
 ----
-$ base64 -w0 <installation_directory>/append-bootstrap.ign > <installation_directory>/append-bootstrap.64
+$ base64 -w0 <installation_directory>/bootstrap.ign > <installation_directory>/bootstrap.64
 ----
 +
 [IMPORTANT]
@@ -120,7 +119,7 @@ $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${
 +
 *** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*.
 *** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
-**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded Ignition config file for this machine type.
+**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded Ignition config file for this machine type. Note for the bootstrap node, the Ignition config file must be provided in `guestinfo.ignition.config.data` in the *Configuration Parameters* window. This is due to a restriction in the maximum size of data that can be provided in a vApp property.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
 *** Alternatively, prior to powering on the virtual machine, use vApp properties to:


### PR DESCRIPTION
Found an issue in https://bugzilla.redhat.com/show_bug.cgi?id=1906890 where `append-bootstrap.ign` is referenced but no details are given on how to create it.  In looking through the history of changes to the process we are intending for the ignition configuration for the bootstrap to be provided as a extra config.  An edit is provided in this pr to add a note to that effect.