### PR TITLE
Fix spelling errors reported in OSSM-197

### DIFF
--- a/modules/ossm-architecture.adoc
+++ b/modules/ossm-architecture.adoc
@@ -13,7 +13,7 @@ The *data plane* is a set of intelligent proxies deployed as sidecars. These pro
 
 The *control plane* manages and configures Istiod to enforce proxies to route traffic.
 
-Istiod provides service discovery, configuration and certificate management. It converts high-level routing rules to Envoy configurations and propogates them to the sidcars at runtime.
+Istiod provides service discovery, configuration and certificate management. It converts high-level routing rules to Envoy configurations and propagates them to the sidecars at runtime.
 
 Security Discovery Service (SDS) distributes certificates and keys to sidecars directly from Istiod.
 

--- a/modules/ossm-cr-example.adoc
+++ b/modules/ossm-cr-example.adoc
@@ -182,98 +182,98 @@ The following table lists the specifications for the `ServiceMeshControlPlane` r
 |===
 |Name |Description |Configurable parameters
 
-|addons
-|Addon is used to configure additional features beyond core control plane components, such as visualization, or metric storage.
+|`addons`
+| You use the `addons` parameter to configure additional features beyond core control plane components, such as visualization, or metric storage.
 |`3scale`, `grafana`, `jaeger`, `kiali`, and `prometheus`.
 
-|cluster
-|Cluster is the general configuration of the cluster (cluster name, network name, multi-cluster, mesh expansion, etc.)
+|`cluster`
+|The `cluster` parameter sets the general configuration of the cluster (cluster name, network name, multi-cluster, mesh expansion, etc.)
 |`meshExpansion`, `multiCluster`, `name`, and `network`
 
-|gateways
-|Gateways configures ingress and egress gateways for the mesh.
+|`gateways`
+| You use the `gateways` parameter to configure ingress and egress gateways for the mesh.
 |`enabled`, `additionalEgress`, `additionalIngress`, `egress`, `ingress`, and  `openshiftRoute`
 
-|general
-|General represents general control plane configuration that does not fit anywhere else.
+|`general`
+|The `general` parameter represents general control plane configuration that does not fit anywhere else.
 |`logging` and `validationMessages`
 
-|policy
-|Policy configures policy checking for the control plane. If `spec.policy.enabled` is set to `true`, policy checking is enabled.
+|`policy`
+|You use the `policy` parameter to configure policy checking for the control plane. Policy checking can be enabled by setting `spec.policy.enabled` to `true`.
 |`mixer` `remote`, or `type`. `type` can be set to `Istiod`, `Mixer` or `None`.
 
-|profiles
-|Profiles selects the `ServiceMeshControlPlane` profile to use for default values.
+|`profiles`
+|You select the `ServiceMeshControlPlane` profile to use for default values using the `profiles` parameter.
 |`default`
 
-|proxy
-|Proxy configures the default behavior for sidecars. 
+|`proxy`
+| You use the `proxy` parameter to configure the default behavior for sidecars. 
 |`accessLogging`, `adminPort`, `concurrency`, and `envoyMetricsService`
 
-|runtime
-|Runtime configuration for the control plane components.
+|`runtime`
+| You use the `runtime` parameter to configure the control plane components.
 |`components`, and `defaults`
 
-|security
-|Security configures aspects of security for the control plane.
+|`security`
+| The `security` parameter allows you to configure aspects of security for the control plane.
 |`certificateAuthority`, `controlPlane`, `identity`, `dataPlane` and `trust`
 
-|techPreview
-|TechPreview is used to enable early access to features that are technology previews.
+|`techPreview`
+|The `techPreview` parameter enables early access to features that are in technology techPreview.
 |N/A
 
-|telemetry
-|If spec.mixer.telemetry.enabled is set to true, telemetry is enabled.
+|`telemetry`
+|If `spec.mixer.telemetry.enabled` is set to `true`, telemetry is enabled.
 |`mixer`, `remote`, and `type`. `type` can be set to `Istiod`, `Mixer` or `None`.
 
-|tracing
-|Tracing enables distributed tracing for the mesh.
+|`tracing`
+|You use the `tracing` parameter to enables distributed tracing for the mesh.
 |`sampling`, `type`. `type` can be set to `Jaeger` or `None`.
 
-|version
-|Version specifies what Maistra version of the control plane to install. When creating a `ServiceMeshControlPlane` with an empty version, the admission webhook sets the version to the current version. New `ServiceMeshControlPlanes` with an empty version are set to v2.0. Existing `ServiceMeshControlPlanes` with an empty version keep their setting.
+|`version`
+|You use the `version` parameter to specify what Maistra version of the control plane to install. When creating a `ServiceMeshControlPlane` with an empty version, the admission webhook sets the version to the current version. New `ServiceMeshControlPlanes` with an empty version are set to `v2.0`. Existing `ServiceMeshControlPlanes` with an empty version keep their setting.
 |string
 |===
 
-ControlPlaneStatus represents the current state of your service mesh.
+`ControlPlaneStatus` represents the current state of your service mesh.
 
 .`ServiceMeshControlPlane` resource `ControlPlaneStatus`
 |===
 |Name |Description |Type
 
-|annotations
-|Annotations is an unstructured key value map used to store additional, usually redundant status information, such as the number of components deployed by the `ServiceMeshControlPlane`. These statuses are used by the command line tool, `oc`, which does not yet allow counting objects in JSONPath expressions.
+|`annotations`
+|The `annotations` parameter stores additional, usually redundant status information, such as the number of components deployed by the `ServiceMeshControlPlane`. These statuses are used by the command line tool, `oc`, which does not yet allow counting objects in JSONPath expressions.
 |Not configurable
 
-|conditions
+|`conditions`
 |Represents the latest available observations of the object’s current state. `Reconciled` indicates whether the operator has finished reconciling the actual state of deployed components with the configuration in the `ServiceMeshControlPlane` resource. `Installed` indicates whether the control plane has been installed. `Ready` indicates whether all control plane components are ready
 |string
 
-|components
+|`components`
 |Shows the status of each deployed control plane component.
 |string
 
-|appliedSpec
+|`appliedSpec`
 |The resulting specification of the configuration options after all profiles have been applied.
 |`ControlPlaneSpec`
 
-|appliedValues
+|`appliedValues`
 |The resulting values.yaml used to generate the charts.
 |`ControlPlaneSpec`
 
-|chartVersion
+|`chartVersion`
 |The version of the charts that were last processed for this resource.
 |string
 
-|observedGeneration
+|`observedGeneration`
 |The generation observed by the controller during the most recent reconciliation. The information in the status pertains to this particular generation of the object. The `status.conditions` are not up-to-date if the `status.observedGeneration` field doesn't match `metadata.generation`.
 |integer
 
-|operatorVersion
+|`operatorVersion`
 |The version of the operator that last processed this resource.
 |string
 
-|readiness
+|`readiness`
 |The readiness status of components & owned resources
 |string
 |===


### PR DESCRIPTION
This fixes various spelling errors found in [OSSM-197](https://issues.redhat.com/browse/OSSM-197) as well as a few other issues in the docs.