### PR TITLE
Change [CAUTION] admonitions to supported types

### DIFF
--- a/modules/installation-osp-creating-image-restricted.adoc
+++ b/modules/installation-osp-creating-image-restricted.adoc
@@ -50,7 +50,7 @@ $ openstack image create --file rhcos-44.81.202003110027-0-openstack.x86_64.qcow
 Depending on your {rh-openstack} environment, you might be able to upload the image in either link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/15/html/instances_and_images_guide/index[`.raw` or `.qcow2` formats]. If you use Ceph, you must use the `.raw` format.
 ====
 +
-[CAUTION]
+[WARNING]
 ====
 If the installation program finds multiple images with the same name, it chooses one of them at random. To avoid this behavior, create unique names for resources in {rh-openstack}.
 ====

--- a/modules/installing-rhv-insecure-mode.adoc
+++ b/modules/installing-rhv-insecure-mode.adoc
@@ -11,7 +11,7 @@ By default, the installer creates a CA certificate, prompts you for confirmation
 
 Although it is not recommended, you can override this functionality and install {product-title} without verifying a certificate by installing {product-title} on {rh-virtualization} in *insecure* mode.
 
-[CAUTION]
+[WARNING]
 ====
 Installing in *insecure* mode is not recommended, because it enables a potential attacker to perform a Man-in-the-Middle attack and capture sensitive credentials on the network.
 ====


### PR DESCRIPTION
[RH supplementary style guide](https://redhat-documentation.github.io/supplementary-style-guide/#admonitions) says that the `[CAUTION]` admonition block type should not be used. Adjusting the few we had in use to other supported types that seem appropriate.