### PR TITLE
4.7 Release notes for Builds

### DIFF
--- a/modules/samples-operator-configuration.adoc
+++ b/modules/samples-operator-configuration.adoc
@@ -95,6 +95,8 @@ not all of the tag spec generations and tag status generations match.
 import, the last seen error is in the message field. The list of pending
 imagestreams is in the reason field.
 
+This condition is deprecated in {product-title}.
+
 |`ConfigurationValid`
 |`True` or `False` based on whether any of the restricted changes noted
 previously are submitted.
@@ -114,5 +116,7 @@ message field.
 |`MigrationInProgress`
 |`True` when the Cluster Samples Operator detects that the version is different than the
 Cluster Samples Operator version with which the current samples set are installed.
+
+This condition is deprecated in {product-title}.
 
 |===

--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -534,6 +534,16 @@ See xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operato
 
 In the current version, when the {product-title} performs a build and the log level is five or higher, the cluster writes the buildah version information to the build log. This information helps Red Hat Engineering reproduce bug reports. Previously, this version information was not available in the build logs.
 
+
+[discrete]
+[id="ocp-4-7-samples-operator-assistance-mirroring"]
+==== Cluster Samples Operator assistance for mirroring
+
+{product-title} now creates a config map named `imagestreamtag-to-image` in the `openshift-cluster-samples-operator` namespace that contains an entry, the populating image, for each image stream tag. You can use this config map as a reference for which images need to be mirrored for your image streams to import.
+
+For more information, see xref:../openshift_images/samples-operator-alt-registry.adoc#installation-images-samples-disconnected-mirroring-assist_samples-operator-alt-registry[Cluster Samples Operator assistance for mirroring].
+
+
 [id="ocp-4-7-images"]
 === Images
 
@@ -830,6 +840,16 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|`ImageChangesInProgress` condition for Cluster Samples Operator
+|GA
+|GA
+|DEP
+
+|`MigrationInProgress` condition for Cluster Samples Operator
+|GA
+|GA
+|DEP
+
 |====
 
 [id="ocp-4-7-deprecated-features"]
@@ -846,6 +866,16 @@ Using a scheduler policy to control pod placement is deprecated and is planned f
 When using the `oc adm catalog mirror` command to mirror catalogs, the `--filter-by-os` flag was previously allowed to filter architectures of mirrored content. This would break references to those images in the catalog that point to the manifest list and not the manifest. The `--filter-by-os` flag now only filters the index image that is pulled and unpacked. To clarify this, the new `--index-filter-by-os` flag is now added and should be used instead.
 
 The `--filter-by-os` flag is also now deprecated.
+
+[id="ocp-4-7-imagechangesinprogress-deprecated"]
+==== ImageChangesInProgress condition for Cluster Samples Operator
+
+Image stream image imports are no longer tracked in real time by conditions on the Cluster Samples Operator configuration resource. In-progress image streams no longer directly affect updates to the `ClusterOperator` instance `openshift-samples`. Prolonged errors with image streams` are now reported by Prometheus alerts.
+
+[id="ocp-4-7-migrationinprogress-deprecated"]
+==== MigrationInProgress condition for Cluster Samples Operator
+
+Upgrade tracking is now achieved by the other conditions and both the individual image stream config maps and the `imagestream-to-image` config map.
 
 [id="ocp-4-7-removed-features"]
 === Removed features


### PR DESCRIPTION
Updating release notes for builds as requested in https://github.com/openshift/openshift-docs/issues/26801. 

Store imagestreamtag to image mappings in configmap imagestreamtag-to-image [BUILD-145](https://issues.redhat.com/browse/BUILD-145)
Improve recording of imagestream import [BUILD-125](https://issues.redhat.com/browse/BUILD-125)
Fire Event if Build was triggered by clearing the last image ID [BUILD-187](https://issues.redhat.com/browse/BUILD-187) [omitted for now because I'm not sure what needs to be announced about this feature]

Direct build previews
Builds: https://deploy-preview-29631--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#builds
Deprecated features: https://deploy-preview-29631--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-deprecated-removed-features
