### PR TITLE
CNV-BZ-1906354 Added note about OVN Kubernetes related regression in …

### DIFF
--- a/modules/virt-about-nmstate.adoc
+++ b/modules/virt-about-nmstate.adoc
@@ -3,7 +3,7 @@
 // * virt/node_network/virt-observing-node-network-state.adoc
 // * virt/node_network/virt-updating-node-network-config.adoc
 // * networking/k8s_nmstate/k8s-nmstate-observing-node-network-state.adoc
-// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc 
+// * networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
 
 [id="virt-about-nmstate_{context}"]
 = About nmstate
@@ -25,3 +25,8 @@ Node networking is monitored and updated by the following objects:
 * Bond
 
 * Ethernet
+
+[NOTE]
+====
+If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider. 
+====


### PR DESCRIPTION
…the nmstate docs

Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1906354

This is a known issue documented in the [2.5 release notes](https://docs.openshift.com/container-platform/4.6/virt/virt-2-5-release-notes.html#virt-2-5-known-issues). It is still not resolved and might stay that way for a while.

Added a note about the regression and its workaround at the end of the `About nmstate` module so that users who refer to the docs are aware.

Label enterprise-4.7 and enterprise-4.6

Preview build: https://deploy-preview-29318--osdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#virt-about-nmstate_virt-updating-node-network-config