### PR TITLE
Added note that OCP on baremetal was tested up to 500 nodes

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -31,7 +31,7 @@
 | 500
 | 500
 | 500
-| 500
+| 500 ^[2]^
 
 | Number of pods per core
 | There is no default value.
@@ -41,7 +41,7 @@
 | There is no default value.
 | There is no default value.
 
-| Number of namespaces ^[2]^
+| Number of namespaces ^[3]^
 | 10,000
 | 10,000
 | 10,000
@@ -57,7 +57,7 @@
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
-| Number of pods per namespace ^[3]^
+| Number of pods per namespace ^[4]^
 | 25,000
 | 25,000
 | 25,000
@@ -65,7 +65,7 @@
 | 25,000
 | 25,000
 
-| Number of services ^[4]^
+| Number of services ^[5]^
 | 10,000
 | 10,000
 | 10,000
@@ -89,7 +89,7 @@
 | 5,000
 | 5,000
 
-| Number of deployments per namespace ^[3]^
+| Number of deployments per namespace ^[4]^
 | 2,000
 | 2,000
 | 2,000
@@ -101,9 +101,10 @@
 [.small]
 --
 1. The pod count displayed here is the number of test pods. The actual number of pods depends on the application’s memory, CPU, and storage requirements.
-2. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.
-3. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
-4. Each service port and each service back end has a corresponding entry in iptables. The number of back ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
+2. {product-title} on baremetal was tested up to 500 nodes.
+3. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentaion, is highly recommended to free etcd storage.
+4. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
+5. Each service port and each service back end has a corresponding entry in iptables. The number of back ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
 --
 
 In {product-title} {product-version}, half of a CPU core (500 millicore) is reserved by the system compared to {product-title} 3.11 and previous versions.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1706
https://issues.redhat.com/browse/PERFSCALE-584

Preview build: https://baremetal-500-nodes--ocpdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums_object-limits

This is not going to make it for 4.7, as it involves several patches. It requires end-to-end 4.7 testing to confirm this statement.