### PR TITLE
removing RHEL supported version from OKD

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -130,12 +130,25 @@ ifndef::ibm-power[|4]
 |16 GB
 |120 GB
 
+ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
 ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.8 - 7.9]
+ifdef::ibm-z,ibm-power[|{op-system}]
+ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.6]
 |2
 |8 GB
 |120 GB
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+|Compute
+ifdef::ibm-z,ibm-power[|{op-system}]
+ifndef::ibm-z,ibm-power[|{op-system}]
+|2
+|8 GB
+|120 GB
+endif::openshift-origin[]
 
 5+a|
 ^1^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -16,7 +16,7 @@ The Red Hat Enterprise Linux (RHEL) compute machine hosts, which are also known 
 * Each system must meet the following hardware requirements:
 ** Physical or virtual system, or an instance running on a public or private IaaS.
 ifdef::openshift-origin[]
-** Base OS: Fedora 21, CentOS 7.4, or link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL 7.7-7.8] with "Minimal" installation option.
+** Base OS: CentOS 7.4.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale[]
 ** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL 7.8 - 7.9] with "Minimal" installation option.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -7,6 +7,7 @@ toc::[]
 After installing {product-title}, you can further expand and customize your
 cluster to your requirements through certain node tasks.
 
+ifndef::openshift-origin[]
 [id="post-install-config-adding-rhel-compute"]
 == Adding RHEL compute machines to an {product-title} cluster
 Understand and work with RHEL compute nodes.
@@ -18,6 +19,7 @@ include::modules/rhel-preparing-node.adoc[leveloffset=+2]
 include::modules/rhel-adding-node.adoc[leveloffset=+2]
 include::modules/rhel-ansible-parameters.adoc[leveloffset=+2]
 include::modules/rhel-removing-rhcos.adoc[leveloffset=+2]
+endif::[]
 
 [id="post-install-config-adding-fcos-compute"]
 == Adding {op-system} compute machines to an {product-title} cluster


### PR DESCRIPTION
Noticed the RHEL versions listed in OKD docs when fixing https://github.com/openshift/openshift-docs/pull/28703