### PR TITLE
CNV-9030 New UI for Virtual Machine Templates

### DIFF
--- a/modules/virt-about-vm-templates.adoc
+++ b/modules/virt-about-vm-templates.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-creating-vm-template.adoc
+
+[id="virt-understanding-vm-templates-web_{context}"]
+= About virtual machine templates
+
+Preconfigured Red Hat virtual machine templates are listed in the *Templates* tab within the *Virtualization* page. These  templates are available for different versions of Red Hat Enterprise Linux, Fedora, Microsoft Windows 10, and Microsoft Windows Servers. Each Red Hat virtual machine template is preconfigured with the operating system image, default settings for the operating system, flavor (CPU and memory), and workload type (server).
+
+The *Templates* tab displays four types of virtual machine templates:
+
+* *Red Hat Supported* templates are fully supported by Red Hat.
+* *User Supported* templates are *Red Hat Supported* templates that were cloned and created by users.
+* *Red Hat Provided* templates have limited support from Red Hat.
+* *User Provided* templates are *Red Hat Provided* templates that were cloned and created by users.
+
+[NOTE]
+====
+In the Templates tab, you cannot edit or delete Red Hat Supported or Red Hat Provided templates. You can only edit or delete custom virtual machine templates that were created by users.
+====
+
+Using a Red Hat template is convenient because the template is already preconfigured. When you select a Red Hat template to create your own custom template, the *Create Virtual Machine Template* wizard prompts you to add a boot source if a boot source was not added previously. Then, you can either save your custom template or continue to customize it and save it.
+
+You can also select the *Create Virtual Machine Template* wizard directly and create a custom virtual machine template. The wizard prompts you to provide configuration details for the operating system, flavor, workload type, and other settings. You can add a boot source and continue to customize your template and save it.

--- a/modules/virt-add-disk-to-vm.adoc
+++ b/modules/virt-add-disk-to-vm.adoc
@@ -9,13 +9,15 @@
 ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm:
 :object: virtual machine
-:object-gui: Virtual Machine
+:object-gui: Virtual Machines
+:object-vm-overview: Virtual Machine Overview
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template:
 :object: virtual machine template
-:object-gui: Virtual Machine Template
+:object-gui: Templates
+:object-vm-overview: VM Template Details
 endif::[]
 
 [id="virt-vm-add-disk_{context}"]
@@ -27,8 +29,8 @@ Use this procedure to add a virtual disk to a {object}.
 .Procedure
 
 . Click *Workloads* -> *Virtualization* from the side menu.
-. Click the *{object-gui}s* tab.
-. Select a {object} to open the *{object-gui} Overview* screen.
+. Click the *{object-gui}* tab.
+. Select a {object} to open the *{object-vm-overview}* screen.
 . Click the *Disks* tab.
 . Click *Add Disk* to open the *Add Disk* window.
 . In the *Add Disk* window, specify the *Source*, *Name*, *Size*, *Interface*, *Type*, and *Storage Class*.
@@ -50,10 +52,12 @@ ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]

--- a/modules/virt-add-nic-to-vm.adoc
+++ b/modules/virt-add-nic-to-vm.adoc
@@ -7,12 +7,14 @@ ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm:
 :object: virtual machine
 :object-gui: Virtual Machine
+:object-vm-overview: Virtual Machine Overview
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template:
 :object: virtual machine template
-:object-gui: Virtual Machine Template
+:object-gui: Templates
+:object-vm-overview: VM Template Details
 endif::[]
 
 [id="virt-vm-add-nic_{context}"]
@@ -24,8 +26,8 @@ Use this procedure to add a network interface to a {object}.
 .Procedure
 
 . Click *Workloads* -> *Virtualization* from the side menu.
-. Click the *{object-gui}s* tab.
-. Select a {object} to open the *{object-gui} Overview* screen.
+. Click the *{object-gui}* tab.
+. Select a {object} to open the *{object-vm-overview}* screen.
 . Click the *Network Interfaces* tab.
 . Click *Add Network Interface*.
 . In the *Add Network Interface* window, specify the *Name*, *Model*, *Network*, *Type*,
