### PR TITLE
Pt 2: Use 'OpenShift CLI' name unambiguously

### DIFF
--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -3,7 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: usage-oc-kubectl
 
-The Kubernetes command line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because OpenShift Container Platform is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with {product-title}, or you can gain extended functionality by using the `oc` binary.
+The Kubernetes command-line interface (CLI), `kubectl`, can be used to run commands against a Kubernetes cluster. Because {product-title} is a certified Kubernetes distribution, you can use the supported `kubectl` binaries that ship with {product-title}, or you can gain extended functionality by using the `oc` binary.
 
 == The oc binary
 

--- a/cli_reference/opm-cli.adoc
+++ b/cli_reference/opm-cli.adoc
@@ -1,11 +1,9 @@
 [id="opm-cli"]
-= `opm` CLI
+= opm CLI
 include::modules/common-attributes.adoc[]
 :context: opm-cli
 
 toc::[]
-
-This guide describes the `opm` CLI provided by the Operator Framework.
 
 include::modules/olm-about-opm.adoc[leveloffset=+1]
 .Additional resources

--- a/modules/cli-about-cli.adoc
+++ b/modules/cli-about-cli.adoc
@@ -5,8 +5,8 @@
 [id="cli-about-cli_{context}"]
 = About the OpenShift CLI
 
-With the {product-title} command-line interface (CLI), you can create applications and manage {product-title} projects from a terminal. The OpenShift CLI is ideal in the following situations:
+With the OpenShift command-line interface (CLI), the `oc` command, you can create applications and manage {product-title} projects from a terminal. The OpenShift CLI is ideal in the following situations:
 
 * Working directly with project source code
 * Scripting {product-title} operations
-* Working while restricted by bandwidth resources and the web console is unavailable
+* Managing projects while restricted by bandwidth resources and the web console is unavailable

--- a/modules/olm-about-opm.adoc
+++ b/modules/olm-about-opm.adoc
@@ -4,7 +4,7 @@
 // * cli_reference/opm-cli.adoc
 
 [id="olm-about-opm_{context}"]
-= About `opm`
+= About opm
 
 The `opm` CLI tool is provided by the Operator Framework for use with the Operator Bundle Format. This tool allows you to create and maintain catalogs of Operators from a list of bundles, called an _index_, that are similar to software repositories. The result is a container image, called an _index image_, which can be stored in a container registry and then installed on a cluster.
 

--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -10,7 +10,7 @@ ifndef::openshift-origin[]
 endif::[]
 
 [id="olm-installing-opm_{context}"]
-= Installing `opm`
+= Installing opm
 
 You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 


### PR DESCRIPTION
Some final edits and peer review changes didn't get pushed to https://github.com/openshift/openshift-docs/pull/29139, so following-up here. :|