### PR TITLE
Add recommendation around disk throughput impacting runtime

### DIFF
--- a/modules/recommended-node-host-practices.adoc
+++ b/modules/recommended-node-host-practices.adoc
@@ -27,6 +27,14 @@ actual container starting. Therefore, a system running 10 pods will actually
 have 20 containers running.
 ====
 
+[NOTE]
+====
+Disk IOPS throttling from the cloud provider might have an impact on CRI-O and kubelet. 
+They might get overloaded when there are large number of I/O intensive pods running on 
+the nodes. It is recommended that you monitor the disk I/O on the nodes and use volumes 
+with sufficient throughput for the workload.
+====
+
 `podsPerCore` sets the number of pods the node can run based on the number of
 processor cores on the node. For example, if `podsPerCore` is set to `10` on a
 node with 4 processor cores, the maximum number of pods allowed on the node will


### PR DESCRIPTION
This commit adds a recommendation around using volumes with high
throughput to make sure kubelet and crio doesn't get overloaded
when running heavy pods on the nodes.