### PR TITLE
search: OKD4 version and URL workaround

### DIFF
--- a/_javascripts/hc-search.js
+++ b/_javascripts/hc-search.js
@@ -27,6 +27,8 @@ function hcSearchCategory(label, version) {
         label: label,
         urlFilter: (typeof version === "undefined" || version == "Branch Build") ? "" : (" url:*\\/" + version.toLowerCase() + "\\/*")
       };
+      // work around the current OKD-specific version=4 and URL discrepancy
+      if (window.location.href.includes("docs.okd.io/latest/") && version == 4) searchParams.urlFilter = " url:*\\/latest\\/*"
       modalSearch.show();
       hcsearch(searchParams);
     }


### PR DESCRIPTION
* Avoids the current OKD 4 docs and URL discrepancy where the version
  is set to 4, but the URL contains the "latest" string instead that
  filters all results with the URL string "/4/" that is never present.
* If future "latest" versions would be represented by other version
  values, this needs to be adjusted accordingly.
* Closes #28979

Signed-off-by: Jiri Fiala <jfiala@redhat.com>