### PR TITLE
Updating OCP3 internal images for OCP4 cluster (1.4.1)

### DIFF
--- a/migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+++ b/migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
@@ -23,6 +23,7 @@ You can configure a migration plan to suit your needs by increasing the number o
 
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+include::modules/migration-updating-internal-images.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 == Additional resources

--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -16,34 +16,5 @@ endif::[]
 * You must upgrade the source cluster to the latest z-stream release.
 * You must have `cluster-admin` privileges on all clusters.
 * The source and target clusters must have unrestricted network access to the replication repository.
-* The cluster on which the `MigrationController` CR is installed must have unrestricted access to the other clusters.
-* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
-+
-If the required images are not present, you must update the image stream tag references to use an available version that is compatible with your application. If the image stream tags cannot be updated, you can manually upload equivalent images to the application namespaces and update the applications to use them.
-
-The following image stream tags have been _removed_ from {product-title} _4.2_:
-
-* `dotnet:1.0`, `dotnet:1.1`, `dotnet:2.0`
-* `dotnet-runtime:2.0`
-* `mariadb:10.1`
-* `mongodb:2.4`, `mongodb:2.6`
-* `mysql:5.5`, `mysql:5.6`
-* `nginx:1.8`
-* `nodejs:0.10`, `nodejs:4`, `nodejs:6`
-* `perl:5.16`, `perl:5.20`
-* `php:5.5`, `php:5.6`
-* `postgresql:9.2`, `postgresql:9.4`, `postgresql:9.5`
-* `python:3.3`, `python:3.4`
-* `ruby:2.0`, `ruby:2.2`
-
-ifeval::["{product-version}" == "4.4"]
-The following image stream tags have been _removed_ from {product-title} _4.4_:
-
-* `dotnet: 2.2`
-* `dotnet-runtime: 2.2`
-* `nginx: 1.12`
-* `nodejs: 8, 8-RHOAR, 10-SCL`
-* `perl:5.24`
-* `php: 7.0, 7.1`
-* `redis: 3.2`
-endif::[]
+* The cluster on which the `MigrationController` CR is installed must have unrestricted network access to the other clusters.
+* If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster. You can manually update an image stream tag in order to use a deprecated {product-title} 3 image on an {product-title} {product-version} cluster.

--- a/modules/migration-updating-internal-images.adoc
+++ b/modules/migration-updating-internal-images.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * migration/migrating_3_4/migrating-applications-with-cam-3-4.adoc
+
+[id='migration-updating-internal-images_{context}']
+= Updating internal images manually
+
+If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
+
+If the {product-title} 3 image is deprecated in {product-title} {product-version}, you can manually update the image stream tag using Podman.
+
+.Prerequisites
+
+* You must have Podman installed.
+* You must have `cluster-admin` privileges.
+
+.Procedure
+
+. Expose the internal registries on the source and target clusters.
+. If you are using insecure registries, add your registry host values to the `[registries.insecure]` section of `/etc/container/registries.conf` to ensure that Podman does not encounter a TLS verification error.
+. Log in to the {product-title} 3 registry:
++
+[source,terminal]
+----
+$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <ocp3_host>
+----
+
+. Log in to the {product-title} 4 registry:
++
+[source,terminal]
+----
+$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <ocp4_host>
+----
+
+. Pull the deprecated image, for example, `python:3.3`:
++
+[source,terminal]
+----
+$ podman pull <ocp3_host>/openshift/python:3.3
+----
+
+. Tag the image for the {product-title} 4 registry:
++
+[source,terminal]
+----
+$ podman tag <ocp3_host>/openshift/python:3.3 <ocp4_host>/openshift/python:3.3
+----
+
+. Push the image to the {product-title} 4 registry:
++
+[source,terminal]
+----
+$ podman push <ocp4_host>/openshift/python:3.3
+----
+
+. Verify that the image has a valid image stream on the {product-title} 4 cluster:
++
+[source,terminal]
+----
+$ oc get imagestream -n openshift | grep python
+----
++
+.Example output
+[source,terminal]
+----
+python    <ocp4_host>/openshift/python     3.3,2.7,2.7-ubi7,2.7-ubi8,3.6-ubi8,3.8 + 3 more...      6 seconds ago
+----


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-529

MTC 1.4.1 (Mar 3, but can be merged earlier)

CP to 4.5, 4.6, 4.7