### PR TITLE
Use v2 config for APIs

### DIFF
--- a/api-config.yaml
+++ b/api-config.yaml
@@ -1,3 +1,43 @@
+version: 2
+outputDir: rest_api
+apisToHide: []
+apiSupportLevels:
+- apiGroup: openshift\.io$
+  supportLevels:
+  - apiVersion: v\d+
+    level: 1
+  - apiVersion: v\d+beta\d+
+    level: 2
+  - apiVersion: v\d+alpha\d+
+    level: 4
+- apiGroup: ^\w+$
+  supportLevels:
+  - apiVersion: v\d+
+    level: 1
+  - apiVersion: v\d+beta\d+
+    level: 2
+- apiGroup: k8s\.io$
+  supportLevels:
+  - apiVersion: v\d+
+    level: 1
+  - apiVersion: v\d+beta\d+
+    level: 2
+- apiGroup: monitoring\.coreos\.com$
+  supportLevels:
+  - apiVersion: v\d+
+    level: 1
+- apiGroup: operators\.coreos\.com$
+  supportLevels:
+  - apiVersion: v\d+
+    level: 1
+  - apiVersion: v\d+alpha\d+
+    level: 3
+- apiGroup: metal3\.io$
+  supportLevels:
+  - apiVersion: v\d+alpha\d+
+    level: 4
+packageMap: {} # replace regex
+apiMap:
 - name: Authorization APIs
   resources:
   - kind: LocalResourceAccessReview


### PR DESCRIPTION
This introduces API support levels and an output dir.

Only relevant for 4.7+.