### PR TITLE
[SRVLS] [SRVCOM-1232] Updating 4.5 docs with new guidelines

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2441,6 +2441,12 @@ Name: Serverless applications
 Dir: serverless
 Distros: openshift-enterprise,openshift-webscale
 Topics:
+# Release notes
+- Name: Release Notes
+  File: serverless-release-notes
+# Support
+- Name: Support
+  File: serverless-support
 # Intro / getting started
 - Name: Getting started
   File: serverless-getting-started
@@ -2502,9 +2508,6 @@ Topics:
 # Channels
   - Name: Event delivery workflows using channels
     File: serverless-channels
-# Sinkbinding
-  - Name: Using SinkBinding
-    File: serverless-sinkbinding
 # Event sources
 - Name: Event sources
   Dir: event_sources
@@ -2513,10 +2516,12 @@ Topics:
     File: knative-event-sources
   - Name: Using the kn CLI to list event sources and event source types
     File: serverless-kn-source
-  - Name: Using ApiServerSource
+  - Name: Using an API server source
     File: serverless-apiserversource
-  - Name: Using PingSource
+  - Name: Using a ping source
     File: serverless-pingsource
+  - Name: Using sink binding
+    File: serverless-sinkbinding
 # Networking
 - Name: Networking
   Dir: networking
@@ -2536,9 +2541,3 @@ Topics:
   Topics:
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources
-# Release notes
-- Name: Release Notes
-  File: serverless-release-notes
-# Support
-- Name: Support
-  File: serverless-support

--- a/cli_reference/kn-cli-tools.adoc
+++ b/cli_reference/kn-cli-tools.adoc
@@ -28,7 +28,7 @@ Key features of `kn` include:
 ====
 Knative Eventing is currently available as a Technology Preview feature of {ServerlessProductName}.
 ====
-* Create xref:../serverless/event_workflows/serverless-sinkbinding.adoc#serverless-sinkbinding[sink binding] to connect existing Kubernetes applications and Knative services.
+* Create xref:../serverless/event_sources/serverless-sinkbinding.adoc#serverless-sinkbinding[sink binding] to connect existing Kubernetes applications and Knative services.
 * Extend `kn` with flexible plugin architecture, similar to `kubectl`.
 // * Easily integrate {ServerlessProductName} with OpenShift Pipelines by using `kn` in an OpenShift Pipelines task
 // TODO: Add integrations later when we have docs about this.

