### PR TITLE
CNV-7494 Documented interface for offline VM snapshots

### DIFF
--- a/modules/virt-creating-offline-vm-snapshot-web.adoc
+++ b/modules/virt-creating-offline-vm-snapshot-web.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-creating-offline-vm-snapshot-web_{context}"]
+= Creating an offline virtual machine snapshot in the web console
+
+You can create a virtual machine (VM) snapshot by using the web console.
+
+[NOTE]
+====
+The VM snapshot only includes disks that meet the following requirements:
+
+* Must be either a data volume or persistent volume claim
+* Belong to a storage class that supports Container Storage Interface (CSI) volume snapshots
+
+If your VM storage includes disks that do not support snapshots, you can either edit them or contact your cluster administrator.
+====
+
+.Procedure
+
+. Click *Workloads* → *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
+
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. If the virtual machine is running, click *Actions* → *Stop Virtual Machine* to power it down.
+
+. Click the *Snapshots* tab and then click *Take Snapshot*.
+
+. Fill in the *Snapshot Name* and optional *Description* fields.
+
+. Expand *Disks included in this Snapshot* to see the storage volumes to be included in the snapshot.
+
+. If your VM has disks that cannot be included in the snapshot and you still wish to proceed, select the *I am aware of this warning and wish to proceed* checkbox.
+
+. Click *Save*.

--- a/modules/virt-deleting-vm-snapshot-web.adoc
+++ b/modules/virt-deleting-vm-snapshot-web.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-deleting-vm-snapshot-web_{context}"]
+= Deleting a virtual machine snapshot in the web console
+
+You can delete an existing virtual machine snapshot by using the web console.
+
+.Procedure
+
+. Click *Workloads* → *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
+
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. Click the *Snapshots* tab. The page displays a list of snapshots associated with the virtual machine.
+
+. Choose one of the following methods to delete a virtual machine snapshot:
+
+.. Click the Options menu {kebab} of the virtual machine snapshot that you want to delete and select *Delete Virtual Machine Snapshot*.
+
+.. Select a snapshot to open the *Snapshot Details* screen and click *Actions* → *Delete Virtual Machine Snapshot*.
+
+. In the confirmation pop-up window, click *Delete* to delete the snapshot.

--- a/modules/virt-restoring-vm-from-snapshot-web.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-web.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+
+[id="virt-restoring-vm-from-snapshot-web_{context}"]
+= Restoring a virtual machine from a snapshot in the web console
+
+You can restore a virtual machine (VM) to a previous configuration represented by a snapshot in the web console.
+
+.Procedure
+
+. Click *Workloads* → *Virtualization* from the side menu.
+
+. Click the *Virtual Machines* tab.
+
+. Select a virtual machine to open the *Virtual Machine Overview* screen.
+
+. If the virtual machine is running, click *Actions* → *Stop Virtual Machine* to power it down.
+
+. Click the *Snapshots* tab. The page displays a list of snapshots associated with the virtual machine.
+
+. Choose one of the following methods to restore a VM snapshot:
+
+.. For the snapshot that you want to use as the source to restore the VM, click *Restore*.
+
+.. Select a snapshot to open the *Snapshot Details* screen and click *Actions* → *Restore Virtual Machine Snapshot*.
+
+. In the confirmation pop-up window, click *Restore* to restore the VM to its previous configuration represented by the snapshot.

--- a/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc
@@ -12,9 +12,15 @@ offline VM snapshots on:
 
 include::modules/virt-about-vm-snapshots.adoc[leveloffset=+1]
 
+include::modules/virt-creating-offline-vm-snapshot-web.adoc[leveloffset=+1]
+
 include::modules/virt-creating-offline-vm-snapshot-cli.adoc[leveloffset=+1]
 
+include::modules/virt-restoring-vm-from-snapshot-web.adoc[leveloffset=+1]
+
 include::modules/virt-restoring-vm-from-snapshot-cli.adoc[leveloffset=+1]
+
+include::modules/virt-deleting-vm-snapshot-web.adoc[leveloffset=+1]
 
 include::modules/virt-deleting-vm-snapshot-cli.adoc[leveloffset=+1]
 


### PR DESCRIPTION
These modules and assembly address https://issues.redhat.com/browse/CNV-7494

Documented UI workflows to create, restore, and delete offline VM snapshots.

Preview builds:
[Creating offline VM snapshot](https://deploy-preview-28600--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.html#virt-creating-offline-vm-snapshot-web_virt-managing-offline-vm-snapshots)
[Restoring VM from snapshot](https://deploy-preview-28600--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.html#virt-restoring-vm-from-snapshot-web_virt-managing-offline-vm-snapshots)
[Deleting VM snapshot](https://deploy-preview-28600--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.html#virt-deleting-vm-snapshot-web_virt-managing-offline-vm-snapshots)

Label branch/enterprise-4.7

