### PR TITLE
BZ1936485 - [enterprise-4.6] Updated the 4.6 documentation to note missing permissions

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -253,3 +253,10 @@ If you use an existing VPC, your account does not require these permissions to d
 * `s3:ListBucketMultipartUploads`
 * `s3:AbortMultipartUpload`
 ====
+
+
+.Optional permission for quota checks for installation
+[%collapsible]
+====
+* `servicequotas:ListAWSDefaultServiceQuotas`
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1936485#c2

For 4.6, I added the new section "Optional permissions for instance and quota checks for installation" and the `servicequotas:ListAWSDefaultServiceQuotas` permission under it.

https://deploy-preview-30320--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account

For 4.7+, a second permission was added. Those changes are tracked here - https://github.com/openshift/openshift-docs/pull/30316 

Source:
`servicequotas:ListAWSDefaultServiceQuotas` - https://github.com/openshift/installer/pull/3820