### PR TITLE
CNV-9454: CDI filesystem overhead RN

### DIFF
--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -57,6 +57,7 @@ Other operating system templates shipped with {VirtProductName} are not supporte
 === Storage
 
 //CNV-9454: On filesystem-based PVCs, CDI now accounts for FS overhead
+* When you add a virtual machine disk to a persistent volume claim (PVC) that uses the `Filesystem` volume mode, the Containerized Data Importer (CDI) now reserves 5.5% of the PVC space for file system overhead. If the default value is not ideal for your use case, you can xref:../virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.adoc#virt-reserving-pvc-space-fs-overhead[change the percentage] that CDI reserves for this purpose.
 
 //CNV-9455: Improvements to KubeVirt and CDI ensure that storage is allocated on the correct node
 


### PR DESCRIPTION
- [CNV-9454](https://issues.redhat.com/browse/CNV-9454)
- [Preview build](https://deploy-preview-29650--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-6-release-notes.html#virt-2-6-storage-new)