### PR TITLE
Use 'OpenShift CLI' name unambiguously

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -449,6 +449,104 @@ Topics:
   File: disabling-web-console
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
 ---
+Name: CLI tools
+Dir: cli_reference
+Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
+Topics:
+- Name: OpenShift CLI (oc)
+  Dir: openshift_cli
+  Topics:
+  - Name: Getting started with the OpenShift CLI
+    File: getting-started-cli
+  - Name: Configuring the OpenShift CLI
+    File: configuring-cli
+  - Name: Extending the OpenShift CLI with plug-ins
+    File: extending-cli-plugins
+    Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  - Name: OpenShift CLI developer commands
+    File: developer-cli-commands
+  - Name: OpenShift CLI administrator commands
+    File: administrator-cli-commands
+    Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  - Name: Usage of oc and kubectl commands
+    File: usage-oc-kubectl
+- Name: Developer CLI (odo)
+  Dir: developer_cli_odo
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
+  Topics:
+  - Name: Understanding odo
+    File: understanding-odo
+  - Name: Installing odo
+    File: installing-odo
+  - Name: Creating and deploying applications with odo
+    Dir: creating_and_deploying_applications_with_odo
+    Topics:
+      - Name: Working with projects
+        File: working-with-projects
+      - Name: Creating a single-component application with odo
+        File: creating-a-single-component-application-with-odo
+      - Name: Creating a multicomponent application with odo
+        File: creating-a-multicomponent-application-with-odo
+      - Name: Creating an application with a database
+        File: creating-an-application-with-a-database
+      - Name: Using devfiles in odo
+        File: using-devfiles-in-odo
+      - Name: Working with storage
+        File: working-with-storage
+      - Name: Deleting applications
+        File: deleting-applications
+      - Name: Debugging applications in odo
+        File: debugging-applications-in-odo
+      - Name: Sample applications
+        File: sample-applications
+  - Name: Using odo in a restricted environment
+    Dir: using_odo_in_a_restricted_environment
+    Topics:
+    - Name: About odo in a restricted environment
+      File: about-odo-in-a-restricted-environment
+    - Name: Pushing the odo init image to the restricted cluster registry
+      File: pushing-the-odo-init-image-to-the-restricted-cluster-registry
+    - Name: Creating and deploying a component to the disconnected cluster
+      File: creating-and-deploying-a-component-to-the-disconnected-cluster
+  - Name: Creating instances of services managed by Operators
+    File: creating-instances-of-services-managed-by-operators
+  - Name: Managing environment variables in odo
+    File: managing-environment-variables-in-odo
+  - Name: Configuring the odo CLI
+    File: configuring-the-odo-cli
+  - Name: odo CLI reference
+    File: odo-cli-reference
+  - Name: odo architecture
+    File: odo-architecture
+  - Name: odo release notes
+    File: odo-release-notes
+- Name: Helm CLI
+  Dir: helm_cli
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  Topics:
+  - Name: Getting started with Helm on OpenShift Container Platform
+    File: getting-started-with-helm-on-openshift-container-platform
+  - Name: Configuring custom Helm chart repositories
+    File: configuring-custom-helm-chart-repositories
+  - Name: Disabling Helm chart repositories
+    File: disabling-helm-chart-repositories
+- Name: Knative CLI (kn) for use with OpenShift Serverless
+  File: kn-cli-tools
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Pipelines CLI (tkn)
+  Dir: tkn_cli
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  Topics:
+  - Name: Installing tkn
+    File: installing-tkn
+  - Name: Configuring tkn
+    File: op-configuring-tkn
+  - Name: Basic tkn commands
+    File: op-tkn-reference
+- Name: opm CLI
+  File: opm-cli
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+---
 Name: Security and compliance
 Dir: security
 Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro
@@ -1706,104 +1804,6 @@ Topics:
     File: migrating-applications-with-cam-4-2-4
   - Name: Troubleshooting
     File: troubleshooting-4-2-4
