### PR TITLE
provide additional instructions for adding more compute machines

### DIFF
--- a/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc
@@ -12,6 +12,11 @@ You can add more compute machines to your {product-title} cluster on bare metal.
 * You xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[installed a cluster on bare metal].
 * You have installation media and {op-system-first} images that you used to create your cluster. If you do not have these files, you must obtain them by following the instructions in the xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[installation procedure].
 
+[IMPORTANT]
+====
+If you do not have access to the {op-system-first} images that were used to create your cluster, you can add more compute machines to your {product-title} cluster with newer versions of {op-system-first} images. For instructions, see link:https://access.redhat.com/solutions/5514051[Adding new nodes to UPI cluster fails after upgrading to OpenShift 4.6+].
+====
+
 [id="creating-machines-bare-metal"]
 == Creating {op-system-first} machines
 


### PR DESCRIPTION
In BZ#1884750[0], it was requested that the OCP documents be updated
to be more clear about adding additional compute machines to bare
metal clusters.  This provides some the additional information
requested.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1884750