### PR TITLE
Making it clear that Operator is always capitalized

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1120,7 +1120,15 @@ For example, the object `kind` for a node is `Node`, not `Nodes`. So do not writ
 ====
 
 [id="operator-name-capitalization"]
-=== Operator name capitalization
+=== Operator capitalization
+
+The term "Operator" is always capitalized. For example:
+
+----
+= Support policy for unmanaged Operators
+
+Individual Operators have a `managementState` parameter in their configuration.
+----
 
 An Operator's full name must be a proper noun, with each word initially
 capitalized. If it includes a product name, defer the product's capitalization

--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -426,6 +426,8 @@ application. A Kubernetes application is an application that is both deployed on
 a Kubernetes cluster (including OpenShift clusters) and managed using the
 Kubernetes APIs and `kubectl` or `oc` tooling.
 
+The term "Operator" is always captalized.
+
 While "containerized" is allowed, do not use "Operatorize" to refer to building an
 Operator that packages an application.
 


### PR DESCRIPTION
Closing out an old to-do to update the guidelines to make it clear that Operator is always capitalized.