### PR TITLE
BZ#1931794: Use product-version tag for community-operator-index

### DIFF
--- a/modules/olm-understanding-operator-catalog-images.adoc
+++ b/modules/olm-understanding-operator-catalog-images.adoc
@@ -40,7 +40,7 @@ The following catalogs are distributed by Red Hat:
 |Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
 
 |`community-operators`
-|`registry.redhat.io/redhat/community-operator-index:latest`
+|`registry.redhat.io/redhat/community-operator-index:{tag}`
 |Software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
 |===
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1931794