### PR TITLE
BZ1897600: Add note that install-config.yaml optional parameters are …

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -20,6 +20,7 @@
 // * installing/installing_openstack/installing-openstack-user-kuryr.adoc
 // * installing/installing_rhv/installing-rhv-custom.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -102,6 +103,11 @@ Before you deploy an {product-title} cluster, you provide parameter values to de
 [NOTE]
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
+====
+
+[IMPORTANT]
+====
+The `openshift-install` command does not validate field names for parameters. If an incorrect name is specified, the related file or object is not created, and no error is reported. Ensure that the field names for any parameters that are specified are correct.
 ====
 
 .Required parameters
@@ -421,7 +427,7 @@ ifdef::osp[]
 |`platform.openstack.computeFlavor`
 |The {rh-openstack} flavor to use for control plane and compute machines.
 
-This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually. 
+This property is deprecated. To use a flavor as the default for all machine pools, add it as the value of the `type` key in the `platform.openstack.defaultMachinePlatform` property. You can also set a flavor value for each machine pool individually.
 
 |String, for example `m1.xlarge`.
 |====


### PR DESCRIPTION
…not validated by openshift-install
https://bugzilla.redhat.com/show_bug.cgi?id=1897600

Preview: https://deploy-preview-30350--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations

Edit to note that this appears in all instances of this topic, not just vSphere. For example: [RHV](https://deploy-preview-30350--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installation-configuration-parameters_installing-rhv-customizations), [OpenStack](https://deploy-preview-30350--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-configuration-parameters_installing-openstack-installer-custom), etc.