### PR TITLE
bug1917655 - typo

### DIFF
--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -89,7 +89,7 @@ egress:
 
 <3> An IP address range in CIDR format.
 
-<4> <4> A DNS domain name.
+<4> A DNS domain name.
 
 <5> Optional: A stanza describing a collection of network ports and protocols for the rule.
 


### PR DESCRIPTION
Fixed BZ 1917655 bug. Typo.
https://bugzilla.redhat.com/show_bug.cgi?id=1917655
