### PR TITLE
Add OLM mirroring using offline media

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -14,6 +14,9 @@ ifndef::openshift-origin[]
 :index-image: redhat-operator-index
 :tag: v{product-version}
 endif::[]
+ifeval::["{context}" == "olm-restricted-networks"]
+:olm-restricted-networks:
+endif::[]
 
 [id="olm-creating-catalog-from-index_{context}"]
 = Creating a catalog from an index image
@@ -27,8 +30,8 @@ You can create an Operator catalog from an index image and apply it to an {produ
 .Procedure
 
 . Create a `CatalogSource` object that references your index image.
-ifeval::["{context}" == "olm-restricted-networks"]
-If you used the `oc adm catalog mirror` command to mirror your catalog to a target registry, you can use the generated `catalogSource.yaml` file as is or further modify the configuration.
+ifdef::olm-restricted-networks[]
+If you used the `oc adm catalog mirror` command to mirror your catalog to a target registry, you can use the generated `catalogSource.yaml` file as a starting point.
 endif::[]
 
 .. Modify the following to your specifications and save it as a `catalogSource.yaml` file:
@@ -38,20 +41,28 @@ endif::[]
 apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
+ifdef::olm-restricted-networks[]
+  name: my-operator-catalog <.>
+endif::[]
+ifndef::olm-restricted-networks[]
   name: my-operator-catalog
+endif::[]
   namespace: openshift-marketplace
 spec:
   sourceType: grpc
-  image: <registry>:<port>/<namespace>/{index-image}:{tag} <1>
+  image: <registry>:<port>/<namespace>/{index-image}:{tag} <.>
   displayName: My Operator Catalog
-  publisher: <publisher_name> <2>
+  publisher: <publisher_name> <.>
   updateStrategy:
-    registryPoll: <3>
+    registryPoll: <.>
       interval: 30m
 ----
-<1> Specify your index image.
-<2> Specify your name or an organization name publishing the catalog.
-<3> Catalog sources can automatically check for new versions to keep up to date.
+ifdef::olm-restricted-networks[]
+<.> If you mirrored content to local files before uploading to a registry, remove any backslash (`/`) characters from the `metadata.name` field to avoid an "invalid resource name" error when you create the object.
+endif::[]
+<.> Specify your index image.
+<.> Specify your name or an organization name publishing the catalog.
+<.> Catalog sources can automatically check for new versions to keep up to date.
 
 .. Use the file to create the `CatalogSource` object:
 +

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -23,14 +23,14 @@ You can mirror the Operator content of a Red Hat-provided catalog, or a custom c
 
 The `oc adm catalog mirror` command also automatically mirrors the index image that is specified during the mirroring process, whether it be a Red Hat-provided index image or your own custom-built index image, to the target registry. You can then use the mirrored index image to create a catalog source that allows Operator Lifecycle Manager (OLM) to load the mirrored catalog onto your {product-title} cluster.
 
-For the steps in this procedure, the target registry is an existing mirror registry that is accessible by both your cluster and a workstation with unrestricted network access.
-
 .Prerequisites
 
-* Workstation with unrestricted network access
-* `podman` version 1.9.3+
+* Workstation with unrestricted network access.
+* `podman` version 1.9.3 or later.
 * Access to mirror registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2].
+* Decide which namespace on your mirror registry you will use to store the mirrored Operator content. For example, you might create an `olm-mirror` namespace.
+* If your mirror registry does not have Internet access, connect removable media to your workstation with unrestricted network access.
 * If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]
@@ -40,15 +40,8 @@ $ REG_CREDS=${XDG_RUNTIME_DIR}/containers/auth.json
 
 .Procedure
 
-. On your workstation with unrestricted network access, use the `podman login` command to authenticate with the target mirror registry:
-+
-[source,terminal]
-----
-$ podman login <mirror_registry>
-----
-
 ifndef::openshift-origin[]
-. Authenticate with `registry.redhat.io`:
+. If you want to mirror a Red Hat-provided catalog, run the following command on your workstation with unrestricted network access to authenticate with `registry.redhat.io`:
 +
 [source,terminal]
 ----
