### PR TITLE
Fix merge conflict with PR#26070 and PR#26521 typo in 4-7

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -97,7 +97,7 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 |===
 
 [discrete]
-== `core.inst` boot options for ISO or PXE install
+== `coreos.inst` boot options for ISO or PXE install
 
 While you can pass most standard installation boot arguments to the live installer, there are several arguments that are specific to the {op-system} live installer.
 
@@ -107,7 +107,7 @@ While you can pass most standard installation boot arguments to the live install
 
 The following table shows the {op-system} live installer boot options for ISO and PXE installs.
 
-.`core.inst` boot options
+.`coreos.inst` boot options
 [source,adoc]
 |===
 |Argument |Description


### PR DESCRIPTION
Fixes a merge conflict caused by a typo in example headers, related to https://github.com/openshift/openshift-docs/pull/26070 and https://github.com/openshift/openshift-docs/pull/26521.
@openshift/team-documentation PTAL