### PR TITLE
Adding context to assembly

### DIFF
--- a/logging/troubleshooting/cluster-logging-must-gather.adoc
+++ b/logging/troubleshooting/cluster-logging-must-gather.adoc
@@ -1,3 +1,4 @@
+:context: cluster-logging-must-gather
 [id="cluster-logging-must-gather"]
 = Collecting logging data for Red Hat Support
 include::modules/ossm-document-attributes.adoc[]


### PR DESCRIPTION
The _cluster-logging-must-gather.adoc_ assembly does not have a context string. Adding it here.