### PR TITLE
fix for determining correct RHCOS image to use

### DIFF
--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -48,7 +48,7 @@ spec:
           disks:
           - autoDelete: true
             boot: true
-            image: <infrastructureID>-rhcos-image <1>
+            image: <path_to_image> <5>
             labels: null
             sizeGb: 128
             type: pd-ssd
@@ -80,3 +80,11 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the infrastructure ID and node label.
 <3> Specify the node label to add.
 <4> Specify the name of the GCP project that you use for your cluster.
+<5> Specify the path to the image that is used in current machine sets. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-api \
+    -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
+    get machineset/<infrastructureID>-worker-a
+----


### PR DESCRIPTION
The current way the docs specify the image to use for a new MachineSet
is incorrect.  Users need to query an existing MachineSet to determine
the correct value to use for the `image:` field.