### PR TITLE
BZ1879833: backporting cred rotation to 4.6.z

### DIFF
--- a/installing/installing_aws/manually-creating-iam.adoc
+++ b/installing/installing_aws/manually-creating-iam.adoc
@@ -3,6 +3,8 @@
 include::modules/common-attributes.adoc[]
 :context: manually-creating-iam-aws
 
+//TO-DO: this should be one file for AWS, Azure, and GCP with conditions for specifics.
+
 toc::[]
 
 In environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace, you can put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
@@ -11,7 +13,10 @@ include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[level
 
 .Additional resources
 
-See xref:../../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator] for a detailed description of all available CCO credential modes and their supported platforms.
+// Not supported in Azure. Condition out if combining topic for AWS/Azure/GCP.
+To learn how to rotate or remove the administrator-level credential secret after installing {product-title}, see xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials].
+
+For a detailed description of all available CCO credential modes and their supported platforms, see the xref:../../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator] reference.
 
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
@@ -27,7 +32,7 @@ include::modules/mint-mode-with-removal-of-admin-credential.adoc[leveloffset=+1]
 == Next steps
 
 * Install an {product-title} cluster:
-** xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[Quickly install a cluster] with default options on installer-provisioned infrastructure
+** xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[Installing a cluster quickly on AWS] with default options on installer-provisioned infrastructure
 ** xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Install a cluster with cloud customizations on installer-provisioned infrastructure]
 ** xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Install a cluster with network customizations on installer-provisioned infrastructure]
 ** xref:../../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates]

--- a/installing/installing_azure/manually-creating-iam-azure.adoc
+++ b/installing/installing_azure/manually-creating-iam-azure.adoc
@@ -5,6 +5,14 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+In environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace, you can put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
+
+include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
+
+.Additional resources
+
+For a detailed description of all available CCO credential modes and their supported platforms, see the xref:../../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator] reference.
+
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
@@ -12,3 +20,11 @@ include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 
 include::modules/mint-mode.adoc[leveloffset=+1]
+
+[id="manually-creating-iam-azure-next-steps"]
+== Next steps
+
+* Install an {product-title} cluster:
+** xref:../../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[Installing a cluster quickly on Azure] with default options on installer-provisioned infrastructure
+** xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Install a cluster with cloud customizations on installer-provisioned infrastructure]
+** xref:../../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[Install a cluster with network customizations on installer-provisioned infrastructure]

--- a/installing/installing_gcp/manually-creating-iam-gcp.adoc
+++ b/installing/installing_gcp/manually-creating-iam-gcp.adoc
@@ -5,6 +5,16 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+In environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace, you can put the Cloud Credential Operator (CCO) into manual mode before you install the cluster.
+
+include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[leveloffset=+1]
+
+.Additional resources
+
+To learn how to rotate or remove the administrator-level credential secret after installing {product-title}, see xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials].
+
+For a detailed description of all available CCO credential modes and their supported platforms, see the xref:../../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator] reference.
+
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 
 include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
@@ -12,3 +22,13 @@ include::modules/admin-credentials-root-secret-formats.adoc[leveloffset=+1]
 include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 
 include::modules/mint-mode.adoc[leveloffset=+1]
+
+include::modules/mint-mode-with-removal-of-admin-credential.adoc[leveloffset=+1]
+
+[id="manually-creating-iam-gcp-next-steps"]
+== Next steps
+
+* Install an {product-title} cluster:
+** xref:../../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[Installing a cluster quickly on GCP] with default options on installer-provisioned infrastructure
+** xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Install a cluster with cloud customizations on installer-provisioned infrastructure]
+** xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[Install a cluster with network customizations on installer-provisioned infrastructure]

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -1,14 +1,44 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_aws/manually-creating-iam.adoc
+// * installing/installing_azure/manually-creating-iam-azure.adoc
 // * installing/installing_gcp/manually-creating-iam-gcp.adoc
 
