### PR TITLE
[OSP] Add provider network incompatibility warning to all installation assemblies

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -15,6 +15,8 @@ xref:../../architecture/architecture-installation.adoc#architecture-installation
 processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
 * Have a storage service installed in {rh-openstack}, like block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
 
 * Have metadata service enabled in {rh-openstack}

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -15,6 +15,8 @@ xref:../../architecture/architecture-installation.adoc#architecture-installation
 processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
 * Have a storage service installed in {rh-openstack}, like block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
 
 include::modules/installation-osp-about-kuryr.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -23,6 +23,8 @@ to complete all installation steps.
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes].
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by consulting the architecture documentation's xref:../../architecture/architecture-installation.html#available-platforms_architecture-installation[list of available platforms]. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
 * Have the metadata service enabled in {rh-openstack}.
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer.adoc
+++ b/installing/installing_openstack/installing-openstack-installer.adoc
@@ -14,6 +14,8 @@ In {product-title} version {product-version}, you can install a cluster on
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
 processes.
 
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
 * On {rh-openstack}, have access to an external network that does not overlap these CIDR ranges:
 ** `10.0.0.0/16`
 ** `172.30.0.0/16`

--- a/installing/installing_openstack/installing-openstack-user-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-kuryr.adoc
@@ -16,7 +16,9 @@ Using your own infrastructure allows you to integrate your cluster with existing
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
-* Have an {rh-openstack} account where you want to install {product-title}
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
+* Have an {rh-openstack} account where you want to install {product-title}.
 
 * On the machine from which you run the installation program, have:
 ** A single directory in which you can keep the files you create during the installation process

--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -16,7 +16,9 @@ Using your own infrastructure allows you to integrate your cluster with existing
 xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 ** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version in the _Available platforms_ section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 
-* Have an {rh-openstack} account where you want to install {product-title}
+* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
+
+* Have an {rh-openstack} account where you want to install {product-title}.
 
 * On the machine from which you run the installation program, have:
 ** A single directory in which you can keep the files you create during the installation process


### PR DESCRIPTION
This change adds a prereq to all OSP installation assemblies that warns
readers that OCP on OSP does not currently support provider networks.

Resolves #28556.

Previews should build shortly. 

LMK what you think, @mandre 

FYI @EricArrakis @sjstout 