--- a/modules/configuring-scale-bounds-knative.adoc
+++ b/modules/configuring-scale-bounds-knative.adoc
@@ -12,7 +12,7 @@ minScale:: If the `minScale` annotation is not set, pods will scale to zero (or 
 
 maxScale:: If the `maxScale` annotation is not set, there will be no upper limit for the number of pods created.
 
-`minScale` and `maxScale` can be configured as follows in the revision template:
+The `minScale` and `maxScale` annotations can be configured as follows in the revision template:
 
 [source,yaml]
 ----
@@ -24,9 +24,9 @@ spec:
         autoscaling.knative.dev/maxScale: "10"
 ----
 
-Using these annotations in the revision template will propagate this confguration to `PodAutoscaler` objects.
+Using these annotations in the revision template will propagate this configuration to `PodAutoscaler` objects.
 
 [NOTE]
 ====
-These annotations apply for the full lifetime of a revision. Even when a revision is not referenced by any route, the minimal Pod count specified by `minScale` will still be provided. Keep in mind that non-routeable revisions may be garbage collected, which enables Knative to reclaim the resources.
+These annotations apply for the full lifetime of a revision. Even when a revision is not referenced by any route, the minimal pod count specified by the `minScale` annotation will still be provided. Keep in mind that non-routeable revisions may be garbage collected, which enables Knative to reclaim the resources.
 ====

--- a/modules/deleting-serverless-CRDs.adoc
+++ b/modules/deleting-serverless-CRDs.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * serverless/installing_serverless/removing-openshift-serverless.adoc
+
+[id="deleting-serverless-CRDs_{context}"]
+= Deleting {ServerlessProductName} CRDs
+
+After uninstalling the {ServerlessProductName}, the Operator and API custom resource definitions (CRDs) remain on the cluster.
+You can use the following procedure to remove the remaining CRDs.
+
+[IMPORTANT]
+====
+Removing the Operator and API CRDs also removes all resources that were defined using them, including Knative services.
+====
+
+.Prerequisites
+* You have uninstalled Knative Serving and Knative Eventing and have removed the {ServerlessOperatorName}.
+
+.Procedure
+* Delete the remaining {ServerlessProductName} CRDs:
++
+[source,terminal]
+----
+$ oc get crd -oname | grep 'knative.dev' | xargs oc delete
+----

--- a/modules/knative-serving-advanced-config.adoc
+++ b/modules/knative-serving-advanced-config.adoc
@@ -16,16 +16,15 @@ Do not modify any YAML contained inside the `config` field. Some of the configur
 image::serving-form-view.png[Create Knative Serving form in web console Administrator Perspective]
 
 [id="knative-serving-controller-custom-certs_{context}"]
-== Controller Custom Certs
+== Controller custom certificates
 
-If your registry uses a self-signed certificate, you must enable tag-to-digest resolution by creating a ConfigMap or Secret.
-The {ServerlessOperatorName} then automatically configures Knative Serving controller access to the registry.
+If your registry uses a self-signed certificate, you must enable tag-to-digest resolution by creating a config map or secret. The {ServerlessOperatorName} then automatically configures Knative Serving controller access to the registry.
 
 To enable tag-to-digest resolution, the Knative Serving controller requires access to the container registry.
 
 [IMPORTANT]
 ====
-The ConfigMap or Secret must reside in the same namespace as the Knative Serving CustomResourceDefinition (CRD).
+The config map or secret must reside in the same namespace as the Knative Serving custom resource definition (CRD).
 ====
 
 The following example triggers the {ServerlessOperatorName} to:
@@ -47,15 +46,20 @@ spec:
     type: ConfigMap
 ----
 
-The following example uses a certificate in a ConfigMap named `certs` in the `knative-serving` namespace.
+The following example uses a certificate in a config map named `certs` in the `knative-serving` namespace.
 
 The supported types are `ConfigMap` and `Secret`.
 
-If no controller custom cert  is specified, this defaults to the `config-service-ca` ConfigMap.
+If no controller custom certificate is specified, this defaults to the `config-service-ca` config map.
 
 .Example default YAML
 [source,yaml]
 ----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
 spec:
   controller-custom-certs:
     name: config-service-ca
@@ -72,6 +76,11 @@ You can set this to `1` to disable HA, or add more replicas by setting a higher 
 .Example YAML
 [source,yaml]
 ----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
 spec:
   high-availability:
     replicas: 2

--- a/modules/knative-serving-concurrent-autoscaling-requests.adoc
+++ b/modules/knative-serving-concurrent-autoscaling-requests.adoc
@@ -5,10 +5,9 @@
 [id="knative-serving-concurrent-autoscaling-requests_{context}"]
 = Configuring concurrent requests for Knative Serving autoscaling
 
-You can specify the number of concurrent requests that should be handled by each instance of an application (revision container) by adding the `target` annotation or the `containerConcurrency` field in the revision template.
+You can specify the number of concurrent requests that should be handled by each instance of an application (revision container) by adding the `target` annotation or the `containerConcurrency` spec in the revision template.
 
-Here is an example of `target` being used in a revision template:
-
+.`target` annotation used in a revision template
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -25,7 +24,7 @@ spec:
       - image: myimage
 ----
 
-Here is an example of `containerConcurrency` being used in a revision template:
+.`containerConcurrency` spec used in a revision template
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1

--- a/modules/serverless-config-replicas.adoc
+++ b/modules/serverless-config-replicas.adoc
@@ -7,8 +7,7 @@
 
 High availability (HA) functionality is available by default on {ServerlessProductName} for the `autoscaler-hpa`, `controller`, `activator`, `kourier-control`, and `kourier-gateway` components. These components are configured with two replicas by default.
 
-You modify the number of replicas that are created per controller by changing the configuration of `KnativeServing.spec.highAvailability` in the KnativeServing custom resource definition.
-// This field also specifies the minimum number of _activators_ if you are using the horizontal pod autoscaler (HPA). For more information about HPA, see
+You modify the number of replicas that are created per controller by changing the configuration of the `KnativeServing.spec.highAvailability` spec in the `KnativeServing` custom resource definition (CRD).
 
 .Prerequisites
 * An {product-title} account with cluster administrator access.
@@ -32,23 +31,23 @@ image::serving-YAML-HA.png[Knative Serving YAML]
 +
 . Edit the custom resource definition YAML:
 +
-
 .Example YAML
-+
-
 [source,yaml]
 ----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
 spec:
   high-availability:
     replicas: 3
 ----
-
 +
 [IMPORTANT]
 ====
 Do not modify any YAML contained inside the `config` field. Some of the configuration values in this field are injected by the {ServerlessOperatorName}, and modifying them will cause your deployment to become unsupported.
 ====
 +
-
 * The default `replicas` value is `2`.
 * Changing the value to `1` will disable HA, or you can increase the number of replicas as required. The example configuration shown specifies a replica count of `3` for all HA controllers.

--- a/modules/serverless-rn-1-10-0.adoc
+++ b/modules/serverless-rn-1-10-0.adoc
@@ -17,7 +17,7 @@
 
 [id="fixed-issues-1-10-0_{context}"]
 == Fixed issues
-* In previous releases, Knative Serving had a fixed, minimum CPU request of 25m for `queue-proxy`. If your cluster had any value set that conflicted with this, for example, if you had set a minimum CPU request for `defaultRequest` of more than `25m`, the Knative Service failed to deploy. This issue is fixed in 1.10.0.
+* In previous releases, Knative Serving had a fixed, minimum CPU request of 25m for `queue-proxy`. If your cluster had any value set that conflicted with this, for example, if you had set a minimum CPU request for `defaultRequest` of more than `25m`, the Knative service failed to deploy. This issue is fixed in 1.10.0.
 
 // [id="known-issues-1-10-0_{context}"]
 // == Known issues

--- a/modules/serverless-rn-1-7-0.adoc
+++ b/modules/serverless-rn-1-7-0.adoc
@@ -23,10 +23,10 @@ Before upgrading to the latest Serverless release, you must remove the community
 
 * High availability (HA) is now enabled by default for the `autoscaler-hpa`, `controller`, `activator` , `kourier-control`, and `kourier-gateway` components.
 +
-If you have installed a previous version of {ServerlessProductName}, after the KnativeServing custom resource (CR) is updated, the deployment will default to a HA configuration with `KnativeServing.spec.high-availability.replicas = 2`.
+If you have installed a previous version of {ServerlessProductName}, after the `KnativeServing` custom resource (CR) is updated, the deployment will default to a HA configuration with `KnativeServing.spec.high-availability.replicas = 2`.
 +
 You can disable HA for these components by completing the procedure in the _Configuring high availability components_ documentation.
-* {ServerlessProductName} now supports the `trustedCA` setting in {product-title}'s cluster-wide proxy, and is now fully compatible with {product-title}'s proxy settings.
+* {ServerlessProductName} now supports the `trustedCA` setting in the {product-title} cluster-wide proxy, and is now fully compatible with {product-title} proxy settings.
 * {ServerlessProductName} now supports HTTPS by using the wildcard certificate that is registered for {product-title} routes. For more information on HTTP and HTTPS on Knative Serving, see the documentation on _Verifying your serverless application deployment_.
 
 [id="fixed-issues-1-7-0_{context}"]
@@ -45,6 +45,6 @@ The {ServerlessOperatorName} now restarts the Knative Serving controller wheneve
 == Known issues
 * When upgrading from {ServerlessProductName} 1.6.0 to 1.7.0, support for HTTPS requires a change to the format of routes. Knative services created on {ServerlessProductName} 1.6.0 are no longer reachable at the old format URLs. You must retrieve the new URL for each service after upgrading {ServerlessProductName}. For more information, see the documentation on _Upgrading OpenShift Serverless_.
 * If you are using Knative Eventing on an Azure cluster, it is possible that the `imc-dispatcher` pod may not start. This is due to the pod's default `resources` settings. As a work-around, you can remove the `resources` settings.
-* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there will be a delay when you create the first new service after KnativeServing becomes Ready.
+* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there will be a delay when you create the first new service after the `KnativeServing` CR becomes Ready.
 +
 The `3scale-kourier-control` controller reconciles all previous Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state will update to `Ready`.

--- a/modules/serverless-rn-1-7-2.adoc
+++ b/modules/serverless-rn-1-7-2.adoc
@@ -10,4 +10,4 @@ This release of {ServerlessProductName} addresses Common Vulnerabilities and Exp
 [id="fixed-issues-1-7-2_{context}"]
 == Fixed issues
 
-* In previous versions of {ServerlessProductName}, KnativeServing custom resources show a status of `Ready`, even if Kourier does not deploy. This bug is fixed in {ServerlessProductName} 1.7.2.
+* In previous versions of {ServerlessProductName}, `KnativeServing` custom resources showed a status of `Ready`, even if Kourier did not deploy. This bug is fixed in {ServerlessProductName} 1.7.2.

--- a/modules/serverless-rn-1-8-0.adoc
+++ b/modules/serverless-rn-1-8-0.adoc
@@ -21,13 +21,11 @@
 
 [id="known-issues-1-8-0_{context}"]
 == Known issues
-* Knative Serving has a fixed, minimum CPU request of 25m for `queue-proxy`.
-If your cluster has any value set that conflicts with this, for example, if you have set a minimum CPU request for `defaultRequest` of more than `25m`, the Knative Service fails to deploy.
-As a workaround, you can configure `resourcePercentage` individually for your Knative Services.
+* Knative Serving has a fixed, minimum CPU request of `25m` for the `queue-proxy` setting.
+If your cluster has any value set that conflicts with this, for example, if you have set a minimum CPU request for `defaultRequest` of more than `25m`, the Knative service fails to deploy.
+As a workaround, you can configure the `resourcePercentage` annotation individually for your Knative services.
 +
 .Example resourcePercentage configuration
-+
-
 [source,yaml]
 ----
 spec:
@@ -40,43 +38,39 @@ spec:
 +
 <1> `queue.sidecar.serving.knative.dev/resourcePercentage` is the percentage of user container resources to be used for `queue-proxy`. This can be between a range of 0.1 - 100.
 
-* On {product-title} 4.5 and newer versions, deploying a Knative Service with traffic distribution shows an invalid URL for the general service address in the *Developer Perspective* of the web console.
+* On {product-title} 4.5 and newer versions, deploying a Knative service with traffic distribution shows an invalid URL for the general service address in the *Developer* perspective of the web console.
 +
 The correct URL is shown in YAML resources and CLI command outputs.
 
-* If you use a PingSource with {ServerlessProductName}, after you uninstall and delete all other Knative Eventing components, the `pingsource-jobrunner` Deployment is not deleted.
+* If you use a ping source with {ServerlessProductName}, after you uninstall and delete all other Knative Eventing components, the `pingsource-jobrunner` `Deployment` resource is not deleted.
 
-* If you delete a sink before you delete the SinkBinding connected to it, the SinkBinding deletion might hang.
+* If you delete a sink before you delete the sink binding connected to it, the `SinkBinding` object deletion might hang.
 +
-As a workaround, you can edit the SinkBinding and remove the finalizer that causes the hanging:
+As a workaround, you can edit the `SinkBinding` object and remove the finalizer that causes the hanging:
 +
-
 [source,yaml]
 ----
   finalizers:
    - sinkbindings.sources.knative.dev
 ----
 
-* The SinkBinding behavior has changed in {ServerlessProductName} 1.8.0, which breaks backwards compatibility.
+* The sink binding behavior has changed in {ServerlessProductName} 1.8.0, which breaks backwards compatibility.
 +
-To use a SinkBinding, cluster administrators must now label the namespace configured in the SinkBinding with `bindings.knative.dev/include:"true"`.
+To use sink binding, cluster administrators must now label the namespace configured in the `SinkBinding` object with `bindings.knative.dev/include:"true"`.
 +
-Resources configured in the SinkBinding must also be labeled with `bindings.knative.dev/include:"true"`; however, this task can be completed by any {ServerlessProductName} user.
+Resources configured in the `SinkBinding` object must also be labeled with `bindings.knative.dev/include:"true"`; however, this task can be completed by any {ServerlessProductName} user.
 +
 . As a cluster administrator, you can label the namespace by entering the following command:
 +
-
 [source,terminal]
 ----
 $ oc label namespace <namespace> bindings.knative.dev/include=true
 ----
-
 +
 . Users must manually add a `bindings.knative.dev/include=true` label to resources.
 +
-For example, to add this label to a CronJob instance, add the following lines to the Job resource YAML definition:
+For example, to add this label to a `CronJob` object, add the following lines to the Job resource YAML definition:
 +
-
 [source,yaml]
 ----
   jobTemplate:

--- a/modules/serverless-rn-1-9-0.adoc
+++ b/modules/serverless-rn-1-9-0.adoc
@@ -17,12 +17,7 @@
 * {ServerlessProductName} now uses Kourier 0.15.0.
 * {ServerlessProductName} now supports some integrated Red Hat OpenShift Service Mesh features, including enabling sidecars, and JSON Web Token (JWT) authentication. Supported features are documented in the _Networking_ guide.
 
-// [id="fixed-issues-1-9-0_{context}"]
-// == Fixed issues
-// * In previous versions of {ServerlessProductName}, deleting a sink before deleting the SinkBinding connected to it caused a hanging issue that required removing a finalizer from the SinkBinding to resolve. This issue is fixed in {ServerlessProductName} 1.9.0.
-// move to 1.12.0 or whenever this lands.
-
 [id="known-issues-1-9-0_{context}"]
 == Known issues
 
-* After deleting the `KnativeEventing` custom resource, the `v0.15.0-upgrade-xr55x` and `storage-version-migration-eventing-99c7q` pods remain on the cluster and show a `Completed` status. You can delete the namespace where the `KnativeEventing` custom resource was installed to completely remove these pods.
+* After deleting the `KnativeEventing` custom resource (CR), the `v0.15.0-upgrade-xr55x` and `storage-version-migration-eventing-99c7q` pods remain on the cluster and show a `Completed` status. You can delete the namespace where the `KnativeEventing` CR was installed to completely remove these pods.

--- a/modules/serverless-service-mesh-enable-sidecar-injection.adoc
+++ b/modules/serverless-service-mesh-enable-sidecar-injection.adoc
@@ -5,13 +5,12 @@
 [id="serverless-enable-sidecar_{context}"]
 = Enabling sidecar injection for a Knative service
 
-You can add an annotation to the Service resource YAML file to enable sidecar injection for a Knative service.
+You can add an annotation to the `Service` resource YAML file to enable sidecar injection for a Knative service.
 
 .Procedure
 
-. Add the `sidecar.istio.io/inject="true"` annotation to the Service resource:
+. Add the `sidecar.istio.io/inject="true"` annotation to the `Service` resource:
 +
-
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -29,10 +28,8 @@ spec:
         name: container
 ----
 <1> Add the `sidecar.istio.io/inject="true"` annotation.
-
-. Apply the Service resource YAML file:
+. Apply the `Service` resource YAML file:
 +
-
 [source,terminal]
 ----
 $ oc apply -f <filename>

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -1,16 +1,16 @@
 // Module included in the following assemblies:
 //
-// serverless/event_workflows/serverless-sinkbinding.adoc
+// serverless/event_sources/serverless-sinkbinding.adoc
 
 [id="serverless-sinkbinding-kn_{context}"]
-= Using SinkBinding with the Knative CLI (`kn`)
+= Using sink binding with the Knative CLI
 
-This guide describes the steps required to create, manage, and delete a SinkBinding instance using `kn` commands.
+This guide describes the steps required to create, manage, and delete a sink binding instance using the `kn` CLI.
 
 .Prerequisites
 
 * You have Knative Serving and Eventing installed.
-* You have the `kn` CLI installed.
+* You have the the `kn` CLI installed.
 
 [NOTE]
 ====
@@ -21,7 +21,7 @@ If you change the names of the YAML files from those used in the examples, you m
 
 [IMPORTANT]
 ====
-Before developers can use a SinkBinding, cluster administrators must label the namespace that will be configured in the SinkBinding with `bindings.knative.dev/include:"true"`:
+Before developers can use sink binding, cluster administrators must label the namespace that will be configured in the `SinkBinding` object with `bindings.knative.dev/include:"true"`:
 
 [source,terminal]
 ----
@@ -31,26 +31,21 @@ $ oc label namespace <namespace> bindings.knative.dev/include=true
 
 .Procedure
 
-. To check that SinkBinding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log:
+. To check that sink binding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log:
 +
-
 [source,terminal]
 ----
 $ kn service create event-display --image quay.io/openshift-knative/knative-eventing-sources-event-display:latest
 ----
-
-. Create a SinkBinding that directs events to the service:
+. Create a `SinkBinding` object that directs events to the service:
 +
-
 [source,terminal]
 ----
 $ kn source binding create bind-heartbeat --subject Job:batch/v1:app=heartbeat-cron --sink ksvc:event-display
 ----
-
 . Create a CronJob.
 .. Create a file named `heartbeats-cronjob.yaml` and copy the following sample code into it:
 +
-
 [source,yaml]
 ----
 apiVersion: batch/v1beta1
@@ -87,13 +82,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
-
 +
 [IMPORTANT]
 ====
-To use SinkBinding, you must manually add a `bindings.knative.dev/include=true` label to your Knative resources.
+To use sink binding, you must manually add a `bindings.knative.dev/include=true` label to your Knative resources.
 
-For example, to add this label to a CronJob instance, add the following lines to the Job resource YAML definition:
+For example, to add this label to a `CronJob` object, add the following lines to the Job resource YAML definition:
 
 [source,yaml]
 ----
@@ -105,28 +99,20 @@ For example, to add this label to a CronJob instance, add the following lines to
 ----
 
 ====
-
+.. After you have created the `heartbeats-cronjob.yaml` file, apply it:
 +
-.. After you have created the `heartbeats-cronjob.yaml` file, apply it by entering:
-+
-
 [source,terminal]
 ----
 $ oc apply --filename heartbeats-cronjob.yaml
 ----
-
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:
 +
-
 [source,terminal]
 ----
 $ kn source binding describe bind-heartbeat
 ----
-
 +
 .Example output
-+
-
 [source,terminal]
 ----
 Name:         bind-heartbeat
@@ -150,24 +136,19 @@ Conditions:
 
 You can verify that the Kubernetes events were sent to the Knative event sink by looking at the message dumper function logs.
 
-* View the message dumper function logs by entering the following commands:
+* View the message dumper function logs:
 +
-
 [source,terminal]
 ----
 $ oc get pods
 ----
 +
-
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
-
 +
 .Example output
-+
-
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
 //
-// serverless/event_workflows/serverless-sinkbinding.adoc
+// serverless/event_sources/serverless-sinkbinding.adoc
 
 [id="serverless-sinkbinding-yaml_{context}"]
-= Using SinkBinding with the YAML method
+= Using sink binding with the YAML method
 
-This guide describes the steps required to create, manage, and delete a SinkBinding instance using YAML files.
+This guide describes the steps required to create, manage, and delete a sink binding instance using YAML files.
 
 .Prerequisites
 
@@ -20,7 +20,7 @@ If you change the names of the YAML files from those used in the examples, you m
 
 [IMPORTANT]
 ====
-Before developers can use a SinkBinding, cluster administrators must label the namespace that will be configured in the SinkBinding with `bindings.knative.dev/include:"true"`:
+Before developers can use sink binding, cluster administrators must label the namespace that will be configured in the `SinkBinding` object with `bindings.knative.dev/include:"true"`:
 
 [source,terminal]
 ----
@@ -30,10 +30,9 @@ $ oc label namespace <namespace> bindings.knative.dev/include=true
 
 .Procedure
 
-. To check that SinkBinding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log.
+. To check that sink binding is set up correctly, create a Knative event display service, or event sink, that dumps incoming messages to its log.
 .. Copy the following sample YAML into a file named `service.yaml`:
 +
-
 [source,yaml]
 ----
 apiVersion: serving.knative.dev/v1
@@ -46,19 +45,15 @@ spec:
       containers:
         - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
 ----
-
-.. After you have created the `service.yaml` file, apply it by entering:
+.. After you have created the `service.yaml` file, apply it:
 +
-
 [source,terminal]
 ----
 $ oc apply -f service.yaml
 ----
-
-. Create a SinkBinding that directs events to the service.
+. Create a `SinkBinding` object that directs events to the service.
 .. Create a file named `sinkbinding.yaml` and copy the following sample code into it:
 +
-
 [source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha1
@@ -79,22 +74,16 @@ spec:
       kind: Service
       name: event-display
 ----
-
-+
 <1> In this example, any Job with the label `app: heartbeat-cron` will be bound to the event sink.
-
-.. After you have created the `sinkbinding.yaml` file, apply it by entering:
+.. After you have created the `sinkbinding.yaml` file, apply it:
 +
-
 [source,terminal]
 ----
 $ oc apply -f sinkbinding.yaml
 ----
-
-. Create a CronJob.
+. Create a `CronJob` object.
 .. Create a file named `heartbeats-cronjob.yaml` and copy the following sample code into it:
 +
-
 [source,yaml]
 ----
 apiVersion: batch/v1beta1
@@ -131,13 +120,12 @@ spec:
                     fieldRef:
                       fieldPath: metadata.namespace
 ----
-
 +
 [IMPORTANT]
 ====
-To use SinkBinding, you must manually add a `bindings.knative.dev/include=true` label to your Knative resources.
+To use sink binding, you must manually add a `bindings.knative.dev/include=true` label to your Knative resources.
 
-For example, to add this label to a CronJob instance, add the following lines to the Job resource YAML definition:
+For example, to add this label to a cron job instance, add the following lines to the `Job` resource YAML definition:
 
 [source,yaml]
 ----
@@ -147,26 +135,20 @@ For example, to add this label to a CronJob instance, add the following lines to
         app: heartbeat-cron
         bindings.knative.dev/include: "true"
 ----
-
 ====
-
 +
-.. After you have created the `heartbeats-cronjob.yaml` file, apply it by entering:
+.. After you have created the `heartbeats-cronjob.yaml` file, apply it:
 +
-
 [source,terminal]
 ----
 $ oc apply -f heartbeats-cronjob.yaml
 ----
-
 . Check that the controller is mapped correctly by entering the following command and inspecting the output:
 +
-
 [source,terminal]
 ----
 $ oc get sinkbindings.sources.knative.dev bind-heartbeat -oyaml
 ----
-
 +
 .Example output
 [source,yaml]
@@ -191,25 +173,19 @@ spec:
 
 You can verify that the Kubernetes events were sent to the Knative event sink by looking at the message dumper function logs.
 
-. View the message dumper function logs by entering the following commands:
+. View the message dumper function logs:
 +
-
 [source,terminal]
 ----
 $ oc get pods
 ----
-
 +
-
 [source,terminal]
 ----
 $ oc logs $(oc get pod -o name | grep event-display) -c user-container
 ----
-
 +
 .Example output
-+
-
 [source,terminal]
 ----
 ☁️  cloudevents.Event

--- a/modules/serverless-upgrade-sub-channel.adoc
+++ b/modules/serverless-upgrade-sub-channel.adoc
@@ -22,22 +22,24 @@ If you have selected Manual updates, you will need to complete additional steps 
 . Select the *{ServerlessOperatorName} Operator*.
 . Click *Subscription* → *Channel*.
 . In the *Change Subscription Update Channel* window, select `4.5`, and then click *Save*.
-. Wait until all pods have been upgraded in the `knative-serving` namespace and the KnativeServing custom resource reports the latest Knative Serving version.
+. Wait until all pods have been upgraded in the `knative-serving` namespace and the `KnativeServing` custom resource (CR) reports the latest Knative Serving version.
 
 .Verification steps
 
-To verify that the upgrade has been successful, you can check the status of pods in the `knative-serving` namespace, and the version of the KnativeServing CR.
+To verify that the upgrade has been successful, you can check the status of pods in the `knative-serving` namespace, and the version of the `KnativeServing` CR.
 
-. Check the status of the pods by entering the following command:
+. Check the status of the pods:
 +
+[source,terminal]
 ----
 $ oc get knativeserving.operator.knative.dev knative-serving -n knative-serving -o=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'
 ----
 +
 The previous command should return a status of `True`.
 
-. Check the version of the KnativeServing CR by entering the following command:
+. Check the version of the `KnativeServing` CR:
 +
+[source,terminal]
 ----
 $ oc get knativeserving.operator.knative.dev knative-serving -n knative-serving -o=jsonpath='{.status.version}'
 ----

--- a/serverless/architecture/serverless-serving-architecture.adoc
+++ b/serverless/architecture/serverless-serving-architecture.adoc
@@ -9,24 +9,22 @@ toc::[]
 Knative Serving on {product-title} enables developers to write link:https://www.redhat.com/en/topics/cloud-native-apps[cloud-native applications] using link:https://www.redhat.com/en/topics/cloud-native-apps/what-is-serverless[serverless architecture].
 Serverless is a cloud computing model where application developers don't need to provision servers or manage scaling for their applications. These routine tasks are abstracted away by the platform, allowing developers to push code to production much faster than in traditional models.
 
-Knative Serving supports deploying and managing cloud-native applications by providing a set of objects as Kubernetes Custom Resource Definitions (CRDs) that define and control the behavior of serverless workloads on an {product-title} cluster. For more information about CRDs, see xref:../../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Extending the Kubernetes API with Custom Resource Definitions].
+Knative Serving supports deploying and managing cloud-native applications by providing a set of objects as Kubernetes custom resource definitions (CRDs) that define and control the behavior of serverless workloads on an {product-title} cluster. For more information about CRDs, see xref:../../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Extending the Kubernetes API with custom resource definitions].
 
 Developers use these CRDs to create custom resource (CR) instances that can be used as building blocks to address complex use cases. For example:
 
 * Rapidly deploying serverless containers.
 * Automatically scaling pods.
