### PR TITLE
4.7 RN: Add known Kuryr issue with UPI

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1026,23 +1026,23 @@ INFO Use the following commands to gather logs from the cluster
 INFO openshift-install gather bootstrap --help
 FATAL failed to wait for bootstrapping to complete: timed out waiting for the condition
 ----
-
++
 The timeout is caused by changes in how Kuryr detects the {rh-openstack} Networking service (neutron) subnet of the cluster's nodes. 
-
++
 As a workaround, do not remove the control plane machine manifests as described by the "Creating the Kubernetes manifest and Ignition config files" section in the installation documentation. When you are instructed to run the following command:
 +
 [source,terminal]
 ----
 $ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
-
++
 Run this command instead:
 +
 [source,terminal]
 ----
 $ rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
-
++
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927244[*BZ#1927244*])
 
 [id="ocp-4-7-asynchronous-errata-updates"]

--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1014,6 +1014,34 @@ The root cause of this issue is unknown and no workaround currently exists.
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1913279[*BZ#1913279*])
 
+* Installing a cluster on {rh-openstack} that uses Kuryr times out with the following messages during bootstrapping: 
++
+[source,terminal]
+----
+INFO Waiting up to 20m0s for the Kubernetes API at https://api.ostest.shiftstack.com:6443...
+INFO API v1.20.0+ba45583 up
+INFO Waiting up to 30m0s for bootstrapping to complete...
+ERROR Attempted to gather ClusterOperator status after wait failure: listing ClusterOperator objects: Get "https://api.ostest.shiftstack.com:6443/apis/config.openshift.io/v1/clusteroperators": dial tcp 10.46.44.166:6443: connect: connection refused
+INFO Use the following commands to gather logs from the cluster
+INFO openshift-install gather bootstrap --help
+FATAL failed to wait for bootstrapping to complete: timed out waiting for the condition
+----
+
+The time out is caused by changes in how Kuryr detects the {rh-openstack} Networking service (neutron) subnet of the cluster's nodes. 
+
+As a workaround, do not remove the control plane machine manifests as described by the "Creating the Kubernetes manifest and Ignition config files" section in the installation documentation. When you are instructed to run the following command:
++
+[source,terminal]
+----
+$ rm -f openshift/99_openshift-cluster-api_master-machines-*.yaml openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+----
+
+Run this command instead:
++
+[source,terminal]
+----
+$ rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
+----
 
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates

--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1027,7 +1027,7 @@ INFO openshift-install gather bootstrap --help
 FATAL failed to wait for bootstrapping to complete: timed out waiting for the condition
 ----
 
-The time out is caused by changes in how Kuryr detects the {rh-openstack} Networking service (neutron) subnet of the cluster's nodes. 
+The timeout is caused by changes in how Kuryr detects the {rh-openstack} Networking service (neutron) subnet of the cluster's nodes. 
 
 As a workaround, do not remove the control plane machine manifests as described by the "Creating the Kubernetes manifest and Ignition config files" section in the installation documentation. When you are instructed to run the following command:
 +

--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1043,6 +1043,8 @@ Run this command instead:
 $ rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 ----
 
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1927244[*BZ#1927244*])
+
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
We've discovered the problem with UPI installations with Kuryr [1] and
realized there's a simple workaround to the issue. This commit adds
information about it to the 4.7 relase notes.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1927244