----
-Name: CLI tools
-Dir: cli_reference
-Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
-Topics:
-- Name: OpenShift CLI (oc)
-  Dir: openshift_cli
-  Topics:
-  - Name: Getting started with the CLI
-    File: getting-started-cli
-  - Name: Configuring the CLI
-    File: configuring-cli
-  - Name: Extending the CLI with plug-ins
-    File: extending-cli-plugins
-    Distros: openshift-enterprise,openshift-webscale,openshift-origin
-  - Name: Developer CLI commands
-    File: developer-cli-commands
-  - Name: Administrator CLI commands
-    File: administrator-cli-commands
-    Distros: openshift-enterprise,openshift-webscale,openshift-origin
-  - Name: Usage of oc and kubectl commands
-    File: usage-oc-kubectl
-- Name: Developer CLI (odo)
-  Dir: developer_cli_odo
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
-  Topics:
-  - Name: Understanding odo
-    File: understanding-odo
-  - Name: Installing odo
-    File: installing-odo
-  - Name: Creating and deploying applications with odo
-    Dir: creating_and_deploying_applications_with_odo
-    Topics:
-      - Name: Working with projects
-        File: working-with-projects
-      - Name: Creating a single-component application with odo
-        File: creating-a-single-component-application-with-odo
-      - Name: Creating a multicomponent application with odo
-        File: creating-a-multicomponent-application-with-odo
-      - Name: Creating an application with a database
-        File: creating-an-application-with-a-database
-      - Name: Using devfiles in odo
-        File: using-devfiles-in-odo
-      - Name: Working with storage
-        File: working-with-storage
-      - Name: Deleting applications
-        File: deleting-applications
-      - Name: Debugging applications in odo
-        File: debugging-applications-in-odo
-      - Name: Sample applications
-        File: sample-applications
-  - Name: Using odo in a restricted environment
-    Dir: using_odo_in_a_restricted_environment
-    Topics:
-    - Name: About odo in a restricted environment
-      File: about-odo-in-a-restricted-environment
-    - Name: Pushing the odo init image to the restricted cluster registry
-      File: pushing-the-odo-init-image-to-the-restricted-cluster-registry
-    - Name: Creating and deploying a component to the disconnected cluster
-      File: creating-and-deploying-a-component-to-the-disconnected-cluster
-  - Name: Creating instances of services managed by Operators
-    File: creating-instances-of-services-managed-by-operators
-  - Name: Managing environment variables in odo
-    File: managing-environment-variables-in-odo
-  - Name: Configuring the odo CLI
-    File: configuring-the-odo-cli
-  - Name: odo CLI reference
-    File: odo-cli-reference
-  - Name: odo architecture
-    File: odo-architecture
-  - Name: odo release notes
-    File: odo-release-notes
-- Name: Helm CLI
-  Dir: helm_cli
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
-  Topics:
-  - Name: Getting started with Helm on OpenShift Container Platform
-    File: getting-started-with-helm-on-openshift-container-platform
-  - Name: Configuring custom Helm chart repositories
-    File: configuring-custom-helm-chart-repositories
-  - Name: Disabling Helm chart repositories
-    File: disabling-helm-chart-repositories
-- Name: Knative CLI (kn) for use with OpenShift Serverless
-  File: kn-cli-tools
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
-- Name: Pipelines CLI (tkn)
-  Dir: tkn_cli
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
-  Topics:
-  - Name: Installing tkn
-    File: installing-tkn
-  - Name: Configuring tkn
-    File: op-configuring-tkn
-  - Name: Basic tkn commands
-    File: op-tkn-reference
-- Name: opm CLI
-  File: opm-cli
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 ---
 Name: API reference
 Dir: rest_api

--- a/cli_reference/openshift_cli/administrator-cli-commands.adoc
+++ b/cli_reference/openshift_cli/administrator-cli-commands.adoc
@@ -1,5 +1,5 @@
 [id="cli-administrator-commands"]
-= Administrator CLI commands
+= OpenShift CLI administrator commands
 include::modules/common-attributes.adoc[]
 :context: cli-administrator-commands
 

--- a/cli_reference/openshift_cli/configuring-cli.adoc
+++ b/cli_reference/openshift_cli/configuring-cli.adoc
@@ -1,5 +1,5 @@
 [id="cli-configuring-cli"]
-= Configuring the CLI
+= Configuring the OpenShift CLI
 include::modules/common-attributes.adoc[]
 :context: cli-configuring-cli
 

--- a/cli_reference/openshift_cli/developer-cli-commands.adoc
+++ b/cli_reference/openshift_cli/developer-cli-commands.adoc
@@ -1,5 +1,5 @@
 [id="cli-developer-commands"]
-= Developer CLI commands
+= OpenShift CLI developer commands
 include::modules/common-attributes.adoc[]
 :context: cli-developer-commands
 

--- a/cli_reference/openshift_cli/extending-cli-plugins.adoc
+++ b/cli_reference/openshift_cli/extending-cli-plugins.adoc
@@ -1,5 +1,5 @@
 [id="cli-extend-plugins"]
-= Extending the CLI with plug-ins
+= Extending the OpenShift CLI with plug-ins
 include::modules/common-attributes.adoc[]
 :context: cli-extend-plugins
 

--- a/cli_reference/openshift_cli/getting-started-cli.adoc
+++ b/cli_reference/openshift_cli/getting-started-cli.adoc
@@ -1,5 +1,5 @@
 [id="cli-getting-started"]
-= Getting started with the CLI
+= Getting started with the OpenShift CLI
 include::modules/common-attributes.adoc[]
 :context: cli-developer-commands
 
