### PR TITLE
GitHub-30414: Adding note for GitHub Enterprise only

### DIFF
--- a/modules/identity-provider-config-map.adoc
+++ b/modules/identity-provider-config-map.adoc
@@ -7,12 +7,25 @@
 // * authentication/identity_providers/configuring-oidc-identity-provider.adoc
 // * authentication/identity_providers/configuring-request-header-identity-provider.adoc
 
+ifeval::["{context}" == "configuring-github-identity-provider"]
+:github:
+endif::[]
+
 [id="identity-provider-creating-configmap_{context}"]
 = Creating a config map
 
 Identity providers use {product-title} `ConfigMap` objects in the `openshift-config`
 namespace to contain the certificate authority bundle. These are primarily
 used to contain certificate bundles needed by the identity provider.
+
+ifdef::github[]
+[NOTE]
+====
+This procedure is only required for GitHub Enterprise.
+====
+endif::github[]
+
+.Procedure
 
 * Define an {product-title} `ConfigMap` object containing the
 certificate authority by using the following command. The certificate
@@ -22,3 +35,8 @@ authority must be stored in the `ca.crt` key of the `ConfigMap` object.
 ----
 $ oc create configmap ca-config-map --from-file=ca.crt=/path/to/ca -n openshift-config
 ----
+
+// Undefining attributes
+ifeval::["{context}" == "configuring-google-identity-provider"]
+:!github:
+endif::[]


### PR DESCRIPTION
Fixes #30414

Preview: https://deploy-preview-30434--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-github-identity-provider.html#identity-provider-creating-configmap_configuring-github-identity-provider