### PR TITLE
BZ#1876376: DNS TTL for egress network policy

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -70,7 +70,7 @@ ifdef::openshift-sdn[]
   - Projects merged by using the `oc adm pod-network join-projects` command cannot use an egress firewall in any of the joined projects.
 endif::openshift-sdn[]
 
-Violating any of these restrictions results in a broken egress firewall for the project, and may cause all external network traffic to be dropped.
+Violating any of these restrictions results in a broken egress firewall for the project, and might cause all external network traffic to be dropped.
 
 [id="policy-rule-order_{context}"]
 == Matching order for egress firewall policy rules
@@ -82,7 +82,12 @@ The egress firewall policy rules are evaluated in the order that they are define
 
 If you use DNS names in any of your egress firewall policy rules, proper resolution of the domain names is subject to the following restrictions:
 
-* Domain name updates are polled based on the TTL (time to live) value of the domain returned by the local non-authoritative servers.
+ifdef::openshift-sdn[]
+* Domain name updates are polled based on a time-to-live (TTL) duration. By default, the duration is 30 seconds. When the egress firewall controller queries the local name servers for a domain name, if the response includes a TTL that is less than 30 seconds, the controller sets the duration to the returned value. If the TTL in the response is greater than 30 minutes, the controller sets the duration to 30 minutes. If the TTL is between 30 seconds and 30 minutes, the controller ignores the value and sets the duration to 30 seconds.
+endif::openshift-sdn[]
+ifdef::ovn[]
+* Domain name updates are polled based on a time-to-live (TTL) duration. By default, the duration is 30 minutes. When the egress firewall controller queries the local name servers for a domain name, if the response includes a TTL and the TTL is less than 30 minutes, the controller sets the duration for that DNS name to the returned value. Each DNS name is queried after the TTL for the DNS record expires.
+endif::ovn[]
 
 * The pod must resolve the domain from the same local name servers when necessary. Otherwise the IP addresses for the domain known by the egress firewall controller and the pod can be different. If the IP addresses for a host name differ, the egress firewall might not be enforced consistently.
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1876376.

This is an update to one bullet (the first one on the foll pages).  Different text is used for SDN than OVN-K:
* SDN: https://deploy-preview-29660--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-firewall.html#domain-name-server-resolution_openshift-sdn-egress-firewall
* OVN-K: https://deploy-preview-29660--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html#domain-name-server-resolution_configuring-egress-firewall-ovn

Applies to enterprise-4.8 and milestone Next Release.