### PR TITLE
BZ-1921831: Excluding etcd quorum guard pods from output

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -163,7 +163,7 @@ static-pod-resources/kube-scheduler-pod-8/kube-scheduler-pod.yaml
 +
 [source,terminal]
 ----
-[core@ip-10-0-143-125 ~]$ oc get pods -n openshift-etcd | grep etcd
+[core@ip-10-0-143-125 ~]$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output
@@ -282,7 +282,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -103,7 +103,7 @@ ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.20.0
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -69,7 +69,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -29,7 +29,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output
@@ -314,7 +314,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep etcd
+$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
 ----
 +
 .Example output


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1921831