### PR TITLE
Rename OSDK 'quickstarts' to 'getting started'

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1157,7 +1157,7 @@ Topics:
   - Name: Go-based Operators
     Dir: golang
     Topics:
-    - Name: Quickstart
+    - Name: Getting started
       File: osdk-golang-quickstart
     - Name: Tutorial
       File: osdk-golang-tutorial
@@ -1166,7 +1166,7 @@ Topics:
   - Name: Ansible-based Operators
     Dir: ansible
     Topics:
-    - Name: Quickstart
+    - Name: Getting started
       File: osdk-ansible-quickstart
     - Name: Tutorial
       File: osdk-ansible-tutorial
@@ -1183,7 +1183,7 @@ Topics:
   - Name: Helm-based Operators
     Dir: helm
     Topics:
-    - Name: Quickstart
+    - Name: Getting started
       File: osdk-helm-quickstart
     - Name: Tutorial
       File: osdk-helm-tutorial

--- a/modules/osdk-quickstart.adoc
+++ b/modules/osdk-quickstart.adoc
@@ -198,7 +198,7 @@ endif::[]
 
 . *Clean up.*
 +
-Run the following command to clean up the resources that have been created as part of this quickstart:
+Run the following command to clean up the resources that have been created as part of this procedure:
 +
 [source,terminal]
 ----

--- a/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
@@ -1,5 +1,5 @@
 [id="osdk-ansible-quickstart"]
-= Operator SDK quickstart for Ansible-based Operators
+= Getting started with Operator SDK for Ansible-based Operators
 include::modules/common-attributes.adoc[]
 :context: osdk-ansible-quickstart
 

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -19,7 +19,7 @@ Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access 
 
 [NOTE]
 ====
-This tutorial goes into greater detail than xref:../../../operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc#osdk-ansible-quickstart[Operator SDK quickstart for Ansible-based Operators].
+This tutorial goes into greater detail than xref:../../../operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc#osdk-ansible-quickstart[Getting started with Operator SDK for Ansible-based Operators].
 ====
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]

--- a/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
@@ -1,5 +1,5 @@
 [id="osdk-golang-quickstart"]
-= Operator SDK quickstart for Go-based Operators
+= Getting started with Operator SDK for Go-based Operators
 include::modules/common-attributes.adoc[]
 :context: osdk-golang-quickstart
 

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -15,7 +15,7 @@ Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access 
 
 [NOTE]
 ====
-This tutorial goes into greater detail than xref:../../../operators/operator_sdk/golang/osdk-golang-quickstart.adoc#osdk-golang-quickstart[Operator SDK quickstart for Go-based Operators].
+This tutorial goes into greater detail than xref:../../../operators/operator_sdk/golang/osdk-golang-quickstart.adoc#osdk-golang-quickstart[Getting started with Operator SDK for Go-based Operators].
 ====
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]

--- a/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
@@ -1,5 +1,5 @@
 [id="osdk-helm-quickstart"]
-= Operator SDK quickstart for Helm-based Operators
+= Getting started with Operator SDK for Helm-based Operators
 include::modules/common-attributes.adoc[]
 :context: osdk-helm-quickstart
 

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -19,7 +19,7 @@ Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access 
 
 [NOTE]
 ====
-This tutorial goes into greater detail than xref:../../../operators/operator_sdk/helm/osdk-helm-quickstart.adoc#osdk-helm-quickstart[Operator SDK quickstart for Helm-based Operators].
+This tutorial goes into greater detail than xref:../../../operators/operator_sdk/helm/osdk-helm-quickstart.adoc#osdk-helm-quickstart[Getting started with Operator SDK for Helm-based Operators].
 ====
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]


### PR DESCRIPTION
To avoid unnecessary confusion with the web console ["quick start"](https://github.com/openshift/openshift-docs/pull/28577) docs going in for OCP 4.7.