### PR TITLE
CNF-846 - Deploy a VRF CNI plugin that makes it possible to assign different secondary networks to different VRF

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -684,9 +684,11 @@ Topics:
   Topics:
   - Name: Understanding multiple networks
     File: understanding-multiple-networks
-  - Name: Attaching a Pod to an additional network
+  - Name: About virtual routing and forwarding
+    File: about-virtual-routing-and-forwarding
+  - Name: Attaching a pod to an additional network
     File: attaching-pod
-  - Name: Removing a Pod from an additional network
+  - Name: Removing a pod from an additional network
     File: removing-pod
   - Name: Configuring a bridge network
     File: configuring-bridge
@@ -704,6 +706,8 @@ Topics:
     File: remove-additional-network
   - Name: Configuring PTP
     File: configuring-ptp
+  - Name: Assigning a secondary network to a VRF
+    File: assigning-a-secondary-network-to-a-vrf
 - Name: Hardware networks
   Dir: hardware_networks
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
@@ -720,7 +724,7 @@ Topics:
     File: configuring-sriov-net-attach
   - Name: Configuring an SR-IOV InfiniBand network attachment
     File: configuring-sriov-ib-attach
-  - Name: Adding Pod to an SR-IOV network
+  - Name: Adding a pod to an SR-IOV network
     File: add-pod
   - Name: Using high performance multicast
     File: using-sriov-multicast

--- a/modules/cnf-about-virtual-routing-and-forwarding.adoc
+++ b/modules/cnf-about-virtual-routing-and-forwarding.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
+
+[id="cnf-about-virtual-routing-and-forwarding_{context}"]
+= About virtual routing and forwarding
+
+Virtual routing and forwarding (VRF) devices combined with IP rules provide the ability to create virtual routing and forwarding domains. VRF reduces the number of permissions needed by CNF, and provides increased visibility of the network topology of secondary networks. VRF is used to provide multi-tenancy functionality, for example, where each tenant has its own unique routing tables and requires different default gateways.
+
+Processes can bind a socket to the VRF device. Packets through the binded socket use the routing table associated with the VRF device. An important feature of VRF is that it impacts only OSI model layer 3 traffic and above so L2 tools, such as LLDP, are not affected. This allows higher priority IP rules such as policy based routing to take precedence over the VRF device rules directing specific traffic.
+
+[id="cnf-benefits-secondary-networks-telecommunications-operators_{context}"]
+== Benefits of secondary networks for pods for telecommunications operators
+
+In telecommunications use cases, each CNF can potentially be connected to multiple different networks sharing the same address space. These secondary networks can potentially conflict with the cluster's main network CIDR. Using the CNI VRF plug-in, network functions can be connected to different customers' infrastructure using the same IP address, keeping different customers isolated. IP addresses are overlapped with {product-title} IP space. The CNI VRF plug-in also reduces the number of permissions needed by CNF and increases the visibility of network topologies of secondary networks.