@@ -8,7 +8,8 @@ toc::[]
 // About the CLI
 include::modules/cli-about-cli.adoc[leveloffset=+1]
 
-== Installing the CLI
+[id="installing-openshift-cli"]
+== Installing the OpenShift CLI
 
 You can install the OpenShift CLI (`oc`) either by downloading the binary or by using an RPM.
 

--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -3,7 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: usage-oc-kubectl
 
-Kubernetes' command line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because OpenShift Container Platform is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with {product-title}, or you can gain extended functionality by using the `oc` binary.
+The Kubernetes command line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because OpenShift Container Platform is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with {product-title}, or you can gain extended functionality by using the `oc` binary.
 
 == The oc binary
 
@@ -25,6 +25,6 @@ The additional command `oc new-app`, for example, makes it easier to get new app
 
 The `kubectl` binary is provided as a means to support existing workflows and scripts for new {product-title} users coming from a standard Kubernetes environment, or for those who prefer to use the `kubectl` CLI. Existing users of `kubectl` can continue to use the binary to interact with Kubernetes primitives, with no changes required to the {product-title} cluster.
 
-You can install the supported `kubectl` binary by following the steps to xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-installing-cli_cli-developer-commands[Install the CLI]. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.
+You can install the supported `kubectl` binary by following the steps to xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-installing-cli_cli-developer-commands[Install the OpenShift CLI]. The `kubectl` binary is included in the archive if you download the binary, or is installed when you install the CLI by using an RPM.
 
 For more information, see the link:https://kubernetes.io/docs/reference/kubectl/overview/[kubectl documentation].

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -339,13 +339,13 @@ xref:../../architecture/networking/routes.adoc#architecture-core-concepts-routes
 .Markup example of cross-referencing
 ----
 Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or
-the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
+the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-openshift-cli[OpenShift CLI].
 
 Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
 ----
 
 .Rendered output of cross-referencing
-> Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-the-cli[OpenShift CLI].
+> Rollbacks revert part of an application back to a previous deployment. Rollbacks can be performed using the REST API or the xref:../cli_reference/openshift_cli/get_started_cli.adoc#installing-openshift-cli[OpenShift CLI].
 >
 > Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
 

--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -68,7 +68,7 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
-To learn more, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the CLI].
+To learn more, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI].
 
 include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -53,7 +53,7 @@ You have completed the steps required to install the cluster. The remaining step
 
 include::modules/cli-installing-cli.adoc[leveloffset=1]
 
-To learn more, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the CLI].
+To learn more, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#getting-started-cli[Getting started with the OpenShift CLI].
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=1]
 

--- a/modules/cli-about-cli.adoc
+++ b/modules/cli-about-cli.adoc
@@ -3,12 +3,10 @@
 // * cli_reference/openshift_cli/getting-started.adoc
 
 [id="cli-about-cli_{context}"]
-= About the CLI
+= About the OpenShift CLI
 
-With the {product-title} command-line interface (CLI), you can create
-applications and manage {product-title} projects from a terminal. The CLI is
-ideal in situations where you:
+With the {product-title} command-line interface (CLI), you can create applications and manage {product-title} projects from a terminal. The OpenShift CLI is ideal in the following situations:
 
-* work directly with project source code.
-* script {product-title} operations.
-* are restricted by bandwidth resources and can not use the web console.
+* Working directly with project source code
+* Scripting {product-title} operations
+* Working while restricted by bandwidth resources and the web console is unavailable

--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/openshift_cli/getting-started.adoc
 
 [id="cli-installing-cli-rpm_{context}"]
