### PR TITLE
consistently use term QoS class not tier

### DIFF
--- a/modules/nodes-cluster-overcommit-configure-nodes.adoc
+++ b/modules/nodes-cluster-overcommit-configure-nodes.adoc
@@ -64,4 +64,4 @@ You can also perform the following configurations for each node:
 
 * Reserve resources for system processes
 
-* Reserve memory across quality of service tiers
+* Reserve memory across quality of service classes

--- a/modules/nodes-cluster-overcommit-qos-about.adoc
+++ b/modules/nodes-cluster-overcommit-qos-about.adoc
@@ -53,7 +53,7 @@ exist.
 these containers are first to be terminated if the system runs out of memory.
 
 [id="qos-about-reserve_{context}"]
-== Understanding how to reserve memory across quality of service tiers
+== Understanding how to reserve memory across quality of service classes
 
 You can use the `qos-reserved` parameter to specify a percentage of memory to be reserved
 by a pod in a particular QoS level. This feature attempts to reserve requested resources to exclude pods

--- a/modules/nodes-cluster-overcommit-qos-about.adoc
+++ b/modules/nodes-cluster-overcommit-qos-about.adoc
@@ -57,7 +57,7 @@ these containers are first to be terminated if the system runs out of memory.
 
 You can use the `qos-reserved` parameter to specify a percentage of memory to be reserved
 by a pod in a particular QoS level. This feature attempts to reserve requested resources to exclude pods
-from lower OoS classes from using resources requested by pods in higher QoS classes.
+from lower QoS classes from using resources requested by pods in higher QoS classes.
 
 {product-title} uses the `qos-reserved` parameter as follows:
 


### PR DESCRIPTION
The term _tier_ is used only twice on https://docs.openshift.com/container-platform/4.6/nodes/clusters/nodes-cluster-overcommit.html while _class_ is used several times. I believe the use of _tier_ is inconsistent. This PR rectifies that.