### PR TITLE
Changed  to  in Update Channels section of upgrade docs

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -13,8 +13,8 @@ In {product-title} 4.1, Red Hat introduced the concept of channels for
 recommending the appropriate release versions for cluster upgrade. By controlling
 the pace of upgrades, these upgrade channels allow you to choose an upgrade
 strategy. Upgrade channels are tied to a minor version of
-{product-title}. For instance, {product-title} {product-version}
-upgrade channels will never include an upgrade to a 4.7 release. This strategy ensures that
+{product-title}. For instance, {product-title} 4.7
+upgrade channels will never include an upgrade to a 4.8 release. This strategy ensures that
 administrators explicitly decide to upgrade to the next minor version of
 {product-title}. Upgrade channels control only release selection and do not impact the version of the cluster that you install; the `openshift-install`
 binary file for a specific version of {product-title} always installs that version.


### PR DESCRIPTION
The _OpenShift Container Platform upgrade channels and releases_ topic has a hard-coded OCP version that needs to be manually updated to the next OCP version.