### PR TITLE
BZ1893600 - add var partition proc to UPI cloud docs

### DIFF
--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -5,13 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a
-cluster on Amazon Web Services (AWS) that uses infrastructure that you provide.
+In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) that uses infrastructure that you provide.
 
-One way to create this infrastructure is to use the provided
-CloudFormation templates. You can modify the templates to customize your
-infrastructure or use the information that they contain to create AWS objects
-according to your company's policies.
+One way to create this infrastructure is to use the provided CloudFormation templates. You can modify the templates to customize your infrastructure or use the information that they contain to create AWS objects according to your company's policies.
 
 == Prerequisites
 
@@ -23,14 +19,7 @@ to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to
-create AWS resources for the entire life of the cluster, so you must
-use key-based, long-lived credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
 * You downloaded the AWS CLI and installed it on your computer. See
 link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)]
@@ -41,11 +30,7 @@ in the AWS documentation.
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
@@ -62,6 +47,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
+
+include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 
 include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
 
@@ -193,5 +180,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -38,14 +38,7 @@ to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to
-create AWS resources for the entire life of the cluster, so you must
-use key-based, long-lived credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
 * You downloaded the AWS CLI and installed it on your computer. See
 link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)]
@@ -56,11 +49,7 @@ in the AWS documentation.
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
@@ -79,6 +68,8 @@ include::modules/installation-aws-permissions.adoc[leveloffset=+2]
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
+
+include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 
 include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
 
@@ -130,10 +121,7 @@ include::modules/installation-creating-aws-worker.adoc[leveloffset=+1]
 [id="installing-workers-aws-user-infra"]
 == Creating worker nodes
 
-You can either manually create worker nodes or use a MachineSet to create worker
-nodes after the cluster deploys. If you use a MachineSet to create and maintain
-the workers, you can allow the cluster to manage them. This allows you to easily
-scale, manage, and upgrade your workers.
+You can either manually create worker nodes or use a MachineSet to create worker nodes after the cluster deploys. If you use a MachineSet to create and maintain the workers, you can allow the cluster to manage them. This allows you to easily scale, manage, and upgrade your workers.
 ////
 
 include::modules/installation-cloudformation-worker.adoc[leveloffset=+2]
@@ -181,5 +169,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -5,34 +5,17 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-Microsoft Azure by using infrastructure that you provide.
+In {product-title} version {product-version}, you can install a cluster on Microsoft Azure by using infrastructure that you provide.
 
-Several
-link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview[Azure Resource Manager]
-(ARM) templates are provided to assist in completing these steps or to help
-model your own. You can also create the required resources through other
-methods; the templates are just an example.
+Several link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/templates/overview[Azure Resource Manager] (ARM) templates are provided to assist in completing these steps or to help model your own. You can also create the required resources through other methods; the templates are just an example.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account]
-to host the cluster.
-* Download the Azure CLI and install it on your computer. See
-link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest[Install the Azure CLI]
-in the Azure documentation. The documentation below was last tested using
-version `2.2.0` of the Azure CLI. Azure CLI commands might perform differently
-based on the version you use.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster.
+* Download the Azure CLI and install it on your computer. See link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest[Install the Azure CLI] in the Azure documentation. The documentation below was last tested using version `2.2.0` of the Azure CLI. Azure CLI commands might perform differently based on the version you use.
+* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 +
 [NOTE]
 ====
@@ -44,38 +27,24 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 [id="installation-azure-user-infra-config-project"]
 == Configuring your Azure project
 
-Before you can install {product-title}, you must configure an Azure project to
-host it.
+Before you can install {product-title}, you must configure an Azure project to host it.
 
 [IMPORTANT]
 ====
-All Azure resources that are available through public endpoints are subject to
-resource name restrictions, and you cannot create resources that use certain
-terms. For a list of terms that Azure restricts, see
-link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resource-name[Resolve reserved resource name errors]
-in the Azure documentation.
+All Azure resources that are available through public endpoints are subject to resource name restrictions, and you cannot create resources that use certain terms. For a list of terms that Azure restricts, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resource-name[Resolve reserved resource name errors] in the Azure documentation.
 ====
 
 include::modules/installation-azure-limits.adoc[leveloffset=+2]
 include::modules/installation-azure-network-config.adoc[leveloffset=+2]
 
