### PR TITLE
Omit hostname from shell commands

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -78,15 +78,15 @@ sshKey: '<ssh_pub_key>'
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ mkdir ~/clusterconfigs
-[kni@provisioner ~]$ cp install-config.yaml ~/clusterconfigs
+$ mkdir ~/clusterconfigs
+$ cp install-config.yaml ~/clusterconfigs
 ----
 
 . Ensure all bare metal nodes are powered off prior to installing the {product-title} cluster.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
+$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.

--- a/modules/ipi-install-configuring-the-metal3-config-file.adoc
+++ b/modules/ipi-install-configuring-the-metal3-config-file.adoc
@@ -13,7 +13,7 @@ You must create and configure a ConfigMap `metal3-config.yaml` file.
 . Create a ConfigMap `metal3-config.yaml.sample`.
 +
 ----
-[kni@provisioner ~]$ vim metal3-config.yaml.sample
+$ vim metal3-config.yaml.sample
 ----
 +
 Provide the following contents:
@@ -45,8 +45,8 @@ Replace `<provisioning_ip>` with an available IP on the `provisioning` network. 
 . Create the final ConfigMap.
 +
 ----
-[kni@provisioner ~]$ export COMMIT_ID=$(./openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
-[kni@provisioner ~]$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .images.openstack.path | sed 's/"//g')
-[kni@provisioner ~]$ export RHCOS_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
-[kni@provisioner ~]$ envsubst < metal3-config.yaml.sample > metal3-config.yaml
+$ export COMMIT_ID=$(./openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
+$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .images.openstack.path | sed 's/"//g')
+$ export RHCOS_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+$ envsubst < metal3-config.yaml.sample > metal3-config.yaml
 ----

--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -205,24 +205,24 @@ On the provisioner node, the `install-config.yaml` file should use the newly cre
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ echo "additionalTrustBundle: |" >> install-config.yaml
-[kni@provisioner ~]$ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
+$ echo "additionalTrustBundle: |" >> install-config.yaml
+$ sed -e 's/^/  /' /opt/registry/certs/domain.crt >> install-config.yaml
 ----
 
 . Add the mirror information for the registry to the `install-config.yaml` file.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ echo "imageContentSources:" >> install-config.yaml
-[kni@provisioner ~]$ echo "- mirrors:" >> install-config.yaml
-[kni@provisioner ~]$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-[kni@provisioner ~]$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
-[kni@provisioner ~]$ echo "- mirrors:" >> install-config.yaml
-[kni@provisioner ~]$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-[kni@provisioner ~]$ echo "  source: registry.svc.ci.openshift.org/ocp/release" >> install-config.yaml
-[kni@provisioner ~]$ echo "- mirrors:" >> install-config.yaml
-[kni@provisioner ~]$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
-[kni@provisioner ~]$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
+$ echo "imageContentSources:" >> install-config.yaml
+$ echo "- mirrors:" >> install-config.yaml
+$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
+$ echo "  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev" >> install-config.yaml
+$ echo "- mirrors:" >> install-config.yaml
+$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
+$ echo "  source: registry.svc.ci.openshift.org/ocp/release" >> install-config.yaml
+$ echo "- mirrors:" >> install-config.yaml
+$ echo "  - registry.example.com:5000/ocp4/openshift4" >> install-config.yaml
+$ echo "  source: quay.io/openshift-release-dev/ocp-release" >> install-config.yaml
 ----
 +
 NOTE: Replace `registry.example.com` with the registry's fully qualified domain name.

--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -16,93 +16,93 @@ Use the following steps to install a container that contains the images.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo dnf install -y podman
+$ sudo dnf install -y podman
 ----
 
 . Open firewall port `8080` to be used for {op-system} image caching.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo firewall-cmd --add-port=8080/tcp --zone=public --permanent
+$ sudo firewall-cmd --add-port=8080/tcp --zone=public --permanent
 ----
 
 . Create a directory to store the `bootstraposimage` and `clusterosimage`.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ mkdir /home/kni/rhcos_image_cache
+$ mkdir /home/kni/rhcos_image_cache
 ----
 
 . Set the appropriate SELinux context for the newly created directory.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(/.*)?"
