### PR TITLE
CNV - BZ#1917499 - net-attach-def and the overall improvement

### DIFF
--- a/modules/virt-attaching-vm-secondary-network-cli.adoc
+++ b/modules/virt-attaching-vm-secondary-network-cli.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+
+[id="virt-attaching-vm-secondary-network-cli_{context}"]
+= Attaching a virtual machine to a secondary network in the CLI
+
+Attach a virtual machine to a secondary network by adding a bridge interface and specifying a network attachment definition in the virtual machine configuration.
+
+This procedure uses a YAML file to demonstrate editing the configuration and applying the updated file to the cluster. You can alternatively use the `oc edit <object> <name>` command to edit an existing virtual machine.
+
+.Prerequisites
+
+* Shut down the virtual machine before editing the configuration. If you edit a running virtual machine, you must restart the virtual machine for the changes to take effect.
+
+.Procedure
+
+. Create or edit a virtual machine configuration that you want to connect to the bridge network. Add the bridge interface to the `spec.template.spec.domain.devices.interfaces` list and the network attachment definition to the `spec.template.spec.networks` list. The name of the `interfaces` entry must be the same as the `networks` entry. The following example adds a bridge interface called `bridge-net` that connects to the `a-bridge-network` network attachment definition:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: VirtualMachine
+metadata:
+    name: example-vm
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+            - masquerade: {}
+              name: default
+            - bridge: {}
+              name: bridge-net <1>
+...
+      networks:
+        - name: default
+          pod: {}
+        - name: bridge-net <1>
+          multus:
+            networkName: <a-bridge-network> <2>
+...
+----
+<1> The name of the bridge interface. This value must match the `name` value of the corresponding `spec.template.spec.networks` entry.
+<2> The name of the network attachment definition.
++
+[NOTE]
+====
+The example virtual machine is connected to both the `default` pod network and `bridge-net`, which is defined by a network attachment definition named `a-bridge-network`.
+====
+
+. Apply the configuration:
++
+[source,terminal]
+----
+$ oc apply -f <example-vm.yaml>
+----
+
+. Optional: If you edited a running virtual machine, you must restart it for the changes to take effect.

--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -5,8 +5,7 @@
 [id="virt-creating-bridge-nad-cli_{context}"]
 = Creating a Linux bridge network attachment definition in the CLI
 
-As a network administrator, you can configure a network attachment definition
-of type `cnv-bridge` to provide Layer-2 networking to pods and virtual machines.
+As a network administrator, you can configure a network attachment definition of type `cnv-bridge` to provide Layer-2 networking to pods and virtual machines.
 
 [NOTE]
 ====
@@ -15,88 +14,56 @@ The network attachment definition must be in the same namespace as the pod or vi
 
 .Procedure
 
-. Create a new file for the network attachment definition in any local directory.
-The file must have the following contents, modified to match your
-configuration:
+. Create a network attachment definition manifest.
+The manifest must have the following contents, modified to match your configuration:
 +
 [source,yaml]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
-  name: a-bridge-network
+  name: <a-bridge-network> <1>
   annotations:
-    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/br0 <1>
+    k8s.v1.cni.cncf.io/resourceName: bridge.network.kubevirt.io/<bridge-interface> <2>
 spec:
   config: '{
     "cniVersion": "0.3.1",
-    "name": "a-bridge-network", <2>
+    "name": "<a-bridge-network>", <3>
     "plugins": [
       {
-        "type": "cnv-bridge", <3>
-        "bridge": "br0", <4>
-        "vlan": 1 <5>
+        "type": "cnv-bridge", <4>
+        "bridge": "<bridge-interface>", <5>
+        "vlan": 1 <6>
       },
       {
-        "type": "cnv-tuning" <6>
+        "type": "cnv-tuning" <7>
       }
     ]
   }'
 ----
-<1> If you add this annotation to your network attachment definition, your virtual machine instances
-will only run on nodes that have the `br0` bridge connected.
-<2> Required. A name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
-<3> The actual name of the Container Network Interface (CNI) plug-in that provides
-the network for this network attachment definition. Do not change this field unless
-you want to use a different CNI.
-<4> You must substitute the actual name of the bridge, if it is not `br0`.
-<5> Optional: The VLAN tag.
-<6> Required. This allows the MAC pool manager to assign a unique MAC address to the connection.
+<1> The name for the `NetworkAttachmentDefinition` object.
+<2> Optional: Annotation key-value pair for node selection, where `bridge-interface` is the name of a bridge configured on some nodes. If you add this annotation to your network attachment definition, your virtual machine instances will only run on the nodes that have the `bridge-interface` bridge connected.
+<3> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
+<4> The actual name of the Container Network Interface (CNI) plug-in that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
+<5> The name of the Linux bridge configured on the node.
+<6> Optional: The VLAN tag.
+<7> The CNI plug-in that allows the MAC pool manager to assign a unique MAC address to the connection.
 
+. Create the network attachment definition: 
 +
 [source,terminal]
 ----
-$ oc create -f <resource_spec.yaml>
+$ oc create -f <network-attachment-definition.yaml> <1>
 ----
+<1> Where `<network-attachment-definition.yaml>` is the file name of the network attachment definition manifest.
 
-. Edit the configuration file of a virtual machine or virtual machine instance that you want to connect to the bridge network, for example:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: VirtualMachine
-metadata:
-    name: example-vm
-spec:
-  domain:
-    devices:
-      interfaces:
-        - masquerade: {}
-          name: default
-        - bridge: {}
-          name: bridge-net <1>
-  ...
+.Verification
 
