### PR TITLE
BZ1839983: Added a warning and additional resource for mirroring addi…

### DIFF
--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -55,9 +55,6 @@ include::modules/installation-restricted-network-samples.adoc[leveloffset=+1]
 
 include::modules/installation-images-samples-disconnected-mirroring-assist.adoc[leveloffset=+2]
 
-See xref:../install_config/installing-restricted-networks-preparations.adoc#installation-restricted-network-samples_installing-restricted-networks-preparations[Using Cluster Samples Operator image streams with alternate or mirrored registries] for a detailed procedure.
-
-
 
 == Next steps
 
@@ -66,3 +63,8 @@ See xref:../install_config/installing-restricted-networks-preparations.adoc#inst
 * Install a cluster on infrastructure that you provision in your restricted nework, such as on
 xref:../../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[VMware vSphere],
 xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal], or xref:../../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[Amazon Web Services].
+
+[id="restricted-networks-additional-resources"]
+== Additional resources
+
+* See xref:../../support/gathering-cluster-data.adoc#gathering-data-specific-features_gathering-cluster-data[Gathering data about specific features] for more information about using must-gather.

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -183,4 +183,6 @@ that you selected, you must extract the installation program from the mirrored
 content.
 
 You must perform this step on a machine with an active Internet connection.
+
+If you are in a disconnected environment, use the `--image` flag as part of must-gather and point to the payload image. 
 ====

--- a/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
+++ b/modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc
@@ -9,9 +9,15 @@ Clusters using a restricted network must import the default must-gather image in
 
 .Procedure
 
-. Import the default must-gather image from your installation payload:
+* Import the default must-gather image from your installation payload:
 +
 [source,terminal]
 ----
 $ oc import-image is/must-gather -n openshift
+----
+
+When running the `oc adm must-gather` command, use the `--image` flag and point to the payload image, as in the following example:
+[source,terminal]
+----
+$ oc adm must-gather --image=$(oc adm release info --image-for must-gather)
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1839983

for 4.5+, since 4.4 is no longer supported for doc updates as of 4.7 GA release
Added a warning and additional resource for mirroring additional images

Link to preview: 
[0] additional step in procedure
[1] additional resource
[2] additional information at the bottom of topic
[0]https://deploy-preview-29546--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations.html#installation-preparing-restricted-cluster-to-gather-support-data_installing-restricted-networks-preparations

[1]https://deploy-preview-29546--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations.html#restricted-networks-additional-resources

[2]https://deploy-preview-29546--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations.html#installation-mirror-repository_installing-restricted-networks-preparations