### PR TITLE
BZ#1841026: Removed -a flag, since it is incorrect in context

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -71,9 +71,8 @@ $ oc adm catalog build \
     --from=registry.redhat.io/openshift4/ose-operator-registry:v4.5 \//<2>
     --filter-by-os="linux/amd64" \//<3>
     --to=<registry_host_name>:<port>/olm/redhat-operators:v1 \//<4>
-    [-a ${REG_CREDS}] \//<5>
-    [--insecure] \//<6>
-    [--auth-token "${AUTH_TOKEN}"] <7>
+    [--insecure] \//<5>
+    [--auth-token "${AUTH_TOKEN}"] <6>
 ----
 <1> Organization (namespace) to pull from an App Registry instance.
 <2> Set `--from` to the `ose-operator-registry` base image using the tag that
@@ -82,9 +81,8 @@ matches the target {product-title} cluster major and minor version.
 base image, which must match the target {product-title} cluster. Valid values
 are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 <4> Name your catalog image and include a tag, for example, `v1`.
-<5> Optional: If required, specify the location of your registry credentials file.
-<6> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<7> Optional: If other application registry catalogs are used that are not public, specify a Quay authentication token.
+<5> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<6> Optional: If other application registry catalogs are used that are not public, specify a Quay authentication token.
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1841026

This is for 4.5 only. `oc adm build` was deprecated in the successive releases. 

Ready for QA: @emmajiafan 