### PR TITLE
RN-CNV-9723 Release note to document new node drain procedure for CLI

### DIFF
--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -33,6 +33,7 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 //CNV-7544: Microsoft's Windows Server Virtualization Validation Program (SVVP) applies to RHCOS workers
 
 //CNV-9723: VMs are now migrated when a node is drained
+* Virtual machines that have the `LiveMigratable` condition set to `True` and the `spec.evictionStrategy` field set to `LiveMigrate` are now migrated when a node is drained in preparation for maintenance. You can xref:../virt/node_maintenance/virt-setting-node-maintenance.adoc#virt-setting-node-maintenance[set a node to maintenance mode in the CLI] by running the `oc adm drain` command. The `NodeMaintenance` custom resource definition is no longer supported.
 
 //CNV-9521: VMs that use UEFI can now be booted by using secure boot
 


### PR DESCRIPTION
OpenShift Virtualization 2.6 release note to document new node drain procedure for CLI

Addresses [CNV-9723](https://issues.redhat.com/browse/CNV-9723)

Preview build: https://deploy-preview-29110--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-6-release-notes.html#virt-2-6-new