### PR TITLE
Add OSDK to CLI Tools guide and update mirror path

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -546,6 +546,9 @@ Topics:
 - Name: opm CLI
   File: opm-cli
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
+- Name: Operator SDK
+  File: operator-sdk
+  Distros: openshift-enterprise,openshift-webscale,openshift-origin
 ---
 Name: Security and compliance
 Dir: security
@@ -1137,7 +1140,7 @@ Topics:
   Topics:
   - Name: About Operator SDK
     File: osdk-about
-  - Name: Installing the CLI
+  - Name: Installing the Operator SDK CLI
     File: osdk-installing-cli
   - Name: Go-based Operators
     Dir: golang

--- a/cli_reference/operator-sdk.adoc
+++ b/cli_reference/operator-sdk.adoc
@@ -1,7 +1,7 @@
-[id="osdk-installing-cli"]
+[id="cli-tools-osdk"]
 = Installing the Operator SDK CLI
 include::modules/common-attributes.adoc[]
-:context: osdk-installing-cli
+:context: cli-tools-osdk
 
 toc::[]
 
@@ -13,3 +13,8 @@ The Operator SDK provides a CLI tool that Operator developers can use to create,
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]
+
+[id="cli-tools-osdk-addtl-resources"]
+== Additional resources
+
+See xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators] for full documentation on the Operator SDK.

--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -2,6 +2,8 @@
 //
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
+:osdk_ver: latest
+
 [id="osdk-installing-cli-linux-macos_{context}"]
 = Installing the Operator SDK CLI on Linux or macOS
 
@@ -19,15 +21,15 @@ endif::[]
 
 .Procedure
 
-. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/4.7.0/[OpenShift mirror site].
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/{osdk_ver}/[OpenShift mirror site].
 
-. From the `4.7.0/` directory, download the latest version of the tarball that matches your operating system. Linux tarballs have a `-linux.tar.gz` suffix, and macOS tarballs have a `-darwin.tar.gz` suffix.
+. From the `{osdk_ver}` directory, download the latest version of the tarball that matches your operating system. Linux tarballs have a `-linux.tar.gz` suffix, and macOS tarballs have a `-darwin.tar.gz` suffix.
 
 . Unpack the archive:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ tar xvzf operator-sdk-<version>-<os>.tar.gz
+$ tar xvf operator-sdk-v1.3.0-ocp-<os>.tar.gz
 ----
 
 . Make the file executable:
@@ -61,237 +63,4 @@ $ sudo mv operator-sdk-<release_version>-x86_64-linux-gnu /usr/local/bin/operato
 $ operator-sdk version
 ----
 
