### PR TITLE
Fix typo in the cluster logging templates

### DIFF
--- a/modules/cluster-logging-elasticsearch-audit.adoc
+++ b/modules/cluster-logging-elasticsearch-audit.adoc
@@ -59,29 +59,32 @@ spec:
   outputs:
    - name: elasticsearch-insecure
      type: "elasticsearch"
-     url: elasticsearch-insecure.svc.messaging.cluster.local
+     url: http://elasticsearch-insecure.messaging.svc.cluster.local
      insecure: true
    - name: elasticsearch-secure
      type: "elasticsearch"
-     url: elasticsearch-secure.svc.messaging.cluster.local
+     url: https://elasticsearch-secure.messaging.svc.cluster.local
      secret: 
-        name: es-audit
+       name: es-audit
    - name: secureforward-offcluster
-     type: "forward"
+     type: "fluentdForward"
      url: https://secureforward.offcluster.com:24224
      secret:
-        name: secureforward
+       name: secureforward
   pipelines: 
    - name: container-logs
-     inputRefs: application
+     inputRefs:
+     - application
      outputRefs:
      - secureforward-offcluster
    - name: infra-logs
-     inputRefs: infrastructure
+     inputRefs:
+     - infrastructure
      outputRefs:
      - elasticsearch-insecure
    - name: audit-logs
-     inputRefs: audit
+     inputRefs:
+     - audit
      outputRefs:
      - elasticsearch-secure
      - default <1>


### PR DESCRIPTION
@vikram-redhat There are two issues on the templates of cluster logging docs, minimum version that the change applies to should be 4.6 in my opinion, could you review them? Thanks.

1. modules/cluster-logging-deploy-console.adoc
    One more same comment for <6>, should remove it.

2. modules/cluster-logging-elasticsearch-audit.adoc
    On OCP 4.6.x(not test on OCP 4.7 yet, might be same):
    spec.outputs.url in body should match '^$|[a-zA-z]+:\/\/.*'" for field "spec.outputs.url".
    supported values: "syslog", "fluentdForward", "elasticsearch", "kafka"" for field "spec.outputs.type". 