### PR TITLE
Bug 1921281: remove --export flag from oc

### DIFF
--- a/modules/templates-create-from-existing-object.adoc
+++ b/modules/templates-create-from-existing-object.adoc
@@ -15,13 +15,13 @@ adding parameters and other customizations as template form.
 +
 [source,terminal]
 ----
-$ oc get -o yaml --export all > <yaml_filename>
+$ oc get -o yaml all > <yaml_filename>
 ----
 +
 You can also substitute a particular resource type or multiple resources instead of `all`.
 Run `oc get -h` for more examples.
 +
-The object types included in `oc get --export all` are:
+The object types included in `oc get -o yaml all` are:
 +
 * BuildConfig
 * Build
@@ -31,3 +31,10 @@ The object types included in `oc get --export all` are:
 * ReplicationController
 * Route
 * Service
+
+[NOTE]
+====
+Using `all` alias is discouraged since the contents of it might vary
+across different clusters and versions. It is advisable to explicitly
+name all the necessary resources.
+====


### PR DESCRIPTION
This applies to 4.6+ versions of OCP. That flag was removed from the product in kubernetes 1.19 (see https://github.com/kubernetes/kubernetes/pull/88649). I'm also adding a note about using `all` alias which is not reliable for those purposes. 

/assign @bergerhoffer 