-You can view Azure's DNS solution by visiting this
-xref:installation-azure-create-dns-zones_{context}[example for creating DNS zones].
+You can view Azure's DNS solution by visiting this xref:installation-azure-create-dns-zones_{context}[example for creating DNS zones].
 
 include::modules/installation-azure-increasing-limits.adoc[leveloffset=+2]
 
 [id="csr-management-azure_{context}"]
 === Certificate signing requests management
 
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.
+Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
 
 include::modules/installation-azure-permissions.adoc[leveloffset=+2]
 include::modules/installation-azure-service-principal.adoc[leveloffset=+2]
@@ -86,6 +55,7 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
+include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 include::modules/installation-initializing.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
@@ -98,8 +68,7 @@ include::modules/installation-azure-user-infra-uploading-rhcos.adoc[leveloffset=
 
 include::modules/installation-azure-create-dns-zones.adoc[leveloffset=+1]
 
-You can learn more about xref:installation-azure-network-config_{context}[configuring a public DNS zone in Azure]
-by visiting that section.
+You can learn more about xref:installation-azure-network-config_{context}[configuring a public DNS zone in Azure] by visiting that section.
 
 include::modules/installation-creating-azure-vnet.adoc[leveloffset=+1]
 include::modules/installation-arm-vnet.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -5,27 +5,15 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-Google Cloud Platform (GCP) that uses infrastructure that you provide.
+In {product-title} version {product-version}, you can install a cluster on Google Cloud Platform (GCP) that uses infrastructure that you provide.
 
-The steps for performing a user-provided infrastructure install are outlined here. Several
-link:https://cloud.google.com/deployment-manager/docs[Deployment Manager] templates are provided to assist in
-completing these steps or to help model your own. You are also free to create
-the required resources through other methods; the templates are just an
-example.
+The steps for performing a user-provided infrastructure install are outlined here. Several link:https://cloud.google.com/deployment-manager/docs[Deployment Manager] templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods; the templates are just an example.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 +
 [NOTE]
 ====
@@ -35,21 +23,12 @@ Be sure to also review this site list if you are configuring a proxy.
 [id="csr-management-gcp_{context}"]
 == Certificate signing requests management
 
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.
+Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
 
 [id="installation-gcp-user-infra-config-project"]
 == Configuring your GCP project
 
-Before you can install {product-title}, you must configure a Google Cloud
-Platform (GCP) project to host it.
+Before you can install {product-title}, you must configure a Google Cloud Platform (GCP) project to host it.
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 include::modules/installation-gcp-enabling-api-services.adoc[leveloffset=+2]
@@ -61,14 +40,12 @@ include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
-
+include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 include::modules/installation-initializing.adoc[leveloffset=+2]
-
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
-
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
-
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
+
 .Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra[Optional: Adding the ingress DNS records]
@@ -114,5 +91,4 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -5,47 +5,31 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-Google Cloud Platform (GCP) that uses infrastructure that you provide and an internal mirror of the installation release content.
+In {product-title} version {product-version}, you can install a cluster on Google Cloud Platform (GCP) that uses infrastructure that you provide and an internal mirror of the installation release content.
 
 [IMPORTANT]
 ====
-While you can install an {product-title} cluster by using mirrored installation
-release content, your cluster still requires internet access to use the GCP APIs.
+While you can install an {product-title} cluster by using mirrored installation release content, your cluster still requires internet access to use the GCP APIs.
 ====
 
-The steps for performing a user-provided infrastructure install are outlined here. Several
-link:https://cloud.google.com/deployment-manager/docs[Deployment Manager] templates are provided to assist in
-completing these steps or to help model your own. You are also free to create
-the required resources through other methods; the templates are just an
-example.
+The steps for performing a user-provided infrastructure install are outlined here. Several link:https://cloud.google.com/deployment-manager/docs[Deployment Manager] templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods; the templates are just an example.
 
 == Prerequisites
 
-* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host]
- and obtain the `imageContentSources` data for your version of {product-title}.
+* xref:../../installing/install_config/installing-restricted-networks-preparations.adoc#installing-restricted-networks-preparations[Create a mirror registry on your bastion host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the bastion host, use that computer
-to complete all installation steps.
+Because the installation media is on the bastion host, use that computer to complete all installation steps.
 ====
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
 [id="installation-restricted-networks-gcp-user-infra-config-project"]
 == Configuring your GCP project
 
