### PR TITLE
OSDOCS#1411 - Bug 1913226: Extending SDN Migration support to other platforms

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -5,13 +5,20 @@
 [id="nw-ovn-kubernetes-migration-about_{context}"]
 = Migration to the OVN-Kubernetes network provider
 
-Migrating to the OVN-Kubernetes Container Network Interface (CNI) default network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+Migrating to the OVN-Kubernetes Container Network Interface (CNI) cluster network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
+
+A migration to the OVN-Kubernetes cluster network provider is supported on installer-provisioned clusters on the following platforms:
+
+* Bare metal hardware
+* Amazon Web Services (AWS)
+* Google Cloud Platform (GCP)
+* Microsoft Azure
+* {rh-openstack-first}
+* VMware vSphere
 
 [NOTE]
 ====
-A migration to the OVN-Kubernetes network provider is supported on installer-provisioned clusters on only bare metal hardware.
-
-Performing a migration on a user-provisioned cluster on bare metal hardware is not supported.
+Performing a migration on a user-provisioned cluster is not supported.
 ====
 
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -16,11 +16,12 @@ Perform the migration only when an interruption in service is acceptable.
 
 .Prerequisites
 
-* A cluster installed on bare metal installer-provisioned infrastructure and configured with the OpenShift SDN default CNI network provider in the network policy isolation mode.
+* A cluster installed on installer-provisioned infrastructure and configured with the OpenShift SDN default CNI network provider in the network policy isolation mode.
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
 * A recent backup of the etcd database is available.
 * The cluster is in a known good state, without any errors.
+* A reboot can be triggered manually for each node.
 
 .Procedure
 
@@ -57,13 +58,35 @@ $ oc patch MachineConfigPool worker --type='merge' --patch \
   '{ "spec":{ "paused" :true } }'
 ----
 
-. To configure the OVN-Kubernetes cluster network provider, enter the following command:
+. Configure the OVN-Kubernetes cluster network provider by using one of the following commands:
+
+** To specify the network provider without changing the cluster network IP address block, enter the following command:
 +
 [source,terminal]
 ----
 $ oc patch Network.config.openshift.io cluster \
   --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
 ----
+
+** To specify a different cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{
+    "spec": {
+      "clusterNetwork": [
+        "cidr": "<cidr>",
+        "hostPrefix": "<prefix>"
+      ]
+      "networkType": "OVNKubernetes"
+    } 
+  }'
+----
++
+where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster. You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block, because the OVN-Kubernetes network provider uses this block internally.
++
+IMPORTANT: You cannot change the service network address block during the migration.
 
 . Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
 +
@@ -90,7 +113,7 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 `mtu`::
 The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
 `port`::
-The UDP port for the Geneve overlay network.
+The UDP port for the Geneve overlay network. If a value is not specified, the default is `6081`. The port cannot be the same as the VXLAN port that is used by OpenShift SDN. The default value for the VXLAN port is `4789`.
 --
 +
 .Example patch command to update `mtu` field
@@ -135,6 +158,8 @@ do
    ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
 done
 ----
++
+If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
 
 . After the nodes in your cluster have rebooted, start all of the machine configuration pools:
 +
@@ -281,36 +306,3 @@ $ oc annotate Network.operator.openshift.io cluster \
 ----
 $ oc delete namespace openshift-sdn
 ----
-
-// https://bugzilla.redhat.com/show_bug.cgi?id=1898159
-////
-. Configure the OVN-Kubernetes cluster network provider with one of the following commands:
-
-** To specify the network provider without changing the cluster network IP address block, enter the following command:
-+
-[source,terminal]
-----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
-----
-
-.. To specify a different cluster network IP address block, enter the following command:
-+
-[source,terminal]
-----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{
-    "spec": {
-      "clusterNetwork": [
-        "cidr": "<cidr>",
-        "hostPrefix": "<prefix>"
-      ]
-      "networkType": "OVNKubernetes"
-    } 
-  }'
-----
-+
-where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster.
-+
-IMPORTANT: You cannot change the service network address block during the migration.
-////

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -17,7 +17,7 @@ Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
-* A cluster installed on bare metal infrastructure configured with the OVN-Kubernetes default CNI network provider.
+* A cluster installed on infrastructure configured with the OVN-Kubernetes default CNI network provider.
 
 .Procedure
 
@@ -78,9 +78,9 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
 +
 --
 `mtu`::
-The MTU for the Geneve overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `100` less than the smallest node MTU value.
+The MTU for the VXLAN overlay network. This value is normally configured automatically, but if the nodes in your cluster do not all use the same MTU, then you must set this explicitly to `50` less than the smallest node MTU value.
 `port`::
-The UDP port for the Geneve overlay network.
+The UDP port for the VXLAN overlay network. If a value is not specified, the default is `4789`. The port cannot be the same as the Geneve port that is used by OVN-Kubernetes. The default value for the Geneve port is `6081`.
 --
 +
 .Example patch command 
@@ -125,6 +125,8 @@ do
    ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
 done
 ----
++
+If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
 
 . After the nodes in your cluster have rebooted, start all of the machine configuration pools:
 +


### PR DESCRIPTION
In 4.7, we extend SDN Migration support to AWS, Azure, GCE, OSP, and vSphere IPI clusters.

Previews:

- [Migrate from the OpenShift SDN cluster network provider](https://github.com/openshift/openshift-docs/pull/28441)
- [Rollback to the OpenShift SDN network provider](http://shell.lab.bos.redhat.com/~jboxman/migration/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html)
