### PR TITLE
Document DNS rules in OVN-Kube egress firewall

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -31,9 +31,7 @@ For example, you can allow one project access to a specified IP range but deny t
 You configure an egress firewall policy by creating an {kind} custom resource (CR) object. The egress firewall matches network traffic that meets any of the following criteria:
 
 - An IP address range in CIDR format
-ifdef::openshift-sdn[]
 - A DNS name that resolves to an IP address
-endif::openshift-sdn[]
 ifdef::ovn[]
 - A port number
 - A protocol that is one of the following protocols: TCP, UDP, and SCTP
@@ -79,7 +77,6 @@ Violating any of these restrictions results in a broken egress firewall for the 
 
 The egress firewall policy rules are evaluated in the order that they are defined, from first to last. The first rule that matches an egress connection from a pod applies. Any subsequent rules are ignored for that connection.
 
-ifdef::openshift-sdn[]
 [id="domain-name-server-resolution_{context}"]
 == How Domain Name Server (DNS) resolution works
 
@@ -97,7 +94,6 @@ The egress firewall always allows pods access to the external interface of the n
 
 If you use domain names in your egress firewall policy and your DNS resolution is not handled by a DNS server on the local node, then you must add egress firewall rules that allow access to your DNS server’s IP addresses. if you are using domain names in your pods.
 ====
-endif::openshift-sdn[]
 
 ifdef::ovn[]
 :!ovn:

--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -79,16 +79,19 @@ egress:
 - type: <type> <1>
   to: <2>
     cidrSelector: <cidr> <3>
-  ports: <4>
+    dnsName: <dns_name> <4>
+  ports: <5>
       ...
 ----
 <1> The type of rule. The value must be either `Allow` or `Deny`.
 
-<2> A stanza describing an egress traffic match rule.
+<2> A stanza describing an egress traffic match rule that specifies the `cidrSelector` field or the `dnsName` field. You cannot use both fields in the same rule.
 
 <3> An IP address range in CIDR format.
 
-<4> Optional: A stanza describing a collection of network ports and protocols for the rule.
+<4> <4> A DNS domain name.
+
+<5> Optional: A stanza describing a collection of network ports and protocols for the rule.
 
 .Ports stanza
 [source,yaml]


### PR DESCRIPTION
In 4.7 OVN-Kube egress firewall added support for DNS rules in the same way that OpenShift SDN already does.  This PR changes the docs to reflect that both SDNs implementations implement it the same way.