### PR TITLE
BZ1819837: Added hyperlink

### DIFF
--- a/logging/config/cluster-logging-storage-considerations.adoc
+++ b/logging/config/cluster-logging-storage-considerations.adoc
@@ -19,3 +19,7 @@ memory setting, though this is not recommended for production environments.
 
 include::modules/cluster-logging-deploy-storage-considerations.adoc[leveloffset=+1]
 
+[id="cluster-logging-storage-considerations-addtl-resources"]
+== Additional resources
+
+* xref:../../logging/config/cluster-logging-log-store.adoc#cluster-logging-elasticsearch-storage_cluster-logging-store[Persistent Elasticsearch Storage]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1819837

I added additional resources and a link to information about Persistent ElasticSearch Storage. 

Preview of the doc is here: https://deploy-preview-29439--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-storage-considerations.html#cluster-logging-storage-considerations-addtl-resources

This is for 4.5+. I discussed with Michael Burke, and he says that the cluster logging docs are different in 4.4 due to a re-org he did for 4.5. I would need to do a separate PR for the 4.4 change. Not sure it's worth it, since 4.4 will be retired soon. I can do it though, so let me know if its warranted.

Ready for QE @bostrt 