### PR TITLE
Adding-a-worker-node-to-an-existing-cluster

### DIFF
--- a/modules/registry-images-viewing.adoc
+++ b/modules/registry-images-viewing.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * registry/accessing-the-registry.adoc
+
+[id="registry-images-viewing_{context}"]
+= registry images viewing
+
+You can view the images inside the registry by using the `oc get imagestreams` command.
+
+.Procedure
+
+. Use the `oc get imagestreams` command to view the images already inside the image registry:
++
+[source,terminal]
+----
+$ oc get imagestreams
+----
++
+.Example output
+[source,terminal]
+----
+Name | IMAGE REPOSITORY | TAGS | UPDATED |
+demo       default-route-openshift-image-registry.apps.shift.cloud.lab.eng.bos.redhat.com/playground/demo       latest   8 mintues ago
+demo1      default-route-openshift-image-registry.apps.shift.cloud.lab.eng.bos.redhat.com/playground/demo1      latest   4 minutes ago
+demo2      default-route-openshift-image-registry.apps.shift.cloud.lab.eng.bos.redhat.com/playground/demo2      latest   2 minutes ago
+demo3      default-route-openshift-image-registry.apps.shift.cloud.lab.eng.bos.redhat.com/playground/demo3      latest   16 seconds ago
+----

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -47,6 +47,8 @@ include::modules/registry-checking-the-status-of-registry-pods.adoc[leveloffset=
 
 include::modules/registry-viewing-logs.adoc[leveloffset=+1]
 
+include::modules/registry-images-viewing.adoc[leveloffset=+1]
+
 include::modules/registry-accessing-metrics.adoc[leveloffset=+1]
 
 .Additional resources

--- a/scalability_and_performance/Adding-a-worker-node-to-an-existing-cluster.adoc
+++ b/scalability_and_performance/Adding-a-worker-node-to-an-existing-cluster.adoc
@@ -1,0 +1,31 @@
+1. Retrieve the username and password of the bare metal node’s baseboard management controller. Then, create base64 strings from the username and password. In the following example, the username is root and the password is secretpassword.
+
+echo -ne "root" | base64
+echo -ne "secretpassword" | base64
+
+2. Create yaml file with below informaion: 
+
+'''
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openshift-worker-<num>-bmc-secret
+type: Opaque
+data:
+  username: <base64-of-uid>
+  password: <base64-of-pwd>
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: openshift-worker-<num>
+spec:
+  online: true
+  bootMACAddress: <NIC1-mac-address>
+  bmc:
+    address: ipmi://<bmc-ip>
+    credentialsName: openshift-worker-<num>-bmc-secret
+'''
+
+3. Replace <num> for the worker number of bare metal node in two name fields and credentialsName field. Replace <base64-of-uid> with the base64 string of the username. Replace <base64-of-pwd> with the base64 string of the password. Replace <NIC1-mac-address> with the MAC address of the bare metal node’s first NIC. Replace <bmc-ip> with the IP address of the bare metal node’s baseboard management controller.


### PR DESCRIPTION
This process Is related to bare-metal install 

https://openshift-kni.github.io/baremetal-deploy/4.7/Deployment.html#adding-a-worker-node-to-an-existing-cluster_ipi-install-expanding:~:text=node.-,4.2.4.%20Adding%20a%20worker%20node%20to%20an%20existing%20cluster

But this kind of documentation cat be found in the product document and i think we should add it :) 

The page came from IPI installation on baremetal :) 

Thank you 