### PR TITLE
BZ#1917881 - Fix double nesting of `ipam` key

### DIFF
--- a/modules/nw-sriov-network-attachment.adoc
+++ b/modules/nw-sriov-network-attachment.adoc
@@ -59,15 +59,13 @@ spec:
   resourceName: net1
   networkNamespace: project2
   ipam: |-
-    {
-      "ipam": {
-        "type": "host-local",
-        "subnet": "10.56.217.0/24",
-        "rangeStart": "10.56.217.171",
-        "rangeEnd": "10.56.217.181",
-        "gateway": "10.56.217.1"
-      }
-    }
+  {
+    "type": "host-local",
+    "subnet": "10.56.217.0/24",
+    "rangeStart": "10.56.217.171",
+    "rangeEnd": "10.56.217.181",
+    "gateway": "10.56.217.1"
+  }
 ----
 
 . To create the object, enter the following command:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1917881

Oops, well that's embarrassing.