### PR TITLE
Bug 1850495 Tolerations shouldn't be defined in rsyslog but in fluentd

### DIFF
--- a/modules/cluster-logging-collector-tolerations.adoc
+++ b/modules/cluster-logging-collector-tolerations.adoc
@@ -53,7 +53,7 @@ that do not match.
   collection:
     logs:
       type: "fluentd"
-      rsyslog:
+      fluentd:
         tolerations:
         - key: "collector"  <1>
           operator: "Exists"  <2>


### PR DESCRIPTION
- For versions 4.5+
- https://bugzilla.redhat.com/show_bug.cgi?id=1850495
- Direct link to doc preview: https://deploy-preview-30439--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-tolerations.html#cluster-logging-collector-tolerations_cluster-logging-tolerations
- Ready for QE review