### PR TITLE
ContainerRuntimeConfig does not get removed when label is removed

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -5,25 +5,25 @@
 [id="create-a-containerruntimeconfig_{context}"]
 = Creating a `ContainerRuntimeConfig` CR to edit CRI-O parameters
 
-The `ContainerRuntimeConfig` custom resource definition (CRD) provides a structured way of changing settings associated with the {product-title} CRI-O runtime. Using a `ContainerRuntimeConfig` custom resource (CR), you select the configuration values you want and the MCO handles rebuilding the `crio.conf` and `storage.conf` configuration files.
+You can change some CRI-O runtime settings for the nodes associated with a specific machine config pool (MCP) using a `ContainerRuntimeConfig` custom resource (CR). In the CR, you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `storage.conf` configuration files on the associated nodes with the updated values.
 
-Parameters you can set in a `ContainerRuntimeConfig` CR include:
+You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
-* **PIDs limit**: Sets the maximum number of processes allowed in a container. By default, the limit is set to 1024 (`pids_limit = 1024`).
-* **Log level**: Sets the level of verbosity for log messages. The default is `info` (`log_level = info`). Other options include `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.
-* **Overlay size**: Sets the maxim size of a container image. The default is 10 GB.
-* **Maximum log size**: Sets the maximum size allowed for the container log file. The default maximum log size is unlimited (`log_size_max = -1`). If it is set to a positive number, it must be at least 8192 to not be smaller than  the `conmon` read buffer. Conmon is a program that
-monitors communications between a container manager (such as Podman or CRI-O) and the OCI runtime (such as runc or crun) for a single container.
+* **PIDs limit**: Sets the `pids_limit` parameter in the `crio.conf` file, which is the maximum number of processes allowed in a container. By default, the limit is 1024.
+* **Log level**: Sets the `log_level` parameter in the `crio.conf` file, which is the level of verbosity for log messages. The options are `info`, `fatal`, `panic`, `error`, `warn`, `debug`, and `trace`.  The default is `info`.
+* **Overlay size**: Sets the `overlay_size` parameter in the `storage.conf` file, which is the maximum size of a container image. The default is 10 GB.
+* **Maximum log size**: Sets the `log_size_max` parameter in the `crio.conf` file, which is the maximum size allowed for the container log file. The default maximum log size is `-1`, which is unlimited. If set to a positive number, the value must be at least 8192 to not be smaller than the `conmon` read buffer. Conmon is a program that monitors communications between a container manager (such as Podman or CRI-O) and the OCI runtime (such as runc or crun) for a single container.
 
-The following procedure describes how to change CRI-O settings using the `ContainerRuntimeConfig` CR.
+[NOTE]
+====
+To revert the changes implemented by using a `ContainerRuntimeConfig` CR, you must delete the CR. Removing the label from the machine config pool does not revert the changes.
+==== 
 
-.Procedure
+The following example configures CRI-O to raise the `pids_limit` parameter to 2048, sets the `log_level` parameter to `debug`, and sets the `overlay_size` parameter to 8 GB on the worker nodes:
 
-. To raise the `pidsLimit` to 2048, set the `logLevel` to `debug`, and set the `overlaySize` to 8 GB, create a CR file (for example, `overlay-size.yaml`) that contains that setting:
-+
+.Example `ContainerRuntimeConfig` CR
 [source,yaml]
 ----
-$ cat << EOF > /tmp/overlay-size.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: ContainerRuntimeConfig
 metadata:
@@ -31,39 +31,66 @@ metadata:
 spec:
  machineConfigPoolSelector:
    matchLabels:
-     custom-crio: overlay-size
+     pools.operator.machineconfiguration.openshift.io/worker= ''
  containerRuntimeConfig:
    pidsLimit: 2048
    logLevel: debug
+   logSizeMax: 8192
    overlaySize: 8G
 EOF
 ----
 
-. To apply the `ContainerRuntimeConfig` object settings, run:
+.Procedure
+
+To configure CRI-O by using a `ContainerRuntimeConfig` CR: 
+
+. Get the labels in the machine config pool associated with the nodes you want to manage:
 +
 [source,terminal]
 ----
-$ oc create -f /tmp/overlay-size
+$ oc get mcp --show-labels
 ----
++
+.Example output
+[source,terminal]
+----
+NAME     CONFIG                                             UPDATED   UPDATING   DEGRADED   MACHINECOUNT   READYMACHINECOUNT   UPDATEDMACHINECOUNT   DEGRADEDMACHINECOUNT   AGE    LABELS
+master   rendered-master-70bbdb350ba73e6751722d56721546fa   True      False      False      3              3                   3                     0                      145m   machineconfiguration.openshift.io/mco-built-in=,operator.machineconfiguration.openshift.io/required-for-upgrade=,pools.operator.machineconfiguration.openshift.io/master=
+worker   rendered-worker-0a6973d53405ec6268ce9e505a82fd72   True      False      False      3              3                   3                     0                      145m   machineconfiguration.openshift.io/mco-built-in=,pools.operator.machineconfiguration.openshift.io/worker=
+---- 
 
-. To verify that the settings wer applied, run:
+. Create a YAML file for the `ContainerRuntimeConfig` CR, similar to the following:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+ name: overlay-size
+spec:
+ machineConfigPoolSelector:
+   matchLabels:
+     pools.operator.machineconfiguration.openshift.io/worker= '' <1>
+ containerRuntimeConfig:
+   logLevel: debug <2>
+   logSizeMax: 8192 <3>
+   overlaySize: 8G <4>
+   pidsLimit: 2048 <5>
+----
+<1> Specify the machine config pool label.
+<2> Set the level of verbosity for log messages, as needed.
+<3> Set the maximum size allowed for the container log file, as needed. If set to a positive number, it must be at least `8192`.
+<4> Set the maximum size of a container image, as needed. 
+<5> Set the maximum number of processes allowed in a container, as needed.
+
+. Create the `ContainerRuntimeConfig` object:
 +
 [source,terminal]
 ----
-$ oc get ContainerRuntimeConfig
-NAME           AGE
-overlay-size   3m19s
-
+$ oc create -f <file-name>.yaml
 ----
 
-. To edit a pool of machines, such as `worker`, run the following command to open a machine config pool:
-+
-[source,terminal]
-----
-$ oc edit machineconfigpool worker
-----
-
-. Check that a new `containerruntime` object has appeared under the `machineconfigs`:
+. Check that a new `containerruntime` machine config is created:
 +
 [source,terminal]
 ----
@@ -87,11 +114,11 @@ worker  rendered-worker-169  False    True      False     3             1       
 
 . Open an `oc debug` session to a worker node and run `chroot /host`.
 
-. Verify the changes by running:
+. Verify the changes in the `crio.conf` file:
 +
 [source,terminal]
 ----
-$ crio config | egrep 'log_level|pids_limit'
+$ crio config | egrep 'log_level|pids_limit|log_size_max'
 ----
 +
 .Example output
@@ -99,8 +126,11 @@ $ crio config | egrep 'log_level|pids_limit'
 [source,terminal]
 ----
 pids_limit = 2048
+log_size_max = 10485760
 log_level = "debug"
 ----
+
+. Verify the change in the `storage.conf`file:
 +
 [source,terminal]
 ----
@@ -109,6 +139,7 @@ $ head -n 7 /etc/containers/storage.conf
 +
 .Example output
 +
+[source,terminal]
 ----
 [storage]
   driver = "overlay"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1874945

* Added note that user must delete CR to address the BZ.
* Reorganized the topic to make the procedure generic (currently it specifies how to set specific parameters. Moved the current example to above the procedure.
* Added a step and text to note the need to get the MCP label and add it to the CR.
* Other editorial changes. 

@umohnani8 requested we add a note that _the max number of ctrcfg or kubeletconfig objects that you can make is 10. Ideally they shouldn't make more if they are rolling out changes to the same mcp, they should update the existing one. But if they really want to make a new one, the max is 10. After they hit that, they will have to delete the cfg objects in reverse order (so most recent first 10, 9, 8...) to free up space to create more_. Will do this in a separate PR.
https://coreos.slack.com/archives/DLLJFC3E3/p1612548746006600  