### PR TITLE
Clarify the warning about modifying manifest files

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -29,6 +29,7 @@ parameter.
 [IMPORTANT]
 ====
 Modifying the {product-title} manifest files directly is not supported.
+All modifications must be supplied in additional manifests.
 ====
 
 .Prerequisites


### PR DESCRIPTION
The documentation warns that modifying manifest files directly is not supported, and then directs users to create additional ones.
The implication here appears to be that creating and changing CRs is allowed, it just needs to happen in a new manifest rather than modifying an existing one.

Updating the documentation to state this explicitly

Preview:
- [Modifying advanced network configuration parameters](https://deploy-preview-29488--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#modifying-nwoperator-config-startup_installing-aws-network-customizations)