### PR TITLE
Fix broken include in virt-2-5-rn

### DIFF
--- a/modules/virt-supported-cluster-version.adoc
+++ b/modules/virt-supported-cluster-version.adoc
@@ -1,10 +1,8 @@
 // Module included in the following assemblies:
 //
-// * virt/about-virt.adoc
-// * virt/virt_release_notes/virt-2-4-release-notes.adoc
+// * virt/virt_release_notes/virt-2-5-release-notes.adoc
 
 [id="virt-supported-cluster-version_{context}"]
 = {VirtProductName} supported cluster version
 
 {VirtProductName} {VirtVersion} is supported for use on {product-title} {product-version} clusters.
-

--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -16,6 +16,7 @@ include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+2]
 // It is included here in the assembly because of the xref ban.
 You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
 //Commented out because for GA release we have special text that covers this info. But going forward, we will want to include the following:
+
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
 [id="virt-2-5-new"]


### PR DESCRIPTION
Needed a blank line before the `include` statement. It was previously rendering the section incorrectly and causing the following error in builds:

```
asciidoctor: ERROR: modules/virt-supported-cluster-version.adoc: line 7: level 0 sections can only be used when doctype is book
```

Also updated the module's list of assemblies.