### PR TITLE
Additional resources and next steps ID guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -84,14 +84,6 @@ Example:
 = Basic CLI commands
 ----
 
-*All headings after the initial title must have a section anchor, with no line spaces between the
-anchor and the section title and the anchor id should be similar to the section title*:
-
-----
-[id="<section-anchor>_{context}"]
-=== Section title
-----
-
 == Assembly/module file names
 
 Try to shorten the file name as much as possible _without_ abbreviating important terms that may cause confusion. For example, the `managing-authorization-policies.adoc` file name would be appropriate for an assembly titled "Managing Authorization Policies".
@@ -132,6 +124,72 @@ To use a discrete heading, just add `[discrete]` to the line before your unique 
 == Managing authorization policies
 ----
 
+== Anchoring titles and section headings
+
+All titles and section headings must have an anchor ID. The anchor ID must be similar to the title or section heading.
+
+=== Anchoring in assembly files
+
+The following is an example anchor ID in an assembly file:
+
+----
+[id="understanding-the-monitoring-stack"]
+= Understanding the monitoring stack
+----
+
+[NOTE]
+====
+Do not include line spaces between the anchor ID and the section title.
+====
+
+=== Anchoring in module files
+
+You must add the `{context}` variable to the end of anchor IDs in module files. When called, the `{context}` variable is resolved into the value declared in the `:context:` attribute in the corresponding assembly file. This enables cross-referencing to module IDs in context to a specific assembly and is useful when a module is included in multiple assemblies.
+
+The following is an example of an anchor ID in a module file:
+
+----
+[id="default-monitoring-components_{context}"]
+= Default monitoring components
+----
+
+[NOTE]
+====
+The `{context}` variable must be preceded by an underscore (`_`) when declared in an anchor ID.
+====
+
+=== Anchoring "Prerequisites", "Additional resources", and "Next steps" titles in assemblies
+
+Use unique IDs for "Prerequisites", "Additional resources", and "Next steps" titles in assemblies. You can add the prefixes `prerequisites_`, `additional-resources_`, or `next-steps_` to a unique string that describes the assembly topic. The unique string can match the value assigned to the `:context:` attribute in the assembly.
+
+[NOTE]
+====
+The `prerequisites_`, `additional-resources_`, and `next-steps_` prefixes must end with an underscore (`_`) when declared in an anchor ID in an assembly.
+====
+
+The following examples include IDs that are unique to the "Understanding the monitoring stack" assembly.
+
+*Example unique ID for a "Prerequisites" title*
+
+----
+[id="prerequisites_understanding-the-monitoring-stack"]
+== Prerequisites
+----
+
+*Example unique ID for an "Additional resources" title*
+
+----
+[id="additional-resources_understanding-the-monitoring-stack"]
+== Additional resources
+----
+
+*Example unique ID for a "Next steps" title*
+
+----
+[id="next-steps_understanding-the-monitoring-stack"]
+== Next steps
+----
+
 == Writing assemblies
 An _assembly_ is a collection of modules that describes how to accomplish a user story.
 
@@ -140,7 +198,7 @@ link:https://redhat-documentation.github.io/modular-docs/#forming-assemblies[Red
 
 [NOTE]
 ====
-When using `Prerequisites`, `Next steps`, and `Additional resources` headings in an assembly, use `==` formatting, such as `== Prerequisites` and `== Additional resources`. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly. Only use `.` syntax (`.Additional resources`) to follow the module as a trailing include at the assembly level, which indicates that the resources apply specifically to the module.
+When using "Prerequisites", "Next steps", and "Additional resources" headings in an assembly, use `==` formatting, such as `== Prerequisites` and `== Additional resources`. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly. Only use `.` syntax (`.Additional resources`) to follow the module as a trailing include at the assembly level, which indicates that the resources apply specifically to the module.
 ====
 
 == Writing concepts


### PR DESCRIPTION
Applies to master only.

This PR adds a subsection to `contributing_to_docs/doc_guidelines.adoc` that provides guidance on creating unique IDs for **Additional resources** and **Next steps** titles.

IDs are automatically built for any title that does not have a defined ID, so it makes sense to define what those are. Having unique IDs for these common subsection titles is also good practice so that contributors can cross-reference to them easily.