-[kni@provisioner ~]$ sudo restorecon -Rv rhcos_image_cache/
+$ sudo semanage fcontext -a -t httpd_sys_content_t "/home/kni/rhcos_image_cache(/.*)?"
+$ sudo restorecon -Rv rhcos_image_cache/
 ----
 
 . Get the commit ID from the installer. The ID determines which images the installer needs to download.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export COMMIT_ID=$(/usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
+$ export COMMIT_ID=$(/usr/local/bin/openshift-baremetal-install version | grep '^built from commit' | awk '{print $4}')
 ----
 
 . Get the URI for the {op-system} image that the installer will deploy on the nodes.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export RHCOS_OPENSTACK_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.openstack.path | sed 's/"//g')
+$ export RHCOS_OPENSTACK_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.openstack.path | sed 's/"//g')
 ----
 
 . Get the URI for the {op-system} image that the installer will deploy on the bootstrap VM.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
+$ export RHCOS_QEMU_URI=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq .images.qemu.path | sed 's/"//g')
 ----
 
 . Get the path where the images are published.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
+$ export RHCOS_PATH=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json | jq .baseURI | sed 's/"//g')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the bootstrap VM.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
+$ export RHCOS_QEMU_SHA_UNCOMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.qemu["uncompressed-sha256"]')
 ----
 
 . Get the SHA hash for the {op-system} image that will be deployed on the nodes.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.openstack.sha256')
+$ export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubusercontent.com/openshift/installer/$COMMIT_ID/data/data/rhcos.json  | jq -r '.images.openstack.sha256')
 ----
 
 . Download the images and place them in the `/home/kni/rhcos_image_cache` directory.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache
-[kni@provisioner ~]$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache
+$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache
+$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache
 ----
 
 . Confirm SELinux type is of `httpd_sys_content_t` for the newly created files.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ ls -Z /home/kni/rhcos_image_cache
+$ ls -Z /home/kni/rhcos_image_cache
 ----
 
 . Create the pod.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ podman run -d --name rhcos_image_cache \
+$ podman run -d --name rhcos_image_cache \
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
 registry.centos.org/centos/httpd-24-centos7:latest

--- a/modules/ipi-install-creating-the-openshift-manifests.adoc
+++ b/modules/ipi-install-creating-the-openshift-manifests.adoc
@@ -9,7 +9,7 @@
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ ./openshift-baremetal-install --dir ~/clusterconfigs create manifests
+$ ./openshift-baremetal-install --dir ~/clusterconfigs create manifests
 ----
 +
 [source,terminal]
@@ -24,6 +24,6 @@ ifeval::[{release} <= 4.3]
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ cp ~/metal3-config.yaml clusterconfigs/openshift/99_metal3-config.yaml
+$ cp ~/metal3-config.yaml clusterconfigs/openshift/99_metal3-config.yaml
 ----
 endif::[]

--- a/modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc
+++ b/modules/ipi-install-deploying-the-cluster-via-the-openshift-installer.adoc
@@ -9,5 +9,5 @@ Run the {product-title} installer:
 
 [source,terminal]
 ----
-[kni@provisioner ~]$ ./openshift-baremetal-install --dir ~/clusterconfigs --log-level debug create cluster
+$ ./openshift-baremetal-install --dir ~/clusterconfigs --log-level debug create cluster
 ----

--- a/modules/ipi-install-extracting-the-openshift-installer.adoc
+++ b/modules/ipi-install-extracting-the-openshift-installer.adoc
@@ -13,23 +13,23 @@ After retrieving the installer, the next step is to extract it.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export cmd=openshift-baremetal-install
-[kni@provisioner ~]$ export pullsecret_file=~/pull-secret.txt
-[kni@provisioner ~]$ export extract_dir=$(pwd)
+$ export cmd=openshift-baremetal-install
+$ export pullsecret_file=~/pull-secret.txt
+$ export extract_dir=$(pwd)
 ----
 
 . Get the `oc` binary:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux-$VERSION.tar.gz | tar zxvf - oc
+$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux-$VERSION.tar.gz | tar zxvf - oc
 ----
 
 . Extract the installer:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo cp oc /usr/local/bin
-[kni@provisioner ~]$ oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${RELEASE_IMAGE}
-[kni@provisioner ~]$ sudo cp openshift-baremetal-install /usr/local/bin
+$ sudo cp oc /usr/local/bin
+$ oc adm release extract --registry-config "${pullsecret_file}" --command=$cmd --to "${extract_dir}" ${RELEASE_IMAGE}
+$ sudo cp openshift-baremetal-install /usr/local/bin
 ----

