### PR TITLE
TELCODOCS-146 - document hyperthreading config in OCP 

### DIFF
--- a/modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc
+++ b/modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+
+[id="about_hyperthreading_for_low_latency_and_real_time_applications_{context}"]
+= About hyperthreading for low latency and real-time applications
+
+Hyperthreading is an Intel processor technology that allows a physical CPU processor core to function as two logical cores, executing two independent threads simultaneously. Hyperthreading allows for better system throughput for certain workload types where parallel processing is beneficial. The default {product-title} configuration expects hyperthreading to be enabled by default.
+
+For telecommunications applications, it is important to design your application infrastructure to minimize latency as much as possible. Hyperthreading can slow performance times and negatively affect throughput for compute intensive workloads that require low latency. Disabling hyperthreading ensures predictable performance and can decrease processing times for these workloads.
+
+[NOTE]
+====
+Hyperthreading implementation and configuration differs depending on the hardware you are running {product-title} on. Consult the relevant host hardware tuning information for more details of the hyperthreading implementation specific to that hardware. Disabling hyperthreading can increase the cost per core of the cluster.
+====

--- a/modules/configuring_hyperthreading_for_a_cluster.adoc
+++ b/modules/configuring_hyperthreading_for_a_cluster.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+
+[id="configuring_hyperthreading_for_a_cluster_{context}"]
+= Configuring hyperthreading for a cluster
+
+To configure hyperthreading for an {product-title} cluster, set the CPU threads in the performance profile to the same cores that are configured for the reserved or isolated CPU pools.
+
+[NOTE]
+====
+If you configure a performance profile, and subsequently change the hyperthreading configuration for the host, ensure that you update the CPU `isolated` and `reserved` fields in the `PerformanceProfile` YAML to match the new configuration.
+====
+
+[WARNING]
+====
+Disabling a previously enabled host hyperthreading configuration can cause the CPU core IDs listed in the `PerformanceProfile` YAML to be incorrect. This incorrect configuration can cause the node to become unavailable because the listed CPUs can no longer be found.
+====
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+* Install the OpenShift CLI (oc).
+
+.Procedure
+
+. Ascertain which threads are running on what CPUs for the host you want to configure.
++
+You can view which threads are running on the host CPUs by logging in to the cluster and running the following command:
++
+[source,terminal]
+----
+$ lscpu --all --extended
+----
++
+.Example output
++
+[source,terminal]
+----
+CPU NODE SOCKET CORE L1d:L1i:L2:L3 ONLINE MAXMHZ    MINMHZ
+0   0    0      0    0:0:0:0       yes    4800.0000 400.0000
+1   0    0      1    1:1:1:0       yes    4800.0000 400.0000
+2   0    0      2    2:2:2:0       yes    4800.0000 400.0000
+3   0    0      3    3:3:3:0       yes    4800.0000 400.0000
+4   0    0      0    0:0:0:0       yes    4800.0000 400.0000
+5   0    0      1    1:1:1:0       yes    4800.0000 400.0000
+6   0    0      2    2:2:2:0       yes    4800.0000 400.0000
+7   0    0      3    3:3:3:0       yes    4800.0000 400.0000
+----
++
+In this example, there are eight logical CPU cores running on four physical CPU cores. CPU0 and CPU4 are running on physical Core0, CPU1 and CPU5 are running on physical Core 1, and so on.
++
+Alternatively, to view the threads that are set for a particular physical CPU core (`cpu0` in the example below), open a command prompt and run the following:
++
+[source,terminal]
+----
+$ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
+----
++
+.Example output
++
+[source,terminal]
+----
+0-4
+----
+
+. Apply the isolated and reserved CPUs in the `PerformanceProfile` YAML. For example, you could set logical cores CPU0 and CPU4 as isolated, and logical cores CPU1 and CPU5 as reserved:
++
+[source,YAML]
+----
+...
+  cpu:
+    isolated: 0-4
+    reserved: 1-5
+...
+----
+
+[IMPORTANT]
+====
+Hyperthreading is enabled by default on most Intel processors. If you enable hyperthreading, all threads processed by a particular core must be isolated or processed on the same core.
+====
+
+[id="disabling_hyperthreading_for_low_latency_applications_{context}"]
+== Disabling hyperthreading for low latency applications
+
+When configuring clusters for low latency processing, consider whether you want to disable hyperthreading before you deploy the cluster. To disable hyperthreading, do the following:
+
+. Create a performance profile that is appropriate for your hardware and topology.
+. Set `nosmt` as an additional kernel argument. The following example performance profile illustrates this setting:
+
+[source,YAML]
+----
+﻿apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: example-performanceprofile
+spec:
+  additionalKernelArgs:
+    - nmi_watchdog=0
+    - audit=0
+    - mce=off
+    - processor.max_cstate=1
+    - idle=poll
+    - intel_idle.max_cstate=0
+    - nosmt
+  cpu:
+    isolated: 2-3
+    reserved: 0-1
+  hugepages:
+    defaultHugepagesSize: 1G
+    pages:
+      - count: 2
+        node: 0
+        size: 1G
+  nodeSelector:
+    node-role.kubernetes.io/performance: ''
+  realTimeKernel:
+    enabled: true
+----

--- a/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+++ b/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
@@ -3,10 +3,15 @@
 include::modules/common-attributes.adoc[]
 :context: cnf-master
 
-
 toc::[]
 
 include::modules/cnf-understanding-low-latency.adoc[leveloffset=+1]
+
+include::modules/cnf-about_hyperthreading_for_low_latency_and_real_time_applications.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#configuring_hyperthreading_for_a_cluster_{context}[Configuring hyperthreading for a cluster]
 
 include::modules/cnf-installing-the-performance-addon-operator.adoc[leveloffset=+1]
 
@@ -19,6 +24,8 @@ include::modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-iso
 include::modules/cnf-use-device-interrupt-processing-for-isolated-cpus.adoc[leveloffset=+2]
 
 include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
+
+include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
 
 include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-146

Document hyperthreading, implications for latency, and how to enable or disable in OCP cluster.