### PR TITLE
Add OLM/OSDK release notes for 4.7

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -217,9 +217,63 @@ The {product-title} internal registry and image streams now support Open Contain
 
 //Add link
 
-[id="ocp-4-7-operators"]
+[id="ocp-4-7-olm"]
 === Operator lifecycle
 
+[id="ocp-4-7-safe-operator-upgrades"]
+==== Safe Operator upgrades
+
+To make upgrades more robust, it is recommend that Operators actively communicate with the service that is about to be updated. If a service is processing a critical operation, such as live migrating virtual machines (VMs) in OpenShift Virtualization or restoring a database, it might be unsafe to upgrade the related Operator at that time.
+
+In {product-title} 4.7, Operators can take advantage of the new `OperatorCondition` resource to communicate a non-upgradeable state to Operator Lifecycle Manager (OLM), such as when a related service is performing a critical operation. The non-upgradeable state delays any pending Operator upgrade, whether automatically or manually approved, until the Operator finishes the operation and reports upgrade readiness.
+
+See xref:../operators/understanding/olm/olm-operatorconditions.adoc#olm-operatorconditions[Operator conditions] for more about how OLM uses this communication channel.
+
+See xref:../operators/admin/olm-managing-operatorconditions.adoc#olm-operatorconditions[Managing Operator conditions] for details on overriding states in OLM as a cluster administrator.
+
+See xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-operatorconditions_osdk-generating-csvs[Enabling Operator conditions] for details on updating your project as an Operator developer to use the communication channel.
+
+[id="ocp-4-7-pull-secrets-cs"]
+==== Adding pull secrets to catalog sources
+
+If certain images relevant to Operators managed by Operator Lifecycle Manager (OLM) are hosted in an authenticated container image registry, also known as a private registry, OLM and OperatorHub are unable to pull the images by default. To enable access, you can create a pull secret that contains the authentication credentials for the registry.
+
+By referencing one or more secrets in a catalog source, some of these required images can be pulled for use in OperatorHub, while other images require updates to the global cluster pull secret or namespace-scoped secrets.
+
+See xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries] for more details.
+
+[id="ocp-4-7-osdk"]
+=== Operator development
+
+[id="ocp-4-7-osdk-supported"]
+==== Operator SDK now fully supported
+
+As of {product-title} 4.7, the Operator SDK is now a fully supported Red Hat offering. With the downstream release of Operator SDK v1.3.0, officially supported and branded Operator SDK tooling is now available for download directly from Red Hat.
+
+The Operator SDK CLI assists Operator developers and independent software vendor (ISV) partners in writing Operators that provide a great user experience and are compatible with OpenShift distributions and Operator Lifecycle Manager (OLM).
+
+The Operator SDK enables Operator authors with cluster administrator access to a Kubernetes-based cluster, such as {product-title}, to develop their own Operators based on Go, Ansible, or Helm. For Go-based Operators, link:https://kubebuilder.io/[Kubebuilder] is embedded into the SDK as the scaffolding solution; this means existing Kubebuilder projects can be used as is with the SDK and continue to work.
+
+The following features highlight some of the capabilities of the Operator SDK:
+
+Native support for Operator Bundle Format:: The Operator SDK includes native support for the xref:../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Operator Bundle Format] introduced in {product-title} 4.6. All metadata required to package an Operator for OLM is generated automatically. Operator developers can use this functionality to package and test their Operator for OLM and OpenShift distributions directly from their CI pipelines.
+
+Operator Lifecycle Manager integration:: The Operator SDK provides developers with a streamlined experience for quickly testing their Operator with OLM from their workstation. You can use the xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-deploy-olm_osdk-working-bundle-images[`run bundle`] subcommand to run Operator on a cluster and test whether the Operator behaves correctly when managed by OLM.
+
+Webhook integration:: The Operator SDK supports xref:../operators/operator_sdk/osdk-generating-csvs.adoc#olm-defining-csv-webhook_osdk-generating-csvs[webhook integration] with OLM, which simplifies installing Operators that have admission or custom resource definition (CRD) conversion webhooks. This feature relieves the cluster administrator of having to manually register the webhooks, add TLS certificates, and set up certificate rotation.
+
+Validation scorecard:: Operator authors should validate that their Operator is packaged correctly and free of syntax errors. To validate an Operator, the xref:../operators/operator_sdk/osdk-scorecard.adoc#osdk-scorecard[scorecard tool] provided by the Operator SDK begins by creating all resources required by any related custom resources (CRs) and the Operator. The scorecard then creates a proxy container in the deployment of the Operator, which is used to record calls to the API server and run some of the tests. The tests performed also examine some of the parameters in the CRs.
+
+Upgrade readiness reporting:: Operator developers can use the Operator SDK to take advantage of code scaffolding support for Operator conditions, including xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-operatorconditions_osdk-generating-csvs[reporting upgrade readiness] to OLM.
+
+Trigger Operator upgrades:: You can quickly test upgrading your Operator by using OLM integration in the Operator SDK, without requiring you to manually manage index images and catalog sources. The xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-upgrade-olm_osdk-working-bundle-images[`run bundle-upgrade`] subcommand automates triggering an installed Operator to upgrade to a later version by specifying a bundle image for the later version.
+
+[NOTE]
+====
+Operator SDK v1.3.0 supports Kubernetes 1.19.
+====
+
+See xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators] for full documentation on the Operator SDK.
 
 [id="ocp-4-7-images"]
 === Images
