### PR TITLE
Bug 1835001: added a note about viewing ChargeBack report if namespace …

### DIFF
--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -12,6 +12,12 @@ You can install metering by deploying the Metering Operator. The Metering Operat
 You cannot create a Project starting with `openshift-` using the web console or by using the `oc new-project` command in the CLI.
 ====
 
+[NOTE]
+====
+If the Metering Operator is installed using a namespace other than `openshift-metering`, the Metering reports are only viewable using the CLI. It is strongly suggested throughout the installation steps to use the `openshift-metering` namespace.
+====
+
+
 [id="metering-install-web-console_{context}"]
 == Installing metering using the web console
 You can use the {product-title} web console to install the Metering Operator.


### PR DESCRIPTION
added a note about viewing ChargeBack report if namespace is other than `openshift-metering`

https://bugzilla.redhat.com/show_bug.cgi?id=1835001

This update is for for 4.5 and 4.6.

Direct link to doc preview: https://deploy-preview-29819--osdocs.netlify.app/openshift-enterprise/latest/metering/metering-installing-metering.html#metering-install-operator_installing-metering

Incorporated SME comments from @EmilyM1. 