### PR TITLE
[virt] Removing patch command known issue from 2.6 RNs

### DIFF
--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -101,17 +101,6 @@ As a workaround, you can reconfigure the virtual machines so that they can be po
 . Remove the `evictionStrategy: LiveMigrate` field. See xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[Configuring virtual machine eviction strategy] for more information on how to configure eviction strategy.
 . Set the `runStrategy` field to `Always`.
 
-* Sometimes, when attempting to edit the subscription channel of the {VirtProductName} Operator in the web console, clicking the *Channel* button of the *Subscription Overview* results in a JavaScript error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1796410[*BZ#1796410*])
-
-** As a workaround, trigger the upgrade process to {VirtProductName} {VirtVersion} from the CLI by running the following `oc` patch command:
-+
-[source,terminal]
-----
-$ export TARGET_NAMESPACE=openshift-cnv CNV_CHANNEL=stable && oc patch -n "${TARGET_NAMESPACE}" $(oc get subscription -n ${TARGET_NAMESPACE} --no-headers -o name) --type='json' -p='[{"op": "replace", "path": "/spec/channel", "value":"'${CNV_CHANNEL}'"}, {"op": "replace", "path": "/spec/installPlanApproval", "value":"Automatic"}]'
-----
-+
-This command points your subscription to the `stable` upgrade channel and enables automatic updates.
-
 * Live migration fails when nodes have different CPU models. Even in cases where nodes have the same physical CPU model, differences introduced by microcode updates have the same effect. This is because the default settings trigger host CPU passthrough behavior, which is incompatible with live migration. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1760028[*BZ#1760028*])
 
 ** As a workaround, set the default CPU model in the `kubevirt-config` ConfigMap, as shown in the following example:


### PR DESCRIPTION
- This RN is no longer needed, based on discussion with @tiraboschi 