### PR TITLE
Fix 4-7 RNs to state that multipath is avail by default for all storage devices

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -49,7 +49,7 @@ This release adds improvements related to the following components and concepts.
 * {op-system} now supports boot disk mirroring, except on s390x, providing redundancy in the case of disk failure.
 * {op-system} on s390x can be installed onto fixed-block architecture (FBA)-type direct access storage device (DASD) disks.
 
-* Multipathing is now supported during initial deployment and early boot for root storage devices when attached to clusters that are created using {product-title} 4.7 or higher.
+* Multipathing is now supported during initial deployment and early boot for storage devices when attached to clusters that are created using {product-title} 4.7 or higher.
 
 [NOTE]
 ====


### PR DESCRIPTION
This relates to PR#28368 and [this comment](https://github.com/openshift/openshift-docs/pull/28505#discussion_r563819873) in particular. Release notes should state that multipathing is available for all storage devices, not just root.