### PR TITLE
Bug 1911487: make deployment config explicit for prune deployments

### DIFF
--- a/modules/pruning-deployments.adoc
+++ b/modules/pruning-deployments.adoc
@@ -3,9 +3,9 @@
 // * applications/pruning-objects.adoc
 
 [id="pruning-deployments_{context}"]
-= Pruning deployments
+= Pruning deployment configs
 
-In order to prune deployments that are no longer required by the system due to age and status, administrators can run the following command:
+In order to prune deployment configs that are no longer required by the system due to age and status, administrators can run the following command:
 
 [source,terminal]
 ----


### PR DESCRIPTION
/assign @bergerhoffer 

This should be picked all the way back to all supported versions to leave no impression that we support pruning deployments, which are different than deployment configs. 