### PR TITLE
Monitoring term style updates for 4.5

### DIFF
--- a/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
+++ b/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
@@ -13,7 +13,7 @@ You can list existing alerting rules for your project.
 
 .Procedure
 
-. To list alerting rules in <project>, run:
+. To list alerting rules in a project, run:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
+++ b/modules/monitoring-accessing-prometheus-alertmanager-grafana-directly.adoc
@@ -38,6 +38,7 @@ prometheus-k8s      prometheus-k8s-openshift-monitoring.apps._url_.openshift.com
 +
 For example, this is the resulting URL for Alertmanager:
 +
+[source,text]
 ----
 https://alertmanager-main-openshift-monitoring.apps._url_.openshift.com
 ----

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -15,7 +15,7 @@ You can assign tolerations to any of the monitoring stack components to enable m
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-configurable-monitoring-components.adoc
+++ b/modules/monitoring-configurable-monitoring-components.adoc
@@ -5,7 +5,7 @@
 [id="configurable-monitoring-components_{context}"]
 = Configurable monitoring components
 
-This table shows the monitoring components you can configure and the keys used to specify the components in the ConfigMap:
+This table shows the monitoring components you can configure and the keys used to specify the components in the config map:
 
 .Configurable monitoring components
 [options="header"]
@@ -23,4 +23,3 @@ This table shows the monitoring components you can configure and the keys used t
 |====
 
 From this list, only Prometheus and Alertmanager have extensive configuration options. All other components usually provide only the `nodeSelector` field for being deployed on a specified node.
-

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -15,7 +15,7 @@ For the Prometheus or Alertmanager to use a persistent volume (PV), you first mu
 
 .Procedure
 
-. Edit the `cluster-monitoring-config` ConfigMap:
+. Edit the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-cluster-monitoring-stack.adoc
@@ -5,17 +5,17 @@
 [id="configuring-the-cluster-monitoring-stack_{context}"]
 = Configuring the cluster monitoring stack
 
-You can configure the Prometheus Cluster Monitoring stack using ConfigMaps. ConfigMaps configure the Cluster Monitoring Operator, which in turn configures components of the stack.
+You can configure the Prometheus Cluster Monitoring stack using config maps. Config maps configure the Cluster Monitoring Operator, which in turn configures components of the stack.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the OpenShift CLI (oc).
-* You have created the `cluster-monitoring-config` ConfigMap object.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----
@@ -39,7 +39,7 @@ data:
 +
 Substitute `<component>` and `<configuration_for_the_component>` accordingly.
 +
-For example, create this ConfigMap to configure a Persistent Volume Claim (PVC) for Prometheus:
+For example, create this `ConfigMap` object to configure a Persistent Volume Claim (PVC) for Prometheus:
 +
 [source,yaml,subs=quotes]
 ----

--- a/modules/monitoring-creating-a-role-for-setting-up-metrics-collection.adoc
+++ b/modules/monitoring-creating-a-role-for-setting-up-metrics-collection.adoc
@@ -29,6 +29,7 @@ This role enables a user to set up metrics collection for services.
 
 . Apply the configuration file to the cluster:
 +
+[source,terminal]
 ----
 $ oc apply -f custom-metrics-role.yaml
 ----

--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -3,9 +3,9 @@
 // * monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
 
 [id="creating-cluster-monitoring-configmap_{context}"]
-= Creating a cluster monitoring ConfigMap
+= Creating a cluster monitoring config map
 
-To configure the {product-title} monitoring stack, you must create the cluster monitoring ConfigMap.
+To configure the {product-title} monitoring stack, you must create the cluster monitoring `ConfigMap` object.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ To configure the {product-title} monitoring stack, you must create the cluster m
 $ oc -n openshift-monitoring get configmap cluster-monitoring-config
 ----
 
-. If the ConfigMap does not exist:
+. If the `ConfigMap` object does not exist:
 .. Create the following YAML manifest. In this example the file is called `cluster-monitoring-config.yaml`:
 +
 [source,yaml]
@@ -35,7 +35,7 @@ data:
   config.yaml: |
 ----
 +
