### PR TITLE
Customer suggested clarifying the network requirements table to note …

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -69,7 +69,7 @@ endif::[]
 . One IP address for each control plane (master) node.
 . One IP address for each worker node, if applicable.
 
-The following table provides an exemplary embodiment of hostnames for each node in the {product-title} cluster.
+The following table provides an exemplary embodiment of fully-qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer. 
 
 [width="100%", cols="3,5e,2e", frame="topbot",options="header"]
 |=====


### PR DESCRIPTION
Customer suggested clarifying the network requirements table to note that hostnames are arbitrary and they can use whatever host naming convention they prefer.

@ahardin-rh please cherry pick to 4.5 and 4.6 as well as 4.7.

https://bugzilla.redhat.com/show_bug.cgi?id=1914440

Fixes # BZ 1914440

Signed-off-by: John Wilkins <jowilkin@redhat.com>