### PR TITLE
Adjust H1 page header size/weight

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -278,8 +278,8 @@ button[name="button-collapse-expand-all"] {
 }
 
 .page-header h1 {
-  font-size: 28px;
-  font-weight: 300;
+  font-size: 30px;
+  font-weight: 400;
   letter-spacing: inherit;
   color: inherit;
   margin: 10px 0 0 0;


### PR DESCRIPTION
The H1 (Level 0) page heading font size and weight has felt strange for a while, oftentimes looking smaller than the H2 (Level 1) subheadings. This PR bumps the H1 font size slightly, and matches the default font weight (400) of the rest of the headings.

Preview (internal): http://file.rdu.redhat.com/~adellape/021621/L0_weight/welcome/

^ Note that this is a slightly hacked-up preview just so that I can show a working build for perusal. Only first-level topics will work; nested topics are broken. It wouldn't be broken like that for the real site tho, after merge & cherry-pick.

Before & after, with context for a few levels of subheading font sizes:

![before_after](https://user-images.githubusercontent.com/3442316/108118387-8758a300-705b-11eb-9546-8cf1788856fb.png)