-[id="alternatives-to-storing-admin-secrets-in-kube-system.adoc_{context}"]
-= Alternatives to storing administrator-level secrets in the `kube-system` project
+ifeval::["{context}" == "manually-creating-iam-aws"]
+:aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-azure"]
+:azure:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-gcp"]
+:google-cloud-platform:
+endif::[]
+
+[id="alternatives-to-storing-admin-secrets-in-kube-system_{context}"]
+= Alternatives to storing administrator-level secrets in the kube-system project
 
 The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubernetes custom resource definitions (CRDs). You can configure the CCO to suit the security requirements of your organization by setting different values for the `credentialsMode` parameter in the `install-config.yaml` file.
 
-If you prefer not to store an administrator-level credential secret in the cluster `kube-system` project, you can choose one of the following options when installing {product-title} on AWS:
+ifdef::aws[]
+If you prefer not to store an administrator-level credential secret in the cluster `kube-system` project, you can choose one of the following options when installing {product-title}:
 
-* *Manage cloud credentials manually*. You can set the `credentialsMode` for the CCO to `Manual` to manage cloud credentials manually. Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. You can also use this mode if your environment does not have connectivity to the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade. You must also manually supply credentials for every component that requests them.
+* *Manage cloud credentials manually*:
++
+You can set the `credentialsMode` parameter for the CCO to `Manual` to manage cloud credentials manually. Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. You can also use this mode if your environment does not have connectivity to the cloud provider public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade. You must also manually supply credentials for every component that requests them.
 
-* *Remove the administrator-level credential secret after installing {product-title} with mint mode*. You can remove or rotate the administrator-level credential after installing {product-title} with the `Mint` CCO credentials mode applied. The `Mint` CCO credentials mode is the default. This option requires the presence of the administrator-level credential during an installation. The administrator-level credential is used during the installation to mint other credentials with some permissions granted. The original credential secret is not stored in the cluster permanently.
+* *Remove the administrator-level credential secret after installing {product-title} with mint mode*:
++
+If you are using the CCO with the `credentialsMode` parameter set to `Mint`, you can remove or rotate the administrator-level credential after installing {product-title}. Mint mode is the default configuration for the CCO. This option requires the presence of the administrator-level credential during an installation. The administrator-level credential is used during the installation to mint other credentials with some permissions granted. The original credential secret is not stored in the cluster permanently.
+
+[NOTE]
+====
+Prior to a non z-stream upgrade, you must reinstate the credential secret with the administrator-level credential. If the credential is not present, the upgrade might be blocked.
+====
+
+endif::aws[]
+
+ifdef::azure,google-cloud-platform[]
+If you prefer not to store an administrator-level credential secret in the cluster `kube-system` project, you can set the `credentialsMode` parameter for the CCO to `Manual` when installing {product-title} and manage your cloud credentials manually.
+
+Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. You can also use this mode if your environment does not have connectivity to the cloud provider public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade. You must also manually supply credentials for every component that requests them.
+endif::azure,google-cloud-platform[]

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+[id="manually-removing-cloud-creds_{context}"]
+= Removing cloud provider credentials
+
+After installing an {product-title} cluster on Amazon Web Services (AWS) with the Cloud Credential Operator (CCO) in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is not required unless something that requires an administrator-level credential needs to be changed, for instance during an upgrade.
+
+[NOTE]
+====
+Prior to a non z-stream upgrade, you must reinstate the credential secret with the administrator-level credential. If the credential is not present, the upgrade might be blocked.
+====
+
+.Prerequisites
+
+* Your cluster is installed on AWS with the CCO configured to use mint mode.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Workloads* -> *Secrets*.
+
+. In the table on the *Secrets* page, find the `aws-creds` root secret for AWS.
+
+. Click the *Options* menu {kebab} in the same row as the secret and select *Delete Secret*.

