### PR TITLE
A couple missed instances of "Machine"

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -3,7 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-azure
 
-You can create a different machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure machine sets and related Machines so that you can move supporting workloads to the new Machines.
+You can create a different machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 toc::[]
 

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -3,10 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-gcp
 
-You can create a different machine set to serve a specific purpose in your
-{product-title} cluster on Google Cloud Platform (GCP). For example, you might
-create infrastructure machine sets and related Machines so that you can move
-supporting workloads to the new Machines.
+You can create a different machine set to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 toc::[]
 

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -3,10 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-osp
 
-You can create a different machine set to serve a specific purpose in your
-{product-title} cluster on {rh-openstack-first}. For example, you might
-create infrastructure machine sets and related Machines so that you can move
-supporting workloads to the new Machines.
+You can create a different machine set to serve a specific purpose in your {product-title} cluster on {rh-openstack-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 toc::[]
 

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can create a different machine set to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure machine sets and related Machines so that you can move supporting workloads to the new Machines.
+You can create a different machine set to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Some references to "Machine" that should be "machine", and unwrapping.