### PR TITLE
updating guidelines for emphasis

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1241,17 +1241,17 @@ and managing a Kubernetes application.
 a|
 > An _Operator_ is a method of packaging, deploying, and managing a Kubernetes application.
 
-|Use of single asterisks for general emphasis is allowed but should only be used
+|Use of underscores for general emphasis is allowed but should only be used
 very sparingly. Let the writing, instead of font usage, create the emphasis
 wherever possible.
 
 a|
 ....
-Do *not* delete the file.
+Do _not_ delete the file.
 ....
 
 a|
-> Do *not* delete the file.
+> Do _not_ delete the file.
 
 |Footnotes
 


### PR DESCRIPTION
Per our team discussion on Monday, we're changing the guidance for general emphasis to match the guidance in the IBM Style Guide. This change is intended to be implemented on an ongoing basis as we see references to it in text.

> To emphasize a word, use italic font. 