### PR TITLE
fixed [source,yaml] typo

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -53,7 +53,7 @@ kind: PerformanceProfile
 metadata:
  name: example-performanceprofile
 spec:
- [...]
+...
   realTimeKernel:
     enabled: true
   nodeSelector:

--- a/modules/configuring_hyperthreading_for_a_cluster.adoc
+++ b/modules/configuring_hyperthreading_for_a_cluster.adoc
@@ -66,7 +66,7 @@ $ cat /sys/devices/system/cpu/cpu0/topology/thread_siblings_list
 
 . Apply the isolated and reserved CPUs in the `PerformanceProfile` YAML. For example, you could set logical cores CPU0 and CPU4 as isolated, and logical cores CPU1 and CPU5 as reserved:
 +
-[source,YAML]
+[source,yaml]
 ----
 ...
   cpu:
@@ -88,7 +88,7 @@ When configuring clusters for low latency processing, consider whether you want 
 . Create a performance profile that is appropriate for your hardware and topology.
 . Set `nosmt` as an additional kernel argument. The following example performance profile illustrates this setting:
 
-[source,YAML]
+[source,yaml]
 ----
 ﻿apiVersion: performance.openshift.io/v2
 kind: PerformanceProfile


### PR DESCRIPTION
A typo `[source,YAML]` caused code blocks to be rendered without code highlighting. This has been corrected as `[source,yaml]`. 