### PR TITLE
BZ#1927841: host network routers and OVN-K

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -11,7 +11,7 @@ In {product-title} {product-version}, OpenShift SDN supports using network polic
 
 [NOTE]
 ====
-IPBlock is supported by network policy with limitations for OpenShift SDN; itsupports IPBlock without except clauses. If you create a policy with an IPBlock section including an except clause, the SDN pods log generates warnings and the entire IPBlock section of that policy is ignored.
+IPBlock is supported by network policy with limitations for OpenShift SDN; it supports IPBlock without except clauses. If you create a policy with an IPBlock section that includes an except clause, the SDN pods log warnings and the entire IPBlock section of that policy is ignored.
 ====
 
 [WARNING]
@@ -42,7 +42,12 @@ spec:
 
 * Only allow connections from the {product-title} Ingress Controller:
 +
-To make a project allow only connections from the {product-title} Ingress Controller, add the following `NetworkPolicy` object:
+To make a project allow only connections from the {product-title} Ingress Controller, add the following `NetworkPolicy` object.
++
+[IMPORTANT]
+====
+For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+====
 +
 [source,yaml]
 ----
@@ -64,7 +69,7 @@ spec:
 If the Ingress Controller is configured with `endpointPublishingStrategy: HostNetwork`, then the Ingress Controller pod runs on the host network.
 When running on the host network, the traffic from the Ingress Controller is assigned the `netid:0` Virtual Network ID (VNID).
 The `netid` for the namespace that is associated with the Ingress Operator is different, so the `matchLabel` in the `allow-from-openshift-ingress` network policy does not match traffic from the `default` Ingress Controller.
-Because the `default` namespace is assigned the `netid:0` VNID, you can allow traffic from the `default` Ingress Controller by labeling your `default` namespace with `network.openshift.io/policy-group: ingress`.
+With OpenShift SDN, the `default` namespace is assigned the `netid:0` VNID and you can allow traffic from the `default` Ingress Controller by labeling your `default` namespace with `network.openshift.io/policy-group: ingress`.
 
 * Only accept connections from pods within a project:
 +

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -19,7 +19,12 @@ project namespaces.
 .Procedure
 
 . Create the following `NetworkPolicy` objects:
-.. A policy named `allow-from-openshift-ingress`:
+.. A policy named `allow-from-openshift-ingress`.
++
+[IMPORTANT]
+====
+For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+====
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1927841

I believe the whole topic indicates that it is for
OpenShift SDN only, but that is several page-scrolls
above the updated section.

https://deploy-preview-29633--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-networkpolicy-about_post-install-network-configuration, then scroll to the para after the second bullet.

Andrew pointed out another spot that needs the similar restriction.  See step 1 at https://deploy-preview-29633--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html#nw-networkpolicy-multitenant-isolation_multitenant-network-policy

Please add labels for enterprise 4.5, 4.6, 4.7, and 4.8 if it exists.  Milestone is Next-Release.