-// TODO: Add other use cases, more advanced tutorials?
 
-For more information about CRs, see xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Managing resources from Custom Resource Definitions].
+For more information about CRs, see xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Managing resources from custom resource definitions].
 
 [id="serverless-serving-architecture-custom-resources"]
 == Knative Serving CRDs
-// TODO: Request a good Serving arch diagram
 
-Service:: The `service.serving.knative.dev` CRD automatically manages the life cycle of your workload to ensure that the application is deployed and reachable through the network. It creates a Route, a Configuration, and a new Revision for each change to a user created Service, or custom resource. Most developer interactions in Knative are carried out by modifying Services.
+Service:: The `service.serving.knative.dev` CRD automatically manages the life cycle of your workload to ensure that the application is deployed and reachable through the network. It creates a route, a configuration, and a new revision for each change to a user created service or CR. Most developer interactions in Knative are carried out by modifying services.
 
 Revision:: The `revision.serving.knative.dev` CRD is a point-in-time snapshot of the code and configuration for each modification made to the workload. Revisions are immutable objects and can be retained for as long as necessary.
 
-Route:: The `route.serving.knative.dev` CRD maps a network endpoint to one or more Revisions. You can manage the traffic in several ways, including fractional traffic and named routes.
+Route:: The `route.serving.knative.dev` CRD maps a network endpoint to one or more revisions. You can manage the traffic in several ways, including fractional traffic and named routes.
 
