### PR TITLE
OSDOCS-1819: Noting control plane pods require root permissions

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -80,3 +80,10 @@ Systemd services are appropriate for services that you need to always come up on
 * Kubelet (kubelet), which accepts requests for managing containers on the machine from master services.
 
 CRI-O and Kubelet must run directly on the host as systemd services because they need to be running before you can run other containers.
+
+The [x-]`installer-*` and [x-]`revision-pruner-*` control plane pods must run with root permissions because they write to the `/etc/kubernetes` directory, which is owned by the root user. These pods are in the following namespaces:
+
+* `openshift-etcd`
+* `openshift-kube-apiserver`
+* `openshift-kube-controller-manager`
+* `openshift-kube-scheduler`


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1819

Preview: https://deploy-preview-30273--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#defining-masters_control-plane