### PR TITLE
GRPA-3235: Document disk mirroring during installation

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 Although directly making changes to {product-title} nodes is discouraged,
 there are times when it is necessary to implement a
-required low-level security, networking, or performance feature.
+required low-level security, redundancy, networking, or performance feature.
 Direct changes to {product-title} nodes can be done by:
 
 * Creating machine configs that are included in manifest files
@@ -15,6 +15,9 @@ to start up a cluster during `openshift-install`.
 
 * Creating machine configs that are passed to running
 {product-title} nodes via the Machine Config Operator.
+
+* Creating an Ignition config that is passed to `coreos-installer`
+when installing bare-metal nodes.
 
 The following sections describe features that you might want to
 configure on your nodes in this way.
@@ -28,6 +31,7 @@ include::modules/installation-special-config-kmod.adoc[leveloffset=+1]
 include::modules/installation-special-config-encrypt-disk.adoc[leveloffset=+1]
 include::modules/installation-special-config-encrypt-disk-tpm2.adoc[leveloffset=+2]
 include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+include::modules/installation-special-config-mirrored-disk.adoc[leveloffset=+1]
 include::modules/installation-special-config-crony.adoc[leveloffset=+1]
 
 ifndef::openshift-origin[]

--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -19,7 +19,6 @@ settings and run `openshift-install` to install a cluster and `oc` to work with 
 for instructions. See link:https://youtu.be/2uLKvB8Z5D0[Securing Automated Decryption New Cryptography and Techniques]
 for a presentation on Tang.
 
-
 . Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line. For both DHCP and static networking, you also must provide the `rd.neednet=1` kernel argument.
 
 [IMPORTANT]
@@ -70,6 +69,11 @@ ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3ps
 ----
 
 . In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
+
+[IMPORTANT]
+====
+If you are also configuring boot disk mirroring on the affected nodes, record the server thumbprint for later use, and skip this step. You will configure disk encryption when configuring boot disk mirroring.
+====
 
 ** For worker nodes, use the following command:
 +

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -23,8 +23,13 @@ This is required on most Dell systems. Check the manual for your computer.
 $ ./openshift-install create manifests --dir=<installation_directory>
 ----
 
-. In the `openshift` directory, create master or worker files to encrypt
-disks for those nodes.
+. In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
+
+[IMPORTANT]
+====
+If you are also configuring boot disk mirroring on the affected nodes, skip this step. You will configure disk encryption when configuring boot disk mirroring.
+====
+
 ** To create a worker file, run the following command:
 +
 [source,terminal]

--- a/modules/installation-special-config-mirrored-disk.adoc
+++ b/modules/installation-special-config-mirrored-disk.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-mirrored-disk_{context}"]
+= Mirroring disks during installation
+
+During {product-title} installation on master and worker nodes, you can enable mirroring of the boot disk to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
+
+Mirroring does not support replacement of a failed disk. To restore the mirror to a pristine, non-degraded state, reprovision the node.
+
+[IMPORTANT]
+====
+Mirroring is available only for user-provisioned infrastructure deployments on {op-system-first} systems. Mirroring support is available on x86_64 nodes booted with BIOS or UEFI and on ppc64le nodes.
+====
+
+.Procedure
+
+To enable boot disk mirroring during {product-title} deployment:
+
+. Follow the bare metal install procedure up to the point where you created Ignition configs for your installation.
++
+For example, you should have entered the following command:
++
+[source,terminal]
+----
+$ openshift-install create ignition-configs --dir $HOME/clusterconfig
+----
++
+. Verify that the Ignition config files were created:
++
+[source,terminal]
+----
+$ ls $HOME/clusterconfig/
+----
++
+[source,terminal]
+.Example output
+----
+auth  bootstrap.ign  master.ign  metadata.json  worker.ign
+----
+
+. Create a {op-system} Config (RCC) with a reference to your `master.ign` or `worker.ign` config, depending on the type of node you are configuring. The RCC must specify the devices to be used for boot disk mirroring. If you want LUKS encryption on the mirrored root filesystem, you must configure it in this RCC.
++
+The following RCC example demonstrates how to create `$HOME/clusterconfig/worker-raid.rcc`:
++
+[source,yaml]
+.RCC example
+----
+variant: rhcos
+version: 0.1.0
+ignition:
+  config:
+    merge:
+      - local: worker.ign <1>
+boot_device:
+  mirror:
+    devices: <2>
+      - /dev/sda
+      - /dev/sdb
+  luks: <3>
+    tpm2: true <4>
+    tang: <5>
+      - url: https://tang.example.com
+        thumbprint: <tang_thumbprint>
+storage: <6>
+  luks:
+    - name: root
+      options: [--cipher, aes-cbc-essiv:sha256]
+----
++
+<1> Use the name of the Ignition config for your node type.
+<2> List all disk devices that should be included in the boot disk mirror, including the disk that {op-system} will be installed onto.
+<3> Include this section if you want to encrypt the root filesystem. See "Encrypting disks during installation" for more details.
+<4> Include this field if you want to use a Trusted Platform Module (TPM) to encrypt the root filesystem. See "Enabling TPM v2 disk encryption" for more details.
+<5> Include this section if you want to use a Tang server. To obtain the server URL and thumbprint, follow the instructions in "Enabling Tang disk encryption".
+<6> Include this section if you want to encrypt the root filesystem.
++
+. Run the Fedora CoreOS Config Transpiler (FCCT) tool to merge your RCC, such as `worker-raid.rcc`, with the Ignition config specified in the RCC that you created in the previous step:
++
+[source,terminal]
+----
+$ podman run --pull=always --rm --volume $HOME/clusterconfig:/pwd --workdir /pwd \
+    quay.io/coreos/fcct:release --files-dir . worker-raid.rcc --output worker-raid.ign
+----
++
+This command produces a combined Ignition config in `$HOME/clusterconfig/worker-raid.ign`.
++
+. Continue with the remainder of the {product-title} deployment, using the combined Ignition config to provision nodes.


### PR DESCRIPTION
Disk mirroring configs are generated by FCCT, which needs to be run as a separate tool for now, limiting this feature to UPI clusters.  In addition, when generating a mirroring config, FCCT needs to know that disk encryption is enabled.  So, for configuring encryption, we need to offer two paths: one via FCCT, which interoperates with mirroring and works on UPI only, and the existing MachineConfig path for other cases.