### PR TITLE
BZ#1926482: no change to net policy for mig

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -35,7 +35,6 @@ If your cluster uses any of the following OpenShift SDN capabilities, you must m
 * Egress network policies
 * Egress router pods
 * Multicast
-* Network policies
 
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN.
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1926482.

No changes to network policies are needed for
an SDN to OVN-Kubernetes migration.

The bullet for "Network policies" is removed from the list on the foll page:
https://deploy-preview-29396--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn