### PR TITLE
OSDOCS-1687 - Adding a 'Preparing to install on AWS' assembly

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -129,6 +129,8 @@ Topics:
 - Name: Installing on AWS
   Dir: installing_aws
   Topics:
+  - Name: Preparing to install on AWS
+    File: preparing-to-install-on-aws
   - Name: Configuring an AWS account
     File: installing-aws-account
   - Name: Manually creating IAM

--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -1,0 +1,46 @@
+[id="preparing-to-install-on-aws"]
+= Preparing to install on AWS
+include::modules/common-attributes.adoc[]
+:context: preparing-to-install-on-aws
+
+toc::[]
+
+[id="preparing-to-install-on-aws-prerequisites"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+
+[id="requirements-for-installing-ocp-on-aws"]
+== Requirements for installing {product-title} on AWS
+
+Before installing {product-title} on Amazon Web Services (AWS), you must create an AWS account. See xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account] for details about configuring an account, account limits, account permissions, IAM user setup, and supported AWS regions.
+
+If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS] for other options.
+
+[id="choosing-an-method-to-install-ocp-on-aws"]
+== Choosing a method to install {product-title} on AWS
+
+You can install {product-title} on AWS by using one of the following deployment methods.
+
+* **xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[Installing a cluster quickly on AWS]**: You can install {product-title} on AWS by using the default configuration options.
+
+* **xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS]**: You can install a customized cluster on AWS infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation]. 
+
+* **xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]**: You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements.
+
+* **xref:../../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[Installing a cluster on an existing Virtual Private Cloud]**: You can install {product-title} on an existing AWS Virtual Private Cloud (VPC). You can use this installation method if you have constraints set by the guidelines of your company, such as limits when creating new accounts or infrastructure.
+
+* **xref:../../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing AWS VPC. You can use this method to deploy {product-title} on an internal network that is not visible to the Internet.
+
+* **xref:../../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[Installing a cluster on AWS into a government or secret region]**: {product-title} can be deployed into AWS regions that are specifically designed for US government agencies at the federal, state, and local level, as well as contractors, educational institutions, and other US customers that must run sensitive workloads in the cloud.
+
+* **xref:../../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[Installing a cluster on AWS infrastructure that you provide]**: You can install {product-title} on AWS infrastructure that you provide. You can use the provided CloudFormation templates to create stacks of AWS resources that represent each of the components required for an {product-title} installation.
+
+* **xref:../../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[Installing a cluster on AWS by using an internal mirror]**: You can install {product-title} on AWS infrastructure that you provide by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active Internet connection to obtain the software components. While you can install {product-title} by using the mirrored content, your cluster still requires Internet access to use the AWS APIs.
+
+[id="preparing-to-install-on-aws-next-steps"]
+== Next steps
+
+* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account]


### PR DESCRIPTION
Applies to master and branch/enterprise-4.7.

This PR creates a new **Installing** -> **Installing on AWS** -> **Preparing to install on AWS** assembly that:

* Summarises the requirements for installing OCP on AWS and provides links to relevant assemblies.
* Provides an overview of each OCP on AWS installation method and the benefits of each one. This will help the reader choose the most appropriate installation method without having to read through each individual deployment assembly.

This relates to https://issues.redhat.com/browse/OSDOCS-1687.

The preview is [here](https://osdocs-1687-preparing-to-install-on-aws--ocpdocs.netlify.com/openshift-enterprise/latest/installing/installing_aws/preparing-to-install-on-aws.html).