### PR TITLE
BZ#1916453 - SR-IOV Operator device config - master node selection

### DIFF
--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -20,19 +20,21 @@ You can configure an SR-IOV network device by creating a SriovNetworkNodePolicy 
 [NOTE]
 =====
 When applying the configuration specified in a `SriovNetworkNodePolicy` object, the SR-IOV Operator might drain the nodes, and in some cases, reboot nodes.
+
 It might take several minutes for a configuration change to apply.
-Ensure that there are enough available nodes in your cluster to handle the evicted workload beforehand.
 =====
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* An account with `cluster-admin` privileges.
-* You must have installed the SR-IOV Operator.
+* You installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the SR-IOV Network Operator.
+* You have enough available nodes in your cluster to handle the evicted workload from drained nodes.
+* You have not selected any control plane nodes for SR-IOV network device configuration.
 
 .Procedure
 
-. Create an SriovNetworkNodePolicy object, and then save the YAML in the `<name>-sriov-node-network.yaml` file. Replace `<name>` with the name for this configuration.
+. Create an `SriovNetworkNodePolicy` object, and then save the YAML in the `<name>-sriov-node-network.yaml` file. Replace `<name>` with the name for this configuration.
 
 ifdef::virt-sriov[]
 // The list breaks because of the [NOTE]


### PR DESCRIPTION
Update documentation to inform users that master nodes should not be selected for SR-IOV device configuration.

- https://bugzilla.redhat.com/show_bug.cgi?id=1916453

Preview: https://deploy-preview-28978--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-configuring-device_configuring-sriov-device