### PR TITLE
Add egress-router-cni to the docs (OSDOCS-979)

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -17,7 +17,7 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |Egress firewall ^[1]^|Supported|Supported
 
-|Egress router|Not supported|Supported
+|Egress router|Partially supported ^[3]^|Supported
 
 |IPsec encryption|Supported|Not supported
 
@@ -32,7 +32,7 @@ ifeval::["{context}" == "about-openshift-sdn"]
 
 |Egress firewall ^[1]^|Supported|Supported
 
-|Egress router|Supported|Not supported
+|Egress router|Supported|Partially supported ^[3]^
 
 |IPsec encryption|Not supported|Supported
 
@@ -45,5 +45,7 @@ endif::[]
 --
 1. Egress firewall is also known as egress network policy in OpenShift SDN. This is not the same as network policy egress.
 
-2. Does not support egress rules and some `ipBlock` rules.
+2. Network policy for OpenShift SDN does not support egress rules and some `ipBlock` rules.
+
+3. Egress router for OVN-Kubernetes supports only redirect mode.
 --


### PR DESCRIPTION
Follow up to state partial support for ER
on OVN-K.

Added a table footnote [3], that appears once for SDN and once for OVN-K:
* SDN: https://deploy-preview-29682--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html#nw-ovn-kubernetes-matrix_about-openshift-sdn
* OVN-K: https://deploy-preview-29682--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-matrix_about-ovn-kubernetes

Applies to enterprise-4.7 an 4.8.  Please add milestone Next Release.