### PR TITLE
Include etcd degragmentation instructions

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * post_installation_configuration/cluster-tasks.adoc
+// * scalability_and_performance/recommended-host-practices.adoc
 
 [id="etcd-defrag_{context}"]
 = Defragmenting etcd data

--- a/modules/recommended-etcd-practices.adoc
+++ b/modules/recommended-etcd-practices.adoc
@@ -1,8 +1,6 @@
 // Module included in the following assemblies:
 //
 // * scalability_and_performance/recommended-host-practices.adoc
-// * post_installation_configuration/cluster-tasks.adoc
-// * post_installation_configuration/node-tasks.adoc
 
 [id="recommended-etcd-practices_{context}"]
 = Recommended etcd practices
@@ -18,7 +16,8 @@ only accepts key reads and deletes. Some of the key metrics to monitor are
 `etcd_mvcc_db_total_size_in_use_in_bytes` which indicates the actual
 database usage after a history compaction, and
 `etcd_debugging_mvcc_db_total_size_in_bytes` which shows the database size
-including free space waiting for defragmentation.
+including free space waiting for defragmentation. Instructions on defragging 
+etcd can be found in the `Defragmenting etcd data` section.
 
 Etcd writes data to disk, so its performance strongly depends on disk performance. Etcd 
 persists proposals on disk. Slow disks and disk activity from other processes might cause long 

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -565,7 +565,6 @@ include::modules/nodes-cluster-enabling-features-cluster.adoc[leveloffset=+1]
 == etcd tasks
 Back up etcd, enable or disable etcd encryption, or defragment etcd data.
 
-include::modules/recommended-etcd-practices.adoc[leveloffset=+2]
 include::modules/about-etcd-encryption.adoc[leveloffset=+2]
 include::modules/enabling-etcd-encryption.adoc[leveloffset=+2]
 include::modules/disabling-etcd-encryption.adoc[leveloffset=+2]

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -56,7 +56,6 @@ include::modules/recommended-node-host-practices.adoc[leveloffset=+1]
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+2]
 include::modules/modify-unavailable-workers.adoc[leveloffset=+2]
 include::modules/master-node-sizing.adoc[leveloffset=+2]
-include::modules/recommended-etcd-practices.adoc[leveloffset=+2]
 include::modules/setting-up-cpu-manager.adoc[leveloffset=+2]
 
 [id="post-install-huge-pages"]

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -17,6 +17,8 @@ include::modules/master-node-sizing.adoc[leveloffset=+1]
 
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
+include::modules/etcd-defrag.adoc[leveloffset=+1]
+
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
 include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+1]


### PR DESCRIPTION
This commit adds instructions on degfragging the etcd to the
scalability and performance guide as part of the recommended etcd
practices. This is needed for etcd to avoid suffering from poor
performance if the keyspace grows excessively large and exceeds
the space quota.