### PR TITLE
Removed prereqs and edited Understanding live migration text

### DIFF
--- a/modules/virt-understanding-live-migration.adoc
+++ b/modules/virt-understanding-live-migration.adoc
@@ -5,17 +5,17 @@
 [id="virt-understanding-live-migration_{context}"]
 = Understanding live migration
 
-Live migration is the process of moving a running virtual machine instance to
+Live migration is the process of moving a running virtual machine instance (VMI) to
 another node in the cluster without interrupting the virtual workload or access.
-This can be a manual process, if you select virtual machine instance
-to migrate to another node, or an automatic process, if the virtual machine
-instance has a `LiveMigrate` eviction strategy and the node on
-which it is running is placed into maintenance.
+If a VMI uses the `LiveMigrate` eviction strategy, it automatically migrates
+when the node that the VMI runs on is placed into maintenance mode. You can also
+manually start live migration by selecting a VMI to migrate.
 
-Virtual machines must have a persistent volume claim (PVC)
-with a shared ReadWriteMany (RWX) access mode to be live migrated.
+Virtual machines must have a persistent volume claim (PVC) with a shared
+ReadWriteMany (RWX) access mode to be live migrated.
 
 [NOTE]
-====
-Live migration is not supported for virtual machines that are attached to an SR-IOV network interface.
+==== 
+Live migration is not supported for virtual machines that are
+attached to an SR-IOV network interface.
 ====

--- a/virt/live_migration/virt-live-migration.adoc
+++ b/virt/live_migration/virt-live-migration.adoc
@@ -4,13 +4,6 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-live-migration
 toc::[]
 
-== Prerequisites
-* Before using live migration, ensure that the storage class used by the
-virtual machine has a persistent volume claim (PVC) with a shared
-ReadWriteMany (RWX) access mode.
-See xref:../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Storage defaults for data volumes]
-to ensure your storage settings are correct.
-
 include::modules/virt-understanding-live-migration.adoc[leveloffset=+1]
 include::modules/virt-updating-access-mode-for-live-migration.adoc[leveloffset=+1]
 
@@ -19,3 +12,4 @@ include::modules/virt-updating-access-mode-for-live-migration.adoc[leveloffset=+
 * xref:../../virt/live_migration/virt-migrate-vmi.adoc#virt-migrate-vmi[Migrating a virtual machine instance to another node]
 * xref:../../virt/node_maintenance/virt-node-maintenance.adoc#virt-node-maintenance[Node maintenance mode]
 * xref:../../virt/live_migration/virt-live-migration-limits.adoc#virt-live-migration-limits[Live migration limiting]
+* xref:../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Storage defaults for data volumes]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1933381

Removed redundant prereqs section and moved link to additional resources, updated the Understanding live migration section for brevity.
4.6, 4.7, 4.8

Preview: https://deploy-preview-30362--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration.html