### PR TITLE
Clarifying that restoring must use etcd backup from same minor version

### DIFF
--- a/backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/backing-up-etcd.adoc
@@ -15,9 +15,11 @@ installation, otherwise the backup will contain expired certificates. It is also
 recommended to take etcd backups during non-peak usage hours, as it is a
 blocking action.
 
+Be sure to take an etcd backup after you upgrade your cluster. This is important because when you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.5.2 cluster must use an etcd backup that was taken from 4.5.2.
+
 [IMPORTANT]
 ====
-You back up your cluster's etcd data by performing a single invocation of the backup script on a master host. Do not take a backup for each master host.
+Back up your cluster's etcd data by performing a single invocation of the backup script on a master host. Do not take a backup for each master host.
 ====
 
 After you have an etcd backup, you can xref:../backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore to a previous cluster state].

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -9,6 +9,11 @@
 
 You can use a saved etcd backup to restore back to a previous cluster state. You use the etcd backup to restore a single control plane host. Then the etcd cluster Operator handles scaling to the remaining master hosts.
 
+[IMPORTANT]
+====
+When you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.5.2 cluster must use an etcd backup that was taken from 4.5.2.
+====
+
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.


### PR DESCRIPTION
Manual cherry pick of #25313 to fix the version example.