### PR TITLE
Update after PR27394 to re-add bootstrap ignition config file

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -14,13 +14,49 @@ To install {product-title} on user-provisioned infrastructure on VMware vSphere,
 
 .Prerequisites
 
-* Obtain the Ignition config files for your cluster.
-* Create a link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.vcenterhost.doc/GUID-B1018F28-3F14-4DFE-9B4B-F48BBDB72C10.html[vSphere cluster].
+* You have obtained the Ignition config files for your cluster.
+* You have access to an HTTP server that you can access from your computer and that the machines that you create can access.
+* You have created a link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.vcenterhost.doc/GUID-B1018F28-3F14-4DFE-9B4B-F48BBDB72C10.html[vSphere cluster].
 
 .Procedure
 
-. Convert the control plane, compute, and bootstrap Ignition config files to Base64 encoding.
-
+. Upload the bootstrap Ignition config file, which is named `<installation_directory>/bootstrap.ign`, that the installation program created to your HTTP server. Note the URL of this file.
++
+. Save the following secondary Ignition config file for your bootstrap node to your computer as `<installation_directory>/merge-bootstrap.ign`:
++
+[source,text]
+----
+{
+  "ignition": {
+    "config": {
+      "merge": [
+        {
+          "source": "<bootstrap_ignition_config_url>", <1>
+          "verification": {}
+        }
+      ]
+    },
+    "timeouts": {},
+    "version": "3.2.0"
+  },
+  "networkd": {},
+  "passwd": {},
+  "storage": {},
+  "systemd": {}
+}
+----
++
+<1> Specify the URL of the bootstrap Ignition config file that you hosted.
++
+When you create the virtual machine (VM) for the bootstrap machine, you use this Ignition config file.
++
+. Locate the following Ignition config files that the installation program created:
++
+* `<installation_directory>/master.ign`
+* `<installation_directory>/worker.ign`
+* `<installation_directory>/merge-bootstrap.ign`
++
+. Convert the Ignition config files to Base64 encoding. Later in this procedure, you must add these files to the extra configuration parameter `guestinfo.ignition.config.data` in your VM.
 +
 For example, if you use a Linux operating system, you can use the `base64` command to encode the files.
 +
@@ -36,7 +72,7 @@ $ base64 -w0 <installation_directory>/worker.ign > <installation_directory>/work
 +
 [source,terminal]
 ----
-$ base64 -w0 <installation_directory>/bootstrap.ign > <installation_directory>/bootstrap.64
+$ base64 -w0 <installation_directory>/merge-bootstrap.ign > <installation_directory>/merge-bootstrap.64
 ----
 +
 [IMPORTANT]
@@ -129,13 +165,9 @@ $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${
 +
 *** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*.
 *** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
-**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded Ignition config file for this machine type. Note for the bootstrap node, the Ignition config file must be provided in `guestinfo.ignition.config.data` in the *Configuration Parameters* window. This is due to a restriction in the maximum size of data that can be provided in a vApp property.
+**** `guestinfo.ignition.config.data`: Locate the base-64 encoded files that you created previously in this procedure, and paste the contents of the base64-encoded Ignition config file for this machine type.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
-*** Alternatively, prior to powering on the virtual machine, use vApp properties to:
-**** Navigate to a virtual machine from the vCenter Server inventory.
-**** On the *Configure* tab, expand *Settings* and select *vApp options.*
-**** Scroll down and under *Properties*, apply the configurations that you just edited.
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 .. Complete the configuration and power on the VM.


### PR DESCRIPTION
**Edit (9/22/21):** This PR should address recent issues reported in https://bugzilla.redhat.com/show_bug.cgi?id=1906890.

**PREVIEW BUILD LINK:** https://deploy-preview-28106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.html#installation-vsphere-machines_installing-restricted-networks-vmc-user-infra

In https://github.com/openshift/openshift-docs/pull/27394, we removed a couple of steps about uploading the `bootstrap.ign` file to the http server based on dev comments that this was no longer necessary [1],[2]. But this seems to only apply in install-provisioned and not user-provisioned installs, so this probably should not have changed. 

In this PR, I'm adding the steps back in, slightly reworded for clarity and to account for @dav1x 's comment that these steps aren't necessary if you store the bootstrap ignition in the VM's extra config properties [2].

~~Also, this PR updates the instructions to use `Ignition spec 3.1.0` in OCP 4.6 and up by replacing `append` with `merge` in the command examples [3].F~~

[1] https://github.com/openshift/openshift-docs/pull/27394#discussion_r526327784
[2] https://github.com/openshift/openshift-docs/pull/27394#discussion_r537834967
[3] https://github.com/RedHatOfficial/ocp4-vsphere-upi-automation/issues/49

~~Once this is approved and merged, separate PRs should be created against enterprise-4.5 and enterprise-4.4 to use similar wording (although without the `merge` wording update for `Ignition spec 3.1.0`)~~. 💫 

**Edit:** The `ignition.config.merge` portion of this PR was removed when the step to create a secondary Ignition config file was removed [here](https://github.com/openshift/openshift-docs/pull/27394/files#diff-0180108d51ee983e7a96405a2e19b7bde93377496523b317c727d1f89a6f2f24L30-L80).