### PR TITLE
Document OCP on OSP with OVNKubernetes networkType

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-ovnk8s.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-ovnk8s.adoc
@@ -1,0 +1,48 @@
+[id="installing-openstack-installer-kuryr"]
+= Installing a cluster on OpenStack with OVN-Kubernetes
+include::modules/common-attributes.adoc[]
+:context: installing-openstack-installer-ovnk8s
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a customized cluster on
+{rh-openstack-first} that uses Open Virtual Networking with Kubernetes. To customize the installation, modify parameters in the `install-config.yaml` before you install the cluster.
+
+[id="prerequisites_installing-openstack-installer-ovnk8s"]
+== Prerequisites
+
+* Review details about the
+xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
+processes.
+** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+
+* Have a storage service installed in {rh-openstack}, like block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
+
+include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]
+include::modules/installation-osp-control-compute-machines.adoc[leveloffset=+2]
+include::modules/installation-osp-bootstrap-machine.adoc[leveloffset=+2]
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+include::modules/installation-osp-enabling-swift.adoc[leveloffset=+1]
+include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1]
+include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+include::modules/installation-initializing.adoc[leveloffset=+1]
+include::modules/installation-configuration-parameters.adoc[leveloffset=+1]
+include::modules/installation-osp-custom-subnet.adoc[leveloffset=+2]
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+include::modules/installation-osp-accessing-api.adoc[leveloffset=+1]
+include::modules/installation-osp-accessing-api-floating.adoc[leveloffset=+2]
+include::modules/installation-osp-accessing-api-no-floating.adoc[leveloffset=+2]
+include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+[id="next-steps_openstack-installer-ovnk8s"]
+== Next steps
+
+* xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
+* If necessary, you can
+xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If you need to enable external access to node ports, xref:../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#nw-using-nodeport_configuring-ingress-cluster-traffic-nodeport[configure ingress cluster traffic by using a node port].
+* If you did not configure {rh-openstack} to accept application traffic over floating IP addresses, xref:../../post_installation_configuration/network-configuration.adoc#installation-osp-configuring-api-floating-ip_post-install-network-configuration[configure {rh-openstack} access with floating IP addresses].

--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -2,12 +2,13 @@
 //
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_openstack/installing-openstack-installer-ovnk8s.adoc
 // * networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
 
 [id="configuring-hybrid-ovnkubernetes_{context}"]
 = Configuring hybrid networking with OVN-Kubernetes
 
-You can configure your cluster to use hybrid networking with OVN-Kubernetes. This allows a hybrid cluster that supports different node networking configurations. For example, this is necessary to run both Linux and Windows nodes in a cluster.
+Here is the procedure to configure your cluster to use hybrid networking with OVN-Kubernetes. This allows a hybrid cluster that supports different node networking configurations. For example, this is necessary to run both Linux and Windows nodes in a cluster.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
OVNKubernetes is a supported backend that enables more use-cases for our
community deploying OCP on OSP.

This patch creates a new page that will explain step by step how to
deploy OCP on OSP with the OVNKubernetes networkType.

Note: the page was inspired from Kuryr, as it's also documented another
networkType.

Jira: https://issues.redhat.com/browse/OSASINFRA-2234
