### PR TITLE
BZ1910319_4.6: removed registry from paths

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -49,7 +49,7 @@ $ oc image extract {registry-image} \
 ifndef::openshift-origin[]
     -a ${REG_CREDS} \
 endif::[]
-    --path /usr/bin/registry/opm:. \
+    --path /usr/bin/opm:. \
     --confirm
 ----
 
@@ -63,7 +63,7 @@ $ oc image extract {registry-image} \
 ifndef::openshift-origin[]
     -a ${REG_CREDS} \
 endif::[]
-    --path /usr/bin/registry/darwin-amd64-opm:. \
+    --path /usr/bin/darwin-amd64-opm:. \
     --confirm
 ----
 
@@ -84,7 +84,7 @@ C:\> oc image extract {registry-image} \
 ifndef::openshift-origin[]
     -a ${REG_CREDS} \
 endif::[]
-    --path /usr/bin/registry/windows-amd64-opm:. \
+    --path /usr/bin/windows-amd64-opm:. \
     --confirm
 ----
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1910319

Removing registry from paths. Applies to enterprise 4.6.

Ready for QE: @zhouying7780  @bandrade 

@bergerhoffer 
