### PR TITLE
Follow-up edits to web console localization in the 4.7 release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -108,7 +108,7 @@ You can now install a cluster on Google Cloud Platform (GCP) and use a personal 
 [id="ocp-4-7-web-console-localization"]
 ==== Web console localization
 
-The web console is now localized and provides language support for global users. English, Japanese, Simplified Chinese, and Korean are currently supported. The displayed language follows your browser preferences, but you can also select a language to override the browser default. From the *Admin* drop-down menu, select *Language preferences* to update your language setting. Localized date and time is now also supported.
+The web console is now localized and provides language support for global users. English, Japanese, and Simplified Chinese are currently supported. The displayed language follows your browser preferences, but you can also select a language to override the browser default. From the *User* drop-down menu, select *Language preferences* to update your language setting. Localized date and time is now also supported.
 
 [id="ocp-4-7-web-console-insights-plugin"]
 ==== Insights plug-in


### PR DESCRIPTION
Follow-up edits per QE: https://github.com/openshift/openshift-docs/issues/26801#issuecomment-761927380

Korean language support is coming in a 4.7.z release.