### PR TITLE
Remove finalizers on CSI snapshot objects

### DIFF
--- a/modules/persistent-storage-csi-snapshots-delete.adoc
+++ b/modules/persistent-storage-csi-snapshots-delete.adoc
@@ -9,10 +9,7 @@ You can configure how {product-title} deletes volume snapshots.
 
 .Procedure
 
-To enable deletion of a volume snapshot in a cluster:
-
 . Specify the deletion policy that you require in the `VolumeSnapshotClass` object, as shown in the following example:
-
 +
 .volumesnapshotclass.yaml
 [source,yaml]
@@ -24,6 +21,47 @@ metadata:
 driver: hostpath.csi.k8s.io
 deletionPolicy: Delete <1>
 ----
-<1> If the `Delete` value is set, the underlying snapshot will be deleted, along with the `VolumeSnapshotContent` object. If the `Retain` value is set, both the underlying snapshot and `VolumeSnapshotContent` object remain.
+<1> When deleting the volume snapshot, if the `Delete` value is set, the underlying snapshot is deleted along with the `VolumeSnapshotContent` object. If the `Retain` value is set, both the underlying snapshot and `VolumeSnapshotContent` object remain.
   +
-If the `Retain` value is set, and the `VolumeSnapshot` object is deleted without deleting the corresponding `VolumeSnapshotContent` object, then the content will remain. The snapshot itself is also retained in the storage back end.
+If the `Retain` value is set and the `VolumeSnapshot` object is deleted without deleting the corresponding `VolumeSnapshotContent` object, the content remains. The snapshot itself is also retained in the storage back end.
+
+. Delete the volume snapshot by entering the following command:
+
++
+[source,terminal]
+----
+$ oc delete volumesnapshot <volumesnapshot_name>
+----
++
+.Example output
+[source, terminal]
+----
+volumesnapshot.snapshot.storage.k8s.io "mysnapshot" deleted
+----
+. If the deletion policy is set to `Retain`, delete the volume snapshot content by entering the following command:
++
+[source,terminal]
+----
+$ oc delete volumesnapshotcontent <volumesnapshotcontent_name>
+----
++
+. Optional: If the `VolumeSnapshot` object is not successfully deleted, enter the following command to remove any finalizers for the leftover resource so that the delete operation can continue:
++
+[IMPORTANT]
+====
+Only remove the finalizers if you are confident that there are no existing references from either persistent volume claims or volume snapshot contents to the `VolumeSnapshot` object.
+Even with the `--force` option, the delete operation does not delete snapshot objects until all finalizers are removed.
+====
++
+[source,terminal]
+----
+$ oc patch -n $PROJECT volumesnapshot/$NAME --type=merge -p '{"metadata": {"finalizers":null}}'
+----
++
+.Example output
+[source, terminal]
+----
+volumesnapshotclass.snapshot.storage.k8s.io "csi-ocs-rbd-snapclass" deleted
+----
++
+The finalizers are removed and the volume snapshot is deleted.


### PR DESCRIPTION
[BZ1896084](https://bugzilla.redhat.com/show_bug.cgi?id=1896084)
Adds instructions for removing finalizers to support volume snapshot delete operations. Includes note that force option is not sufficient.