### PR TITLE
Add all of the Kubernetes node conditions to docs

### DIFF
--- a/machine_management/deploying-machine-health-checks.adoc
+++ b/machine_management/deploying-machine-health-checks.adoc
@@ -12,8 +12,12 @@ include::modules/machine-health-checks-about.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-short-circuiting_deploying-machine-health-checks[Short-circuiting machine health check remediation] for more information about short circuiting
+* For more information about the node conditions you can define in a `MachineHealthCheck` CR, see xref:../nodes/nodes/nodes-nodes-viewing.html#nodes-nodes-viewing-listing_nodes-nodes-viewing[About listing all the nodes in a cluster].
+
+* For more information about short-circuiting, see xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-short-circuiting_deploying-machine-health-checks[Short-circuiting machine health check remediation].
 
 include::modules/machine-health-checks-resource.adoc[leveloffset=+1]
+
+.Additional resources
 
 include::modules/machine-health-checks-creating.adoc[leveloffset=+1]

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -14,6 +14,13 @@ You can get detailed information on the nodes in the cluster.
 $ oc get nodes
 ----
 +
+The following example is a cluster with healthy nodes:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
 .Example output
 [source,terminal]
 ----
@@ -22,12 +29,39 @@ master.example.com     Ready     master    7h        v1.20.0
 node1.example.com      Ready     worker    7h        v1.20.0
 node2.example.com      Ready     worker    7h        v1.20.0
 ----
++
+The following example is a cluster with one unhealthy node:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   STATUS                      ROLES     AGE       VERSION
+master.example.com     Ready                       master    7h        v1.20.0
+node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.20.0
+node2.example.com      Ready                       worker    7h        v1.20.0
+----
++
+The conditions that trigger a `NotReady` status are shown later in this section.
 
-* The `-wide` option provides additional information on all nodes.
+* The `-o wide` option provides additional information on nodes.
 +
 [source,terminal]
 ----
 $ oc get nodes -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                STATUS   ROLES    AGE    VERSION           INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                      KERNEL-VERSION                 CONTAINER-RUNTIME
+master.example.com  Ready    master   171m   v1.20.0+39c0afe   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.21.0-30.rhaos4.8.gitf2f339d.el8-dev
+node1.example.com   Ready    worker   72m    v1.20.0+39c0afe   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.21.0-30.rhaos4.8.gitf2f339d.el8-dev
+node2.example.com   Ready    worker   164m   v1.20.0+39c0afe   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.21.0-30.rhaos4.8.gitf2f339d.el8-dev 
 ----
 
 * The following command lists information about a single node:
@@ -37,25 +71,19 @@ $ oc get nodes -o wide
 $ oc get node <node>
 ----
 +
-The `STATUS` column in the output of these commands can show nodes with the
-following conditions:
+For example:
 +
-.Node Conditions [[node-conditions]]
-[cols="3a,8a",options="header"]
-|===
-
-|Condition |Description
-
-|`Ready`
-|The node reports its own readiness to the API server by returning `True`.
-
-|`NotReady`
-|One of the underlying components, such as the container runtime or network, is experiencing issues or is not yet configured.
-
-|`SchedulingDisabled`
-|Pods cannot be scheduled for placement on the node.
-
-|===
+[source,terminal]
+----
+$ oc get node node1.example.com
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   STATUS    ROLES     AGE       VERSION
+node1.example.com      Ready     worker    7h        v1.20.0
+----
 
 * The following command provides more detailed information about a specific node, including the reason for
 the current condition:
@@ -171,9 +199,46 @@ Events:     <11>
 <3> The labels applied to the node.
 <4> The annotations applied to the node.
 <5> The taints applied to the node.
-<6> Node conditions.
+<6> The node conditions and status. The `conditions` stanza lists the `Ready`, `PIDPressure`, `PIDPressure`, `MemoryPressure`, `DiskPressure` and `OutOfDisk` status. These condition are described later in this section.
 <7> The IP address and host name of the node.
 <8> The pod resources and allocatable resources.
 <9> Information about the node host.
 <10> The pods on the node.
-<11> The events reported by the node.
+<11> The events reported by the node.   
+
+Among the information shown for nodes, the following node conditions appear in the output of the commands shown in this section:
+
+[discrete]
+[id="machine-health-checks-resource-conditions"]
+.Node Conditions
+[cols="3a,8a",options="header"]
+|===
+
+|Condition |Description
+
+|`Ready`
+|If `true`, the node is healthy and ready to accept pods. If `false`, the node is not healthy and is not accepting pods. If `unknown`, the node controller has not received a heartbeat from the node for the `node-monitor-grace-period` (the default is 40 seconds).
+
+|`DiskPressure`
+|If `true`, the disk capacity is low.
+
+|`MemoryPressure`
+|If `true`, the node memory is low.
+
+|`PIDPressure`
+|If `true`, there are too many processes on the node.
+
+|`OutOfDisk`
+|If `true`, the node has insufficient free space on the node for adding new pods.
+
+|`NetworkUnavailable`
+| If `true`, the network for the node is not correctly configured. 
+
+|`NotReady`
+|If `true`, one of the underlying components, such as the container runtime or network, is experiencing issues or is not yet configured.
+
+|`SchedulingDisabled`
+|Pods cannot be scheduled for placement on the node.
+
+|===
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1458

I added the node conditions to the docs: Ready, DiskPressure, MemoryPressure, PIDPressure, OutOfDisk, NetworkUnavailable, NotReady, SchedulingDisabled. Moved the conditions table above the commands that display conditions, rather than inside of one command.

Preview of Nodes topic: https://deploy-preview-28656--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-viewing.html#nodes-nodes-viewing-listing_nodes-nodes-viewing