### PR TITLE
CNV-9806: Release note for 2.5 ONLY

### DIFF
--- a/virt/virt-2-5-release-notes.adoc
+++ b/virt/virt-2-5-release-notes.adoc
@@ -149,6 +149,8 @@ The *Pending Changes* banner at the top of the page displays a list of all chang
 
 * When nodes are evicted, for example, when they are placed in maintenance mode during an {product-title} cluster upgrade, virtual machines are migrated twice instead of just once. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1888790[*BZ#1888790*])
 
+* Following an upgrade, there might be more than one template per operating system workload. When creating a Microsoft Windows virtual machine from a cloned PVC using the default operating system (OS) images feature, the OS must have the correct workload value defined. Selecting an incorrect *Workload* value does not allow you to use a default OS image, even though the *(Source available)* label displays in the web console. The default OS image is attached to the newer template but the wizard might use the old template, which is not configured to support default OS images. Windows 2010 systems only support a workload value of *Desktop*, while Windows 2012, Windows 2016, and Windows 2019 only support a workload value of *Server*. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1907183[*BZ#1907183*])
+
 //The issues below are from the 2.4 release. See items above for new known issues for 2.5.
 
 //This defect is on Verified status


### PR DESCRIPTION
This release note only impacts 2.5 releases. It is ready for peer review and merge to _enterprise-4.6_

* Following upgrade, there may be more than one template per operating system workload. When creating a Windows virtual machine from a cloned PVC (default OS image), the *OS* must have the correct *Workload* defined. A template is defined with the following GUI labels: *OS*, *Flavor*, and *Workload*. On Microsoft Windows, for example, selecting a *Workload* value of *server* does not allow you to use a default OS image, even though the *(Source available)* label displays in the GUI. The default OS image image is attached to the newer template but the wizard may use the old template, which is not configured to support default OS images. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1907183[*BZ#1907183*])
