### PR TITLE
Added soft shutdown commentary per KNIDEPLOY-3821.

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -655,6 +655,13 @@ The Machine Config Operator (MCO) no longer automatically reboots all correspond
 
 For more information, see xref:../architecture/control-plane.adoc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
 
+[id="ocp-4-7-bmh-soft-shutdown"]
+==== BareMetalHost API supports soft shutdown
+
+In {product-title} 4.6, when the online flag in the BareMetalHost API is set to `false`, the Bare Metal Operator shuts down nodes "hard." That is, it turns the power off without giving the operating system or workloads time to react. In {product-title} 4.7 and subsequent releases, the API sends the node's operating system a signal telling it to shut down, and then waits for the node to power off in "soft" mode. If the operating system does not shut down the node within three minutes, the Bare Metal Operator executes a "hard" shutdown.
+
+{product-title} 4.8 will execute a "hard" shutdown for remediation purposes, such as if there is a known problem with the node. The behavior of executing a "hard" shutdown for remediation purposes will be back ported to {product-title} 4.7.
+
 [id="ocp-4-7-nodes"]
 === Nodes
 


### PR DESCRIPTION
Per Ramon Acedo Rodriguez, "We added https://issues.redhat.com/browse/KNIDEPLOY-3821 in 4.7 at the request of Fujitsu and the work is done but we’d like to have it mentioned in the release notes in 4.7.  There isn't additional downstream documentation (it’s no-doc) but it changes the default behaviour when powering down nodes managed by the BMO."

The notes have been reviewed via email and signed off by Doug Hellman.

@ahardin-rh
@vikram-redhat 

Signed-off-by: John Wilkins <jowilkin@redhat.com>