### PR TITLE
Update examples to Ignition config spec v3-2-0

### DIFF
--- a/modules/installation-special-config-crony.adoc
+++ b/modules/installation-special-config-crony.adoc
@@ -54,7 +54,7 @@ spec:
       security:
         tls: {}
       timeouts: {}
-      version: 3.1.0
+      version: 3.2.0
     networkd: {}
     passwd: {}
     storage:

--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -343,7 +343,7 @@ $ mkdir kmods; cd kmods
 ----
 $ cat <<EOF > ./baseconfig.ign
 {
-  "ignition": { "version": "3.1.0" },
+  "ignition": { "version": "3.2.0" },
   "passwd": {
     "users": [
       {


### PR DESCRIPTION
Based on [4.7 Release Notes](https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-ignition), RHCOS now supports Ignition config spec 3.2.0. This PR updates a couple of instances in MCO examples from 3.1.0 -> 3.2.0. 