### PR TITLE
BZ#1853249 allocating node resources

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -625,8 +625,6 @@ Topics:
 - Name: Setting Multi-Project Quotas
   File: multiproject_quota
   Distros: openshift-origin,openshift-enterprise
-- Name: Setting Limit Ranges
-  File: limits
 - Name: Pruning objects
   File: pruning_resources
   Distros: openshift-origin,openshift-enterprise
@@ -639,17 +637,19 @@ Topics:
 - Name: Allocating Node Resources
   File: allocating_node_resources
   Distros: openshift-origin,openshift-enterprise,atomic-*
-- Name: Node Problem Detector
-  File: node_problem_detector
-  Distros: openshift-origin,openshift-enterprise
 - Name: Overcommitting
   File: overcommit
   Distros: openshift-origin,openshift-enterprise
-- Name: Assigning Unique External IPs for Ingress Traffic
-  File: tcp_ingress_external_ports
-  Distros: openshift-origin,openshift-enterprise
 - Name: Out of Resource Handling
   File: out_of_resource_handling
+  Distros: openshift-origin,openshift-enterprise
+- Name: Setting Limit Ranges
+  File: limits
+- Name: Node Problem Detector
+  File: node_problem_detector
+  Distros: openshift-origin,openshift-enterprise
+- Name: Assigning Unique External IPs for Ingress Traffic
+  File: tcp_ingress_external_ports
   Distros: openshift-origin,openshift-enterprise
 - Name: Monitoring and Debugging Routers
   File: router

--- a/admin_guide/allocating_node_resources.adoc
+++ b/admin_guide/allocating_node_resources.adoc
@@ -11,76 +11,72 @@
 
 toc::[]
 
-== Overview
+== Purpose for Allocating Node Resources
 
 To provide more reliable scheduling and minimize node resource overcommitment,
-each node can reserve a portion of its resources for use by all underlying
-xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[node
-components] (e.g., kubelet, kube-proxy, Docker) and the remaining system
-components (e.g., *sshd*, *NetworkManager*) on the host. Once specified, the
-scheduler has more information about the resources (e.g., memory, CPU) a node
-has allocated for pods.
+reserve a portion of the CPU and memory resources for use by the underlying xref:../architecture/infrastructure_components/kubernetes_infrastructure.adoc#node[node components] such as kubelet, kube-proxy, and the container engine. The resources that you reserve are also used by the remaining system components such as *sshd*, *NetworkManager*, and so on. Specifying the resources to reserve provides the scheduler with more information about the remaining memory and CPU resources that a node has available for use by pods.
 
 [[allocating-node-settings]]
 == Configuring Nodes for Allocated Resources
 
-Resources reserved for node components are based on two node settings: `kube-reserved` and `system-reserved`.
+Resources are reserved for node components and system components in {product-title} by configuring the `system-reserved` node setting.
 
-You can use the `kube-reserved` setting to reserve a portion of memory dedicated for kubelet and the `system-reserved` setting for the rest of the system processes. 
+{product-title} does not use the `kube-reserved` setting. Documentation for Kubernetes and some cloud vendors that provide a Kubernetes environment might suggest configuring `kube-reserved`. That information does not apply to an {product-title} cluster.
 
-[NOTE]
-====
-Use caution when setting these parameters. Enforcing `kube-reserved` and `system-reserved` limits
-can lead to critical system services on that node being starved of CPU or OOM killed. For more information
-on the effects of these settings, see xref:computing-allocated-resources[Computing Allocated Resources].
-====
+Use caution when you tune your cluster with resource limits and enforcing limits with evictions. Enforcing `system-reserved` limits can prevent critical system services from receiving CPU time or ending the critical system services when memory resources run low.
+
+In most cases, tuning resource allocation is performed by making an adjustment and then monitoring the cluster performance with a production-like workload. That process is repeated until the cluster is stable and meets service-level agreements.
+
+For more information on the effects of these settings, see xref:computing-allocated-resources[Computing Allocated Resources].
 
 [options="header",cols="1,2"]
 |===
 
 |Setting |Description
 
-|`*kube-reserved*`
-| Resources reserved for node resources, such as kubelet, the Docker daemon, SkyDNS, and kube-proxy. Default is none.
+|`kube-reserved`
+| This setting is not used with {product-title}. Add the CPU and memory resources that you planned to reserve to `system-reserved` setting.
 
-|`*system-reserved*`
-| Resources reserved for the remaining system components. Default is none.
+|`system-reserved`
+| Resources that are reserved for the node components and system components. Default is none.
 |===
 
-You can see which services are controlled by `system-reserved`  with a tool such as libcgroup:
+View the services that are controlled by `system-reserved` with a tool such as `lscgroup` by running the following commands:
 
 [source,terminal]
 ----
-$ yum install libcgroup-tools 
+# yum install libcgroup-tools
+----
+
+[source,terminal]
+----
 $ lscgroup memory:/system.slice
 ----
 
-You can set these in the `*kubeletArguments*` section of the
+Reserve resources in the `kubeletArguments` section of the
 xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node
-configuration map] by using a set of `<resource_type>=<resource_quantity>` pairs 
-(e.g., *cpu=200m,memory=512Mi*). Add the section if it does not already exist:
+configuration map] by adding a set of `<resource_type>=<resource_quantity>` pairs. For example, `cpu=500m,memory=1Gi` reserves 500 millicores of CPU and one gigabyte of memory.
 
-.Node Allocatable Resources Settings
+.Node-Allocatable Resources Settings
 ====
 [source,yaml]
 ----
 kubeletArguments:
-  kube-reserved:
-    - "cpu=200m,memory=512Mi"
   system-reserved:
-    - "cpu=200m,memory=512Mi"
+    - "cpu=500m,memory=1Gi"
 ----
 ====
+
+Add the `system-reserved` field if it does not exist.
 
 [NOTE]
 ====
 Do not edit the `node-config.yaml` file directly.
-==== 
+====
 
-To determine appropriate values for these settings, determine a node's resource usage using the node summary API.
-For more information, see xref:system-resources-reported-by-node[System Resources Reported by Node].
+To determine appropriate values for these settings, view the resource usage of a node by using the node summary API. For more information, see xref:system-resources-reported-by-node[System Resources Reported by Node].
 
-After setting `kube-reserved` and `system-reserved`: 
+After you set `system-reserved`:
 
 * Monitor the memory usage of a node for high-water marks:
 +
@@ -99,19 +95,23 @@ USER       PID   %CPU  %MEM  VSZ     RSS  TTY    STAT  START  TIME  COMMAND
 root       11089 11.5  0.3   112712  996  pts/1  R+    16:23  0:00  grep --color=auto atomic-openshift-node
 ----
 +
-If this value is close to your `kube-reserved` mark, you can increase the `kube-reserved` value. 
+If this value is close to your `system-reserved` mark, you can increase the `system-reserved` value.
 
-* Monitor the memory usage of system services with a tool such as libcgroup:
+* Monitor the memory usage of system services with a tool such as `cgget` by running the following commands:
 +
 [source,terminal]
 ----
-$ yum install libcgroup-tools
+# yum install libcgroup-tools
+----
++
+[source,terminal]
+----
 $ cgget -g memory  /system.slice | grep memory.usage_in_bytes
 ----
 +
-If this value is close to your `system-reserved` mark, you can increase the `system-reserved` value. 
+If this value is close to your `system-reserved` mark, you can increase the `system-reserved` value.
 
-* Use the {product-title} xref:../scaling_performance/using_cluster_loader.html#scaling-performance-using-cluster-loader[Cluster Loader]
+* Use the {product-title} xref:../scaling_performance/using_cluster_loader.html#scaling-performance-using-cluster-loader[cluster loader]
 to measure performance metrics of your deployment at various cluster states.
 
 [[computing-allocated-resources]]
@@ -120,35 +120,35 @@ to measure performance metrics of your deployment at various cluster states.
 An allocated amount of a resource is computed based on the following formula:
 
 ----
-[Allocatable] = [Node Capacity] - [kube-reserved] - [system-reserved] - [Hard-Eviction-Thresholds]
+[Allocatable] = [Node Capacity] - [system-reserved] - [Hard-Eviction-Thresholds]
 ----
 
 [NOTE]
 ====
-The withholding of `Hard-Eviction-Thresholds` from allocatable is a change in behavior to improve
-system reliability now that allocatable is enforced for end-user pods at the node level.
-The `*experimental-allocatable-ignore-eviction*` setting is available to preserve legacy behavior,
-but it will be deprecated in a future release.
+The withholding of `Hard-Eviction-Thresholds` from allocatable improves system reliability because the value for allocatable is enforced for pods at the node level. The `experimental-allocatable-ignore-eviction` setting is available to preserve legacy behavior, but it will be deprecated in a future release.
 ====
 
-
-If `[Allocatable]` is negative, it is set to *0*.
+If `[Allocatable]` is negative, it is set to `0`.
 
 [[viewing-node-allocatable-resources-and-capacity]]
-== Viewing Node Allocatable Resources and Capacity
+== Viewing Node-Allocatable Resources and Capacity
 
-To see a node's current capacity and allocatable resources, you can run:
+To view the current capacity and allocatable resources for a node, run the following command:
 
