### PR TITLE
Removing incorrect source specification on a table

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -24,7 +24,6 @@ When adding networking arguments, you must also add the `rd.neednet=1` kernel ar
 The following table describes how to use `ip=`, `nameserver=`, and `bond=` kernel arguments for live ISO installs.
 
 .Routing and bonding options for ISO
-[source,adoc]
 |===
 |Description |Examples
 
@@ -107,7 +106,6 @@ While you can pass most standard boot arguments to the live installer, there are
 The following table shows the {op-system} live installer boot options for ISO and PXE installs.
 
 .`coreos.inst` boot options
-[source,adoc]
 |===
 |Argument |Description
 
@@ -164,7 +162,6 @@ You can also install {op-system} by invoking the `coreos-installer` command dire
 The following table shows the options and subcommands you can pass to the `coreos-installer` command during a live install.
 
 .`coreos-installer` command-line options, arguments, and subcommands
-[source,adoc]
 |===
 
 2+|_Command-line options_


### PR DESCRIPTION
Just removing some `[source,adoc]` which don't belong on tables.

https://deploy-preview-29097--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-user-infra-machines-static-network_installing-bare-metal-network-customizations