### PR TITLE
Add the docs on configuring TLS and SASL for Kafka

### DIFF
--- a/modules/serverless-kafka-sasl.adoc
+++ b/modules/serverless-kafka-sasl.adoc
@@ -1,0 +1,90 @@
+// Module is included in the following assemblies:
+//
+// serverless/serverless-kafka.adoc
+
+[id="serverless-configuring-sasl-authentication-against-an-apache-kafka_{context}"]
+= Configuring SASL authentication
+
+.Prerequisites
+
+* A username and password for the Kafka cluster.
+* Choose the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+* If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
+
+[NOTE]
+====
+Red Hat recommends to enable TLS in addition to SASL.
+====
+
+.Procedure
+
+. Create the certificate files as secrets in your chosen namespace:
++
+[source,terminal]
+----
+$ kubectl create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-file=ca.crt=caroot.pem \
+  --from-literal=password="SecretPassword" \
+  --from-literal=saslType="SCRAM-SHA-512" \
+  --from-literal=user="my-sasl-user"
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `password`, and `saslType`. Do not change them.
+====
+
+. Start editing the `KnativeKafka` custom resource:
++
+[source,terminal]
+----
+$ oc edit knativekafka
+----
+
+. Reference your secret and the namespace of the secret:
++
+[source,terminal]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  channel:
+    authSecretName: <kafka_auth_secret>
+    authSecretNamespace: <kafka_auth_secret_namespace>
+    bootstrapServers: <bootstrap_server>
+    enabled: true
+  source:
+    enabled: true
+----
++
+[NOTE]
+====
+Make sure to specify the matching port in the bootstrap server.
+====
++
+For example:
++
+[source,terminal]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  channel:
+    authSecretName: scram-user
+    authSecretNamespace: kafka
+    bootstrapServers: eventing-kafka-bootstrap.kafka.svc:9093
+    enabled: true
+  source:
+    enabled: true
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]
+

--- a/modules/serverless-kafka-tls.adoc
+++ b/modules/serverless-kafka-tls.adoc
@@ -1,0 +1,82 @@
+// Module is included in the following assemblies:
+//
+// serverless/serverless-kafka.adoc
+
+[id="serverless-configuring-tls-authentication-against-an-apache-kafka_{context}"]
+= Configuring TLS authentication
+
+.Prerequisites
+
+* A Kafka cluster CA certificate as a `.pem` file.
+* A Kafka cluster client certificate and key as `.pem` files.
+
+.Procedure
+
+. Create the certificate files as secrets in your chosen namespace:
++
+----
+$ kubectl create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-file=ca.crt=caroot.pem \
+  --from-file=user.crt=certificate.pem \
+  --from-file=user.key=key.pem
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `user.crt`, and `user.key`. Do not change them.
+====
+
+. Start editing the `KnativeKafka` custom resource:
++
+[source,terminal]
+----
+$ oc edit knativekafka
+----
+
+. Reference your secret and the namespace of the secret:
++
+[source,terminal]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  channel:
+    authSecretName: <kafka_auth_secret>
+    authSecretNamespace: <kafka_auth_secret_namespace>
+    bootstrapServers: <bootstrap_server>
+    enabled: true
+  source:
+    enabled: true
+----
++
+[NOTE]
+====
+Make sure to specify the matching port in the bootstrap server.
+====
++
+For example:
++
+[source,terminal]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  channel:
+    authSecretName: tls-user
+    authSecretNamespace: kafka
+    bootstrapServers: eventing-kafka-bootstrap.kafka.svc:9094
+    enabled: true
+  source:
+    enabled: true
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]
+

--- a/serverless/serverless-kafka.adoc
+++ b/serverless/serverless-kafka.adoc
@@ -36,6 +36,19 @@ spec:
 // Install Kafka
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
 
+// Configure TLS and SASL for Kafka
+== Configuring authentication for Kafka
+
+In production, Kafka clusters are often secured using the TLS or SASL authentication methods. This section shows how to configure the Kafka channel to work against a protected Red Hat AMQ Streams (Kafka) cluster using TLS or SASL.
+
+[NOTE]
+====
+If you choose to enable SASL, Red Hat recommends to also enable TLS.
+====
+
+include::modules/serverless-kafka-tls.adoc[leveloffset=+2]
+include::modules/serverless-kafka-sasl.adoc[leveloffset=+2]
+
 [id="serverless-kafka-next-steps"]
 == Next steps
 


### PR DESCRIPTION
Preview: https://deploy-preview-29059--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-kafka.html#configuring-authentication-for-kafka
For versions 4.6+.