### PR TITLE
[enterprise-4.5] Require --filter-by-os='.*' for OLM mirroring

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -66,13 +66,13 @@ $ oc adm catalog mirror \
     <registry_host_name>:<port> \
     [-a ${REG_CREDS}] \//<2>
     [--insecure] \//<3>
-    [--filter-by-os="<os>/<arch>"] \//<4>
+    --filter-by-os='.*' \//<4>
     [--manifests-only] <5>
 ----
 <1> Specify your Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<4> This flag is currently required due to a known issue with multiple architecture support. If unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
 <5> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
 +
 .Example output

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -92,12 +92,12 @@ $ oc adm catalog mirror \
     <registry_host_name>:<port> \
     [-a ${REG_CREDS}] \//<2>
     [--insecure] \//<3>
-    [--filter-by-os="<os>/<arch>"] <4>
+    --filter-by-os='.*' <4>
 ----
 <1> Specify your new Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> Optional: Because the catalog might reference images that support multiple architectures and operating systems, you can filter by architecture and operating system to mirror only the images that match. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<4> This flag is currently required due to a known issue with multiple architecture support. If unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
 
 . Apply the newly generated manifests:
 +


### PR DESCRIPTION
4.5 version of https://github.com/openshift/openshift-docs/pull/27855.