### PR TITLE
Clarify that you should almost never manually override the MTU

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -120,10 +120,11 @@ configuration.
 are `Multitenant`, `Subnet`, or `NetworkPolicy`. The default value is
 `NetworkPolicy`.
 
-<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This
-value is normally configured automatically, but if the nodes in your cluster do
-not all use the same MTU, then you must set this explicitly to 50 less than the
-smallest node MTU value.
+<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
++
+If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
++
+If your cluster requires different MTU values for different nodes, you must set this value to `50` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1450`.
 
 <5> The port to use for all VXLAN packets. The default value is `4789`. If you
 are running in a virtualized environment with existing nodes that are part of
@@ -191,10 +192,11 @@ ifdef::operator[]
 endif::operator[]
 
 ifndef::operator[]
-<3> The MTU for the Geneve (Generic Network Virtualization Encapsulation)
-overlay network. This value is normally configured automatically, but if the
-nodes in your cluster do not all use the same MTU, then you must set this
-explicitly to 100 less than the smallest node MTU value.
+<3> The maximum transmission unit (MTU) for the Geneve (Generic Network Virtualization Encapsulation) overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
++
+If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
++
+If your cluster requires different MTU values for different nodes, you must set this value to `100` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
 endif::operator[]
 
 ifdef::operator[]


### PR DESCRIPTION
There is a bug open about doing a more detailed update to the MTU information (https://bugzilla.redhat.com/show_bug.cgi?id=1877570) but people are continuing to get confused by the existing documentation (https://bugzilla.redhat.com/show_bug.cgi?id=1891887) so let's improve it.

/cc @jboxman 

Preview:

https://deploy-preview-29016--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#nw-operator-configuration-parameters-for-openshift-sdn_installing-aws-network-customizations