### PR TITLE
Bug 1931794: Use {product-version} for tag in creating-catalog-from-index

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -12,7 +12,7 @@ ifdef::openshift-origin[]
 endif::[]
 ifndef::openshift-origin[]
 :index-image: redhat-operator-index
-:tag: v4.6
+:tag: v{product-version}
 endif::[]
 
 [id="olm-creating-catalog-from-index_{context}"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1931794