### PR TITLE
[WIP] update index-commercial for ARO docs

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -131,6 +131,9 @@ AddType text/vtt                            vtt
     # Redirect ARO non versioned docs to go to version 3 docs
     RewriteRule ^(aro)/(?!3/|4/)(.*)$ /aro/3/$2 [NE,R=301]
 
+    # remove aro docs to just the welcome page
+    RewriteRule aro/4/(?!welcome)(.*)?$ /container-platform/latest/$1 [L,R=301]
+
     # Redirects for "latest" version
     RewriteRule ^(container-platform|enterprise)/?$ /container-platform/latest [R=301]
     RewriteRule ^(container-platform|enterprise)/latest/?(.*)$ /container-platform/4\.6/$2 [NE,R=301]

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -223,7 +223,6 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
               <p class="list-group-item-text">Azure Red Hat OpenShift provides single-tenant, high-availability Kubernetes clusters on Azure, supported by Red Hat and Microsoft.</p>
               <p><a role="button" class="btn btn-primary" href="aro/4/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> ARO Docs 4</a></p>
 <p><a role="button" class="btn btn-primary" href="aro/3/welcome/index.html"><i class="fa fa-arrow-circle-o-right"></i> ARO Docs 3</a></p>
-                <p><a role="button" class="btn btn-primary" href="https://access.redhat.com/documentation/ja-jp/azure_red_hat_openshift/4/"><i class="fa fa-arrow-circle-o-right"></i> ARO 4 日本語翻訳</a></p>
 
             </div>
           </div>


### PR DESCRIPTION
It leaves link to version 3 and version 4 docs but not the portal Japanese docs.

Multiple commits are deliberate. 