-Configuration:: The `configuration.serving.knative.dev` CRD maintains the desired state for your deployment. It provides a clean separation between code and configuration. Modifying a configuration creates a new Revision.
+Configuration:: The `configuration.serving.knative.dev` CRD maintains the desired state for your deployment. It provides a clean separation between code and configuration. Modifying a configuration creates a new revision.

--- a/serverless/event_sources/knative-event-sources.adoc
+++ b/serverless/event_sources/knative-event-sources.adoc
@@ -15,13 +15,13 @@ Currently, {ServerlessProductName} supports the following event source types:
 API server source:: Connects a sink to the Kubernetes API server by creating an `APIServerSource` object.
 Ping source:: Periodically sends ping events with a constant payload. A ping source can be used as a timer, and is created as a `PingSource` object.
 
-xref:../../serverless/event_workflows/serverless-sinkbinding.adoc#serverless-sinkbinding[Sink binding] is also supported, which allows you to connect core Kubernetes resources such as `Deployment`, `Job`, or `StatefulSet` with a sink.
+xref:../../serverless/event_sources/serverless-sinkbinding.adoc#serverless-sinkbinding[Sink binding] is also supported, which allows you to connect core Kubernetes resources such as `Deployment`, `Job`, or `StatefulSet` with a sink.
 
 You can create and manage Knative event sources using the **Developer** perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
 
 * Create an xref:../../serverless/event_sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source].
 * Create a xref:../../serverless/event_sources/serverless-pingsource.adoc#serverless-pingsource[ping source].
