### PR TITLE
Remove misleading lines in builds-create-custom-build-artifacts

### DIFF
--- a/modules/builds-create-custom-build-artifacts.adoc
+++ b/modules/builds-create-custom-build-artifacts.adoc
@@ -16,11 +16,6 @@ You must create the image you want to use as your custom build image.
 ----
 FROM docker.io/centos:7
 RUN yum install -y buildah
-----
-+
-.Example output
-[source,terminal]
-----
 # In this example, `/tmp/build` contains the inputs that build when this
 # custom builder image is run. Normally the custom builder image fetches
 # this content from some location at build time, by using git clone as an example.
@@ -45,11 +40,6 @@ RUN touch /tmp/built
 [source,terminal]
 ----
 #!/bin/sh
-----
-+
-.Example output
-[source,terminal]
-----
 # Note that in this case the build inputs are part of the custom builder image, but normally this
 # is retrieved from an external source.
 cd /tmp/input


### PR DESCRIPTION
Remove "Example output" misleading lines that are splitting the code
snippet in two misleading sections, confusing the reader, there is no
output there, is just a dockerfile and a bash script.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>