### PR TITLE
RN: Move Updated blocked item from machine to install

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -160,6 +160,11 @@ The installer for installer-provisioned installation on bare metal nodes provide
 
 Cluster nodes deployed with installer-provisioned installation on bare metal clusters can deploy with static IP addresses. To deploy a cluster so that nodes use static IP addresses, configure a DHCP server to provide infinite leases to cluster nodes. After the installer finishes provisioning each node, a dispatcher script will execute on each provisioned node and convert the DHCP infinite lease to a static IP address using the same static IP address provided by the DHCP server.
 
+[id="ocp-4-7-mcp-degraded-wait-upgrade"]
+==== Updates are immediately blocked if a machine config pool is degraded
+
+If a machine config pool (MCP) is in a `degraded` state, the Machine Config Operator (MCO) now reports its *Upgradeable* status as *False*. As a result, you are now prevented from performing an update within a minor version, for example, from 4.7 to 4.8, until all machine config pools are healthy. Previously, with a degraded machine config pool, the Machine Config Operator did not report its *Upgradeable* status as *false*. The update was allowed and would eventually fail when updating the Machine Config Operator because of the degraded machine config pool. There is no change in this behavior for updates within z-stream releases, for example, from 4.7.1 to 4.7.2. As such, you should check the machine config pool status before performing a z-stream update.
+
 [id="ocp-4-7-web-console"]
 === Web console
 
@@ -548,11 +553,6 @@ For more information, see xref:../openshift_images/samples-operator-alt-registry
 
 [id="ocp-4-7-machine-api"]
 === Machine API
-
-[id="ocp-4-7-machine-api-wait-upgrade"]
-==== Updates are immediately blocked if a machine config pool is degraded
-
-If a machine config pool (MCP) is in a `degraded` state, the Machine Config Operator (MCO) now reports its *Upgradeable* status as *False*. As a result, you are now prevented from performing an update within a minor version, for example, from 4.7 to 4.8, until all machine config pools are healthy. Previously, with a degraded machine config pool, the Machine Config Operator did not report its *Upgradeable* status as *false*. The update was allowed and would eventually fail when updating the Machine Config Operator because of the degraded machine config pool. There is no change in this behavior for updates within z-stream releases, for example, from 4.7.1 to 4.7.2. As such, you should check the machine config pool status before performing a z-stream update.
 
 [id="ocp-4-7-aws-tenancy-dedicated"]
 ==== Machine sets running on AWS support Dedicated Instances


### PR DESCRIPTION
Moved the _Updates are immediately blocked if a machine config pool is degraded_ item from _Machine API_ to _Installation and upgrade_ per Cloud Team and @lbarbeevargas 