### PR TITLE
CNV - 4-7 about-virt copy

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -1,11 +1,15 @@
-[id="about-virt"]
-= OpenShift Virtualization
 include::modules/virt-document-attributes.adoc[]
+[id="about-virt"]
+= About {VirtProductName}
 :context: about-virt
 toc::[]
 
-Documentation for OpenShift Virtualization will be available for {product-title} 4.6 in the near future.
+Learn about {VirtProductName}'s capabilities and support scope.
 
-In the meantime, the https://docs.openshift.com/container-platform/4.5/virt/about-virt.html[OpenShift Virtualization 2.4 documentation] is available as part of the {product-title} 4.5 documentation.
+include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
 
-// Container-native virtualization 2.3 is also supported for use in {product-title} 4.5.
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
+
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]


### PR DESCRIPTION
Copying the 'about-virt' assembly from master as enterprise-4.7 branch currently has the old placeholder assembly, no doubt from when the 4.7 branch was originally created and we were pre-2.5