### PR TITLE
Direct volume/image migration requirements (1.4.0)

### DIFF
--- a/migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+++ b/migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
@@ -11,6 +11,10 @@ You must add your clusters and a replication repository to the {mtc-short} web c
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 
 include::modules/migration-creating-ca-bundle.adoc[leveloffset=+1]
+include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+1]
+include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+1]
+include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+1]
+include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+1]
 
 [id='configuring-migration-plan_{context}']
 == Configuring a migration plan
@@ -20,9 +24,14 @@ You can configure a migration plan to suit your needs by increasing the number o
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 
-include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+1]
-include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+1]
-include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+1]
-include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+1]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually on an {product-title} 4 cluster]
+* xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#file-system-copy-method_migrating-3-4[{mtc-short} file system copy method]
+* xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#snapshot-copy-method_migrating-3-4[{mtc-short} snapshot copy method]
+* xref:../../migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc#migration-adding-cluster-to-cam_migrating-3-4[Adding a cluster to the {mtc-short} web console]
+* xref:../../migration/migrating_3_4/troubleshooting-3-4.adoc#migration-viewing-migration-crs_migrating-3-4[Viewing migration custom resources]
+* xref:../../migration/migrating_3_4/migrating-application-workloads-3-4.adoc#migration-understanding-migration-hooks_migrating-3-4[About migration hooks]
 
 :!migrating-3-4:

--- a/migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
+++ b/migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc
@@ -11,16 +11,27 @@ You must add your clusters and a replication repository to the {mtc-short} web c
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 
 include::modules/migration-creating-ca-bundle.adoc[leveloffset=+1]
-
-[id='configuring-migration-plan_{context}']
-== Configuring a migration plan
-
-include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
-
 include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+1]
 include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+1]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+1]
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+1]
+
+[id='configuring-migration-plan_{context}']
+== Configuring a migration plan
+
+You can configure a migration plan to suit your needs by increasing the number of objects migrated or excluding resources from migration.
+
+include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually on an {product-title} 4 cluster]
+* xref:../../migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc#file-system-copy-method_migrating-4-1-4[{mtc-short} file system copy method]
+* xref:../../migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc#snapshot-copy-method_migrating-4-1-4[{mtc-short} snapshot copy method]
+* xref:../../migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.adoc#migration-adding-cluster-to-cam_migrating-4-1-4[Adding a cluster to the {mtc-short} web console]
+* xref:../../migration/migrating_4_1_4/troubleshooting-4-1-4.adoc#migration-viewing-migration-crs_migrating-4-1-4[Viewing migration custom resources]
+* xref:../../migration/migrating_4_1_4/migrating-application-workloads-4-1-4.adoc#migration-understanding-migration-hooks_migrating-4-1-4[About migration hooks]
 
 :!migrating-4-1-4:

--- a/migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
+++ b/migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
@@ -11,16 +11,27 @@ You must add your clusters and a replication repository to the {mtc-short} web c
 If your cluster or replication repository are secured with self-signed certificates, you can create a CA certificate bundle file or disable SSL verification.
 
 include::modules/migration-creating-ca-bundle.adoc[leveloffset=+1]
-
-[id='configuring-migration-plan_{context}']
-== Configuring a migration plan
-
-include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
-
 include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+1]
 include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+1]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+1]
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+1]
+
+[id='configuring-migration-plan_{context}']
+== Configuring a migration plan
+
+You can configure a migration plan to suit your needs by increasing the number of objects migrated or excluding resources from migration.
+
+include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually on an {product-title} 4 cluster]
+* xref:../../migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc#file-system-copy-method_migrating-4-2-4[{mtc-short} file system copy method]
+* xref:../../migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc#snapshot-copy-method_migrating-4-2-4[{mtc-short} snapshot copy method]
+* xref:../../migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc#migration-adding-cluster-to-cam_migrating-4-2-4[Adding a cluster to the {mtc-short} web console]
+* xref:../../migration/migrating_4_2_4/troubleshooting-4-2-4.adoc#migration-viewing-migration-crs_migrating-4-2-4[Viewing migration custom resources]
+* xref:../../migration/migrating_4_2_4/migrating-application-workloads-4-2-4.adoc#migration-understanding-migration-hooks_migrating-4-2-4[About migration hooks]
 
 :!migrating-4-2-4:

