### PR TITLE
Add 4.7 known issue for macOS OSDK binary

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1322,11 +1322,18 @@ $ rm -f openshift/99_openshift-cluster-api_worker-machineset-*.yaml
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927244[*BZ#1927244*])
 
-* In {product-title} 4.3 and 4.4, if the user has the console open in multiple tabs, some sidebar links in the *Developer perspective* do not directly link to the project, and there is an unexpected shift in the selected project. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1839101[BZ#1839101])
-* In {product-title} 4.5, a user with scale permissions cannot scale a deployment or deployment config using the console if they do not have edit rights to the deployment or deployment config. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1886888[BZ#1886888])
-* In {product-title} 4.5, when there is minimal or no data in the *Developer Console*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[BZ#1904106])
-* Currently, the prerequisites in the web console quick start cards appear as a paragraph instead of a list. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905147[BZ#1905147])
-* Currently, in the *Search Page*, the *Pipelines* resources table is not immediately updated after the *Name* filter is applied or removed. However, if you refresh the page or close and expand the *Pipelines* section, the *Name* filter is applied. The same behavior is seen when you remove the *Name* filter. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1901207[BZ#1901207]).
+* In {product-title} 4.3 and 4.4, if the user has the console open in multiple tabs, some sidebar links in the *Developer perspective* do not directly link to the project, and there is an unexpected shift in the selected project. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1839101[*BZ#1839101*])
+
+* In {product-title} 4.5, a user with scale permissions cannot scale a deployment or deployment config using the console if they do not have edit rights to the deployment or deployment config. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1886888[*BZ#1886888*])
+
+* In {product-title} 4.5, when there is minimal or no data in the *Developer Console*, most of the monitoring charts or graphs (CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
+
+* Currently, the prerequisites in the web console quick start cards appear as a paragraph instead of a list. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905147[*BZ#1905147*])
+
+* Currently, in the *Search Page*, the *Pipelines* resources table is not immediately updated after the *Name* filter is applied or removed. However, if you refresh the page or close and expand the *Pipelines* section, the *Name* filter is applied. The same behavior is seen when you remove the *Name* filter. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1901207[*BZ#1901207*]).
+
+[id="ocp-4-7-osdk-macos-ki"]
+* The Operator SDK CLI tool supports running on macOS, however the macOS binary is currently missing from the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/operator-sdk/[OpenShift mirror site]. The macOS binary will be added in a future update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930357[*BZ#1930357*])
 
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Add a known issue for https://bugzilla.redhat.com/show_bug.cgi?id=1929959.

Also adjust bullet spacing and BZ number bold mark-up to a few entries so that it aligns with the other Known Issue formatting.

Preview build: https://deploy-preview-29656--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-osdk-macos-ki

xref: [Relevant change in OSDK CLI install docs](https://github.com/openshift/openshift-docs/pull/29655)