### PR TITLE
RHDEVDOCS-2604 Wrong value and definition for legacy syslog hostname

### DIFF
--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -81,27 +81,26 @@ To configure {product-title} to forward logs using the legacy configuration meth
 @type <type> <1>
 remote_syslog <syslog-server> <2>
 port 514 <3>
-hostname <host> <4>
-remove_tag_prefix <prefix> <5>
+hostname ${hostname}
+remove_tag_prefix <prefix> <4>
 facility <value>
 severity <value>
 use_record <value>
 payload_key message
-rfc 3164 <6>
+rfc 3164 <5>
 </store>
 ----
 <1> Specify the protocol to use, either: `syslog` or `syslog_buffered`.
 <2> Specify the FQDN or IP address of the syslog server.
 <3> Specify the port of the syslog server.
-<4> Specify a name for this syslog server.
-<5> Optional. Specify the appropriate syslog parameters, for example:
+<4> Optional: Specify the appropriate syslog parameters, for example:
 ** Parameter to  remove the specified `tag` field from the syslog prefix.
 ** Parameter to set the specified field as the syslog key.
 ** Parameter to specify the syslog log facility or source.
 ** Parameter to specify the syslog log severity.
 ** Parameter to use the severity and facility from the record if available. If `true`, the `container_name`, `namespace_name`, and `pod_name` are included in the output content.
 ** Parameter to specify the key to set the payload of the syslog message. Defaults to `message`.
-<6> Specify the RFC protocol to use: `3164`.
+<5> With the legacy syslog method, you must specify `3164` for the `rfc` value.
 
 . Create a config map named `syslog` in the `openshift-logging` project from the configuration file:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/RHDEVDOCS-2604
[enterprise-4.6][enterprise-4.7][enterprise-4.8]