### PR TITLE
Note that the MachineConfig for infra nodes is optional.

### DIFF
--- a/modules/creating-infra-machines.adoc
+++ b/modules/creating-infra-machines.adoc
@@ -75,7 +75,7 @@ rendered-worker-afc758e194d6188677eb837842d3b379            02c07496ba0417b3e12b
 rendered-worker-daa08cc1e8f5fcdeba24de60cd955cc3            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             13d
 ----
 
-. To deploy changes to a custom pool, create a machine config that uses the custom pool name as the label, such as `infra` in this example:
+. Optional: To deploy changes to a custom pool, create a machine config that uses the custom pool name as the label, such as `infra`. Note that this is not required and only shown for instructional purposes. In this manner, you can apply any custom configurations specific to only your infra nodes.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
As noted in [here](https://github.com/openshift/machine-config-operator/blob/master/docs/custom-pools.md#deploy-changes-to-a-custom-pool-optional), this step is optional.  Customers really shouldn't and don't need to do this.  It is, however, informative as to how MachineConfigs and MachingConfigPools are related.