### PR TITLE
remove ibm pz restriction

### DIFF
--- a/modules/op-release-notes-1-2.adoc
+++ b/modules/op-release-notes-1-2.adoc
@@ -16,11 +16,6 @@
 * IBM Power Systems on {product-title} 4.6
 * IBM Z and LinuxONE on {product-title} 4.6
 
-[NOTE]
-====
-Currently you must use the `preview` channel to install {pipelines-title} on IBM Power Systems,  IBM Z, and LinuxONE.
-====
-
 In addition to the fixes and stability improvements, here is a highlight of what’s new in OpenShift Pipelines 1.2.
 
 === Pipelines


### PR DESCRIPTION
@Preeticp 
The issue to move OCP Pipelines to the ocp-4.6 channel was closed.  https://issues.redhat.com/browse/SRVKP-988

I've removed the restriction from the Release Notes. 