### PR TITLE
BZ#1920839 Fix variable expansion in logging docs

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -75,12 +75,13 @@ For more information on systemd settings, see link:https://www.freedesktop.org/s
 $ export jrnl_cnf=$( cat /journald.conf | base64 -w0 )
 ----
 
-. Create a new `MachineConfig` object for master or worker and add the `journal.conf` parameters:
+. Create a `MachineConfig` object that includes the `jrnl_cnf` variable, which is the encoded contents of the `journald.conf` you created in the previous step.
 +
 For example:
 +
-[source,yaml]
+[source,terminal]
 ----
+$ cat > /tmp/40-worker-custom-journald.yaml <<EOF
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -98,15 +99,16 @@ spec:
         mode: 0644 <1>
         overwrite: true
         path: /etc/systemd/journald.conf <2>
+EOF
 ----
 <1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions.
 <2> Specify the path to the base64-encoded `journal.conf` file.
 
-. Create the machine config:
+. Create the machine config. For example:
 +
 [source,terminal]
 ----
-$ oc apply -f <filename>.yaml
+$ oc apply -f /tmp/40-worker-custom-journald.yaml
 ----
 +
 The controller detects the new `MachineConfig` object and generates a new `rendered-worker-<hash>` version.


### PR DESCRIPTION
The jrnl_cnf variable needs to be expanded locally before being applied.
This change expands the variable similar to the MCO documentation:
modules/machineconfig-modify-journald.adoc