-====
 [source,terminal]
 ----
 $ oc get node/<node_name> -o yaml
-...
+----
+
+In the following partial output, the allocatable values are less than the capacity. The difference is expected and matches a `cpu=500m,memory=1Gi` resource allocation for `system-reserved`.
+
+[source,yaml]
+----
 status:
 ...
   allocatable:
-    cpu: "4"
-    memory: 8010948Ki
+    cpu: "3500m"
+    memory: 6857952Ki
     pods: "110"
   capacity:
     cpu: "4"
@@ -156,21 +156,25 @@ status:
     pods: "110"
 ...
 ----
-====
+
+The scheduler uses the values for `allocatable` to decide if a node is a candidate for pod scheduling.
 
 [[system-resources-reported-by-node]]
 == System Resources Reported by Node
 
-Each node reports system resources utilized by the container runtime and kubelet.
-To better aid your ability to configure `*--system-reserved*` and `*--kube-reserved*`,
-you can determine a node's resource usage using the node summary API,
-which is accessible at *_<master>/api/v1/nodes/<node>/proxy/stats/summary_*.
+Each node reports the system resources that are used by the container runtime and kubelet. To simplify configuring `system-reserved`, view the resource usage for the node by using the node summary API. The node summary is available at `<master>/api/v1/nodes/<node>/proxy/stats/summary`.
 
-For instance, to access the resources from *cluster.node22* node, you can run:
+For instance, to access the resources from *cluster.node22* node, run the following command:
 
 [source,terminal]
 ----
 $ curl <certificate details> https://<master>/api/v1/nodes/cluster.node22/proxy/stats/summary
+----
+
+The response includes information that is similar to the following:
+
+[source,json]
+----
 {
     "node": {
         "nodeName": "cluster.node22",
@@ -207,21 +211,13 @@ $ curl <certificate details> https://<master>/api/v1/nodes/cluster.node22/proxy/
 See xref:../rest_api/index.adoc#rest-api-index[REST API Overview] for more details about certificate details.
 
 [[node-enforcement-1]]
-== Node enforcement
+== Node Enforcement
 
-The node is able to limit the total amount of resources that pods
-may consume based on the configured allocatable value.  This feature significantly
-improves the reliability of the node by preventing pods from starving
-system services (for example: container runtime, node agent, etc.) for resources.
-It is strongly encouraged that administrators reserve
-resources based on the desired node utilization target
-in order to improve node reliability.
+The node is able to limit the total amount of resources that pods can consume based on the configured allocatable value. This feature significantly improves the reliability of the node by preventing pods from using CPU and memory resources that are needed by system services such as the container runtime and node agent. To improve node reliability, administrators should reserve resources based on a target for resource use.
 
-The node enforces resource constraints using a new cgroup hierarchy
-that enforces quality of service.  All pods are launched in a
-dedicated cgroup hierarchy separate from system daemons.
+The node enforces resource constraints using a new cgroup hierarchy that enforces quality of service. All pods are launched in a dedicated cgroup hierarchy that is separate from system daemons.
 
-To configure node enforcement, use the following parameters in the 
+To configure node enforcement, use the following parameters in the
 appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map].
 
 .Node Cgroup Settings
@@ -236,44 +232,25 @@ kubeletArguments:
   enforce-node-allocatable:
     - "pods" <3>
 ----
-<1> Enable or disable the new cgroup hierarchy managed by the node.  Any change
-of this setting requires a full drain of the node.  This flag must be true to allow the node to
-enforce node allocatable.  We do not recommend users change this value.
-<2> The cgroup driver used by the node when managing cgroup hierarchies.  This
-value must match the driver associated with the container runtime.  Valid values
-are `systemd` and `cgroupfs`.  The default is `systemd`.
-<3> A comma-delimited list of scopes for where the node should enforce node
-resource constraints.  Valid values are `pods`, `system-reserved`, and `kube-reserved`.
-The default is `pods`.  We do not recommend users change this value.
+<1> Enable or disable a cgroup hierarchy for each quality of service. The cgroups are managed by the node. Any change of this setting requires a full drain of the node. This flag must be `true` to enable the node to enforce the node-allocatable resource constraints. The default value is `true` and Red Hat does not recommend that customers change this value.
+
+<2> The cgroup driver that is used by the node to manage the cgroup hierarchies. This value must match the driver that is associated with the container runtime. Valid values are `systemd` and `cgroupfs`, but Red Hat supports `systemd` only.
+
+<3> A comma-delimited list of scopes for where the node should enforce node resource constraints. The default value is `pods` and Red Hat supports `pods` only.
 ====
 
-Optionally, the node can be made to enforce kube-reserved and system-reserved by
-specifying those tokens in the enforce-node-allocatable flag.  If specified, the
-corresponding `--kube-reserved-cgroup` or `--system-reserved-cgroup` needs to be provided.
-In future releases, the node and container runtime will be packaged in a common cgroup
-separate from `system.slice`.  Until that time, we do not recommend users
-change the default value of enforce-node-allocatable flag.
+Administrators should treat system daemons similar to pods that have a guaranteed quality of service. System daemons can burst within their bounding control groups and this behavior must be managed as part of cluster deployments. Reserve CPU and memory resources for system daemons by specifying the resources in `system-reserved` as shown in section xref:allocating-node-settings[Configuring Nodes for Allocated Resources].
 
-Administrators should treat system daemons similar to Guaranteed pods.  System daemons
-can burst within their bounding control groups and this behavior needs to be managed
-as part of cluster deployments.  Enforcing system-reserved limits
-can lead to critical system services on that node being starved of CPU or OOM killed. The
-recommendation is to enforce system-reserved only if operators have profiled their nodes
-exhaustively to determine precise estimates and are confident in their ability to
-recover if any process in that group is OOM killed.
+To view the cgroup driver that is set, run the following command:
 
-As a result, we strongly recommended that users only enforce node allocatable for
-`pods` by default, and set aside appropriate reservations for system daemons to maintain
-overall node reliability.
-
-You can verify which cgroup driver is set using the following command:
-
+[source,terminal]
 ----
 $ systemctl status atomic-openshift-node -l | grep cgroup-driver=
 ----
 
-The output includes a response similar to the following:
+The output includes a response that is similar to the following:
 
+[source,terminal]
 ----
 --cgroup-driver=systemd
 ----
@@ -283,48 +260,12 @@ For more information on managing and troubleshooting cgroup drivers, see link:ht
 [[eviction-thresholds-1]]
 == Eviction Thresholds
 
-If a node is under memory pressure, it can impact the entire node and all pods running on
-it.  If a system daemon is using more than its reserved amount of memory, an OOM
-event may occur that can impact the entire node and all pods running on it.  To avoid
-(or reduce the probability of) system OOMs the node
-provides xref:../admin_guide/out_of_resource_handling.adoc#admin-guide-handling-out-of-resource-errors[Out Of Resource Handling].
+If a node is under memory pressure, it can impact the entire node and all pods running on it. If a system daemon uses more than its reserved amount of memory, an out-of-memory event can occur that impacts the entire node and all pods running on the node. To avoid or reduce the probability of system out-of-memory events, the node provides xref:../admin_guide/out_of_resource_handling.adoc#admin-guide-handling-out-of-resource-errors[out of resource handling].
 
-By reserving some memory via the `--eviction-hard` flag, the node attempts to evict
-pods whenever memory availability on the node drops below the absolute value or percentage.
-If system daemons did not exist on a node, pods are limited to the memory
-`capacity - eviction-hard`. For this reason, resources set aside as a buffer for eviction
-before reaching out of memory conditions are not available for pods.
+== Related Resources
 
-Here is an example to illustrate the impact of node allocatable for memory:
+* xref:../admin_guide/overcommit.adoc#admin-guide-overcommit[Overcommitting]
 
-* Node capacity is `32Gi`
-* --kube-reserved is `2Gi`
-* --system-reserved is `1Gi`
-* --eviction-hard is set to `<100Mi`.
+* xref:../admin_guide/out_of_resource_handling.adoc#admin-guide-handling-out-of-resource-errors[Handling Out of Resource Errors]
 
-For this node, the effective node allocatable value is `28.9Gi`. If the node
-and system components use up all their reservation, the memory available for pods is `28.9Gi`,
-and kubelet will evict pods when it exceeds this usage.
-
-If we enforce node allocatable (`28.9Gi`) via top level cgroups, then pods can never exceed `28.9Gi`.
-Evictions would not be performed unless system daemons are consuming more than `3.1Gi` of memory.
-
-If system daemons do not use up all their reservation, with the above example,
-pods would face memcg OOM kills from their bounding cgroup before node evictions kick in.
-To better enforce QoS under this situation, the node applies the hard eviction thresholds to
-the top-level cgroup for all pods to be `Node Allocatable + Eviction Hard Thresholds`.
-
-If system daemons do not use up all their reservation, the node will evict pods whenever
-they collectively consume more than `28.9Gi` of memory. If eviction does not occur in time, a pod
-will be OOM killed if pods collectively consume `29Gi` of memory.
-
-
-[[allocating-node-scheduler]]
-== Scheduler
-
-The scheduler now uses the value of `*node.Status.Allocatable*` instead of
-`*node.Status.Capacity*` to decide if a node will become a candidate for pod
-scheduling.
-
-By default, the node will report its machine capacity as fully schedulable by
-the cluster.
+* xref:../admin_guide/limits.adoc#admin-guide-limits[Setting Limit Ranges]

--- a/admin_guide/limits.adoc
+++ b/admin_guide/limits.adoc
@@ -11,35 +11,20 @@
 
 toc::[]
 
-== Overview
+== Purpose for Limit Ranges
 
 // tag::admin_limits_overview[]
-A limit range, defined by a `*LimitRange*` object, enumerates
-xref:../dev_guide/compute_resources.adoc#dev-compute-resources[compute resource
-constraints] in a xref:../dev_guide/projects.adoc#dev-guide-projects[project] at the pod,
-container, image, image stream, and persistent volume claim level, and specifies the amount of resources
-that a pod, container, image, image stream, or persistent volume claim can consume.
+A limit range, defined by a `LimitRange` object, enumerates xref:../dev_guide/compute_resources.adoc#dev-compute-resources[compute resource constraints] in a xref:../dev_guide/projects.adoc#dev-guide-projects[project] at the pod, container, image, image stream, and persistent volume claim level, and specifies the amount of resources that a pod, container, image, image stream, or persistent volume claim can consume.
 
