### PR TITLE
Rename left-nav Welcome to About

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -22,7 +22,7 @@
 # topic groups and topics on the main page.
 
 ---
-Name: Welcome
+Name: About
 Dir: welcome
 Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
 Topics:


### PR DESCRIPTION
The top item in the left-nav on docs.openshift.com builds from OCP 3.1 thru 3.11 was titled "About" (and the first topic was title "Welcome"), but starting with the 4.x builds, this left-nav directory was renamed to also be "Welcome". This makes an awkward/redundant navigation of "Welcome -> Welcome".

Revert this back to "About" to match the 3.x builds, but only in the topic_map file. Leave the file names and directories as-is, so that no existing links are broken.

Preview (internal): http://file.rdu.redhat.com/~adellape/012921/about_welcome/welcome/