### PR TITLE
CNV - 2.6 release - returning about-virt assembly

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -4,6 +4,12 @@ include::modules/virt-document-attributes.adoc[]
 :context: about-virt
 toc::[]
 
-Documentation for OpenShift Virtualization will be available for {product-title} 4.7 in the near future.
+Learn about {VirtProductName}'s capabilities and support scope.
 
-In the meantime, the https://docs.openshift.com/container-platform/4.6/virt/about-virt.html[OpenShift Virtualization 2.5 documentation] is available as part of the {product-title} 4.6 documentation.
+include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
+
+// This line is attached to the above `virt-what-you-can-do-with-virt` module.
+// It is included here in the assembly because of the xref ban.
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
+
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]


### PR DESCRIPTION
Removing the pre-release placeholder and returning about-virt assembly