@@ -47,10 +49,12 @@ ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]

--- a/modules/virt-adding-a-boot-source-web.adoc
+++ b/modules/virt-adding-a-boot-source-web.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-creating-vm-template.adoc
+
+[id="virt-adding-a-boot-source-web_{context}"]
+= Adding a boot source for a virtual machine template
+
+A boot source can be configured for any virtual machine template that you want to use for creating virtual machines or custom templates. When  virtual machine templates are configured with a boot source, they are labeled *Available* in the *Templates* tab.
+
+.Procedure
+
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+
+. Click the *Templates* tab.
+
+. Identify the virtual machine template for which you want to configure a boot source and click *Add source*.
+
+. In the *Add boot source to template* window, click *Select boot source*, select a method for creating a persistent volume claim (PVC): *Upload local file*, *Import via URL*, *Clone existing PVC*, or *Import via Registry*.
+
+.. Optional: Click *Mount this as a CD-ROM boot source* to add an additional disk and mount the disk as a CD-ROM.
+
+. Enter a value for *Persistent Volume Claim size* to specify the PVC size that is adequate for the uncompressed image and any additional space that is required.
+
+.. Optional: Enter a name for *Source provider* to associate the name with this template.
+
+.. Advanced: Click *Storage class* and select the storage class that is used to create the disk.
+
+.. Advanced: Click *Access mode* and select an access mode for the persistent volume. Supported access modes are: *Single User (RWO)*, *Shared Access (RWX)*, and *Read Only (ROX)*.
+
+.. Advanced: Click *Volume mode* if you want to select *Block* instead of the default value *Filesystem*.
+
+. Select the appropriate method to save your boot source:
+
+.. Click *Save and upload* if you uploaded a local file.
+
+.. Click *Save and import* if you imported content from a URL or the registry.
+
+.. Click *Save and clone* if you cloned an existing PVC.
+
+Your custom virtual machine template with a boot source is listed in the *Templates* tab, and you can create virtual machines by using this template.

--- a/modules/virt-cloud-init-fields-web.adoc
+++ b/modules/virt-cloud-init-fields-web.adoc
@@ -13,7 +13,7 @@
 |Hostname
 |Sets a specific host name for the virtual machine.
 
-|Authenticated SSH Keys
+|Authorized SSH Keys
 |The user's public key that is copied to *_~/.ssh/authorized_keys_* on the virtual machine.
 
 |Custom script

--- a/modules/virt-creating-template-wizard-web.adoc
+++ b/modules/virt-creating-template-wizard-web.adoc
@@ -3,34 +3,48 @@
 // * virt/vm_templates/virt-creating-vm-template.adoc
 
 [id="virt-creating-template-wizard-web_{context}"]
-= Creating a virtual machine template with the interactive wizard in the web console
+= Creating a virtual machine template with the wizard in the web console
 
-The web console features an interactive wizard that guides you through the *General*,
-*Networking*, *Storage*, *Advanced*, and *Review* steps to simplify the process of creating virtual machine templates.
-All required fields are marked with a `*`. The wizard prevents you from moving to the next step
-until you provide values in the required fields.
+The web console features the *Create Virtual Machine Template* wizard that guides you through the *General*, *Networking*, *Storage*, *Advanced*, and *Review* steps to simplify the process of creating virtual machine templates. All required fields are marked with a ++*++. The *Create Virtual Machine Template* wizard prevents you from moving to the next step until you provide values in the required fields.
+
+[NOTE]
+====
+The wizard guides you to create a custom virtual machine template where you specify the operating system, boot source, flavor, and other settings.
+====
 
 .Procedure
 
 . In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
