### PR TITLE
CNV-7058 Autofill Flavour and Workload

### DIFF
--- a/modules/virt-vm-wizard-fields-web.adoc
+++ b/modules/virt-vm-wizard-fields-web.adoc
@@ -2,6 +2,8 @@
 //
 // * virt/virtual_machines/virt-create-vms.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+// * virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+// * virt/vm_templates/virt-creating-vm-template.adoc
 
 // VM wizard includes additional options to VM template wizard
 // Call appropriate attribute in the assembly
@@ -48,7 +50,12 @@ endif::[]
 
 |Operating System
 |
-|The primary operating system that is selected for the virtual machine.
+ifdef::virtualmachine[]
+|The primary operating system that is selected for the virtual machine in the template. You cannot edit this field when creating a virtual machine from a template.
+endif::[]
+ifdef::vmtemplate[]
+|The primary operating system that is selected for the virtual machine. Selecting an operating system automatically selects the default *Flavor* and *Workload Type* for that operating system.
+endif::[]
 
 .4+|Boot Source
 |Import via URL (creates PVC)


### PR DESCRIPTION
Added line to Operating System in the VM wizard table explaining that selecting OS pre-fills Flavor and Workload with defaults.

[CNV-7058](https://issues.redhat.com/browse/CNV-7058)
