### PR TITLE
BZ-1920414: Clarifying the revision numbers are examples

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -211,10 +211,11 @@ Review the `NodeInstallerProgressing` status condition for etcd to verify that a
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 3
+3 nodes are at revision 7 <1>
 ----
+<1> In this example, the latest revision number is `7`.
 +
-If the output shows a message such as `2 nodes are at revision 3; 1 nodes are at revision 4`, this means that the update is still in progress. Wait a few minutes and try again.
+If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
 . After etcd is redeployed, force new rollouts for the control plane. The Kubernetes API server will reinstall itself on the other nodes because the kubelet is connected to API servers using an internal load balancer.
 +
@@ -239,8 +240,11 @@ Review the `NodeInstallerProgressing` status condition to verify that all nodes 
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 3
+3 nodes are at revision 7 <1>
 ----
+<1> In this example, the latest revision number is `7`.
++
+If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
 .. Update the `kubecontrollermanager`:
 +
@@ -261,8 +265,11 @@ Review the `NodeInstallerProgressing` status condition to verify that all nodes 
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 3
+3 nodes are at revision 7 <1>
 ----
+<1> In this example, the latest revision number is `7`.
++
+If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
 .. Update the `kubescheduler`:
 +
@@ -283,8 +290,11 @@ Review the `NodeInstallerProgressing` status condition to verify that all nodes 
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 3
+3 nodes are at revision 7 <1>
 ----
+<1> In this example, the latest revision number is `7`.
++
+If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
 . Verify that all master hosts have started and joined the cluster.
 +

--- a/modules/nodes-nodes-audit-policy.adoc
+++ b/modules/nodes-nodes-audit-policy.adoc
@@ -48,8 +48,9 @@ Review the `NodeInstallerProgressing` status condition for the Kubernetes API se
 [source,terminal]
 ----
 AllNodesAtLatestRevision
-3 nodes are at revision 12
+3 nodes are at revision 12 <1>
 ----
+<1> In this example, the latest revision number is `12`.
 +
 If the output shows a message similar to one of the following, this means that the update is still in progress. Wait a few minutes and try again.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1920414

Preview: 

* https://deploy-preview-30077--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html
* https://deploy-preview-30077--osdocs.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#configuring-audit-policy_audit-log-policy-config