### PR TITLE
[OSP] Deprecate computeFlavor in install-config.yaml

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -412,6 +412,9 @@ ifdef::osp[]
 
 |`platform.openstack.computeFlavor`
 |The {rh-openstack} flavor to use for control plane and compute machines.
+
+This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually. 
+
 |String, for example `m1.xlarge`.
 |====
 
@@ -470,6 +473,7 @@ The value can also be the name of an existing Glance image, for example `my-rhco
    }
 }
 ----
+
 |`platform.openstack.ingressFloatingIP`
 |An existing floating IP address to associate with the Ingress port. To use this property, you must also define the `platform.openstack.externalNetwork` property.
 |An IP address, for example `128.0.0.1`.


### PR DESCRIPTION
Implements [OSDOCS-1716](https://issues.redhat.com/browse/OSDOCS-1716)