### PR TITLE
Manual cherrypick of PR#29409 RHDEVDOCS-2608 The name of the indices …

### DIFF
--- a/modules/cluster-logging-updating-logging.adoc
+++ b/modules/cluster-logging-updating-logging.adoc
@@ -32,8 +32,8 @@ If your cluster logging version is prior to 4.4, you must upgrade cluster loggin
 
 * Back up your Elasticsearch and Kibana data.
 
-* If your internal Elasticsearch instance uses persistent volume claims (PVCs), the PVCs must contain a `logging-cluster:elasticsearch` label. Without the label, during the upgrade the garbage collection process removes those PVCs and the Elasticsearch operator creates new PVCs. 
-** If you are updating from an {product-title} version prior to version 4.4.30, you must manually add the label to the Elasticsearch PVCs. 
+* If your internal Elasticsearch instance uses persistent volume claims (PVCs), the PVCs must contain a `logging-cluster:elasticsearch` label. Without the label, during the upgrade the garbage collection process removes those PVCs and the Elasticsearch operator creates new PVCs.
+** If you are updating from an {product-title} version prior to version 4.4.30, you must manually add the label to the Elasticsearch PVCs.
 +
 For example, you can use the following command to add a label to all the Elasticsearch PVCs:
 +
@@ -42,7 +42,7 @@ For example, you can use the following command to add a label to all the Elastic
 $ oc label pvc --all -n openshift-logging logging-cluster=elasticsearch
 ----
 
-** After {product-title} 4.4.30, the Elasticsearch operator automatically adds the label to the PVCs. 
+** After {product-title} 4.4.30, the Elasticsearch operator automatically adds the label to the PVCs.
 
 .Procedure
 
@@ -161,7 +161,7 @@ elasticsearch-rollover-infra   */15 * * * *   False     0        <none>         
 $ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- indices
 ----
 +
-You should see the `app-0000x`, `infra-0000x`, `audit-0000x`, `.security` indices.
+Verify that the output includes the `app-00000x`, `infra-00000x`, `audit-00000x`, `.security` indices.
 +
 .Sample output with indices in a green status
 [%collapsible]
@@ -210,7 +210,7 @@ green  open   audit-000001                                                      
 $ oc get ds fluentd -o json | grep fluentd-init
 ----
 +
-You should see a `fluentd-init` container:
+Verify that the output includes a `fluentd-init` container:
 +
 [source,terminal]
 ----
@@ -224,7 +224,7 @@ You should see a `fluentd-init` container:
 $ oc get kibana kibana -o json
 ----
 +
-You should see a Kibana pod with the `ready` status:
+Verify that the output includes a Kibana pod with the `ready` status:
 +
 .Sample output with a ready Kibana pod
 [%collapsible]
@@ -282,10 +282,9 @@ cronjob.batch/elasticsearch-rollover-audit
 cronjob.batch/elasticsearch-rollover-infra
 ----
 +
-You should see the `elasticsearch-delete-\*` and `elasticsearch-rollover-*` indices.
+Verify that the output includes the `elasticsearch-delete-\*` and `elasticsearch-rollover-*` indices.
 
 == Post-update tasks
 
 If you use Kibana, after the Elasticsearch Operator and Cluster Logging Operator are fully updated to 4.5, you must recreate your Kibana index patterns and visualizations.
 Because of changes in the security plug-in, the cluster logging upgrade does not automatically create index patterns.
-


### PR DESCRIPTION
…is {app,infra,audit]-{00000x} not {app,infra,audit]-{0000x}
based on https://github.com/openshift/openshift-docs/pull/29409/ which has already been merged to enterprise-4.7 and 4.8