### PR TITLE
Remove note that says that no CSI drivers are installed

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi.adoc
@@ -10,16 +10,6 @@ storage from storage back ends that implement the
 link:https://github.com/container-storage-interface/spec[CSI interface]
 as persistent storage.
 
-[IMPORTANT]
-====
-{product-title} does not ship with any CSI drivers. It is recommended
-to use the CSI drivers provided by
-link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors].
-
-Installation instructions differ by driver, and are found in each driver's
-documentation. Follow the instructions provided by the CSI driver.
-====
-
 include::modules/persistent-storage-csi-architecture.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-external-controllers.adoc[leveloffset=+2]


### PR DESCRIPTION
This is for 4.5+.

@vikram-redhat Hemant Kumar is interested in having this merged for 4.7 GA. The note being removed with this PR is completely wrong and contradicts material in the same topic further down.

@openshift/storage PTAL.