### PR TITLE
Adding node name and IPv4 address formatting guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -217,8 +217,84 @@ Considering that we use distinct branches to keep content for product versions s
 
 If it makes more sense in context to refer to the major version of the product instead of a specific minor version (for example, if comparing how something in OpenShift Container Platform 4 differs from OpenShift Container Platform 3), just use the major version number. Do not prepend with a `v`, as in `v3` or `v4`.
 
-*Do not use internal company server names in command or example output*. See suggested host name examples https://docs.openshift.com/container-platform/3.11/install/example_inventories.html#multi-masters-single-etcd-using-native-ha[here].
+== Node names
 
+Do not use internal company server names in commands or example output. Provide generic OpenShift Container Platform node name examples that are not provider-specific, unless required. Where possible, use the example.com domain name when providing fully qualified domain names (FQDNs).
+
+The following table includes example OpenShift Container Platform 4 node names and their corresponding role types:
+
+[options="header"]
+|===
+
+|Node name |Role type
+
+|*node-1.example.com*
+.3+.^|You can use this format for nodes that do not need role-specific node names.
+
+|*node-2.example.com*
+
+|*node-3.example.com*
+
+|*control-plane-1.example.com*
+.3+.^|You can use this format if you need to describe the control plane role type within a node name.
+
+|*control-plane-2.example.com*
+
+|*control-plane-3.example.com*
+
+|*compute-1.example.com*
+.2+.^|You can use this format if you need to describe the compute node role type within a node name.
+
+|*compute-2.example.com*
+
+|*bootstrap.example.com*
+|You can use this format if you need to describe the bootstrap node role type within a node name.
+|===
+
+This example lists the status of cluster nodes that use the node name formatting guidelines:
+
+....
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          STATUS   ROLES    AGE   VERSION
+compute-1.example.com         Ready    worker   33m   v1.19.0+9f84db3
+control-plane-1.example.com   Ready    master   41m   v1.19.0+9f84db3
+control-plane-2.example.com   Ready    master   45m   v1.19.0+9f84db3
+compute-2.example.com         Ready    worker   38m   v1.19.0+9f84db3
+compute-3.example.com         Ready    worker   33m   v1.19.0+9f84db3
+control-plane-3.example.com   Ready    master   41m   v1.19.0+9f84db3
+----
+....
+
+[NOTE]
+====
+Some provider-formatted host names include IPv4 addresses. An OpenShift Container Platform node name typically reflects the host name of a node. If node names in your output need to be provider-specific and require this format, use private IPv4 addresses. For example, you could use `ip-10-0-48-9.example.com` as a node name that includes a private IPv4 address.
+====
+
+== IP addresses
+
+You may include IPv4 addresses from test clusters in examples in the documentation, as long as they are private. Private IPv4 addresses fall into one of the following ranges:
+
+* 10.0.0.0 to 10.255.255.255 (class A address block 10.0.0.0/8)
+* 172.16.0.0 to 172.31.255.255 (class B address block 172.16.0.0/12)
+* 192.168.0.0 to 192.168.255.255 (class C address block 192.168.0.0/16)
+
+Replace all public IP addresses with an address from the following blocks. These address blocks are reserved for documentation:
+
+* 192.0.2.0 to 192.0.2.255 (TEST-NET-1 address block 192.0.2.0/24)
+* 198.51.100.0 to 198.51.100.255 (TEST-NET-2 address block 198.51.100.0/24)
+* 203.0.113.0 to 203.0.113.255 (TEST-NET-3 address block 203.0.113.0/24)
+
+[NOTE]
+====
+There might be advanced networking examples that require specific IP addresses, or cloud provider-specific examples that require a public IP address. Contact a subject matter expert if you need assistance with replacing IP addresses.
+====
 
 == Links, hyperlinks, and cross references
 Links can be used to cross-reference internal assemblies or send readers to external information resources for further reading.


### PR DESCRIPTION
This applies to master only.

This PR adds node name and IPv4 address formatting guidelines to `contributing_to_docs/doc_guidelines.adoc`.

The auto-preview link detailed in [this comment](https://github.com/openshift/openshift-docs/pull/28378#issuecomment-755231513) is not found. As an alternative, you can display the rich diff in the [Files changed](https://github.com/openshift/openshift-docs/pull/28378/files) tab.