### PR TITLE
[virt] version number attributes for CNV 2.6

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -12,10 +12,10 @@
 :VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
-:VirtVersion: 2.5
-:KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.4
-// :LastHCOVersion: 2.4.4
+:VirtVersion: 2.6
+:KubeVirtVersion: v0.36.2
+:HCOVersion: 2.6.0
+// :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]


### PR DESCRIPTION
- [CNV-10319](https://issues.redhat.com/browse/CNV-10319)
- CP to enterprise-4.7
- The KubeVirtVersion can be found in the virt-api container: http://pkgs.devel.redhat.com/cgit/containers/virt-api/tree/Dockerfile?h=cnv-2.6-rhel-8#n49

@stu-gott and @tiraboschi please confirm these version numbers - thanks!

Note: Simone, the HCOVersion attribute is used in places like the following:
- [must-gather command](https://deploy-preview-29635--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data.html#virt-about-collecting-virt-data_virt-collecting-virt-data)
- [example output when deleting virt](https://deploy-preview-29635--osdocs.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt-cli.html#virt-deleting-virt-cli_uninstalling-virt-cli)
- [manifest for subscribing](https://deploy-preview-29635--osdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html#virt-subscribing-cli_installing-virt-cli)
- [manifests in the node placement assembly](https://deploy-preview-29635--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html)