### PR TITLE
Update Logging documentation for RHDEVDOCS-2619 and RHDEVDOCS-2627

### DIFF
--- a/logging/dedicated-cluster-logging.adoc
+++ b/logging/dedicated-cluster-logging.adoc
@@ -3,6 +3,8 @@
 = Configuring OpenShift Logging in {product-title}
 include::modules/common-attributes.adoc[]
 
+toc::[]
+
 As a cluster administrator, you can deploy OpenShift Logging
 to aggregate logs for a range of services.
 
@@ -42,8 +44,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       resources:
+        limits:
+          memory: 16G
         request:
-          memory: 8G
+          memory: 16G
   visualization:
     type: "kibana"
     kibana:

--- a/modules/cluster-logging-collector-pod-location.adoc
+++ b/modules/cluster-logging-collector-pod-location.adoc
@@ -5,11 +5,11 @@
 [id="cluster-logging-collector-pod-location_{context}"]
 = Viewing logging collector pods
 
-You can use the `oc get pods  --all-namespaces -o wide` command to see the nodes where the Fluentd are deployed.
+You can view the Fluentd logging collector pods and the corresponding nodes that they are running on. The Fluentd logging collector pods run only in the `openshift-logging` project.
 
 .Procedure
 
-Run the following command in the `openshift-logging` project:
+* Run the following command in the `openshift-logging` project to view the Fluentd logging collector pods and their details:
 
 [source,terminal]
 ----

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -99,8 +99,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       resources:
+        limits:
+          memory: 16G
         requests:
-          memory: 8G
+          memory: 16G
   visualization:
     type: "kibana"
     kibana:


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: `enterprise-4.7` and `4.8`
JIRA issues: [RHDEVDOCS-2619](https://issues.redhat.com/browse/RHDEVDOCS-2619), [RHDEVDOCS-2627](https://issues.redhat.com/browse/RHDEVDOCS-2627)
Preview pages: 
- For [RHDEVDOCS-2619](https://issues.redhat.com/browse/RHDEVDOCS-2619):
-- [Installing OpenShift Logging and Elasticsearch Operators](https://deploy-preview-30438--osdocs.netlify.app/openshift-dedicated/latest/logging/dedicated-cluster-deploying.html#dedicated-cluster-install-deploy)
-- "dedicated-cluster-logging.adoc" file changes:  No preview available, as the file is not yet published or included in any assembly.
- For [RHDEVDOCS-2627](https://issues.redhat.com/browse/RHDEVDOCS-2627):
-- [Viewing logging collector pods](https://deploy-preview-30438--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-collector.html#cluster-logging-collector-pod-location_cluster-logging-collector)

This pull request has been reviewed and approved by SME/QE: @anpingli and @lukas-vlcek 