### PR TITLE
CCO: adding missing cloud provider details to cred rotation proc

### DIFF
--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -20,7 +20,7 @@ You can also use the command line interface to complete all parts of this proced
 
 * Your cluster is installed on a platform that supports rotating cloud credentials manually with the CCO mode that you are using:
 
-** For mint mode, AWS, Azure, and GCP are supported.
+** For mint mode, Amazon Web Services (AWS), Azure, and Google Cloud Platform (GCP) are supported.
 
 ** For passthrough mode, AWS, Azure, GCP, {rh-openstack-first}, {rh-virtualization-first}, and VMware vSphere are supported.
 
@@ -48,6 +48,15 @@ You can also use the command line interface to complete all parts of this proced
 |GCP
 |`gcp-credentials`
 
+|{rh-openstack}
+|`openstack-credentials`
+
+|{rh-virtualization}
+|`ovirt-credentials`
+
+|vSphere
+|`vsphere-creds`
+
 |===
 
 . Click the *Options* menu {kebab} in the same row as the secret and select *Edit Secret*.
@@ -67,7 +76,23 @@ You can also use the command line interface to complete all parts of this proced
 $ oc -n openshift-cloud-credential-operator get CredentialsRequest -o json | jq -r '.items[] | select (.spec[].kind=="<provider_spec>") | .spec.secretRef'
 ----
 +
-Where `<provider_spec>` is the corresponding value for your cloud provider: `AWSProviderSpec` for AWS, `AzureProviderSpec` for Azure, or `GCPProviderSpec` for GCP.
+Where `<provider_spec>` is the corresponding value for your cloud provider:
++
+[cols=2,options=header]
+|===
+|Platform
+|`<provider_spec>`
+
+|AWS
+|`AWSProviderSpec`
+
+|Azure
+|`AzureProviderSpec`
+
+|GCP
+|`GCPProviderSpec`
+
+|===
 +
 .Partial example output for AWS
 +


### PR DESCRIPTION
Discrepancy found while backporting rotation steps to 4.6, should go into 4.7+

Preview: https://deploy-preview-29840--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#manually-rotating-cloud-creds_post-install-cluster-tasks

Content is already being reviewed by dev and QE in https://github.com/openshift/openshift-docs/pull/29818  (sort of like a backwards cherrypick?), so when that review is complete this just needs peer review.