-* Create a xref:../../serverless/event_workflows/serverless-sinkbinding.adoc#serverless-sinkbinding[sink binding].
+* Create a xref:../../serverless/event_sources/serverless-sinkbinding.adoc#serverless-sinkbinding[sink binding].
 
 [id="knative-event-sources-additional-resources"]
 == Additional resources

--- a/serverless/event_sources/serverless-pingsource.adoc
+++ b/serverless/event_sources/serverless-pingsource.adoc
@@ -10,6 +10,7 @@ A ping source is used to periodically send ping events with a constant payload t
 A ping source can be used to schedule sending events, similar to a timer, as shown in the example:
 
 .Example ping source
+[source,yaml]
 ----
 apiVersion: sources.knative.dev/v1alpha2
 kind: PingSource

--- a/serverless/event_sources/serverless-sinkbinding.adoc
+++ b/serverless/event_sources/serverless-sinkbinding.adoc
@@ -1,22 +1,21 @@
 include::modules/serverless-document-attributes.adoc[]
 [id="serverless-sinkbinding"]
-= Using SinkBinding
+= Using sink binding
 include::modules/common-attributes.adoc[]
 :context: serverless-sinkbinding
 
 toc::[]
 
-SinkBinding is used to connect event producers, or _event sources_, to an event consumer, or _event sink_, for example, a Knative service or application.
+Sink binding is used to connect event producers, or _event sources_, to an event consumer, or _event sink_, for example, a Knative service or application.
 
 [IMPORTANT]
 ====
-Before developers can use a SinkBinding, cluster administrators must label the namespace that will be configured in the SinkBinding with `bindings.knative.dev/include:"true"`:
+Before developers can use sink binding, cluster administrators must label the namespace that will be configured in the `SinkBinding` object with `bindings.knative.dev/include:"true"`:
 
 [source,terminal]
 ----
 $ oc label namespace <namespace> bindings.knative.dev/include=true
 ----
-
 ====
 
 include::modules/serverless-sinkbinding-kn.adoc[leveloffset=+1]

--- a/serverless/event_workflows/serverless-channels.adoc
+++ b/serverless/event_workflows/serverless-channels.adoc
@@ -9,13 +9,12 @@ toc::[]
 Events can be sent from a source to a sink by using channels and subscriptions for event delivery.
 
 image::serverless-event-channel-workflow.png[Channel workflow overview]
-// just sources or do we need to talk about other event producers?
 
 Channels are custom resources that define a single event-forwarding and persistence layer.
 
 After events have been sent to a channel, these events can be sent to multiple Knative services, or other sinks, by using a subscription.
 
-The default configuration for channel instances is defined in the `default-ch-webhook` ConfigMap.
+The default configuration for channel instances is defined in the `default-ch-webhook` config map.
 Developers can create their own channels directly by instantiating a supported `Channel` object.
 
 [id="serverless-channels-supported-types"]
@@ -23,11 +22,11 @@ Developers can create their own channels directly by instantiating a supported `
 
 Currently, {ServerlessProductName} only supports `InMemoryChannel` kind channels for development use, as part of the Knative Eventing Technology Preview.
 
-The following are limitations of InMemoryChannel type channels:
+The following are limitations of `InMemoryChannel` channels:
 
-* No event persistence is available. If a Pod goes down, events on that Pod are lost.
-* InMemoryChannel type channels do not implement event ordering, so two events that are received in the channel at the same time can be delivered to a subscriber in any order.
-* If a subscriber rejects an event, there are no re-delivery attempts. Instead, the rejected event is sent to a `deadLetterSink` if this sink exists, or is otherwise dropped.
+* No event persistence is available. If a pod goes down, events on that pod are lost.
+* `InMemoryChannel` channels do not implement event ordering, so two events that are received in the channel at the same time can be delivered to a subscriber in any order.
+* If a subscriber rejects an event, there are no re-delivery attempts. Instead, the rejected event is sent to a `deadLetterSink` object if this exists, or is dropped.
 
 include::modules/serverless-inmemorychannel.adoc[leveloffset=+2]
 include::modules/serverless-create-inmemorychannel.adoc[leveloffset=+1]

--- a/serverless/installing_serverless/removing-openshift-serverless.adoc
+++ b/serverless/installing_serverless/removing-openshift-serverless.adoc
@@ -23,23 +23,4 @@ include::modules/serverless-uninstalling-knative-eventing.adoc[leveloffset=+1]
 
 You can remove the {ServerlessOperatorName} from the host cluster by following the documentation on xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[deleting Operators from a cluster].
 
-[id="deleting-serverless-CRDs"]
-== Deleting {ServerlessProductName} CRDs
-
-After uninstalling the {ServerlessProductName}, the Operator and API CRDs remain on the cluster.
-You can use the following procedure to remove the remaining CRDs.
-
-[IMPORTANT]
-====
-Removing the Operator and API CRDs also removes all resources that were defined using them, including Knative services.
-====
-
-== Prerequisites
-*  You uninstalled Knative Serving and removed the {ServerlessOperatorName}.
-
-.Procedure
-. To delete the remaining {ServerlessProductName} CRDs, enter the following command:
-+
-----
-$ oc get crd -oname | grep 'knative.dev' | xargs oc delete
-----
+include::modules/deleting-serverless-CRDs.adoc[leveloffset=+1]

--- a/serverless/installing_serverless/serverless-install-config-options.adoc
+++ b/serverless/installing_serverless/serverless-install-config-options.adoc
@@ -10,10 +10,7 @@ This guide provides information for cluster administrators about advanced instal
 
 include::modules/knative-serving-advanced-config.adoc[leveloffset=+1]
 
-// == Knative Eventing supported installation configuration options
-// image::eventing-form-view.png[Create Knative Eventing form]
-// TODO: Add when there's more information for eventing.
-
+[id="serverless-install-config-options-additional-resources"]
 == Additional resources
 
 * For more information about configuring high availability, see xref:../../serverless/serverless-HA.adoc#serverless-HA[High availability on {ServerlessProductName}].

--- a/serverless/knative_serving/configuring-knative-serving-autoscaling.adoc
+++ b/serverless/knative_serving/configuring-knative-serving-autoscaling.adoc
@@ -6,7 +6,7 @@ include::modules/serverless-document-attributes.adoc[]
 
 toc::[]
 
-{ServerlessProductName} provides capabilities for automatic Pod scaling, including scaling inactive Pods to zero, by enabling the Knative Serving autoscaling system in an {product-title} cluster.
+{ServerlessProductName} provides capabilities for automatic pod scaling, including scaling inactive pods to zero, by enabling the Knative Serving autoscaling system in an {product-title} cluster.
 
 To enable autoscaling for Knative Serving, you must configure concurrency and scale bounds in the revision template.
 

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -7,7 +7,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can enable JSON Web Token (JWT) authentication for Knative services.
+You can enable JSON Web Token (JWT) authentication for Knative services by creating a policy in your serverless application namespace that only allows requests with valid JWTs.
 
 .Prerequisites
 * Install xref:../../serverless/installing_serverless/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessProductName}].
@@ -16,21 +16,18 @@ You can enable JSON Web Token (JWT) authentication for Knative services.
 
 [IMPORTANT]
 ====
-Adding sidecar injection to Pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
+Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
 
 .Procedure
 
-. Create a policy in your serverless application namespace that only allows requests with valid JSON Web Tokens (JWT):
-
-.. Copy the following Policy resource into a YAML file:
+. Copy the following `Policy` resource into a YAML file:
 +
 [IMPORTANT]
 ====
-The paths `/metrics` and `/healthz` must be included in `excludedPaths` because they are accessed from system Pods in the `knative-serving` namespace.
+The paths `/metrics` and `/healthz` must be included in `excludedPaths` because they are accessed from system pods in the `knative-serving` namespace.
 ====
 +
-
 [source,yaml]
 ----
 apiVersion: authentication.istio.io/v1alpha1
@@ -48,10 +45,8 @@ spec:
         - prefix: /healthz
   principalBinding: USE_ORIGIN
 ----
-
-.. Apply the Policy resource YAML file:
+. Apply the `Policy` resource YAML file:
 +
-
 [source,terminal]
 ----
 $ oc apply -f <filename>
@@ -61,39 +56,31 @@ $ oc apply -f <filename>
 
 . If you try to use a `curl` request to get the Knative service URL, it is denied.
 +
-
 [source,terminal]
 ----
 $ curl http://hello-example-default.apps.mycluster.example.com/
 ----
-
 +
 .Example output
 [source,terminal]
 ----
 Origin authentication failed.
 ----
-
 . Verify the request with a valid JWT.
 .. Get the valid JWT token by entering the following command:
 +
-
 [source,terminal]
 ----
 $ TOKEN=$(curl https://raw.githubusercontent.com/istio/istio/release-1.6/security/tools/jwt/samples/demo.jwt -s) && echo "$TOKEN" | cut -d '.' -f2 - | base64 --decode -
 ----
-
 .. Access the service by using the valid token in the `curl` request header:
 +
-
 [source,terminal]
 ----
 $ curl http://hello-example-default.apps.mycluster.example.com/ -H "Authorization: Bearer $TOKEN"
 ----
-
 +
 The request is now allowed.
-
 +
 .Example output
 [source,terminal]

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -17,7 +17,6 @@ These options include setting custom domains, using TLS certificates, and using 
 .Procedure
 . Add the `default` namespace to the xref:../../service_mesh/v1x/installing-ossm.adoc#ossm-member-roll-create_installing-ossm[ServiceMeshMemberRoll] as a member:
 +
-
 [source,yaml]
 ----
 apiVersion: maistra.io/v1
@@ -29,33 +28,26 @@ spec:
   members:
     - default
 ----
-
 +
 [IMPORTANT]
 ====
 Adding sidecar injection to Pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
-
-. Create a network policy that permits traffic flow from Knative system Pods to Knative services:
+. Create a network policy that permits traffic flow from Knative system pods to Knative services:
 .. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving` namespace:
 +
-
 [source,terminal]
 ----
 $ oc label namespace knative-serving serving.knative.openshift.io/system-namespace=true
 ----
-
 .. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving-ingress` namespace:
 +
-
 [source,terminal]
 ----
 $ oc label namespace knative-serving-ingress serving.knative.openshift.io/system-namespace=true
 ----
-
-.. Copy the following NetworkPolicy resource into a YAML file:
+.. Copy the following `NetworkPolicy` resource into a YAML file:
 +
-
 [source,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -73,10 +65,8 @@ spec:
   policyTypes:
   - Ingress
 ----
-
-.. Apply the NetworkPolicy resource:
+.. Apply the `NetworkPolicy` resource:
 +
-
 [source,terminal]
 ----
 $ oc apply -f <filename>


### PR DESCRIPTION
Just some updates for 4.5 with the new guidelines.
Only one assembly has moved location, I've added this to the register doc to update the redirect.