### PR TITLE
Make OLM img tags use product-version

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -13,9 +13,9 @@ ifdef::openshift-origin[]
 :example-registry: example.com
 endif::[]
 ifndef::openshift-origin[]
-:index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v4.6
+:index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
 :index-image: redhat-operator-index
-:tag: v4.6
+:tag: v{product-version}
 :catalog-name: redhat-operators
 :example-registry: registry.redhat.io
 endif::[]

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -16,8 +16,8 @@ ifdef::openshift-origin[]
 endif::[]
 ifndef::openshift-origin[]
 :catalog-name: redhat-operators
-:index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v4.6
-:index-image: redhat-operator-index:v4.6
+:index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
+:index-image: redhat-operator-index:v{product-version}
 :package1: advanced-cluster-management
 :package2: jaeger-product
 :package3: quay-operator

--- a/modules/olm-understanding-operator-catalog-images.adoc
+++ b/modules/olm-understanding-operator-catalog-images.adoc
@@ -3,6 +3,8 @@
 // * operators/admin/olm-managing-custom-catalogs.adoc
 // * operators/admin/olm-restricted-networks.adoc
 
+:tag: v{product-version}
+
 [id="olm-understanding-operator-catalog-images_{context}"]
 = Understanding Operator catalogs
 
@@ -26,15 +28,15 @@ The following catalogs are distributed by Red Hat:
 |Description
 
 |`redhat-operators`
-|`registry.redhat.io/redhat/redhat-operator-index:v4.6`
+|`registry.redhat.io/redhat/redhat-operator-index:{tag}`
 |Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
 
 |`certified-operators`
-|`registry.redhat.io/redhat/certified-operator-index:v4.6`
+|`registry.redhat.io/redhat/certified-operator-index:{tag}`
 |Products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
 
 |`redhat-marketplace`
-|`registry.redhat.io/redhat/redhat-marketplace-index:v4.6`
+|`registry.redhat.io/redhat/redhat-marketplace-index:{tag}`
 |Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
 
 |`community-operators`
@@ -51,3 +53,5 @@ As a cluster administrator, you can create your own custom index image, either b
 ====
 When creating custom catalog images, previous versions of {product-title} 4 required using the `oc adm catalog build` command, which has been deprecated for several releases. With the availability of Red Hat-provided index images starting in {product-title} 4.6, catalog builders should start switching to using the `opm index` command to manage index images before the `oc adm catalog build` command is removed in a future release.
 ====
+
+:!tag:


### PR DESCRIPTION
Update a few 4.6 spots to 4.7, and use the `{product-version}` entity.