### PR TITLE
OCPCLOUD-840 AWS Machine API dedicated tenancy

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -16,3 +16,7 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 
 include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]
+
+include::modules/machineset-dedicated-instances.adoc[leveloffset=+1]
+
+include::modules/machineset-creating-dedicated-instances.adoc[leveloffset=+1]

--- a/modules/machineset-creating-dedicated-instances.adoc
+++ b/modules/machineset-creating-dedicated-instances.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+[id="machineset-creating-dedicated-instance_{context}"]
+= Creating Dedicated Instances by using machine sets
+
+You can run a machine that is backed by a Dedicated Instance by using Machine API integration. Set the `tenancy` field in your machine set YAML file to launch a Dedicated Instance on AWS.
+
+.Procedure
+
+* Specify a dedicated tenancy under the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  placement:
+    tenancy: dedicated
+----

--- a/modules/machineset-dedicated-instances.adoc
+++ b/modules/machineset-dedicated-instances.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+
+[id="machineset-dedicated-instance_{context}"]
+= Machine sets that deploy machines as Dedicated Instances
+
+You can create a machine set running on AWS that deploys machines as Dedicated Instances. Dedicated Instances run in a virtual private cloud (VPC) on hardware that is dedicated to a single customer. These Amazon EC2 instances are physically isolated at the host hardware level. The isolation of Dedicated Instances occurs even if the instances belong to different AWS accounts that are linked to a single payer account. However, other instances that are not dedicated can share hardware with Dedicated Instances if they belong to the same AWS account.
+
+Instances with either public or dedicated tenancy are supported by the Machine API. Instances with public tenancy run on shared hardware. Public tenancy is the default tenancy. Instances with dedicated tenancy run on single-tenant hardware.


### PR DESCRIPTION
4.7 - [Docs] [OCPCLOUD-840](https://issues.redhat.com/browse/OSDOCS-1725) - RFE: Add "tenancy: dedicated" to AWS machine API