-All resource create and modification requests are evaluated against each
-`*LimitRange*` object in the project. If the resource violates any of the
-enumerated constraints, then the resource is rejected. If the resource does not
-set an explicit value, and if the constraint supports a default value, then the
-default value is applied to the resource.
+All requests to create and modify resources are evaluated against each `LimitRange` object in the project. If the resource violates any of the enumerated constraints, the resource is rejected. If the resource does not set an explicit value, and if the constraint supports a default value, the default value is applied to the resource.
 
-For CPU and Memory limits, if you specify a `max` value, but do not specify a
-`min` limit, the resource can consume CPU/memory resources greater than `max` value`.
-
+For CPU and memory limits, if you specify a maximum value but do not specify a minimum limit, the resource can consume more CPU and memory resources than the maximum value.
 
 ifdef::openshift-origin,openshift-enterprise[]
-You can specify limits and requests for ephemeral
-storage by using the ephemeral storage technology preview. This feature is
-disabled by default. To enable this feature,  see
-xref:../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[configuring for ephemeral
-storage].
+You can specify limits and requests for ephemeral storage by using the ephemeral storage technology preview. This feature is disabled by default. To enable this feature, see xref:../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[configuring for ephemeral storage].
 endif::openshift-origin,openshift-enterprise[]
 
 // end::admin_limits_overview[]
-
 
 [[limit-range-def]]
 // tag::admin_limits_sample_definitions[]
@@ -93,26 +78,17 @@ spec:
 containers.
 <3> The maximum amount of memory that a pod can request on a node across all
 containers.
-<4> The minimum amount of CPU that a pod can request on a node across all
-containers. Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
-<5> The minimum amount of memory that a pod can request on a node across all
-containers. Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value. 
+<4> The minimum amount of CPU that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` CPU value.
+<5> The minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
 <6> The maximum amount of CPU that a single container in a pod can request.
 <7> The maximum amount of memory that a single container in a pod can request.
-<8> The minimum amount of CPU that a single container in a pod can request.
-Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
-<9> The minimum amount of memory that a single container in a pod can request.
-Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
-<10> The default amount of CPU that a container will be limited to use if not
-specified.
-<11> The default amount of memory that a container will be limited to use if not specified.
-<12> The default amount of CPU that a container will request to use if not specified.
-<13> The default amount of memory that a container will request to use if not specified.
-<14> The maximum amount of CPU burst that a container can make as a ratio of its limit over request.
+<8> The minimum amount of CPU that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` CPU value.
+<9> The minimum amount of memory that a single container in a pod can request. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` memory value.
+<10> The default CPU limit for a container if you do not specify a limit in the pod specification.
+<11> The default memory limit for a container if you do not specify a limit in the pod specification.
+<12> The default CPU request for a container if you do not specify a request in the pod specification.
+<13> The default memory request for a container if you do not specify a request in the pod specification.
+<14> The maximum limit-to-request ratio for a container.
 
 For more information on how CPU and memory are measured, see xref:../dev_guide/compute_resources.adoc#dev-compute-resources[Compute Resources].
 
@@ -139,30 +115,25 @@ spec:
     - type: "Pod"
       max:
         cpu: "2" <4>
-      	memory: "1Gi" <5>
-      	ephemeral-storage: "1Gi" <6>
+        memory: "1Gi" <5>
+        ephemeral-storage: "1Gi" <6>
      max:
         cpu: "1" <7>
-      	memory: "1Gi" <8>
+        memory: "1Gi" <8>
 ----
 <1> The maximum size of an image that can be pushed to an internal registry.
-<2> The maximum number of unique image tags per image stream's spec.
-<3> The maximum number of unique image references per image stream's status.
+<2> The maximum number of unique image tags as defined in the specification for the image stream.
+<3> The maximum number of unique image references as defined in the specification for the image stream status.
 <4> The maximum amount of CPU that a pod can request on a node across all containers.
 <5> The maximum amount of memory that a pod can request on a node across all containers.
 <6> The maximum amount of ephemeral storage that a pod can request on a node
 across all containers, if the ephemeral storage technology preview is enabled.
