### PR TITLE
The DHCP shim configuration should include type: Raw 

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -128,15 +128,16 @@ spec:
   additionalNetworks:
   - name: dhcp-shim
     namespace: default
+    type: Raw
     rawCNIConfig: |-
-    {
-      "name": "dhcp-shim",
-      "cniVersion": "0.3.1",
-      "type": "bridge",
-      "ipam": {
-        "type": "dhcp"
+      {
+        "name": "dhcp-shim",
+        "cniVersion": "0.3.1",
+        "type": "bridge",
+        "ipam": {
+          "type": "dhcp"
+        }
       }
-    }
 ----
 ====
 


### PR DESCRIPTION
This adds the `type: Raw` field, as well as indents the curly braces.