### PR TITLE
BZ#1933042 - The CNO configuration is immutable after installation

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -14,11 +14,22 @@ ifeval::["{context}" == "cluster-network-operator"]
 :operator:
 endif::[]
 
+ifeval::["{context}" == "post-install-network-configuration"]
+:post-install-network-configuration:
+endif::[]
+
 [id="nw-operator-cr_{context}"]
 = Cluster Network Operator configuration
 
 The configuration for the cluster network is specified as part of the Cluster Network Operator (CNO) configuration and stored in a custom resource (CR) object that is named `cluster`. The CR specifies the parameters for the `Network` API in the `operator.openshift.io` API group.
 
+ifdef::post-install-network-configuration[]
+[NOTE]
+====
+After cluster installation, you cannot modify the configuration for the cluster network provider.
+====
+endif::post-install-network-configuration[]
+ifndef::post-install-network-configuration[]
 You can specify the cluster network configuration for your {product-title} cluster by setting the parameter values for the `defaultNetwork` parameter in the CNO CR. The following CR displays the default configuration for the CNO and explains both the parameters you can configure and the valid parameter values:
 
 .Cluster Network Operator custom resource
@@ -252,7 +263,12 @@ spec:
       iptables-min-sync-period:
       - 0s
 ----
+endif::post-install-network-configuration[]
 
 ifeval::["{context}" == "cluster-network-operator"]
 :!operator:
+endif::[]
+
+ifdef::post-install-network-configuration[]
+:!post-install-network-configuration:
 endif::[]

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -8,35 +8,11 @@ toc::[]
 After installing {product-title}, you can further expand and customize your
 network to your requirements.
 
-[id="post-install-configuring-network-policy"]
-== Configuring network policy with OpenShift SDN
-
-Understand and work with network policy.
-
-include::modules/nw-networkpolicy-about.adoc[leveloffset=+2]
-include::modules/nw-networkpolicy-object.adoc[leveloffset=+2]
-include::modules/nw-networkpolicy-create.adoc[leveloffset=+2]
-include::modules/nw-networkpolicy-delete.adoc[leveloffset=+2]
-include::modules/nw-networkpolicy-view.adoc[leveloffset=+2]
-include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+2]
-
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-[id="post-install-nw-networkpolicy-creating-default-networkpolicy-objects-for-a-new-project"]
-=== Creating default network policies for a new project
-
-As a cluster administrator, you can modify the new project template to
-automatically include `NetworkPolicy` objects when you create a new project.
-
-include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
-
-include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+3]
-endif::[]
-
-include::modules/private-clusters-setting-dns-private.adoc[leveloffset=+1]
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
 
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]
 
-include::modules/nw-operator-cr.adoc[leveloffset=+1]
+include::modules/private-clusters-setting-dns-private.adoc[leveloffset=+1]
 
 [id="post-install-configuring_ingress_cluster_traffic"]
 == Configuring ingress cluster traffic
@@ -66,6 +42,42 @@ include::modules/nw-operator-cr.adoc[leveloffset=+1]
 |xref:../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configure a `NodePort`]
 |Expose a service on all nodes in the cluster.
 |===
+
+[id="post-install-configuring-node-port-service-range"]
+== Configuring the node port service range
+
+As a cluster administrator, you can expand the available node port range. If your cluster uses of a large number of node ports, you might need to increase the number of available ports.
+
+The default port range is `30000-32767`. You can never reduce the port range, even if you first expand it beyond the default range.
+
+[id="post-install-configuring-node-port-service-range-prerequisites"]
+=== Prerequisites
+
+- Your cluster infrastructure must allow access to the ports that you specify within the expanded range. For example, if you expand the node port range to `30000-32900`, the inclusive port range of `32768-32900` must be allowed by your firewall or packet filtering configuration.
+
+include::modules/nw-nodeport-service-range-edit.adoc[leveloffset=+3]
+
+[id="post-install-configuring-network-policy"]
+== Configuring network policy
+
+As a cluster administrator or project administrator, you can configure network policies for a project.
+
+include::modules/nw-networkpolicy-about.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-object.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-create.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+2]
+
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+[id="post-install-nw-networkpolicy-creating-default-networkpolicy-objects-for-a-new-project"]
+=== Creating default network policies for a new project
+
+As a cluster administrator, you can modify the new project template to
+automatically include `NetworkPolicy` objects when you create a new project.
+
+include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
+
+include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+3]
+endif::[]
 
 include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1933042

This also reshuffles the networking content into a more accessible order. Some sections are better earlier.

Preview:

- https://deploy-preview-29966--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-operator-cr_post-install-network-configuration

![Screenshot_20210308_140410](https://user-images.githubusercontent.com/354496/110368567-37944880-8017-11eb-8afa-552dc5ec2223.png)
