### PR TITLE
BZ1906518-v1 fix apiVersion in 4-7

### DIFF
--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -29,7 +29,7 @@ To dynamically create a volume snapshot:
 .volumesnapshotclass.yaml
 [source,yaml]
 ----
-apiVersion: snapshot.storage.k8s.io
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass <1>
 metadata:
   name: csi-hostpath-snap
@@ -52,7 +52,7 @@ $ oc create -f volumesnapshotclass.yaml
 .volumesnapshot-dynamic.yaml
 [source,yaml]
 ----
-apiVersion: snapshot.storage.k8s.io
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: mysnap
@@ -82,7 +82,7 @@ To manually provision a snapshot:
 .volumesnapshot-manual.yaml
 [source,yaml]
 ----
-apiVersion: snapshot.storage.k8s.io
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: snapshot-demo
@@ -114,7 +114,7 @@ The following example displays details about the `mysnap` volume snapshot:
 .volumesnapshot.yaml
 [source,yaml]
 ----
-apiVersion: snapshot.storage.k8s.io
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshot
 metadata:
   name: mysnap

--- a/modules/persistent-storage-csi-snapshots-delete.adoc
+++ b/modules/persistent-storage-csi-snapshots-delete.adoc
@@ -17,7 +17,7 @@ To enable deletion of a volume snapshot in a cluster:
 .volumesnapshot.yaml
 [source,yaml]
 ----
-apiVersion: snapshot.storage.k8s.io
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snap

--- a/modules/persistent-storage-csi-snapshots-operator.adoc
+++ b/modules/persistent-storage-csi-snapshots-operator.adoc
@@ -11,7 +11,7 @@ The CSI Snapshot Controller Operator installs the CSI snapshot controller, which
 
 == Volume snapshot CRDs
 
-During {product-title} installation, the CSI Snapshot Controller Operator creates the following snapshot custom resource definitions (CRDs) in the `snapshot.storage.k8s.io/` API group:
+During {product-title} installation, the CSI Snapshot Controller Operator creates the following snapshot custom resource definitions (CRDs) in the `snapshot.storage.k8s.io/v1` API group:
 
 `VolumeSnapshotContent`::
 A snapshot taken of a volume in the cluster that has been provisioned by a cluster administrator.

--- a/modules/persistent-storage-csi-snapshots-restore.adoc
+++ b/modules/persistent-storage-csi-snapshots-restore.adoc
@@ -30,7 +30,7 @@ spec:
   dataSource:
     name: mysnap <1>
     kind: VolumeSnapshot <2>
-    apiGroup: snapshot.storage.k8s.io <3>
+    apiGroup: snapshot.storage.k8s.io/v1 <3>
   accessModes:
     - ReadWriteOnce
   resources:
@@ -39,7 +39,7 @@ spec:
 ----
 <1> Name of the `VolumeSnapshot` object representing the snapshot to use as source.
 <2> Must be set to the `VolumeSnapshot` value.
-<3> Must be set to the `snapshot.storage.k8s.io` value.
+<3> Must be set to the `snapshot.storage.k8s.io/v1` value.
 
 . Create a PVC by entering the following command:
 


### PR DESCRIPTION
[BZ 1906518](https://github.com/openshift/cluster-csi-snapshot-controller-operator/pull/69) - also relates to https://bugzilla.redhat.com/show_bug.cgi?id=1906284.

Updates snapshot CRD references for `apiVersion` to `snapshot.storage.k8s.io/v1`. Applies to 4.7+ as noted in https://github.com/openshift/openshift-docs/pull/28034/files#r546900158.

@openshift/team-documentation PTAL