### PR TITLE
CNV-10094 - HCO bump for 2.5.4

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.5
 :KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.3
+:HCOVersion: 2.5.4
 // :LastHCOVersion: 2.4.4
 :product-build:
 :DownloadURL: registry.access.redhat.com

--- a/modules/virt-upgrade-pathways.adoc
+++ b/modules/virt-upgrade-pathways.adoc
@@ -22,6 +22,6 @@ If your *Approval Strategy* is *Automatic*, which is the default, {VirtProductNa
 [id="virt-upgrade-pathways-2.4.4_{context}"]
 == Upgrading from 2.4.4 or 2.4.5 to {HCOVersion}
 
-You can upgrade from 2.4.4 or 2.4.5 directly to 2.5.2. You can then upgrade from 2.5.2 to 2.5.3.
+You can upgrade from 2.4.4 or 2.4.5 directly to 2.5.2. You can then upgrade from 2.5.2 to 2.5.3 and so on.
 
 If your *Approval Strategy* is *Automatic*, which is the default, {VirtProductName} upgrades the z-stream automatically after you have upgraded to 2.5.2.


### PR DESCRIPTION
Increasing the HCO version attribute for 2.5.4 and making final minor change to upgrade pathway doc to cover future releases.