### PR TITLE
BZ1853309: removed unhelpful link and redirected customers to the location of the image needed for their release

### DIFF
--- a/modules/installation-gcp-user-infra-rhcos.adoc
+++ b/modules/installation-gcp-user-infra-rhcos.adoc
@@ -12,9 +12,7 @@ your {product-title} nodes.
 
 ifndef::openshift-origin[]
 . Obtain the {op-system} image from the
-link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
-Hat customer portal or the
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/<opsystem/latest/[{op-system} image mirror]
 page.
 +
 [IMPORTANT]

--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -42,10 +42,8 @@ installation, do not delete these files.
 ifndef::openshift-origin[]
 . Obtain the {op-system} images that are required for your preferred method
 of installing operating system instances from the
-link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
-Hat customer portal or the
 ifndef::ibm-power[]
-link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/[{op-system} image mirror]
+link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror]
 endif::ibm-power[]
 ifdef::ibm-power[]
 link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/[{op-system} image mirror]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -42,14 +42,14 @@ If you plan to add more compute machines to your cluster after you finish instal
 ====
 
 ifndef::openshift-origin[]
-. Obtain the {op-system} OVA image from the link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red Hat Customer Portal or the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/[{op-system} image mirror] page.
-+
+. Obtain the {op-system} OVA image. Images are available from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror] page.
+
 [IMPORTANT]
 ====
 The {op-system} images might not change with every release of {product-title}. You must download an image with the highest version that is less than or equal to the {product-title} version that you install. Use the image version that matches your {product-title} version if it is available.
 ====
 +
-The filename contains the {product-title} version number in the format `rhcos-<version>-vmware.<architecture>.ova`.
+The filename contains the {product-title} version number in the format `rhcos-vmware.<architecture>.ova`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 . Obtain the {op-system} images from the link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page


### PR DESCRIPTION
For versions 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1853309

Direct link to doc preview: https://deploy-preview-30123--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#installation-vsphere-machines_installing-restricted-networks-vsphere

Ready for QA: @wjiangjay 