### PR TITLE
BZ1929998 - Clarify that EUS repos are available for all subs

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -66,6 +66,12 @@ Although there is no difference between `stable-4.y` and `eus-4.y` channels unti
 When upgrades to the next EUS channel are offered, you can switch to the next EUS channel and upgrade until you have reached the next EUS version.
 
 This upgrade process does not apply for the `eus-4.6` channel.
+
+[NOTE]
+====
+Both standard and non-EUS subscribers can access all EUS repositories and necessary RPMs (`rhel-*-eus-rpms`) to be able to support critical purposes such as debugging and building drivers.
+====
+
 endif::openshift-origin[]
 
 [id="upgrade-version-paths_{context}"]


### PR DESCRIPTION
Addresses [BZ1929998](https://bugzilla.redhat.com/show_bug.cgi?id=1929998) to describe that in OCP 4.6, which is an Extended Update Support (EUS) release, both standard and premium subscribes can access  RPM repositories.

This PR seems suited for this file (`modules/understanding-upgrade-channels.adoc`), which is the only OCP docs where I could find EUS content.

~~I've commented out where I'm unclear as to whether we need to provide instructions for how non-EUS customers can access these repos.~~

~~(This PR also fixes minor typos and removes hardwraps in this section per docs conventions in lines 89-95. SMEs can ignore these touches.)~~

**Preview link:** https://deploy-preview-30133--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release#eus-4y-channel_understanding-upgrade-channels-releases