### PR TITLE
BZ1834832: added that users can also have an HTTP or HTTPS proxy

### DIFF
--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -34,7 +34,7 @@ for your cluster.
 * You used the Ignition config files to create {op-system} machines for your
 cluster.
 ifndef::restricted[]
-* Your machines have direct Internet access.
+* Your machines have direct Internet access or have an HTTP or HTTPS proxy available.
 endif::restricted[]
 
 .Procedure


### PR DESCRIPTION
Based on [BZ1834832](https://bugzilla.redhat.com/show_bug.cgi?id=1834832) I added that users can also have an HTTP or HTTPS proxy to the pre-requisites 

Ready for QE: @wjiangjay 

For 4.4, 4.5, 4.6, 4.7