### PR TITLE
BZ-1903699 Prometheus database storage requirements note 4.x

### DIFF
--- a/modules/prometheus-database-storage-requirements.adoc
+++ b/modules/prometheus-database-storage-requirements.adoc
@@ -8,6 +8,11 @@
 
 Red Hat performed various tests for different scale sizes.
 
+[NOTE]
+====
+The Prometheus storage requirements below are not prescriptive. Higher resource consumption might be observed in your cluster depending on workload activity and resource use.
+====
+
 .Prometheus Database storage requirements based on number of nodes/pods in the cluster
 [options="header"]
 |===
@@ -42,22 +47,18 @@ Red Hat performed various tests for different scale sizes.
 |46 MB
 |===
 
-Approximately 20 percent of the expected size was added as overhead to ensure
-that the storage requirements do not exceed the calculated value.
+Approximately 20 percent of the expected size was added as overhead to ensure that the storage requirements do not exceed the calculated value.
 
-The above calculation is for the default {product-title} Cluster Monitoring
-Operator.
+The above calculation is for the default {product-title} Cluster Monitoring Operator.
 
 [NOTE]
 ====
-CPU utilization has minor impact. The ratio is approximately 1 core out of 40
-per 50 nodes and 1800 pods.
+CPU utilization has minor impact. The ratio is approximately 1 core out of 40 per 50 nodes and 1800 pods.
 ====
 
 *Lab environment*
 
-In a previous release, all experiments were performed in an {product-title} on
-{rh-openstack} environment:
+In a previous release, all experiments were performed in an {product-title} on {rh-openstack} environment:
 
 * Infra nodes (VMs) - 40 cores, 157 GB RAM.
 * CNS nodes (VMs) - 16 cores, 62 GB RAM, NVMe drives.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1903699

This PR handles a new note in the 4.5-4.7 _Prometheus database storage requirements_ section. A separate PR will be opened for 3.11.

Preview: https://deploy-preview-29503--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-cluster-monitoring-operator.html#prometheus-database-storage-requirements_cluster-monitoring-operator