--- a/modules/migration-adding-cluster-to-cam.adoc
+++ b/modules/migration-adding-cluster-to-cam.adoc
@@ -5,7 +5,7 @@
 // * migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.adoc
 
 [id='migration-adding-cluster-to-cam_{context}']
-= Adding a cluster to the {mtc-full} web console
+= Adding a cluster to the {mtc-short} web console
 
 You can add a cluster to the {mtc-full} ({mtc-short}) web console.
 

--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -7,36 +7,59 @@
 [id='migration-creating-migration-plan-cam_{context}']
 = Creating a migration plan in the {mtc-short} web console
 
-You can create a migration plan in the  for the {mtc-full} ({mtc-short}) web console.
+You can create a migration plan in the {mtc-full} ({mtc-short}) web console.
+
+You can use _direct image migration_ and _direct volume migration_ to migrate images or volumes directly from the source cluster to the target cluster. Direct migration improves performance significantly.
 
 .Prerequisites
 
-* The source and target clusters must have network access to each other and to the replication repository.
-* If you use snapshots to copy data, the source and target clusters must run on the same cloud provider (AWS, GCP, or Azure) and be located in the same region.
+* You must add source and target clusters and a replication repository to the {mtc-short} web console.
+* The clusters must have network access to each other.
+* The clusters must have network access to the replication repository.
+* The clusters must be able to communicate using OpenShift routes on port 443.
+* The clusters must have no `Critical` conditions.
+* The clusters must be in a `Ready` state.
+* The migration plan name must not exceed 253 lower-case alphanumeric characters (`a-z, 0-9`) and must not contain spaces or underscores (`_`).
+* PV `Move` copy method: The clusters must have network access to the remote volume.
+* PV `Snapshot` copy method:
+** The clusters must have the same cloud provider (AWS, GCP, or Azure).
+** The clusters must be located in the same geographic region.
+** The storage class must be the same on the source and target clusters.
+
+* Direct image migration:
+** The source cluster must have its internal registry exposed to external traffic.
+** The exposed registry route of the source cluster must be added to the cluster configuration using the {mtc-short} web console or with the `exposedRegistryPath` parameter in the `MigCluster` CR manifest.
+
+* Direct volume migration:
+** The PVs to be migrated must be valid.
+** The PVs must be in a `bound` state.
+** The PV migration method must be `Copy` and the copy method must be `filesystem`.
 
 .Procedure
 
 . In the {mtc-short} web console, click *Migration plans*.
-. Click *Add migration plan* to launch the Migration Plan wizard.
-. In the *General* screen, enter the *Plan name*.
-. Select a source cluster, a target cluster, and a replication repository and then click *Next*.
-. In the *Namespaces* screen, select the projects to be migrated and then click *Next*.
+. Click *Add migration plan*.
+. Enter the *Plan name* and click *Next*.
+. Select a *Source cluster*.
+. Select a *Target cluster*.
+. Select a *Replication repository*.
+. Select the projects to be migrated and click *Next*.
+. Select a *Source cluster*, a *Target cluster*, and a *Repository*, and click *Next*.
+. In the *Namespaces* screen, select the projects to be migrated and click *Next*.
 . In the *Persistent volumes* screen, click a *Migration type* for each PV:
+
 * The *Copy* option copies the data from the PV of a source cluster to the replication repository and then restores it on a newly created PV, with similar characteristics, in the target cluster.
-+
-If you specified a route to an image registry when you added the source cluster to the web console, you can migrate images directly from the source cluster to the target cluster.
 * The *Move* option unmounts a remote volume, for example, NFS, from the source cluster, creates a PV resource on the target cluster pointing to the remote volume, and then mounts the remote volume on the target cluster. Applications running on the target cluster use the same remote volume that the source cluster was using. The remote volume must be accessible to the source and target clusters.