@@ -56,36 +49,35 @@ $ podman login registry.redhat.io
 ----
 endif::[]
 
-. The `oc adm catalog mirror` command extracts the contents of an index image to generate the manifests required for mirroring. You can choose either of the following:
+. The `oc adm catalog mirror` command extracts the contents of an index image to generate the manifests required for mirroring. The default behavior of the command generates manifests, then automatically mirrors all of the image content from the index image, as well as the index image itself, to your mirror registry. Alternatively, if your mirror registry is on a completely disconnected, or _airgapped_, host, you can first mirror the content to removable media, move the media to the disconnected environment, then mirror the content from the media to the registry.
+
+** *Option A: If your mirror registry is on the same network* as your workstation with unrestricted network access, take the following actions on your workstation:
+
+.. If your mirror registry requires authentication, run the following command to log in to the registry:
 +
---
-* Allow the default behavior of the command to automatically mirror all of the image content from the index image, as well as the index image itself, to your mirror registry after generating manifests.
-* Add the `--manifests-only` flag to only generate the manifests required for mirroring, but do not actually mirror the image content to the registry yet. This can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you only require a subset of packages. You can then use that file with the `oc image mirror` command to mirror the modified list of images in a later step.
-+
-[NOTE]
-====
-The `--manifests-only` flag is intended for advanced selective mirroring of content from the catalog. The `opm index prune` command, if you used it previously to prune the index image, is suitable for most use cases.
-====
---
-+
-On your workstation with unrestricted network access, run the following command:
+[source,terminal]
+----
+$ podman login <mirror_registry>
+----
+
+.. Run the following command to mirror the content:
 +
 [source,terminal]
 ----
 $ oc adm catalog mirror \
     <index_image> \//<1>
