### PR TITLE
CNF-846 - Deploy a VRF CNI plugin that makes it possible to assign different secondary networks to different VRF - release note

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -377,6 +377,13 @@ New pod annotations `irq-load-balancing.crio.io` and `cpu-quota.crio.io` are use
 
 For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus_cnf-master[Managing device interrupt processing for guaranteed pod isolated CPUs].
 
+[id="ocp-4-7-scale-new-vrf-cni-plugin"]
+==== New VRF CNI plug-in allows secondary networks to be assigned to VRFs
+
+A new VRF CNI plugin that allows you to assign additional networks to a VRF is now available. When you create a secondary network using a `rawConfig` configuration for the CNO custom resource and configure a VRF for it, the interface created for the pod is associated with the VRF. You can also use the VRF CNI plug-in to assign an SR-IOV network to a VRF.
+
+For more information, see xref:../networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc#cnf-assigning-a-secondary-network-to-a-vrf[Assigning a secondary network to a VRF] and xref:../networking/hardware_networks/configuring-sriov-device.adoc#cnf-assigning-a-sriov-network-to-a-vrf_configuring-sriov-device[Assigning an SR-IOV network to a VRF].
+
 [id="ocp-4-7-dev-exp"]
 === Developer experience
 


### PR DESCRIPTION
Release Note for https://issues.redhat.com/browse/CNF-846