### PR TITLE
BZ:1924176 - Replacing DNS name servers

### DIFF
--- a/modules/machineconfig-modify-dns-nameservers.adoc
+++ b/modules/machineconfig-modify-dns-nameservers.adoc
@@ -1,0 +1,177 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+[id="machineconfig-modify-dns-nameservers_{context}"]
+= Modifying the DNS name servers
+
+You can override the DNS name servers and search list in the `/etc/resolv.conf` file.
+Some operating systems use `NetworkManager` to manage network interfaces.
+When `NetworkManager` manages some interfaces, it also manages the contents of the `/etc/resolv.conf` file.
+The following procedure shows how to replace the `/etc/resolv.conf` file and prevent `NetworkManager` from managing the file.
+
+.Prerequisites
+
+* Have a running OpenShift Container Platform cluster.
+
+* Log in to the cluster as a user with administrative privileges.
+
+.Procedure
+
+. Create the contents of the `resolv.conf` file and encode it as base64:
++
+[source,terminal]
+----
+$ cat << EOF | base64 -w0
+# Custom resolv.conf added with Machine Config Operator
+# and the override-etc-resolv-conf.yaml file.
+search svc.cluster.local cluster.local example.com
+nameserver 192.168.24.1
+nameserver 10.0.0.1
+nameserver 10.0.0.2
+EOF
+----
++
+The output is a single line:
++
+.Example output
+[source,terminal]
+----
+IyBDdXN0b20gcmVzb2x2LmNvbmYgYWRkZWQgd2l0aCBNYWNoaW5lIENvbmZpZyBPcGVyYXRvcgojIGFuZCB0aGUgb3ZlcnJpZGUtZXRjLXJlc29sdi1jb25mLnlhbWwgZmlsZS4Kc2VhcmNoIHN2Yy5jbHVzdGVyLmxvY2FsIGNsdXN0ZXIubG9jYWwgZXhhbXBsZS5jb20KbmFtZXNlcnZlciAxOTIuMTY4LjI0LjEKbmFtZXNlcnZlciAxMC4wLjAuMQpuYW1lc2VydmVyIDEwLjAuMC4yCg==
+----
+
+. Create the contents of a `disable-network-manager-dns.conf` file to prevent `NetworkManager` from managing the `/etc/resolv.conf` file:
++
+[source,terminal]
+----
+$ cat << EOF | base64 -w0
+[main]
+dns=none
+EOF
+----
++
+.Example output
+[source,terminal]
+----
+W21haW5dCmRucz1ub25lCg==
+----
+
+. Create the `MachineConfig` object file.
+This example adds the machine configuration to the nodes with the `master` role.
+You can change it to `worker` or make an additional `MachineConfig` object for the `worker` role:
++
+[source,terminal]
+----
+$ cat << EOF > ./override-etc-resolv-conf.yaml
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: override-etc-resolv-conf
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<encoded-resolv-conf> <.>
+        mode: 420
+        overwrite: true
+        path: /etc/resolv.conf
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<encoded-file> <.>
+        mode: 420
+        overwrite: true
+        path: /etc/NetworkManager/conf.d/disable-network-manager-dns.conf
+EOF
+----
+<.> Replace `<encoded-resolv-conf>` with the base64-encoded `resolv.conf` file contents from step 1. Make sure the content is a single line.
+<.> Replace `<encoded-file>` with the base64-encoded configuration file contents from step 2. Make sure the content is a single line.
+
+. Apply the machine config to the pool:
++
+[source,terminal]
+----
+ $ oc apply -f ./override-etc-resolv-conf.yaml
+----
+
+.Verification
+
+. Monitor the progress of the Machine Config Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get machineconfigpool
+----
++
+.Expected output
+[source,terminal]
+----
+NAME   CONFIG             UPDATED UPDATING DEGRADED MACHINECOUNT READYMACHINECOUNT UPDATEDMACHINECOUNT DEGRADEDMACHINECOUNT AGE
+master rendered-master-35 False   True     False    1            1                 1                   0                    34m
+worker rendered-worker-d8 True    False    False    3            3                 3                   0                    34m
+----
++
+Wait until the output from the command reports `True` for node role in the `UPDATED` column.
+
+. Display the contents of the `/etc/resolv.conf` file on a host.
+
+.. Store the host name for one master node in a variable:
++
+[source,terminal]
+----
+$ export ONE_HOST=$(oc get node -l node-role.kubernetes.io/master="" \
+    -o jsonpath="{.items[0].metadata.name}")
+----
+
+.. Display the file contents from the node. As an alternative, you can specify `oc debug node/<host-name>` for each host in your cluster:
++
+[source,terminal]
+----
+$ oc debug node/${ONE_HOST} -- chroot /host cat /etc/resolv.conf <.>
+----
+<.> `ONE_HOST` specifies the host name that the previous command stored in an environment variable.
++
+.Expected output
+[source,terminal]
+----
+# Custom resolv.conf added with Machine Config Operator
+# and the override-etc-resolv-conf.yaml file.
+search svc.cluster.local cluster.local example.com
+nameserver 192.168.24.1
+nameserver 10.0.0.1
+nameserver 10.0.0.2
+----
+
+. Confirm the `/etc/resolv.conf` updates propagated to the DNS service:
+
+.. Store the pod name that is running on the same node in a variable:
++
+[source,terminal]
+----
+$ export DNS_POD=$(oc get pods -n openshift-dns \
+    --field-selector spec.nodeName=${ONE_HOST} \
+    -o jsonpath="{.items[].metadata.name}")
+----
+
+.. Display the file contents from the `dns` container:
++
+[source,terminal]
+----
+$ oc exec -it -n openshift-dns ${DNS_POD} -c dns -- cat /etc/resolv.conf <.>
+----
+<.> `DNS_POD` specifies a pod name that the previous command stored in an environment variable.
++
+.Expected output
+[source,terminal]
+----
+search svc.cluster.local cluster.local example.com
+nameserver 192.168.24.1
+nameserver 10.0.0.1
+nameserver 10.0.0.2
+----
++
+The command prints the file contents to the terminal.
+Unlike the file contents from the host, the file contents from the pod do not include leading comment lines.

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -18,15 +18,24 @@ include::modules/machine-config-overview.adoc[leveloffset=+2]
 include::modules/checking-mco-status.adoc[leveloffset=+2]
 
 [id="using-machineconfigs-to-change-machines"]
