### PR TITLE
CNV - sriov #26628 - live migration not supported for VMs with sriov 

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -140,7 +140,7 @@ ifdef::virt-features-for-storage[]
 You cannot live migrate virtual machines that use:
 
 * A storage class with ReadWriteOnce (RWO) access mode
-* Passthrough features such as SRI-OV and GPU
+* Passthrough features such as SR-IOV and GPU
 
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====

--- a/modules/virt-understanding-live-migration.adoc
+++ b/modules/virt-understanding-live-migration.adoc
@@ -12,8 +12,10 @@ to migrate to another node, or an automatic process, if the virtual machine
 instance has a `LiveMigrate` eviction strategy and the node on
 which it is running is placed into maintenance.
 
-[IMPORTANT]
-====
 Virtual machines must have a persistent volume claim (PVC)
 with a shared ReadWriteMany (RWX) access mode to be live migrated.
+
+[NOTE]
+====
+Live migration is not supported for virtual machines that are attached to an SR-IOV network interface.
 ====

--- a/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
+++ b/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
@@ -7,6 +7,11 @@ toc::[]
 You can configure a Single Root I/O Virtualization (SR-IOV) device for virtual machines in your cluster.
 This process is similar but not identical to configuring an SR-IOV device for {product-title}.
 
+[NOTE]
+====
+Live migration is not supported for virtual machines that are attached to an SR-IOV network interface.
+====
+
 == Prerequisites
 * You must have xref:../../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Operator.]
 


### PR DESCRIPTION
Adding note to livemigration and sriov concepts re: live migration not supported for VMs attached to sriov interfaces. Also a random typo
#26628