### PR TITLE
CNV-10445 [1926199] VM Migration of mixed CPU (AMD,Intel)

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -37,6 +37,8 @@ Without an external monitoring system or a qualified human monitoring node healt
 
 * To use proxy with {VirtProductName}, you must xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager].
 
+* If your cluster uses worker nodes from multiple CPU vendors, live migration failures can occur. For example, a virtual machine with an AMD CPU might attempt to live-migrate to a node with an Intel CPU and likely fail migration. To avoid this, label nodes with a vendor-specific label, such as `Vendor=Intel` or `Vendor=AMD`, and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
+
 {VirtProductName} works with {product-title} by default, but the following installation configurations are recommended:
 
 * Configure xref:../../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[monitoring] in the cluster.


### PR DESCRIPTION
Label for *enterprise-4.5, 4.6, 4.7, 4.8*

Added this bullet to the prereqs listed in the **Configuring your cluster for OpenShift Virtualization** assembly:

_Before you migrate virtual machines to a cluster, ensure that all nodes in a single pool use the same type of CPU. For example, place nodes that use AMD processors in one pool and place nodes that use Intel processors in a different pool. Do not mix different CPU types in the same pool._

Jira: https://issues.redhat.com/browse/CNV-10445
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1926199
Test Build: https://deploy-preview-30340--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html

Tagging @kobi86 for Code Review
Tagging Israel Pinto for QE Review in Jira record.