### PR TITLE
Issue-24921 - Adding hyper-threading footnote

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -112,7 +112,7 @@ Each cluster machine must meet the following minimum requirements:
 
 |Machine
 |Operating System
-|vCPU
+|vCPU^1^
 |Virtual RAM
 |Storage
 
@@ -136,6 +136,9 @@ ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.6]
 |2
 |8 GB
 |120 GB
+
+5+a|
+^1^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.
 
 |===
 


### PR DESCRIPTION
This applies to master, branch/enterprise-4.4, branch/enterprise-4.5, branch/enterprise-4.6 and branch/enterprise-4.7.

This relates to https://github.com/openshift/openshift-docs/issues/24921.

The preview is [here](https://issue-24921-hyperthread-cpus--ocpdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal).