### PR TITLE
Add infrastructure nodes sizing recommendations for 4.6

### DIFF
--- a/modules/infrastructure-node-sizing.adoc
+++ b/modules/infrastructure-node-sizing.adoc
@@ -7,23 +7,36 @@
 
 The infrastructure node resource requirements depend on the cluster age, nodes, and objects in the cluster, as these factors can lead to an increase in the number of metrics or time series in Prometheus. The following infrastructure node size recommendations are based on the results of cluster maximums and control plane density focused testing.
 
-[options="header",cols="3*"]
+[IMPORTANT]
+====
+The sizing recommendations below are only applicable for the Prometheus, Router, and Registry infrastructure components, which are installed during cluster installation. Logging is a day-two operation and its sizing recommendation are given in the last two columns.
+====
+
+[options="header",cols="5*"]
 |===
-| Number of worker nodes |CPU cores |Memory (GB)
+| Number of worker nodes |CPU cores |Memory (GB)|CPU cores with Logging |Memory (GB) with Logging
 
 | 25
 | 4
-| 32
+| 16
+| 4
+| 64
 
 | 100
 | 8
-| 64
+| 32
+| 8
+| 128
 
 | 250
-| 32
-| 192
+| 16
+| 128
+| 16
+| 128
 
 | 500
+| 32
+| 128
 | 32
 | 192
 
@@ -32,8 +45,6 @@ The infrastructure node resource requirements depend on the cluster age, nodes, 
 [IMPORTANT]
 ====
 These sizing recommendations are based on scale tests, which create a large number of objects across the cluster. These tests include reaching some of the cluster maximums. In the case of 250 and 500 node counts on a {product-title} {product-version} cluster, these maximums are 10000 namespaces with 61000 pods, 10000 deployments, 181000 secrets, 400 config maps, and so on. Prometheus is a highly memory intensive application; the resource usage depends on various factors including the number of nodes, objects, the Prometheus metrics scraping interval, metrics or time series, and the age of the cluster. The disk size also depends on the retention period. You must take these factors into consideration and size them accordingly.
-
-The sizing recommendations are applicable only for the infrastructure components which gets installed during the cluster install - Prometheus, Router and Registry. Logging is a day two operation and the recommendations do not take it into account.
 ====
 
 [NOTE]


### PR DESCRIPTION
This commit adds information on infrastructure nodes which hosts
Router, Registry, Logging and Monitoring components for various
nodes scale. The data is based on the cluster maximums and density
focused scale test runs.