### PR TITLE
Missing note that HPA feature is in Tech preview for 3.11

### DIFF
--- a/dev_guide/pod_autoscaling.adoc
+++ b/dev_guide/pod_autoscaling.adoc
@@ -182,6 +182,19 @@ you can specify the minimum number of pods and the average memory utilization
 your pods should target as well, otherwise those are given default values from
 the {product-title} server.
 
+[IMPORTANT]
+====
+Autoscaling for Memory Utilization is a Technology Preview feature.
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+For more information on Red Hat Technology Preview features support scope, see
+https://access.redhat.com/support/offerings/techpreview/.
+====
+
 [NOTE]
 ====
 Memory-based autoscaling is only available with the `v2beta1` version of the

--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -1552,6 +1552,11 @@ features marked *GA* indicate _General Availability_.
 |-
 |GA
 
+|xref:../dev_guide/pod_autoscaling.html#pod-autoscaling-memory[Autoscaling for Memory Utilization]
+|TP
+|TP
+|TP
+
 |xref:ocp-311-operator-lifecycle-manager[Operator Lifecycle Manager]
 |-
 |-


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1933086

The Technology Preview note to the "Autoscaling for memory utilization" section of the 3.11 Horizontal Pod Autoscaler documentation [1] was accidentally removed [2] based in part on this email thread [3]. (There is a note in the docs that states that the the v2beta1 version of theautoscaling API must be used.) 

Autoscaling for memory utilization went GA in 4.7 [4] 

[1] https://docs.openshift.com/container-platform/3.11/dev_guide/pod_autoscaling.html#pod-autoscaling-memory
[2] https://bugzilla.redhat.com/show_bug.cgi?id=1673645
[3] http://post-office.corp.redhat.com/archives/openshift-sme/2019-February/msg00302.html
[4] https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-nodes-autoscaling-ga
