### PR TITLE
Bug 1910665: Kuryr: Add note about expected OpenStack subnet

### DIFF
--- a/modules/installation-osp-kuryr-config-yaml.adoc
+++ b/modules/installation-osp-kuryr-config-yaml.adoc
@@ -40,7 +40,7 @@ networking:
   machineNetwork:
   - cidr: 10.0.0.0/16
   serviceNetwork:
-  - 172.30.0.0/16
+  - 172.30.0.0/16 <1>
   networkType: Kuryr
 platform:
   openstack:
@@ -48,17 +48,17 @@ platform:
     externalNetwork: external
     computeFlavor: m1.xlarge
     lbFloatingIP: 128.0.0.1
-    trunkSupport: true
-    octaviaSupport: true
+    trunkSupport: true <2>
+    octaviaSupport: true <2>
 pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ----
-
-[NOTE]
-====
-Both `trunkSupport` and `octaviaSupport` are automatically discovered by the
+<1> The Amphora Octavia driver creates two ports per load balancer. As a
+result, the service subnet that the installer creates is twice the size of the
+CIDR that is specified as the value of the `serviceNetwork` property. The larger range is
+required to prevent IP address conflicts.
+<2> Both `trunkSupport` and `octaviaSupport` are automatically discovered by the
 installer, so there is no need to set them. But if your environment does not
 meet both requirements, Kuryr SDN will not properly work. Trunks are needed
 to connect the pods to the {rh-openstack} network and Octavia is required to create the
 {product-title} services.
-====


### PR DESCRIPTION
With Kuryr the subnet created for the services will be twice the size of
the subnet specified in install-config.yaml which might be
counterintuitive for the users. This commit adds a note about it.