### PR TITLE
Add TP note to kdump doc

### DIFF
--- a/modules/investigating-kernel-crashes.adoc
+++ b/modules/investigating-kernel-crashes.adoc
@@ -5,9 +5,14 @@
 [id="investigating-kernel-crashes"]
 = Investigating kernel crashes
 
-== Enabling `kdump`
+== Enabling kdump
 
 The `kdump` service, included in `kexec-tools`, provides a crash-dumping mechanism. You can use this service to save the contents of the system’s memory for later analysis.
+
+The `kdump` service is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview
+features, see https://access.redhat.com/support/offerings/techpreview/.
 
 {op-system} ships with `kexec-tools`, but manual configuration is required to enable `kdump`.
 


### PR DESCRIPTION
This feature is being introduced in OCP 4.7 as tech preview, as stated in the [4.7 Release Notes](https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-rhcos-kdump). This PR adds the TP note in the kdump module, as opposed to the assembly, to keep it as part of kdump only.

Preview link: https://deploy-preview-29249--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operating-system-issues.html