-. Click the *Virtual Machine Templates* tab.
-. Click *Create Template* and select *New with Wizard*.
+
+. Click the *Templates* tab.
+
+. Click *Create* and select *Template with Wizard*.
+
 . Fill in all required fields in the *General* step.
-. Click *Next* to progress to the *Networking* screen. A NIC that is named `nic0` is attached by default.
+
+. Click *Next* to progress to the *Networking* step. A NIC that is named `nic0` is attached by default.
+
 .. Optional: Click *Add Network Interface* to create additional NICs.
+
 .. Optional: You can remove any or all NICs by clicking the Options menu {kebab} and selecting *Delete*. Virtual machines created from a template do not need a NIC attached. NICs can be created after a virtual machine has been created.
-. Click *Next* to progress to the *Storage* screen.
-.. Optional: Click *Add Disk* to create additional disks.
-.. Optional: Click a disk to modify available fields. Click the &#10003; button to save the changes.
-.. Optional: Click *Disk* to choose an available disk from the *Select Storage* list.
+
+. Click *Next* to progress to the *Storage* step.
+
+. Click *Add Disk* to add a disk, and complete your selections for the fields in the *Add Disk* screen.
 +
 [NOTE]
 ====
-If either *URL* or *Container* are selected as the *Source* in the *General* step, a `rootdisk` disk is created and attached to virtual machines as the *Bootable Disk*. You can modify the `rootdisk` but you cannot remove it.
+If either *Import via URL (creates PVC)* or *Import via Registry (creates PVC)* is selected as the *Source*, a `rootdisk` disk is created and attached to virtual machines as the *Bootable Disk*.
 
 A *Bootable Disk* is not required for virtual machines provisioned from a *PXE* source if there are no disks attached to the virtual machine. If one or more disks are attached to the virtual machine, you must select one as the *Bootable Disk*.
 ====
 
-. Click *Create Virtual Machine Template >*. The *Results* screen displays the JSON configuration file for the virtual machine template.
-+
-The template is listed in the *Virtual Machine Templates* tab.
+. Optional: Click *Advanced* to configure Cloud-init.
+
+. Click *Review* to review and confirm your settings.
+
+. Click *Create Virtual Machine template*.
+
+. Click *See virtual machine template details* to view details about the virtual machine template.
+
+The template is also listed in the *Templates* tab.

--- a/modules/virt-creating-vm-wizard-web.adoc
+++ b/modules/virt-creating-vm-wizard-web.adoc
@@ -5,7 +5,7 @@
 [id="virt-creating-vm-wizard-web_{context}"]
 = Running the virtual machine wizard to create a virtual machine
 
-The web console features an interactive wizard that guides you through *General*, *Networking*, *Storage*, *Advanced*, and *Review* steps to simplify the process of creating virtual machines. All required fields are marked by a `*`. When the required fields are completed, you can review and create your virtual machine.
+The web console features a wizard that guides you through *General*, *Networking*, *Storage*, *Advanced*, and *Review* steps to simplify the process of creating virtual machines. All required fields are marked by a ++*++. When the required fields are completed, you can review and create your virtual machine.
 
 Network interface cards (NICs) and storage disks can be created and attached to virtual machines after they have been created.
 

--- a/modules/virt-deleting-template-web.adoc
+++ b/modules/virt-deleting-template-web.adoc
@@ -7,15 +7,19 @@
 
 Deleting a virtual machine template permanently removes it from the cluster.
 
+[NOTE]
+====
+You can delete virtual machine templates that were created by using a Red Hat template or the *Create Virtual Machine Template* wizard. Preconfigured virtual machine templates that are provided by Red Hat cannot be deleted.
+====
+
 .Procedure
 
 . In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
-. Click the *Virtual Machine Templates* tab.
-. You can delete the virtual machine template from this pane, which makes it
-easier to perform actions on multiple templates in the one pane, or from the
- *Virtual Machine Template Details* pane where you can view comprehensive
-details of the selected template:
+
+. Click the *Templates* tab. Select the appropriate method to delete a virtual machine template:
+
 ** Click the Options menu {kebab} of the template to delete and select *Delete Template*.
