### PR TITLE
CNV-9521 and CNV-7544 - CNV 2.6 release notes updates

### DIFF
--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -32,9 +32,25 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 
 //CNV-7544: Microsoft's Windows Server Virtualization Validation Program (SVVP) applies to RHCOS workers
 
+* OpenShift Virtualization is certified in Microsoft’s Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
++
+The SVVP Certification applies to:
++
+** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS__.
+
+** Intel and AMD CPUs.
+
 //CNV-9723: VMs are now migrated when a node is drained
 
 //CNV-9521: VMs that use UEFI can now be booted by using secure boot
+
+* You can now about xref:../virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc#virt-efi-mode-for-vms[boot a virtual machine (VM) in Extensible Firmware Interface (EFI) mode].
+
++
+[NOTE]
+====
+{VirtProductName} only supports a VM with Secure Boot when using EFI mode. If Secure Boot is not enabled, the VM crashes repeatedly. However, the VM might not support Secure Boot. Before you boot a VM, verify that it supports Secure Boot by checking the VM settings.
+====
 
 
 [id="virt-2-6-installation-new"]


### PR DESCRIPTION
This PR covers [CNV-9521](https://issues.redhat.com/browse/CNV-9521) (https://issues.redhat.com/browse/CNV-9521) and [CNV-7544](https://issues.redhat.com/browse/CNV-7544) (https://issues.redhat.com/browse/CNV-7544 )

[CNV-9521](https://issues.redhat.com/browse/CNV-9521) is a release note pertaining to VMs ability to be booted in EFI mode.
[CNV-7544](https://issues.redhat.com/browse/CNV-7544) is a release note pertaining to the Microsoft Windows Server Virtualization Validation Program (SVVP)

Preview: https://deploy-preview-29507--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-6-release-notes.html#virt-2-6-new 