### PR TITLE
BZ1910319_4.5-removing registry from paths

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -35,7 +35,7 @@ endif::[]
 ifdef::openshift-origin[]
 ----
 $ oc image extract quay.io/openshift/origin-operator-registry:4.5.0 \
-    --path /usr/bin/registry/opm:. \
+    --path /usr/bin/opm:. \
     --confirm
 ----
 endif::[]
@@ -43,7 +43,7 @@ ifdef::openshift-enterprise,openshift-webscale[]
 ----
 $ oc image extract registry.redhat.io/openshift4/ose-operator-registry:v4.5 \
     -a ${REG_CREDS} \//<1>
-    --path /usr/bin/registry/opm:. \
+    --path /usr/bin/opm:. \
     --confirm
 ----
 <1> Specify the location of your registry credentials file.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1910319

Removing registry from paths. Applies to [enterprise-4](https://issues.redhat.com/browse/enterprise-4).5.

Ready for QE: @zhouying7780   @bandrade 

@bergerhoffer 