### PR TITLE
Added 4.7 cluster metrics section + no backticks in headings

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -62,7 +62,7 @@ On new clusters, LUKS configuration must use the native Ignition mechanism, as p
 ====
 
 [id="ocp-4-7-bootupd"]
-==== Update the bootloader by using `bootupd`
+==== Update the bootloader by using bootupd
 
 With `bootupd`, {op-system} users now have access to a cross-distribution, system-agnostic OS update tool that manages firmware and boot updates in UEFI and legacy BIOS boot modes that run on modern architectures.
 
@@ -72,7 +72,7 @@ With `bootupd`, {op-system} users now have access to a cross-distribution, syste
 {op-system} is now using Red Hat Enterprise Linux (RHEL) 8.3 packages. {product-title} 4.6 and below will stay with RHEL 8.2 packages. This enables you to have the latest fixes, features, and enhancements, such as NetworkManager features, as well as the latest hardware support and driver updates.
 
 [id="ocp-4-7-rhcos-kdump"]
-==== {op-system} now supports `kdump` service (Technical Preview)
+==== {op-system} now supports kdump service (Technical Preview)
 The `kdump` service is introduced in Technical Preview in {op-system} to provide a crash-dumping mechanism for debugging kernel issues. You can use this service to save system memory content for later analysis. The `kdump` service is not managed at the cluster-level and must be enabled and configured manually on a per-node basis.
 
 [id="ocp-4-7-ignition"]
@@ -509,6 +509,13 @@ This dashboard provides API server metrics, such as:
 [id="ocp-4-7-scale"]
 === Scale
 
+[id="ocp-4-7-scale-cluster-maximums"]
+==== Cluster maximums
+
+Updated guidance around xref:../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[cluster maximums] for {product-title} {product-version} is now available.
+
+Use the link:https://access.redhat.com/labs/ocplimitscalculator/[{product-title} Limit Calculator] to estimate cluster limits for your environment.
+
 [id="ocp-4-7-cnf-latency-test"]
 ==== Test to determine CPU latency
 The latency test, a part of the CNF-test container, provides a way to measure if the isolated CPU latency is below the requested upper bound.
@@ -516,7 +523,7 @@ The latency test, a part of the CNF-test container, provides a way to measure if
 For information about running a latency test, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-performing-end-to-end-tests-running-the-latency_tests[Running the latency tests].
 
 [id="ocp-4-7-scale-pao-disable-interrupt-processing"]
-==== New `globallyDisableIrqLoadBalancing` feature in Performance Addon Operator allows global device interrupt processing to be disabled for guaranteed pod CPUs
+==== New globallyDisableIrqLoadBalancing feature in Performance Addon Operator allows global device interrupt processing to be disabled for guaranteed pod CPUs
 
 The Performance Addon Operator manages host CPUs by dividing them into reserved CPUs for cluster and operating system housekeeping duties, and isolated CPUs for workloads. A new performance profile field `globallyDisableIrqLoadBalancing` is available to manage whether or not device interrupts are processed by the isolated CPU set.
 


### PR DESCRIPTION
Preview build: https://deploy-preview-29420--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-scale