--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -1,0 +1,186 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/cluster-tasks.adoc
+
+[id="manually-rotating-cloud-creds_{context}"]
+= Rotating cloud provider credentials manually
+
+If your cloud provider credentials are changed for any reason, you must manually update the secret that the Cloud Credential Operator (CCO) uses to manage cloud provider credentials.
+
+The process for rotating cloud credentials depends on the mode that the CCO is configured to use. After you rotate credentials for a cluster that is using mint mode, you must manually remove the component credentials that were created by the removed credential.
+
+////
+[NOTE]
+====
+You can also use the command line interface to complete all parts of this procedure.
+====
+////
+
+.Prerequisites
+
+* Your cluster is installed on a platform that supports rotating cloud credentials manually with the CCO mode that you are using:
+
+** For mint mode, Amazon Web Services (AWS), Azure, and Google Cloud Platform (GCP) are supported.
+
+** For passthrough mode, AWS, Azure, GCP, {rh-openstack-first}, {rh-virtualization-first}, and VMware vSphere are supported.
+
+* You are using {product-title} version 4.6.18 or later.
+
+* You have changed the credentials that are used to interface with your cloud provider.
+
+* The new credentials have sufficient permissions for the mode CCO is configured to use in your cluster.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Workloads* -> *Secrets*.
+
+. In the table on the *Secrets* page, find the root secret for your cloud provider.
++
+[cols=2,options=header]
+|===
+|Platform
+|Secret name
+
+|AWS
+|`aws-creds`
+
+|Azure
+|`azure-credentials`
+
+|GCP
+|`gcp-credentials`
+
+|{rh-openstack}
+|`openstack-credentials`
+
+|{rh-virtualization}
+|`ovirt-credentials`
+
+|vSphere
+|`vsphere-creds`
+
+|===
+
+. Click the *Options* menu {kebab} in the same row as the secret and select *Edit Secret*.
+
+. Record the contents of the *Value* field or fields. You can use this information to verify that the value is different after updating the credentials.
+
+. Update the text in the *Value* field or fields with the new authentication information for your cloud provider, and then click *Save*.
+
+. If the CCO for your cluster is configured to use mint mode, delete each component secret that is referenced by the individual `CredentialsRequest` objects.
+
+.. Log in to the {product-title} CLI as a user with the `cluster-admin` role.
+
+.. Get the names and namespaces of all referenced component secrets:
++
+[source,terminal]
+----
+$ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq -r '.items[] | select (.spec[].kind=="<provider_spec>") | .spec.secretRef'
+----
++
+Where `<provider_spec>` is the corresponding value for your cloud provider:
++
+[cols=2,options=header]
+|===
+|Platform
+|`<provider_spec>`
+
+|AWS
+|`AWSProviderSpec`
+
+|Azure
+|`AzureProviderSpec`
+
+|GCP
+|`GCPProviderSpec`
+
+|===
++
+.Partial example output for AWS
++
+[source,json]
+----
+{
+  "name": "ebs-cloud-credentials",
+  "namespace": "openshift-cluster-csi-drivers"
+}
+{
+  "name": "cloud-credential-operator-iam-ro-creds",
+  "namespace": "openshift-cloud-credential-operator"
+}
+...
+----
+
+.. Delete each of the referenced component secrets:
++
+[source,terminal]
+----
+$ oc delete secret <secret_name> -n <secret_namespace>
+----
++
+Where `<secret_name>` is the name of a secret and `<secret_namespace>` is the namespace that contains the secret.
++
+.Example deletion of an AWS secret
++
+[source,terminal]
+----
+$ oc delete secret ebs-cloud-credentials -n openshift-cluster-csi-drivers
+----
++
+You do not need to manually delete the credentials from your provider console. Deleting the referenced component secrets will cause the CCO to delete the existing credentials from the platform and create new ones.
+
+. To verify that the credentials have changed:
+
+.. In the *Administrator* perspective of the web console, navigate to *Workloads* -> *Secrets*.
+
+.. Verify that the contents of the *Value* field or fields are different than the previously recorded information.
+
+////
+// Provider-side verification also possible, though cluster-side is cleaner process.
+. To verify that the credentials have changed from the console of your cloud provider:
+
+.. Get the `CredentialsRequest` CR names for your platform:
++
+[source,terminal]
+----
+$ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq -r '.items[] | select (.spec[].kind=="<provider_spec>") | .metadata.name'
+----
++
+Where `<provider_spec>` is the corresponding value for your cloud provider: `AWSProviderSpec` for AWS, `AzureProviderSpec` for Azure, or `GCPProviderSpec` for GCP.
++
+.Example output for AWS
++
+[source,terminal]
+----
+aws-ebs-csi-driver-operator
+cloud-credential-operator-iam-ro
+openshift-image-registry
+openshift-ingress
+openshift-machine-api-aws
+----
+
+.. Get the IAM username that corresponds to each `CredentialsRequest` CR name:
++
+[source,terminal]
+----
+$ oc get credentialsrequest <cr_name> -n openshift-cloud-credential-operator -o json | jq -r ".status.providerStatus"
+----
++
+Where `<cr_name>` is the name of a `CredentialsRequest` CR.
++
+.Example output for AWS
++
+[source,json]
+----
+{
+  "apiVersion": "cloudcredential.openshift.io/v1",
+  "kind": "AWSProviderStatus",
+  "policy": "<example-iam-username-policy>",
+  "user": "<example-iam-username>"
+}
+----
++
+Where `<example-iam-username>` is the name of an IAM user on the cloud provider.
+
+.. For each IAM username, view the details for the user on the cloud provider. The credentials should show that they were created after being rotated on the cluster.
+////

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -96,3 +96,22 @@ Understand and configure pod disruption budgets.
 
 include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+2]
 include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
