### PR TITLE
adding dummy file for 2.6 release notes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1785,7 +1785,7 @@ Topics:
   - Name: Configuring custom Helm chart repositories
     File: configuring-custom-helm-chart-repositories
   - Name: Disabling Helm chart repositories
-    File: disabling-helm-chart-repositories  
+    File: disabling-helm-chart-repositories
 - Name: Knative CLI (kn) for use with OpenShift Serverless
   File: kn-cli-tools
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
@@ -2414,7 +2414,7 @@ Topics:
 - Name: About OpenShift Virtualization
   File: about-virt
 - Name: OpenShift Virtualization release notes
-  File: virt-2-4-release-notes
+  File: virt-2-6-release-notes
 - Name: OpenShift Virtualization installation
   Dir: install
   Topics:

--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -1,0 +1,10 @@
+[id="virt-2-6-release-notes"]
+= {RN_BookName}
+include::modules/virt-document-attributes.adoc[]
+:context: virt-2-6-release-notes
+toc::[]
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
As requested in #28401, this updates the dummy file situation for CNV 2.6 in the master branch.

Not to be cherrypicked.