+
 . Click *Next*.
-. In the *Copy options* screen, click a *Copy method* for each PV:
-* The *Snapshot copy* option backs up and restores the disk using the cloud provider's snapshot functionality. Copying snapshots is faster than copying the file system.
-+
-[NOTE]
-====
-The storage and clusters must be in the same region and the storage classes must be compatible.
-====
-* The *Filesystem copy* option backs up the files on the source cluster and restores them on the target cluster.
-. Select *Verify copy* if you want to verify data migrated with *Filesystem copy*. Data is verified by generating a checksum for each source file and checking the checksum after restoration. This option significantly reduces performance.
-. Select a *Target storage class* for each PV.
+. In the *Copy options* screen, select a *Copy method* for each PV:
+
+* *Snapshot copy* backs up and restores data using the cloud provider's snapshot functionality. It is significantly faster than *Filesystem copy*.
+* *Filesystem copy* backs up the files on the source cluster and restores them on the target cluster.
+
+. You can select *Verify copy* to verify data migrated with *Filesystem copy*. Data is verified by generating a checksum for each source file and checking the checksum after restoration. Data verification significantly reduces performance.
+
+. Select a *Target storage class*.
 +
 You can change the storage class of data migrated with *Filesystem copy*.
 . Click *Next*.

--- a/modules/migration-understanding-data-copy-methods.adoc
+++ b/modules/migration-understanding-data-copy-methods.adoc
@@ -18,11 +18,12 @@ The {mtc-full} ({mtc-short}) supports the file system and snapshot data copy met
 .File system copy method summary
 |===
 |Benefits |Limitations
-a|* Clusters can have different storage classes
-* Supported for all S3 storage providers
-* Optional data verification with checksum
-a|* Slower than the snapshot copy method
-* Optional data verification significantly reduces performance
+a|* Clusters can have different storage classes.
+* Supported for all S3 storage providers.
+* Optional data verification with checksum.
+* Supports direct volume migration, which significantly increases performance.
+a|* Slower than the snapshot copy method.
+* Optional data verification significantly reduces performance.
 |===
 
 [id='snapshot-copy-method_{context}']
@@ -36,10 +37,25 @@ AWS, Google Cloud Provider, and Microsoft Azure support the snapshot copy method
 .Snapshot copy method summary
 |===
 |Benefits |Limitations
-a|* Faster than the file system copy method
+a|* Faster than the file system copy method.
 a|* Cloud provider must support snapshots.
 * Clusters must be on the same cloud provider.
 * Clusters must be in the same location or region.
 * Clusters must have the same storage class.
 * Storage class must be compatible with snapshots.
+* Does not support direct volume migration.
 |===
+
+[id="direct-migration_{context}"]
+== Direct volume migration and direct image migration
+
+You can use _direct image migration_ and _direct volume migration_ to migrate images and data directly from the source cluster to the target cluster.
+
+Direct migration has significant performance benefits because it skips the intermediate steps of backing up files from the source cluster to the replication repository and restoring files from the replication repository to the target cluster.
+
+Direct migration uses link:https://rsync.samba.org/[Rsync] to transfer the files.
+
+[NOTE]
+====
+Direct image migration and direct volume migration have additional prerequisites.
+====

--- a/modules/migration-viewing-migration-crs.adoc
+++ b/modules/migration-viewing-migration-crs.adoc
@@ -4,7 +4,7 @@
 // * migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
 // * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 [id='migration-viewing-migration-crs_{context}']
-= Viewing migration Custom Resources
+= Viewing migration custom resources
 
 The {mtc-full} ({mtc-short}) creates the following custom resources (CRs):
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-484

For MTC 1.4.0 (Feb 10)

Updated sections: 

Migrating applications: https://deploy-preview-28908--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/migrating-applications-with-cam-3-4.html#migration-creating-migration-plan-cam_migrating-3-4

New: Additional resources section: https://deploy-preview-28908--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/migrating-applications-with-cam-3-4.html#additional-resources

CP to 4.5, 4.6, 4.7