### PR TITLE
Update Welcome topic to be ROSA-centric 

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -16,7 +16,7 @@ endif::[]
 ifdef::openshift-rosa[]
 To navigate the {product-title} (ROSA) documentation, use the left navigation bar.
 
-For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/4.7/welcome/index.html[OpenShift Container Platform documentation].
+For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
@@ -334,7 +334,7 @@ ifdef::openshift-rosa[]
 While cluster maintenance and host configuration is performed by the Red Hat Site Reliability Engineering (SRE) team, other ongoing tasks on your {product-title} {product-version} cluster can be performed by {product-title} cluster administrators. As a {product-title} cluster administrator, the ROSA documentation helps you:
 
 - *Manage Dedicated Administrators*: Grant or revoke permissions to `dedicated admin` users.
-- *Work with Logging*: Learn about {product-title} logging and configure the logging add-on services.
+- *Work with Logging*: Learn about {product-title} Logging and configure the logging add-on services.
 - *Monitor clusters*: Learn to use the Web UI to access monitoring dashboards.
 - *Manage nodes*: Learn to manage nodes, including configuring machine pools and autoscaling.
 endif::[]

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -6,10 +6,18 @@ include::modules/common-attributes.adoc[]
 [.lead]
 Welcome to the official {product-title} {product-version} documentation, where you can find information to help you learn about {product-title} and start exploring its features.
 
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online,openshift-aro[]
 To navigate the {product-title} {product-version} documentation, you can either
 
 * Use the left navigation bar to browse the documentation or
 * Select the activity that interests you from the contents of this Welcome page
+endif::[]
+
+ifdef::openshift-rosa[]
+To navigate the {product-title} (ROSA) documentation, use the left navigation bar.
+
+For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/4.7/welcome/index.html[OpenShift Container Platform documentation].
+endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 You can start with xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture] and
@@ -90,6 +98,7 @@ Internet access is still required to access the cloud APIs and installation medi
 - **xref:../storage/persistent_storage/persistent-storage-ocs.adoc#red-hat-openshift-container-storage[Install Red Hat OpenShift Container Storage]**: You can install Red Hat OpenShift Container Storage as an Operator to provide highly integrated and simplified persistent storage management for containers.
 endif::[]
 
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online,openshift-aro[]
 == Developer activities
 Ultimately, {product-title} is a platform for developing and deploying containerized applications. As an application developer, {product-title} documentation helps you:
 
@@ -140,6 +149,35 @@ xref:../operators/operator_sdk/helm/osdk-helm-support.adoc#osdk-helm-support[Hel
 
 - **xref:../rest_api/index.adoc#api-index[REST API reference]**: Lists {product-title} application programming interface endpoints.
 endif::[]
+endif::[]
+
+ifdef::openshift-rosa[]
+== Developer activities
+Ultimately, {product-title} is a platform for developing and deploying containerized applications. As an application developer, {product-title} and OpenShift Container Platform documentation helps you:
+
+- *Understand {product-title} development*: Learn the different types of containerized applications, from simple containers to advanced Kubernetes deployments and Operators.
+
+- *Work with projects*: Create projects from the web console or CLI to organize and share the software you develop.
+
+- *Work with applications*: Use the Developer perspective in the {product-title} web console to easily create and deploy applications. Use the Topology view to visually interact with your applications, monitor status, connect and group components, and modify your code base.
+
+- *Use the developer CLI tool (odo)*: The odo CLI tool lets developers create single or multi-component applications easily and automates deployment, build, and service route configurations.
+It abstracts complex Kubernetes and {product-title} concepts, allowing developers to focus on developing their applications.
+
+- *Create CI/CD Pipelines*: Pipelines are serverless, cloud-native, continuous integration and continuous deployment systems that run in isolated containers. They use standard Tekton custom resources to automate deployments and are designed for decentralized teams that work on microservices-based architecture.
+
+- *Understand Operators*: Operators are the preferred method for creating on-cluster applications for {product-title} {product-version}. Learn about the Operator Framework and how to deploy applications using installed Operators into your projects.
+
+- *Understand image builds*: Choose from different build strategies (Docker, S2I, custom, and pipeline) that can include different kinds of source materials (from places like Git repositories, local binary inputs, and external artifacts). Then, follow examples of build types from basic builds to advanced builds.
+
+- *Create container images*: A container image is the most basic building block in {product-title} (and Kubernetes) applications. Defining image streams lets you gather multiple versions of an image in one place as you continue its development. S2I containers let you insert your source code into a base container that is set up to run code of a particular type (such as Ruby, Node.js, or Python).
+
+- *Create deployments*:  Use `Deployment` and `DeploymentConfig` objects to exert fine-grained management over applications.
+Use the Workloads page or `oc` CLI to manage deployments. Learn rolling, recreate, and custom deployment strategies.
+
+- *Create templates*: Use existing templates or create your own templates that describe how an application is built or deployed. A template can combine images with descriptions, parameters, replicas, exposed ports and other content that defines how an application can be run or built.
+endif::[]
+
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster administrator activities
@@ -288,4 +326,15 @@ In addition to infrastructure metrics, you can also scrape and view metrics for 
 
 - **xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring_about-remote-health-monitoring[Remote health monitoring]**: {product-title} collects anonymized aggregated information about your cluster and reports it to Red Hat via Telemetry and the Insights Operator. This information allows Red Hat to improve {product-title} and to react to issues that impact customers more quickly. You can view the xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring_showing-data-collected-by-remote-health-monitoring[data collected by remote health monitoring].
 ////
+endif::[]
+
+ifdef::openshift-rosa[]
+== Cluster administrator activities
+
+While cluster maintenance and host configuration is performed by the Red Hat Site Reliability Engineering (SRE) team, other ongoing tasks on your {product-title} {product-version} cluster can be performed by {product-title} cluster administrators. As a {product-title} cluster administrator, the ROSA documentation helps you:
+
+- *Manage Dedicated Administrators*: Grant or revoke permissions to `dedicated admin` users.
+- *Work with Logging*: Learn about {product-title} logging and configure the logging add-on services.
+- *Monitor clusters*: Learn to use the Web UI to access monitoring dashboards.
+- *Manage nodes*: Learn to manage nodes, including configuring machine pools and autoscaling.
 endif::[]


### PR DESCRIPTION
and remove hyperlinks to OCP-specific topics, linking instead to the OCP docs in general at the beginning of the Welcome topic.