### PR TITLE
OCPRHV-428 removing Setting up the CA certificate instructions from R…  [enterprise-4.7]  

### DIFF
--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -52,8 +52,6 @@ include::modules/installing-rhv-verifying-the-rhv-environment.adoc[leveloffset=+
 
 include::modules/installing-rhv-preparing-the-network-environment.adoc[leveloffset=+1]
 
-include::modules/installing-rhv-setting-up-ca-certificate.adoc[leveloffset=+1]
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -47,8 +47,6 @@ include::modules/installing-rhv-verifying-the-rhv-environment.adoc[leveloffset=+
 
 include::modules/installing-rhv-preparing-the-network-environment.adoc[leveloffset=+1]
 
-include::modules/installing-rhv-setting-up-ca-certificate.adoc[leveloffset=+1]
-
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]


### PR DESCRIPTION
…HV installation instructions

https://issues.redhat.com/browse/OCPRHV-428
applies to OCP enterprise_4.7