### PR TITLE
The field is not fully indented

### DIFF
--- a/modules/virt-example-nmstate-multiple-interfaces.adoc
+++ b/modules/virt-example-nmstate-multiple-interfaces.adoc
@@ -12,7 +12,7 @@ The following example snippet creates a bond that is named `bond10` across two N
 [source,yaml]
 ----
 ...
-interfaces:
+    interfaces:
     - name: bond10
       description: Bonding eth2 and eth3 for Linux bridge
       type: bond


### PR DESCRIPTION
The following indentation is correct:

```
spec:
  desiredState:
    interfaces:
```

@aburdenthehand FYI