### PR TITLE
Reconcile machineset platform differences

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -7,7 +7,7 @@
 [id="machineset-yaml-aws_{context}"]
 =  Sample YAML for a machine set custom resource on AWS
 
-This sample YAML defines a machine set that runs in the `us-east-1a` Amazon Web Services (AWS) zone and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`
+This sample YAML defines a machine set that runs in the `us-east-1a` Amazon Web Services (AWS) zone and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
 
 In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -18,6 +18,8 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
   name: <infrastructureID>-<role>-<zone> <2>
   namespace: openshift-machine-api
 spec:

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -23,7 +23,7 @@ metadata:
   name: <infrastructureID>-<role>-<zone> <2>
   namespace: openshift-machine-api
 spec:
-  replicas: 1
+  replicas: <number_of_replicas>
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -23,7 +23,7 @@ metadata:
   name: <infrastructureID>-<role>-<region> <3>
   namespace: openshift-machine-api
 spec:
-  replicas: 1
+  replicas: <number_of_replicas>
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -69,7 +69,7 @@ spec:
           sshPublicKey: ""
           subnet: <infrastructureID>-<role>-subnet <1> <2>
           userDataSecret:
-            name: <role>-user-data <2>
+            name: worker-user-data
           vmSize: Standard_D2s_v3
           vnet: <infrastructureID>-vnet <1>
           zone: "1" <4>

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -30,7 +30,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<region> <3>
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <role> <2>
@@ -38,7 +37,6 @@ spec:
         machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<region> <3>
     spec:
       metadata:
-        creationTimestamp: null
         labels:
           node-role.kubernetes.io/<role>: "" <2>
       providerSpec:
@@ -57,8 +55,6 @@ spec:
           kind: AzureMachineProviderSpec
           location: centralus
           managedIdentity: <infrastructureID>-identity <1>
-          metadata:
-            creationTimestamp: null
           natRule: null
           networkResourceGroup: ""
           osDisk:

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -7,7 +7,7 @@
 [id="machineset-yaml-gcp_{context}"]
 =  Sample YAML for a machine set custom resource on GCP
 
-This sample YAML defines a machine set that runs in Google Cloud Platform (GCP) and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`
+This sample YAML defines a machine set that runs in Google Cloud Platform (GCP) and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
 
 In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 
@@ -20,7 +20,7 @@ metadata:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
     machine.openshift.io/cluster-api-machine-role: <role>
     machine.openshift.io/cluster-api-machine-type: <role>
-  name: <infrastructureID>-w-a <1>
+  name: <infrastructureID>-<role>-w-a <1>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -23,7 +23,7 @@ metadata:
   name: <infrastructureID>-w-a <1>
   namespace: openshift-machine-api
 spec:
-  replicas: 1
+  replicas: <number_of_replicas>
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -18,6 +18,8 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
   name: <infrastructureID>-w-a <1>
   namespace: openshift-machine-api
 spec:

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -28,7 +28,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: <infrastructureID>-w-a <1>
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <role> <3>
@@ -54,8 +53,6 @@ spec:
             type: pd-ssd
           kind: GCPMachineProviderSpec
           machineType: n1-standard-4
-          metadata:
-            creationTimestamp: null
           networkInterfaces:
           - network: <infrastructureID>-network <1>
             subnetwork: <infrastructureID>-<role>-subnet <2>

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -35,6 +35,9 @@ spec:
         machine.openshift.io/cluster-api-machine-type: <role> <2>
         machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>
     spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/<role>: "" <2>
       providerSpec:
         value:
           apiVersion: openstackproviderconfig.openshift.io/v1alpha1

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -8,7 +8,7 @@
 
 This sample YAML defines a machine set that runs on {rh-openstack-first} and creates nodes that are labeled with `node-role.openshift.io/<node_role>: ""`
 
-In this sample, `infrastructure_ID` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `node_role` is the node label to add.
+In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `node_role` is the node label to add.
 
 [source,yaml]
 ----
@@ -16,24 +16,24 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
     machine.openshift.io/cluster-api-machine-role: <node_role> <2>
     machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-  name: <infrastructure_ID>-<node_role> <3>
+  name: <infrastructureID>-<node_role> <3>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role> <3>
+      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<node_role> <3>
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <node_role> <2>
         machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role> <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<node_role> <3>
     spec:
       providerSpec:
         value:
@@ -51,16 +51,16 @@ spec:
             subnets:
             - filter:
                 name: <subnet_name>
-                tags: openshiftClusterID=<infrastructure_ID>
+                tags: openshiftClusterID=<infrastructureID>
           primarySubnet: <rhosp_subnet_UUID> <6>
           securityGroups:
           - filter: {}
-            name: <infrastructure_ID>-<node_role>
+            name: <infrastructureID>-<node_role>
           serverMetadata:
-            Name: <infrastructure_ID>-<node_role>
-            openshiftClusterID: <infrastructure_ID>
+            Name: <infrastructureID>-<node_role>
+            openshiftClusterID: <infrastructureID>
           tags:
