### PR TITLE
OSDOCS-1720 bug fixes for 4-5 branch only

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi.adoc
+
+[id="csi-drivers-supported_{context}"]
+= CSI drivers supported by {product-title}
+
+{product-title} supports certain CSI drivers that give users storage options that are not possible with in-tree volume plug-ins.
+
+To create CSI-provisioned persistent volumes that mount to these supported storage assets, you can install and configure the CSI driver Operator, which will install the necessary CSI driver and storage class. For more details about installing the Operator and driver, see the documentation for the specific CSI Driver Operator.
+
+The following table describes the CSI drivers that are available with {product-title} and which CSI features they support, such as volume snapshots, cloning, and resize.
+
+.Supported CSI drivers and features in {product-title}
+[cols=",^v,^v,^v", width="100%",options="header"]
+|===
+|CSI driver  |CSI volume snapshots  |CSI cloning  |CSI resize
+
+|AWS EBS (Tech Preview) | ✅ | - | ✅
+|OpenStack Manila | ✅ | ✅ | ✅
+|===
+
+[IMPORTANT]
+====
+If your CSI driver is not listed in the preceding table, you must follow the installation instructions provided by your CSI storage vendor to use their supported CSI features.
+====

--- a/modules/persistent-storage-csi-snapshots-operator.adoc
+++ b/modules/persistent-storage-csi-snapshots-operator.adoc
@@ -7,30 +7,30 @@
 
 The CSI Snapshot Controller Operator runs in the `openshift-cluster-storage-operator` namespace. It is installed by the Cluster Version Operator (CVO) in all clusters by default.
 
-The CSI Snapshot Controller Operator installs the CSI snapshot controller, which runs in the `csi-snapshot-controller` namespace.
+The CSI Snapshot Controller Operator installs the CSI snapshot controller, which runs in the `openshift-cluster-storage-operator` namespace.
 
 == Volume snapshot CRDs
 
-During {product-title} installation, the CSI Snapshot Controller Operator creates the following snapshot custom resource definitions (CRDs) in the `snapshot.storage.k8s.io/` API group:
+During {product-title} installation, the CSI Snapshot Controller Operator creates the following snapshot custom resource definitions (CRDs) in the `snapshot.storage.k8s.io/v1beta1` API group:
 
 `VolumeSnapshotContent`::
 A snapshot taken of a volume in the cluster that has been provisioned by a cluster administrator.
 +
-Similar to the `PersistentVolume` CRD, the `VolumeSnapshotContent` CRD is a cluster resource that points to a real snapshot in the storage back end.
+Similar to the `PersistentVolume` object, the `VolumeSnapshotContent` CRD is a cluster resource that points to a real snapshot in the storage back end.
 +
-For manually pre-provisioned snapshots, a cluster administrator creates a number of `VolumeSnapshotContent` objects. These carry the details of the real volume snapshot in the storage system.
+For manually pre-provisioned snapshots, a cluster administrator creates a number of `VolumeSnapshotContent` CRDs. These carry the details of the real volume snapshot in the storage system.
 +
 The `VolumeSnapshotContent` CRD is not namespaced and is for use by a cluster administrator.
 
 `VolumeSnapshot`::
 
-Similar to the `PersistentVolumeClaim` CRD, the `VolumeSnapshot` CRD defines a developer request for a snapshot. The CSI Snapshot Controller Operator runs the CSI snapshot controller, which handles the binding of a `VolumeSnapshot` object with an appropriate `VolumeSnapshotContent` object. The binding is a one-to-one mapping.
+Similar to the `PersistentVolumeClaim` object, the `VolumeSnapshot` CRD defines a developer request for a snapshot. The CSI Snapshot Controller Operator runs the CSI snapshot controller, which handles the binding of a `VolumeSnapshot` CRD with an appropriate `VolumeSnapshotContent` CRD. The binding is a one-to-one mapping.
 +
 The `VolumeSnapshot` CRD is namespaced. A developer uses the CRD as a distinct request for a snapshot.
 
 `VolumeSnapshotClass`::
 
-Allows a cluster administrator to specify different attributes belonging to a `VolumeSnapshot` object. These attributes may differ among snapshots taken of the same volume on the storage system, in which case they would not be expressed by using the same storage class of a persistent volume claim.
+Allows a cluster administrator to specify different attributes belonging to a `VolumeSnapshot` CRD. These attributes may differ among snapshots taken of the same volume on the storage system, in which case they would not be expressed by using the same storage class of a persistent volume claim.
 +
 The `VolumeSnapshotClass` CRD defines the parameters for the `csi-external-snapshotter` sidecar to use when creating a snapshot. This allows the storage back end to know what kind of snapshot to dynamically create if multiple options are supported.
 +

--- a/modules/persistent-storage-csi-snapshots-overview.adoc
+++ b/modules/persistent-storage-csi-snapshots-overview.adoc
@@ -26,7 +26,7 @@ With CSI volume snapshots, an app developer can:
 Be aware of the following when using volume snapshots:
 
 * Support is only available for CSI drivers. In-tree and FlexVolumes are not supported.
-* {product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
+* {product-title} only ships with select CSI drivers. For CSI drivers that are not provided by an {product-title} Driver Operator, it is recommended to use the CSI drivers provided by
 link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
 * CSI drivers may or may not have implemented the volume snapshot functionality. CSI drivers that have provided support for volume snapshots will likely use the `csi-external-snapshotter` sidecar. See documentation provided by the CSI driver for details.
 * {product-title} {product-version} supports version 1.1.0 of the link:https://github.com/container-storage-interface/spec[CSI specification].

--- a/modules/persistent-storage-csi-snapshots-restore.adoc
+++ b/modules/persistent-storage-csi-snapshots-restore.adoc
@@ -5,9 +5,9 @@
 [id="persistent-storage-csi-snapshots-restore_{context}"]
 = Restoring a volume snapshot
 
-After your `VolumeSnapshot` object is bound, you can use that object to provision a new volume that is pre-populated with data from the snapshot.
+The `VolumeSnapshot` CRD content can be used to restore the existing volume to a previous state.
 
-The volume snapshot content object is used to restore the existing volume to a previous state.
+After your `VolumeSnapshot` CRD is bound and the `readyToUse` value is set to `true`, you can use that resource to provision a new volume that is pre-populated with data from the snapshot.
 
 .Prerequisites
 * Logged in to a running {product-title} cluster.

--- a/storage/container_storage_interface/persistent-storage-csi.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi.adoc
@@ -26,6 +26,8 @@ include::modules/persistent-storage-csi-external-controllers.adoc[leveloffset=+2
 
 include::modules/persistent-storage-csi-driver-daemonset.adoc[leveloffset=+2]
 
+include::modules/persistent-storage-csi-drivers-supported.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-csi-dynamic-provisioning.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-mysql-example.adoc[leveloffset=+1]


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/28034 and to this [comment](https://github.com/openshift/openshift-docs/pull/28034#issuecomment-749778592) that brings OCP 4.5 docs up to date for: 
- CSI snapshot controller namespace, as reported in https://bugzilla.redhat.com/show_bug.cgi?id=1906288
- Use of snapshot apiVersion `snapshot.storage.k8s.io/v1beta1`
- Adding `modules/persistent-storage-csi-drivers-supported.adoc` using the drivers supported up to OCP 4.5