### PR TITLE
Rel Notes doc text for 4.7.0 GA release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-(link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.20] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2020:5633[RHSA-2020:5633]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.20] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.7.0 as the GA version and, instead, is releasing {product-title} 4.7.z as the GA version.
 
@@ -611,11 +611,6 @@ In the current version, when the {product-title} performs a build and the log le
 {product-title} now creates a config map named `imagestreamtag-to-image` in the `openshift-cluster-samples-operator` namespace that contains an entry, the populating image, for each image stream tag. You can use this config map as a reference for which images need to be mirrored for your image streams to import.
 
 For more information, see xref:../openshift_images/samples-operator-alt-registry.adoc#installation-images-samples-disconnected-mirroring-assist_samples-operator-alt-registry[Cluster Samples Operator assistance for mirroring].
-
-
-[id="ocp-4-7-images"]
-=== Images
-
 
 [id="ocp-4-7-machine-api"]
 === Machine API
@@ -1820,32 +1815,17 @@ In the table below, features are marked with the following statuses:
 |Precision Time Protocol (PTP)
 |TP
 |TP
-|
+|TP
 
 |`oc` CLI Plug-ins
 |TP
 |TP
-|
-
-|experimental-qos-reserved
 |TP
-|TP
-|
-
-|Ephemeral Storage Limit/Requests
-|TP
-|TP
-|
 
 |Descheduler
 |TP
 |TP
 |GA
-
-|Podman
-|TP
-|TP
-|
 
 |OVN-Kubernetes Pod network provider
 |TP
@@ -1855,7 +1835,7 @@ In the table below, features are marked with the following statuses:
 |HPA custom metrics adapter based on Prometheus
 |TP
 |TP
-|
+|TP
 
 |HPA for memory utilization
 |TP
@@ -1865,7 +1845,7 @@ In the table below, features are marked with the following statuses:
 |Service Binding
 |TP
 |TP
-|
+|GA
 
 |Log forwarding
 |TP
@@ -1950,7 +1930,7 @@ In the table below, features are marked with the following statuses:
 |Vertical Pod Autoscaler
 |TP
 |TP
-|
+|TP
 
 |Operator API
 |TP
@@ -1960,7 +1940,7 @@ In the table below, features are marked with the following statuses:
 |Adding kernel modules to nodes
 |TP
 |TP
-|
+|TP
 
 |Egress router CNI plug-in
 |-
@@ -1978,8 +1958,8 @@ In the table below, features are marked with the following statuses:
 |TP
 
 |Kubernetes NMState Operator
-|
-|
+|-
+|-
 |TP
 
 |====
@@ -2148,12 +2128,12 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 [id="ocp-4-7-0-ga"]
-=== RHBA-2021:1234 - {product-title} 4.7 image release and bug fix advisory
+=== RHEA-2020:5633 - {product-title} 4.7.0 image release, bug fix, and security update advisory
 
-Issued: 2021-xx-xx
+Issued: 2021-02-24
 
-{product-title} release 4.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:1234[RHBA-2020:1234] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:5678[RHBA-2020:5678] advisory.
+{product-title} release 4.7.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2020:5633[RHSA-2020:5633] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2020:5634[RHSA-2020:5634] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
-link:https://access.redhat.com/solutions/<ARTICLE_ID>[{product-title} 4.7.0 container image list]
+link:https://access.redhat.com/solutions/5820231[{product-title} 4.7.0 container image list]


### PR DESCRIPTION
For release 24 Feb 2021
- Standard RN text
- Lingering Tech Preview table items resolved
Preview: https://deploy-preview-29651--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html