### PR TITLE
CNF-802 Infrastructure-provided enablement/disablement of interrupt processing for guaranteed pod CPUs  Telco - release note

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -302,6 +302,15 @@ The latency test, a part of the CNF-test container, provides a way to measure if
 
 For information about running a latency test, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-performing-end-to-end-tests-running-the-latency_tests[Running the latency tests].
 
+[id="ocp-4-7-scale-pao-disable-interrupt-processing"]
+==== New `globallyDisableIrqLoadBalancing` feature in Performance Addon Operator allows global device interrupt processing to be disabled for guaranteed pod CPUs
+
+The Performance Addon Operator manages host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, and isolated CPUs for workloads. A new performance profile field `globallyDisableIrqLoadBalancing` is available to manage whether or not device interrupts are processed by the isolated CPU set.
+
+New pod annotations `irq-load-balancing.crio.io` and `cpu-quota.crio.io` are used in conjunction with `globallyDisableIrqLoadBalancing` to define whether or not device interrupts are processed for a pod. When configured, CRI-O disables device interrupts only as long as the pod is running.
+
+For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_cnf-master[Managing device interrupt processing for guaranteed pod isolated CPUs].
+
 [id="ocp-4-7-dev-exp"]
 === Developer experience
 


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/CNF-802