### PR TITLE
Update AWS AMIs due to boot image update

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,55 +23,64 @@ importing your own AMI.
 |AWS zone
 |AWS AMI
 
+|`af-south-1`
+|`ami-09921c9c1c36e695c`
+
+|`ap-east-1`
+|`ami-01ee8446e9af6b197`
+
 |`ap-northeast-1`
-|`ami-0cb46ba6945dbfebe`
+|`ami-04e5b5722a55846ea`
 
 |`ap-northeast-2`
-|`ami-01e554d608de6087a`
+|`ami-0fdc25c8a0273a742`
 
 |`ap-south-1`
-|`ami-09253ba33f828d47f`
+|`ami-09e3deb397cc526a8`
 
 |`ap-southeast-1`
-|`ami-0a6a0f1f6106708c4`
+|`ami-0630e03f75e02eec4`
 
 |`ap-southeast-2`
-|`ami-0e3e2b2ea00c35823`
+|`ami-069450613262ba03c`
 
 |`ca-central-1`
-|`ami-0f5825ef10c76de32`
+|`ami-012518cdbd3057dfd`
 
 |`eu-central-1`
-|`ami-0a51f61236e6fc6f2`
+|`ami-0bd7175ff5b1aef0c`
 
 |`eu-north-1`
-|`ami-06d01bfaf14ad66a3`
+|`ami-06c9ec42d0a839ad2`
+
+|`eu-south-1`
+|`ami-0614d7440a0363d71`
 
 |`eu-west-1`
-|`ami-0e514a30ad261c978`
+|`ami-01b89df58b5d4d5fa`
 
 |`eu-west-2`
-|`ami-0291fd4543d6940f4`
+|`ami-06f6e31ddd554f89d`
 
 |`eu-west-3`
-|`ami-083f281d2864a71de`
+|`ami-0dc82e2517ded15a1`
 
 |`me-south-1`
-|`ami-05a6ae5eadb5b244d`
+|`ami-07d181e3aa0f76067`
 
 |`sa-east-1`
-|`ami-081f13881a31af160`
+|`ami-0cd44e6dd20e6c7fa`
 
 |`us-east-1`
-|`ami-009cbe327d180d666`
+|`ami-04a16d506e5b0e246`
 
 |`us-east-2`
-|`ami-0346f64579665ce3c`
+|`ami-0a1f868ad58ea59a7`
 
 |`us-west-1`
-|`ami-07c185c787029b522`
+|`ami-0a65d76e3a6f6622f`
 
 |`us-west-2`
-|`ami-01105d480bb47353f`
+|`ami-0dd9008abadc519f1`
 
 |===


### PR DESCRIPTION
Due to boot image updates post GA, the AWS AMIs (and region list) now differ from the original GA.