### PR TITLE
CNV 778 - Booting VMs in EFI Mode

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2349,6 +2349,8 @@ Topics:
 #Advanced virtual machine configuration
     - Name: Automating management tasks
       File: virt-automating-management-tasks
+    - Name: EFI mode for virtual machines
+      File: virt-efi-mode-for-vms
     - Name: Configuring PXE booting for virtual machines
       File: virt-configuring-pxe-booting
     - Name: Managing guest memory

--- a/modules/virt-about-efi-mode-for-vms.adoc
+++ b/modules/virt-about-efi-mode-for-vms.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
+
+[id="virt-about-efi-mode-for-vms_{context}"]
+= About EFI mode for virtual machines
+
+Extensible Firmware Interface (EFI), like legacy BIOS, initializes hardware components and operating system image files when a computer starts. EFI supports more modern features and customization options than BIOS, enabling faster boot times.
+
+It stores all the information about initialization and startup in a file with a `.efi` extension, which is stored on a special partition called EFI System Partition (ESP). The ESP also contains the boot loader programs for the operating system that is installed on the computer.
+
+
+[NOTE]
+====
+{VirtProductName} only supports a virtual machine (VM) with Secure Boot when using EFI mode. If Secure Boot is not enabled, the VM crashes repeatedly. However, the VM might not support Secure Boot. Before you boot a VM, verify that it supports Secure Boot by checking the VM settings.
+====

--- a/modules/virt-booting-efi-mode.adoc
+++ b/modules/virt-booting-efi-mode.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
+
+[id="virt-booting-vms-efi-mode_{context}"]
+= Booting virtual machines in EFI mode
+
+You can configure a virtual machine to boot in EFI mode by editing the VM or VMI manifest.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a YAML file that defines a VM object or a Virtual Machine Instance (VMI) object. Use the firmware stanza of the example YAML file:
++
+.Booting in EFI mode with secure boot active
+[source,yaml]
+----
+  apiversion: kubevirt.io/v1
+  kind: VirtualMachineInstance
+  metadata:
+    labels:
+      special: vmi-secureboot
+    name: vmi-secureboot
+  spec:
+    domain:
+      devices:
+        disks:
+        - disk:
+            bus: virtio
+          name: containerdisk
+      features:
+        acpi: {}
+        smm:
+          enabled: true <1>
+      firmware:
+        bootloader:
+          efi:
+            secureBoot: true <2>
+...
+----
+<1> {VirtProductName} requires System Management Mode (`SMM`) to be enabled for Secure Boot in EFI mode to occur.
+<2> {VirtProductName} only supports a virtual machine (VM) with Secure Boot when using EFI mode. If Secure Boot is not enabled, the VM crashes repeatedly. However, the VM might not support Secure Boot. Before you boot a VM, verify that it supports Secure Boot by checking the VM settings.
+
+. Apply the manifest to your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----

--- a/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
@@ -1,0 +1,11 @@
+[id="virt-efi-mode-for-vms"]
+= Using EFI mode for virtual machines
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-efi-mode-for-vms
+toc::[]
+
+You can boot a virtual machine (VM) in Extensible Firmware Interface (EFI) mode.
+
+include::modules/virt-about-efi-mode-for-vms.adoc[leveloffset=+1]
+include::modules/virt-booting-efi-mode.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR address JIRA story [CNV-778](https://issues.redhat.com/browse/CNV-778) (https://issues.redhat.com/browse/CNV-778).

Added information to Advanced VM Management about Booting a VM in EFI Mode.

Preview link - https://deploy-preview-28761--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.html