### PR TITLE
Followup to PR#28828 - minor edits for docs style

### DIFF
--- a/administering_a_cluster/cluster-admin-role.adoc
+++ b/administering_a_cluster/cluster-admin-role.adoc
@@ -5,10 +5,10 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 As an administrator of an {product-title} cluster with Customer Cloud Subscriptions (link:https://www.openshift.com/dedicated/ccs[CCS]),
-you have access to the *cluster-admin*. While logged into an account with the cluster-admin role, users have mostly unrestricted
+you have access to the `cluster-admin` role. While logged in to an account with the `cluster-admin` role, users have mostly unrestricted
 access to control and configure the cluster. There are some configurations that are blocked with webhooks to prevent destablizing
 the cluster, or because they are managed in OpenShift Cluster Manager (link:https://cloud.redhat.com/openshift[OCM]) and any in-cluster
-changes would be overwritten. Usage of the cluster-admin role is subject to the restrictions listed in your
+changes would be overwritten. Usage of the `cluster-admin` role is subject to the restrictions listed in your
 link:https://www.redhat.com/en/about/agreements[Appendix 4 agreement] with Red Hat.
 
 include::modules/dedicated-cluster-admin-grant.adoc[leveloffset=+1]

--- a/modules/dedicated-cluster-admin-grant.adoc
+++ b/modules/dedicated-cluster-admin-grant.adoc
@@ -6,19 +6,19 @@
 = Granting the cluster-admin role to users
 
 .Prerequisites
-* Only the cluster creator or Organization Administrators have the ability to grant this access.
+* Only the cluster creator or organization administrators have the ability to grant this access.
 
 .Procedure
-. In OpenShift Cluster Manager, select the cluster you want to assign cluster-admin privileges.
+. In OpenShift Cluster Manager, select the cluster you want to assign `cluster-admin` privileges.
 . Under the *Access Control* tab, locate the *Cluster Administrative Users* section. Click *Add user*.
 . After determining an appropriate User ID, select *cluster-admin* from the *Group* selection, then click *Add user*.
 +
 [NOTE]
 ====
-Cluster-admin user creation can take several minutes to complete.
+The `cluster-admin` user creation can take several minutes to complete.
 ====
 +
 [NOTE]
 ====
-Existing dedicated-admin users cannot elevate their role to cluster-admin. A new user must be created with the cluster-admin role assigned.
+Existing `dedicated-admin` users cannot elevate their role to `cluster-admin`. A new user must be created with the `cluster-admin` role assigned.
 ====


### PR DESCRIPTION
Applied latest OCP docs style guidelines for how to format [object references](https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#object-references) such as `cluster-admin` role using backticks.