### PR TITLE
Add module for manual CSV annotations

### DIFF
--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-generating-csvs.adoc
+
+[id="osdk-csv-manual-annotations_{context}"]
+= Operator metadata annotations
+
+Operator developers can manually define certain annotations in the metadata of a cluster service version (CSV) to enable features or highlight capabilities in user interfaces (UIs), such as OperatorHub.
+
+The following table lists Operator metadata annotations that can be manually defined using `metadata.annotations` fields.
+
+.Annotations
+[cols="5a,5a",options="header"]
+|===
+|Field |Description
+
+|`alm-examples`
+|Provide custom resource definition (CRD) templates with a minimum set of configuration. Compatible UIs pre-fill this template for users to further customize.
+
+|`operatorframework.io/initialization-resource`
+|Specify a single required custom resource that must be created at the time that the Operator is installed. Must include a template that contains a complete YAML definition.
+
+|`operatorframework.io/suggested-namespace`
+|Set a suggested namespace where the Operator should be deployed.
+
+|`operators.openshift.io/infrastructure-features`
+|Infrastructure features supported by the Operator. Users can view and filter by these features when discovering Operators through OperatorHub in the web console. Valid values:
+
+- `disconnected`: Operator supports running in disconnected mode. All related images required for mirroring are listed by the Operator.
+- `proxy`: Operator supports running on a cluster behind a proxy. Required environment variables are passed down to Operands.
+- `fipsmode`: Operator supports running in FIPS mode.
+
+|`operators.openshift.io/valid-subscription`
+|Indicate a specific subscription is required to use the Operator. For example, `3Scale Commercial License` or `Red Hat Managed Integration`.
+
+|`operators.operatorframework.io/internal-objects`
+|Hides CRDs in the UI that are not meant for user manipulation.
+
+|===

--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -5,9 +5,11 @@
 [id="osdk-manually-defined-csv-fields_{context}"]
 = Manually-defined CSV fields
 
-Many CSV fields cannot be populated using generated, generic manifests that are not specific to Operator SDK. These fields are mostly human-written, English metadata about the Operator and various custom resource definitions (CRDs).
+Many CSV fields cannot be populated using generated, generic manifests that are not specific to Operator SDK. These fields are mostly human-written metadata about the Operator and various custom resource definitions (CRDs).
 
 Operator authors must directly modify their cluster service version (CSV) YAML file, adding personalized data to the following required fields. The Operator SDK gives a warning during CSV generation when a lack of data in any of the required fields is detected.
+
+The following tables detail which manually-defined CSV fields are required and which are optional.
 
 .Required
 [cols="2a,8a",options="header"]
@@ -69,6 +71,8 @@ Operator authors must directly modify their cluster service version (CSV) YAML f
 
 |`spec.maturity`
 |The level of maturity the software has achieved at this version. Options include `planning`, `pre-alpha`, `alpha`, `beta`, `stable`, `mature`, `inactive`, and `deprecated`.
+
+|`metadata.annotations`
 |===
 
 Further details on what data each field above should hold are found in the link:https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/building-your-csv.md[CSV spec].

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -11,33 +11,26 @@ The Operator SDK includes the CSV generator to generate a CSV for the current Op
 
 A CSV-generating command removes the responsibility of Operator authors having in-depth OLM knowledge in order for their Operator to interact with OLM or publish metadata to the Catalog Registry. Further, because the CSV spec will likely change over time as new Kubernetes and OLM features are implemented, the Operator SDK is equipped to easily extend its update system to handle new CSV features going forward.
 
-////
-Operator authors can use the `--csv-version` flag to have their Operator state encapsulated in a CSV with the supplied semantic version:
-
-[source,terminal]
-----
-$ operator-sdk generate csv --csv-version <version>
-----
-
-This action is idempotent and only updates the CSV file when a new version is supplied, or a YAML manifest or source file is changed. Operator authors should not have to directly modify most fields in a CSV manifest. Those that require modification are defined in this guide. For example, the CSV version must be included in `metadata.name`.
-////
-
 include::modules/osdk-how-csv-gen-works.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial[Bundling and deploying your Operator by using OLM] for a tutorial that includes generating a CSV.
 
-////
-include::modules/osdk-csv-composition-configuration.adoc[leveloffset=+1]
-////
 include::modules/osdk-manually-defined-csv-fields.adoc[leveloffset=+1]
 .Additional resources
 
 - xref:../../operators/understanding/olm-what-operators-are.adoc#olm-maturity-model_olm-what-operators-are[Operator maturity model]
 
-////
-include::modules/osdk-generating-a-csv.adoc[leveloffset=+1]
-////
+include::modules/osdk-csv-manual-annotations.adoc[leveloffset=+2]
+.Additional resources
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-crds-templates_osdk-generating-csvs[CRD templates]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-init-resource_osdk-generating-csvs[Initializing required custom resources
+]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace_osdk-generating-csvs[Setting a suggested namespace]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments] (disconnected mode)
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-hiding-internal-objects_osdk-generating-csvs[Hiding internal objects]
+- xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS crytography]
+
 include::modules/olm-enabling-operator-restricted-network.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]
 .Additional resources
@@ -74,7 +67,3 @@ include::modules/osdk-hiding-internal-objects.adoc[leveloffset=+2]
 include::modules/osdk-init-resource.adoc[leveloffset=+2]
 
 include::modules/osdk-apiservices.adoc[leveloffset=+1]
-
-////
-TODO: discuss whether multiple CSV files can be present, each with a unique file name (ex. `app-operator.csv.0.1.1.yaml`), or a single `app-operator.csv.yaml` file that relies on VCS (git) to version the file.
-////


### PR DESCRIPTION
Shoring up the various relevant annotations into a reference table.

Preview (internal): http://file.rdu.redhat.com/~adellape/020221/operator_attrs/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs