### PR TITLE
BZ-1898620 Clipboard line wraps fix

### DIFF
--- a/_javascripts/clipboard.js
+++ b/_javascripts/clipboard.js
@@ -11,14 +11,19 @@ document.querySelectorAll('span.clipboard-button').forEach((copybutton, index) =
 var clipboard = new ClipboardJS('.clipboard-button', {
     text: function(target) {
       const targetId = target.getAttribute('data-clipboard-target').substr(1);
-      const clipboardText = document.getElementById(targetId).innerText.replace(/\$[ ]/g, "");
+      let clipboardText;
+      clipboardText = document.getElementById(targetId).innerText.replace(/\$[ ]/g, "");
 
-      if (clipboardText.slice(0, 2) === "# ") {
-        return clipboardText.substr(2);
+      if (clipboardText.slice(0,2) === "# ") {
+        clipboardText = clipboardText.substr(2);
       }
 
       if (clipboardText.slice(0,5) === "sh-4.") {
-        return clipboardText.substr(8)
+        clipboardText = clipboardText.substr(8);
+      }
+
+      if (clipboardText.split(/\r\n|\n|\r/)[0].endsWith("\\ ") | clipboardText.split(/\r\n|\n|\r/)[0].endsWith("\\")) {
+        clipboardText = clipboardText.replace(/(\\[ ]\r\n|\\[ ]\n|\\[ ]\r|\\\r\n|\\\n|\\\r)/g,"").replace(/(\s+|\t)/g," ");
       }
 
       return clipboardText;


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1898620

Removing line wraps `/` in code blocks to prevent commands from executing prematurely.

Preview examples:
**Note** - To check for other examples, the example must be x2 levels into the side ToC/books. For example, Installing > Installing on AWS > example.

http://shell.lab.bos.redhat.com/~lbarbeev/031121/BZ-1898620-clipboard-line-wraps/installing/installing_aws/installing-aws-default.html#ssh-agent-using_installing-aws-default
`ssh-keygen -t ed25519 -N '' -f <path>/<file_name> `

http://shell.lab.bos.redhat.com/~lbarbeev/031121/BZ-1898620-clipboard-line-wraps/service_mesh/v2x/ossm-security.html#ossm-cert-manage-add-cert-key_ossm-security
`oc create secret generic cacerts -n istio-system --from-file=<path>/ca-cert.pem --from-file=<path>/ca-key.pem --from-file=<path>/root-cert.pem --from-file=<path>/cert-chain.pem`