### PR TITLE
Improvements to admonition blocks

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -869,7 +869,28 @@ table > tbody > tr > td > div > div > p > code {
      background: none;
      width: 100%;
 }
+ .admonitionblock.note {
+    background: #4e9fde15;
+    border-left: solid #4e9fde;
+}
+ .admonitionblock.important {
+    background: #ee210015;
+    border-left: solid #ee2100;
+}
+ .admonitionblock.warning {
+    background: #ec7a0915;
+    border-left: solid #ec7a09;
+}
+ .admonitionblock.caution {
+    background: #ec7a0915;
+    border-left: solid #ec7a09;
+}
+ .admonitionblock.tip {
+    background: #32859615;
+    border-left: solid #328596;
+}
  .admonitionblock > table td.icon {
+     vertical-align: top;
      text-align: center;
      width: 80px;
 }
@@ -884,6 +905,37 @@ table > tbody > tr > td > div > div > p > code {
      padding-left: 0;
      padding-right: 1.25em;
      color: #6e6e6e;
+     font-size: .85rem;
+}
+ .admonitionblock.note td.content:before {
+    content: "NOTE\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+ .admonitionblock.important td.content:before {
+    content: "IMPORTANT\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+ .admonitionblock.warning td.content:before {
+    content: "WARNING\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+ .admonitionblock.tip td.content:before {
+    content: "TIP\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
+}
+ .admonitionblock.caution td.content:before {
+    content: "CAUTION\a";
+    white-space: pre;
+    color: #404040;
+    font-weight: bold;
 }
  .admonitionblock > table td.content > :last-child > :last-child {
      margin-bottom: 0;
@@ -1256,6 +1308,10 @@ table > tbody > tr > td > div > div > p > code {
   line-height: 1.8;
   margin: 0.5em 0;
 }
+.colist .admonitionblock {
+  margin-top: 0.5em;
+  padding-top: 0.75em;
+}
 .qanda > ol > li > p > em:only-child {
      color: #1d4b8f;
 }
@@ -1522,6 +1578,7 @@ table > tbody > tr > td > div > div > p > code {
  .admonitionblock td.icon [class^="fa icon-"] {
      font-size: 2.5em;
      cursor: default;
+     padding-top: .125em;
 }
  .admonitionblock td.icon .icon-note:before {
      content: "\f05a";


### PR DESCRIPTION
- Bump the admonition block font-size slightly for readability.
- Prepend the admonition type before the body content.
  - This matches closer with the Customer Portal styling as well.
- Add bgcolor and left-border (thx @gaurav-nelson!)
- Vertical align icon to top (with minor padding).
- Add padding/margin to top of admonitions within callouts.

Preview build (internal): http://file.rdu.redhat.com/~adellape/030921/admonition_tweaks/welcome/index.html

Examples:

_After normal body text_
![note2](https://user-images.githubusercontent.com/3442316/110135284-8d54c080-7d8b-11eb-86d9-c1b6e02d0cd7.png)

_Within unordered list_
![warning2](https://user-images.githubusercontent.com/3442316/110135291-90e84780-7d8b-11eb-83fe-0ff894e9c5a7.png)

_More complex body content_
![important2](https://user-images.githubusercontent.com/3442316/110135343-a52c4480-7d8b-11eb-9ec2-c263265c0499.png)

_Within a callout list_
![colist2](https://user-images.githubusercontent.com/3442316/110135302-93e33800-7d8b-11eb-8d5d-f4ceb2c0b6e4.png)

_Within a table cell_
![cell2](https://user-images.githubusercontent.com/3442316/110135309-96de2880-7d8b-11eb-843f-d02561b20e62.png)

_Caution block_ (note that this type should not be used per [RH supplementary style guide](https://redhat-documentation.github.io/supplementary-style-guide/#admonitions))
![caution2](https://user-images.githubusercontent.com/3442316/110135933-54691b80-7d8c-11eb-869c-daf95a523618.png)

_Tip block_
![tip2](https://user-images.githubusercontent.com/3442316/110135942-5632df00-7d8c-11eb-99cd-9ae3a3d97532.png)