+
+[id="post-install-rotate-remove-cloud-creds"]
+== Rotating or removing cloud provider credentials
+After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
+
+To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.
+
+include::modules/manually-rotating-cloud-creds.adoc[leveloffset=+2]
+
+include::modules/manually-removing-cloud-creds.adoc[leveloffset=+2]
+
+[discrete]
+[id="manually-rotating-cloud-creds-addtl-resources"]
+=== Additional resources
+
+* xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator] reference
+* xref:../installing/installing_aws/manually-creating-iam.adoc#admin-credentials-root-secret-formats_manually-creating-iam-aws[Amazon Web Services (AWS) secret format]
+* xref:../installing/installing_azure/manually-creating-iam-azure.adoc#admin-credentials-root-secret-formats_manually-creating-iam-azure[Microsoft Azure secret format]
+* xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#admin-credentials-root-secret-formats_manually-creating-iam-gcp[Google Cloud Platform (GCP) secret format]

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2606,6 +2606,11 @@ link:https://access.redhat.com/solutions/5812591[{product-title} 4.6.18 containe
 
 With this update, the Insights Operator now collects information for `ContainerRuntimeConfig` objects. This information is useful for troubleshooting. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1891544[*BZ#1891544*].
 
+[id="ocp-4-6-18-cco-cred-rotation"]
+===== Support for rotating cloud provider credentials
+
+With this release, you can manually update the secret that the Cloud Credential Operator (CCO) uses to manage cloud provider credentials. For more information, see xref:../post_installation_configuration/cluster-tasks.adoc#manually-rotating-cloud-creds_post-install-cluster-tasks[Rotating cloud provider credentials manually].
+
 [id="ocp-4-6-18-upgrading"]
 ==== Upgrading
 


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1879833

Credential rotation fixes have been backported to 4.6.18, as such it must be documented as supported. Backporting relevant docs (and a few related clean-up changes) from 4.7.

**Previews:**
- [Rotating or removing cloud provider credentials](https://deploy-preview-29818--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-rotate-remove-cloud-creds)
- [Manually creating IAM for AWS](https://deploy-preview-29818--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html)
- [Manually creating IAM for Azure](https://deploy-preview-29818--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/manually-creating-iam-azure.html)
- [Manually creating IAM for GCP](https://deploy-preview-29818--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html)
- [Release Notes blurb](https://deploy-preview-29818--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-18-cco-cred-rotation)