### PR TITLE
OSDOCS-1715 AlertmanagerConfig CRD not supported

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -20,3 +20,4 @@ The Alertmanager configuration is deployed as a secret resource in the `openshif
 * *Modifying the monitoring stack Grafana instance.*
 * *Installing custom Prometheus instances on {product-title}.*
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
+* *Modifying Alertmanager configurations by using the `AlertmanagerConfig` CRD in Prometheus Operator.*


### PR DESCRIPTION
[OSDOCS-1715:](https://issues.redhat.com/browse/OSDOCS-1715) Mention AlertmanagerConfig CRD as not supported in 4.7.

@openshift/team-documentation PTAL. Thank you!