--- a/modules/ipi-install-following-the-installation.adoc
+++ b/modules/ipi-install-following-the-installation.adoc
@@ -9,5 +9,5 @@ During the deployment process, you can check the installation's overall status b
 
 [source,terminal]
 ----
-[kni@provisioner ~]$ tail -f /path/to/install-dir/.openshift_install.log
+$ tail -f /path/to/install-dir/.openshift_install.log
 ----

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -14,33 +14,33 @@ Preparing the bare metal node requires executing the following procedure from th
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
+$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
 ----
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo cp oc /usr/local/bin
+$ sudo cp oc /usr/local/bin
 ----
 
 . Install the `ipmitool`.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo dnf install -y OpenIPMI ipmitool
+$ sudo dnf install -y OpenIPMI ipmitool
 ----
 
 . Power off the bare metal node and ensure it is off.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
+$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 +
 Where `<management-server-ip>` is the IP address of the bare metal node's base board management controller.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power status
+$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power status
 ----
 +
 [source,bash]
@@ -52,19 +52,19 @@ Chassis Power is off
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ echo -ne "root" | base64
+$ echo -ne "root" | base64
 ----
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ echo -ne "calvin" | base64
+$ echo -ne "calvin" | base64
 ----
 
 . Create a configuration file for the bare metal node.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ vim bmh.yaml
+$ vim bmh.yaml
 ----
 +
 [source,yaml]
@@ -97,7 +97,7 @@ Replace `<num>` for the worker number of bare metal node in two `name` fields an
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc -n openshift-machine-api create -f bmh.yaml
+$ oc -n openshift-machine-api create -f bmh.yaml
 ----
 +
 [source,bash]
@@ -112,7 +112,7 @@ Where `<num>` will be the worker number.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc -n openshift-machine-api get bmh openshift-worker-<num>
+$ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
 Where `<num>` is the worker node number.

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -33,15 +33,15 @@ Perform the following steps to prepare the environment.
 [source,terminal]
 ----
 [root@provisioner ~]# su - kni
-[kni@provisioner ~]$
+$
 ----
 
 . Use Red Hat Subscription Manager to register the provisioner node.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo subscription-manager register --username=<user> --password=<pass> --auto-attach
-[kni@provisioner ~]$ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=rhel-8-for-x86_64-baseos-rpms
+$ sudo subscription-manager register --username=<user> --password=<pass> --auto-attach
+$ sudo subscription-manager repos --enable=rhel-8-for-x86_64-appstream-rpms --enable=rhel-8-for-x86_64-baseos-rpms
 ----
 +
 [NOTE]
@@ -53,40 +53,40 @@ For more information about Red Hat Subscription Manager, see link:https://access
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo dnf install -y libvirt qemu-kvm mkisofs python3-devel jq ipmitool
+$ sudo dnf install -y libvirt qemu-kvm mkisofs python3-devel jq ipmitool
 ----
 
 . Modify the user to add the `libvirt` group to the newly created user.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo usermod --append --groups libvirt <user>
+$ sudo usermod --append --groups libvirt <user>
 ----
 
 . Restart `firewalld` and enable the `http` service.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo systemctl start firewalld
-[kni@provisioner ~]$ sudo firewall-cmd --zone=public --add-service=http --permanent
-[kni@provisioner ~]$ sudo firewall-cmd --reload
+$ sudo systemctl start firewalld
+$ sudo firewall-cmd --zone=public --add-service=http --permanent
+$ sudo firewall-cmd --reload
 ----
 
 . Start and enable the `libvirtd` service.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo systemctl start libvirtd
-[kni@provisioner ~]$ sudo systemctl enable libvirtd --now
+$ sudo systemctl start libvirtd
+$ sudo systemctl enable libvirtd --now
 ----
 
 . Create the `default` storage pool and start it.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo virsh pool-define-as --name default --type dir --target /var/lib/libvirt/images
-[kni@provisioner ~]$ sudo virsh pool-start default
-[kni@provisioner ~]$ sudo virsh pool-autostart default
+$ sudo virsh pool-define-as --name default --type dir --target /var/lib/libvirt/images
+$ sudo virsh pool-start default
+$ sudo virsh pool-autostart default
 ----
 
 . Configure networking.