--- a/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
@@ -1,0 +1,128 @@
+// Module included in the following assemblies:
+//
+// networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
+
+
+[id="cnf-assigning-a-secondary-network-to-a-vrf_{context}"]
+= Assigning a secondary network to a VRF
+
+As a cluster administrator, you can configure an additional network for your VRF domain by using the CNI VRF plug-in. The virtual network created by this plug-in is associated with a physical interface that you specify.
+
+[id="cnf-creating-an-additional-network-attachment-with-the-cni-vrf-plug-in_{context}"]
+== Creating an additional network attachment with the CNI VRF plug-in
+
+The Cluster Network Operator (CNO) manages additional network definitions. When you specify an additional network to create, the CNO creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
+
+[NOTE]
+====
+Do not edit the `NetworkAttachmentDefinition` CRs that the Cluster Network Operator manages. Doing so might disrupt network traffic on your additional network.
+====
+
+.Prerequisites
+
+* Install the {product-title} CLI (oc).
+* Log in to the OpenShift cluster as a user with cluster-admin privileges.
+
+.Procedure
+
+. Create the CNO CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit networks.operator.openshift.io cluster
+----
+. Extend the CR that you are creating by adding the `rawCNIConfig` configuration for the additional network, as in the example CR below. The following YAML configures the CNI VRF plug-in:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+  spec:
+  additionalNetworks:
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "macvlan-vrf",
+      "plugins": [  <1>
+      {
+        "type": "macvlan",  <2>
+        "master": "eth1",
+        "ipam": {
+            "type": "static",
+            "addresses": [
+            {
+                "address": "191.168.1.23/24"
+            }
+            ]
+        }
+      },
+      {
+        "type": "vrf",
+        "vrfname": "example-vrf-name",  <3>
+        "table": 1001   <4>
+      }]
+    }'
+----
+<1> `plugins` must be a list. The first item in the list must be secondary network underpinning the VRF network. The second item in the list is the VRF plugin configuration.
+<2> `type` must be set to `vrf`.
+<3> `vrfname` is the name of the VRF that the interface is assigned to. If it does not exist in the pod, it is created.
+<4> `table` is the routing table ID. Optional. By default, the `tableid` parameter is used. If it is not specified, the CNI assigns a free routing table ID to the VRF.
++
+[NOTE]
+====
+VRF will function correctly only when the resource is of type `netdevice`.
+====
+. Save your changes and quit the text editor to commit your changes.
+. Confirm that the CNO created the `NetworkAttachmentDefinition` CR by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the CR.
++
+[source,terminal]
+----
+$ oc get network-attachment-definitions -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                       AGE
+additional-network-1       14m
+----
+
+.Verifying that the additional VRF network attachment is successful
+
+To verify that the VRF CNI is correctly configured and the additional network attachment is attached, do the following:
+
+. Create a network that uses the VRF CNI.
+. Assign the network to a pod.
+. Verify that the pod network attachment is connected to the VRF additional network. SSH into the pod and run the following command:
++
+[source,terminal]
+----
+$ ip vrf show
+----
++
+.Example output
++
+[source,terminal]
+----
+Name              Table
+-----------------------
+red                 10
+----
+. Confirm the VRF interface is master of the secondary interface:
++
+[source,terminal]
+----
+$ ip link
+----
++
+.Example output
++
+[source,terminal]
+----
+5: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master red state UP mode
+----
+

