### PR TITLE
Eliminate unclear descriptions on the 'Setting Deployment Resources' section follow up

### DIFF
--- a/dev_guide/deployments/basic_deployment_operations.adoc
+++ b/dev_guide/deployments/basic_deployment_operations.adoc
@@ -125,7 +125,6 @@ Add the `command` parameters to the `spec` field of the deployment
 configuration. You can also add an `args` field, which modifies the
 `command` (or the `ENTRYPOINT` if `command` does not exist).
 
-====
 ----
 ...
 spec:
@@ -141,12 +140,10 @@ spec:
       - '<argument_3>'
 ...
 ----
-====
 
 For example, to execute the `java` command with the `-jar` and
 *_/opt/app-root/springboots2idemo.jar_* arguments:
 
-====
 ----
 ...
 spec:
@@ -161,7 +158,6 @@ spec:
       - /opt/app-root/springboots2idemo.jar
 ...
 ----
-====
 
 [[viewing-deployment-logs]]
 
@@ -219,14 +215,11 @@ the deployment configuration itself is created and it is not paused.
 
 
 .A ConfigChange Trigger
-====
-
 [source,yaml]
 ----
 triggers:
   - type: "ConfigChange"
 ----
-====
 
 [[image-change-trigger]]
 === ImageChange Trigger
@@ -237,7 +230,6 @@ xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-stream
 stream tag] changes (when a new version of the image is pushed).
 
 .An ImageChange Trigger
-====
 [source,yaml]
 ----
 triggers:
@@ -253,7 +245,6 @@ triggers:
 ----
 <1> If the `imageChangeParams.automatic` field is set to `false`,
 the trigger is disabled.
-====
 
 With the above example, when the `latest` tag value of the *origin-ruby-sample*
 image stream changes and the new image value differs from the current image
@@ -291,22 +282,20 @@ $ oc set triggers --help
 [[deployment-resources]]
 == Setting Deployment Resources
 
+A deployment is completed by a deployment pod. By default, a deployment pod consumes unbounded node resources on the compute node where it is scheduled. In most cases, the unbound resource consumption does not cause a problem, because deployment pods consume low resources and run for a short period of time. If a project specifies default container limits, the resources used by a deployment pod, along with any other pods, count against those limits.
+
+You can limit the resources used by a deployment pod through the
+deployment strategy in the deployment configuration. Resource limits for a deployment pod can be used with the Recreate,
+Rolling, or Custom deployment strategy.
+
 [NOTE]
 ====
-`ephemeral-storage` is available only if your administrator enabled the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview. This feature is disabled by default.
+The ability to limit ephemeral storage is available only if an administrator enables the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview. This feature is disabled by default.
 ====
-
-A deployment is completed by a deploy pod that consumes resources (memory, CPU, and ephemeral storage) on a
-worker node like other usual pods. By default, a deploy pod consumes unbounded node resources on the scheduled worker node. Usually, it's no problem, because the deploy pod consumes trivial resources and it runs during short deployment period. However, if a project specifies default container limits, then pods inluding the deploy pod consume resources up to those limits.
-
-You can also limit resource use by specifying resource limits as part of the
-deployment strategy. Deployment resources for a deploy pod can be used with the Recreate,
-Rolling, or Custom deployment strategies.
 
 In the following example, each of `resources`, `cpu`, `memory`, and `ephemeral-storage` is
 optional:
 
-====
 [source,yaml]
 ----
 type: "Recreate"
@@ -320,15 +309,13 @@ resources:
 <1> `cpu` is in CPU units: `100m` represents 0.1 CPU units (100 * 1e-3).
 <2> `memory` is in bytes: `256Mi` represents 268435456 bytes (256 * 2 ^ 20).
 <3> `ephemeral-storage` is in bytes: `1Gi` represents 1073741824 bytes (2 ^ 30).
-This applies only if your administrator enabled the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview.
-====
+The `ephemeral-storage` parameter is available only if an administrator enables the xref:../../install_config/configuring_ephemeral.adoc#install-config-configuring-ephemeral-storage[ephemeral storage] technology preview.
 
 However, if a quota has been defined for your project, one of the following two
 items is required:
 
 - A `resources` section set with an explicit `requests`:
 +
-====
 [source,yaml]
 ----
   type: "Recreate"
@@ -340,8 +327,7 @@ items is required:
 ----
 <1> The `requests` object contains the list of resources that correspond to
 the list of resources in the quota.
-====
-
++
 See
 xref:../../dev_guide/compute_resources.adoc#dev-guide-compute-resources[Quotas
 and Limit Ranges] to learn more about compute resources and the differences


### PR DESCRIPTION
Editorial follow-up to https://github.com/openshift/openshift-docs/pull/25580/

Associated BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1880238

Preview: https://deploy-preview-28692--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/deployments/basic_deployment_operations.html#deployment-resources