### PR TITLE
Changed Topology view to Graph view as text wherever required.

### DIFF
--- a/modules/odc-interacting-with-applications-and-components.adoc
+++ b/modules/odc-interacting-with-applications-and-components.adoc
@@ -5,9 +5,8 @@
 [id="odc-interacting-with-applications-and-components_{context}"]
 = Interacting with applications and components
 
-The *Topology view* in the *Developer* perspective of the web console provides the following options to interact with applications and components:
+The *Topology* view in the *Developer* perspective of the web console provides the following options to interact with applications and components:
 
-* Use the *Shortcuts* menu on the upper-right of the screen to navigate components in the *Topology view*.
 * Click *Open URL* (image:odc_open_url.png[title="Application Link"]) to see your application exposed by the route on a public URL.
 * Click *Edit Source code* to access your source code and modify it.
 +
@@ -37,5 +36,5 @@ The application resource name is appended with indicators for the different type
 +
 [NOTE]
 ====
-Serverless applications take some time to load and display on the *Topology view*. When you create a serverless application, it first creates a service resource and then a revision. After that, it is deployed and displayed on the *Topology view*. If it is the only workload, you might be redirected to the *Add* page. After the revision is deployed, the serverless application is displayed on the *Topology view*.
+Serverless applications take some time to load and display on the *Graph view*. When you deploy a serverless application, it first creates a service resource and then a revision. After that, it is deployed and displayed on the *Graph view*. If it is the only workload, you might be redirected to the *Add* page. After the revision is deployed, the serverless application is displayed on the *Graph view*.
 ====

--- a/modules/odc-viewing-application-topology.adoc
+++ b/modules/odc-viewing-application-topology.adoc
@@ -5,9 +5,9 @@
 [id="odc-viewing-application-topology_{context}"]
 = Viewing the topology of your application
 
-You can navigate to the *Topology view* using the left navigation panel in the *Developer* perspective. After you create an application, you are directed automatically to the *Topology view* where you can see the status of the application pods, quickly access the application on a public URL, access the source code to modify it, and see the status of your last build. You can zoom in and out to see more details for a particular application.
+You can navigate to the *Topology* view using the left navigation panel in the *Developer* perspective. After you deploy an application, you are directed automatically to the *Graph view* where you can see the status of the application pods, quickly access the application on a public URL, access the source code to modify it, and see the status of your last build. You can zoom in and out to see more details for a particular application.
 
-The *Topology view* also provides you the option to monitor your applications using the *List* view. Use the *List view* icon (image:odc_list_view_icon.png[title="List view icon"]) to see a list of all your applications and use the *Topology view* icon (image:odc_topology_view_icon.png[title="Topology view icon"]) to switch back to the graph view.
+The *Topology* view also provides you the option to monitor your applications using the *List* view. Use the *List view* icon (image:odc_list_view_icon.png[title="List view icon"]) to see a list of all your applications and use the *Graph view* icon (image:odc_topology_view_icon.png[title="Topology view icon"]) to switch back to the graph view.
 
 You can customize the views as required using the following:
 


### PR DESCRIPTION
Changed text "**Topology view**" to "**Graph view**" in the documentation.

For Openshift 4.7

This change is based on the dev issue: https://issues.redhat.com/browse/ODC-5355