-== Using `MachineConfig` objects to configure nodes
+== Using machine config objects to configure nodes
 
-Tasks in this section let you create `MachineConfig` objects to modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see
- content related to link:https://access.redhat.com/solutions/5307301[changing MTU network settings], link:https://access.redhat.com/solutions/5096731[adding] or
-link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys, link:https://access.redhat.com/solutions/4518671[replacing DNS nameservers], link:https://access.redhat.com/verify-images-ocp4[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
+The following sections show you how to create and use `MachineConfig` objects to modify files, `systemd` unit files, and other operating system features running on {product-title} nodes. For other examples, see the following Red Hat Knowledgebase articles:
 
-{product-title} version 4.7 supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2].  All new machine configs you create going forward should be based on Ignition specification version 3.2.  If you are upgrading your {product-title} cluster, any existing Ignition specification version 2.x machine configs will be translated automatically to specification version 3.2.
+* link:https://access.redhat.com/solutions/5307301[changing MTU network settings]
+
+* link:https://access.redhat.com/solutions/5096731[adding] or link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys
+
+* link:https://access.redhat.com/verify-images-ocp4[verifying image signatures]
+
+* link:https://access.redhat.com/solutions/4727321[enabling Stream Control Transmission Protocol (SCTP)]
+
+* link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames]
+
+{product-title} version 4.7 supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2]. When you create a new machine config, use specification version 3.2. If you upgraded your {product-title} cluster from an earlier version, existing Ignition specification version 2.x machine configs were translated automatically to specification version 3.2.
 
 include::modules/installation-special-config-crony.adoc[leveloffset=+2]
+include::modules/machineconfig-modify-dns-nameservers.adoc[leveloffset=+2]
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+2]
 include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+2]
 include::modules/machineconfig-modify-journald.adoc[leveloffset=+2]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924176

* From https://access.redhat.com/solutions/7412, configure
  NetworkManager not to update `/etc/resolv.conf`.

* Follow the general guidance for replacing a file with
  the Machine Config Operator.

Updates are at the following heading: https://deploy-preview-30283--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machineconfig-modify-dns-nameservers_post-install-machine-configuration-tasks

Note to self: This PR applies to 4.8 and 4.7. The Ignition config file version is 3.1 for 4.6.