### PR TITLE
[enterprise-4.5]Fix URLs in the cluster logging templates

### DIFF
--- a/modules/cluster-logging-collector-log-forward-about.adoc
+++ b/modules/cluster-logging-collector-log-forward-about.adoc
@@ -65,7 +65,7 @@ spec:
         name: fluentd
    - name: elasticsearch-insecure
      type: "elasticsearch"
-     endpoint: elasticsearch-insecure.svc.messaging.cluster.local
+     endpoint: elasticsearch-insecure.messaging.svc.cluster.local
      insecure: true <8>
    - name: secureforward-offcluster
      type: "forward"

--- a/modules/cluster-logging-collector-log-forward-configure.adoc
+++ b/modules/cluster-logging-collector-log-forward-configure.adoc
@@ -32,7 +32,7 @@ spec:
         name: fluentd
    - name: elasticsearch-insecure
      type: "elasticsearch"
-     endpoint: elasticsearch-insecure.svc.messaging.cluster.local
+     endpoint: elasticsearch-insecure.messaging.svc.cluster.local
      insecure: true
    - name: secureforward-offcluster
      type: "forward"

--- a/modules/cluster-logging-elasticsearch-audit.adoc
+++ b/modules/cluster-logging-elasticsearch-audit.adoc
@@ -112,7 +112,7 @@ spec:
         name: fluentd
    - name: elasticsearch-insecure
      type: "elasticsearch"
-     endpoint: elasticsearch-insecure.svc.messaging.cluster.local
+     endpoint: elasticsearch-insecure.messaging.svc.cluster.local
      insecure: true
    - name: secureforward-offcluster
      type: "forward"


### PR DESCRIPTION
Based on the feedback from #29637, 4.5 used the wrong URLs in the cluster logging templates.

@vikram-redhat This PR is only for the branch `enterprise-4.5`, thanks.