### PR TITLE
Document causes of automated reboots and MCO pause behavior in Console

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco-cli.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco-cli.adoc
@@ -1,0 +1,141 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-operator-issues.adoc
+
+[id="troubleshooting-disabling-autoreboot-mco-cli_{context}"]
+= Disabling the Machine Config Operator from automatically rebooting by using the CLI
+
+To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can modify the machine config pool (MCP) using the  OpenShift CLI (oc) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process. 
+
+[NOTE]
+====
+Pausing an MCP stops all updates to your {op-system} nodes, including updates to the operating system, security, certificate, as well as any other updates related to the machine config. Pausing should be done for short periods of time only.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+To pause or unpause automatic MCO update rebooting: 
+
+* Pause the autoreboot process:
+
+. Update the `MachineConfigPool` custom resource to set the `spec.paused` field to `true`.
++
+.Control plane (master) nodes
+[source,terminal]
+----
+$ oc patch --type=merge --patch='{"spec":{"paused":true}}' machineconfigpool/master
+----
++
+.Worker nodes
+[source,terminal]
+----
+$ oc patch --type=merge --patch='{"spec":{"paused":true}}' machineconfigpool/worker
+----
+
+. Verify that the MCP is paused:
++
+.Control plane (master) nodes
+[source,terminal]
+----
+$ oc get machineconfigpool/master --template='{{.spec.paused}}'
+----
++
+.Worker nodes
+[source,terminal]
+----
+$ oc get machineconfigpool/worker --template='{{.spec.paused}}'
+----
++
+.Example output
+[source,terminal]
+----
+true
+----
++
+The `spec.paused` field is `true` and the MCP is paused.
+
+. Determine if the MCP has pending changes:
++
+[source,terminal]
+----
+# oc get machineconfigpool
+----
++
+.Example output
+----
+NAME     CONFIG                                             UPDATED   UPDATING   
+master   rendered-master-33cf0a1254318755d7b48002c597bf91   True      False      
+worker   rendered-worker-e405a5bdb0db1295acea08bcca33fa60   False     False    
+----
++
+If the *UPDATED* column is *False* and *UPDATING* is *False*, there are pending changes. When *UPDATED* is *True* and *UPDATING* is *False*, there are no pending changes. In the previous example, the worker node has pending changes. The master node does not have any pending changes.
++
+[IMPORTANT]
+====
+If there are pending changes (where both the *Updated* and *Updating* columns are *False*), it is recommended to schedule a maintenance window for a reboot as early as possible. Use the following steps for unpausing the autoreboot process to apply the changes that were queued since the last reboot.
+====
+
+* Unpause the autoreboot process: 
+
+. Update the `MachineConfigPool` custom resource to set the `spec.paused` field to `false`.
++
+.Control plane (master) nodes
+[source,terminal]
+----
+$ oc patch --type=merge --patch='{"spec":{"paused":false}}' machineconfigpool/master
+----
++
+.Worker nodes
+[source,terminal]
+----
+$ oc patch --type=merge --patch='{"spec":{"paused":false}}' machineconfigpool/worker
+----
++
+[NOTE]
+====
+By unpausing an MCP, the MCO applies all paused changes and reboots {op-system-first} as needed.
+====
++
+. Verify that the MCP is unpaused:
++
+.Control plane (master) nodes
+[source,terminal]
+----
+$ oc get machineconfigpool/master --template='{{.spec.paused}}'
+----
++
+.Worker nodes
+[source,terminal]
+----
+$ oc get machineconfigpool/worker --template='{{.spec.paused}}'
+----
++
+.Example output
+[source,terminal]
+----
+false
+----
++
+The `spec.paused` field is `false` and the MCP is unpaused.
+
+. Determine if the MCP has pending changes:
++
+[source,terminal]
+----
+$ oc get machineconfigpool
+----
++
+.Example output
+----
+NAME     CONFIG                                   UPDATED  UPDATING
+master   rendered-master-546383f80705bd5aeaba93   True     False
+worker   rendered-worker-b4c51bb33ccaae6fc4a6a5   False    True
+----
++
+If the MCP is applying any pending changes, the *UPDATED* column is *False* and the *UPDATING* column is *True*. When *UPDATED* is *True* and *UPDATING* is *False*, there are no further changes being made. In the previous example, the MCO is updating the worker node.
+

