### PR TITLE
Fix curl and add configuration instructions

### DIFF
--- a/modules/ipi-install-creating-an-rhcos-images-cache.adoc
+++ b/modules/ipi-install-creating-an-rhcos-images-cache.adoc
@@ -87,8 +87,8 @@ $ export RHCOS_OPENSTACK_SHA_COMPRESSED=$(curl -s -S https://raw.githubuserconte
 +
 [source,terminal]
 ----
-$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache
-$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache
+$ curl -L ${RHCOS_PATH}${RHCOS_QEMU_URI} -o /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI}
+$ curl -L ${RHCOS_PATH}${RHCOS_OPENSTACK_URI} -o /home/kni/rhcos_image_cache/${RHCOS_OPENSTACK_URI}
 ----
 
 . Confirm SELinux type is of `httpd_sys_content_t` for the newly created files.
@@ -106,4 +106,28 @@ $ podman run -d --name rhcos_image_cache \
 -v /home/kni/rhcos_image_cache:/var/www/html \
 -p 8080:8080/tcp \
 registry.centos.org/centos/httpd-24-centos7:latest
+----
+
+. Generate the bootstrapOSImage and clusterOSImage configuration
++
+[source,terminal]
+----
+$ export BAREMETAL_IP=$(ip addr show dev baremetal | awk '/inet /{print $2}' | cut -d"/" -f1
+$ export RHCOS_OPENSTACK_SHA256=$(zcat /home/kni/rhcos_image_cache/${RHCOS_OPENSTACK_URI} | sha256sum | awk '{print $1}')
+$ export RHCOS_QEMU_SHA256=$(zcat /home/kni/rhcos_image_cache/${RHCOS_QEMU_URI} | sha256sum | awk '{print $1}')
+$ export CLUSTER_OS_IMAGE="http://${BAREMETAL_IP}:8080/${RHCOS_OPENSTACK_URI}?sha256=${RHCOS_OPENSTACK_SHA256}"
+$ export BOOTSTRAP_OS_IMAGE="http://${BAREMETAL_IP}:8000/${RHCOS_QEMU_URI}?sha256=${RHCOS_QEMU_SHA256}"
+$ echo "${RHCOS_OPENSTACK_SHA256}  ${RHCOS_OPENSTACK_URI}" > /home/kni/rhcos_image_cache/rhcos-ootpa-latest.qcow2.md5sum
+$ echo "    bootstrapOSImage=${BOOTSTRAP_OS_IMAGE}"
+$ echo "    clusterOSImage=${CLUSTER_OS_IMAGE}"
+----
+
+. Add the required configuration to the `install-config.yaml` under `platform.baremetal`
++
+[source,yaml]
+----
+platform:
+  baremetal:
+    bootstrapOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_QEMU_URI>?sha256=<RHCOS_QEMU_SHA256>
+    clusterOSImage: http://<BAREMETAL_IP>:8080/<RHCOS_OPENSTACK_URI>?sha256=<RHCOS_OPENSTACK_SHA256>
 ----


### PR DESCRIPTION
The curl commands failed because a directory was specified as the output. Instructions were missing for downloading or otherwise generating the checksums and configuration needed for the install-config.yaml leaving the user uncertain as to how to use the rhcos_image_cache pod or directory to make the cache usable, especially required for air-gapped deployments.