### PR TITLE
OSDOCS-1653: Adding TP docs for scheduler profiles

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1308,6 +1308,8 @@ Topics:
     File: nodes-scheduler-about
   - Name: Configuring the default scheduler to control pod placement
     File: nodes-scheduler-default
+  - Name: Scheduling pods using a scheduler profile
+    File: nodes-scheduler-profiles
   - Name: Placing pods relative to other pods using pod affinity and anti-affinity rules
     File: nodes-scheduler-pod-affinity
   - Name: Controlling pod placement on nodes using node affinity rules

--- a/modules/nodes-scheduler-profiles-about.adoc
+++ b/modules/nodes-scheduler-profiles-about.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-scheduler-profiles.adoc
+
+[id="nodes-scheduler-profiles-about_{context}"]
+= About scheduler profiles
+
+You can specify a scheduler profile to control how pods are scheduled onto nodes.
+
+[NOTE]
+====
+Scheduler profiles are an alternative to configuring a scheduler policy. Do not set both a scheduler policy and a scheduler profile. If both are set, the scheduler policy takes precedence.
+====
+
+The following scheduler profiles are available:
+
+`LowNodeUtilization`:: This profile attempts to spread pods evenly across nodes to get low resource usage per node. This profile provides the default scheduler behavior.
+
+`HighNodeUtilization`:: This profile attempts to place as many pods as possible on to as few nodes as possible. This minimizes node count and has high resource usage per node.
+
+`NoScoring`:: This is a low-latency profile that strives for the quickest scheduling cycle by disabling all score plug-ins. This might sacrifice better scheduling decisions for faster ones.

--- a/modules/nodes-scheduler-profiles-configuring.adoc
+++ b/modules/nodes-scheduler-profiles-configuring.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * nodes/scheduling/nodes-scheduler-profiles.adoc
+
+[id="nodes-scheduler-profiles-configuring_{context}"]
+= Configuring a scheduler profile
+
+You can configure the scheduler to use a scheduler profile.
+
+[NOTE]
+====
+Do not set both a scheduler policy and a scheduler profile. If both are set, the scheduler policy takes precedence.
+====
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the `Scheduler` object:
++
+[source,terminal]
+----
+$ oc edit scheduler cluster
+----
+
+. Specify the profile to use in the `spec.profile` field:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  ...
+  name: cluster
+  resourceVersion: "601"
+  selfLink: /apis/config.openshift.io/v1/schedulers/cluster
+  uid: b351d6d0-d06f-4a99-a26b-87af62e79f59
+spec:
+  mastersSchedulable: false
+  policy:
+    name: ""
+  profile: LowNodeUtilization <1>
+----
+<1> Set to `LowNodeUtilization`, `HighNodeUtilization`, or `NoScoring`.
+
+. Save the file to apply the changes.

--- a/nodes/scheduling/nodes-scheduler-default.adoc
+++ b/nodes/scheduling/nodes-scheduler-default.adoc
@@ -15,7 +15,12 @@ independent and exists as a standalone/pluggable solution. It does not modify
 the pod and just creates a binding for the pod that ties the pod to the
 particular node.
 
-A selection of predicates and priorities defines the policy for the scheduler. See xref:../../nodes/scheduling/nodes-scheduler-default.adoc#nodes-scheduler-default-modifying_nodes-scheduler-default[Modifying scheduler policy] for a list of predicates and priorities. 
+[IMPORTANT]
+====
+Configuring a scheduler policy is deprecated and is planned for removal in a future release. For more information on the Technology Preview alternative, see xref:../../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[Scheduling pods using a scheduler profile].
+====
+
+A selection of predicates and priorities defines the policy for the scheduler. See xref:../../nodes/scheduling/nodes-scheduler-default.adoc#nodes-scheduler-default-modifying_nodes-scheduler-default[Modifying scheduler policy] for a list of predicates and priorities.
 
 .Sample default scheduler object
 [source,yaml]

--- a/nodes/scheduling/nodes-scheduler-profiles.adoc
+++ b/nodes/scheduling/nodes-scheduler-profiles.adoc
@@ -1,0 +1,17 @@
+[id="nodes-scheduler-profiles"]
+= Scheduling pods using a scheduler profile
+include::modules/common-attributes.adoc[]
+:context: nodes-scheduler-profiles
+
+toc::[]
+
+You can configure {product-title} to use a scheduling profile to schedule pods onto nodes within the cluster.
+
+:FeatureName: Enabling a scheduler profile
+include::modules/technology-preview.adoc[leveloffset=+0]
+
+// About scheduler profiles
+include::modules/nodes-scheduler-profiles-about.adoc[leveloffset=+1]
+
+// Configuring a scheduler profile
+include::modules/nodes-scheduler-profiles-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1653

Preview:
* https://deploy-preview-28893--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-profiles.html
* https://deploy-preview-28893--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-default.html