### PR TITLE
RHDEVDOCS-2607 Little typo in output name fluentd-server-inecure

### DIFF
--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -7,7 +7,7 @@
 
 You can use the Log forwarding API to send a copy of the application logs from specific projects to an external log aggregator instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
-To configure forwarding application logs from a project, create a `ClusterLogForwarder` custom resource (CR) with at least one input from a project, optional outputs for other log aggregators, and pipelines that use those inputs and outputs. 
+To configure forwarding application logs from a project, create a `ClusterLogForwarder` custom resource (CR) with at least one input from a project, optional outputs for other log aggregators, and pipelines that use those inputs and outputs.
 
 .Procedure
 
@@ -27,7 +27,7 @@ spec:
      url: 'tls://fluentdserver.security.example.com:24224' <5>
      secret: <6>
         name: fluentd-secret
-   - name: fluentd-server-inecure
+   - name: fluentd-server-insecure
      type: fluentdForward
      url: 'tcp://fluentdserver.home.example.com:24224'
   inputs: <7>


### PR DESCRIPTION
Little typo in output name fluentd-server-inecure
https://issues.redhat.com/browse/RHDEVDOCS-2607
[enterprise-4.6][enterprise-4.7][enterprise-4.8]