@@ -98,9 +98,9 @@ This step can also be run from the web console.
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ export PUB_CONN=<baremetal_nic_name>
-[kni@provisioner ~]$ export PROV_CONN=<prov_nic_name>
-[kni@provisioner ~]$ sudo nohup bash -c "
+$ export PUB_CONN=<baremetal_nic_name>
+$ export PROV_CONN=<prov_nic_name>
+$ sudo nohup bash -c "
     nmcli con down \"$PROV_CONN\"
     nmcli con down \"$PUB_CONN\"
     nmcli con delete \"$PROV_CONN\"
@@ -139,7 +139,7 @@ Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol w
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo nmcli con show
+$ sudo nmcli con show
 ----
 +
 [source,terminal]
@@ -156,7 +156,7 @@ bridge-slave-eno2  f31c3353-54b7-48de-893a-02d2b34c4736  ethernet  eno2
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ vim pull-secret.txt
+$ vim pull-secret.txt
 ----
 +
 In a web browser, navigate to link:https://cloud.redhat.com/openshift/install/metal/user-provisioned[Install on Bare Metal with user-provisioned infrastructure], and scroll down to the **Downloads** section. Click **Copy pull secret**. Paste the contents into the `pull-secret.txt` file and save the contents in the `kni` user's home directory.

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -13,7 +13,7 @@ Provisioning the bare metal node requires executing the following procedure from
 +
 [source,bash]
 ----
-[kni@provisioner ~]$  oc -n openshift-machine-api get bmh openshift-worker-<num>
+$  oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
 Where `<num>` is the worker node number.
@@ -28,7 +28,7 @@ openshift-worker-<num>   OK       ready                            ipmi://<out-o
 [source,bash]
 +
 ----
-[kni@provisioner ~]$ oc get nodes
+$ oc get nodes
 ----
 +
 [source,bash]
@@ -46,7 +46,7 @@ openshift-worker-1.openshift.example.com            Ready    master          30h
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc get machinesets -n openshift-machine-api
+$ oc get machinesets -n openshift-machine-api
 ----
 +
 [source,bash]
@@ -61,7 +61,7 @@ openshift-worker-1.example.com      1         1         1       1           55m
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc scale --replicas=<num> machineset <machineset> -n openshift-machine-api
+$ oc scale --replicas=<num> machineset <machineset> -n openshift-machine-api
 ----
 +
 Replace `<num>` with the new number of worker nodes. Replace `<machineset>` with the name of the machine set from the previous step.
@@ -70,7 +70,7 @@ Replace `<num>` with the new number of worker nodes. Replace `<machineset>` with
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc -n openshift-machine-api get bmh openshift-worker-<num>
+$ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
 Where `<num>` is the worker node number. The status changes from `ready` to `provisioning`.
@@ -93,7 +93,7 @@ openshift-worker-<num>   OK       provisioned           openshift-worker-<num>-6
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc get nodes
+$ oc get nodes
 ----
 +
 [source,bash]
@@ -112,7 +112,7 @@ You can also check the kubelet.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ssh openshift-worker-<num>
+$ ssh openshift-worker-<num>
 ----
 +
 [source,bash]

--- a/modules/ipi-install-retrieving-the-openshift-installer.adoc
+++ b/modules/ipi-install-retrieving-the-openshift-installer.adoc
@@ -11,6 +11,6 @@ available version of {product-title}:
 
 [source,terminal]
 ----
-[kni@provisioner ~]$ export VERSION=latest-4.6
+$ export VERSION=latest-4.6
 export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
 ----

--- a/modules/ipi-install-troubleshooting-api-not-accessible.adoc
+++ b/modules/ipi-install-troubleshooting-api-not-accessible.adoc
@@ -13,21 +13,21 @@ When the cluster is running and clients cannot access the API, domain name resol
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ hostname
+$ hostname
 ----
 +
 If a hostname is not set, set the correct hostname. For example:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ hostnamectl set-hostname <hostname>
+$ hostnamectl set-hostname <hostname>
 ----
 
 . **Incorrect Name Resolution:** Ensure that each node has the correct name resolution in the DNS server using `dig` and `nslookup`. For example:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ dig api.<cluster-name>.example.com
+$ dig api.<cluster-name>.example.com
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-troubleshooting-bootstrap-vm-cannot-boot.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-cannot-boot.adoc
@@ -21,7 +21,7 @@ To verify the issue, there are three containers related to `ironic`:
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ssh core@172.22.0.2
+$ ssh core@172.22.0.2
 ----
 
 . To check the container logs, execute the following:
@@ -42,5 +42,5 @@ installation over IPMI:
 
 [source,bash]
 ----