--- a/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+//networking/hardware_networks/configuring-sriov-device.adoc
+
+[id="cnf-assigning-a-sriov-network-to-a-vrf_{context}"]
+= Assigning an SR-IOV network to a VRF
+
+As a cluster administrator, you can assign an SR-IOV network interface to your VRF domain by using the CNI VRF plug-in.
+
+To do this, add the VRF configuration to the optional `metaPlugins` parameter of the `SriovNetwork` resource.
+
+[id="cnf-creating-an-additional-sriov-network-with-vrf-plug-in_{context}"]
+== Creating an additional SR-IOV network attachment with the CNI VRF plug-in
+
+The SR-IOV Network Operator manages additional network definitions. When you specify an additional SR-IOV network to create, the SR-IOV Network Operator creates the `NetworkAttachmentDefinition` custom resource (CR) automatically.
+
+[NOTE]
+====
+Do not edit `NetworkAttachmentDefinition` custom resources that the SR-IOV Network Operator manages. Doing so might disrupt network traffic on your additional network.
+====
+
+.Prerequisites
+* Install the {product-title} CLI (oc).
+* Log in to the {product-title} cluster as a user with cluster-admin privileges.
+
+.Procedure
+. Create the `SriovNetwork` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create sriovnetwork.openshift.io cluster
+----
+. Extend the CR that you are creating by adding the `metaPlugins` configuration for the additional network you are creating, as in the following example CR.
+. Save your changes and quit the text editor to commit your changes. The following YAML configures the `SriovNetwork` object:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
+  name: example-network
+  namespace: additional-sriov-network-1
+spec:
+  ipam: |
+    {
+      "type": "host-local",
+      "subnet": "10.56.217.0/24",
+      "rangeStart": "10.56.217.171",
+      "rangeEnd": "10.56.217.181",
+      "routes": [{
+        "dst": "0.0.0.0/0"
+      }],
+      "gateway": "10.56.217.1"
+    }
+  vlan: 0
+  resourceName: intelnics
+  metaPlugins : |
+    {
+      "type": "vrf", <1>
+      "vrfname": "example-vrf-name" <2>
+    }
+----
+<1> `type` must be set to `vrf`.
+<2> `vrfname` is the name of the VRF that the interface is assigned to. If it does not exist in the pod, it is created.
+
+.Verify the `NetworkAttachmentDefinition` CR is successfully created
+Confirm that the SR-IOV Network Operator created the `NetworkAttachmentDefinition` CR by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the SR-IOV Network Operator creates the CR.
+
+[source,terminal]
+----
+$ oc get network-attachment-definitions -n <namespace>
+----
+
+.Example output
+[source,terminal]
+----
+NAME                            AGE
+additional-sriov-network-1      14m
+----
+
+.Verifying that the additional SR-IOV network attachment is successful
+
+To verify that the VRF CNI is correctly configured and the additional SR-IOV network attachment is attached, do the following:
+
+. Create an SR-IOV network that uses the VRF CNI.
+. Assign the network to a pod.
+. Verify that the pod network attachment is connected to the SR-IOV additional network. SSH into the pod and run the following command:
++
+[source,terminal]
+----
+$ ip vrf show
+----
++
+.Example output
+[source,terminal]
+----
+Name              Table
+-----------------------
+red                 10
+----
+. Confirm the VRF interface is master of the secondary interface:
++
+[source,terminal]
+----
+$ ip link
+----
++
+.Example output
+[source,terminal]
+----
+5: net1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc noqueue master red state UP mode
+----
+

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -10,8 +10,10 @@ You can configure a Single Root I/O Virtualization (SR-IOV) device in your clust
 include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
 // A direct companion to nw-sriov-networknodepolicy-object
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
-
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
+:FeatureName: CNI VRF plug-in
+include::modules/technology-preview.adoc[leveloffset=+1]
+include::modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc[leveloffset=+1]
 
 [id="configuring-sriov-device-next-steps"]
 == Next steps

--- a/networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
+++ b/networking/multiple_networks/about-virtual-routing-and-forwarding.adoc
@@ -1,0 +1,8 @@
+[id="about-virtual-routing-and-forwarding"]
+= About virtual routing and forwarding
+include::modules/common-attributes.adoc[]
+:context: about-virtual-routing-and-forwarding
+
+toc::[]
+
+include::modules/cnf-about-virtual-routing-and-forwarding.adoc[leveloffset=+1]

--- a/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
+++ b/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
@@ -1,0 +1,11 @@
+[id="assigning-a-secondary-network-to-a-vrf"]
+= Assigning a secondary network to a VRF
+include::modules/common-attributes.adoc[]
+:context: assigning-a-secondary-network-to-a-vrf
+
+toc::[]
+
+:FeatureName: CNI VRF plug-in
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+include::modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc[leveloffset=+1]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -64,3 +64,5 @@ A macvlan additional network can be configured in two ways:
  - xref:../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Configuring a macvlan-based additional network]
 
  * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configuring an SR-IOV based additional network] allows pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+
+include::modules/nw-multus-remove-pod.adoc[leveloffset=+1]


### PR DESCRIPTION
Updates to support https://issues.redhat.com/browse/CNF-846

Dev Epic Goal:
Deploy a VRF CNI plugin that makes it possible to assign different secondary networks to different VRF (Virtual Routing and Forwarding)

Doc Epics:
https://issues.redhat.com/browse/TELCODOCS-100
https://issues.redhat.com/browse/TELCODOCS-97
https://issues.redhat.com/browse/TELCODOCS-84