### PR TITLE
Adding MCO behavior changes from #28090

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -56,7 +56,7 @@ status:
 Either the `allowedRegistries` parameter or the `blockedRegistries` parameter can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to registries and reboots the nodes when it detects changes. Changes to the allowed registries creates or updates the image signature policy in the `/host/etc/containers/policy.json` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. Changes to the allowed registries creates or updates the image signature policy in the `/host/etc/containers/policy.json` file on each node.
 
 . To check that the registries have been added to the policy file, use the following command on a node:
 +

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -49,7 +49,7 @@ status:
 Either the `blockedRegistries` registry or the `allowedRegistries` registry can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to registries and reboots the nodes when it detects changes. Changes to the blocked registries appear in the `/etc/containers/registries.conf` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. Changes to the blocked registries appear in the `/etc/containers/registries.conf` file on each node.
 
 . To check that the registries have been added to the policy file, use the following command on a node:
 +


### PR DESCRIPTION
Adding wording changes around MCO reboot behavior that I didn't add with https://github.com/openshift/openshift-docs/pull/28090. I tracked these changes in https://github.com/openshift/openshift-docs/pull/28152, but that doesn't seem appropriate.