### PR TITLE
OSDOCS-1768 document mutating .spec.endpointPublishingStrategy

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -39,7 +39,7 @@ If not set, the default value is based on `infrastructure.config.openshift.io/cl
 * Bare metal: `NodePortService`
 * Other: `HostNetwork`
 
-The `endpointPublishingStrategy` value cannot be updated.
+The `endpointPublishingStrategy` value can be updated.
 
 |`defaultCertificate`
 |The `defaultCertificate` value is a reference to a secret that contains the default certificate that is served by the Ingress controller. When Routes do not specify their own certificate, `defaultCertificate` is used.

--- a/modules/nw-ingress-default-internal.adoc
+++ b/modules/nw-ingress-default-internal.adoc
@@ -15,7 +15,7 @@ If you do not, all of your nodes will lose egress connectivity to the internet.
 
 [IMPORTANT]
 ====
-If you want to change the `scope` for an `IngressController` object, you must delete and then recreate that `IngressController` object. You cannot change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
+If you want to change the `scope` for an `IngressController`, you can change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
 ====
 
 .Prerequisites

--- a/modules/nw-ingress-setting-internal-lb.adoc
+++ b/modules/nw-ingress-setting-internal-lb.adoc
@@ -16,7 +16,7 @@ If you do not, all of your nodes will lose egress connectivity to the internet.
 
 [IMPORTANT]
 ====
-If you want to change the `scope` for an `IngressController` object, you must delete and then recreate that `IngressController` object. You cannot change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
+If you want to change the `scope` for an `IngressController`, you can change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
 ====
 
 See the link:https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer[Kubernetes Services documentation]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1768

Possible backport to [enterprise-4](https://issues.redhat.com/browse/enterprise-4).6, leaving the label off for now. 