### PR TITLE
Manual CP of RHDEVDOCS-2583 to 4.6

### DIFF
--- a/logging/cluster-logging-uninstall.adoc
+++ b/logging/cluster-logging-uninstall.adoc
@@ -14,5 +14,6 @@ You can remove cluster logging from your {product-title} cluster.
 
 include::modules/cluster-logging-uninstall.adoc[leveloffset=+1]
 
+.Additional resources
 
-
+* xref:../storage/understanding-persistent-storage.adoc#reclaim-manual_understanding-persistent-storage[Reclaiming a persistent volume manually]

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -24,7 +24,7 @@ ifdef::openshift-origin[]
 +
 If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
 endif::[]
- 
+
 .Procedure
 
 To install the Elasticsearch Operator and Cluster Logging Operator using the {product-title} web console:
@@ -76,7 +76,7 @@ scrapes the `openshift-operators-redhat` namespace.
 
 .. Select *Enable operator recommended cluster monitoring on this namespace*.
 +
-This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object. 
+This option sets the `openshift.io/cluster-monitoring: "true"` label in the Namespace object.
 You must select this option to ensure that cluster monitoring
 scrapes the `openshift-logging` namespace.
 
@@ -226,7 +226,6 @@ However, an unmanaged deployment does not receive updates until the cluster logg
 <4> Specify the length of time that Elasticsearch should retain each log source. Enter an integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s). For example, `7d` for seven days. Logs older than the `maxAge` are deleted. You must specify a retention policy for each log source or the Elasticsearch indices will not be created for that source.
 <5> Specify the number of Elasticsearch nodes. See the note that follows this list.
 <6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys cluster logging with ephemeral storage only.
-<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys cluster logging with ephemeral storage only.
 <7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `16G` for the memory request and `1` for the CPU request.
 <8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `256Mi` for the memory request and `100m` for the CPU request.
 <9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana nodes. For more information, see *Configuring the log visualizer*.
@@ -279,4 +278,3 @@ You should see several pods for cluster logging, Elasticsearch, Fluentd, and Kib
 * fluentd-pb2f8
 * fluentd-zqgqx
 * kibana-7fb4fd4cc9-bvt4p
-

--- a/modules/cluster-logging-uninstall.adoc
+++ b/modules/cluster-logging-uninstall.adoc
@@ -5,7 +5,10 @@
 [id="cluster-logging-uninstall_{context}"]
 = Uninstalling cluster logging from {product-title}
 
-You can stop log aggregation by deleting the `ClusterLogging` custom resource (CR). However, after deleting the CR there are other cluster logging components that remain, which you can optionally remove. 
+You can stop log aggregation by deleting the `ClusterLogging` custom resource (CR). After deleting the CR, there are other cluster logging components that remain, which you can optionally remove.
+
+
+Deleting the `ClusterLogging` CR does not remove the persistent volume claims (PVCs). To preserve or delete the remaining PVCs, persistent volumes (PVs), and associated data, you must take further action.
 
 .Prerequisites
 
@@ -43,7 +46,7 @@ To remove cluster logging:
 
 .. Click the Options menu {kebab} next to the Elasticsearch Operator and select *Uninstall Operator*.
 
-. Optional: Remove the Cluster Logging and Elasticsearch projects. 
+. Optional: Remove the Cluster Logging and Elasticsearch projects.
 
 .. Switch to the *Home* -> *Projects* page.
 
@@ -60,9 +63,17 @@ Do not delete the `openshift-operators-redhat` project if other global operators
 
 .. Confirm the deletion by typing `openshift-operators-redhat` in the dialog box and click *Delete*.
 
-. Optional: Remove any Cluster Logging persistent volume claims (PVC):
+. To keep the PVCs for reuse with other pods, keep the labels or PVC names that you need to reclaim the PVCs.
+
+. Optional: If you do not want to keep the PVCs, you can delete them.
++
+[WARNING]
+====
+Releasing or deleting PVCs can delete PVs and cause data loss.
+====
 
 .. Switch to the *Storage* -> *Persistent Volume Claims* page.
 
 .. Click the Options menu {kebab} next to each PVC and select *Delete Persistent Volume Claim*.
 
+.. If you want to recover storage space, you can delete the PVs.

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -142,7 +142,6 @@ EOF
 * If the RHV VM migration mode is `Allow manual and automatic migration`, the default access mode is `ReadWriteMany`.
 * If the RHV virtual disk access mode is `ReadOnly`, the default access mode is `ReadOnlyMany`.
 * For all other settings, the default access mode is `ReadWriteOnce`.
-
 <13> Specify the source VM disk ID, for example, `8181ecc1-5db8-4193-9c92-3ddab3be7b05`. You can obtain the disk ID by entering `\https://www.example.com/ovirt-engine/api/vms/vm23` in a web browser on the Manager machine and reviewing the VM details.
 <14> Specify the target storage class.
 


### PR DESCRIPTION
- Manual CP of https://github.com/openshift/openshift-docs/pull/30137 to enterprise-4.6 
- For version 4.6 only
- https://issues.redhat.com/browse/RHDEVDOCS-2583
- Direct link to doc preview: https://deploy-preview-30280--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-uninstall.html
- Ready for merge