### PR TITLE
Bug 1908514: additional supported AWS regions

### DIFF
--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -7,6 +7,8 @@
 
 You can deploy an {product-title} cluster to the following public regions:
 
+* `af-south-1` (Cape Town)
+* `ap-east-1` (Hong Kong)
 * `ap-northeast-1` (Tokyo)
 * `ap-northeast-2` (Seoul)
 * `ap-south-1` (Mumbai)
@@ -15,6 +17,7 @@ You can deploy an {product-title} cluster to the following public regions:
 * `ca-central-1` (Central)
 * `eu-central-1` (Frankfurt)
 * `eu-north-1` (Stockholm)
+* `eu-south-1` (Milan)
 * `eu-west-1` (Ireland)
 * `eu-west-2` (London)
 * `eu-west-3` (Paris)


### PR DESCRIPTION
As part of a 4.6.z release, we included support for three new regions:

- `af-south-1`
- `ap-east-1`
- `eu-south-1`

This updates the docs accordingly.