-  networks:
-    - name: default
-      pod: {}
-    - name: bridge-net <1>
-      multus:
-        networkName: a-bridge-network <2>
-...
-----
-<1> The `name` value for the bridge interface and network must be the same.
-<2> You must substitute the actual `name` value from the network attachment definition.
-+
-[NOTE]
-====
-The virtual machine instance will be connected to both the `default` pod network and `bridge-net`, which is
-defined by a network attachment definition named `a-bridge-network`.
-====
-
-. Apply the configuration file to the resource:
+* Verify that the network attachment definition is created by running either `oc get network-attachment-definition <name>` or `oc get net-attach-def <name>`. For example:
 +
 [source,terminal]
 ----
-$ oc create -f <local/path/to/network-attachment-definition.yaml>
+$ oc get network-attachment-definition <a-bridge-network> <1>
 ----
+<1> Where `<a-bridge-network>` is the name specified in the network attachment definition config.
+

--- a/modules/virt-vm-creating-nic-web.adoc
+++ b/modules/virt-vm-creating-nic-web.adoc
@@ -2,8 +2,8 @@
 //
 // * virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
 
-[id="virt-vm-create-nic-web_{context}"]
-= Creating a NIC for a virtual machine
+[id="virt-vm-creating-nic-web_{context}"]
+= Creating a NIC for a virtual machine in the web console
 
 Create and attach additional NICs to a virtual machine from the web console.
 
@@ -14,5 +14,6 @@ Create and attach additional NICs to a virtual machine from the web console.
 . Select a virtual machine to open the *Virtual Machine Overview* screen.
 . Click *Network Interfaces* to display the NICs already attached to the virtual machine.
 . Click *Add Network Interface* to create a new slot in the list.
-. Fill in the *Name*, *Model*, *Network*, *Type*, and *MAC Address* for the new NIC.
+. Use the *Network* drop-down list to select the network attachment definition for the additional network.
+. Fill in the *Name*, *Model*, *Type*, and *MAC Address* for the new NIC.
 . Click the *Add* button to save and attach the NIC to the virtual machine.

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -5,13 +5,15 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-{VirtProductName} provides layer-2 networking capabilities that allow you to connect
-virtual machines to multiple networks. You can import virtual machines with
-existing workloads that depend on access to multiple interfaces. You can also
-configure a PXE network so that you can boot machines over the network.
+You can attach virtual machines to multiple networks by using Linux bridges.
+You can also import virtual machines with existing workloads that depend on access to multiple interfaces.
 
-To get started, a network administrator configures a bridge network attachment definition
-for a namespace in the web console or CLI. Users can then create a NIC to attach pods and virtual machines in that namespace to the bridge network.
+To attach a virtual machine to an additional network:
+
+. Configure a bridge network attachment definition for a namespace in the web console or CLI.
+. Attach the virtual machine to the network attachment definition by using either the web console or the CLI:
+** In the web console, create a NIC for a new or existing virtual machine.
+** In the CLI, include the network information in the virtual machine configuration.
 
 [NOTE]
 ====
@@ -20,9 +22,11 @@ The _KubeMacPool_ component provides a MAC address pool service for virtual mach
 
 include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 
+[id="virt-creating-network-attachment-definition"]
 == Creating a network attachment definition
 
-== Prerequisites
+[id="{context}_prerequisites"]
+=== Prerequisites
 
 * A Linux bridge must be configured and attached on every node.
 See the xref:../../../virt/node_network/virt-updating-node-network-config.adoc#virt-about-nmstate_virt-updating-node-network-config[node networking] section for more information.
@@ -36,18 +40,20 @@ include::modules/virt-creating-bridge-nad-web.adoc[leveloffset=+2]
 
 include::modules/virt-creating-bridge-nad-cli.adoc[leveloffset=+2]
 
-[NOTE]
-====
-When defining the NIC in the next section, ensure that the *NETWORK* value is
-the bridge network name from the network attachment definition you created
-in the previous section.
-====
+[id="virt-attaching-vm-to-additional-network"]
+== Attaching the virtual machine to the additional network
 
-include::modules/virt-vm-create-nic-web.adoc[leveloffset=+1]
+include::modules/virt-vm-creating-nic-web.adoc[leveloffset=+2]
 
-include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+1]
+include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
+
+include::modules/virt-attaching-vm-secondary-network-cli.adoc[leveloffset=+2]
 
 [id="{context}_additional-resources"]
 == Additional resources
 
 * xref:../../../virt/virtual_machines/vm_networking/virt-configuring-ip-for-vms.adoc#virt-configuring-ip-for-vms[Configuring IP addresses for virtual machines]
+
+* xref:../../../virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc#configuring-pxe-booting[Configuring PXE booting for virtual machines]
+
+* xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc#virt-attaching-vm-to-sriov-network[Attaching a virtual machine to an SR-IOV network]


### PR DESCRIPTION
The ask of [BZ#1917499](https://bugzilla.redhat.com/show_bug.cgi?id=1917499) is ultimately to provide an example that uses the `network-attachment-definition` object on the cli, which can be solved by inserting a validation step into. However there's a knock-on effect of that (splitting up the cli procedure, which should already be two separate modules) and now is as good a time as ever to improve this assembly as a whole.

Makes sense to backport this to 2.5 and 2.6

Preview builds:
- [The assembly](https://deploy-preview-30387--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html)
- [The verification step that addresses the bug in particular](https://deploy-preview-30387--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-bridge-nad-cli_virt-attaching-multiple-networks)