### PR TITLE
bug 1913821: Provide instructions for uninstalling descheduler

### DIFF
--- a/modules/nodes-descheduler-uninstalling.adoc
+++ b/modules/nodes-descheduler-uninstalling.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-descheduler.adoc
+
+[id="nodes-descheduler-uninstalling_{context}"]
+= Uninstalling the descheduler
+
+.Prerequisites
+
+* Cluster administrator privileges.
+* Access to the {product-title} web console.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+. Delete a descheduler instance.
+.. From the *Operators* -> *Installed Operators* page, click the *Kube Descheduler Operator*.
+.. Select the *Kube Descheduler* tab
+.. Find *cluster* entry, click on the three dots of the entry, click the *Delete KubeDescheduler*
+. Uninstall the Kube Descheduler Operator.
+.. Navigate to *Operators* -> *InstalledOperators,
+.. Find *Kube Descheduler Operator* entry, click on the three dots of the entry, click the *Uninstall Operator*
+. Delete `openshift-kube-descheduler-operator` namespace
+.. Navigate to *Administration* -> *Namespaces*
+.. Type `openshift-kube-descheduler-operator` into the filter box.
+.. Find `openshift-kube-descheduler-operator` entry, click on the three dots of the entry, click the *Delete Namespace*
+. Delete `KubeDescheduler` CRD
+.. Navigate to *Administration* -> *Custom Resource Definitions*
+.. Type `KubeDescheduler` into the filter box.
+.. Find `KubeDescheduler` entry, click on the three dots of the entry, click the *Delete CustomResourceDefinitions*

--- a/nodes/scheduling/nodes-descheduler.adoc
+++ b/nodes/scheduling/nodes-descheduler.adoc
@@ -30,3 +30,6 @@ include::modules/nodes-descheduler-filtering-priority.adoc[leveloffset=+1]
 
 // Configuring additional descheduler settings
 include::modules/nodes-descheduler-configuring-other-settings.adoc[leveloffset=+1]
+
+// Uninstalling the descheduler
+include::modules/nodes-descheduler-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
cc @kasturinarra @damemi

Following the steps there are still some bits left:
```
$ oc get crd | grep descheduler
kubedeschedulers.operator.openshift.io                            2021-01-12T09:11:08Z
$ oc get clusterrole | grep descheduler
kubedeschedulers.operator.openshift.io-v1beta1-admin                        2021-01-12T09:11:34Z
kubedeschedulers.operator.openshift.io-v1beta1-crdview                      2021-01-12T09:11:35Z
kubedeschedulers.operator.openshift.io-v1beta1-edit                         2021-01-12T09:11:34Z
kubedeschedulers.operator.openshift.io-v1beta1-view                         2021-01-12T09:11:35Z
```