### PR TITLE
[enterprise-4.4] OperatorHub inconsistent to Documentation

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -14,6 +14,12 @@ requires its own storage volume.
 +
 Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
+ifdef::openshift-origin[]
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in *Configuring {product-title} to use Red Hat Operators*.
+endif::[]
+
 .Procedure
 
 To install the Elasticsearch Operator and Cluster Logging Operator using the CLI:

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -14,6 +14,12 @@ requires its own storage volume.
 +
 Elasticsearch is a memory-intensive application. By default, {product-title} installs three Elasticsearch nodes with memory requests and limits of 16 GB. This initial set of three {product-title} nodes might not have enough memory to run Elasticsearch within your cluster. If you experience memory issues that are related to Elasticsearch, add more Elasticsearch nodes to your cluster rather than increasing the memory on existing nodes.
 
+ifdef::openshift-origin[]
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
+endif::[]
+
 .Procedure
 
 To install the Elasticsearch Operator and Cluster Logging Operator using the {product-title} web console:

--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -13,6 +13,14 @@ You can install the OpenShift Container Storage Operator and configure a Multi-C
 
 You can install the OpenShift Container Storage Operator from OperatorHub.
 
+ifdef::openshift-origin[]
+.Prerequisites
+
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
+endif::[]
+
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -11,6 +11,11 @@ The descheduler is not available by default. To enable the descheduler, you must
 
 * Cluster administrator privileges.
 * Access to the {product-title} web console.
+ifdef::openshift-origin[]
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
+endif::[]
 
 .Procedure
 

--- a/modules/olm-installing-operators-from-operatorhub-configure.adoc
+++ b/modules/olm-installing-operators-from-operatorhub-configure.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * operators/user/olm-installing-operators-in-namespace.adoc
+// * operators/admin/olm-adding-operators-to-cluster.adoc
+// * post_installation_configuration/preparing-for-users.adoc
+//
+// Module watched for changes by Ecosystem Catalog team:
+// https://projects.engineering.redhat.com/projects/RHEC/summary
+
+
+[id="olm-installing-operators-from-operatorhub-configure_{context}"]
+= Configuring {product-title} to use Red Hat Operators
+
+In {product-title}, Red Hat Operators are not available by default. You can access and install these Operators if you have a pull secret from the Red Hat OpenShift Cluster Manager site by editing the `OperatorHub` custom resource (CR). 
+
+.Prerequisites
+
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in the installation procedure.
+
+.Procedure
+
+To access the Red Hat Operators in a {product-title} cluster: 
+
+. Edit the `OperatorHub` CR using the web console or CLI:
+
+.. Using the CLI:
+
+... Edit the `OperatorHub` CR:
++
+[source,terminal]
+----
+$ oc edit OperatorHub cluster
+----
+
+... Add `redhat-operators` to the list of sources as `disabled: false`:
++
+.Example `OperatorHub` CR
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+spec:
+  disableAllDefaultSources: true
+  sources:
+  - disabled: false <1>
+    name: redhat-operators
+  - disabled: false
+    name: community-operators
+----
+<1> Add the `name: redhat-operators` and `disabled: false` parameters. 
+
+.. Using the web console:
+
+... Switch to the *Administration* -> *Custom Resource Definitions* page.
+
+... On the *Custom Resource Definitions* page, click *OperatorHub*.
+
+... On the *Custom Resource Definition Overview* page, click *Instances*.
+
+... On the *Instances* tab, click *cluster*.
+
+... On the *Instances* tab, click *YAML*.
+
+... In the YAML field, add `redhat-operators` to the list of sources as `disabled: false`:
++
+.Example `OperatorHub` CR
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+spec:
+  disableAllDefaultSources: true
+  sources:
+  - disabled: false <1>
+    name: redhat-operators
+  - disabled: false
+    name: community-operators
+----
+<1> Add the `name: redhat-operators` and `disabled: false` parameters. 
+
+... Click *Save*.
+
+. Log out of the web console, and then log back in.

--- a/operators/olm-adding-operators-to-cluster.adoc
+++ b/operators/olm-adding-operators-to-cluster.adoc
@@ -8,6 +8,15 @@ toc::[]
 This guide walks cluster administrators through installing Operators to an
 {product-title} cluster and subscribing Operators to namespaces.
 
+ifdef::openshift-origin[]
+[id="olm-adding-operators-to-a-cluster-prereqs"]
+== Prerequisites
+
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in _Obtaining the installation program_ in the installation documentation for your platform.
++
+If you have the pull secret, add the `redhat-operators` catalog to the `OperatorHub` custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
+endif::[]
+
 include::modules/olm-installing-operators-from-operatorhub.adoc[leveloffset=+1]
 include::modules/olm-installing-from-operatorhub-using-web-console.adoc[leveloffset=+2]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]

--- a/pipelines/installing-pipelines.adoc
+++ b/pipelines/installing-pipelines.adoc
@@ -15,6 +15,12 @@ toc::[]
 * You have installed `oc` CLI.
 * You have installed xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[OpenShift Pipelines (`tkn`) CLI] on your local system.
 
+ifdef::openshift-origin[]
+* Ensure that you have downloaded the link:https://cloud.redhat.com/openshift/install/pull-secret[pull secret from the Red Hat OpenShift Cluster Manager site] as shown in the xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-obtaining-installer_installing-gcp-customizations[Obtaining the installation program] to install this Operator.
++
+If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in xref:../post_installation_configuration/preparing-for-users.adoc#olm-installing-operators-from-operatorhub-configure_post-install-preparing-for-users[Configuring {product-title} to use Red Hat Operators].
+endif::[]
+
 
 //Installing Pipelines Operator using web console
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/28779/