### PR TITLE
BZ1936485 - Added 2 optional permissions to a new section in the AWS installer guide

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -251,3 +251,10 @@ If you use an existing VPC, your account does not require these permissions to d
 * `s3:ListBucketMultipartUploads`
 * `s3:AbortMultipartUpload`
 ====
+
+.Optional permissions for instance and quota checks for installation
+[%collapsible]
+====
+* `ec2:DescribeInstanceTypeOfferings`
+* `servicequotas:ListAWSDefaultServiceQuotas`
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1936485

For 4.7+, I  added the new section "Optional permissions for instance and quota checks for installation" and the two items, `ec2:DescribeInstanceTypeOfferings` and `servicequotas:ListAWSDefaultServiceQuotas`, under it.

https://deploy-preview-30316--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account

For 4.6, only one permission was defined. This change can be tracked here - https://github.com/openshift/openshift-docs/compare/master...EricPonvelle:6485-MissingAWSPermissions-4.6?expand=1

Source:
`ec2:DescribeInstanceTypeOfferings` - https://github.com/openshift/installer/pull/4258
`servicequotas:ListAWSDefaultServiceQuotas` - https://github.com/openshift/installer/pull/3820