-<7> The minimum amount of CPU that a pod can request on a node across all containers.
-Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
-<8> The minimum amount of memory that a pod can request on a node across all containers.
-Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
+<7> The minimum amount of CPU that a pod can request on a node across all containers. If you do set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more than the `max` CPU value.
+<8> The minimum amount of memory that a pod can request on a node across all containers. If you do not set a `min` value or you set `min` to `0`, the result` is no limit and the pod can consume more than the `max` memory value.
 // end::admin_limits_sample_definitions_2[]
 
-Both core and {product-title} resources can be specified in just one limit range
-object. They are separated here into two examples for clarity.
-
+You can specify both core and {product-title} resources in one limit range
+object. They are shown separately in two examples for clarity.
 
 [[container-limits]]
 === Container Limits
@@ -183,36 +154,25 @@ Per container, the following must hold true if specified:
 
 |Constraint |Behavior
 
-|`*Min*`
+|`Min`
 |`Min[resource]` less than or equal to `container.resources.requests[resource]`
 (required) less than or equal to `container/resources.limits[resource]`
 (optional)
 
-If the configuration defines a `min` CPU, then the request value must be greater
-than the CPU value. Not setting a `min` value or setting `0` is unlimited 
-allowing the pod to consume more than the `max` value.
+If the configuration defines a `min` CPU, the request value must be greater than the CPU value. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more of the resource than the `max` value.
 
-|`*Max*`
+|`Max`
 |`container.resources.limits[resource]` (required) less than or equal to
 `Max[resource]`
 
-If the configuration defines a `max` CPU, then you do not need to define a
-request value, but a limit value does need to be set that satisfies the maximum
-CPU constraint.
+If the configuration defines a `max` CPU, you do not need to define a CPU request value. However, you must set a limit that satisfies the maximum CPU constraint that is specified in the limit range.
 
-|`*MaxLimitRequestRatio*`
-|`MaxLimitRequestRatio[resource]` less than or equal to (
-`container.resources.limits[resource]` /
-`container.resources.requests[resource]`)
+|`MaxLimitRequestRatio`
+|`MaxLimitRequestRatio[resource]` less than or equal to (`container.resources.limits[resource]` / `container.resources.requests[resource]`)
 
-If a configuration defines a `maxLimitRequestRatio` value, then any new
-containers must have both a request and limit value. Additionally,
-{product-title} calculates a limit to request ratio by dividing the limit by the
-request. This value should be a non-negative integer greater than 1.
+If the limit range defines a `maxLimitRequestRatio` constraint, any new containers must have both a `request` and a `limit` value. Additionally, {product-title} calculates a limit-to-request ratio by dividing the `limit` by the `request`. The result should be an integer greater than 1.
 
-For example, if a container has `cpu: 500` in the `limit` value, and
-`cpu: 100` in the `request` value, then its limit to request ratio for `cpu` is
-`5`. This ratio must be less than or equal to the `maxLimitRequestRatio`.
+For example, if a container has `cpu: 500` in the `limit` value, and `cpu: 100` in the `request` value, the limit-to-request ratio for `cpu` is `5`. This ratio must be less than or equal to the `maxLimitRequestRatio`.
 |===
 
 *Supported Defaults:*
@@ -240,20 +200,14 @@ Across all containers in a pod, the following must hold true:
 
 |Constraint |Enforced Behavior
 
-|`*Min*`
-|`Min[resource]` less than or equal to `container.resources.requests[resource]`
-(required) less than or equal to `container.resources.limits[resource]`.
-Not setting a `min` value or setting `0` is unlimited allowing the 
-pod to consume more than the `max` value.
+|`Min`
+|`Min[resource]` less than or equal to `container.resources.requests[resource]` (required) less than or equal to `container.resources.limits[resource]`. If you do not set a `min` value or you set `min` to `0`, the result is no limit and the pod can consume more of the resource than the `max` value.
 
-|`*Max*`
-|`container.resources.limits[resource]` (required) less than or equal to
-`Max[resource]`.
+|`Max`
+|`container.resources.limits[resource]` (required) less than or equal to `Max[resource]`.
 
-|`*MaxLimitRequestRatio*`
-|`MaxLimitRequestRatio[resource]` less than or equal to (
-`container.resources.limits[resource]` /
-`container.resources.requests[resource]`).
+|`MaxLimitRequestRatio`
+|`MaxLimitRequestRatio[resource]` less than or equal to (`container.resources.limits[resource]` / `container.resources.requests[resource]`).
 
 |===
 // end::admin_limits_pod_limits[]
@@ -278,28 +232,20 @@ Per image, the following must hold true if specified:
 |===
 |Constraint |Behavior
 
-|`*Max*`
+|`Max`
 |`image.dockerimagemetadata.size` less than or equal to `Max[resource]`
 |===
 
 ifdef::openshift-enterprise,openshift-origin[]
 [NOTE]
 ====
-To prevent blobs exceeding the limit from being uploaded to the registry, the
-registry must be configured to enforce quota. An environment variable
-`REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA` must be set to
-`true` which is done by default for new deployments.
+To prevent blobs that exceed the limit from being uploaded to the registry, the registry must be configured to enforce quota. The `REGISTRY_MIDDLEWARE_REPOSITORY_OPENSHIFT_ENFORCEQUOTA` environment variable must be set to `true`. By default, the environment variable is set to `true` for new deployments.
 ====
 endif::[]
 
 [WARNING]
 ====
-The image size is not always available in the manifest of an uploaded image.
-This is especially the case for images built with Docker 1.10 or higher and
-pushed to a v2 registry. If such an image is pulled with an older Docker daemon,
-the image manifest will be converted by the registry to schema v1 lacking all
-the size information. No storage limit set on images will prevent it from being
-uploaded.
+The image size is not always available in the manifest of an uploaded image. This is especially the case for images built with Docker 1.10 or higher and pushed to a v2 registry. If such an image is pulled with an older Docker daemon, the image manifest is converted by the registry to schema v1 and does not include all the size information. No storage limit set on images will prevent it from being uploaded.
 
 link:https://github.com/openshift/origin/issues/7706[The issue] is being
 addressed.
@@ -328,39 +274,25 @@ Per image stream, the following must hold true if specified:
 |===
 |Constraint |Behavior
 
-|`*Max[openshift.io/image-tags]*`
+|`Max[openshift.io/image-tags]`
 |`length( uniqueimagetags( imagestream.spec.tags ) )` less than or equal to `Max[openshift.io/image-tags]`
 
 `uniqueimagetags` returns unique references to images of given spec tags.
 
-|`*Max[openshift.io/images]*`
+|`Max[openshift.io/images]`
 |`length( uniqueimages( imagestream.status.tags ) )` less than or equal to `Max[openshift.io/images]`
 
-`uniqueimages` returns unique image names found in status tags. The name equals
-image's digest.
+`uniqueimages` returns unique image names found in status tags. The name is equal to the digest for the image.
 
 |===
 
 ==== Counting of Image References
 
-Resource `openshift.io/image-tags` represents unique
-xref:../dev_guide/managing_images.adoc#referencing-images-in-image-streams[image
-references]. Possible references are an `*ImageStreamTag*`, an
-`*ImageStreamImage*` and a `*DockerImage*`. They may be created using commands
-`oc tag` and `oc import-image` or by using
-xref:../dev_guide/managing_images.adoc#adding-tag[tag tracking]. No distinction
-is made between internal and external references. However, each unique reference
-tagged in the image stream's specification is counted just once. It does not
-restrict pushes to an internal container image registry in any way, but is useful for tag
-restriction.
+The `openshift.io/image-tags` resource represents unique xref:../dev_guide/managing_images.adoc#referencing-images-in-image-streams[image references]. Possible references are an `ImageStreamTag`, an `ImageStreamImage`, or a `DockerImage`. Tags can be created by using the `oc tag` and `oc import-image` commands or by using xref:../dev_guide/managing_images.adoc#adding-tag[tag tracking]. No distinction is made between internal and external references. However, each unique reference that is tagged in an image stream specification is counted just once. It does not restrict pushes to an internal container image registry in any way, but is useful for tag restriction.
 
-Resource `openshift.io/images` represents unique image names recorded in image
-stream status. It allows for restriction of a number of images that can be
-pushed to the internal registry. Internal and external references are not
-distinguished.
+The `openshift.io/images` resource represents unique image names that are recorded in image stream status. It allows for restriction of a number of images that can be pushed to the internal registry. Internal and external references are not distinguished.
 
 // end::admin_limits_image_stream_limits[]
-
 
 [[claim-limits]]
 === PersistentVolumeClaim Limits
@@ -380,11 +312,11 @@ Across all persistent volume claims in a project, the following must hold true:
 
 |Constraint |Enforced Behavior
 
-|`*Min*`
-|Min[resource] <= claim.spec.resources.requests[resource] (required)
+|`Min`
+|Min[resource] +<=+ claim.spec.resources.requests[resource] (required)
 
-|`*Max*`
-|claim.spec.resources.requests[resource] (required) <= Max[resource]
+|`Max`
+|claim.spec.resources.requests[resource] (required) +<=+ Max[resource]
 |===
 
 [[limit-range-obj-def]]
@@ -414,8 +346,8 @@ Across all persistent volume claims in a project, the following must hold true:
 }
 ----
 <1> The name of the limit range object.
-<2> The minimum amount of storage that can be requested in a persistent volume claim
-<3> The maximum amount of storage that can be requested in a persistent volume claim
+<2> The minimum amount of storage that can be requested in a persistent volume claim.
+<3> The maximum amount of storage that can be requested in a persistent volume claim.
 
 // end::admin_limits_claim_limits[]
 
@@ -423,49 +355,57 @@ ifdef::openshift-dedicated[]
 [[dedicated-project-limits]]
 === Project Limits
 
-For information on enforcing different limits on the number of projects that
-your users can create, as well as on managing limits and quota on project
-resources, see
-xref:../admin_guide/managing_projects.adoc#admin-guide-managing-projects[Managing
-Projects].
+For information about enforcing different limits on the number of projects that your users can create, as well as on managing limits and quota on project resources, see xref:../admin_guide/managing_projects.adoc#admin-guide-managing-projects[Managing Projects].
 endif::openshift-dedicated[]
 
 [[creating-a-limit-range]]
 == Creating a Limit Range
 
-To apply a limit range to a project, create a limit range
-object definition on your file system to your desired specifications, then run:
+To apply a limit range to a project:
 
+. Create a limit range object definition with your required specifications.
+
+. Create the object:
++
 [source,terminal]
 ----
 $ oc create -f <limit_range_file> -n <project>
 ----
 
 [[viewing-limits]]
-== Viewing Limits
+== Viewing a Limit
 
 // tag::admin_limits_viewing[]
-You can view any limit ranges defined in a project by navigating in the web
-console to the project's *Quota* page.
+You can view any limit ranges that are defined in a project by navigating in the web console to the *Quota* page for the project.
 
-You can also use the CLI to view limit range details:
+You can also use the CLI to view limit range details by performing the following steps:
 
-. First, get the list of limit ranges defined in the project. For example, for a
-project called *demoproject*:
+. Get the list of limit range objects that are defined in the project. For example, for a project called *demoproject*:
 +
 [source,terminal]
 ----
 $ oc get limits -n demoproject
+----
++
+.Example Output
++
+[source,terminal]
+----
 NAME              AGE
 resource-limits   6d
 ----
 
-. Then, describe the limit range you are interested in, for example the
-*resource-limits* limit range:
+. Describe the limit range. For example, for a limit range called *resource-limits*:
 +
 [source,terminal]
 ----
 $ oc describe limits resource-limits -n demoproject
+----
++
+.Example Output
++
+[source,terminal]
+----
 Name:                           resource-limits
 Namespace:                      demoproject
 Type                            Resource                Min     Max     Default Request Default Limit   Max Limit/Request Ratio
@@ -481,10 +421,12 @@ openshift.io/ImageStream        openshift.io/image-tags -       10      -       
 // end::admin_limits_viewing[]
 
 [[deleting-limits]]
-== Deleting Limits
+== Deleting a Limit Range
 
-Remove any active limit range to no longer enforce the limits of a project:
+To remove a limit range and no longer enforce the limits of a project:
 
+* Run the following command:
++
 [source,terminal]
 ----
 $ oc delete limits <limit_name>

--- a/admin_guide/out_of_resource_handling.adoc
+++ b/admin_guide/out_of_resource_handling.adoc
@@ -14,9 +14,7 @@ toc::[]
 
 This topic discusses best-effort attempts to prevent {product-title} from experiencing out-of-memory (OOM) and out-of-disk-space conditions.
 
-A node must maintain stability when available compute resources are low.
-This is especially important when dealing with incompressible resources such as
-memory or disk. If either resource is exhausted, the node becomes unstable.
+A node must maintain stability when available compute resources are low. This is especially important when dealing with incompressible resources such as memory or disk. If either resource is exhausted, the node becomes unstable.
 
 Administrators can proactively monitor nodes for and prevent against situations where the node runs out of compute and memory resources using configurable xref:out-of-resource-eviction-policy[eviction policies].
 
@@ -29,97 +27,84 @@ This topic also provides information on how {product-title} handles out-of-resou
 
 [WARNING]
 ====
-If swap memory is enabled for a node, that node cannot detect that it is under *MemoryPressure*.
+If swap memory is enabled for a node, that node cannot detect that it is under memory pressure.
 
-To take advantage of memory based evictions, operators must
-xref:../admin_guide/overcommit.adoc#disabling-swap-memory[disable swap].
+To take advantage of memory based evictions, operators must xref:../admin_guide/overcommit.adoc#disabling-swap-memory[disable swap].
 ====
-
 
 [[out-of-resource-eviction-policy]]
 == Configuring Eviction Policies
 
-An _eviction policy_ allows a node to fail one or more pods when the node is running low on available resources.
-Failing a pod allows the node to reclaim needed resources.
+An _eviction policy_ allows a node to fail one or more pods when the node is running low on available resources. Failing a pod allows the node to reclaim needed resources.
 
 An eviction policy is a combination of an xref:out-of-resource-eviction-signals[eviction trigger signal] with a specific xref:out-of-resource-eviction-thresholds[eviction threshold value] that is set in the node configuration file or through the xref:out-of-resource-eviction-thresholds[command line]. Evictions can be either xref:out-of-resource-hard-eviction-thresholds[hard], where a node takes immediate action on a pod that exceeds a threshold, or xref:out-of-resource-soft-eviction-thresholds[soft], where a node allows a grace period before taking action.
 
 [NOTE]
 ====
-To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed. 
-Do not manually edit the `node-config.yaml` file.
+To modify a node in your cluster, update the xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration maps] as needed. Do not manually edit the `node-config.yaml` file.
 ====
 
-By using well-configured eviction policies, a node can proactively monitor for and prevent
-against total starvation of a compute resource.
+By using well-configured eviction policies, a node can proactively monitor for and prevent against total resource consumption of a compute resource.
 
 [NOTE]
 ====
-When the node fails a pod, it terminates all containers in the pod, and
-the link:https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase[`PodPhase`] is transitioned to *Failed*.
+When the node fails a pod, the node ends all the containers in the pod, and the link:https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase[`PodPhase`] is transitioned to *Failed*.
 ====
 
 When detecting disk pressure, the node supports the `nodefs` and `imagefs` file system partitions.
 
-The `nodefs`, or `rootfs`, is the file system that the node uses for local disk volumes, daemon logs, emptyDir,
-and so on (for example, the file system that provides `/`). The `rootfs` contains `openshift.local.volumes`,
-by default *_/var/lib/origin/openshift.local.volumes_*.
+The `nodefs`, or `rootfs`, is the file system that the node uses for local disk volumes, daemon logs, emptyDir, and other local storage. For example, `rootfs` is the file system that provides *_/_*. The `rootfs` contains `openshift.local.volumes`, by default *_/var/lib/origin/openshift.local.volumes_*.
 
-The `imagefs` is the file system that the container runtime uses for storing images and
-individual container-writable layers. Eviction thresholds are at 85% full for `imagefs`. The `imagefs` file system depends on the runtime and, 
-in the case of Docker, which storage driver you are using.
+The `imagefs` is the file system that the container runtime uses for storing images and individual container-writable layers. Eviction thresholds are at 85% full for `imagefs`. The `imagefs` file system depends on the runtime and, in the case of Docker, which storage driver that the container uses.
 
 * For Docker:
 +
-** If you are using the `devicemapper` storage driver, the `imagefs` is thin pool. 
+** If you use the `devicemapper` storage driver, the `imagefs` is thin pool.
 +
-You can limit the read/write layer for the container by setting the `--storage-opt dm.basesize` flag in the Docker daemon. 
+You can limit the read and write layer for the container by setting the `--storage-opt dm.basesize` flag in the Docker daemon.
 +
 [source,terminal]
 ----
 $ sudo dockerd --storage-opt dm.basesize=50G
 ----
 +
-** If you are using the `overlay2` storage driver, the `imagefs` is the file system that contains `/var/lib/docker/overlay2`.  
+** If you use the `overlay2` storage driver, the `imagefs` is the file system that contains *_/var/lib/docker/overlay2_*.
 
-* For CRI-O, which uses the overlay driver, the imagefs is *_/var/lib/containers/storage_* by default. 
+* For CRI-O, which uses the overlay driver, the `imagefs` is *_/var/lib/containers/storage_* by default.
 
 [NOTE]
 ====
-If you do not use local storage isolation (ephemeral storage) and not using XFS quota (volumeConfig), you cannot limit local disk usage by the pod. 
+If you do not use local storage isolation (ephemeral storage) and you do not use XFS quota (volumeConfig), you cannot limit local disk usage by the pod.
 ====
 
 [[out-of-resource-create-config]]
 === Using the Node Configuration to Create a Policy
 
-To configure an eviction policy, edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
-to specify the eviction thresholds under the `eviction-hard` or `eviction-soft` parameters.
+To configure an eviction policy, edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] to specify the eviction thresholds under the `eviction-hard` or `eviction-soft` parameters.
 
-For example:
+The following samples show eviction thresholds:
 
-.Sample Node Configuration file for a hard eviction
-====
+.Sample Node Configuration File for a Hard Eviction
+[source,yaml]
 ----
 kubeletArguments:
   eviction-hard: <1>
   - memory.available<100Mi <2>
   - nodefs.available<10%
-  - nodefs.inodesFree<5% 
+  - nodefs.inodesFree<5%
   - imagefs.available<15%
-  - imagefs.inodesFree<10% 
+  - imagefs.inodesFree<10%
 ----
-
 <1> The type of eviction: Use this parameter for a xref:out-of-resource-hard-eviction-thresholds[hard eviction].
 <2> Eviction thresholds based on a specific eviction trigger signal.
-====
 
 [NOTE]
 ====
 You must provide percentage values for the `inodesFree` parameters. You can provide a percentage or a numerical value for the other parameters.
 ====
 
-.Sample Node Configuration file for a soft eviction
-====
+.Sample Node Configuration File for a Soft Eviction
+[source,yaml]
 ----
 kubeletArguments:
   eviction-soft: <1>
@@ -135,11 +120,9 @@ kubeletArguments:
   - imagefs.available=1m30s
   - imagefs.inodesFree=1m30s
 ----
-
 <1> The type of eviction: Use this parameter for a xref:out-of-resource-hard-eviction-thresholds[soft eviction].
 <2> An eviction threshold based on a specific eviction trigger signal.
 <3> The grace period for the soft eviction. Leave the default values for optimal performance.
-====
 
 Restart the {product-title} service for the changes to take effect:
 
@@ -161,10 +144,9 @@ endif::[]
 
 You can configure a node to trigger eviction decisions on any of the signals described in the table below. You add an eviction signal to an xref:out-of-resource-eviction-thresholds[eviction threshold] along with a threshold value.
 
-The value of each signal is described in the *Description* column based on the node summary API.
-
 To view the signals:
 
+[source,terminal]
 ----
 curl <certificate details> \
   https://<master>/api/v1/nodes/<node>/proxy/stats/summary
@@ -181,27 +163,27 @@ curl --cacert /path/to/ca.crt
 
 |Node Condition |Eviction Signal | Value |Description
 
-|`*MemoryPressure*`
-|`*memory.available*`
+|`MemoryPressure`
+|`memory.available`
 |`memory.available` = `node.status.capacity[memory]` - `node.stats.memory.workingSet`
 | Available memory on the node has exceeded an eviction threshold.
 
-.4+|`*DiskPressure*`
-|`*nodefs.available*`
+.4+|`DiskPressure`
+|`nodefs.available`
 |`nodefs.available` = `node.stats.fs.available`
-.4+| Available diskspace on either the node root file system or image file system has exceeded an eviction threshold.
+.4+| Available disk space on either the node root file system or image file system has exceeded an eviction threshold.
 
-|`*nodefs.inodesFree*`
+|`nodefs.inodesFree`
 |`nodefs.inodesFree` = `node.stats.fs.inodesFree`
 
-|`*imagefs.available*`
+|`imagefs.available`
 |`imagefs.available` = `node.stats.runtime.imagefs.available`
 
-|`*imagefs.inodesFree*`
+|`imagefs.inodesFree`
 |`imagefs.inodesFree` = `node.stats.runtime.imagefs.inodesFree`
 |===
 
-Each of the above signals supports either a literal or percentage-based value, except `inodesFree`, which must be a percentage. The percentage-based value is calculated relative to the total capacity associated with each signal.
+Each of the signals in the preceding table supports either a literal or percentage-based value, except `inodesFree`. The `inodesFree` signal must be specified as a percentage. The percentage-based value is calculated relative to the total capacity associated with each signal.
 
 A script derives the value for `memory.available` from your cgroup driver using the same set of steps that the kubelet performs. The script excludes inactive file memory (that is, the number of bytes of file-backed memory on inactive LRU list) from its calculation as it assumes that inactive file memory is reclaimable under pressure.
 
@@ -212,41 +194,27 @@ Do not use tools like `free -m`, because `free -m` does not work in a container.
 
 {product-title} monitors these file systems every 10 seconds.
 
-If you store volumes and logs in a dedicated file system, the node will not
-monitor that file system.
+If you store volumes and logs in a dedicated file system, the node does not monitor that file system.
 
 [NOTE]
 ====
-The node supports the ability to trigger eviction
-decisions based on disk pressure. Before evicting pods becuase of disk pressure, the node also
-performs
-xref:../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container
-and image garbage collection].
+The node supports the ability to trigger eviction decisions based on disk pressure. Before evicting pods because of disk pressure, the node also performs xref:../admin_guide/garbage_collection.adoc#admin-guide-garbage-collection[container and image garbage collection].
 ====
 
 [[out-of-resource-eviction-thresholds]]
 === Understanding Eviction Thresholds
 
-You can configure a node to specify eviction thresholds, which triggers the node
-to reclaim resources, by adding a threshold to the xref:out-of-resource-eviction-policy[node configuration file].
+You can configure a node to specify eviction thresholds. Reaching a threshold triggers the node to reclaim resources. You can configure a threshold in the xref:out-of-resource-eviction-policy[node configuration file].
 
-If an eviction threshold is met, independent of its associated grace period, the
-node reports a condition indicating that the node is under memory or disk pressure. This prevents the scheduler from scheduling any additional pods on the node while attempts to reclaim resources are made.
+If an eviction threshold is met, independent of its associated grace period, the node reports a condition to indicate that the node is under memory or disk pressure. Reporting the pressure prevents the scheduler from scheduling any additional pods on the node while attempts to reclaim resources are made.
 
-The node continues to report node status updates at the frequency specified by the `node-status-update-frequency` argument, which
-defaults to `10s` (ten seconds).
+The node continues to report node status updates at the frequency specified by the `node-status-update-frequency` argument. The default frequency is `10s` (ten seconds).
 
-Eviction thresholds can be xref:out-of-resource-hard-eviction-thresholds[hard], for when the node takes immediate action when a
-threshold is met, or xref:out-of-resource-soft-eviction-thresholds[soft], for when you allow a grace period before
-reclaiming resources.
+Eviction thresholds can be xref:out-of-resource-hard-eviction-thresholds[hard], for when the node takes immediate action when a threshold is met, or xref:out-of-resource-soft-eviction-thresholds[soft], for when you allow a grace period before reclaiming resources.
 
 [NOTE]
 ====
-Soft eviction usage is more common when you are targeting a certain level of
-utilization, but can tolerate temporary spikes. We recommended
-setting the soft eviction threshold lower than the hard eviction
-threshold, but the time period can be operator-specific. The system reservation
-should also cover the soft eviction threshold.
+Soft eviction usage is more common when you target a certain level of utilization, but can tolerate temporary spikes. We recommended setting the soft eviction threshold lower than the hard eviction threshold, but the time period can be operator-specific. The system reservation should also cover the soft eviction threshold.
 
 The soft eviction threshold is an advanced feature. You should configure a hard eviction threshold before attempting to use soft eviction thresholds.
 ====
@@ -257,13 +225,14 @@ Thresholds are configured in the following form:
 <eviction_signal><operator><quantity>
 ----
 
-* the `eviction-signal` value can be any xref:out-of-resource-eviction-signals-supported[supported eviction signal].
-* the `operator` value is `<`.
-* the `quantity` value must match the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities[quantity representation] used by
+* The `eviction-signal` value can be any xref:out-of-resource-eviction-signals-supported[supported eviction signal].
+* The `operator` value is `<`.
+* The `quantity` value must match the link:https://github.com/kubernetes/community/blob/master/contributors/design-proposals/scheduling/resources.md#resource-quantities[quantity representation] used by
 Kubernetes and can be expressed as a percentage if it ends with the `%` token.
 
 For example, if an operator has a node with 10Gi of memory, and that operator wants to induce eviction if available memory falls below 1Gi, an eviction threshold for memory can be specified as either of the following:
 
+[source,yaml]
 ----
 memory.available<1Gi
 memory.available<10%
@@ -273,21 +242,18 @@ memory.available<10%
 
 [NOTE]
 ====
-The node evaluates and monitors eviction thresholds every 10 seconds and the
-value can not be modified. This is the housekeeping interval.
+The node evaluates and monitors eviction thresholds every 10 seconds and the value can not be modified. This is the housekeeping interval.
 ====
-
 
 [[out-of-resource-hard-eviction-thresholds]]
 ==== Understanding Hard Eviction Thresholds
 
-A hard eviction threshold has no grace period and, if observed, the node takes immediate action to reclaim the associated starved resource. If a hard eviction
-threshold is met, the node kills the pod immediately with no graceful termination.
+A hard eviction threshold has no grace period. When a hard eviction threshold is met, the node takes immediate action to reclaim the associated resource. For example, the node can end one or more pods immediately with no graceful termination.
 
-To configure hard eviction thresholds, add eviction thresholds to the xref:out-of-resource-eviction-policy[node configuration file]
-under `eviction-hard`, as shown in xref:out-of-resource-create-config[Using the Node Configuration to Create a Policy].
+To configure hard eviction thresholds, add eviction thresholds to the xref:out-of-resource-eviction-policy[node configuration file] under `eviction-hard`, as shown in xref:out-of-resource-create-config[Using the Node Configuration to Create a Policy].
 
-.Sample Node Configuration file with hard eviction thresholds
+.Sample Node Configuration File with Hard Eviction Thresholds
+[source,yaml]
 ----
 kubeletArguments:
   eviction-hard:
@@ -302,6 +268,7 @@ This example is a general guideline and not recommended settings.
 
 [[out-of-resource-hard-eviction-thresholds-default]]
 ===== Default Hard Eviction Thresholds
+
 {product-title} uses the following default configuration for `eviction-hard`.
 
 [source,yaml]
@@ -316,24 +283,25 @@ kubeletArguments:
 ...
 ----
 
-
 [[out-of-resource-soft-eviction-thresholds]]
 ==== Understanding Soft Eviction Thresholds
 
-A soft eviction threshold pairs an eviction threshold with a required administrator-specified grace period. The node does not reclaim resources associated with the eviction signal until that grace period is exceeded. If no grace period is provided in the node configuration the node errors on startup.
+A soft eviction threshold pairs an eviction threshold with a required administrator-specified grace period. The node does not reclaim resources associated with the eviction signal until that grace period is exceeded. If no grace period is provided in the node configuration, the node produces an error on startup.
 
-In addition, if a soft eviction threshold is met, an operator can specify a maximum allowed pod termination grace period to use when evicting pods from the
-node. If `eviction-max-pod-grace-period` is specified, the node uses the lesser value among the `pod.Spec.TerminationGracePeriodSeconds` and the maximum-allowed grace period. If not specified, the node kills pods immediately with no graceful termination.
+In addition, if a soft eviction threshold is met, an operator can specify a maximum-allowed pod termination grace period to use when evicting pods from the node. If `eviction-max-pod-grace-period` is specified, the node uses the lesser value among the `pod.Spec.TerminationGracePeriodSeconds` and the maximum-allowed grace period. If not specified, the node ends pods immediately with no graceful termination.
 
 For soft eviction thresholds the following flags are supported:
 
-* `eviction-soft`: a set of eviction thresholds (for example, `memory.available<1.5Gi`) that, if met over a corresponding grace period, triggers a pod eviction.
-* `eviction-soft-grace-period`: a set of eviction grace periods (for example, `memory.available=1m30s`) that correspond to how long a soft eviction threshold must hold before triggering a pod eviction.
+* `eviction-soft`: a set of eviction thresholds, such as `memory.available<1.5Gi`. If the threshold is met over a corresponding grace period, the threshold triggers a pod eviction.
+
+* `eviction-soft-grace-period`: a set of eviction grace periods, such as `memory.available=1m30s`. The grace period corresponds to how long a soft eviction threshold must hold before triggering a pod eviction.
+
 * `eviction-max-pod-grace-period`: the maximum-allowed grace period (in seconds) to use when terminating pods in response to a soft eviction threshold being met.
 
 To configure soft eviction thresholds, add eviction thresholds to the xref:out-of-resource-eviction-policy[node configuration file] under `eviction-soft`, as shown in xref:out-of-resource-create-config[Using the Node Configuration to Create a Policy].
 
-.Sample Node Configuration files with soft eviction thresholds
+.Sample Node Configuration Files with Soft Eviction Thresholds
+[source,yaml]
 ----
 kubeletArguments:
   eviction-soft:
@@ -355,22 +323,18 @@ This example is a general guideline and not recommended settings.
 [[out-of-resource-allocatable]]
 == Configuring the Amount of Resource for Scheduling
 
-You can control how much of a node resource is made available for scheduling in order to allow the scheduler to fully allocate a node and to prevent
-evictions.
+You can control how much of a node resource is made available for scheduling in order to allow the scheduler to fully allocate a node and to prevent evictions.
 
-Set `system-reserved` equal to the amount of resource you want available to the scheduler for deploying pods and for system-daemons.
-`system-reserved` are resources reserved for operating system daemons such as *sshd* and *NetworkManager*.
-Evictions should only occur if pods use more than their requested amount of an allocatable resource.
+Set `system-reserved` equal to the amount of resource that you want available to the scheduler for deploying pods and for system-daemons. The `system-reserved` resources are reserved for operating system daemons such as *sshd* and *NetworkManager*. Evictions should only occur if pods use more than their requested amount of an allocatable resource.
 
 A node reports two values:
 
-* `Capacity`: How much resource is on the machine
+* `Capacity`: How much resource is on the machine.
 * `Allocatable`: How much resource is made available for scheduling.
 
+To configure the amount of allocatable resources, edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] to add or modify the `system-reserved` parameter for `eviction-hard` or `eviction-soft`.
 
-To configure the amount of allocatable resources, edit the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] 
-to add or modify the `system-reserved` parameter for `eviction-hard` or `eviction-soft`.
-
+[source,yaml]
 ----
 kubeletArguments:
   eviction-hard: <1>
@@ -380,8 +344,7 @@ kubeletArguments:
 ----
 <1> This threshold can either be `eviction-hard` or `eviction-soft`.
 
-To determine appropriate values for the `system-reserved` setting, determine a node's resource usage using the node summary API.
-For more information, see xref:../admin_guide/allocating_node_resources.adoc#allocating-node-settings[Configuring Nodes for Allocated Resources].
+To determine appropriate values for the `system-reserved` setting, determine a node's resource usage using the node summary API. For more information, see xref:../admin_guide/allocating_node_resources.adoc#allocating-node-settings[Configuring Nodes for Allocated Resources].
 
 Restart the {product-title} service for the changes to take effect:
 
@@ -401,27 +364,23 @@ endif::[]
 [[out-of-resource-oscillation-of-node-conditions]]
 == Controlling Node Condition Oscillation
 
-If a node is oscillating above and below a soft eviction threshold, but not exceeding its associated grace period, the corresponding node condition
-oscillates between *true* and *false*, which can cause problems for the scheduler.
+If a node oscillates above and below a soft eviction threshold, but does not exceed an associated grace period, the oscillation can cause problems for the scheduler.
 
-To prevent this oscillation, set the `eviction-pressure-transition-period` parameter to control how long the node must wait before transitioning out of a pressure condition.
+To prevent the oscillation, set the `eviction-pressure-transition-period` parameter to control how long the node must wait before transitioning out of a pressure condition.
 
-. Edit or add the parameter to the `kubeletArguments` section of the appropriate 
-xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]
-using a set of `<resource_type>=<resource_quantity>` pairs.
+. Edit or add the parameter to the `kubeletArguments` section of the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map] using a set of `<resource_type>=<resource_quantity>` pairs.
 +
+[source,yaml]
 ----
 kubeletArguments:
   eviction-pressure-transition-period="5m"
 ----
 +
-The node toggles the condition back to *false* when the node has not observed an eviction threshold being met
-for the specified pressure condition for the specified period.
+The node toggles the condition back to false when the node has not met an eviction threshold for the specified pressure condition during the specified period.
 +
 [NOTE]
 ====
-Use the default value (5 minutes) before doing any adjustments.
-The default choice is intended to allow the system to stabilize, and to prevent the scheduler from assigning new pods to the node before it has settled.
+Use the default value, 5 minutes, before making any adjustments. The default value is intended to enable the system to stabilize and to prevent the scheduler from scheduling new pods to the node before it has settled.
 ====
 
 . Restart the {product-title} services for the changes to take effect:
@@ -442,10 +401,9 @@ endif::[]
 [[out-of-resource-reclaiming-node-level-resources]]
 == Reclaiming Node-level Resources
 
-If an eviction criteria is satisfied, the node initiates the process of reclaiming the pressured resource until the signal goes below the defined threshold. During this time, the node does not support scheduling any new pods.
+If an eviction criteria is satisfied, the node initiates the process of reclaiming the pressured resource until the signal is below the defined threshold. During this time, the node does not support scheduling any new pods.
 
-The node attempts to reclaim node-level resources prior to evicting end-user pods, based on whether the host system has a dedicated `imagefs` configured for the
-container runtime.
+The node attempts to reclaim node-level resources before the node evicts end-user pods, based on whether the host system has a dedicated `imagefs` configured for the container runtime.
 
 [discrete]
 [[reclaiming-with-imagefs]]
@@ -453,15 +411,13 @@ container runtime.
 
 If the host system has `imagefs`:
 
-* If the `nodefs` file system meets eviction thresholds, the node frees up disk
-space in the following order:
+* If the `nodefs` file system meets eviction thresholds, the node frees disk space in the following order:
 
-** Delete dead pods/containers
+** Delete dead pods and containers.
 
-* If the `imagefs` file system meets eviction thresholds, the node frees up disk
-space in the following order:
+* If the `imagefs` file system meets eviction thresholds, the node frees disk space in the following order:
 
-** Delete all unused images
+** Delete all unused images.
 
 [discrete]
 [[reclaiming-without-imagefs]]
@@ -469,24 +425,21 @@ space in the following order:
 
 If the host system does not have `imagefs`:
 
-* If the `nodefs` file system meets eviction thresholds, the node frees up disk
-space in the following order:
+* If the `nodefs` file system meets eviction thresholds, the node frees disk space in the following order:
 
-** Delete dead pods/containers
-** Delete all unused images
+** Delete dead pods and containers.
+** Delete all unused images.
 
 [[out-of-resource-eviction-of-pods]]
 == Understanding Pod Eviction
 
-If an eviction threshold is met and the grace period is passed, the node initiates the process of evicting pods until the signal goes below
-the defined threshold.
+If an eviction threshold is met and the grace period is passed, the node initiates the process of evicting pods until the signal is below the defined threshold.
 
-The node ranks pods for eviction by their xref:../admin_guide/overcommit.adoc#qos-classes[quality of service], and, among those with the same quality of service, by the consumption of the starved compute resource relative to the pod's scheduling request.
+The node ranks pods for eviction by their xref:../admin_guide/overcommit.adoc#qos-classes[quality of service]. Among pods with the same quality of service, the node ranks the pods by the consumption of the compute resource relative to the pod's scheduling request.
 
-Each QOS level has an OOM score, which the Linux out-of-memory tool (OOM killer) uses to determine which pods to kill.
-See xref:out-of-resource-node-out-of-resource-and-out-of-memory[Understanding Quality of Service and Out of Memory Killer] below.
+Each quality of service level has an out-of-memory score. The Linux out-of-memory tool (OOM killer) uses the score to determine which pods to end. For more information, see xref:out-of-resource-node-out-of-resource-and-out-of-memory[Understanding Quality of Service and Out of Memory Killer].
 
-The following table lists each QOS level and the associated OOM score.
+The following table lists each quality of service level and the associated out-of-memory score.
 
 .Quality of Service Levels
 [cols="3a,8a",options="header"]
@@ -495,36 +448,27 @@ The following table lists each QOS level and the associated OOM score.
 | Quality of Service | Description
 
 |`Guaranteed`
-| Pods that consume the highest amount of the starved resource relative to
-their request are failed first. If no pod has exceeded its request, the strategy
-targets the largest consumer of the starved resource.
+| Pods that consume the highest amount of the resource relative to their request are failed first. If no pod exceeds its request, the strategy targets the largest consumer of the resource.
 
 |`Burstable`
-|Pods that consume the highest amount of the starved resource relative to their
-request for that resource are failed first. If no pod has exceeded its request,
-the strategy targets the largest consumer of the starved resource.
+|Pods that consume the highest amount of the resource relative to their request for that resource are failed first. If no pod exceeds its request, the strategy targets the largest consumer of the resource.
 
 |`BestEffort`
-| Pods that consume the highest amount of the starved resource are failed
-first.
+| Pods that consume the highest amount of the resource are failed first.
 |===
 
-A `Guaranteed` pod will never be evicted because of another pod's resource consumption unless a system daemon (such as node, *docker*, *journald*) is consuming more resources than were reserved using *system-reserved*, or *kube-reserved* allocations or if the node has only `Guaranteed` pods remaining.
+A guaranteed quality of service pod is never evicted due to resource consumption by another pod unless a system daemon, such as node or the container engine, consumes more resources than were reserved using the `system-reserved` allocations or if the node has only guaranteed quality of service pods remaining.
 
-If the node has only `Guaranteed` pods remaining, the node evicts a `Guaranteed` pod that least impacts node stability and limits the impact of the unexpected consumption to other `Guaranteed` pods.
+If the node has only guaranteed quality of service pods remaining, the node evicts a pod that least impacts node stability and limits the impact of the unexpected consumption to the other guaranteed quality of service pods.
 
-Local disk is a `BestEffort` resource. If necessary, the node evicts pods one at a time to reclaim disk when `DiskPressure` is encountered. The node ranks
-pods by quality of service. If the node is responding to inode starvation, it will reclaim inodes by evicting pods with the lowest quality of service first.
-If the node is responding to lack of available disk, it will rank pods within a quality of service that consumes the largest amount of local disk, and evict
-those pods first.
-
+Local disk is a best-effort quality of service resource. If necessary, the node evicts pods one at a time to reclaim disk space when disk pressure is encountered. The node ranks pods by quality of service. If the node is responding to a lack of free inodes, the node reclaims inodes by evicting pods with the lowest quality of service first. If the node is responding to lack of available disk, the node ranks pods within a quality of service that consumes the largest amount of local disk and then evicts those pods first.
 
 [[out-of-resource-node-out-of-resource-and-out-of-memory]]
 === Understanding Quality of Service and Out of Memory Killer
 
-If the node experiences a system out of memory (OOM) event before it is able to reclaim memory, the node depends on the OOM killer to respond.
+If the node experiences a system out-of-memory (OOM) event before it is able to reclaim memory, the node depends on the OOM killer to respond.
 
-The node sets a `oom_score_adj` value for each container based on the quality of service for the pod.
+The node sets a `oom_score_adj` value for each container that is based on the quality of service for the pod.
 
 .Quality of Service Levels
 [cols="3a,8a",options="header"]
@@ -542,29 +486,28 @@ The node sets a `oom_score_adj` value for each container based on the quality of
 | 1000
 |===
 
-If the node is unable to reclaim memory prior to experiencing a system OOM event, the `oom_killer` calculates an `oom_score`:
+If the node is unable to reclaim memory before the node experiences a system OOM event, the OOM killer process calculates an OOM score:
 
 ----
-% of node memory a container is using + `oom_score_adj` = `oom_score`
+% of node memory a container is using + oom_score_adj = oom_score
 ----
 
-The node then kills the container with the highest score.
+The node then ends the container with the highest score.
 
-Containers with the lowest quality of service that are consuming the largest amount of memory relative to the scheduling request are failed first.
+Containers with the lowest quality of service and that consume the largest amount of memory, relative to the scheduling request, are ended first.
 
-Unlike pod eviction, if a pod container is OOM failed, it can be restarted by the node based on the node restart policy.
-
+Unlike pod eviction, if a pod container is ended due to OOM, the node can restart the container according to the node restart policy.
 
 [[out-of-resource-scheduler]]
 == Understanding the Pod Scheduler and OOR Conditions
 
-The scheduler views node conditions when placing additional pods on the node. For example, if the node has an eviction threshold like the following:
+The scheduler views node conditions when the scheduler places additional pods on the node. For example, if the node has an eviction threshold like the following:
 
 ----
 eviction-hard is "memory.available<500Mi"
 ----
 
-and available memory falls below 500Mi, the node reports a value in `Node.Status.Conditions` as `MemoryPressure` as true.
+If available memory falls below 500Mi, the node reports a value in `Node.Status.Conditions` as `MemoryPressure` as true.
 
 .Node Conditions and Scheduler Behavior
 [cols="3a,8a",options="header"]
@@ -572,33 +515,27 @@ and available memory falls below 500Mi, the node reports a value in `Node.Status
 
 |Node Condition |Scheduler Behavior
 
