### PR TITLE
Bug 1908750 - 'queuedChunkLimitSize' parameter not getting applied in… [enterprise-4.5][enterprise-4.6][enterprise-4.7]

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -70,10 +70,6 @@ a|The chunking behavior when the queue is full:
 * `drop_oldest_chunk`: Drop the oldest chunk to accept new incoming chunks. Older chunks have less value than newer chunks.
 |`block`
 
-|`queuedChunkLimitSize`
-|The number of chunks in the queue.
-|`32`
-
 |`retryMaxInterval`
 |The maximum time in seconds for the `exponential_backoff` retry method.
 |`300s`


### PR DESCRIPTION
… clusterlogging instance
https://bugzilla.redhat.com/show_bug.cgi?id=1908750