--- a/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-operator-issues.adoc
+
+[id="troubleshooting-disabling-autoreboot-mco-console_{context}"]
+= Disabling the Machine Config Operator from automatically rebooting by using the console
+
+To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can use the {product-title} web console to modify the machine config pool (MCP) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process. 
+
+[NOTE]
+====
+Pausing an MCP stops all updates to your {op-system} nodes, including updates to the operating system, security, certificate, and any other updates related to the machine config. Pausing should be done for short periods of time only.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+To pause or unpause automatic MCO update rebooting: 
+
+* Pause the autoreboot process:
+
+. Log in to the {product-title} web console as a user with the `cluster-admin` role.
+
+. Click *Compute* -> *Machine Config Pools*.
+
+. On the *Machine Config Pools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
+
+. On the *master* or *worker* page, click *YAML*.
+
+. In the YAML, update the `spec.paused` field to `true`.
++
+.Sample MachineConfigPool object 
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+ ...
+spec:
+ ...
+  paused: true <1>
+----
+<1> Update the `spec.paused` field to `true` to pause rebooting.
+
+. To verify that the MCP is paused, return to the *Machine Config Pools* page.
++
+On the *Machine Config Pools* page, the *Paused* column reports *True* for the MCP you modified.
++
+If the MCP has pending changes while paused, the *Updated* column is *False* and *Updating* is *False*. When *Updated* is *True* and *Updating* is *False*, there are no pending changes.
++
+[IMPORTANT]
+====
+If there are pending changes (where both the *Updated* and *Updating* columns are *False*), it is recommended to schedule a maintenance window for a reboot as early as possible. Use the following steps for unpausing the autoreboot process to apply the changes that were queued since the last reboot.
+====
+
+* Unpause the autoreboot process: 
+
+. Log in to the {product-title} web console as a user with the `cluster-admin` role.
+
+. Click *Compute* -> *Machine Config Pools*.
+
+. On the *Machine Config Pools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
+
+. On the *master* or *worker* page, click *YAML*.
+
+. In the YAML, update the `spec.paused` field to `false`.
++
+.Sample MachineConfigPool object 
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+ ...
+spec:
+ ...
+  paused: false <1>
+----
+<1> Update the `spec.paused` field to `false` to allow rebooting.
++
+[NOTE]
+====
+By unpausing an MCP, the MCO applies all paused changes reboots {op-system-first} as needed.
+====
+
+. To verify that the MCP is paused, return to the *Machine Config Pools* page.
++
+On the *Machine Config Pools* page, the *Paused* column reports *False* for the MCP you modified.
++
+If the MCP is applying any pending changes, the *Updated* column is *False* and the *Updating* column is *True*. When *Updated* is *True* and *Updating* is *False*, there are no further changes being made.
+

--- a/modules/troubleshooting-disabling-autoreboot-mco.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco.adoc
@@ -3,7 +3,7 @@
 // * support/troubleshooting/troubleshooting-operator-issues.adoc
 
 [id="troubleshooting-disabling-autoreboot-mco_{context}"]
-= Disabling Machine Config Operator from automatically rebooting
+= Disabling the Machine Config Operator from automatically rebooting
 
 When configuration changes are made by the Machine Config Operator (MCO), {op-system-first} must reboot for the changes to take effect. Whether the configuration change is automatic, such as when a `kube-apiserver-to-kubelet-signer` certificate authority (CA) is rotated, or manual, an {op-system} node reboots automatically unless it is paused.
 
@@ -18,106 +18,10 @@ The following modifications do not trigger a node reboot:
 When the MCO detects any of these changes, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
 ====
 
-To avoid unwanted disruptions, you can modify the machine config pool to prevent automatic rebooting after the Operator makes changes to the machine config.
+To avoid unwanted disruptions, you can modify the machine config pool (MCP) to prevent automatic rebooting after the Operator makes changes to the machine config.
 
 [NOTE]
 ====
 Pausing a machine config pool stops all system reboot processes and all configuration changes from being applied.
 ====
 
