### PR TITLE
Change 'node selector` to 'label' and fix secret name in example

### DIFF
--- a/modules/nodes-pods-secrets-certificates-creating.adoc
+++ b/modules/nodes-pods-secrets-certificates-creating.adoc
@@ -56,7 +56,7 @@ $ oc get secrets
 .Example output
 [source,terminal]
 ----
-NAME                         TYPE                                  DATA      AGE
+NAME                     TYPE                                  DATA      AGE
 my-cert                  kubernetes.io/tls                     2         9m
 ----
 +
@@ -64,28 +64,26 @@ my-cert                  kubernetes.io/tls                     2         9m
 +
 [source,terminal]
 ----
-$ oc describe secret my-service-pod
+$ oc describe secret my-cert
 ----
 +
 .Example output
 [source,terminal]
 ----
-Name:         my-service-pod
+Name:         my-cert
 Namespace:    openshift-console
 Labels:       <none>
-Annotations:  kubernetes.io/service-account.name: builder
-              kubernetes.io/service-account.uid: ab-11e9-988a-0eb4e1b4a396
+Annotations:  service.alpha.openshift.io/expiry: 2023-03-08T23:22:40Z
+              service.alpha.openshift.io/originating-service-name: my-service
+              service.alpha.openshift.io/originating-service-uid: 640f0ec3-afc2-4380-bf31-a8c784846a11
+              service.beta.openshift.io/expiry: 2023-03-08T23:22:40Z
 
-Type:  kubernetes.io/service-account-token
+Type:  kubernetes.io/tls
 
 Data
-
-ca.crt:     5802 bytes
-namespace:  17 bytes
-token:      eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Ii
-wia3ViZXJuZXRlcy5pby9zZXJ2aWNlYWNjb3VudC9uYW1lc3BhY2UiOiJvcGVuc2hpZnQtY29uc29sZSIsImt1YmVyb
-cnZpY2VhY2NvdW50L3NlcnZpY2UtYWNjb3VudC51aWQiOiJhYmE4Y2UyZC00MzVlLTExZTktOTg4YS0wZWI0ZTFiNGEz
-OTYiLCJzdWIiOiJzeXN0ZW06c2VydmljZWFjY291bnQ6b3BlbnNoaWZ
+====
+tls.key:  1679 bytes
+tls.crt:  2595 bytes
 ----
 
 . Edit your `Pod` spec with that secret.

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -137,13 +137,13 @@ After making this change, wait for the pods in the `openshift-kube-apiserver` pr
 
 * Use a `MachineSet` object to add labels to nodes managed by the machine set when a node is created:
 
-.. Run the following command to add a node selector to a `MachineSet` object:
+.. Run the following command to add labels to a `MachineSet` object:
 +
 [source,terminal]
 ----
 $ oc patch MachineSet <name> --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"<key>"="<value>","<key>"="<value>"}}]'  -n openshift-machine-api <1>
 ----
-<1> Add a `<key>/<value>` pair for each node selector.
+<1> Add a `<key>/<value>` pair for each label.
 +
 For example:
 +
@@ -152,7 +152,7 @@ For example:
 $ oc patch MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'  -n openshift-machine-api
 ----
 +
-.. Verify that the label is added to the `MachineSet` object by using the `oc edit` command:
+.. Verify that the labels are added to the `MachineSet` object by using the `oc edit` command:
 +
 For example:
 +
@@ -231,7 +231,7 @@ For example, to label a node:
 $ oc label nodes ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49 type=user-node region=east
 ----
 
-.. Verify that the label is added to the node using the `oc get` command:
+.. Verify that the labels are added to the node using the `oc get` command:
 +
 [source,terminal]
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -5,7 +5,7 @@
 [id="nodes-scheduler-node-selectors-pod_{context}"]
 = Using node selectors to control pod placement
 
-You can use node selector labels on pods to control where the pod is scheduled.
+You can use node selectors on pods to control where the pod is scheduled.
 
 With node selectors, {product-title} schedules the pods on nodes that contain matching labels.
 
@@ -64,7 +64,7 @@ The web console lists the controlling object under `ownerReferences` in the pod 
 
 * Use a `MachineSet` object to add labels to nodes managed by the machine set when a node is created:
 
-.. Run the following command to add a node selector to a `MachineSet` object:
+.. Run the following command to add labels to a `MachineSet` object:
 +
 [source,terminal]
 ----
@@ -78,7 +78,7 @@ For example:
 $ oc patch MachineSet abc612-msrtw-worker-us-east-1c  --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'  -n openshift-machine-api
 ----
 
-.. Verify that the label is added to the `MachineSet` object by using the `oc edit` command:
+.. Verify that the labels are added to the `MachineSet` object by using the `oc edit` command:
 +
 For example:
 +
@@ -124,7 +124,7 @@ For example, to label a node:
 $ oc label nodes ip-10-0-142-25.ec2.internal type=user-node region=east
 ----
 
-.. Verify that the label is added to the node:
+.. Verify that the labels are added to the node:
 +
 [source,terminal]
 ----

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -9,7 +9,7 @@ You can use node selectors in a project together with labels on nodes to constra
 
 When you create a pod in this project, {product-title} adds the node selectors to the pods in the project and schedules the pods on a node with matching labels in the project. If there is a cluster-wide default node selector, a project node selector takes preference.
 
-You add labels to a project by editing the `Namespace` object to add the `openshift.io/node-selector` parameter, which contains the label definitions. You add labels to a node by editing the `Node` object, a `MachineSet` object, or a `MachineConfig` object. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
+You add node selectors to a project by editing the `Namespace` object to add the `openshift.io/node-selector` parameter. You add labels to a node by editing the `Node` object, a `MachineSet` object, or a `MachineConfig` object. Adding the label to the machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
 
 [NOTE]
 ====
@@ -135,7 +135,7 @@ status:
 
 * Use a `MachineSet` object to add labels to nodes managed by the machine set when a node is created:
 
-.. Run the following command to add a node selector to a `MachineSet` object:
+.. Run the following command to add labels to a `MachineSet` object:
 +
 [source,terminal]
 ----
@@ -149,7 +149,7 @@ For example:
 $ oc patch MachineSet ci-ln-l8nry52-f76d1-hl7m7-worker-c --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'  -n openshift-machine-api
 ----
 
-.. Verify that the label is added to the `MachineSet` object by using the `oc edit` command:
+.. Verify that the labels are added to the `MachineSet` object by using the `oc edit` command:
 +
 For example:
 +
@@ -228,7 +228,7 @@ For example, to label a node:
 $ oc label nodes ci-ln-l8nry52-f76d1-hl7m7-worker-c-tgq49 type=user-node region=east
 ----
 
-.. Verify that the label is added to the `Node` object using the `oc get` command:
+.. Verify that the labels are added to the `Node` object using the `oc get` command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Change _node selector_ to _label_: https://github.com/openshift/openshift-docs/issues/29478

Preview: https://deploy-preview-30221--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-pod_nodes-scheduler-node-selectors

https://deploy-preview-30221--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-project_nodes-scheduler-node-selectors

Change name of secret (and output): https://github.com/openshift/openshift-docs/issues/29255

Preview: https://deploy-preview-30221--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-certificates-creating_nodes-pods-secrets