### PR TITLE
removing XREFs from modules

### DIFF
--- a/modules/ossm-rn-technology-preview.adoc
+++ b/modules/ossm-rn-technology-preview.adoc
@@ -5,11 +5,6 @@ Module included in the following assemblies:
 
 [id="ossm-rn-tech-preview_{context}"]
 = Technology Preview
-////
-Provide the following info for each issue if possible:
-Description -  Describe the new functionality available to the customer.  For enhancements, try to describe as specifically as possible where the customer will see changes.  Avoid the word “supports” as in [product] now supports [feature] to avoid customer confusion with full support.  Say, for example, “available as a Technology Preview.”
-Package - A brief description of what the customer has to install or enable in order to use the Technology Preview feature.    (e.g., available in quickstart.zip on customer portal, JDF website, container on registry, enable option, etc.)
-////
 
 [IMPORTANT]
 ====
@@ -25,8 +20,6 @@ Up through release 1.5, Istio implemented extensions using the Mixer Telemetry a
 link:https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/#mixer-deprecation[Istio 1.5] Mixer was deprecated and link:https://istio.io/latest/news/releases/1.5.x/announcing-1.5/upgrade-notes/#mixer-deprecation[WebAssembly was introduced] as the new mechanism for extensions in Istio.  Envoy now allows extensions using WebAssembly (“WASM”) - a format for executing code written in multiple programming languages. Mixer has been deprecated as of Istio 1.5, and will be removed in 1.8.  Going forward, extensions to Istio will be implemented with Envoy plugins written with WebAssembly.
 
 The new Telemetry architecture is based on these WebAssembly extensions. For {ProductShortName} 2.0, we are introducing WebAssembly extensions as a Tech Preview feature.  WebAssembly extensions is the new way of extending Istio functionality, replacing the Mixer component, which has been deprecated and will eventually be removed.
-
-For more information about WebAssembly extensions, see the xref:../../service_mesh/v2x/ossm-extensions.adoc[Extensions].
 
 [NOTE]
 ====

--- a/modules/ossm-threescale-integrate.adoc
+++ b/modules/ossm-threescale-integrate.adoc
@@ -19,8 +19,6 @@ You can use these examples to configure requests to your services using the 3sca
 * Mixer policy and telemetry must be enabled if you are using a mixer plug-in.
 ** You will need to properly configure the Service Mesh Control Plane (SMCP) when upgrading.
 
-IMPORTANT: When you want to enable 3scale backend cache with the 3scale Istio adapter, you must also enable mixer policy and mixer telemetry. See xref:../../service_mesh/v2x/installing-ossm.adoc#ossm-control-plane-deploy_installing-ossm[Deploying the Red Hat OpenShift Service Mesh control plane].
-
 [NOTE]
 ====
 To configure the 3scale Istio Adapter, refer to {ProductName} custom resources for instructions on adding adapter parameters to the custom resource file.

--- a/modules/threescale-backend-cache.adoc
+++ b/modules/threescale-backend-cache.adoc
@@ -38,7 +38,7 @@ The following are trade-offs for having lower latencies:
 
 The following points explain the backend cache configuration settings:
 
-* Find the settings to configure the backend cache in the xref:../../service_mesh/v2x/threescale-adapter.adoc#ossm-threescale-cr_threescale-adapter[Example 3scale configuration options].
+* Find the settings to configure the backend cache in the 3scale configuration options.
 * The last 3 settings control enabling of backend cache:
 ** `PARAM_USE_CACHE_BACKEND` - set to true to enable backend cache.
 ** `PARAM_BACKEND_CACHE_FLUSH_INTERVAL_SECONDS` - sets time in seconds between consecutive attempts to flush cache data to the API manager.

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -35,6 +35,10 @@ include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-new-features.adoc[leveloffset=+1]
 
+include::modules/ossm-rn-technology-preview.adoc[leveloffset=+1]
+
+For more information about WebAssembly extensions, see xref:../../service_mesh/v2x/ossm-extensions.adoc#ossm-extensions[Extensions].
+
 include::modules/ossm-rn-deprecated-features.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-known-issues.adoc[leveloffset=+1]
@@ -44,5 +48,3 @@ include::modules/jaeger-rn-known-issues.adoc[leveloffset=+2]
 include::modules/ossm-rn-fixed-issues.adoc[leveloffset=+1]
 
 include::modules/jaeger-rn-fixed-issues.adoc[leveloffset=+2]
-
-

--- a/service_mesh/v2x/threescale-adapter.adoc
+++ b/service_mesh/v2x/threescale-adapter.adoc
@@ -7,6 +7,10 @@ toc::[]
 The 3scale Istio Adapter is an optional adapter that allows you to label a service running within the {ProductName} and integrate that service with the 3scale API Management solution.
 It is not required for {ProductName}.
 
+[IMPORTANT]
+====
+If you want to enable 3scale backend cache with the 3scale Istio adapter, you must also enable Mixer policy and Mixer telemetry. See xref:../../service_mesh/v2x/installing-ossm.adoc#ossm-control-plane-deploy_installing-ossm[Deploying the Red Hat OpenShift Service Mesh control plane].
+====
 
 include::modules/ossm-threescale-integrate.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR moves or removes xrefs from 3Scale modules.  It also adds the Technology Preview topic to the Service Mesh Release Notes.