### PR TITLE
[OSSMDOC-224] instructions on how to set the minimum and maximum protocol versions is incorrect

### DIFF
--- a/modules/ossm-security-mtls.adoc
+++ b/modules/ossm-security-mtls.adoc
@@ -66,16 +66,16 @@ spec:
 [id="ossm-security-min-max-tls_{context}"]
 == Setting the minimum and maximum protocol versions
 
-If your environment has specific requirements for encrypted traffic in your service mesh, you can control the cryptographic functions that are allowed by setting the `spec.istio.global.tls.minProtocolVersion` or `spec.istio.global.tls.maxProtocolVersion` in your `ServiceMeshControlPlane` resource. Those values, configured in your control plane resource, define the minimum and maximum TLS version used by mesh components when communicating securely over TLS.
+If your environment has specific requirements for encrypted traffic in your service mesh, you can control the cryptographic functions that are allowed by setting the `spec.security.controlPlane.tls.minProtocolVersion` or `spec.security.controlPlane.tls.maxProtocolVersion` in your `ServiceMeshControlPlane` resource. Those values, configured in your control plane resource, define the minimum and maximum TLS version used by mesh components when communicating securely over TLS.
 
 [source,yaml]
 ----
 kind: ServiceMeshControlPlane
 spec:
-  istio:
-    global:
+  security:
+    controlPlane:
       tls:
-        minProtocolVersion: TLSv1_0
+        minProtocolVersion: TLSv1_2
 ----
 
 The default is `TLS_AUTO` and does not specify a version of TLS.


### PR DESCRIPTION
Configuring the ServiceMeshControlPlane object according to the documentation does not work, the documentation specifies incorrect keys.

Fixes https://issues.redhat.com/browse/OSSMDOC-224