-////
-. Set the release version variable:
-+
-[source,terminal]
-----
-$ RELEASE_VERSION=v0.19.4
-----
-
-. Download the release binary.
-+
---
-* For Linux:
-+
-[source,terminal]
-----
-$ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
-----
-
-* For macOS:
-+
-[source,terminal]
-----
-$ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
-----
---
-
-. Verify the downloaded release binary.
-
-.. Download the provided `.asc` file.
-+
---
-* For Linux:
-+
-[source,terminal]
-----
-$ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
-----
-
-* For macOS:
-+
-[source,terminal]
-----
-$ curl -OJL https://github.com/operator-framework/operator-sdk/releases/download/${RELEASE_VERSION}/operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
-----
---
-
-.. Place the binary and corresponding `.asc` file into the same directory and run the following command to verify the binary:
-+
---
-* For Linux:
-+
-[source,terminal]
-----
-$ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu.asc
-----
-
-* For macOS:
-+
-[source,terminal]
-----
-$ gpg --verify operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin.asc
-----
---
-+
-If you do not have the public key of the maintainer on your workstation, you will get the following error:
-+
-.Example output with error
-[source,terminal]
-----
-$ gpg: assuming signed data in 'operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin'
-$ gpg: Signature made Fri Apr  5 20:03:22 2019 CEST
-$ gpg:                using RSA key <key_id> <1>
-$ gpg: Can't check signature: No public key
-----
-<1> RSA key string.
-+
-To download the key, run the following command, replacing `<key_id>` with the RSA key string provided in the output of the previous command:
-+
-[source,terminal]
-----
-$ gpg [--keyserver keys.gnupg.net] --recv-key "<key_id>" <1>
-----
-<1> If you do not have a key server configured, specify one with the `--keyserver` option.
-
-. Install the release binary in your `PATH`:
-+
---
-* For Linux:
-+
-[source,terminal]
-----
-$ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
-----
-+
-[source,terminal]
-----
-$ sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu /usr/local/bin/operator-sdk
-----
-+
-[source,terminal]
-----
-$ rm operator-sdk-${RELEASE_VERSION}-x86_64-linux-gnu
-----
-
-* For macOS:
-+
-[source,terminal]
-----
-$ chmod +x operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
-----
-+
-[source,terminal]
-----
-$ sudo cp operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin /usr/local/bin/operator-sdk
-----
-+
-[source,terminal]
-----
-$ rm operator-sdk-${RELEASE_VERSION}-x86_64-apple-darwin
-----
---
-
-. Verify that the CLI tool was installed correctly:
-+
-[source,terminal]
-----
-$ operator-sdk version
-----
-
-[id="osdk-installing-cli-homebrew_{context}"]
-== Installing from Homebrew
-
-You can install the SDK CLI using Homebrew.
-
-.Prerequisites
-
-- link:https://brew.sh/[Homebrew]
-ifdef::openshift-origin[]
-- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
-endif::[]
-ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
-endif::[]
-- OpenShift CLI (`oc`) v{product-version}+ installed
-- Access to a cluster based on Kubernetes v1.12.0+
-- Access to a container registry
-
-.Procedure
-
-. Install the SDK CLI using the `brew` command:
-+
-[source,terminal]
-----
-$ brew install operator-sdk
-----
-
-. Verify that the CLI tool was installed correctly:
-+
-[source,terminal]
-----
-$ operator-sdk version
-----
-
-[id="osdk-installing-cli-source_{context}"]
-== Compiling and installing from source
-
-You can obtain the Operator SDK source code to compile and install the SDK CLI.
-
-.Prerequisites
-
-- link:https://git-scm.com/downloads[Git]
-- link:https://golang.org/dl/[Go] v1.13+
-ifdef::openshift-origin[]
-- link:https://docs.docker.com/install/[`docker`] v17.03+, link:https://github.com/containers/libpod/blob/master/install.md[`podman`] v1.2.0+, or link:https://github.com/containers/buildah/blob/master/install.md[`buildah`] v1.7+
-endif::[]
-ifndef::openshift-origin[]
-- `docker` v17.03+, `podman` v1.9.3+, or `buildah` v1.7+
-endif::[]
-- OpenShift CLI (`oc`) v{product-version}+ installed
-- Access to a cluster based on Kubernetes v1.12.0+
-- Access to a container registry
-
-.Procedure
-
-. Clone the `operator-sdk` repository:
-+
-[source,terminal]
-----
-$ mkdir -p $GOPATH/src/github.com/operator-framework
-----
-+
-[source,terminal]
-----
-$ cd $GOPATH/src/github.com/operator-framework
-----
-+
-[source,terminal]
-----
-$ git clone https://github.com/operator-framework/operator-sdk
-----
-+
-[source,terminal]
-----
-$ cd operator-sdk
-----
-
-. Check out the desired release branch:
-+
-[source,terminal]
-----
-$ git checkout master
-----
-
-. Compile and install the SDK CLI:
-+
-[source,terminal]
-----
-$ make dep
-----
-+
-[source,terminal]
-----
-$ make install
-----
-+
-This installs the CLI binary `operator-sdk` at *_$GOPATH/bin_*.
-
-. Verify that the CLI tool was installed correctly:
-+
-[source,terminal]
-----
-$ operator-sdk version
-----
-////
+:!osdk_ver:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1927072

Updates the mirror path to the latest RC build of `operator-sdk`. Will update to the final version when it's closer to 4.7 GA.

Also duplicates the "Installing the Operator SDK CLI" doc into the _CLI Tools_ guide.

Preview:

* [CLI Tools -> Installing the Operator SDK CLI](https://deploy-preview-29336--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/operator-sdk.html)
* [Operators -> Developing Operators -> Installing the Operator SDK CLI](https://deploy-preview-29336--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html)