### PR TITLE
Issue #30364 remove wrong content from cicd/pipelines/understanding-o…

### DIFF
--- a/modules/op-about-tasks.adoc
+++ b/modules/op-about-tasks.adoc
@@ -7,7 +7,7 @@
 
 _Tasks_ are the building blocks of a Pipeline and consist of sequentially executed Steps. Tasks are reusable and can be used in multiple Pipelines.
 
-_Steps_ are a series of commands that achieve a specific goal, such as building an image. Every Task runs as a pod and each Step runs in its own container within the same pod. Because Steps run within the same pod, they have access to the same volumes for caching files, ConfigMaps, and Secrets.
+_Steps_ are a series of commands that achieve a specific goal, such as building an image. Every Task runs as a pod, and each Step runs as a container within that pod. Because Steps run within the same pod, they can access the same volumes for caching files, config maps, and secrets.
 
 The following example shows the `apply-manifests` Task.
 
@@ -32,15 +32,13 @@ spec: <4>
       command: ["/bin/bash", "-c"]
       args:
         - |-
-          echo Applying manifests in $(inputs.params.manifest_dir) directory
-          oc apply -f $(inputs.params.manifest_dir)
+          echo Applying manifests in $(params.manifest_dir) directory
+          oc apply -f $(params.manifest_dir)
           echo -----------------------------------
 ----
-<1> Task API version `v1beta1`.
-<2> Specifies the type of Kubernetes object. In this example, `Task`.
-<3> Unique name of this Task.
-<4> Lists the parameters and Steps in the Task and the workspace used by the Task.
+<1> The Task API version, `v1beta1`.
+<2> The type of Kubernetes object, `Task`.
+<3> The unique name of this Task.
+<4> The list of parameters and Steps in the Task and the workspace used by the Task.
 
-This Task starts the pod and runs a container inside that pod using the `maven:3.6.0-jdk-8-slim` image to run the specified commands. It receives an input directory called `workspace-git` that contains the source code of the application.
-
-The Task only declares the placeholder for the Git repository, it does not specify which Git repository to use. This allows Tasks to be reusable for multiple Pipelines and purposes.
+This Task starts the pod and runs a container inside that pod using the specified image to run the specified commands.


### PR DESCRIPTION
…penshift-pipelines.adoc

Removed the content that doesn't belong in this topic.

- For versions 4.7+
- Issue #30364
- Direct link to doc preview: https://deploy-preview-30421--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/understanding-openshift-pipelines.html#about-tasks_understanding-openshift-pipelines
- Ready for peer review and merge
- Please close Issue #30364 after merging