### PR TITLE
SecureBoot for enterprise-4.7.

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -10,7 +10,7 @@ Installer-provisioned installation involves a number of hardware node requiremen
 
 - **CPU architecture:** All nodes must use `x86_64` CPU architecture.
 
-- **Similar nodes:** Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory, and storage configuration.
+- **Similar nodes:** Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory and storage configuration.
 
 ifeval::[{release} < 4.5]
 - **Intelligent Platform Management Interface (IPMI):** Installer-provisioned installation requires IPMI enabled on each node.
@@ -28,10 +28,14 @@ endif::[]
 
 - **Control plane:** Installer-provisioned installation requires three control plane nodes for high availability.
 
-- **Worker nodes:** While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development and testing. 
+- **Worker nodes:** While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
 
 - **Network interfaces:** Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network *when using the `provisioning` network* for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
 
 ifeval::[{release} > 4.3]
 - **Unified Extensible Firmware Interface (UEFI):** Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but *omitting the `provisioning` network removes this requirement.*
+endif::[]
+
+ifeval::[{release} > 4.6]
+- **Secure Boot:** Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications and the operating system. To deploy a {product-title} cluster with Secure Boot, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot **only** when installer-provisioned installation uses Red Fish Virtual Media. Red Hat **does not** support Secure Boot with self-generated keys.
 endif::[]


### PR DESCRIPTION
Fixes: [TELCODOCS-121](https://issues.redhat.com/browse/TELCODOCS-121)

https://issues.redhat.com/browse/TELCODOCS-121
Verified by Lubov Shilin

Signed-off-by: John Wilkins <jowilkin@redhat.com>

@ahardin-rh Cherry pick to 4.7