### PR TITLE
Add \ to multi-line pruning cmd

### DIFF
--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -122,7 +122,7 @@ $ grpcurl -plaintext localhost:50051 api.Registry/ListPackages > packages.out
 $ opm index prune \
     -f {index-image-pullspec} \// <1>
     -p {package1},{package2},{package3} \// <2>
-    -t <target_registry>:<port>/<namespace>/{index-image} <3>
+    -t <target_registry>:<port>/<namespace>/{index-image} \// <3>
     -i registry.redhat.io/openshift4/ose-operator-registry/{index-image} <4>
 ----
 <1> Index to prune.


### PR DESCRIPTION
Missing from a recent addition of new line at the end of the command.