-Before you can install {product-title}, you must configure a Google Cloud
-Platform (GCP) project to host it.
+Before you can install {product-title}, you must configure a Google Cloud Platform (GCP) project to host it.
 
 include::modules/installation-gcp-project.adoc[leveloffset=+2]
 include::modules/installation-gcp-enabling-api-services.adoc[leveloffset=+2]
@@ -57,10 +41,10 @@ include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
-
+include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 include::modules/installation-initializing.adoc[leveloffset=+2]
-
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
+
 .Additional resources
 
 * xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra[Optional: Adding the ingress DNS records]
@@ -107,5 +91,4 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-user-infra.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+// * installing/installing_azure/installing-azure-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+// Similar content to what is in this module is also present in modules/installation-disk-partitioning.adoc. <-- This module is in use with the following vSphere assemblies:
+//    * installing-vsphere.adoc
+//    * installing-vsphere-network-customizations.adoc
+//    * installing-restricted-networks-vsphere.adoc
+
+// Similar content to what is in this module is also present in modules/installation-user-infra-machines-advanced.adoc. <-- This module is in use with the following bare metal assemblies:
+//    * installing-bare-metal-network-customizations.adoc
+//    * installing-bare-metal.adoc
+//    * installing-restricted-networks-bare-metal.adoc
+
+[id="installation-disk-partitioning-upi-templates_{context}"]
+= Optional: Creating a separate `/var` partition
+It is recommended that disk partitioning for {product-title} be left to the installer. However, there are cases where you might want to create separate partitions in a part of the filesystem that you expect to grow.
+
+{product-title} supports the addition of a single partition to attach storage to either the `/var` partition or a subdirectory of `/var`. For example:
+
+* `/var/lib/containers`: Holds container-related content that can grow as more images and containers are added to a system.
+* `/var/lib/etcd`: Holds data that you might want to keep separate for purposes such as performance optimization of etcd storage.
+* `/var`: Holds data that you might want to keep separate for purposes such as auditing.
+
+Storing the contents of a `/var` directory separately makes it easier to grow storage for those areas as needed and reinstall {product-title} at a later date and keep that data intact. With this method, you will not have to pull all your containers again, nor will you have to copy massive log files when you update systems.
+
+Because `/var` must be in place before a fresh installation of {op-system-first}, the following procedure sets up the separate `/var` partition by creating a machine config that is inserted during the `openshift-install` preparation phases of an {product-title} installation.
+
+[IMPORTANT]
+====
+If you follow the steps to create a separate `/var` partition in this procedure, it is not necessary to create the Kubernetes manifest and Ignition config files again as described later in this section.
+====
+
+.Procedure
+
+. Create a directory to hold the {product-title} installation files:
++
+[source,terminal]
+----
+$ mkdir $HOME/clusterconfig
+----
+
+. Run `openshift-install` to create a set of files in the `manifest` and `openshift` subdirectories. Answer the system questions as you are prompted:
++
+[source,terminal]
+----
+$ openshift-install create manifests --dir $HOME/clusterconfig
+? SSH Public Key ...
+$ ls $HOME/clusterconfig/openshift/
+99_kubeadmin-password-secret.yaml
+99_openshift-cluster-api_master-machines-0.yaml
+99_openshift-cluster-api_master-machines-1.yaml
+99_openshift-cluster-api_master-machines-2.yaml
+...
+----
+
+. Create a `MachineConfig` object and add it to a file in the `openshift` directory. For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This attaches storage to a separate `/var` directory.
+
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 98-var-partition
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      disks:
+      - device: /dev/<device_name> <1>
+        partitions:
+        - sizeMiB: <partition_size>
+          startMiB: <partition_start_offset> <2>
+          label: var
+      filesystems:
+        - path: /var
+          device: /dev/disk/by-partlabel/var
+          format: xfs
+    systemd:
+      units:
+        - name: var.mount
+          enabled: true
+          contents: |
+            [Unit]
+            Before=local-fs.target
+            [Mount]
+            Where=/var
+            What=/dev/disk/by-partlabel/var
+            [Install]
+            WantedBy=local-fs.target
+----
++
+<1> The storage device name of the disk that you want to partition.
+<2> When adding a data partition to the boot disk, a minimum value of 25000 MiB (Mebibytes) is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+
+. Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
++
+[source,terminal]
+----
+$ openshift-install create ignition-configs --dir $HOME/clusterconfig
+$ ls $HOME/clusterconfig/
+auth  bootstrap.ign  master.ign  metadata.json  worker.ign
+----
+
+Now you can use the Ignition config files as input to the installation procedures to install {op-system-first} systems.

