### PR TITLE
Fix subsequent paras for same callout

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -1250,7 +1250,13 @@ table > tbody > tr > td > div > div > p > code {
  .colist > table tr > td:last-of-type {
      padding: 0 0 0.5em 0;
 }
- .qanda > ol > li > p > em:only-child {
+/* Fix subsequent paras for same bullet */
+.colist .paragraph p {
+  font-size: 14px;
+  line-height: 1.8;
+  margin: 0.5em 0;
+}
+.qanda > ol > li > p > em:only-child {
      color: #1d4b8f;
 }
  .thumb, .th {


### PR DESCRIPTION
This has been annoying for two years now.

Original, with incorrect font size and spacing:

https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-network-customizations.html#nw-operator-configuration-parameters-for-openshift-sdn_installing-aws-network-customizations

Fixed:

<img width="698" alt="Screen Shot 2021-03-02 at 8 50 32 PM" src="https://user-images.githubusercontent.com/354496/109740616-8c5c3d00-7b99-11eb-915e-61c93c497f01.png">
