### PR TITLE
[enterprise-4.6] Restricted network installs are no longer UPI-only

### DIFF
--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -6,6 +6,7 @@
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc 
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc 
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
@@ -20,11 +21,7 @@ endif::[]
 = About installations in restricted networks
 
 In {product-title} {product-version}, you can perform an installation that does not
-require an active connection to the Internet to obtain software components. You
-complete an installation in a restricted network on only infrastructure that you provision,
-not infrastructure that the installation program provisions, so your platform selection is
-limited.
-// maybe point out that you can follow the bare metal installation rules on supported hardware and link to the matrix
+require an active connection to the Internet to obtain software components. Restricted network installations can be completed using installer-provisioned infrastructure or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
 ifndef::ibm-power[]
 If you choose to perform a restricted network installation on a cloud platform, you
@@ -45,12 +42,7 @@ that meet your restrictions.
 ifndef::osp[]
 [IMPORTANT]
 ====
-Restricted network installations always use user-provisioned infrastructure.
-Because of the complexity of the configuration for user-provisioned installations,
-consider completing a standard user-provisioned infrastructure installation before
-you attempt a restricted network installation. Completing this test installation might
-make it easier to isolate and troubleshoot any issues that might arise
-during your installation in a restricted network.
+Because of the complexity of the configuration for user-provisioned installations, consider completing a standard user-provisioned infrastructure installation before you attempt a restricted network installation using user-provisioned infrastructure. Completing this test installation might make it easier to isolate and troubleshoot any issues that might arise during your installation in a restricted network.
 ====
 endif::osp[]
 


### PR DESCRIPTION
Manual cherrypick of #29552