### PR TITLE
The post-installation section of the documentation does not include any information on adding additional FCOS nodes

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -15,7 +15,7 @@ You can add more compute machines to your {product-title} cluster on bare metal.
 [id="creating-machines-bare-metal"]
 == Creating {op-system-first} machines
 
-Before you add more compute machines to a cluster that you installed on bare metal infrastructure, you must create {op-system} machines for it to use. Follow either the steps to use an ISO image or network PXE booting to create the machines.
+Before you add more compute machines to a cluster that you installed on bare metal infrastructure, you must create {op-system} machines for it to use. You can either use an ISO image or network PXE booting to create the machines.
 
 include::modules/machine-user-infra-machines-iso.adoc[leveloffset=+2]
 

--- a/modules/machine-user-infra-machines-iso.adoc
+++ b/modules/machine-user-infra-machines-iso.adoc
@@ -1,11 +1,12 @@
 // Module included in the following assemblies:
 //
 // * machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+// * post_installation_configuration/node-tasks.adoc
 
 [id="machine-user-infra-machines-iso_{context}"]
-= Creating more {op-system-first} machines using an ISO image
+= Creating more {op-system} machines using an ISO image
 
-You can create more compute machines for your bare metal cluster by using an ISO image to create the machines.
+You can create more {op-system-first} compute machines for your bare metal cluster by using an ISO image to create the machines.
 
 .Prerequisites
 

--- a/modules/machine-user-infra-machines-pxe.adoc
+++ b/modules/machine-user-infra-machines-pxe.adoc
@@ -1,11 +1,12 @@
 // Module included in the following assemblies:
 //
 // * machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+// * post_installation_configuration/node-tasks.adoc
 
 [id="machine-user-infra-machines-pxe_{context}"]
-= Creating more {op-system-first} machines by PXE or iPXE booting
+= Creating more {op-system} machines by PXE or iPXE booting
 
-You can create more compute machines for your bare metal cluster by using PXE or iPXE booting.
+You can create more {op-system-first} compute machines for your bare metal cluster by using PXE or iPXE booting.
 
 .Prerequisites
 

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -19,6 +19,25 @@ include::modules/rhel-adding-node.adoc[leveloffset=+2]
 include::modules/rhel-ansible-parameters.adoc[leveloffset=+2]
 include::modules/rhel-removing-rhcos.adoc[leveloffset=+2]
 
+[id="post-install-config-adding-fcos-compute"]
+== Adding {op-system} compute machines to an {product-title} cluster
+
+You can add more {op-system-first} compute machines to your {product-title} cluster on bare metal.
+
+Before you add more compute machines to a cluster that you installed on bare metal infrastructure, you must create {op-system} machines for it to use. You can either use an ISO image or network PXE booting to create the machines.
+
+//Prerequisites also in adding-bare-metal-compute-user-infra.adoc
+=== Prerequisites
+
+* You installed a cluster on bare metal.
+* You have installation media and {op-system-first} images that you used to create your cluster. If you do not have these files, you must obtain them by following the instructions in the xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[installation procedure].
+
+include::modules/machine-user-infra-machines-iso.adoc[leveloffset=+2]
+
+include::modules/machine-user-infra-machines-pxe.adoc[leveloffset=+2]
+
+include::modules/installation-approve-csrs.adoc[leveloffset=+2]
+
 [id="post-installation-config-deploying-machine-health-checks"]
 == Deploying machine health checks
 


### PR DESCRIPTION
https://github.com/openshift/okd/issues/344

cc. @codyhoag 
* Added the modules from https://docs.okd.io/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html [1] [2] to existing _node-tasks.adoc_ assembly, per https://github.com/openshift/okd/issues/344
* Created new section in _node-tasks_ to emulate the _adding-bare-metal-compute-user-infra.adoc_ assembly. Removed prerequisite links from the new section. 
* Did not include the _Creating Fedora CoreOS (FCOS) machines_ heading from _adding-bare-metal-compute-user-infra.adoc_ (seemed superfluous here and would force me to use H4s for the section, which would not be in TOC), but added the text to the new section. 

[1] https://docs.openshift.com/container-platform/4.6/machine_management/user_infra/adding-bare-metal-compute-user-infra.html#machine-user-infra-machines-iso_adding-bare-metal-compute-user-infra
[2] https://docs.openshift.com/container-platform/4.6/machine_management/user_infra/adding-bare-metal-compute-user-infra.html#machine-user-infra-machines-pxe_adding-bare-metal-compute-user-infra