### PR TITLE
Updates to 4-7 RNs for CSI links and add CSI expansion to TP tracker

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -166,12 +166,14 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 The Google Cloud Platform (GCP) persistent disk (PD) CSI driver is automatically deployed and managed on GCP environments, allowing you to dynamically provision these volumes without having to install the driver manually. The GCP PD CSI Driver Operator that manages this driver is in Technology Preview.
 
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc#persistent-storage-csi-gcp-pd[GCP PD CSI Driver Operator].
+
 [id="ocp-4-5-persistent-storage-csi-cinder"]
-==== Persistent storage using the OpenStack Cinder CSI Driver Operator (Technology Preview)
+==== Persistent storage using the OpenStack Cinder CSI Driver Operator
 
 You can now use CSI to provision a persistent volume using the CSI driver for OpenStack Cinder.
 
-// Add [OpenStack Cinder CSI Driver Operator] link if docs are added to Storage --> CSI for OCP 4.7:
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-cinder.adoc#persistent-storage-csi-cinder[OpenStack Cinder CSI Driver Operator].
 
 [id="ocp-4-7-storage-vsphere-problem-detector"]
 ==== vSphere Problem Detector Operator
@@ -441,6 +443,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |GA
 |GA
+
+|CSI volume expansion
+|TP
+|TP
+|TP
 
 |vSphere Problem Detector Operator
 |-


### PR DESCRIPTION
The CSI volume expansion feature was introduced in OCP 4.3. While it was noted in the 4.3 Release Notes, it was never added to the TP tracker table. This PR adds it to the table in OCP 4.7 Release Notes.

In addition, I've included links to new 4.7 Storage CSI feature docs and dropped the TP designation for CSI Cinder, as it is now slated for GA instead.