### PR TITLE
Update FC link to RHEL8 doc

### DIFF
--- a/storage/persistent_storage/persistent-storage-fibre.adoc
+++ b/storage/persistent_storage/persistent-storage-fibre.adoc
@@ -25,7 +25,7 @@ storage provider.
 
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/storage_administration_guide/ch-fibrechanel[Fibre Channel]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/managing_storage_devices/using-fibre-channel-devices_managing-storage-devices[Using Fibre Channel devices]
 
 include::modules/persistent-storage-fibre-provisioning.adoc[leveloffset=+1]
 


### PR DESCRIPTION
It was brought up by multi-arch team that the "Additional resources" link to Fibre Channel points to an old RHEL7 page that should be updated to RHEL8 FC. This PR fixes that.

@qinpingli PTAL and confirm that this can be applied to 4.4, 4.5., 4.6, and 4.7.