### PR TITLE
Description on namespaces that users might want to change

### DIFF
--- a/modules/serverless-access-custom-domain.adoc
+++ b/modules/serverless-access-custom-domain.adoc
@@ -26,7 +26,8 @@ Hello OpenShift!
 ====
 You must substitute your own value for `<ingress-router-IP-or-hostname>`.
 Steps for finding this IP or hostname value may vary depending on your {product-title} provider.
-.Example command to find the ingress IP (valid for GCP, Azure, ...)
+
+Example command to find the ingress IP for GCP or Azure:
 [source,terminal]
 ----
 $ oc get svc -n openshift-ingress router-default -o jsonpath='{.status.loadBalancer.ingress[0].ip}'

--- a/modules/serverless-access-custom-domain.adoc
+++ b/modules/serverless-access-custom-domain.adoc
@@ -16,20 +16,21 @@ $ curl -H "Host: custom-ksvc-domain.example.com" \
     http://<ingress-router-IP-or-hostname>
 ----
 
++
+where `<ingress-router-IP-or-hostname>` is the IP address that the {product-title} ingress router is exposed to.
+. Obtain the ingress IP address or host name for the ingress router. This process varies depending on the platform that hosts the {product-title} cluster.
++
+For example, to find the IP address for GCP or Azure:
++
+[source,terminal]
+----
+$ oc get svc -n openshift-ingress router-default \
+    -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+----
++
+
 .Example output
 [source,terminal]
 ----
 Hello OpenShift!
 ----
-
-[NOTE]
-====
-You must substitute your own value for `<ingress-router-IP-or-hostname>`.
-Steps for finding this IP or hostname value may vary depending on your {product-title} provider.
-
-Example command to find the ingress IP for GCP or Azure:
-[source,terminal]
-----
-$ oc get svc -n openshift-ingress router-default -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
-----
-====

--- a/modules/serverless-access-custom-domain.adoc
+++ b/modules/serverless-access-custom-domain.adoc
@@ -12,15 +12,23 @@
 
 [source,terminal]
 ----
-$ curl -H "Host: custom-ksvc-domain.example.com" http://<ip_address>
+$ curl -H "Host: custom-ksvc-domain.example.com" \
+    http://<ingress-router-IP-or-hostname>
 ----
-
-+
-where `<ip_address>` is the IP address that the {product-title} ingress router is exposed to.
-+
 
 .Example output
 [source,terminal]
 ----
 Hello OpenShift!
 ----
+
+[NOTE]
+====
+You must substitute your own value for `<ingress-router-IP-or-hostname>`.
+Steps for finding this IP or hostname value may vary depending on your {product-title} provider.
+.Example command to find the ingress IP (valid for GCP, Azure, ...)
+[source,terminal]
+----
+$ oc get svc -n openshift-ingress router-default -o jsonpath='{.status.loadBalancer.ingress[0].ip}'
+----
+====

--- a/modules/serverless-service-mesh-enable-sidecar-injection.adoc
+++ b/modules/serverless-service-mesh-enable-sidecar-injection.adoc
@@ -17,7 +17,7 @@ You can add an annotation to the Service resource YAML file to enable sidecar in
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: hello-example-1
+  name: hello
 spec:
   template:
     metadata:

--- a/modules/serverless-service-mesh-resources.adoc
+++ b/modules/serverless-service-mesh-resources.adoc
@@ -7,7 +7,7 @@
 
 .Procedure
 
-. Create an Istio gateway, in your namespace, to accept traffic.
+. Create an Istio gateway in your namespace to accept traffic:
 .. Create a YAML file, and copy the following YAML into it:
 +
 
@@ -37,7 +37,7 @@ spec:
 $ oc apply -f <filename>
 ----
 
-. Create an Istio `VirtualService` object, in your namespace, to rewrite the host header.
+. Create an Istio `VirtualService` object in your namespace to rewrite the host header:
 .. Create a YAML file, and copy the following YAML into it:
 +
 

--- a/modules/serverless-service-mesh-resources.adoc
+++ b/modules/serverless-service-mesh-resources.adoc
@@ -7,7 +7,7 @@
 
 .Procedure
 
-. Create an Istio gateway to accept traffic.
+. Create an Istio gateway, in your namespace, to accept traffic.
 .. Create a YAML file, and copy the following YAML into it:
 +
 
@@ -37,7 +37,7 @@ spec:
 $ oc apply -f <filename>
 ----
 
-. Create an Istio `VirtualService` object to rewrite the host header.
+. Create an Istio `VirtualService` object, in your namespace, to rewrite the host header.
 .. Create a YAML file, and copy the following YAML into it:
 +
 

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -23,12 +23,14 @@ These options include setting custom domains, using TLS certificates, and using 
 apiVersion: maistra.io/v1
 kind: ServiceMeshMemberRoll
 metadata:
-  name: default
+  name: default <1>
   namespace: istio-system
 spec:
   members:
-    - default
+    - default <2>
 ----
+<1> A name of {ProductShortName} Member Roll object, that isn't connected to namespace from <2>
+<2> A list of namespaces you like to integrate {ServerlessProductName} with {ProductName}
 
 +
 [IMPORTANT]
@@ -62,7 +64,7 @@ apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
   name: allow-from-serving-system-namespace
-  namespace: default
+  namespace: default <1>
 spec:
   ingress:
   - from:
@@ -73,6 +75,7 @@ spec:
   policyTypes:
   - Ingress
 ----
+<1> NetworkPolicy must be created for every namespace used in {ProductShortName} Member Roll object
 
 .. Apply the NetworkPolicy resource:
 +

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -29,8 +29,8 @@ spec:
   members:
     - default <2>
 ----
-<1> A name of {ProductShortName} Member Roll object, that isn't connected to namespace from <2>
-<2> A list of namespaces you like to integrate {ServerlessProductName} with {ProductName}
+<1> The name of a {ProductShortName} `ServiceMeshMemberRoll` object that isn't connected to a namespace listed in the `spec` field.
+<2> A list of namespaces where {ServerlessProductName} will be integrated with {ProductName}.
 
 +
 [IMPORTANT]
@@ -75,7 +75,7 @@ spec:
   policyTypes:
   - Ingress
 ----
-<1> NetworkPolicy must be created for every namespace used in {ProductShortName} Member Roll object
+<1> You must create a network policy for every namespace in a `ServiceMeshMemberRoll` object.
 
 .. Apply the NetworkPolicy resource:
 +


### PR DESCRIPTION
While reviewing #27660 I found those shortcomings of TLS docs prerequisites.

Also, I propose to change the name of Kservice in `modules/serverless-service-mesh-enable-sidecar-injection.adoc` as we refer to `hello` service in custom domain doc.

/assign @abrennan89 