### PR TITLE
[enterprise-4.6] Fix #28278: Using current release tag for descheduler image

### DIFF
--- a/modules/nodes-descheduler-configuring-other-settings.adoc
+++ b/modules/nodes-descheduler-configuring-other-settings.adoc
@@ -32,7 +32,7 @@ spec:
   deschedulingIntervalSeconds: 3600 <1>
   flags:
   - --dry-run <2>
-  image: quay.io/openshift/origin-descheduler:4.4 <3>
+  image: quay.io/openshift/origin-descheduler:4.6 <3>
 ...
 ----
 <1> Set number of seconds between descheduler runs. A value of `0` in this field runs the descheduler once and exits.


### PR DESCRIPTION
Manual cherrypick of #28279. Updated version for topic branch.