### PR TITLE
CNV-7193 for CNV 2.5 ONLY: Moving Xref to assembly

### DIFF
--- a/modules/virt-creating-pvcs-to-store-default-os-images.adoc
+++ b/modules/virt-creating-pvcs-to-store-default-os-images.adoc
@@ -30,6 +30,3 @@ Follow these steps to create a persistent volume claim (PVC), which you use to u
 
 +
 The *Persistent Volume Claim Details* screen displays information about the PVC that you created.
-
-.Additional Resources
-* xref:../../../virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-web.adoc#virt-uploading-local-disk-images-web[Uploading local disk images]

--- a/virt/virtual_machines/virtual_disks/virt-creating-and-using-default-os-images.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-and-using-default-os-images.adoc
@@ -11,3 +11,6 @@ To use default OS images, you must install the latest version of {VirtProductNam
 include::modules/virt-creating-pvcs-to-store-default-os-images.adoc[leveloffset=+1]
 
 include::modules/virt-creating-a-vm-from-a-default-os-image.adoc[leveloffset=+1]
+
+== Additional resources
+* xref:../../../virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-web.adoc#virt-uploading-local-disk-images-web[Uploading local disk images]


### PR DESCRIPTION
This PR is in response to comment from @vikram-redhat.

Moving the Xref into the assembly. Vikram, if you approve this change please merge to _enterprise-4.6_ only. This feature has new doc for 4.7/2.6 going forward.

Test Build: https://deploy-preview-29588--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-creating-and-using-default-os-images.html

@sjhala-ccs has given thumbs up.

Thanks and sorry for the inconvenience,

Bob

cc: @ctomasko