### PR TITLE
Testing the cancellation of builds with a really long message to see …

### DIFF
--- a/applications/application-health.adoc
+++ b/applications/application-health.adoc
@@ -5,6 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+Test Cancel
 
 In software systems, components can become unhealthy due to transient issues such as temporary connectivity loss, configuration errors, or problems with external dependencies. {product-title} applications have a number of options to detect and handle unhealthy containers.
 


### PR DESCRIPTION
…where the skip part needs to be to avoid this to be triggered and wherher [skip netlify] can be in the middle of the sentence too