### PR TITLE
[enterprise-4.5] Removing IBM Z comment

### DIFF
--- a/installing/install_config/installation-types.adoc
+++ b/installing/install_config/installation-types.adoc
@@ -111,11 +111,3 @@ Not all installation options are supported for all platforms, as shown in the fo
 |
 
 |===
-
-////
-*If IBM Z is added to 4.5, replace the following in place of the | before Network Operator. Remove spaces after xref.
-ifndef::openshift-origin[]
-|xref:    ../../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[X]
-endif::[]
-////
-


### PR DESCRIPTION
This applies to branch/enterprise-4.5 only.

This PR removes an IBM Z related comment that does not exist in the master branch from the 4.5 branch.