### PR TITLE
Resources migrated and excluded by MTC

### DIFF
--- a/modules/migration-excluding-resources.adoc
+++ b/modules/migration-excluding-resources.adoc
@@ -6,7 +6,9 @@
 [id='migration-excluding-resources_{context}']
 = Excluding resources from a migration plan
 
-You can exclude resources, for example, image streams, persistent volumes (PVs), or subscriptions, from a  {mtc-full} ({mtc-short}) migration plan in order to reduce the load or to migrate images or PVs with a different tool.
+You can exclude resources, for example, image streams, persistent volumes (PVs), or subscriptions, from a {mtc-full} ({mtc-short}) migration plan in order to reduce the resource load for migration or to migrate images or PVs with a different tool.
+
+By default, the {mtc-short} excludes service catalog resources and Operator Lifecycle Manager (OLM) resources from migration. These resources are parts of the service catalog API group and the OLM API group, neither of which is supported for migration at this time.
 
 .Procedure
 
@@ -41,10 +43,12 @@ spec:
   - serviceclasses
   - serviceinstances
   - serviceplans
+  - operatorgroups
+  - events
 ----
 <1> Add `disable_image_migration: true` to exclude image streams from the migration. Do not edit the `excluded_resources` parameter. `imagestreams` is added to `excluded_resources` when the `MigrationController` pod restarts.
 <2> Add `disable_pv_migration: true` to exclude PVs from the migration plan. Do not edit the `excluded_resources` parameter. `persistentvolumes` and `persistentvolumeclaims` are added to `excluded_resources` when the `MigrationController` pod restarts. Disabling PV migration also disables PV discovery when you create the migration plan.
-<3> You can add {product-title} resources to the `excluded_resources` list. Do not delete any of the default excluded resources. These resources are known to be problematic for migration.
+<3> You can add {product-title} resources to the `excluded_resources` list. Do not delete the default excluded resources. These resources are problematic to migrate and must be excluded.
 
 . Wait two minutes for the `MigrationController` pod to restart so that the changes are applied.
 

--- a/modules/migration-mtc-workflow.adoc
+++ b/modules/migration-mtc-workflow.adoc
@@ -7,7 +7,19 @@
 [id='migration-mtc-workflow_{context}']
 = {mtc-full} workflow
 
-Migrating an application with the {mtc-short} web console involves the following workflow:
+You use the {mtc-full} ({mtc-short}) to migrate Kubernetes resources, persistent volume data, and internal container images from an {product-title} source cluster to an {product-title} {product-version} target cluster by using the {mtc-short} web console or the Kubernetes API.
+
+The ({mtc-short}) migrates the following resources:
+
+* A namespace specified in a migration plan.
+
+* Namespace-scoped resources: When the {mtc-short} migrates a namespace, it migrates all the objects and resources associated with that namespace, such as services or pods. Additionally, if a resource that exists in the namespace but not at the cluster level depends on a resource that exists at the cluster level, the {mtc-short} migrates both resources.
++
+For example, a security context constraint (SCC) is a resource that exists at the cluster level and a service account (SA) is a resource that exists at the namespace level. If an SA exists in a namespace that the {mtc-short} migrates, the {mtc-short} automatically locates any SCCs that are linked to the SA and also migrates those SCCs. Similarly, the {mtc-short} migrates persistent volume claims that are linked to the persistent volumes of the namespace.
+
+* Custom resources (CRs) and custom resource definitions (CRDs): The {mtc-short} automatically migrates any CRs that exist at the namespace level as well as the CRDs that are linked to those CRs.
+
+Migrating an application with the {mtc-short} web console involves the following steps:
 
 . Install the {mtc-full} Operator on all clusters.
 +


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MIG-417
Content based on the upstream content approved in https://github.com/konveyor/mig-operator/pull/561/files and comments on the Jira. 

Previews: https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/migrating-application-workloads-3-4.html#about-resources-mtc-migrates_migrating-3-4  
https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/migrating-applications-with-cam-3-4.html#migration-excluding-resources_migrating-3-4

The same content is found in: https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/migrating-application-workloads-4-1-4.html#about-resources-mtc-migrates_migrating-4-1-4
https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.html#migration-excluding-resources_migrating-4-1-4

and

https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_2_4/migrating-application-workloads-4-2-4.html#about-resources-mtc-migrates_migrating-4-2-4
https://deploy-preview-29096--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_2_4/migrating-applications-with-cam-4-2-4.html#migration-excluding-resources_migrating-4-2-4