-** Click the template name to open the *Virtual Machine Template Details*
-pane and click *Actions* -> *Delete Template*.
+
+** Click the template name to open the *Virtual Machine Template Details* screen and click *Actions* -> *Delete Template*.
+
 . In the confirmation pop-up window, click *Delete* to permanently delete the template.

--- a/modules/virt-edit-cdrom-vm.adoc
+++ b/modules/virt-edit-cdrom-vm.adoc
@@ -13,7 +13,7 @@ endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :object: virtual machine template
-:object-gui: Virtual Machine Templates
+:object-gui: Templates
 endif::[]
 
 [id="virt-vm-edit-cdrom_{context}"]

--- a/modules/virt-editing-template-yaml-web.adoc
+++ b/modules/virt-editing-template-yaml-web.adoc
@@ -20,8 +20,8 @@ Navigating away from the YAML screen while editing cancels any changes to the
 .Procedure
 
 . In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
-. Click the *Virtual Machine Templates* tab.
-. Select a template.
+. Click the *Templates* tab.
+. Select a template to open the *Details* screen.
 . Click the *YAML* tab to display the editable configuration.
 . Edit the file and click *Save*.
 

--- a/modules/virt-editing-vm-web.adoc
+++ b/modules/virt-editing-vm-web.adoc
@@ -14,29 +14,30 @@
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template:
 :object: virtual machine template
-:object-gui: Virtual Machine Template
+:object-gui: Virtual Machines
+:object-vm-overview: VM Template Details
 endif::[]
 
 ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm:
 :object: virtual machine
-:object-gui: Virtual Machine
+:object-gui: Virtual Machines
+:object-vm-overview: Virtual Machine Overview
 endif::[]
 
 [id="virt-editing-vm-web_{context}"]
 
 = Editing a {object} in the web console
 
-Edit select values of a {object} in the *{object-gui} Overview* screen
-of the web console by clicking on the pencil icon next to the relevant field.
-Other values can be edited using the CLI.
+Edit select values of a {object} that displays in the *{object-vm-overview}* screen of the web console by clicking on the pencil icon next to the relevant field. Other values can be edited using the CLI.
+
+Labels and annotations are editable for both preconfigured Red Hat templates and your custom virtual machine templates. All other values are editable only for custom virtual machine templates that users have created using the Red Hat templates or the *Create Virtual Machine Template* wizard.
 
 .Procedure
 
 . Click *Workloads* -> *Virtualization* from the side menu.
-. Click the *{object-gui}s* tab.
-. Select a {object} to open the *{object-gui} Overview* screen.
-. Click the *Details* tab.
+. Click the *{object-gui}* tab.
+. Select a {object} to open the *Virtual Machine Overview* screen.
 . Click the pencil icon to make a field editable.
 . Make the relevant changes and click *Save*.
 
@@ -64,10 +65,12 @@ ifeval::["{context}" == "virt-edit-vms"]
 :virt-vm!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]
 
 ifeval::["{context}" == "virt-editing-vm-template"]
 :virt-vm-template!:
 :object!:
 :object-gui!:
+:object-vm-overview!:
 endif::[]

--- a/modules/virt-enabling-dedicated-resources.adoc
+++ b/modules/virt-enabling-dedicated-resources.adoc
@@ -21,16 +21,14 @@ endif::[]
 [id="virt-enabling-dedicated-resources_{context}"]
 = Enabling dedicated resources for a {object}
 
-You can enable dedicated resources for a {object} in the
-*{object-gui} Overview* page of the web console.
+You can enable dedicated resources for a {object} in the *Details* tab. Virtual machines that were created by using a Red Hat template or the wizard can be enabled with dedicated resources.
 
 .Procedure
 
 . Click *Workloads* -> *{object-gui}s* from the side menu.
