### PR TITLE
[enterprise-4.6] Adding a product-title and product-version comment to common-attributes.adoc

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -1,5 +1,7 @@
-{product-author}
-{product-version}
+// The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.8".
+// {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
+// See https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#product-name-version for more information on this topic.
+// Other common attributes are defined in the following lines:
 :data-uri:
 :icons:
 :experimental:


### PR DESCRIPTION
Cherry picked from e04c6c3c25d21eb927e31021296bb7d224577fed xref: https://github.com/openshift/openshift-docs/pull/30291