### PR TITLE
Updates for scheduling a pod with a node selector

### DIFF
--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -9,10 +9,8 @@ You can use node selector labels on pods to control where the pod is scheduled.
 
 With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
-To add node selectors to an existing pod, add a node selector to the controlling object for that node, such as
-a replica set, daemon set, or stateful set. Any existing pods under that controlling object are recreated on a node
-with a matching label. If you are creating a new pod, you can add the node selector directly
-to the `Pod` spec.
+To add node selectors to an existing pod, add a node selector to the controlling object for that pod, such as a `ReplicaSet` object, `DaemonSet` object, `StatefulSet` object, `Deployment` object, or `DeploymentConfig` object.
+Any existing pods under that controlling object are recreated on a node with a matching label. If you are creating a new pod, you can add the node selector directly to the `Pod` spec.
 
 You can add labels to a node or machine config, but the labels will not persist if the node or machine goes down.
 Adding the label to the machine set ensures that new nodes or machines will have the label.


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/27371

> To add node selectors to an existing pod, add a node selector to the controlling object for that pod, such as a `ReplicaSet` object, `DaemonSet` object, `StatefulSet` object, `Deployment` object, or `DeploymentConfig` object.
Any existing pods under that controlling object are recreated on a node with a matching label. If you are creating a new pod, you can add the node selector directly to the `Pod` spec