-    <mirror_registry>:<port> \//<2>
+    <mirror_registry>:<port>/<namespace> \//<2>
     [-a ${REG_CREDS}] \//<3>
     [--insecure] \//<4>
     [--index-filter-by-os='<platform>/<arch>'] \//<5>
     [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<2> Specify the target registry to mirror the Operator content to.
+<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
-<6> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
+<6> Optional: Generate only the manifests required for mirroring, and do not actually mirror the image content to a registry. This option can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you require only a subset of packages. You can then use the `mapping.txt` file with the `oc image mirror` command to mirror the modified list of images in a later step. This flag is intended for only advanced selective mirroring of content from the catalog; the `opm index prune` command, if you used it previously to prune the index image, is suitable for most catalog management use cases.
 +
 .Example output
 [source,terminal,subs="attributes+"]
@@ -94,29 +86,111 @@ src image has index label for database path: /database/index.db
 using database path mapping: /database/index.db:/tmp/153048078
 wrote database to /tmp/153048078 <1>
 ...
-wrote mirroring manifests to manifests-{index-image}-1614211642
+wrote mirroring manifests to manifests-{index-image}-1614211642 <2>
 ----
 <1> Directory for the temporary `index.db` database generated by the command.
+<2> Record the manifests directory name that is generated. This directory name is used in a later step.
+
+** *Option B: If your mirror registry is on a disconnected host,* take the following actions.
+
+.. Run the following command on your workstation with unrestricted network access to mirror the content to local files:
 +
-After running the command, a `manifests-<index_image_name>-<random_number>/` directory is created in the current directory and generates the following files:
+[source,terminal]
+----
+$ oc adm catalog mirror \
+    <index_image> \//<1>
+    file:///local/index \//<2>
+    [-a ${REG_CREDS}] \
+    [--insecure]
+----
+<1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+<2> Mirrors content to local files in your current directory.
++
+.Example output
+[source,terminal]
+----
+...
+info: Mirroring completed in 5.93s (5.915MB/s)
+wrote mirroring manifests to manifests-my-index-1614985528 <1>
+
+To upload local images to a registry, run:
+
+	oc adm catalog mirror file://local/index/myrepo/my-index:v1 REGISTRY/REPOSITORY <2>
+----
+<1> Record the manifests directory name that is generated. This directory name is used in a later step.
+<2> Record the expanded `file://` path that based on your provided index image. This path is used in a later step.
+
+.. Copy the `v2/` directory that is generated in your current directory to removable media.
+
+.. Physically remove the media and attach it to a host in the disconnected environment that has access to the mirror registry.
+
+.. If your mirror registry requires authentication, run the following command on your host in the disconnected environment to log in to the registry:
++
+[source,terminal]
+----
+$ podman login <mirror_registry>
+----
+
+.. Run the following command from the parent directory containing the `v2/` directory to upload the images from local files to the mirror registry:
++
+[source,terminal]
+----
+$ oc adm catalog mirror \
+    file://local/index/<repo>/<index_image>:<tag> \//<1>
+    <mirror_registry>:<port>/<namespace> \//<2>
+    [-a ${REG_CREDS}] \
+    [--insecure]
+----
+<1> Specify the `file://` path from the previous command output.
+<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+
+. After mirroring the content to your registry, inspect the manifests directory that is generated in your current directory.
++
+[NOTE]
+====
+The manifests directory name is used in a later step.
+====
++
+If you mirrored content to a registry on the same network in the previous step, the directory name takes the following form:
++
+[source,text]
+----
+manifests-<index_image_name>-<random_number>
+----
++
+If you mirrored content to a registry on a disconnected host in the previous step, the directory name takes the following form:
++
+[source,text]
+----
+manifests-index/<namespace>/<index_image_name>-<random_number>
+----
++
+The manifests directory contains the following files, some of which might require further modification:
 +
 --
 * The `catalogSource.yaml` file is a basic definition for a `CatalogSource` object that is pre-populated with your index image tag and other relevant metadata. This file can be used as is or modified to add the catalog source to your cluster.
-* The `imageContentSourcePolicy.yaml` file defines an `ImageContentSourcePolicy` object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
-* The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
---
 +
 [IMPORTANT]
 ====
-If you used the `--manifests-only` flag in this step and want to further trim the subset of packages to be mirrored, see the steps in the _Mirroring a Package Manifest Format catalog image_ procedure about modifying your `mapping.txt` file and using the file with the `oc image mirror` command. After following those further actions, you can continue this procedure.
+If you mirrored the content to local files, you must modify your `catalogSource.yaml` file to remove any backslash (`/`) characters from the `metadata.name` field. Otherwise, when you attempt to create the object, it fails with an "invalid resource name" error.
 ====
+* The `imageContentSourcePolicy.yaml` file defines an `ImageContentSourcePolicy` object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
+* The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
++
+[IMPORTANT]
+====
+If you used the `--manifests-only` flag during the mirroring process and want to further trim the subset of packages to be mirrored, see the steps in the "Mirroring a Package Manifest Format catalog image" procedure about modifying your `mapping.txt` file and using the file with the `oc image mirror` command. After following those further actions, you can continue this procedure.
+====
+--
 
-. Create the `ImageContentSourcePolicy` object:
+. On a host with access to the disconnected cluster, create the `ImageContentSourcePolicy` object by running the following command to specify the `imageContentSourcePolicy.yaml` file in your manifests directory:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc create -f ./manifests-{index-image}-<random_number>/imageContentSourcePolicy.yaml
+$ oc create -f <path/to/manifests/dir>/imageContentSourcePolicy.yaml
 ----
++
+where `<path/to/manifests/dir>` is the path to the manifests directory for your mirrored content.
 
 You can now create a `CatalogSource` object to reference your mirrored index image and Operator content.
 

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -26,12 +26,12 @@ endif::[]
 [id="olm-pruning-index-image_{context}"]
 = Pruning an index image
 
-An index image, based on the Operator Bundle Format, is a containerized snapshot of an Operator catalog. You can prune an index of all but a specified list of packages, creating a copy of the source index containing only the Operators that you want.
+An index image, based on the Operator Bundle Format, is a containerized snapshot of an Operator catalog. You can prune an index of all but a specified list of packages, which creates a copy of the source index containing only the Operators that you want.
 
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
 When configuring Operator Lifecycle Manager (OLM) to use mirrored content on restricted network {product-title} clusters, use this pruning method if you want to only mirror a subset of Operators from the default catalogs.
 
-For the steps in this procedure, the target registry is an existing mirror registry that is accessible by both your cluster and a workstation with unrestricted network access. This example also shows pruning the index image for the default `{catalog-name}` catalog, but the process is the same for all index images.
+For the steps in this procedure, the target registry is an existing mirror registry that is accessible by your workstation with unrestricted network access. This example also shows pruning the index image for the default `{catalog-name}` catalog, but the process is the same for any index image.
 endif::[]
 
 .Prerequisites

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -9,7 +9,7 @@
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Disabling the default OperatorHub sources
 
-Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation. Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs.
+Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation. Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs as a cluster administrator.
 
 .Procedure
 
@@ -20,3 +20,8 @@ Operator catalogs that source content provided by Red Hat and community projects
 $ oc patch OperatorHub cluster --type json \
     -p '[{"op": "add", "path": "/spec/disableAllDefaultSources", "value": true}]'
 ----
+
+[TIP]
+====
+Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Global Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, delete, disable, and enable individual sources.
+====

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -5,15 +5,17 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-For {product-title} clusters that are installed on restricted networks, also known as disconnected clusters, Operator Lifecycle Manager (OLM) by default cannot access the Red Hat-provided OperatorHub sources hosted remotely on Quay.io because those remote sources require full Internet connectivity.
+For {product-title} clusters that are installed on restricted networks, also known as _disconnected clusters_, Operator Lifecycle Manager (OLM) by default cannot access the Red Hat-provided OperatorHub sources hosted on remote registries because those remote sources require full Internet connectivity.
 
-However, as a cluster administrator you can still enable your cluster to use OLM in a restricted network if you have a workstation that has full Internet access. The workstation is used to prepare local mirrors of the remote OperatorHub sources, and requires full Internet access to pull the remote content.
+However, as a cluster administrator you can still enable your cluster to use OLM in a restricted network if you have a workstation that has full Internet access. The workstation, which requires full Internet access to pull the remote OperatorHub content, is used to prepare local mirrors of the remote sources, and push the content to a mirror registry.
+
+The mirror registry can be located on a bastion host, which requires connectivity to both your workstation and the disconnected cluster, or a completely disconnected, or _airgapped_, host, which requires removable media to physically move the mirrored content to the disconnected environment.
 
 This guide describes the following process that is required to enable OLM in restricted networks:
 
 * Disable the default remote OperatorHub sources for OLM.
-* Use a workstation with full Internet access to create local mirrors of the OperatorHub content.
-* Configure OLM to install and manage Operators from the local sources instead of the default remote sources.
+* Use a workstation with full Internet access to create and push local mirrors of the OperatorHub content to a mirror registry.
+* Configure OLM to install and manage Operators from local sources on the mirror registry instead of the default remote sources.
 
 After enabling OLM in a restricted network, you can continue to use your unrestricted workstation to keep your local OperatorHub sources updated as newer versions of Operators are released.
 
@@ -38,6 +40,7 @@ include::modules/olm-understanding-operator-catalog-images.adoc[leveloffset=+1]
 [id="olm-restricted-network-prereqs"]
 == Prerequisites
 
+* Log in to your {product-title} cluster as a user with `cluster-admin` privileges.
 * If you want to prune the default catalog and selectively mirror only a subset of Operators, install the xref:../../cli_reference/opm-cli.adoc#opm-cli[`opm` CLI].
 
 [NOTE]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1384 (also related to https://bugzilla.redhat.com/show_bug.cgi?id=1841885)

Preview: [Mirroring an Operator catalog](https://deploy-preview-30230--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks)

* Update the "Mirroring an Operator catalog" procedure to include two options in step 3: either mirroring directly to a target mirror registry, or first mirroring the files locally and then moving removable/offline media to another host (the airgapped scenario).
* Modify the target registry path in `oc adm catalog mirror` commands to include `/<namespace>`, so that the mirroring process can transform the paths in the ISCP accordingly.
* Mention in the "Disabling the default OperatorHub sources" section as a `[TIP]` that the web console can now also be used to manage catalog sources.