### PR TITLE
BZ-1907402: Removing startup probe references as they aren't supporte…

### DIFF
--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -6,7 +6,7 @@
 = Understanding health checks
 
 A health check periodically performs diagnostics on a
-running container using any combination of the readiness, liveness, and startup health checks.
+running container using any combination of the readiness and liveness health checks.
 
 You can include one or more probes in the specification for the pod that contains the container which you want to perform the health checks.
 
@@ -29,14 +29,7 @@ responds based on its restart policy.
 For example, a liveness probe on a pod with a `restartPolicy` of `Always` or `OnFailure`
 kills and restarts the container.
 
-Startup probe::
-A _startup probe_ indicates whether the application within a container is started. All other probes are disabled until the startup succeeds. If the startup probe does not succeed within a specified time period, the kubelet kills the container, and the container is subject to the pod `restartPolicy`.
-+
-Some applications can require additional start-up time on their first initialization. You can use a startup probe with a liveness or readiness probe to delay that probe long enough to handle lengthy start-up time using the `failureThreshold` and `periodSeconds` parameters.
-+
-For example, you can add a startup probe, with a `failureThreshold` of 30 failures and a `periodSeconds` of 10 seconds (30 * 10s = 300s) for a maximum of 5 minutes, to a liveness probe. After the startup probe succeeds the first time, the liveness probe takes over.
-
-You can configure liveness, readiness, and startup probes with any of the following types of tests:
+You can configure liveness and readiness probes with any of the following types of tests:
 
 * HTTP `GET`: When using an HTTP `GET` test, the test determines the healthiness of the container by using a web hook. The test is successful if the HTTP response code is between `200` and `399`.
 +
@@ -57,7 +50,6 @@ You can configure several fields to control the behavior of a probe:
 * `failureThreshold`: The number of times that the probe is allowed to fail. The default is 3. After the specified attempts:
 ** for a liveness probe, the container is restarted
 ** for a readiness probe, the pod is marked `Unready`
-** for a startup probe, the container is killed and is subject to the pod's `restartPolicy`
 +
 [NOTE]
 ====
@@ -101,50 +93,6 @@ spec:
 <3> A readiness probe.
 <4> A container command test.
 <5> The commands to execute on the container.
-
-.Sample container command startup probe and liveness probe with container command tests in a pod spec
-[source,yaml]
-----
-apiVersion: v1
-kind: Pod
-metadata:
-  labels:
-    test: health-check
-  name: my-application
-...
-spec:
-  containers:
-  - name: goproxy-app <1>
-    args:
-    image: k8s.gcr.io/goproxy:0.1 <2>
-    livenessProbe: <3>
-      httpGet: <4>
-        scheme: HTTPS <5>
-        path: /healthz
-        port: 8080 <6>
-        httpHeaders:
-        - name: X-Custom-Header
-          value: Awesome
-    startupProbe: <7>
-      httpGet: <8>
-        path: /healthz
-        port: 8080 <9>
-   failureThreshold: 30 <10>
-   periodSeconds: 10 <11>
-...
-----
-
-<1> The container name.
-<2> Specify the container image to deploy.
-<3> A liveness probe.
-<4> An HTTP `GET` test.
-<5> The internet scheme: `HTTP` or `HTTPS`. The default value is `HTTP`.
-<6> The port on which the container is listening.
-<7> A startup probe.
-<8> An HTTP `GET` test.
-<9> The port on which the container is listening.
-<10> The number of times to try the probe after a failure.
-<11> The number of seconds to perform the probe.
 
 .Sample liveness probe with a container command test that uses a timeout in a pod spec
 [source,yaml]

--- a/modules/application-health-configuring.adoc
+++ b/modules/application-health-configuring.adoc
@@ -5,7 +5,7 @@
 [id="application-health-configuring_{context}"]
 = Configuring health checks
 
-To configure readiness, liveness, and startup probes, add one or more probes to the specification for the pod that contains the container which you want to perform the health checks
+To configure readiness and liveness probes, add one or more probes to the specification for the pod that contains the container that you want to perform the health checks on.
 
 [NOTE]
 ====
@@ -42,13 +42,6 @@ spec:
         scheme: HTTPS <11>
         path: /healthz
         port: 8080 <12>
-    startupProbe: <13>
-      exec: <14>
-        command: <15>
-        - cat
-        - /tmp/healthy
-      failureThreshold: 30 <16>
-      periodSeconds: 10 <17>
 ----
 <1> Specify the container name.
 <2> Specify the container image to deploy.
@@ -62,11 +55,6 @@ spec:
 <10> Specify a host IP address. When `host` is not defined, the `PodIP` is used.
 <11> Specify `HTTP` or `HTTPS`. When `scheme` is not defined, the `HTTP` scheme is used.
 <12> Specify the port on which the container is listening.
-<13> Optional: Create a Startup probe.
-<14> Specify the type of test to perform, here an Container Execution probe.
-<15> Specify the commands to execute on the container.
-<16> Specify the number of times to try the probe after a failure.
-<17> Specify the number of seconds to perform the probe.
 +
 [NOTE]
 ====


### PR DESCRIPTION
…d in 4.4

https://bugzilla.redhat.com/show_bug.cgi?id=1907402

Preview (internal): http://file.rdu.redhat.com/~ahoffer/2020/BZ-1907402-startup-probes/applications/application-health.html