### PR TITLE
CNV-BZ-1918467 Added note to install doc about RHCOS support

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -7,7 +7,12 @@ toc::[]
 Before you install {VirtProductName}, ensure that your {product-title} cluster meets the following requirements:
 
 * Your cluster must be installed on
-xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal] infrastructure with Red Hat Enterprise Linux CoreOS workers.
+xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal] infrastructure with Red Hat Enterprise Linux CoreOS (RHCOS) workers.
+
+[NOTE]
+====
+{VirtProductName} only supports RHCOS worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
+====
 
 * Additionally, your cluster must use xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[installer-provisioned infrastructure] and xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[deploy machine health checks] to maintain high availability (HA) of virtual machines.
 


### PR DESCRIPTION
Addresses https://bugzilla.redhat.com/show_bug.cgi?id=1918467

Added note in the "Preparing your cluster for OpenShift Virtualization" assembly to point out that only RHCOS workers are supported. RHEL 7/8 nodes are not supported.

Preview: https://deploy-preview-29539--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html
