### PR TITLE
BZ#1907505 - Fix ExternalIP assignment

### DIFF
--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -5,18 +5,16 @@
 [id="nw-externalip-about_{context}"]
 = About ExternalIP
 
-For non-cloud environments, {product-title} supports the assignment of external IP addresses to a `Service` object `spec.externalIPs` field through the *ExternalIP* facility.
-This exposes an additional virtual IP address, assigned to the service, that can be outside the service network defined for the cluster.
-A service configured with an external IP functions similarly to a service with `type=NodePort`, allowing you to direct traffic to a local node for load balancing.
+For non-cloud environments, {product-title} supports the assignment of external IP addresses to a `Service` object `spec.externalIPs[]` field through the *ExternalIP* facility.
+By setting this field, {product-title} assigns an additional virtual IP address to the service. The IP address can be outside the service network defined for the cluster.
+A service configured with an ExternalIP functions similarly to a service with `type=NodePort`, allowing you to direct traffic to a local node for load balancing.
 
 You must configure your networking infrastructure to ensure that the external IP address blocks that you define are routed to the cluster.
 
 {product-title} extends the ExternalIP functionality in Kubernetes by adding the following capabilities:
 
-- Restrictions on the use of external IP addresses through a configurable policy
+- Restrictions on the use of external IP addresses by users through a configurable policy
 - Allocation of an external IP address automatically to a service upon request
-
-By default, only a user with `cluster-admin` privileges can create a `Service` object with `spec.externalIPs[]` set to IP addresses defined within an external IP address block.
 
 [WARNING]
 ====
@@ -99,6 +97,8 @@ status:
 == Restrictions on the assignment of an external IP address
 
 As a cluster administrator, you can specify IP address blocks to allow and to reject.
+
+Restrictions apply only to users without `cluster-admin` privileges. A cluster administrator can always set the service `spec.externalIPs[]` field to any IP address.
 
 You configure IP address policy with a `policy` object defined by specifying the `spec.ExternalIP.policy` field.
 The policy object has the following shape:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1907505

This aims to clarify the language regarding ExternalIP address assignment.

## Preview

- [Configuring ExternalIPs for services](https://deploy-preview-28953--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip.html)

## Highlights

So this deletes:

> ~By default, only a user with `cluster-admin` privileges can create a `Service` object with `spec.externalIPs[]` set to IP addresses defined within an external IP address block.~

And later adds, when discussing policy:

> Restrictions apply only to users without `cluster-admin` privileges. A cluster administrator can always set the service `spec.externalIPs[]` field to any IP address.

And some other updates to improve clarity.