### PR TITLE
[virt] removing irrelevant note

### DIFF
--- a/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
@@ -9,11 +9,6 @@ You must configure SELinux before you create the `HostPathProvisioner` custom
 resource. To configure SELinux on Red Hat Enterprise Linux CoreOS 8 workers, you
 must create a `MachineConfig` object on each node.
 
-[NOTE]
-====
-If you do not use Red Hat Enterprise Linux CoreOS workers, skip this procedure.
-====
-
 .Prerequisites
 
 * Create a backing directory on each node for the persistent volumes (PVs)


### PR DESCRIPTION
This note is irrelevant because a prereq for CNV is: "Your cluster must be installed on bare metal infrastructure with Red Hat Enterprise Linux CoreOS workers."

No QE needed. CP to 4.6 and 4.7.