### PR TITLE
adding alternate codeblock annotations

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -713,6 +713,27 @@ code example 2 <2>
 <2> A note about the second example value.
 ....
 
+* If you must provide additional information on what a line of a code block
+represents and the use of callouts is impractical, you can use a description list
+to provide information about the variables in the code block. Using callouts
+might be impractical if a code block contains too many conditional statements to
+easily use numbered callouts or if the same note applies to multiple lines of the codeblock.
++
+....
+----
+code <variable_1>
+code <variable_2>
+----
++
+where:
+
+<variable_1>:: Specifies the explanation of the first variable.
+<variable_2>:: Specifies the explanation of the first variable.
+....
++
+Be sure to introduce the description list with "where:" and start each variable
+description with "Specifies."
+
 * For long lines of code that you want to break up among multiple lines, use a
 backslash to show the line break. For example:
 +


### PR DESCRIPTION
Per our discussion at the team meeting, I'm suggesting an alternate method of providing additional information to a codeblock. It's based on the first option presented in the latest version of the IBM Style Guide.