### PR TITLE
Removing typo colon from metering shared volumes section

### DIFF
--- a/modules/metering-store-data-in-shared-volumes.adoc
+++ b/modules/metering-store-data-in-shared-volumes.adoc
@@ -103,7 +103,7 @@ spec:
 
 ..  Configure a `Service` resource object with the `nfs-server` role:
 +
-.Example `nfs_service.yaml` file:
+.Example `nfs_service.yaml` file
 [source,yaml]
 ----
 apiVersion: v1


### PR DESCRIPTION
I noticed this typo/colon after merging [this PR](https://github.com/openshift/openshift-docs/pull/23749) to update the Metering "Storing data in shared volumes" section. Removing the colon from the example title.

Preview: https://deploy-preview-29751--osdocs.netlify.app/openshift-enterprise/latest/metering/configuring_metering/metering-configure-persistent-storage.html#metering-store-data-in-shared-volumes_metering-configure-persistent-storage