### PR TITLE
Machine API 4-7 Release Notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -292,6 +292,25 @@ See xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operato
 
 If a machine config pool (MCP) is in a `degraded` state, the Machine Config Operator (MCO) now reports its *Upgradeable* status as *False*. As a result, you are now prevented from performing an update within a minor version, for example, from 4.7 to 4.8, until all machine config pools are healthy. Previously, with a degraded machine config pool, the Machine Config Operator did not report its *Upgradeable* status as *false*. The update was allowed and would eventually fail when updating the Machine Config Operator because of the degraded machine config pool. There is no change in this behavior for updates within z-stream releases, for example, from 4.7.1 to 4.7.2. As such, you should check the machine config pool status before performing a z-stream update.
 
+[id="ocp-4-7-aws-tenancy-dedicated"]
+==== Machine sets running on AWS support Dedicated Instances
+
+Machine sets running on AWS now support Dedicated Instances. Configure Dedicated Instances by specifying a dedicated tenancy under the `providerSpec` field in the machine set YAML file.
+
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-dedicated-instance_creating-machineset-aws[Machine sets that deploy machines as Dedicated Instances].
+
+[id="ocp-4-7-gcp-customer-managed-encryption-keys"]
+==== Machine sets running on GCP support customer-managed encryption keys
+
+You can now enable encryption with a customer-managed key for machine sets running on GCP. Users can configure an encryption key under the `providerSpec` field in the machine set YAML file. The key is used to encrypt the data encryption key, not to encrypt the customer's data.
+
+For more information, see xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set].
+
+[id="ocp-4-7-machine-api-cluster-wide-proxy-settings"]
+==== Machine API components honor cluster-wide proxy settings
+
+The Machine API now honors cluster-wide proxy settings. When a cluster-wide proxy is configured, all Machine API components will route traffic through the configured proxy.
+
 [id="ocp-4-7-nodes"]
 === Nodes
 


### PR DESCRIPTION
Machine API 4.7 Release Notes for:
[OSDOCS-1725](https://issues.redhat.com/browse/OSDOCS-1725) - RFE: Add "tenancy: dedicated" to AWS machine API
[OSDOCS-1726](https://issues.redhat.com/browse/OSDOCS-1726) - Support Google Cloud DiskEncryptionSets for machines
[OCPCLOUD-975](https://issues.redhat.com/browse/OCPCLOUD-975) - [RFE] Machine API should be able to handle proxy