-|`*MemoryPressure*`
-|If a node reports this condition, the scheduler will not place `BestEffort` pods on that node.
+|`MemoryPressure`
+|If a node reports this condition, the scheduler does not place `BestEffort` pods on that node.
 
-|`*DiskPressure*`
-|If a node reports this condition, the scheduler will not place any additional pods on that node.
+|`DiskPressure`
+|If a node reports this condition, the scheduler does not place any additional pods on that node.
 |===
-
-
 
 [[out-of-resource-schedulable-resources-and-eviction-policies]]
 == Example Scenario
 
-Consider the following scenario.
+An Operator:
 
-An opertator:
-
-* has a node with a memory capacity of `10Gi`;
-* wants to reserve 10% of memory capacity for system daemons
-(kernel, node, etc.);
-* wants to evict pods at 95% memory utilization to reduce
-thrashing and incidence of system OOM.
+* Has a node with a memory capacity of 10Gi.
+* Wants to reserve 10% of memory capacity for system daemons such as kernel, node, and other daemons.
+* Wants to evict pods at 95% memory utilization to reduce thrashing and incidence of system OOM.
 
 Implicit in this configuration is the understanding that `system-reserved` should include the amount of memory covered by the eviction threshold.
 
-To reach that capacity, either some pod is using more than its request, or the system is using more than `1Gi`.
+To reach that capacity, either some pod is using more than its request, or the system is using more than 1Gi.
 
