### PR TITLE
Removing unneeded IP addresses when not using a provisioning network

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -1,18 +1,23 @@
 [id="ipi-install-configuration-files"]
 = Configuration files
 :context: ipi-install-configuration-files
-:release: 4.6
+:release: 4.7
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+1]
 
-include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+1]
+ifeval::[{release} <= 4.3]
+include::modules/ipi-install-configuring-the-metal3-config-file.adoc[leveloffset=+1]
+endif::[]
 
+ifeval::[{release} >= 4.4]
+include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+1]
+endif::[]
+
+ifeval::[{release} >= 4.6]
 include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+1]
-
 include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+1]
-
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
-
 include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -1,7 +1,9 @@
 [id="ipi-install-expanding-the-cluster"]
 = Expanding the cluster
 include::modules/common-attributes.adoc[]
-:context: ipi-install
+:context: ipi-install-expanding
+:release: 4.7
+
 
 After deploying an installer-provisioned {product-title} cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
 

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -143,15 +143,15 @@ a|`provisioningNetworkCIDR`
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP of the `provisioning` subnet. For example, `172.22.0.2`
-ifdef::upstream[]
+|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the `provisioning` subnet. For example, `172.22.0.2`
 ifeval::[{release} >= 4.5]
 or `2620:52:0:1307::2`
 endif::[]
-endif::[]
 .
 
- When using no `provisioning` network, set this value to an IP address that is available on the `baremetal` network.
+ifeval::[{release} == 4.6]
+Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
+endif::[]
 
 | `externalBridge`
 | `baremetal`
@@ -190,9 +190,11 @@ Set this parameter to `managed`, which is the default, to fully manage the provi
 Set this parameter to `unmanaged` to still enable the provisioning network but take care of manual configuration of DHCP. Virtual Media provisioning is recommended but PXE is still available if required.
 endif::[]
 
-| `provisioningHostingIp`
+ifeval::[{release} == 4.6]
+| `provisioningHostIP`
 |
 | Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
+endif::[]
 
 ifeval::[{release} > 4.4]
 | `httpProxy`

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -8,6 +8,7 @@
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 
+ifeval::[{release} == 4.6]
 [source,yaml]
 ----
 platform:
@@ -23,3 +24,15 @@ platform:
 ====
 Requires providing two IP addresses from the `baremetal` network for the `provisioningHostIP` and `bootstrapProvisioningIP` configuration settings, and removing the `provisioningBridge` and `provisioningNetworkCIDR` configuration settings.
 ====
+endif::[]
+
+ifeval::[{release} >= 4.7]
+[source,yaml]
+----
+platform:
+  baremetal:
+    apiVIP: <apiVIP>
+    ingressVIP: <ingress/wildcard VIP>
+    provisioningNetwork: "Disabled"
+----
+endif::[]

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -48,6 +48,7 @@ For assistance in configuring the DNS server, check xref:ipi-install-upstream-ap
 
 endif::[]
 
+
 .Reserving IP addresses for nodes with the DHCP server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
@@ -60,7 +61,7 @@ ifeval::[{release} <= 4.5]
 endif::[]
 +
 - One IP address for the API endpoint
-- One IP address for the wildcard Ingress endpoint
+- One IP address for the wildcard ingress endpoint
 ifeval::[{release} <= 4.5]
 - One IP address for the name server
 endif::[]
@@ -69,11 +70,19 @@ endif::[]
 . One IP address for each control plane (master) node.
 . One IP address for each worker node, if applicable.
 
-The following table provides an exemplary embodiment of fully-qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer. 
+ifeval::[{release}>4.6]
+[IMPORTANT]
+.Reserving IP addresses so they become static IP addresses
+====
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, *reserve the IP addresses with an infinite lease*. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
+====
+endif::[]
+
+The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The host names of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
 [width="100%", cols="3,5e,2e", frame="topbot",options="header"]
 |=====
-| Usage | Hostname | IP
+| Usage | Host Name | IP
 | API | api.<cluster-name>.<domain> | <ip>
 | Ingress LB (apps) |  *.apps.<cluster-name>.<domain>  | <ip>
 ifeval::[{release} <= 4.5]
@@ -95,6 +104,7 @@ For assistance in configuring the DHCP server, check xref:ipi-install-upstream-a
 - xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
 endif::[]
 
+ifeval::[{release} == 4.6]
 .Additional requirements with no provisioning network
 
 All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