--- a/modules/installation-user-infra-generate.adoc
+++ b/modules/installation-user-infra-generate.adoc
@@ -50,18 +50,10 @@ endif::[]
 = Creating the installation files for {cp}
 
 ifdef::azure[]
-To install {product-title} on {cp-first} using user-provisioned
-infrastructure, you must generate the files that the installation
-program needs to deploy your cluster and modify them so that the cluster creates
-only the machines that it will use. You generate and customize the
-`install-config.yaml` file, Kubernetes manifests, and Ignition config files.
+To install {product-title} on {cp-first} using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use. You generate and customize the `install-config.yaml` file, Kubernetes manifests, and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
 endif::azure[]
 ifdef::aws,gcp[]
-To install {product-title} on {cp-first} ({cp}) using user-provisioned
-infrastructure, you must generate the files that the installation
-program needs to deploy your cluster and modify them so that the cluster creates
-only the machines that it will use. You generate and customize the
-`install-config.yaml` file, Kubernetes manifests, and Ignition config files.
+To install {product-title} on {cp-first} ({cp}) using user-provisioned infrastructure, you must generate the files that the installation program needs to deploy your cluster and modify them so that the cluster creates only the machines that it will use. You generate and customize the `install-config.yaml` file, Kubernetes manifests, and Ignition config files. You also have the option to first set up a separate `var` partition during the preparation phases of installation.
 endif::aws,gcp[]
 
 ifeval::["{context}" == "installing-restricted-networks-aws"]


### PR DESCRIPTION
Reopened [BZ1893600](https://bugzilla.redhat.com/show_bug.cgi?id=1893600) with the request to add the `/var` partitioning procedure to UPI cloud platform docs (AWS, GCP, Azure). Previously, this procedure was added to only vSphere and bare metal.

This PR modularizes the `/var` partitioning procedure so it can be reused across cloud. Unfortunately, it is out of scope at this time to modularize the previous content added in https://github.com/openshift/openshift-docs/pull/27810 and https://github.com/openshift/openshift-docs/pull/27394.

Cc: @codyhoag - thanks for letting me know that UPI docs for cloud providers are found by the template types that they install:
- AWS CloudFormation templates: https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-user-infra.html
- Azure ARM templates: https://docs.openshift.com/container-platform/4.6/installing/installing_azure/installing-azure-user-infra.html
- GCP Deployment Manager templates: https://docs.openshift.com/container-platform/4.6/installing/installing_gcp/installing-gcp-user-infra.html

I've attempted to add this module where it makes the most sense in comparison to its already-published location in [vSphere](https://docs.openshift.com/container-platform/4.6/installing/installing_vsphere/installing-vsphere.html#installation-disk-partitioning_installing-vsphere) and [bare metal](https://docs.openshift.com/container-platform/4.6/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced_disk_installing-bare-metal) docs.

Applies to 4.6+.