-If a node has 10 Gi of capacity, and you want to reserve 10% of that capacity for the system daemons (`system-reserved`), perform the following calculation:
+If a node has 10 Gi of capacity and you want to reserve 10% of that capacity for the system daemons with the `system-reserved` setting, perform the following calculation:
 
 ----
 capacity = 10 Gi
@@ -614,11 +551,7 @@ allocatable = capacity - system-reserved = 9 Gi
 This means by default, the scheduler will schedule pods that request 9 Gi of
 memory to that node.
 
-If you want to turn on eviction so that eviction is triggered when the node
-observes that available memory falls below 10% of capacity for 30 seconds, or
-immediately when it falls below 5% of capacity, you need the scheduler to see
-allocatable as 8Gi. Therefore, ensure your system reservation covers the greater
-of your eviction thresholds.
+If you want to enable eviction so that eviction is triggered when the node observes that available memory is below 10% of capacity for 30 seconds, or immediately when it falls below 5% of capacity, you need the scheduler to evaluate allocatable as 8Gi. Therefore, ensure your system reservation covers the greater of your eviction thresholds.
 
 ----
 capacity = 10 Gi
@@ -628,6 +561,8 @@ allocatable = capacity - system-reserved = 8 Gi
 ----
 
 Add the following to the appropriate xref:../admin_guide/manage_nodes.adoc#modifying-nodes[node configuration map]:
