### PR TITLE
CNV-9233 - Inclusive language for virt node names

### DIFF
--- a/modules/virt-troubleshooting-incorrect-policy-config.adoc
+++ b/modules/virt-troubleshooting-incorrect-policy-config.adoc
@@ -9,7 +9,7 @@
 You can apply changes to the node network configuration across your entire cluster by applying a node network configuration policy.
 If you apply an incorrect configuration, you can use the following example to troubleshoot and correct the failed node network policy.
 
-In this example, a Linux bridge policy is applied to an example cluster that has three master nodes and three worker nodes.
+In this example, a Linux bridge policy is applied to an example cluster that has three control plane nodes (master) and three compute (worker) nodes.
 The policy fails to be applied because it references an incorrect interface.
 To find the error, investigate the available NMState resources. You can then update the policy with the correct configuration.
 
@@ -83,19 +83,19 @@ The output shows that the policy failed on all nodes:
 [source,terminal]
 ----
 NAME                                   STATUS
-master-1.ens01-bridge-testfail         FailedToConfigure
-master-2.ens01-bridge-testfail         FailedToConfigure
-master-3.ens01-bridge-testfail         FailedToConfigure
-worker-1.ens01-bridge-testfail         FailedToConfigure
-worker-2.ens01-bridge-testfail         FailedToConfigure
-worker-3.ens01-bridge-testfail         FailedToConfigure
+control-plane-1.ens01-bridge-testfail        FailedToConfigure
+control-plane-2.ens01-bridge-testfail        FailedToConfigure
+control-plane-3.ens01-bridge-testfail        FailedToConfigure
+compute-1.ens01-bridge-testfail              FailedToConfigure
+compute-2.ens01-bridge-testfail              FailedToConfigure
+compute-3.ens01-bridge-testfail              FailedToConfigure
 ----
 
 . View one of the failed enactments and look at the traceback. The following command uses the output tool `jsonpath` to filter the output:
 +
 [source,terminal]
 ----
-$ oc get nnce worker-1.ens01-bridge-testfail -o jsonpath='{.status.conditions[?(@.type=="Failing")].message}'
+$ oc get nnce compute-1.ens01-bridge-testfail -o jsonpath='{.status.conditions[?(@.type=="Failing")].message}'
 ----
 +
 This command returns a large traceback that has been edited for brevity:
@@ -188,10 +188,10 @@ difference
 +
 The `NmstateVerificationError` lists the `desired` policy configuration, the `current` configuration of the policy on the node, and the `difference` highlighting the parameters that do not match. In this example, the `port` is included in the `difference`, which suggests that the problem is the port configuration in the policy.
 
-. To ensure that the policy is configured properly, view the network configuration for one or all of the nodes by requesting the `NodeNetworkState` object. The following command returns the network configuration for the `master-1` node:
+. To ensure that the policy is configured properly, view the network configuration for one or all of the nodes by requesting the `NodeNetworkState` object. The following command returns the network configuration for the `control-plane-1` node:
 +
 ----
-$ oc get nns master-1 -o yaml
+$ oc get nns control-plane-1 -o yaml
 ----
 +
 The output shows that the interface name on the nodes is `ens1` but the failed policy incorrectly uses `ens01`:


### PR DESCRIPTION
Replacing the term 'master' with 'control plane' for node names as per the new guidelines for inclusive language. Also replaced 'worker' with 'compute' in this module. 
There remains other instances of the term 'worker nodes' in the docs, which are currently waiting on changes upstream, so this module uses the preferred 'control plane' and 'compute' with the legacy terms in parenthesis in the first instance. 
The vast majority of references in this module are for specific node names, which now follows the [OCP contributor guidelines](https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#node-names)