### PR TITLE
Add CSI volume expansion to TP tracker table in 4-4 release notes

### DIFF
--- a/release_notes/ocp-4-4-release-notes.adoc
+++ b/release_notes/ocp-4-4-release-notes.adoc
@@ -1430,6 +1430,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
+|CSI volume expansion
+|-
+|-
+|TP
+
 |OpenShift Pipelines
 |-
 |-


### PR DESCRIPTION
The CSI volume expansion feature was introduced in OCP 4.3. While it was noted in the 4.3 Release Notes, it was never added to the TP tracker table. This PR adds it to the table in OCP 4.4 Release Notes.