+
+[source,yaml]
 ----
 kubeletArguments:
   system-reserved:
@@ -640,21 +575,14 @@ kubeletArguments:
   - "memory.available=30s"
 ----
 
-This configuration ensures that the scheduler does not place pods on a node that immediately induce memory pressure and trigger eviction assuming those pods use
-less than their configured request.
-
+This configuration ensures that the scheduler does not place pods on a node and immediately induce memory pressure and trigger an eviction. This configuration assumes those pods use less than their configured request.
 
 [[out-of-resource-recommended-practices]]
 == Recommended Practice
 
 [[out-of-resource-best-practice-daemonset]]
-=== DaemonSets and Out of Resource Handling
+=== Daemon Sets and Out of Resource Handling
 
-If a node evicts a pod that was created by a DaemonSet, the pod will
-immediately be recreated and rescheduled back to the same node, because the node
-has no ability to distinguish a pod created from a DaemonSet versus any other
-object.
+If a node evicts a pod that was created by a daemon set, the pod is immediately recreated and rescheduled to the same node. The scheduler operates this way because the node has no ability to distinguish a pod that is created by a daemon set versus any other object.
 
-In general, DaemonSets should not create `BestEffort` pods to avoid being
-identified as a candidate pod for eviction. Instead DaemonSets should ideally
-launch `Guaranteed` pods.
+In general, daemon sets should not create best effort pods to avoid being identified as a candidate pod for eviction. Instead, daemon sets should launch pods and configure them with a guaranteed quality of service.