-= Installing the CLI by using an RPM
+= Installing the OpenShift CLI by using an RPM
 
 For {op-system-base-full}, you can install the OpenShift CLI (`oc`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
 

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -37,7 +37,7 @@ ifeval::["{context}" == "updating-restricted-network-cluster"]
 endif::[]
 
 [id="cli-installing-cli_{context}"]
-= Installing the CLI by downloading the binary
+= Installing the OpenShift CLI by downloading the binary
 
 You can install the OpenShift CLI (`oc`) in order to interact with {product-title} from a
 command-line interface. You can install `oc` on Linux, Windows, or macOS.
@@ -53,7 +53,7 @@ endif::restricted[]
 ====
 
 [id="cli-installing-cli-on-linux_{context}"]
-== Installing the CLI on Linux
+== Installing the OpenShift CLI on Linux
 
 You can install the OpenShift CLI (`oc`) binary on Linux by using the following procedure.
 
@@ -91,7 +91,7 @@ $ oc <command>
 ----
 
 [id="cli-installing-cli-on-windows_{context}"]
-== Installing the CLI on Windows
+== Installing the OpenShift CLI on Windows
 
 You can install the OpenShift CLI (`oc`) binary on Windows by using the following procedure.
 
@@ -124,7 +124,7 @@ C:\> oc <command>
 ----
 
 [id="cli-installing-cli-on-macos_{context}"]
-== Installing the CLI on macOS
+== Installing the OpenShift CLI on macOS
 
 You can install the OpenShift CLI (`oc`) binary on macOS by using the following procedure.
 

--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/openshift_cli/getting-started.adoc
 
 [id="cli-logging-in_{context}"]
-= Logging in to the CLI
+= Logging in to the OpenShift CLI
 
 You can log in to the `oc` CLI to access and manage your cluster.
 

--- a/modules/cli-logging-out.adoc
+++ b/modules/cli-logging-out.adoc
@@ -3,9 +3,9 @@
 // * cli_reference/openshift_cli/getting-started.adoc
 
 [id="cli-logging-out_{context}"]
-= Logging out of the CLI
+= Logging out of the OpenShift CLI
 
-You can log out the CLI to end your current session.
+You can log out the OpenShift CLI to end your current session.
 
 * Use the `oc logout` command.
 +

--- a/modules/cli-using-cli.adoc
+++ b/modules/cli-using-cli.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/openshift_cli/getting-started.adoc
 
 [id="cli-using-cli_{context}"]
-= Using the CLI
+= Using the OpenShift CLI
 
 Review the following sections to learn how to complete common tasks using the CLI.
 

--- a/serverless/installing_serverless/installing-kn.adoc
+++ b/serverless/installing_serverless/installing-kn.adoc
@@ -12,7 +12,7 @@ toc::[]
 
 Installation options for the `oc` CLI will vary depending on your operating system.
 
-For more information on installing the `oc` CLI for your operating system and logging in with `oc`, see the xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[CLI getting started] documentation.
+For more information on installing the `oc` CLI for your operating system and logging in with `oc`, see the xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI getting started] documentation.
 ====
 
 include::modules/serverless-installing-cli-web-console.adoc[leveloffset=+1]

--- a/service_mesh/v1x/preparing-ossm-installation.adoc
+++ b/service_mesh/v1x/preparing-ossm-installation.adoc
@@ -22,7 +22,7 @@ If you are installing {ProductName} on a xref:../../installing/install_config/in
 ====
 +
 * Install the version of the {product-title} command line utility (the `oc` client tool) that matches your {product-title} version and add it to your path.
-** If you are using {product-title} {product-version}, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-about-cli_cli-developer-commands[About the CLI].
+** If you are using {product-title} {product-version}, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-about-cli_cli-developer-commands[About the OpenShift CLI].
 
 include::modules/ossm-supported-configurations-v1x.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/preparing-ossm-installation.adoc
+++ b/service_mesh/v2x/preparing-ossm-installation.adoc
@@ -24,7 +24,7 @@ If you are installing {ProductName} on a xref:../../installing/install_config/in
 ====
 +
 * Install the version of the {product-title} command line utility (the `oc` client tool) that matches your {product-title} version and add it to your path.
-** If you are using {product-title} {product-version}, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-about-cli_cli-developer-commands[About the CLI].
+** If you are using {product-title} {product-version}, see xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-about-cli_cli-developer-commands[About the OpenShift CLI].
 
 include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
 

--- a/virt/install/uninstalling-virt-cli.adoc
+++ b/virt/install/uninstalling-virt-cli.adoc
@@ -5,8 +5,9 @@ include::modules/virt-document-attributes.adoc[]
 toc::[]
 
 You can uninstall {VirtProductName} by using the {product-title}
-  xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[CLI].
+xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[CLI].
 
+[id="uninstalling-virt-cli-prereqs"]
 == Prerequisites
 
 * You must have {VirtProductName} {VirtVersion} installed.
@@ -20,6 +21,5 @@ and xref:../../virt/virtual_machines/virtual_disks/virt-deleting-datavolumes.ado
 Attempting to uninstall {VirtProductName} without deleting these objects
 results in failure.
 ====
-+
 
 include::modules/virt-deleting-virt-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
The OpenShift product family involves a number of different CLIs at this point (`oc`, `odo`, `rosa`, `opm`, `kn`, `tkn`, `operator-sdk`, etc.). `odo` also uses the name "Developer CLI" in places, which has some cross-over with a few `oc` headings. So OpenShift docs about `oc` should be more specific than they have been. Use "OpenShift CLI" unambiguously as much as possible when referring previously to simply "the CLI".

It's also been weird to me how far down the left-nav list "CLI tools" has gotten. This moves it further up, right after "Web console".

Preview (internal): http://file.rdu.redhat.com/~adellape/020421/openshift_cli_naming/cli_reference/openshift_cli/getting-started-cli.html