-[kni@provisioner ~]$ ipmitool -I lanplus -U root -P <password> -H <out-of-band-ip> power off
+$ ipmitool -I lanplus -U root -P <password> -H <out-of-band-ip> power off
 ----

--- a/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
@@ -24,7 +24,7 @@ The `ipa-downloader` and `coreos-downloader` containers download resources from 
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ssh core@172.22.0.2
+$ ssh core@172.22.0.2
 ----
 
 . Check the status of the `ipa-downloader` and `coreos-downloader` containers within the bootstrap VM:

--- a/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
@@ -13,7 +13,7 @@ The {product-title} installer spawns a bootstrap node virtual machine, which han
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo virsh list
+$ sudo virsh list
 ----
 +
 [source,bash]
@@ -35,7 +35,7 @@ If the bootstrap VM is not running after 10-15 minutes, troubleshoot why it is n
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ systemctl status libvirtd
+$ systemctl status libvirtd
 ----
 +
 [source,bash]
@@ -58,7 +58,7 @@ If the bootstrap VM is operational, log into it.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ sudo virsh console example.com
+$ sudo virsh console example.com
 ----
 +
 [source,bash]
@@ -90,7 +90,7 @@ In the console output of the previous step, you can use the IPv6 IP address prov
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ ssh core@172.22.0.2
+$ ssh core@172.22.0.2
 ----
 
 If you are not successful logging in to the bootstrap VM, you have likely encountered one of the following scenarios:

--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -12,7 +12,7 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
+$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
@@ -32,5 +32,5 @@ done
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ rm -rf ~/clusterconfigs/auth ~/clusterconfigs/terraform* ~/clusterconfigs/tls ~/clusterconfigs/metadata.json
+$ rm -rf ~/clusterconfigs/auth ~/clusterconfigs/terraform* ~/clusterconfigs/tls ~/clusterconfigs/metadata.json
 ----

--- a/modules/ipi-install-troubleshooting-install-config.adoc
+++ b/modules/ipi-install-troubleshooting-install-config.adoc
@@ -15,7 +15,7 @@ The `install-config.yaml` configuration file represents all of the nodes that ar
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ curl -s -o /dev/null -I -w "%{http_code}\n" http://webserver.example.com:8080/rhcos-44.81.202004250133-0-qemu.x86_64.qcow2.gz?sha256=7d884b46ee54fe87bbc3893bf2aa99af3b2d31f2e19ab5529c60636fbd0f1ce7
+$ curl -s -o /dev/null -I -w "%{http_code}\n" http://webserver.example.com:8080/rhcos-44.81.202004250133-0-qemu.x86_64.qcow2.gz?sha256=7d884b46ee54fe87bbc3893bf2aa99af3b2d31f2e19ab5529c60636fbd0f1ce7
 ----
 +
 If the output is `200`, there is a valid response from the webserver storing the bootstrap VM image.

--- a/modules/ipi-install-troubleshooting-misc-issues.adoc
+++ b/modules/ipi-install-troubleshooting-misc-issues.adoc
@@ -21,7 +21,7 @@ The Cluster Network Operator is responsible for deploying the networking compone
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get all -n openshift-network-operator
+$ oc get all -n openshift-network-operator
 ----
 +
 [source,terminal]
@@ -35,7 +35,7 @@ pod/network-operator-69dfd7b577-bg89v   0/1   ContainerCreating 0          149m
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ kubectl get network.config.openshift.io cluster -oyaml
+$ kubectl get network.config.openshift.io cluster -oyaml
 ----
 +
 [source,terminal]
@@ -57,21 +57,21 @@ If it does not exist, the installer did not create it. To determine why the inst
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ openshift-install create manifests
+$ openshift-install create manifests
 ----
 
 . Check that the `network-operator` is running:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ kubectl -n openshift-network-operator get pods
+$ kubectl -n openshift-network-operator get pods
 ----
 
 . Retrieve the logs:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ kubectl -n openshift-network-operator logs -l "name=network-operator"
+$ kubectl -n openshift-network-operator logs -l "name=network-operator"
 ----
 +
 On high availability clusters with three or more control plane (master) nodes, the Operator will perform leader election and all other Operators will sleep. For additional details, see https://github.com/openshift/installer/blob/master/docs/user/troubleshooting.md[Troubleshooting].
