### PR TITLE
RHDEVDOCS-2765 Fix product name in enterprise-4.7 release notes

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,5 +1,5 @@
 [id="cluster-logging-release-notes"]
-= {ProductName} 5.0 release notes
+= Red Hat OpenShift Logging 5.0 release notes
 include::modules/cluster-logging-document-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 


### PR DESCRIPTION
- For versions 4.7 only
- https://issues.redhat.com/browse/RHDEVDOCS-2765
- Direct link to doc preview: https://deploy-preview-30223--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html
- Ready for merge