### PR TITLE
CNV-10446 Adding single space required in CDI Supported operations matrix

### DIFF
--- a/modules/virt-cdi-supported-operations-matrix.adoc
+++ b/modules/virt-cdi-supported-operations-matrix.adoc
@@ -18,7 +18,7 @@ This matrix shows the supported CDI operations for content types against endpoin
 |===
 |Content types | HTTP | HTTPS | HTTP basic auth | Registry | Upload
 
-| KubeVirt(QCOW2)
+| KubeVirt (QCOW2)
 |&#10003; QCOW2 +
 &#10003; GZ* +
 &#10003; XZ*


### PR DESCRIPTION
This PR covers [CNV-10446](https://issues.redhat.com/browse/CNV-10446) ( https://issues.redhat.com/browse/CNV-10446 ) as well as BZ1927726 ( https://bugzilla.redhat.com/show_bug.cgi?id=1927726 ).

This story requests a space be added to between KubeVirt and (QCOW2) in the CDI supported operations matrix table to prevent an unsightly line break when viewed on the Customer Portal

Preview: https://deploy-preview-30151--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.html#virt-cdi-supported-operations-matrix_virt-preparing-cdi-scratch-space 