### PR TITLE
Bug 1917643: Add documentation of VolumeSnapshotClass.Driver parameter

### DIFF
--- a/modules/persistent-storage-csi-snapshots-create.adoc
+++ b/modules/persistent-storage-csi-snapshots-create.adoc
@@ -30,14 +30,15 @@ To dynamically create a volume snapshot:
 [source,yaml]
 ----
 apiVersion: snapshot.storage.k8s.io/v1
-kind: VolumeSnapshotClass <1>
+kind: VolumeSnapshotClass
 metadata:
   name: csi-hostpath-snap
-driver: hostpath.csi.k8s.io
+driver: hostpath.csi.k8s.io <1>
 deletionPolicy: Delete
 ----
-
 +
+<1> The name of the CSI driver that will be used to create snapshots of this `VolumeSnapshotClass`. It must be the same as `Provisioner` field of StorageClass that is responsible for the PVC that is being snapshotted.
+
 . Create the object you saved in the previous step by entering the following command:
 +
 [source,terminal]


### PR DESCRIPTION
It must be the same as StorageClass.Provisioner, i.e. the same CSI driver must be used both for PVs/PVCs and their VolumeSnapshots.

cc @bobfuru 