### PR TITLE
BZ#1760675 Add steps for taint config when moving workloads to infra nodes

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -45,9 +45,9 @@ include::modules/machineset-creating.adoc[leveloffset=+2]
 [id="assigning-machineset-resources-to-infra-nodes"]
 == Assigning machine set resources to infrastructure nodes
 
-After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes. The `worker` role is required for infra nodes during startup. Nodes with the `infra` role applied are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
+After creating an infrastructure machine set, the `worker` and `infra` roles are applied to new infra nodes. Nodes with the `infra` role applied are not counted toward the total number of subscriptions that are required to run the environment, even when the `worker` role is also applied.
 
-However, with an infra node being assigned as a worker, there is a chance user workloads could get inadvertently assigned to an infra node. To avoid this, you must apply a taint to the infra node and tolerations for the pods you want to control.
+However, with an infra node being assigned as a worker, there is a chance user workloads could get inadvertently assigned to an infra node. To avoid this, you can apply a taint to the infra node and tolerations for the pods you want to control.
 
 include::modules/binding-infra-node-workloads-using-taints-tolerations.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Late clean-up from https://bugzilla.redhat.com/show_bug.cgi?id=1760675. This gives some clarity on the need for configuring tolerations for the infra component pods we're scheduling.