### PR TITLE
Add CSI snapshot support note for OCS, OpenShift Virtualization in 4-6

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-snapshots.adoc
@@ -11,6 +11,11 @@ This document describes how to use volume snapshots with supported Container Sto
 
 include::modules/technology-preview.adoc[leveloffset=+0]
 
+[NOTE]
+====
+CSI volume snapshot is a fully supported feature in {product-title} 4.6 only for {rh-storage-first} or OpenShift Virtualization.
+====
+
 include::modules/persistent-storage-csi-snapshots-overview.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-snapshots-controller-sidecar.adoc[leveloffset=+1]


### PR DESCRIPTION
The CSI Volume Snapshot feature is Tech Preview in OCP 4.4-4.6. However, it is fully supported (GA) in OCP 4.6 for **Red Hat OpenShift Container Storage** and **OpenShift Virtualization** (formerly Container-Native Virtualization or CNV). This PR adds a note in the 4.6 docs only about this fact. This was a request from OCS to clarify in the OCP docs to be in line with OCS docs that make a similar notation.