### PR TITLE
For global proxy `noProxy` can be ignored

### DIFF
--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -93,15 +93,20 @@ spec:
   trustedCA:
     name: user-ca-bundle <5>
 ----
++
+--
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
 URL scheme must be `http`.
 <2> A proxy URL to use for creating HTTPS connections outside the cluster. If
 this is not specified, then `httpProxy` is used for both HTTP and HTTPS
 connections.
 <3> A comma-separated list of destination domain names, domains, IP addresses or
-other network CIDRs to exclude proxying. Preface a domain with `.` to include
-all subdomains of that domain. Use `*` to bypass proxy for all destinations.
-Note that if you scale up workers not included in `networking.machineNetwork[].cidr` from the installation configuration, you must add them to this list to prevent connection issues.
+other network CIDRs to exclude proxying.
++
+Preface a domain with `.` to include all the subdomains of that domain. Use `*` to bypass the proxy for all destinations.
+If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
++
+This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
 <4> One or more URLs external to the cluster to use to perform a readiness check
 before writing the `httpProxy` and `httpsProxy` values to status.
 <5> A reference to the ConfigMap in the `openshift-config` namespace that
@@ -109,5 +114,6 @@ contains additional CA certificates required for proxying HTTPS connections.
 Note that the ConfigMap must already exist before referencing it here. This
 field is required unless the proxy's identity certificate is signed by an
 authority from the RHCOS trust bundle.
+--
 
 . Save the file to apply the changes.


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/28782

Preview: [Enabling the cluster-wide proxy](https://deploy-preview-29093--osdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html#nw-proxy-configure-object_config-cluster-wide-proxy)

Change:

> This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.