### PR TITLE
4.7 Release Notes for Metering - deprecation table

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -75,7 +75,7 @@ You can now remove or rotate the GCP admin-level credential that the xref:../ope
 [id="ocp-4-7-registry-oci-support"]
 ==== Open Container Initiative images support
 
-The {product-title} internal registry and image streams now support Open Container Initiative (OCI) images. You can use OCI images in the same way you would use Docker `schema2` images. 
+The {product-title} internal registry and image streams now support Open Container Initiative (OCI) images. You can use OCI images in the same way you would use Docker `schema2` images.
 
 //Add link
 
@@ -170,7 +170,7 @@ In the table, features are marked with the following statuses:
 |Metering Operator
 |GA
 |DEP
-|
+|DEP
 
 |====
 


### PR DESCRIPTION
Added `DEP` for the Metering Operator in 4.7 to the Deprecated Features Tracker table.