### PR TITLE
Remove 'clusterID' from ShiftStack install-config.yaml mods

### DIFF
--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -17,7 +17,6 @@ This sample file is provided for reference only. You must obtain your
 ----
 apiVersion: v1
 baseDomain: example.com
-clusterID: os-test
 controlPlane:
   name: master
   platform: {}

--- a/modules/installation-osp-kuryr-config-yaml.adoc
+++ b/modules/installation-osp-kuryr-config-yaml.adoc
@@ -21,7 +21,6 @@ This sample file is provided for reference only. You must obtain your
 ----
 apiVersion: v1
 baseDomain: example.com
-clusterID: os-test
 controlPlane:
   name: master
   platform: {}

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -18,7 +18,6 @@ This sample file is provided for reference only. You must obtain your
 ----
 apiVersion: v1
 baseDomain: example.com
-clusterID: os-test
 controlPlane:
   name: master
   platform: {}


### PR DESCRIPTION
This PR resolves https://bugzilla.redhat.com/show_bug.cgi?id=1916088