--- a/scaling_performance/using_cpu_manager.adoc
+++ b/scaling_performance/using_cpu_manager.adoc
@@ -62,7 +62,7 @@ kubeletArguments:
   - static
   cpu-manager-reconcile-period:
   - 5s
-  kube-reserved: <1>
+  system-reserved: <1>
   - cpu=500m
 ----
 +
@@ -70,8 +70,7 @@ kubeletArguments:
 ----
 # systemctl restart atomic-openshift-node
 ----
-<1> `kube-reserved` is a required setting. The value may need to be adjusted
-depending on your environment.
+<1> `system-reserved` is a required setting. The value might need to be adjusted depending on your environment.
 
 . Create a pod that requests a core or multiple cores. Both limits and requests
 must have their CPU value set to a whole integer. That is the number of cores
@@ -198,7 +197,7 @@ the system can not run on the core allocated for the `Guaranteed` pod:
 ----
 +
 .Example Output
-[source,terminal]
+[source,yaml]
 ----
 ...
 Capacity:
@@ -223,7 +222,7 @@ Allocated resources:
   3 (85%)       3 (85%)     5437500k (32%)   9250M (55%)
 ----
 +
-This VM has four CPU cores. You set `kube-reserved` to 500 millicores, meaning
+This VM has four CPU cores. You set `system-reserved` to 500 millicores, meaning
 half of one core is subtracted from the total capacity of the node to arrive at
 the `Node Allocatable` amount.
 +


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1853249#

Also fixes https://bugzilla.redhat.com/show_bug.cgi?id=1867706

- OCP does not use kube-reserved, according to notes
  in the first bz.

- cpu-manager file change of kube-reserved to system-reserved

  I'm making a bit of a guess that the replacement
  is OK based on the foll page indicating that
  either is OK.

  https://kubernetes.io/docs/tasks/administer-cluster/cpu-management-policies/#static-policy

- cosmetic reformat in limits.adoc

- revise sequence in left nav to group related topics