### PR TITLE
CNV - #27444 HPP - replacing string with boolean

### DIFF
--- a/modules/virt-using-hostpath-provisioner.adoc
+++ b/modules/virt-using-hostpath-provisioner.adoc
@@ -49,7 +49,7 @@ spec:
   imagePullPolicy: IfNotPresent
   pathConfig:
     path: "</path/to/backing/directory>" <1>
-    useNamingPrefix: "false" <2>
+    useNamingPrefix: false <2>
 ----
 <1> Specify the backing directory where you want the provisioner to create PVs.
 <2> Change this value to `true` if you want to use the name of the persistent volume claim (PVC)


### PR DESCRIPTION
Changing value to boolean rather than string
as per #27444
(checks out in the hostpath-provisioner.go file)