-          - openshiftClusterID=<infrastructure_ID>
+          - openshiftClusterID=<infrastructureID>
           trunk: true
           userDataSecret:
             name: <node_role>-user-data <2>

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -6,9 +6,9 @@
 [id="machineset-yaml-osp_{context}"]
 =  Sample YAML for a machine set custom resource on {rh-openstack}
 
-This sample YAML defines a machine set that runs on {rh-openstack-first} and creates nodes that are labeled with `node-role.openshift.io/<node_role>: ""`
+This sample YAML defines a machine set that runs on {rh-openstack-first} and creates nodes that are labeled with `node-role.openshift.io/<role>: ""`.
 
-In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `node_role` is the node label to add.
+In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 
 [source,yaml]
 ----
@@ -17,23 +17,23 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
-    machine.openshift.io/cluster-api-machine-role: <node_role> <2>
-    machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-  name: <infrastructureID>-<node_role> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> <2>
+    machine.openshift.io/cluster-api-machine-type: <role> <2>
+  name: <infrastructureID>-<role> <3>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<node_role> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>
   template:
     metadata:
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
-        machine.openshift.io/cluster-api-machine-role: <node_role> <2>
-        machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<node_role> <3>
+        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>
     spec:
       providerSpec:
         value:
@@ -55,9 +55,9 @@ spec:
           primarySubnet: <rhosp_subnet_UUID> <6>
           securityGroups:
           - filter: {}
-            name: <infrastructureID>-<node_role>
+            name: <infrastructureID>-<role>
           serverMetadata:
-            Name: <infrastructureID>-<node_role>
+            Name: <infrastructureID>-<role>
             openshiftClusterID: <infrastructureID>
           tags:
           - openshiftClusterID=<infrastructureID>

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -63,7 +63,7 @@ spec:
           - openshiftClusterID=<infrastructureID>
           trunk: true
           userDataSecret:
-            name: <node_role>-user-data <2>
+            name: worker-user-data
           availabilityZone: <optional_openstack_availability_zone>
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:

--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -8,7 +8,7 @@
 
 This sample YAML defines a machine set that runs on {rh-virtualization} and creates nodes that are labeled with `node-role.kubernetes.io/<node_role>: ""`.
 
-In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
+In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 
 [source,yaml,subs="+quotes"]
 ----
@@ -16,24 +16,24 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
     machine.openshift.io/cluster-api-machine-role: <role> <2>
     machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructure_id>-<role> <3>
+  name: <infrastructureID>-<role> <3>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas> <4>
   Selector: <5>
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
+      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <role> <2>
         machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>
     spec:
       metadata:
         labels:

--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -6,7 +6,7 @@
 [id="machineset-yaml-rhv_{context}"]
 =  Sample YAML for a machine set custom resource on {rh-virtualization}
 
-This sample YAML defines a machine set that runs on {rh-virtualization} and creates nodes that are labeled with `node-role.kubernetes.io/<node_role>: ""`.
+This sample YAML defines a machine set that runs on {rh-virtualization} and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
 
 In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 

--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -23,7 +23,7 @@ metadata:
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas> <4>
-  Selector: <5>
+  selector: <5>
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
       machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <3>

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -23,7 +23,7 @@ metadata:
   name: <infrastructureID>-<role> <2>
   namespace: openshift-machine-api
 spec:
-  replicas: 1
+  replicas: <number_of_replicas>
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -18,6 +18,8 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-machine-role: <role>
+    machine.openshift.io/cluster-api-machine-type: <role>
   name: <infrastructureID>-<role> <2>
   namespace: openshift-machine-api
 spec:

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -9,7 +9,7 @@
 
 This sample YAML defines a machine set that runs on VMware vSphere and creates nodes that are labeled with `node-role.kubernetes.io/<role>: ""`.
 
-In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
+In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `<role>` is the node label to add.
 
 [source,yaml]
 ----
@@ -18,23 +18,23 @@ kind: MachineSet
 metadata:
   creationTimestamp: null
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-  name: <infrastructure_id>-<role> <2>
+    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+  name: <infrastructureID>-<role> <2>
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <2>
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <role> <3>
         machine.openshift.io/cluster-api-machine-type: <role> <3>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <2>
     spec:
       metadata:
         creationTimestamp: null

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -16,7 +16,6 @@ In this sample, `<infrastructureID>` is the infrastructure ID label that is base
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  creationTimestamp: null
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
   name: <infrastructureID>-<role> <2>
@@ -29,7 +28,6 @@ spec:
       machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <2>
   template:
     metadata:
-      creationTimestamp: null
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
         machine.openshift.io/cluster-api-machine-role: <role> <3>
@@ -37,7 +35,6 @@ spec:
         machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role> <2>
     spec:
       metadata:
-        creationTimestamp: null
         labels:
           node-role.kubernetes.io/<role>: "" <3>
       providerSpec:
@@ -48,8 +45,6 @@ spec:
           diskGiB: 120
           kind: VSphereMachineProviderSpec
           memoryMiB: 8192
-          metadata:
-            creationTimestamp: null
           network:
             devices:
             - networkName: "<vm_network_name>" <4>


### PR DESCRIPTION
Removes most differences between the instructions for creating machinesets across the different cloud providers.

For openshift/openshift-docs#23632