-.Prerequisites
-
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the OpenShift CLI (`oc`).
-* You have root access in {product-title}.
-
-.Procedure
-. To pause the autoreboot process after machine config changes are applied:
-
-* As root, update the `spec.paused` field to `true` in the `MachineConfigPool` custom resource.
-+
-.Control plane (master) nodes
-[source,terminal]
-----
-# oc patch --type=merge --patch='{"spec":{"paused":true}}' machineconfigpool/master
-----
-+
-.Worker nodes
-[source,terminal]
-----
-# oc patch --type=merge --patch='{"spec":{"paused":true}}' machineconfigpool/worker
-----
-
-. To verify that the machine config pool is paused:
-+
-.Control plane (master) nodes
-[source,terminal]
-----
-# oc get machineconfigpool/master --template='{{.spec.paused}}'
-----
-+
-.Worker nodes
-[source,terminal]
-----
-# oc get machineconfigpool/worker --template='{{.spec.paused}}'
-----
-+
-The `spec.paused` field is `true` and the machine config pool is paused.
-
-. Alternatively, to unpause the autoreboot process:
-
-* As root, update the `spec.paused` field to `false` in the MachineConfigPool CustomResourceDefinition (CRD).
-+
-.Control plane (master) nodes
-[source,terminal]
-----
-# oc patch --type=merge --patch='{"spec":{"paused":false}}' machineconfigpool/master
-----
-+
-.Worker nodes
-[source,terminal]
-----
-# oc patch --type=merge --patch='{"spec":{"paused":false}}' machineconfigpool/worker
-----
-+
-[NOTE]
-====
-By unpausing a machine config pool, all paused changes are applied at reboot.
-====
-+
-. To verify that the machine config pool is unpaused:
-+
-.Control plane (master) nodes
-[source,terminal]
-----
-# oc get machineconfigpool/master --template='{{.spec.paused}}'
-----
-+
-.Worker nodes
-[source,terminal]
-----
-# oc get machineconfigpool/worker --template='{{.spec.paused}}'
-----
-+
-The `spec.paused` field is `false` and the machine config pool is unpaused.
-
-. To see if the machine config pool has pending changes:
-+
-[source,terminal]
-----
-# oc get machineconfigpool
-----
-+
-.Example output
-----
-NAME     CONFIG                                   UPDATED   UPDATING
-master   rendered-master-546383f80705bd5aeaba93   True      False
-worker   rendered-worker-b4c51bb33ccaae6fc4a6a5   True      False
-----
-+
-When `UPDATED` is `True` and `UPDATING` is `False`, there are no pending changes, and vice versa.
-
-[IMPORTANT]
-====
-It is recommended to schedule a maintenance window for a reboot as early as possible by setting `spec.paused` to `false` so that the queued changes since last reboot will take effect.
-====

--- a/support/troubleshooting/troubleshooting-operator-issues.adoc
+++ b/support/troubleshooting/troubleshooting-operator-issues.adoc
@@ -27,6 +27,9 @@ include::modules/gathering-operator-logs.adoc[leveloffset=+1]
 
 // Disabling Machine Config Operator from autorebooting
 include::modules/troubleshooting-disabling-autoreboot-mco.adoc[leveloffset=+1]
+include::modules/troubleshooting-disabling-autoreboot-mco-console.adoc[leveloffset=+2]
+include::modules/troubleshooting-disabling-autoreboot-mco-cli.adoc[leveloffset=+2]
 
 // Refreshing failing subscriptions
 include::modules/olm-refresh-subs.adoc[leveloffset=+1]
+


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1904457

Created a new module to address the request in the BZ, called _Disabling Machine Config Operator from automatically rebooting by using the console_

Split the existing _Disabling Machine Config Operator from automatically rebooting_ topic [1] to an intro topic and moved the existing CLI steps to a new module. Created a new module for the console steps. Most of the text in the CLI topic is existing, but edited. The console topic is all new.  

Preview: https://deploy-preview-28440--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues

[1] https://docs.openshift.com/container-platform/4.6/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues