### PR TITLE
Update webhook info for OLM certs in Security guide

### DIFF
--- a/security/certificate_types_descriptions/olm-certificates.adoc
+++ b/security/certificate_types_descriptions/olm-certificates.adoc
@@ -9,10 +9,6 @@ toc::[]
 
 All certificates for OpenShift Lifecycle Manager (OLM) components (`olm-operator`, `catalog-operator`, `packageserver`, and `marketplace-operator`) are managed by the system.
 
-Operators installed via OLM can have certificates generated for them if they are providing API services. `packageserver` is one example.
+When installing Operators that include webhooks or API services in their `ClusterServiceVersion` (CSV) object, OLM creates and rotates the certificates for these resources. Certificates for resources in the `openshift-operator-lifecycle-manager` namespace are managed by OLM.
 
-Certificates in the `openshift-operator-lifecycle-manager` namespace are managed by OLM with the exception of certificates used by Operators that require a validating or mutating webhook.
-
-Operators that install validating or mutating webhooks must currently manage those certificates themselves. They do not require the user to manage the certificates.
-
-OLM will not update the certificates of Operators that it manages in proxy environments. These certificates must be managed by the user via the subscription config.
+OLM will not update the certificates of Operators that it manages in proxy environments. These certificates must be managed by the user using the subscription config.


### PR DESCRIPTION
PTAL @awgreene. Looking to remove/update as far back as 4.4 docs, if accurate.

Preview (internal): http://file.rdu.redhat.com/~adellape/011220/olm_certs/security/certificate_types_descriptions/olm-certificates.html