### PR TITLE
Fix typos from CP error

### DIFF
--- a/modules/cluster-logging-manual-rollout-rolling.adoc
+++ b/modules/cluster-logging-manual-rollout-rolling.adoc
@@ -45,7 +45,7 @@ For example:
 +
 [source,terminal]
 ----
-$ oc exec -c elasticsearch-cdm-5ceex6ts-1-dcd6c4c7c-jpw6  -c elasticsearch -- es_util es_util --query="_flush/synced" -XPOST
+$ oc exec -c elasticsearch-cdm-5ceex6ts-1-dcd6c4c7c-jpw6  -c elasticsearch -- es_util --query="_flush/synced" -XPOST
 ----
 +
 .Example output
@@ -75,7 +75,7 @@ $ oc exec elasticsearch-cdm-5ceex6ts-1-dcd6c4c7c-jpw6 -c elasticsearch -- es_uti
 {"acknowledged":true,"persistent":{"cluster":{"routing":{"allocation":{"enable":"primaries"}}}},"transient":
 ----
 
-. After complete, for each deployment you have for an ES cluster:
+. After the command is complete, for each deployment you have for an ES cluster:
 
 .. By default, the {product-title} Elasticsearch cluster blocks rollouts to their nodes. Use the following command to allow rollouts
 and allow the pod to pick up the changes:
@@ -105,7 +105,7 @@ move on to the next deployment.
 $ oc get pods | grep elasticsearch-
 ----
 +
-.Example outputs
+.Example output
 [source,terminal]
 ----
 NAME                                            READY   STATUS    RESTARTS   AGE
@@ -114,7 +114,7 @@ elasticsearch-cdm-5ceex6ts-2-f799564cb-l9mj7    2/2     Running   0          22h
 elasticsearch-cdm-5ceex6ts-3-585968dc68-k7kjr   2/2     Running   0          22h
 ----
 
-.. After complete, reset the pod to disallow rollouts:
+.. After the deployments are complete, reset the pod to disallow rollouts:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
When fixing cherrypick errors, I noticed a few typos in the original PR that I missed. 