### PR TITLE
BZ#1934653 - fix typo, duplicated attributes in overview of RHV CSI Driver 

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
@@ -7,11 +7,11 @@ toc::[]
 
 == Overview
 
-{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for {rh-virtualization-first} ({rh-virtualization}).
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for {rh-virtualization-first}.
 
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a Container Storage Interface (CSI) Operator and driver.
 
-To create CSI-provisioned PVs that mount to {rh-virtualization-first} ({rh-virtualization}) storage assets, {product-title} installs the oVirt CSI Driver Operator and the oVirt CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
+To create CSI-provisioned PVs that mount to {rh-virtualization} storage assets, {product-title} installs the oVirt CSI Driver Operator and the oVirt CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
 
 * The _oVirt CSI Driver Operator_ provides a default `StorageClass` object that you can use to create Persistent Volume Claims (PVCs).
 


### PR DESCRIPTION
[enterprise-4.7] 
[enterprise-4.8]
[BZ#1934653](https://bugzilla.redhat.com/show_bug.cgi?id=1934653)  removing duplicated attributes from chapter persistent-storage-csi-ovirt.adoc