### PR TITLE
Bug Fixes for ODC 4.7

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1258,6 +1258,10 @@ If you are using the option `--keep-manifest-list=true`, the only valid value fo
 
 * Previously, monitoring alerts with severity levels such as `critical` and `warning` were treated as `info` level alerts. As a result, the *Monitoring Alert* icon was not displayed on the workload in the *Topology* view for these alerts. This issue is now fixed; alerts like `critical` are treated as `warning` level alerts and a *Monitoring Alert* icon is displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925200[*BZ#1925200*])
 
+* Previously, in the *YAML view* of the Helm installation form only the YAML code was shown. Now a *Schema* viewer is added in the YAML editor to show the schema and its description. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1886861[*BZ#1886861*])
+
+* Previously, all Pods were failing with the `ErrImagePull` and `ImagePullBackOff` errors, even after an Image Pull Secret was added to access the external private image container registry. This is because the image download failed as it had no permissions for the external image registry and the cluster tried to load the container image directly from the external URL without the provided secret. As a result, the deployment was stuck until the service account or deployment was updated manually. Now, the issue is fixed and new deployments can start pods from the internal private container registry and import a container image from an external private container registry without any additional changes to the service account or deployment. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1924955[*BZ#1924955*])
+
 *DNS*
 
 * Previously, a cluster might experience intermittent DNS resolution errors because the `/etc/hosts` file on some nodes included invalid entries. With this release, DNS resolution no longer fails because of an `/etc/hosts` file with invalid entries. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1882485[*BZ#1882485*])


### PR DESCRIPTION
This PR has additional Bugfixes for the ODC 4.7.

- Applies to 4.7
- Reviewed by SMEs/QEs
- Aligned team label DevTools