### PR TITLE
Removing incorrect source specification on a table

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -12,7 +12,6 @@ when you boot that image to configure the node's networking.
 The following table describes and illustrates how to use those kernel arguments.
 
 .Configure advanced networking
-[source,adoc]
 |===
 |Description |Examples
 


### PR DESCRIPTION
Manual CP of #29097 to 4.5.