@@ -187,21 +187,21 @@ If the cluster node is not getting the correct hostname over DHCP after the clus
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get csr
+$ oc get csr
 ----
 
 . Verify if a pending `csr` contains `Subject Name: localhost.localdomain`:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get csr <pending_csr> -o jsonpath='{.spec.request}' | base64 -d | openssl req -noout -text
+$ oc get csr <pending_csr> -o jsonpath='{.spec.request}' | base64 -d | openssl req -noout -text
 ----
 
 . Remove any `csr` that contains `Subject Name: localhost.localdomain`:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc delete csr <wrong_csr>
+$ oc delete csr <wrong_csr>
 ----
 
 == Routes do not reach endpoints
@@ -212,14 +212,14 @@ During the installation process, it is possible to encounter a Virtual Router Re
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get route oauth-openshift
+$ oc get route oauth-openshift
 ----
 
 . Check the service endpoint:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get svc oauth-openshift
+$ oc get svc oauth-openshift
 ----
 +
 [source,terminal]
@@ -254,7 +254,7 @@ oauth-openshift   ClusterIP   172.30.19.162   <none>        443/TCP   59m
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc logs deployment/authentication-operator -n openshift-authentication-operator
+$ oc logs deployment/authentication-operator -n openshift-authentication-operator
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -13,7 +13,7 @@ The deployment of {product-title} clusters depends on NTP synchronized clocks am
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get nodes
+$ oc get nodes
 ----
 +
 [source,terminal]
@@ -29,7 +29,7 @@ worker-2.cloud.example.com   Ready    worker   100m   v1.16.2
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc get bmh -n openshift-machine-api
+$ oc get bmh -n openshift-machine-api
 ----
 +
 [source,terminal]
@@ -39,7 +39,7 @@ master-1   error registering master-1  ipmi://<out-of-band-ip>
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo timedatectl
+$ sudo timedatectl
 ----
 +
 [source,terminal]
@@ -59,7 +59,7 @@ System clock synchronized: no
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ cat << EOF | base 64
+$ cat << EOF | base 64
 server <NTP-server> iburst<1>
 stratumweight 0
 driftfile /var/lib/chrony/drift
@@ -86,7 +86,7 @@ the `[text-in-base-64]` string generated in the output of the previous step. The
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ cat << EOF > ./99_masters-chrony-configuration.yaml
+$ cat << EOF > ./99_masters-chrony-configuration.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -123,21 +123,21 @@ spec:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ cp 99_masters-chrony-configuration.yaml 99_masters-chrony-configuration.yaml.backup
+$ cp 99_masters-chrony-configuration.yaml 99_masters-chrony-configuration.yaml.backup
 ----
 
 . Apply the configuration file:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ oc apply -f ./masters-chrony-configuration.yaml
+$ oc apply -f ./masters-chrony-configuration.yaml
 ----
 
 . Ensure the `System clock synchronized` value is **yes**:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ sudo timedatectl
+$ sudo timedatectl
 ----
 +
 [source,terminal]
@@ -155,7 +155,7 @@ To setup clock synchronization prior to deployment, generate the manifest files 
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ cp chrony-masters.yaml ~/clusterconfigs/openshift/99_masters-chrony-configuration.yaml
+$ cp chrony-masters.yaml ~/clusterconfigs/openshift/99_masters-chrony-configuration.yaml
 ----
 +
 Then, continue to create the cluster.

--- a/modules/ipi-install-troubleshooting-registry-issues.adoc
+++ b/modules/ipi-install-troubleshooting-registry-issues.adoc
@@ -39,6 +39,6 @@ disconnected environment:
 +
 [source,terminal]
 ----
-[kni@provisioner ~]$ curl -k -u <user>:<password> https://registry.example.com:<registry-port>/v2/_catalog
+$ curl -k -u <user>:<password> https://registry.example.com:<registry-port>/v2/_catalog
 {"repositories":["<Repo-Name>"]}
 ----

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -13,7 +13,7 @@ After installation, ensure the installer deployed the nodes and pods successfull
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc get nodes
+$ oc get nodes
 ----
 +
 [source,bash]
@@ -29,5 +29,5 @@ removes any pods that are still running or have completed as part of the output.
 +
 [source,bash]
 ----
-[kni@provisioner ~]$ oc get pods --all-namespaces | grep -iv running | grep -iv complete
+$ oc get pods --all-namespaces | grep -iv running | grep -iv complete
 ----


### PR DESCRIPTION
It is already clear what system these commands must be entered
on and including the hostname breaks the click to copy feature.

@openshift/team-documentation - just a thought.