### PR TITLE
Bz1825256: added xref to a cross-namespace image access module

### DIFF
--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -49,8 +49,10 @@ include::modules/registry-viewing-logs.adoc[leveloffset=+1]
 
 include::modules/registry-accessing-metrics.adoc[leveloffset=+1]
 
-.Additional resources
+[id="accessing-the-registry-additional-resources"]
+== Additional resources
 
+* For more information on allowing pods in a project to reference images in another project, see xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-across-projects_using-image-pull-secrets[Allowing pods to reference images across projects].
 * A `kubeadmin` can access the registry until deleted. See
 xref:../authentication/remove-kubeadmin.adoc[Removing the kubeadmin user] for
 more information.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1825256

For versions 4.5+

Direct link to doc preview: https://deploy-preview-30284--osdocs.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html

@sferich888 I added an additional resource at the bottom of this page to existing doc that basically has the info from StackOverflow (more info in BZ)

Ready for QA @wzheng1 
