### PR TITLE
Update opm install to use mirror binaries

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -2,13 +2,6 @@
 //
 // * cli_reference/opm-cli.adoc
 
-ifdef::openshift-origin[]
-:registry-image: quay.io/openshift/origin-operator-registry:4.7.0
-endif::[]
-ifndef::openshift-origin[]
-:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v4.7
-endif::[]
-
 [id="olm-installing-opm_{context}"]
 = Installing opm
 
@@ -22,91 +15,32 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Procedure
 
-ifndef::openshift-origin[]
-. Set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI on Linux:
-+
-[source,terminal]
-----
-$ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
-----
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
 
-. Authenticate with `registry.redhat.io`:
-+
-[source,terminal]
-----
-$ podman login registry.redhat.io
-----
-endif::[]
+. Unpack the archive.
 
-. Extract the `opm` binary for the operating system you want from the Operator Registry image and copy it to your local file system.
-+
---
-* For Linux:
+** For Linux or macOS:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc image extract {registry-image} \
-ifndef::openshift-origin[]
-    -a ${REG_CREDS} \
-endif::[]
-    --path /usr/bin/registry/opm:. \
-    --confirm
+$ tar xvf <file>
 ----
 
-* For macOS:
+** For Windows, unzip the archive with a ZIP program.
 
-.. Extract the binary:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc image extract {registry-image} \
-ifndef::openshift-origin[]
-    -a ${REG_CREDS} \
-endif::[]
-    --path /usr/bin/registry/darwin-amd64-opm:. \
-    --confirm
-----
-
-.. Rename the file to `opm`:
-+
-[source,terminal]
-----
-$ mv darwin-amd64-opm opm
-----
-
-* For Windows:
-
-.. Extract the binary:
-+
-[source,terminal,subs="attributes+"]
-----
-C:\> oc image extract {registry-image} \
-ifndef::openshift-origin[]
-    -a ${REG_CREDS} \
-endif::[]
-    --path /usr/bin/registry/windows-amd64-opm:. \
-    --confirm
-----
-
-.. Rename the file to `opm.exe`:
-+
-[source,terminal]
-----
-C:\> rename windows-amd64-opm opm.exe
-----
---
-
-. For Linux or macOS, make the binary executable:
-+
-[source,terminal]
-----
-$ chmod +x ./opm
-----
-
-. Place the file anywhere in your `PATH`. For example:
+. Place the file anywhere in your `PATH`.
 +
 --
 * For Linux or macOS:
+
+.. Check your `PATH`:
++
+[source,terminal]
+----
+$ echo $PATH
+----
+
+.. Move the file. For example:
 +
 [source,terminal]
 ----
@@ -130,7 +64,9 @@ C:\> move opm.exe <directory>
 ----
 --
 
-. Verify that the client was installed correctly:
+.Verification
+
+* After you install the `opm` CLI, verify that it is available:
 +
 [source,terminal]
 ----
@@ -140,7 +76,5 @@ $ opm version
 .Example output
 [source,terminal]
 ----
-Version: version.Version{OpmVersion:"1.12.3", GitCommit:"", BuildDate:"2020-07-01T23:18:58Z", GoOs:"linux", GoArch:"amd64"}
+Version: version.Version{OpmVersion:"v1.14.3-29-ge82c4649", GitCommit:"e82c4649b208cd0b08dbd5b88da55450f97b3a2d", BuildDate:"2021-02-13T02:20:52Z", GoOs:"linux", GoArch:"amd64"}
 ----
-
-:!registry-image:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1825

Previously to install `opm`, users had to use `oc image extract` to get the binaries out of an image. However, binaries are now being built and published on the OpenShift mirror site, so update these steps to use those binaries instead of extracting from the image, which greatly simplifies the procedure! :tada: 

Preview build: https://deploy-preview-29666--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm-cli.html#olm-installing-opm_opm-cli