### PR TITLE
[virt] typo fix: prellocation to preallocation

### DIFF
--- a/modules/virt-enabling-preallocation-globally.adoc
+++ b/modules/virt-enabling-preallocation-globally.adoc
@@ -5,7 +5,7 @@
 [id="virt-enabling-preallocation-globally_{context}"]
 = Enabling preallocation globally
 
-You can enable cluster-wide preallocation mode for the Containerized Data Importer (CDI) by adding the `prellocation` field to the `CDI` object.
+You can enable cluster-wide preallocation mode for the Containerized Data Importer (CDI) by adding the `preallocation` field to the `CDI` object.
 
 .Prerequisites
 
@@ -34,6 +34,6 @@ spec:
 ----
 <1> The `preallocation` field is a boolean that defaults to false.
 
-. Save and exit your editor to update the `CDI` object and enable prellocation mode.
+. Save and exit your editor to update the `CDI` object and enable preallocation mode.
 
 


### PR DESCRIPTION
- this typo was pointed out in the localization effort
- enterprise-4.7 and 4.8