### PR TITLE
Adjust unneededTime

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -37,7 +37,7 @@ spec:
     delayAfterAdd: 10m <12>
     delayAfterDelete: 5m <13>
     delayAfterFailure: 30s <14>
-    unneededTime: 60s <15>
+    unneededTime: 5m <15>
 ----
 <1> Specify the priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Enter a 32-bit integer value. The `podPriorityThreshold` value is compared to the value of the `PriorityClass` that you assign to each pod.
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.


### PR DESCRIPTION
For my use-case, which I believe is pretty typical, during an upgrade nodes tend to get deleted immediately after they are upgraded with the unneededTime set to 60s.  I adapted the example cluster-autoscaler yaml for my own cluster (I think this is typical for someone looking for a starting point).  To avoid others befalling my fate I suggest providing an example which will not cause subtle problems down the line. For reference I was upgrading an IPI OKD cluster in GCP from 4.6.0-0.okd-2020-11-27-200126 to 4.6.0-0.okd-2020-12-12-135354 with 3 Master Nodes sized n1-standard-4 and 5-6 Worker Nodes sized n1-highmem-4. Upon deletion a new node was almost immediately provisioned by the AutoScaler because the next Worker was draining and pods were unschedulable.