@@ -354,7 +408,17 @@ With this additional information, Red Hat can provide improved remediation steps
 
 {product-title} 4.7 introduces the following notable technical changes.
 
+[discrete]
+[id="ocp-4-7-olm-k8s-1-20"]
+==== Operator Lifecycle Manager updated to use Kubernetes 1.20
 
+Operator Lifecycle Manager (OLM) strives to keep up to date with Kubernetes releases when they become available. The OLM-provided `ClusterServiceVersion` (CSV) resource is composed of a number of core Kubernetes resources. When OLM increments Kubernetes dependencies, the embedded resources are updated as well.
+
+As of {product-title} 4.7, OLM and its associated components have been updated to use Kubernetes 1.20. Typically, Kubernetes is backwards compatible with a few of its previous versions. Operator authors are encouraged to keep their projects up to date to maintain compatibility and take advantage of updated resources.
+
+See xref:../release_notes/versioning-policy.adoc#ocp-versioning-policy[OpenShift Container Platform Versioning Policy] for more specific details on backwards compatibility guarantees.
+
+See link:https://kubernetes.io/docs/setup/release/version-skew-policy/[Kubernetes documentation] for details about version skew policies in the upstream Kubernetes project.
 
 [id="ocp-4-7-deprecated-removed-features"]
 == Deprecated and removed features
@@ -382,17 +446,22 @@ In the table, features are marked with the following statuses:
 |Package Manifest Format (Operator Framework)
 |DEP
 |DEP
-|
+|DEP
 
 |`oc adm catalog build`
 |DEP
 |DEP
-|
+|DEP
+
+|`--filter-by-os` flag for `oc adm catalog mirror`
+|GA
+|GA
+|DEP
 
 |v1beta1 CRDs
 |DEP
 |DEP
-|
+|DEP
 
 |Docker Registry v1 API
 |GA
@@ -418,6 +487,13 @@ In the table, features are marked with the following statuses:
 ==== Scheduler policy
 
 Using a scheduler policy to control pod placement is deprecated and is planned for removal in a future release. For more information on the Technology Preview alternative, see xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[Scheduling pods using a scheduler profile].
+
+[id="ocp-4-7-filterbyos-deprecated"]
+==== Catalog mirroring using filter-by-os flag
+
+When using the `oc adm catalog mirror` command to mirror catalogs, the `--filter-by-os` flag was previously allowed to filter architectures of mirrored content. This would break references to those images in the catalog that point to the manifest list and not the manifest. The `--filter-by-os` flag now only filters the index image that is pulled and unpacked. To clarify this, the new `--index-filter-by-os` flag is now added and should be used instead.
+
+The `--filter-by-os` flag is also now deprecated.
 
 [id="ocp-4-7-removed-features"]
 === Removed features

--- a/release_notes/versioning-policy.adoc
+++ b/release_notes/versioning-policy.adoc
@@ -1,4 +1,4 @@
-[id="ocp-4-3-versioning-policy"]
+[id="ocp-versioning-policy"]
 = {product-title} Versioning Policy
 include::modules/common-attributes.adoc[]
 :context: release-notes


### PR DESCRIPTION
Preview (internal): 

* New features
  * [Operator lifecycle](http://file.rdu.redhat.com/~adellape/012921/opframework_47_rn/release_notes/ocp-4-7-release-notes.html#ocp-4-7-olm) (OLM-related)
  * [Operator development](http://file.rdu.redhat.com/~adellape/012921/opframework_47_rn/release_notes/ocp-4-7-release-notes.html#ocp-4-7-osdk) (OSDK-related)
* Notable technical changes
  * [OLM updated to use Kubernetes 1.20](http://file.rdu.redhat.com/~adellape/012921/opframework_47_rn/release_notes/ocp-4-7-release-notes.html#ocp-4-7-olm-k8s-1-20)
* Deprecated features
  * Updated [Deprecated and removed features tracker](http://file.rdu.redhat.com/~adellape/012921/opframework_47_rn/release_notes/ocp-4-7-release-notes.html#ocp-4-7-deprecated-removed-features) table 4.7 entries for:
    * Package Manifest Format
    * `oc adm catalog build`
    * `--filter-by-os`
    * v1beta1 CRDs
  * [--filter-by-os flag](http://file.rdu.redhat.com/~adellape/012921/opframework_47_rn/release_notes/ocp-4-7-release-notes.html#ocp-4-7-filterbyos-deprecated) (per https://github.com/openshift/openshift-docs/issues/26801#issuecomment-762346949)