### PR TITLE
Fix topic title section to use title case

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -61,7 +61,7 @@ topic titled "Managing Authorization Policies".
 
 == Topic Titles and Section Headings
 
-Use sentence case in all topic titles and section headings. See http://www.titlecase.com/ or
+Use title case in all topic titles and section headings. Note that this is different from OpenShift 4.x docs that use sentence case. See http://www.titlecase.com/ or
 https://convertcase.net/ for a conversion tool.
 
 Try to be as descriptive as possible with the topic title or section headings


### PR DESCRIPTION
Fixes 3.11 doc guidelines to instruct authors to use title case and not sentence case in OCP 3.11 docs only.