### PR TITLE
BZ1850965: removed wildcard domain name statement

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -23,7 +23,7 @@ from the API are not affected by this policy. Typically only cluster
 administrators will have the appropriate permissions.
 
 Every element of this list contains a location of the registry specified by the
-registry domain name. The domain name can include wildcards.
+registry domain name.
 
 `domainName`: Specifies a domain name for the registry. In case the registry uses a
 non-standard (80 or 443) port, the port should be included in the domain name


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1850965

For 4.5+