### PR TITLE
Explicitly state UPI in restricted network titles to avoid confusion

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -149,7 +149,7 @@ Topics:
     File: installing-aws-government-region
   - Name: Installing a cluster on AWS using CloudFormation templates
     File: installing-aws-user-infra
-  - Name: Installing a cluster on AWS in a restricted network
+  - Name: Installing a cluster on AWS in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-aws
   - Name: Uninstalling a cluster on AWS
     File: uninstalling-cluster-aws
@@ -197,7 +197,7 @@ Topics:
     File: installing-gcp-user-infra
   - Name: Installing a cluster on GCP using Deployment Manager templates and a shared VPC
     File: installing-gcp-user-infra-vpc
-  - Name: Restricted network GCP installation
+  - Name: Installing a cluster on GCP in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-gcp
   - Name: Uninstalling a cluster on GCP
     File: uninstalling-cluster-gcp
@@ -304,7 +304,7 @@ Topics:
     File: installing-vsphere
   - Name: Installing a cluster on vSphere with user-provisioned infrastructure and network customizations
     File: installing-vsphere-network-customizations
-  - Name: Restricted network vSphere installation with user-provisioned infrastructure
+  - Name: Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-vsphere
   - Name: Uninstalling a cluster on vSphere that uses installer-provisioned infrastructure
     File: uninstalling-cluster-vsphere-installer-provisioned

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -1,5 +1,5 @@
 [id="installing-restricted-networks-aws"]
-= Installing a cluster on AWS that uses mirrored installation content
+= Installing a cluster on AWS in a restricted network with user-provisioned infrastructure
 include::modules/common-attributes.adoc[]
 :context: installing-restricted-networks-aws
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -1,5 +1,5 @@
 [id="installing-restricted-networks-gcp"]
-= Installing a cluster on GCP in a restricted network
+= Installing a cluster on GCP in a restricted network with user-provisioned infrastructure
 include::modules/common-attributes.adoc[]
 :context: installing-restricted-networks-gcp
 


### PR DESCRIPTION
With plans to document the IPI restricted network paths for AWS/GCP/vSphere in the 4.7.z time frame, this PR changes the UPI restricted network paths to explicitly state they're for "UPI".