### PR TITLE
BZ#1838164: prereqs for multiple interfaces

### DIFF
--- a/install/prerequisites.adoc
+++ b/install/prerequisites.adoc
@@ -571,6 +571,10 @@ network with interfaces in multiple zones, the interface that nodes communicate
 on must be in the default zone.
 ====
 
+[[hosts-multiple-network-interfaces]]
+==== Hosts with Multiple Network Interfaces
+
+If a host has more then one network interface, {product-title} uses only one network interface for installation, the cluster network, and the service network. You can use additional network interfaces for communication that is not related to {product-title}, but there is no support to route some cluster-related traffic over one network interface and different cluster-related traffic over another network interface.
 
 [[required-ports]]
 ==== Required Ports


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1838164

The case for the BZ includes a link to a second BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1879077.
In the second BZ, Dan Williams that we need the iface
with a default route and the lowest metric.

Peek at the new "Multiple Network Interface Support" heading: https://deploy-preview-29873--osdocs.netlify.app/openshift-enterprise/latest/install/prerequisites.html#network-interfaces

@openshift/team-documentation, PTAL.  Please add enterprise-3.11 label and milestone Next-Release.