### PR TITLE
vSphere provides IPI network customization docs

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -132,7 +132,7 @@ endif::openshift-origin[]
 |
 |
 |
-|
+|xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[X]
 |
 |
 


### PR DESCRIPTION
Preview: https://deploy-preview-30113--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms

This PR adds the `X` for vSphere/Network Operator in the support table.