### PR TITLE
OSDOCS-1689 - Adding external alert configuration to post-installation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -358,6 +358,8 @@ Topics:
   File: storage-configuration
 - Name: Preparing for users
   File: preparing-for-users
+- Name: Configuring alert notifications
+  File: configuring-alert-notifications
 ---
 Name: Support
 Dir: support

--- a/modules/monitoring-configuring-alert-receivers.adoc
+++ b/modules/monitoring-configuring-alert-receivers.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
+// * post_installation_configuration/configuring-alert-notifications.adoc
 
 [id="configuring-alert-receivers_{context}"]
 = Configuring alert receivers

--- a/modules/monitoring-sending-notifications-to-external-systems.adoc
+++ b/modules/monitoring-sending-notifications-to-external-systems.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * monitoring/managing-alerts.adoc
+// * post_installation_configuration/configuring-alert-notifications.adoc
 
 [id="sending-notifications-to-external-systems_{context}"]
 = Sending notifications to external systems

--- a/post_installation_configuration/configuring-alert-notifications.adoc
+++ b/post_installation_configuration/configuring-alert-notifications.adoc
@@ -1,0 +1,17 @@
+[id="configuring-alert-notifications"]
+= Configuring alert notifications
+include::modules/common-attributes.adoc[]
+:context: configuring-alert-notifications
+
+toc::[]
+
+In {product-title}, an alert is fired when the conditions defined in an alerting rule are true. An alert provides a notification that a set of circumstances are apparent within a cluster. Firing alerts can be viewed in the Alerting UI in the {product-title} web console by default. After an installation, you can configure {product-title} to send alert notifications to external systems.
+
+include::modules/monitoring-sending-notifications-to-external-systems.adoc[leveloffset=+1]
+include::modules/monitoring-configuring-alert-receivers.adoc[leveloffset=+2]
+
+[id="configuring-alert-notifications-additional-resources"]
+== Additional resources
+
+* xref:../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Understanding the monitoring stack]
+* xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]


### PR DESCRIPTION
This applies to master, branch/enterprise-4.6 and branch/enterprise-4.7.

This PR adds a 'Post-installation configuration -> Configuring alert notifications' assembly that provides guidance on setting up external alert notifications after an installation. The PR reuses two monitoring modules on this topic that were created for 4.6 GA.

This relates to https://issues.redhat.com/browse/OSDOCS-1689.

The preview is [here](https://osdocs-1689-adding-alert-config-to-post-install--ocpdocs.netlify.com/openshift-enterprise/latest/post_installation_configuration/configuring-alert-notifications.html).