### PR TITLE
RHDEVDOCS-2685 Document that we test Logstash with fluent forward v1 …

### DIFF
--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins.adoc
@@ -6,7 +6,6 @@
 
 = Supported log data output types
 
-[role="_abstract"]
 Red Hat OpenShift Logging version 5.0 provides the following output types and protocols for sending log data to target log collectors.
 
 Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
@@ -15,17 +14,30 @@ Red Hat tests each of the combinations shown in the following table. However, yo
 |====
 | Output types   | Protocols          | Tested with
 
-| fluentdForward | fluent forward v1  | fluentd 1.7.4
+| fluentdForward
+| fluentd forward v1
+a| fluentd 1.7.4
 
-| elasticsearch  | elasticsearch v?	  | Elasticsearch 6.8.1
+logstash 7.10.1
 
-| syslog         | RFC-3164, RFC-5424 | rsyslog 8.37.0-9.el7
+| elasticsearch
+| elasticsearch
+a| Elasticsearch 6.8.1
 
-| kafka          | kafka 0.11         | kafka 2.4.1
+Elasticsearch 7.10.1
+
+| syslog
+| RFC-3164, RFC-5424
+| rsyslog 8.37.0-9.el7
+
+| kafka
+| kafka 0.11
+| kafka 2.4.1
 
 |====
 
-// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock. This file is the authoritative source of information about which items and versions Red Hat tests and supports.
+// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
+// This file is the authoritative source of information about which items and versions Red Hat tests and supports.
 // According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
 
 [NOTE]


### PR DESCRIPTION
- For versions 4.7+
- https://issues.redhat.com/browse/RHDEVDOCS-2685 Document that we test Logstash 7.10 with Fluent forward v.1 output type.
- https://issues.redhat.com/browse/RHDEVDOCS-2735 Document that we test Elasticsearch 7.10.1 with the elasticsearch
output type.
- Direct link to doc preview: https://deploy-preview-30088--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forwarding-supported-plugins_cluster-logging-external
- Ready for peer review and merge
