### PR TITLE
CNF-802 - typo in performance profile snippet

### DIFF
--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -28,8 +28,7 @@ kind: PerformanceProfile
 metadata:
   name: manual
 spec:
-  globallyDisableIrqLoadBalancing:
-    enabled: "true"
+  globallyDisableIrqLoadBalancing: true
 ...
 ----
 


### PR DESCRIPTION
A typo that was missed in QE review has been fixed. This typo made the performance profile YAML invalid. 

Changed: 

`spec:
  globallyDisableIrqLoadBalancing:
    enabled: "true"`

to

`spec:
  globallyDisableIrqLoadBalancing:
    enabled: true`

