### PR TITLE
[enterprise-4.5] Restricted network installs are no longer UPI-only

### DIFF
--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
@@ -18,11 +19,7 @@ endif::[]
 = About installations in restricted networks
 
 In {product-title} {product-version}, you can perform an installation that does not
-require an active connection to the Internet to obtain software components. You
-complete an installation in a restricted network on only infrastructure that you provision,
-not infrastructure that the installation program provisions, so your platform selection is
-limited.
-// maybe point out that you can follow the bare metal installation rules on supported hardware and link to the matrix
+require an active connection to the Internet to obtain software components. Restricted network installations can be completed using installer-provisioned infrastructure or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
 ifndef::ibm-power[]
 If you choose to perform a restricted network installation on a cloud platform, you
@@ -43,12 +40,7 @@ that meet your restrictions.
 ifndef::osp[]
 [IMPORTANT]
 ====
-Restricted network installations always use user-provisioned infrastructure.
-Because of the complexity of the configuration for user-provisioned installations,
-consider completing a standard user-provisioned infrastructure installation before
-you attempt a restricted network installation. Completing this test installation might
-make it easier to isolate and troubleshoot any issues that might arise
-during your installation in a restricted network.
+Because of the complexity of the configuration for user-provisioned installations, consider completing a standard user-provisioned infrastructure installation before you attempt a restricted network installation using user-provisioned infrastructure. Completing this test installation might make it easier to isolate and troubleshoot any issues that might arise during your installation in a restricted network.
 ====
 endif::osp[]
 


### PR DESCRIPTION
Manual cherrypick of #29552