@@ -109,3 +119,17 @@ All installer-provisioned installations require a `baremetal` network. The `bare
 ====
 Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
 ====
+endif::[]
+
+ifeval::[{release} > 4.6]
+.State-driven network configuration requirements (Technology Preview)
+
+{product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
+
+[NOTE]
+====
+Configuration must occur before scheduling pods.
+====
+
+State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
+endif::[]

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -6,6 +6,16 @@
 
 = Preparing the bare metal node
 
+Expanding the cluster requires a DHCP server. Each node must have a DHCP reservation.
+
+ifeval::[{release}>4.6]
+[IMPORTANT]
+.Reserving IP addresses so they become static IP addresses
+====
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, *reserve the IP addresses in the DHCP server with an infinite lease*. After the installer provisions the node successfully, the dispatcher script will check the node's network configuration. If the dispatcher script finds that the network configuration contains a DHCP infinite lease, it will recreate the connection as a static IP connection using the IP address from the DHCP infinite lease. NICs without DHCP infinite leases will remain unmodified.
+====
+endif::[]
+
 Preparing the bare metal node requires executing the following procedure from the provisioner node.
 
 .Procedure
@@ -14,57 +24,33 @@ Preparing the bare metal node requires executing the following procedure from th
 +
 [source,bash]
 ----
-$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp-dev-preview/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
+[kni@provisioner ~]$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux-$VERSION.tar.gz | tar zxvf - oc
 ----
 +
 [source,bash]
 ----
-$ sudo cp oc /usr/local/bin
+[kni@provisioner ~]$ sudo cp oc /usr/local/bin
 ----
 
-. Install the `ipmitool`.
-+
-[source,bash]
-----
-$ sudo dnf install -y OpenIPMI ipmitool
-----
+. Power off the bare metal node via the baseboard management controller and ensure it is off.
 
-. Power off the bare metal node and ensure it is off.
+. Retrieve the user name and password of the bare metal node's baseboard management controller. Then, create `base64` strings from the user name and password. In the following example, the user name is `root` and the password is `calvin`.
 +
 [source,bash]
 ----
-$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
-----
-+
-Where `<management-server-ip>` is the IP address of the bare metal node's base board management controller.
-+
-[source,bash]
-----
-$ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power status
+[kni@provisioner ~]$ echo -ne "root" | base64
 ----
 +
 [source,bash]
 ----
-Chassis Power is off
-----
-
-. Retrieve the username and password of the bare metal node's baseboard management controller. Then, create `base64` strings from the username and password. In the following example, the username is `root` and the password is `calvin`.
-+
-[source,bash]
-----
-$ echo -ne "root" | base64
-----
-+
-[source,bash]
-----
-$ echo -ne "calvin" | base64
+[kni@provisioner ~]$ echo -ne "calvin" | base64
 ----
 
 . Create a configuration file for the bare metal node.
 +
 [source,bash]
 ----
-$ vim bmh.yaml
+[kni@provisioner ~]$ vim bmh.yaml
 ----
 +
 [source,yaml]
@@ -87,17 +73,20 @@ spec:
   online: true
   bootMACAddress: <NIC1-mac-address>
   bmc:
-    address: ipmi://<bmc-ip>
+    address: <protocol>://<bmc-ip>
     credentialsName: openshift-worker-<num>-bmc-secret
 ----
 +
-Replace `<num>` for the worker number of bare metal node in two `name` fields and `credentialsName` field. Replace `<base64-of-uid>` with the `base64` string of the username. Replace `<base64-of-pwd>` with the `base64` string of the password. Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC. Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
+Replace `<num>` for the worker number of the bare metal node in the two `name` fields and the `credentialsName` field. Replace `<base64-of-uid>` with the `base64` string of the user name. Replace `<base64-of-pwd>` with the `base64` string of the password. Replace `<NIC1-mac-address>` with the MAC address of the bare metal node's first NIC.
++
+Refer to the BMC addressing section for additional BMC configuration options. Replace `<protocol>` with the BMC protocol, such as IPMI, RedFish, or others.
+Replace `<bmc-ip>` with the IP address of the bare metal node's baseboard management controller.
 
 . Create the bare metal node.
 +
 [source,bash]
 ----
-$ oc -n openshift-machine-api create -f bmh.yaml
+[kni@provisioner ~]$ oc -n openshift-machine-api create -f bmh.yaml
 ----
 +
 [source,bash]
@@ -112,7 +101,7 @@ Where `<num>` will be the worker number.
 +
 [source,bash]
 ----
-$ oc -n openshift-machine-api get bmh openshift-worker-<num>
+[kni@provisioner ~]$ oc -n openshift-machine-api get bmh openshift-worker-<num>
 ----
 +
 Where `<num>` is the worker node number.


### PR DESCRIPTION
The following PR is for the 4.7 release, and removes requirement for additional static IP address when using no provisioning network. Some text is made conditional to 4.6, where it is still applicable. This PR also contains a few upstream/downstream synchronization modifications that are unrelated to [KNIDEPLOY-3704](https://issues.redhat.com/browse/KNIDEPLOY-3704) and the related TELCODOCS Jiras. 

Fixes: [KNIDEPLOY-3704](https://issues.redhat.com/browse/KNIDEPLOY-3704), TELCODOCS 118, 120 and 129

osher@redhat.com or designee to sign off on QE. 

@ahardin-rh

Signed-off-by: John Wilkins <jowilkin@redhat.com>