### PR TITLE
Reintroducing IBM Z feature note

### DIFF
--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -11,6 +11,11 @@ After installing {product-title}, you can further expand and customize your clus
 
 You complete most of the cluster configuration and customization after you deploy your {product-title} cluster. A number of _configuration resources_ are available.
 
+[NOTE]
+====
+If you install your cluster on IBM Z, not all features and functions are available.
+====
+
 You modify the configuration resources to configure the major features of the
 cluster, such as the image registry, networking configuration, image build
 behavior, and the identity provider.


### PR DESCRIPTION
This applies to branch/enterprise-4.7 only.

This PR reintroduces a note that was originally added [here](https://github.com/openshift/openshift-docs/pull/18523/files) in 4.2 but was not added to 4.3. As such, it existed in master but not the enterprise branches. In this new PR, it is added into the 4.7 content that was relocated in the 4.7 CP for [PR 28335](https://github.com/openshift/openshift-docs/pull/28335). The note is already in the relocated content in master.

The addition uses the version from [this later edit in the master branch](https://github.com/openshift/openshift-docs/commit/e0bc473014f3e7f21cc7785d0f697b4f4f739f79#diff-da4ccc22e09e0b588048ac33ee496486be71ca239e253be2cab5d1eb9feb0507).