### PR TITLE
Fix incorrect use of taint, should be toleration

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -154,7 +154,7 @@ spec:
         tolerationSeconds: 3600
 ----
 
-Here, if this pod is running but does not have a matching taint, the pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the pod is not evicted.
+Here, if this pod is running but does not have a matching toleration, the pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the pod is not evicted.
 
 [id="nodes-scheduler-taints-tolerations-about-multiple_{context}"]
 == Understanding how to use multiple taints


### PR DESCRIPTION
https://docs.openshift.com/container-platform/4.7/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations

_Here, if this pod is running but does not have a matching taint, the pod stays bound..._

I think it should say _Here, if this pod is running and it does have a matching toleration, the pod stays bound..._

If the pod doesn't have a matching toleration, the NoExecute parameter it gets removed.

The point of the text is to demonstrate the tolerationSeconds parameter and that it delays removing pods for that duration. We want to have an example where the pod would be removed.

https://github.com/openshift/openshift-docs/issues/29460