### PR TITLE
Adding a product title and product version comment to `modules/common-attributes.adoc`

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -33,7 +33,13 @@ include::modules/common-attributes.adoc[]                       <3>
 
 <1> A unique (within OpenShift docs) anchor id for this assembly. Example: cli-developer-commands
 <2> Human readable title (notice the '=' top-level header)
-<3> Includes all attributes common to OpenShift docs
+<3> Includes attributes common to OpenShift docs.
++
+[NOTE]
+====
+The `{product-name}` and `{product-version}` common attributes are not defined in the `modules/common-attributes.adoc` file. Those attributes are pulled by AsciiBinder from the distro mapping definitions in the https://github.com/openshift/openshift-docs/blob/master/_distro_map.yml[_distro_map.yml] file. See xref:product-name-and-version[Product name and version] for more information on this topic.
+====
++
 <4> Context used for identifying headers in modules that is the same as the anchor id. Example: cli-developer-commands.
 
 After the heading block and a single whitespace line, you can include any content for this assembly.
@@ -158,12 +164,13 @@ link:https://redhat-documentation.github.io/modular-docs/#creating-procedure-mod
 When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syntax to suppress TOC formatting within a module. Do not use `==` headings or xrefs in modules.
 ====
 
-== Product name & version
+[id="product-name-and-version"]
+== Product name and version
 
-When possible, generalize references to the product name and/or version using
+When possible, generalize references to the product name and/or version by using
 the `{product-title}` and/or `{product-version}` attributes. These attributes
-are pulled from distro mapping definitions in the
-https://github.com/openshift/openshift-docs/blob/master/_distro_map.yml[distro_map.yml]
+are pulled by AsciiBinder from the distro mapping definitions in the
+https://github.com/openshift/openshift-docs/blob/master/_distro_map.yml[_distro_map.yml]
 file.
 
 The `{product-title}` comes from the first `name:` field in a distro mapping,
@@ -216,6 +223,11 @@ And for the `openshift-origin` distro:
 Considering that we use distinct branches to keep content for product versions separated, global use of `{product-version}` across all branches is probably less useful, but it is available if you come across a requirement for it. Just consider how it will render across any branches that the content appears in.
 
 If it makes more sense in context to refer to the major version of the product instead of a specific minor version (for example, if comparing how something in OpenShift Container Platform 4 differs from OpenShift Container Platform 3), just use the major version number. Do not prepend with a `v`, as in `v3` or `v4`.
+
+[NOTE]
+====
+Other common attribute values are defined in the `modules/common-attributes.adoc` file. Where possible, generalize references to those values by using the common attributes. For example, use `{cloud-redhat-com}` to refer to Red Hat OpenShift Cluster Manager.
+====
 
 == Node names
 

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -1,5 +1,7 @@
-{product-author}
-{product-version}
+// The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.8".
+// {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
+// See https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#product-name-version for more information on this topic.
+// Other common attributes are defined in the following lines:
 :data-uri:
 :icons:
 :experimental:


### PR DESCRIPTION
Applies to branch/enterprise-4.5 onward.

This PR adds a comment to `modules/common-attributes.adoc` that briefly explains how `{product-title}` and `{product-version}` are parsed in the OpenShift docs library. Contributors can review the `modules/common-attributes.adoc` file to determine what attribute values will be resolved in a documentation build.  The `{product-title}` and `{product-version}` values are not defined in `modules/common-attributes.adoc` and the comment will help to provide an understanding about how those are resolved.

The PR also clarifies in the existing documentation guidelines on this topic that it is AsciiBinder that pulls the attributes from the distro mapping.