### PR TITLE
Add missing wipeVolume to MachineConfig luks sections

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -99,6 +99,7 @@ spec:
               - url: https://tang.example.com
                 thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
           options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
       filesystems:
         - device: /dev/mapper/root
           format: xfs
@@ -131,6 +132,7 @@ spec:
               - url: https://tang.example.com
                 thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
           options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
       filesystems:
         - device: /dev/mapper/root
           format: xfs

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -52,6 +52,7 @@ spec:
           clevis:
             tpm2: true
           options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
       filesystems:
         - device: /dev/mapper/root
           format: xfs
@@ -81,6 +82,7 @@ spec:
           clevis:
             tpm2: true
           options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
       filesystems:
         - device: /dev/mapper/root
           format: xfs


### PR DESCRIPTION
We're reusing the existing root partition, so Ignition will fail without this.

The RCCs in `installation-special-config-mirrored-disk.adoc` don't need this because `boot_device.luks` automatically adds `wipeVolume` when desugared.

This should also be cherry-picked to 4.7.

cc @arithx @bobfuru 