### PR TITLE
OSDOCS-1786: Adding a link to common parameters to all IDP assemblies

### DIFF
--- a/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-basic-authentication-identity-provider.adoc
@@ -23,3 +23,7 @@ include::modules/identity-provider-add.adoc[leveloffset=+1]
 include::modules/example-apache-httpd-configuration.adoc[leveloffset=+1]
 
 include::modules/identity-provider-basic-authentication-troubleshooting.adoc[leveloffset=+1]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-github-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-github-identity-provider.adoc
@@ -39,3 +39,7 @@ include::modules/identity-provider-github-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 endif::[]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-gitlab-identity-provider.adoc
@@ -24,3 +24,7 @@ include::modules/identity-provider-config-map.adoc[leveloffset=+1]
 include::modules/identity-provider-gitlab-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-google-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-google-identity-provider.adoc
@@ -31,3 +31,7 @@ include::modules/identity-provider-google-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 endif::[]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-htpasswd-identity-provider.adoc
@@ -43,3 +43,7 @@ include::modules/identity-provider-add.adoc[leveloffset=+1]
 include::modules/identity-provider-htpasswd-update-users.adoc[leveloffset=+1]
 
 include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-keystone-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-keystone-identity-provider.adoc
@@ -29,3 +29,7 @@ include::modules/identity-provider-config-map.adoc[leveloffset=+1]
 include::modules/identity-provider-keystone-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-ldap-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-ldap-identity-provider.adoc
@@ -22,3 +22,7 @@ include::modules/identity-provider-ldap-CR.adoc[leveloffset=+1]
 
 include::modules/identity-provider-add.adoc[leveloffset=+1]
 endif::[]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-oidc-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-oidc-identity-provider.adoc
@@ -94,3 +94,7 @@ include::modules/identity-provider-add.adoc[leveloffset=+1]
 
 include::modules/identity-provider-configuring-using-web-console.adoc[leveloffset=+1]
 endif::[]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.

--- a/authentication/identity_providers/configuring-request-header-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-request-header-identity-provider.adoc
@@ -29,3 +29,7 @@ include::modules/identity-provider-apache-custom-proxy-configuration.adoc[levelo
 
 [discrete]
 include::modules/identity-provider-configuring-apache-request-header.adoc[leveloffset=+2]
+
+== Additional resources
+
+* See xref:../../authentication/understanding-identity-provider.adoc#identity-provider-parameters_understanding-identity-provider[Identity provider parameters] for information on parameters that are common to all identity providers.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1786

Preview: https://deploy-preview-29750--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-ldap-identity-provider.html#additional-resources