### PR TITLE
BZ1919829: RateLimitInterval-->RateLimitIntervalSec/update default value

### DIFF
--- a/logging/config/cluster-logging-systemd.adoc
+++ b/logging/config/cluster-logging-systemd.adoc
@@ -5,12 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Because Fluentd reads from the journal, and the journal default 
-settings are very low, journal entries can be lost because the journal cannot keep up 
-with the logging rate from system services. 
+Because Fluentd reads from the journal, and the journal default settings are very low, journal entries can be lost because the journal cannot keep up with the logging rate from system services.
 
-We recommend setting `RateLimitInterval=1s` and `RateLimitBurst=10000` (or even higher if necessary)
-to prevent the journal from losing entries.
+We recommend setting `RateLimitIntervalSec=30s` and `RateLimitBurst=10000` (or even higher if necessary) to prevent the journal from losing entries.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
@@ -19,6 +16,3 @@ to prevent the journal from losing entries.
 
 
 include::modules/cluster-logging-systemd-scaling.adoc[leveloffset=+1]
-
-
-

--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -3,14 +3,14 @@
 // * logging/config/cluster-logging-systemd
 
 [id="cluster-logging-systemd-scaling_{context}"]
-= Configuring systemd-journald for OpenShift Logging 
+= Configuring systemd-journald for OpenShift Logging
 
 As you scale up your project, the default logging environment might need some
 adjustments.
 
 For example, if you are missing logs, you might have to increase the rate limits for journald.
 You can adjust the number of messages to retain for a specified period of time to ensure that
-OpenShift Logging does not use excessive resources without dropping logs. 
+OpenShift Logging does not use excessive resources without dropping logs.
 
 You can also determine if you want the logs compressed, how long to retain logs, how or if the logs are stored,
 and other settings.
@@ -26,7 +26,7 @@ ForwardToConsole=no <2>
 ForwardToSyslog=no
 MaxRetentionSec=1month <3>
 RateLimitBurst=10000 <4>
-RateLimitInterval=1s
+RateLimitIntervalSec=30s
 Storage=persistent <5>
 SyncIntervalSec=1s <6>
 SystemMaxUse=8g <7>
@@ -34,24 +34,24 @@ SystemKeepFree=20% <8>
 SystemMaxFileSize=10M <9>
 ----
 +
-<1> Specify whether you want logs compressed before they are written to the file system. 
+<1> Specify whether you want logs compressed before they are written to the file system.
 Specify `yes` to compress the message or `no` to not compress. The default is `yes`.
 <2> Configure whether to forward log messages. Defaults to `no` for each. Specify:
 * `ForwardToConsole` to forward logs to the system console.
 * `ForwardToKsmg` to forward logs to the kernel log buffer.
 * `ForwardToSyslog` to forward to a syslog daemon.
 * `ForwardToWall` to forward messages as wall messages to all logged-in users.
-<3> Specify the maximum time to store journal entries. Enter a number to specify seconds. Or 
-include a unit: "year", "month", "week", "day", "h" or "m". Enter `0` to disable. The default is `1month`. 
-<4> Configure rate limiting. If, during the time interval defined by `RateLimitIntervalSec`, more logs than specified in `RateLimitBurst` 
-are received, all further messages within the interval are dropped until the interval is over. It is recommended to set 
-`RateLimitInterval=1s` and `RateLimitBurst=10000`, which are the defaults.
-<5> Specify how logs are stored. The default is `persistent`: 
-* `volatile` to store logs in memory in `/var/log/journal/`. 
-* `persistent` to store logs to disk  in `/var/log/journal/`. systemd creates the directory if it does not exist. 
+<3> Specify the maximum time to store journal entries. Enter a number to specify seconds. Or
+include a unit: "year", "month", "week", "day", "h" or "m". Enter `0` to disable. The default is `1month`.
+<4> Configure rate limiting. If, during the time interval defined by `RateLimitIntervalSec`, more logs than specified in `RateLimitBurst`
+are received, all further messages within the interval are dropped until the interval is over. It is recommended to set
+`RateLimitIntervalSec=30s` and `RateLimitBurst=10000`, which are the defaults.
+<5> Specify how logs are stored. The default is `persistent`:
+* `volatile` to store logs in memory in `/var/log/journal/`.
+* `persistent` to store logs to disk  in `/var/log/journal/`. systemd creates the directory if it does not exist.
 * `auto` to store logs in  in `/var/log/journal/` if the directory exists. If it does not exist, systemd temporarily stores logs in `/run/systemd/journal`.
 * `none` to not store logs. systemd drops all logs.
-<6> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs. 
+<6> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs.
 systemd immediately syncs after receiving a *CRIT*, *ALERT*, or *EMERG* log. The default is `1s`.
 <7> Specify the maximum size the journal can use. The default is `8g`.
 <8> Specify how much disk space systemd must leave free. The default is `20%`.
@@ -77,7 +77,7 @@ $ export jrnl_cnf=$( cat /journald.conf | base64 -w0 )
 
 . Create a new `MachineConfig` object for master or worker and add the `journal.conf` parameters:
 +
-For example: 
+For example:
 +
 [source,yaml]
 ----
@@ -87,7 +87,7 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
   name: 50-corp-journald
-spec:  
+spec:
   config:
     ignition:
       version: 3.1.0
@@ -99,7 +99,7 @@ spec:
         overwrite: true
         path: /etc/systemd/journald.conf <2>
 ----
-<1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions. 
+<1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions.
 <2> Specify the path to the base64-encoded `journal.conf` file.
 
 . Create the machine config:
@@ -109,7 +109,7 @@ spec:
 $ oc apply -f <filename>.yaml
 ----
 +
-The controller detects the new `MachineConfig` object and generates a new `rendered-worker-<hash>` version. 
+The controller detects the new `MachineConfig` object and generates a new `rendered-worker-<hash>` version.
 
 . Monitor the status of the rollout of the new rendered configuration to each node:
 +
@@ -122,7 +122,7 @@ $ oc describe machineconfigpool/worker
 [source,terminal]
 ----
 Name:         worker
-Namespace:    
+Namespace:
 Labels:       machineconfiguration.openshift.io/mco-built-in=
 Annotations:  <none>
 API Version:  machineconfiguration.openshift.io/v1
@@ -131,6 +131,6 @@ Kind:         MachineConfigPool
 ...
 
 Conditions:
-  Message:               
+  Message:
   Reason:                All nodes are updating to rendered-worker-913514517bcea7c93bd446f4830bc64e
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1919829

I updated the default value and changed instances of RateLimitInterval to RateLimitIntervalSec. I also found this to further validate the need for the parameter name change: https://github.com/systemd/systemd/commit/f0367da7d1a61ad698a55d17b5c28ddce0dc265a

This change is for 4.6/4.7

Ready for QE: @anpingli 