-. Select a {object} to open the *{object-gui} Overview* page.
+. Select a {object} to open the *{object-gui}* tab.
 . Click the *Details* tab.
-. Click the pencil icon to the right of the *Dedicated Resources* field to open
-the *Dedicated Resources* window.
+. Click the pencil icon to the right of the *Dedicated Resources* field to open the *Dedicated Resources* window.
 . Select *Schedule this workload with dedicated resources (guaranteed policy)*.
 . Click *Save*.
 

--- a/modules/virt-filtering-vm-templates.adoc
+++ b/modules/virt-filtering-vm-templates.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-creating-vm-template.adoc
+
+[id="virt-filtering-vm-templates_{context}"]
+= Filtering the list of virtual machine templates by providers
+
+In the *Templates* tab, you can use the *Search by name* field to search for virtual machine templates by specifying either the name of the template or a label that identfies the template. You can also filter templates by the provider, and display only those templates that meet your filtering criteria.
+
+.Procedure
+
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Templates* tab.
+. To filter templates, click *Filter*.
+. Select the appropriate checkbox from the list to filter the templates: *Red Hat Supported*, *User Supported*, *Red Hat Provided*, and *User Provided*.

--- a/modules/virt-marking-vm-templates-favorites.adoc
+++ b/modules/virt-marking-vm-templates-favorites.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-creating-vm-template.adoc
+
+[id="virt-marking-vm-templates-favorites_{context}"]
+= Marking virtual machine templates as favorites
+
+For easier access to virtual machine templates that are used frequently, you can mark those templates as favorites.
+
+.Procedure
+
+. In the {VirtProductName} console, click *Workloads* -> *Virtualization* from the side menu.
+. Click the *Templates* tab.
+. Identify the Red Hat template that you want to mark as a favorite.
+. Click the Options menu {kebab} and select *Favorite template*. The template moves up higher in the list of displayed templates.

--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -8,36 +8,61 @@
 = Storage fields
 
 |===
-|Name | Description
+|Name |Selection |Description
 
-|Source
-|Select a blank disk for the virtual machine or choose from the options available: *URL*,  *Container*, *Attach Cloned Disk*, or *Attach Disk*. To select an existing disk and attach it to the virtual machine, choose *Attach Cloned Disk* or *Attach Disk* from a list of available persistent volume claims (PVCs).
+.6+|Source
+|Blank (creates PVC)
+|Create an empty disk.
+
+|Import via URL (creates PVC)
+|Import content via URL (HTTP or S3 endpoint).
+
+|Use an existing PVC
+|Use a PVC that is already available in the cluster.
+
+|Clone existing PVC (creates PVC)
+|Select an existing PVC available in the cluster and clone it.
+
+|Import via Registry (creates PVC)
+|Import content via container registry.
+
+|Container (ephemeral)
+|Upload content from a container located in a registry accessible from the cluster. The container disk should be used only for read-only filesystems such as CD-ROMs or temporary virtual machines.
 
 |Name
+|
 |Name of the disk. The name can contain lowercase letters (`a-z`), numbers (`0-9`), hyphens (`-`), and periods (`.`), up to a maximum of 253 characters. The first and last characters must be alphanumeric. The name must not contain uppercase letters, spaces, or special characters.
 
-|Size (GiB)
-|Size, in GiB, of the disk.
+|Size
+|
+|Size of the disk in GiB.
+
+|Type
+|
+|Type of disk. Example: Disk or CD-ROM
 
 |Interface
+|
 |Type of disk device. Supported interfaces are *virtIO*, *SATA*, and *SCSI*.
 
 |Storage Class
+|
 |The storage class that is used to create the disk.
 
 |Advanced -> Volume Mode
+|
 |Defines whether the persistent volume uses a formatted file system or raw block state. Default is *Filesystem*.
 
 |Advanced -> Access Mode
