### PR TITLE
Fix storage class CSI note in Creating SC-EBS/GCE

### DIFF
--- a/modules/storage-create-storage-class.adoc
+++ b/modules/storage-create-storage-class.adoc
@@ -31,12 +31,6 @@ persistent volumes.
 .. Select the reclaim policy.
 
 .. Select `{Provisioner}` from the drop down list.
-+
-
-[NOTE]
-====
-For Container Storage Interface (CSI) provisioning, select `ebs.csi.aws.com`.
-====
 
 .. Enter additional parameters for the storage class as desired.
 


### PR DESCRIPTION
In the portal, when I select provisioner drop-down, I do not see an option for `<foo>.csi.<bar>.com`. The instruction in this note to select the CSI option for provisioning is not a valid option. This note was added in 4.6 and I have tested this functionality on a 4.7 cluster. The note appears in both the [GCE PD](https://docs.openshift.com/container-platform/4.6/storage/persistent_storage/persistent-storage-gce.html) and the [AWS EBS](https://docs.openshift.com/container-platform/4.6/storage/persistent_storage/persistent-storage-aws.html) sections.

This note was added in https://github.com/openshift/openshift-docs/pull/24911 from [this](https://github.com/openshift/openshift-docs/pull/24911#discussion_r474366972) comment.