### PR TITLE
Remove experimental-allocatable-ignore-eviction

### DIFF
--- a/modules/nodes-nodes-resources-configuring-about.adoc
+++ b/modules/nodes-nodes-resources-configuring-about.adoc
@@ -36,8 +36,6 @@ An allocated amount of a resource is computed based on the following formula:
 ====
 The withholding of `Hard-Eviction-Thresholds` from allocatable is a change in behavior to improve
 system reliability now that allocatable is enforced for end-user pods at the node level.
-The `experimental-allocatable-ignore-eviction` setting is available to preserve legacy behavior,
-but it will be deprecated in a future release.
 ====
 
 If `[Allocatable]` is negative, it is set to *0*.


### PR DESCRIPTION
Per @rphillips the `experimental-allocatable-ignore-eviction` env var is not supported in 4.x