-|Access mode of the persistent volume. Supported access modes are *ReadWriteOnce*, *ReadOnlyMany*, and *ReadWriteMany*.
+|
+|Access mode of the persistent volume. Supported access modes are *Single User (RWO)*, *Shared Access (RWX)*, and *Read Only (ROX)*.
 
 |===
 
 [id="virt-storage-wizard-fields-advanced-web_{context}"]
 [discrete]
 == Advanced storage settings
-The following advanced storage settings are available for *Blank*, *URL*, and *Attach Cloned Disk* disks.
-These parameters are optional. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` config map.
+The following advanced storage settings are available for *Blank*, *Import via URL*, and *Clone existing PVC* disks. These parameters are optional. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` config map.
 
 [cols="2a,3a,5a"]
 |===

--- a/modules/virt-template-fields-for-boot-source.adoc
+++ b/modules/virt-template-fields-for-boot-source.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_templates/virt-creating-vm-template.adoc
+
+[id="virt-template-fields-for-boot-source_{context}"]
+= Virtual machine template fields for adding a boot source
+
+The following table describes the fields for *Add boot source to template* window. This window displays when you click *Add Source* for a virtual machine template in the *Templates* tab.
+[cols="2a,3a,5a"]
+|===
+|Name | Parameter |  Description
+
+.4+|Boot source type
+|Upload local file (creates PVC)
+|Upload a file from your local device. Supported file types include gz, xz, tar, and qcow2.
+
+|Import via URL (creates PVC)
+|Import content from an image available from an HTTP or S3 endpoint. Obtain the download link URL from the web page where the image download is available and enter that URL link in the *Import via URL (creates PVC)* field. Example: For a Red Hat Enterprise Linux image, log on to the Red Hat customer portal, access the image download page, and copy the download link URL for the KVM guest image.
+
+|Clone existing PVC (creates PVC)
+|Use a PVC that is already available in the cluster and clone it.
+
+|Import via Registry (creates PVC)
+|Specify the bootable operating system container that is located in a registry and accessible from the cluster. Example: kubevirt/cirros-registry-dis-demo.
+
+|Source provider
+|
+|Optional field. Add descriptive text about the source for the template or the name of the user who created the template. Example: Red Hat.
+
+.3+|Advanced
+|Storage class
+|The storage class that is used to create the disk.
+
+|Access mode
+|Access mode of the persistent volume. Supported access modes are *Single User (RWO)*, *Shared Access (RWX)*, *Read Only (ROX)*. If *Single User (RWO)* is selected, the disk can be mounted as read/write by a single node. If *Shared Access (RWX)* is selected, the disk can be mounted as read-write by many nodes. The `kubevirt-storage-class-defaults` config map provides access mode defaults for data volumes. The default value is set according to the best option for each storage class in the cluster.
++
+[NOTE]
+====
+Shared Access (RWX) is required for some features, such as live migration of virtual machines between nodes.
+====
+
+|Volume mode
+|Defines whether the persistent volume uses a formatted file system or raw block state. Supported modes are *Block* and *Filesystem*. The `kubevirt-storage-class-defaults` config map provides volume mode defaults for data volumes. The default value is set according to the best option for each storage class in the cluster.
+|===

--- a/modules/virt-vm-template-wizard-fields-web.adoc
+++ b/modules/virt-vm-template-wizard-fields-web.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/virt-create-vms.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+// * virt/vm_templates/virt-creating-vm-template.adoc
 
 // VM wizard includes additional options to VM template wizard
 // Call appropriate attribute in the assembly
 
-[id="virt-vm-wizard-fields-web_{context}"]
+[id="virt-vm-template-wizard-fields-web_{context}"]
 ifdef::virtualmachine[]
 = Virtual machine wizard fields
 endif::[]
@@ -65,11 +65,11 @@ endif::[]
 
 |Persistent Volume Claim project
 |
-|Project name that you want to use for cloning the PVC.
+|Select the project name that you want to use for cloning the PVC.
 
 |Persistent Volume Claim name
 |
