### PR TITLE
GitOps release note entry and TP updates

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -730,7 +730,9 @@ For more information, see xref:../scalability_and_performance/cnf-performance-ad
 [id="ocp-4-7-dev-exp"]
 === Developer experience
 
-
+==== Red Hat OpenShift GitOps (Technology Preview)
+The Red Hat OpenShift GitOps 1.0 Technology Preview release introduces a declarative way to implement continuous deployment for cloud native applications. You can use Red Hat OpenShift GitOps to adopt GitOps principles for managing cluster configurations, and for automating secure, predictable, traceable, and repeatable application delivery across hybrid, multi-cluster, Kubernetes environments.
+It uses Argo CD as the core, and adds other tooling to enable teams to implement GitOps workflows across clusters. For more information, see, xref:../cicd/gitops/understanding-openshift-gitops.adoc#about-gitops_understanding-openshift-gitops[Understanding OpenShift GitOps].
 
 [id="ocp-4-7-insights-operator"]
 === Insights Operator
@@ -1151,7 +1153,12 @@ In the table below, features are marked with the following statuses:
 |OpenShift Pipelines
 |TP
 |TP
-|
+|TP
+
+|OpenShift GitOps
+|-
+|TP
+|TP
 
 |Vertical Pod Autoscaler
 |TP


### PR DESCRIPTION
This PR adds a small note for GitOps in the new features and adds it to the TP table. It also adds TP status to Pipelines 4.7 in the TP table.

