### PR TITLE
Use correct branch name for page history in OSD

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -84,7 +84,7 @@
 
       <% if (distro_key != "openshift-origin") %>
       <span text-align="right" style="float: right !important">
-        <a href="https://github.com/openshift/openshift-docs/commits/enterprise-<%= (distro_key == "openshift-enterprise") ? version : ((distro_key == "openshift-dedicated") ? "3.11" : "3.11") %>/<%= repo_path %>">
+        <a href="https://github.com/openshift/openshift-docs/commits/enterprise-<%= (distro_key == "openshift-enterprise") ? version : ((distro_key == "openshift-dedicated") ? ((version == "4") ? "4.3" : "3.11") : "3.11") %>/<%= repo_path %>">
           Page history
         </a>
         <%


### PR DESCRIPTION
Fix to the Page History part of #25003
The build had been using 3.11 as the branch link for the openshift_dedicated distro.

I'm not sure if the branch referenced here is correct for OSD 4, I've used [enterprise-4](https://issues.redhat.com/browse/enterprise-4).3 as that is referenced in the _distro_map.yml for dedicated