-|PVC name that should apply to this virtual machine template if you are cloning an existing PVC.
+|Select the PVC name that should apply to this virtual machine template if you cloning an existing PVC.
 
 |Flavor
 |Tiny, Small, Medium, Large, Custom

--- a/virt/vm_templates/virt-creating-vm-template.adoc
+++ b/virt/vm_templates/virt-creating-vm-template.adoc
@@ -4,21 +4,22 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-creating-vm-template
 toc::[]
 
-You can use virtual machine templates to create multiple virtual machines that have
-similar configurations. After a template is created, reference the template
-when creating virtual machines.
-
+include::modules/virt-about-vm-templates.adoc[leveloffset=+1]
+include::modules/virt-adding-a-boot-source-web.adoc[leveloffset=+1]
+include::modules/virt-template-fields-for-boot-source.adoc[leveloffset=+2]
+include::modules/virt-marking-vm-templates-favorites.adoc[leveloffset=+1]
+include::modules/virt-filtering-vm-templates.adoc[leveloffset=+1]
 include::modules/virt-creating-template-wizard-web.adoc[leveloffset=+1]
 
 [id="virt-template-wizard-fields"]
-== Virtual machine template interactive wizard fields
+== Virtual machine template wizard fields
 
-The following tables describe the fields for the *Basic Settings*, *Networking*,
-and *Storage* panes in the *Create Virtual Machine Template* interactive wizard.
+The following tables describe the fields for the *General*, *Networking*,
+*Storage*, and *Advanced* steps in the *Create Virtual Machine Template* wizard.
 
 :vmtemplate:
 include::modules/virt-vm-wizard-fields-web.adoc[leveloffset=+2]
-include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+2]
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+2]
 :vmtemplate!:

--- a/virt/vm_templates/virt-deleting-vm-template.adoc
+++ b/virt/vm_templates/virt-deleting-vm-template.adoc
@@ -4,8 +4,9 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-deleting-vm-template
 toc::[]
 
-You can delete a virtual machine template in the web console.
+Red Hat virtual machine templates cannot be deleted. You can use the web console to delete:
+
+* Virtual machine templates created from Red Hat templates
+* Custom virtual machine templates that were created by using the *Create Virtual Machine Template* wizard.
 
 include::modules/virt-deleting-template-web.adoc[leveloffset=+1]
-
-

--- a/virt/vm_templates/virt-editing-vm-template.adoc
+++ b/virt/vm_templates/virt-editing-vm-template.adoc
@@ -5,8 +5,7 @@ include::modules/virt-document-attributes.adoc[]
 toc::[]
 
 You can update a virtual machine template in the web console, either by editing
-the full configuration in the YAML editor or by editing a subset of the
-parameters in the *Virtual Machine Template Overview* screen.
+the full configuration in the YAML editor or by selecting a custom template in the *Templates* tab and modifying the editable items.
 
 include::modules/virt-editing-vm-web.adoc[leveloffset=+1]
 include::modules/virt-editing-template-yaml-web.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is associated with [CNV-9030](https://issues.redhat.com/browse/CNV-9030). In the OpenShift Virtualization web console, a new UI has been introduced with major new features for virtual machine templates. We now provide preconfigured Red Hat templates for Linux, Windows, and Fedora. Users can open a preconfigured Red Hat template, customize it by adding a boot source, and create a customized template for creating multiple virtual machines. 

The Templates tab lists all of the Red Hat templates and any custom templates created by users. Users have the flexibility to use either Red Hat templates or the interactive wizard to create virtual machine templates. By offering preconfigured Red Hat templates to our users, we make it easy for them to choose a template and quickly customize it for their needs.

Virtual machine templates provided by Red Hat cannot be edited or deleted. Users can, however, delete templates that they have created.

This new UI also impacts how our users use Red Hat templates to create virtual machines. The tasks applying to the creation of virtual machines by using Red Hat templates and custom templates are covered by a different Jira story that will be released for review when that PR is ready.