-.. Apply the configuration to create the ConfigMap:
+.. Apply the configuration to create the `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
+++ b/modules/monitoring-enabling-monitoring-of-your-own-services.adoc
@@ -5,17 +5,17 @@
 [id="enabling-monitoring-of-your-own-services_{context}"]
 = Enabling monitoring of your own services
 
-You can enable monitoring your own services by setting the `techPreviewUserWorkload/enabled` flag in the cluster monitoring ConfigMap.
+You can enable monitoring your own services by setting the `techPreviewUserWorkload/enabled` flag in the cluster monitoring config map.
 
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
 * You have installed the OpenShift CLI (oc).
-* You have created the `cluster-monitoring-config` ConfigMap object.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----
@@ -24,6 +24,7 @@ $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 
 . Set the `techPreviewUserWorkload` setting to `true` under `data/config.yaml`:
 +
+[source,yaml]
 ----
 apiVersion: v1
 kind: ConfigMap
@@ -38,7 +39,7 @@ data:
 
 . Save the file to apply the changes. Monitoring your own services is enabled automatically.
 
-. Optional: You can check that the `prometheus-user-workload` Pods were created:
+. Optional: You can check that the `prometheus-user-workload` pods were created:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-granting-user-permissions-using-cli.adoc
+++ b/modules/monitoring-granting-user-permissions-using-cli.adoc
@@ -7,31 +7,32 @@
 
 This procedure shows how to grant users permissions for monitoring their own services using the CLI.
 
+[IMPORTANT]
+====
+Whichever role you choose, you must bind it against a specific namespace.
+====
+
 .Prerequisites
 
+* You have access to the cluster as a user with the cluster-admin role.
 * Have a user created.
 * Log in using the `oc` command.
 
 .Procedure
 
-* Run this command to assign <role> to <user> in <namespace>:
+* Run this command to assign a role to a user in a defined namespace:
 +
 [source,terminal]
 ----
 $ oc policy add-role-to-user <role> <user> -n <namespace>
 ----
 +
-Substitute <role> with `monitoring-rules-view`, `monitoring-rules-edit`, or `monitoring-edit`.
+Substitute `<role>` with `monitoring-rules-view`, `monitoring-rules-edit`, or `monitoring-edit`.
 +
 --
-** `monitoring-rules-view` allows reading PrometheusRule custom resources within the namespace.
-** `monitoring-rules-edit` allows creating, modifying, and deleting PrometheusRule custom resources matching the permitted namespace.
-** `monitoring-edit` gives the same permissions as `monitoring-rules-edit`. Additionally, it allows creating new scraping targets for services or Pods. It also allows creating, modifying, and deleting ServiceMonitors and PodMonitors.
+** `monitoring-rules-view` allows reading `PrometheusRule` custom resources within the namespace.
+** `monitoring-rules-edit` allows creating, modifying, and deleting `PrometheusRule` custom resources matching the permitted namespace.
+** `monitoring-edit` gives the same permissions as `monitoring-rules-edit`. Additionally, it allows creating scraping targets for services or pods. It also allows creating, modifying, and deleting `ServiceMonitor` and `PodMonitor` resources.
 --
 +
-[IMPORTANT]
-====
-Whichever role you choose, you must bind it against a specific namespace as a cluster administrator.
-====
-+
-As an example, substitute <role> with `monitoring-edit`, <user> with `johnsmith`, and <namespace> with `ns1`. This assigns to user `johnsmith` the permissions for setting up metrics collection and creating alerting rules in the `ns1` namespace.
+As an example, substitute the role with `monitoring-edit`, the user with `johnsmith`, and the namespace with `ns1`. This assigns to user `johnsmith` the permissions for setting up metrics collection and creating alerting rules in the `ns1` namespace.

--- a/modules/monitoring-granting-user-permissions-using-web-console.adoc
+++ b/modules/monitoring-granting-user-permissions-using-web-console.adoc
@@ -21,9 +21,9 @@ This procedure shows how to grant users permissions for monitoring their own ser
 . In *Role Name*, enter `monitoring-rules-view`, `monitoring-rules-edit`, or `monitoring-edit`.
 +
 --
-** `monitoring-rules-view` allows reading PrometheusRule custom resources within the namespace.
-** `monitoring-rules-edit` allows creating, modifying, and deleting PrometheusRule custom resources matching the permitted namespace.
-** `monitoring-edit` gives the same permissions as `monitoring-rules-edit`. Additionally, it allows creating new scraping targets for services or Pods. It also allows creating, modifying, and deleting ServiceMonitors and PodMonitors.
+** `monitoring-rules-view` allows reading `PrometheusRule` custom resources within the namespace.
+** `monitoring-rules-edit` allows creating, modifying, and deleting `PrometheusRule` custom resources matching the permitted namespace.
+** `monitoring-edit` gives the same permissions as `monitoring-rules-edit`. Additionally, it allows creating scraping targets for services or pods. It also allows creating, modifying, and deleting `ServiceMonitor` and `PodMonitor` resources.
 --
 +
 [IMPORTANT]

--- a/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-for-prometheus-metrics-data.adoc
@@ -15,7 +15,7 @@ By default, the Prometheus Cluster Monitoring stack configures the retention tim
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -15,7 +15,7 @@ You can move any of the monitoring stack components to specific nodes.
 
 .Procedure
 
-. Start editing the `cluster-monitoring-config` ConfigMap:
+. Start editing the `cluster-monitoring-config` `ConfigMap` object:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-removing-alerting-rules.adoc
+++ b/modules/monitoring-removing-alerting-rules.adoc
@@ -13,7 +13,7 @@ You can remove an alerting rule.
 
 .Procedure
 
-* To remove rule <foo> in <namespace>, run:
+* To remove a rule in a namespace, run:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-setting-up-metrics-collection.adoc
+++ b/modules/monitoring-setting-up-metrics-collection.adoc
@@ -5,9 +5,9 @@
 [id="setting-up-metrics-collection_{context}"]
 = Setting up metrics collection
 
-To use the metrics exposed by your service, you must configure OpenShift Monitoring to scrape metrics from the `/metrics` endpoint. You can do this using a ServiceMonitor, which is a custom resource definition (CRD) that specifies how a service should be monitored, or a PodMonitor, which is a CRD that specifies how a Pod should be monitored. The former requires a Service object, while the latter does not, allowing Prometheus to directly scrape metrics from the metrics endpoint exposed by a Pod.
+To use the metrics exposed by your service, you must configure OpenShift Monitoring to scrape metrics from the `/metrics` endpoint. You can do this by using a `ServiceMonitor` custom resource definition (CRD) that specifies how to monitor a service or a `PodMonitor` CRD that specifies how to monitor a pod. The former requires a `Service` object, while the latter does not, which allows Prometheus to directly scrape metrics from the metrics endpoint exposed by a pod.
 
-This procedure shows how to create a ServiceMonitor for the service.
+This procedure shows how to create a `ServiceMonitor` resource for the service.
 
 .Prerequisites
 
@@ -15,9 +15,9 @@ This procedure shows how to create a ServiceMonitor for the service.
 
 .Procedure
 
-. Create a YAML file for the ServiceMonitor configuration. In this example, the file is called `example-app-service-monitor.yaml`.
+. Create a YAML file for the `ServiceMonitor` resource configuration. In this example, the file is called `example-app-service-monitor.yaml`.
 
-. Fill the file with the configuration for creating the ServiceMonitor:
+. Fill the file with the configuration for creating the `ServiceMonitor` resource:
 +
 [source,yaml]
 ----
@@ -47,9 +47,9 @@ This configuration makes OpenShift Monitoring scrape the metrics exposed by the 
 $ oc apply -f example-app-service-monitor.yaml
 ----
 +
-It will take some time to deploy the ServiceMonitor.
+It will take some time to deploy the `ServiceMonitor` resource.
 
-. You can check that the ServiceMonitor is running:
+. You can check that the `ServiceMonitor` resource is running:
 +
 [source,terminal]
 ----
@@ -65,4 +65,4 @@ prometheus-example-monitor   81m
 
 .Additional resources
 
-See the link:https://github.com/openshift/prometheus-operator/blob/release-4.5/Documentation/api.md[Prometheus Operator API documentation] for more information on ServiceMonitors and PodMonitors.
+See the link:https://github.com/openshift/prometheus-operator/blob/release-4.5/Documentation/api.md[Prometheus Operator API documentation] for more information on `ServiceMonitor` and `PodMonitor` resources.

--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -21,14 +21,14 @@ include::modules/monitoring-configuring-the-cluster-monitoring-stack.adoc[levelo
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 
 include::modules/monitoring-configurable-monitoring-components.adoc[leveloffset=+1]
 include::modules/monitoring-moving-monitoring-components-to-different-nodes.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * See xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors] for more information about using node selectors.
 * See the link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#nodeselector[Kubernetes documentation] for details on the `nodeSelector` constraint.
 
@@ -36,7 +36,7 @@ include::modules/monitoring-assigning-tolerations-to-monitoring-components.adoc[
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * See the xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[{product-title} documentation] on taints and tolerations.
 * See the link:https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/[Kubernetes documentation] on taints and tolerations.
 
@@ -62,7 +62,7 @@ include::modules/monitoring-modifying-retention-time-for-prometheus-metrics-data
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 * xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage]
 * xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
 
@@ -91,7 +91,7 @@ include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-
 
 .Additional resources
 
-* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 
 == Next steps
 

--- a/monitoring/monitoring-your-own-services.adoc
+++ b/monitoring/monitoring-your-own-services.adoc
@@ -20,7 +20,7 @@ include::modules/monitoring-enabling-monitoring-of-your-own-services.adoc[levelo
 
 .Additional resources
 
-* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring ConfigMap] to learn how to create the `cluster-monitoring-config` ConfigMap object.
+* See xref:../monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc#creating-cluster-monitoring-configmap_configuring-monitoring[Creating a cluster monitoring config map] to learn how to create the `cluster-monitoring-config` `ConfigMap` object.
 
 include::modules/monitoring-deploying-a-sample-service.adoc[leveloffset=+1]
 include::modules/monitoring-granting-user-permissions-using-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
Style updates to terminology in the Monitoring book for 4.5.

Updates to 4.4 were handled in a separate [PR](https://github.com/openshift/openshift-docs/pull/28057). Updates to 4.6 and 4.7 were made in a separate [PR](https://github.com/openshift/openshift-docs/pull/27662) as there was a major overhaul of the Monitoring book in 4.6.