### PR TITLE
luks: use AES-CBC for FIPS 140-2

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -94,6 +94,7 @@ spec:
             tang:
               - url: https://tang.example.com
                 thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
+          options: [--cipher, aes-cbc-essiv:sha256]
       filesystems:
         - device: /dev/mapper/root
           format: xfs
@@ -125,6 +126,7 @@ spec:
             tang:
               - url: https://tang.example.com
                 thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
+          options: [--cipher, aes-cbc-essiv:sha256]
       filesystems:
         - device: /dev/mapper/root
           format: xfs

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -46,6 +46,7 @@ spec:
           device: /dev/disk/by-partlabel/root
           clevis:
             tpm2: true
+          options: [--cipher, aes-cbc-essiv:sha256]
       filesystems:
         - device: /dev/mapper/root
           format: xfs
@@ -74,6 +75,7 @@ spec:
           device: /dev/disk/by-partlabel/root
           clevis:
             tpm2: true
+          options: [--cipher, aes-cbc-essiv:sha256]
       filesystems:
         - device: /dev/mapper/root
           format: xfs


### PR DESCRIPTION
The default is AES-XTS.

cc @arithx @bobfuru