### PR TITLE
Fix supported OSDK version for OCP 4.6

### DIFF
--- a/operators/operator_sdk/osdk-getting-started.adoc
+++ b/operators/operator_sdk/osdk-getting-started.adoc
@@ -11,7 +11,7 @@ This is accomplished using two centerpieces of the Operator Framework: Operator 
 
 [NOTE]
 ====
-{product-title} 4.4 supports Operator SDK v0.15.0 or later.
+{product-title} 4.6 supports Operator SDK v0.19.4.
 ====
 
 include::modules/osdk-architecture.adoc[leveloffset=+1]

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1253,7 +1253,7 @@ The performance of `COPY` and `ADD` instructions in {product-title} builds are i
 [id="ocp-4-6-operator-sdk-v-0-19-4"]
 ==== Operator SDK v0.19.4
 
-{product-title} supports Operator SDK v0.19.4, which introduces the following notable technical changes:
+{product-title} 4.6 supports Operator SDK v0.19.4, which introduces the following notable technical changes:
 
 * Operator SDK now aligns with the {product-title}-wide switch to using UBI-8 and Python 3. Downstream base images now use UBI-8 and include Python 3.
 * The command `run --local` is deprecated in favor of `run local`.
@@ -2409,7 +2409,7 @@ link:https://access.redhat.com/solutions/5625331[{product-title} 4.6.8 container
 New {op-system} boot images are now available as part of the {product-title} 4.6.8 release. The updated {op-system} boot images provide improvements to the cluster boot experience. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1899176[*BZ#1899176*])
 
 [id="ocp-4-6-8-eus-channel"]
-===== EUS 4.6 upgrade channel now available 
+===== EUS 4.6 upgrade channel now available
 
 The `eus-4.6` upgrade channel is now available. This channel offers link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support (EUS)]. EUS versions extend the maintenance phase for customers with Premium Subscriptions to 14 months. {product-title}. For more information, see xref:../updating/updating-cluster-between-minor.adoc#understanding-upgrade-channels_updating-cluster-between-minor[{product-title} upgrade channels and releases].
 


### PR DESCRIPTION
Typo in 4.6 branch, somehow the 4.4 text got pulled in.