### PR TITLE
Add OCS to common attributes

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -22,6 +22,8 @@ endif::[]
 :rh-openstack-first: Red Hat OpenStack Platform (RHOSP)
 :rh-openstack: RHOSP
 :cloud-redhat-com: Red Hat OpenShift Cluster Manager
+:rh-storage-first: Red Hat OpenShift Container Storage
+:rh-storage: OpenShift Container Storage
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
 ifdef::openshift-origin[]


### PR DESCRIPTION
Adding attribute product tags for "Red Hat OpenShift Container Storage" and "OpenShift Container Storage".
**Cc: @Erin-Donnelly** 