### PR TITLE
ISSUE-27701 - Minor edit for emphasis

### DIFF
--- a/modules/storage-multi-attach-error.adoc
+++ b/modules/storage-multi-attach-error.adoc
@@ -30,7 +30,7 @@ For most storage solutions, you can use ReadWriteMany (RWX) volumes to prevent m
 +
 For storage that does not support RWX, such as VMware vSphere, RWO volumes must be used instead. However, RWO volumes cannot be mounted on multiple nodes.
 +
-If you encounter a multi-attach error message with an RWO volume, force delete the pod on a shut down or crashed node.
+If you encounter a multi-attach error message with an RWO volume, force delete the pod on a shutdown or crashed node to avoid data loss in critical workloads, such as when dynamic persistent volumes are attached.
 +
 [source,terminal]
 ----

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -160,7 +160,7 @@ endif::[]
 |===
 [.small]
 --
-1. ReadWriteOnce (RWO) volumes cannot be mounted on multiple nodes. If a node fails, the system does not allow the attached RWO volume to be mounted on a new node because it is already assigned to the failed node. If you encounter a multi-attach error message as a result, force delete the pod on a shut down or crashed node.
+1. ReadWriteOnce (RWO) volumes cannot be mounted on multiple nodes. If a node fails, the system does not allow the attached RWO volume to be mounted on a new node because it is already assigned to the failed node. If you encounter a multi-attach error message as a result, force delete the pod on a shutdown or crashed node to avoid data loss in critical workloads, such as when dynamic persistent volumes are attached.
 2. Use a recreate deployment strategy for pods that rely on AWS EBS.
 // GCE Persistent Disks, or Openstack Cinder PVs.
 --


### PR DESCRIPTION
Addresses https://github.com/openshift/openshift-docs/issues/27701#issuecomment-790678254. 

The previous fix referred to in the GH Issue has already been implemented and the docs currently instruct users to force delete crashed or shutdown nodes (https://github.com/openshift/openshift-docs/pull/27703 and https://github.com/openshift/openshift-docs/pull/27719). 

This PR addresses the reporter's comment about mentioning data loss prevention. No QE required.