### PR TITLE
CNV - Removing the virt* redirects for 2.6 release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -153,10 +153,7 @@ AddType text/vtt                            vtt
 
     RewriteRule ^container-platform/4\.7/installing/install_config/customizations.html /container-platform/4.7/post_installation_configuration/cluster-tasks.html#available_cluster_customizations [NE,R=301]
 
-    RewriteRule ^container-platform/4\.7/installing/install_config/configuring-private-cluster.html /container-platform/4.7/post_installation_configuration/configuring-private-cluster.html [NE,R=301]
-
-    # CNV redirects for 4.7 GA till CNV GAs
-    RewriteRule container-platform/4\.7/virt/(?!about-virt\.html) /container-platform/4.7/virt/about-virt.html [NE,R=302]    
+    RewriteRule ^container-platform/4\.7/installing/install_config/configuring-private-cluster.html /container-platform/4.7/post_installation_configuration/configuring-private-cluster.html [NE,R=301] 
 
     # end 4.7 redirects
 


### PR DESCRIPTION
Removing the virt* redirects for 2.6 release

Do not merge until #29716 is merged