### PR TITLE
Add information about TZ for CronJobs

### DIFF
--- a/modules/nodes-nodes-jobs-about.adoc
+++ b/modules/nodes-nodes-jobs-about.adoc
@@ -56,6 +56,13 @@ two jobs might be created. Therefore, jobs must be idempotent and you must
 configure history limits.
 ====
 
+
+[WARNING]
+====
+A cron job creates a job object based on the timezone configured on the
+master that is currently running the cronjob controller.
+====
+
 [id="jobs-create_{context}"]
 = Understanding how to create jobs
 


### PR DESCRIPTION
@bergerhoffer this adds a warning to explicitly tell users that Jobs created from CronJob are created using time zone which is configured on the master which is currently running the cronjob controller loop. This is applicable to all openshift version so we'll need to backport that all the way back. As usual feel free to pick and update as you like :) 

