### PR TITLE
BZ1918270 - update Azure storage class kind annotations in docs

### DIFF
--- a/modules/dynamic-provisioning-azure-disk-definition.adoc
+++ b/modules/dynamic-provisioning-azure-disk-definition.adoc
@@ -9,35 +9,35 @@
 .azure-advanced-disk-storageclass.yaml
 [source,yaml]
 ----
-kind: StorageClass
 apiVersion: storage.k8s.io/v1
+kind: StorageClass
 metadata:
-  name: slow
+  name: managed-premium
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: kubernetes.io/azure-disk
+volumeBindingMode: WaitForFirstConsumer <1>
+allowVolumeExpansion: true
 parameters:
-  storageAccount: azure_storage_account_name  <1>
-  storageaccounttype: Standard_LRS  <2>
-  kind: Dedicated  <3>
+  kind: Managed <2>
+  storageaccounttype: Premium_LRS <3>
+reclaimPolicy: Delete
 ----
-<1> Azure storage account name. This must reside in the same resource
-group as the cluster. If a storage account is specified, the `location`
-is ignored. If a storage account is not specified, a new storage
-account gets created in the same resource group as the cluster. If you
-are specifying a `storageAccount`, the value for `kind` must be `Dedicated`.
-<2> Azure storage account SKU tier. Default is empty. Note that Premium
-VMs can attach both `Standard_LRS` and `Premium_LRS` disks, Standard VMs
-can only attach `Standard_LRS` disks, Managed VMs can only attach
-managed disks, and unmanaged VMs can only attach unmanaged disks.
-<3> Possible values are `Shared` (default), `Dedicated`, and `Managed`.
+<1> Using `WaitForFirstConsumer` is strongly recommended. This provisions the volume while allowing enough storage to schedule the pod on a free worker node from an available zone.
+<2> Possible values are `Shared` (default), `Managed`, and `Dedicated`.
 +
-.. If `kind` is set to `Shared`, Azure creates all unmanaged disks in a
-few shared storage accounts in the same resource group as the cluster.
+[IMPORTANT]
+====
+Red Hat only supports the use of `kind: Managed` in the storage class.
+
+With `Shared` and `Dedicated`, Azure creates unmanaged disks, while {product-title} creates a managed disk for machine OS (root) disks. But because Azure Disk does not allow the use of both managed and unmanaged disks on a node, unmanaged disks created with `Shared` or `Dedicated` cannot be attached to {product-title} nodes.
+====
+
+<3> Azure storage account SKU tier. Default is empty. Note that Premium VMs can attach both `Standard_LRS` and `Premium_LRS` disks, Standard VMs can only attach `Standard_LRS` disks, Managed VMs can only attach managed disks, and unmanaged VMs can only attach unmanaged disks.
++
+.. If `kind` is set to `Shared`, Azure creates all unmanaged disks in a few shared storage accounts in the same resource group as the cluster.
 .. If `kind` is set to `Managed`, Azure creates new managed disks.
-.. If `kind` is set to `Dedicated` and a `storageAccount` is specified,
-Azure uses the specified storage account for the new unmanaged disk in
-the same resource group as the cluster. For this to work:
+.. If `kind` is set to `Dedicated` and a `storageAccount` is specified, Azure uses the specified storage account for the new unmanaged disk in the same resource group as the cluster. For this to work:
  * The specified storage account must be in the same region.
- * Azure Cloud Provider must have a write access to the storage account.
-.. If `kind` is set to `Dedicated` and a `storageAccount` is not
-specified, Azure creates a new dedicated storage account for the new
-unmanaged disk in the same resource group as the cluster.
+ * Azure Cloud Provider must have write access to the storage account.
+.. If `kind` is set to `Dedicated` and a `storageAccount` is not specified, Azure creates a new dedicated storage account for the new unmanaged disk in the same resource group as the cluster.

--- a/modules/storage-azure-create-storage-class.adoc
+++ b/modules/storage-azure-create-storage-class.adoc
@@ -33,6 +33,13 @@ storage account SKU tier. Valid options are `Premium_LRS`, `Standard_LRS`,
 
 ... Enter the kind of account. Valid options are `shared`, `dedicated,`
 and `managed`.
++
+[IMPORTANT]
+====
+Red Hat only supports the use of `kind: Managed` in the storage class.
+
+With `Shared` and `Dedicated`, Azure creates unmanaged disks, while {product-title} creates a managed disk for machine OS (root) disks. But because Azure Disk does not allow the use of both managed and unmanaged disks on a node, unmanaged disks created with `Shared` or `Dedicated` cannot be attached to {product-title} nodes.
+====
 
 .. Enter additional parameters for the storage class as desired.
 


### PR DESCRIPTION
[BZ1918270](https://bugzilla.redhat.com/show_bug.cgi?id=1918270) 
- Changed annotation to denote that `kind: Dedicated` in Azure Disk storage class is not supported by Red Hat. 
- Updated recommendation in Azure File to use `volumeBindingMode: WaitForFirstConsumer`.
- Removes some hard-wraps

For OCP 4.4+.

**PREVIEW LINKS:**

- Adds note that `kind: Dedicated` is not supported by Red Hat:
**Post-installation configuration -> Storage configuration -> Azure Disk object definition** https://deploy-preview-28932--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/storage-configuration.html#azure-disk-definition_post-install-storage-configuration

- Adds note that `kind: Dedicated` is not supported by Red Hat:
**Storage -> Persistent storage using Azure Disk -> Creating the Azure storage class** - https://deploy-preview-28932--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-azure.html#storage-create-azure-storage-class_persistent-storage-azure

- Updates doc to `volumeBindingMode: WaitForFirstConsumer`:
**Storage -> Dynamic provisioning -> Azure Disk object definition** - https://deploy-preview-28932--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#azure-file-definition_dynamic-provisioning

- Updates doc to `volumeBindingMode: WaitForFirstConsumer`:
**Storage -> Dynamic provisioning -> Azure Disk object definition** - https://deploy-preview-28932--osdocs.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning.html#azure-disk-definition_dynamic-provisioning