### PR TITLE
Updated auto table numbering

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -11,6 +11,7 @@ ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
 The following table describes the {VirtProductName} storage types that support VM import.
 endif::[]
 
+[caption=]
 .{VirtProductName} storage feature matrix
 ifdef::virt-features-for-storage[]
 [cols="40%,15%,15%,15%,15%",options="header"]

--- a/modules/virt-live-migration-limits-reftable.adoc
+++ b/modules/virt-live-migration-limits-reftable.adoc
@@ -6,6 +6,7 @@
 [id="virt-live-migration-limits-ref_{context}"]
 = Cluster-wide live migration limits and timeouts
 
+[caption=]
 .Migration parameters
 |===
 |Parameter |Description |Default
@@ -23,14 +24,14 @@
 |64Mi
 
 |`completionTimeoutPerGiB`
-|The migration will be canceled if it has not completed in this time, in seconds
-per GiB of memory. For example, a virtual machine instance with 6GiB memory will timeout if it has
+|The migration is canceled if it has not completed in this time, in seconds
+per GiB of memory. For example, a virtual machine instance with 6GiB memory times out if it has
 not completed migration in 4800 seconds. If the `Migration Method` is
 `BlockMigration`, the size of the migrating disks is included in the calculation.
 |800
 
 |`progressTimeout`
-|The migration will be canceled if memory copy fails to make progress in this
+|The migration is canceled if memory copy fails to make progress in this
 time, in seconds.
 |150
 |===


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1933382
4.6, 4.7, and 4.8
Table numbering and passive voice: https://deploy-preview-29948--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits.html
Table numbering: https://deploy-preview-29948--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-features-for-storage-matrix_virt-importing-rhv-vm