### PR TITLE
Fixed a typo in a comment in `build_for_portal.py`

### DIFF
--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -739,7 +739,7 @@ def extract_file_ids(file_path):
 
 def build_file_id(file_title, file_to_id_map, existing_ids):
     """
-    Generates a unique id for a file, based on it's title.
+    Generates a unique id for a file, based on its title.
     """
     file_id = base_id = re.sub(r"[\[\]\(\)#]", "", file_title.lower().replace("_", "-").replace(" ", "-"))
     count = 1


### PR DESCRIPTION
Applies to master and enterprise-4.5+.

Fixed a typo in a comment in `build_for_portal.py`.