### PR TITLE
Update default sc gce-pd

### DIFF
--- a/modules/dynamic-provisioning-gce-definition.adoc
+++ b/modules/dynamic-provisioning-gce-definition.adoc
@@ -9,13 +9,18 @@
 .gce-pd-storageclass.yaml
 [source,yaml]
 ----
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
-  name: slow
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/gce-pd
 parameters:
-  type: pd-standard  <1>
+  type: pd-standard <1>
   replication-type: none
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
 ----
-<1> Select either `pd-standard` or `pd-ssd`. The default is `pd-ssd`.
+<1> Select either `pd-standard` or `pd-ssd`. The default is `pd-standard`.


### PR DESCRIPTION
It was brought to my attention by the keen eye of @wgordon17 that GCE PD default storage class should be `pd-standard` and not `pd-ssd`. This PR updates the docs as such.

@qinpingli PTAL to confirm from QE perspective. Thanks!