### PR TITLE
Adding must gather to topic map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1228,6 +1228,9 @@ Topics:
 - Name: Manually rolling out Elasticsearch
   File: cluster-logging-manual-rollout
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Collecting logging data for Red Hat Support
+  File: cluster-logging-must-gather
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 - Name: Troubleshooting Kibana
   File: cluster-logging-troubleshooting
   Distros: openshift-enterprise,openshift-webscale,openshift-origin

--- a/logging/cluster-logging-must-gather.adoc
+++ b/logging/cluster-logging-must-gather.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 When opening a support case, it is helpful to provide debugging information about your cluster to Red Hat Support.
 
-The xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[`must-gather` tool] enables you to collect diagnostic information for project-level resources, cluster-level resources, and each of the cluster logging components.
+The xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[`must-gather` tool] enables you to collect diagnostic information for project-level resources, cluster-level resources, and each of the cluster logging components.
 
 For prompt support, supply diagnostic information for both {product-title} and cluster logging.
 


### PR DESCRIPTION
When merging the [must-gather PR](https://github.com/openshift/openshift-docs/pull/25276), the addition to the topic map didn't make 4.4 as the file structure is different than master and subsequent versions. 