### PR TITLE
JIRA OS_DOCS-1830 Added more autoscaling content for ROSA.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -116,8 +116,10 @@ Topics:
   Topics:
   - Name: Managing worker nodes
     File: rosa-managing-worker-nodes
-  - Name: Autoscaling worker nodes
-    File: rosa-autoscale-nodes
+  - Name: Enabling autoscaling on worker nodes
+    File: rosa-enabling-autoscaling-nodes
+  - Name: Disabling autoscaling on worker nodes
+    File: rosa-disabling-autoscaling-nodes
 ---
 Name: Logging
 Dir: logging

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -168,11 +168,11 @@ Create a cluster with a specific AWS region:
 $ rosa create cluster --cluster=mycluster --region=us-east-2
 ----
 
-Create a cluster with autoscaling enabled and the autoscaling set to non-default limits:
+Create a cluster with autoscaling enabled on the default worker machine pool:
 
 [source,terminal]
 ----
-$ rosa create cluster --cluster=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5
+$ rosa create cluster --cluster=mycluster -region=us-east-1 --enable-autoscaling --min-replicas=2 --max-replicas=5
 ----
 
 [id="rosa-create-idp_{context}"]
@@ -463,7 +463,14 @@ Interactively add a machine pool to a cluster named `mycluster`:
 $ rosa create machinepool --cluster=mycluster --interactive
 ----
 
-Add a machine pool `mp-1` with 3 replicas of `m5.xlarge` to a cluster:
+Add a machine pool that is named `mp-1` to a cluster with autoscaling enabled:
+
+[source,terminal]
+----
+$ rosa create machinepool --cluster=mycluster --enable-autoscaling --min-replicas=2 --max-replicas=5 --name=mp-1
+----
+
+Add a machine pool that is named `mp-1` with 3 replicas of `m5.xlarge` to a cluster:
 
 [source,terminal]
 ----

--- a/modules/rosa-disabling-autoscaling-nodes.adoc
+++ b/modules/rosa-disabling-autoscaling-nodes.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// rosa-nodes/rosa-disabling-autoscaling-nodes.adoc
+
+[id="rosa-disabling-autoscaling_{context}"]
+= Disabling autoscaling nodes in an existing cluster
+
+Disable autoscaling for worker nodes in the machine pool definition.
+
+.Procedure
+
+Enter the following command:
++
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> --enable-autoscaling=false --replicas=<number>
+----
++
+.Example
++
+Disable autoscaling on the `default` machine pool on a cluster named `mycluster`:
++
+[source,terminal]
+----
+$ rosa edit machinepool --cluster=mycluster default --enable-autoscaling=false --replicas=3
+----

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -157,8 +157,8 @@ $ rosa edit machinepool --cluster=<cluster_name> <machinepool_ID> [arguments]
 |--cluster
 |Required: The name or ID (string) of the cluster to edit on which the additional machine pool will be edited.
 
---enable-autoscaling
-|Enable autoscaling of compute nodes. Use this argument with the `--min-replicas` and `--max-replicas` arguments.
+|--enable-autoscaling
+|Enable or disable autoscaling of compute nodes. To enable autoscaling, use this argument with the `--min-replicas` and `--max-replicas` arguments. To disable autoscaling, use `--enable-autoscaling=false` with the `--replicas` argument.
 
 |--max-replicas
 |Specifies the maximum number of compute nodes when enabling autoscaling.
@@ -197,12 +197,26 @@ Set 4 replicas on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster=mycluster mp1 --replicas=4
+$ rosa edit machinepool --cluster=mycluster --replicas=4 --name=mp1
 ----
 
 Enable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster-name=mycluster --name=mp1 --enable-autoscaling --min-replicas=3 --max-replicas=5
+$ rosa edit machinepool --cluster-name=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5 --name=mp1
+----
+
+Disable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa edit machinepool --cluster-name=mycluster  --enable-autoscaling=false --replicas=3 --name=mp1
+----
+
+Modify the autoscaling range on a machine pool named `mp1` on a cluster named `mycluster`.
+
+[source,terminal]
+----
+$ rosa edit machinepool --max-replicas=9 --cluster=mycluster --name=mp1
 ----

--- a/modules/rosa-enabling-autoscaling-nodes.adoc
+++ b/modules/rosa-enabling-autoscaling-nodes.adoc
@@ -1,15 +1,13 @@
 
-
-
 // Module included in the following assemblies:
 //
-// rosa-nodes/rosa-autoscale-nodes.adoc
+// rosa-nodes/rosa-enabling-autoscaling-nodes.adoc
 
-[id="rosa-autoscaling_{context}"]
-= Autoscaling nodes in a cluster
+[id="rosa-enabling-autoscaling_{context}"]
+= Enabling autoscaling nodes in an existing cluster
 
 
-Configure autoscaling to dynamically scale the number of worker nodes up or down based on load. Autoscaling for worker nodes is configured in the machine pool definition.
+Configure autoscaling to dynamically scale the number of worker nodes up or down based on load.
 
 Successful autoscaling is dependent on having the correct AWS resource quotas in your AWS account. Verify resource quotas and request quota increases from the link:https://aws.amazon.com/console/[AWS console].
 
@@ -27,10 +25,11 @@ $ rosa list machinepools --cluster=<cluster_name>
 [source,terminal]
 ----
 ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TINTS   AVAILABILITY ZONES
+default   No            2           m5.xlarge                        us-east-1a
 mp1       No            2           m5.xlarge                        us-east-1a
 ----
 +
-Decide which machine pool ID you want to configure for autoscaling.
+Decide which machine pool ID you want to configure.
 
 . To enable autoscaling on a machine pool, enter the following command:
 +

--- a/nodes/nodes/rosa-autoscale-nodes.adoc
+++ b/nodes/nodes/rosa-autoscale-nodes.adoc
@@ -1,9 +1,0 @@
-include::modules/attributes-openshift-dedicated.adoc[]
-[id="rosa-autoscaling-nodes"]
-= Autoscaling nodes on a cluster
-:context: rosa-autoscaling-nodes
-toc::[]
-
-Autoscale worker nodes on a cluster to increase or decrease the number of resources available.
-
-include::modules/rosa-autoscaling-nodes.adoc[leveloffset=+1]

--- a/nodes/nodes/rosa-disabling-autoscaling-nodes.adoc
+++ b/nodes/nodes/rosa-disabling-autoscaling-nodes.adoc
@@ -1,0 +1,19 @@
+include::modules/attributes-openshift-dedicated.adoc[]
+[id="rosa-disabling-autoscaling-nodes"]
+= Autoscaling nodes on a cluster
+:context: rosa-autoscaling-nodes
+
+toc::[]
+
+Autoscale worker nodes on a cluster to increase or decrease the number of resources available. Autoscaling for worker nodes is configured in the machine pool definition if you are configuring an existing cluster.
+
+[NOTE]
+====
+Additionally, you can configure autoscaling on the default machine pool when you xref:../../rosa_getting_started/rosa-creating-cluster.adoc#rosa-creating-cluster[create the cluster using interactive mode].
+====
+
+include::modules/rosa-disabling-autoscaling-nodes.adoc[leveloffset=+1]
+
+[id="rosa-disabling-autoscaling-nodes-additional-resources"]
+.Additional resources
+xref:../../rosa_cli/rosa-manage-objects-cli.adoc#rosa-managing-objects-cli[Managing objects with the rosa CLI]

--- a/nodes/nodes/rosa-enabling-autoscaling-nodes.adoc
+++ b/nodes/nodes/rosa-enabling-autoscaling-nodes.adoc
@@ -1,0 +1,19 @@
+include::modules/attributes-openshift-dedicated.adoc[]
+[id="rosa-enabling-autoscaling-nodes"]
+= Enabling autoscaling nodes on a cluster
+:context: rosa-enabling-autoscaling-nodes
+toc::[]
+
+Autoscale worker nodes on a cluster to increase or decrease the number of resources available. Autoscaling for worker nodes is configured in the machine pool definition if you are configuring an existing cluster.
+
+[NOTE]
+====
+Additionally, you can configure autoscaling on the default machine pool when you xref:../../rosa_getting_started/rosa-creating-cluster.adoc#rosa-creating-cluster[create the cluster using interactive mode].
+====
+
+include::modules/rosa-enabling-autoscaling-nodes.adoc[leveloffset=+1]
+
+
+[id="rosa-enabling-autoscaling-nodes-additional-resources"]
+.Additional resources
+xref:../../rosa_cli/rosa-manage-objects-cli.adoc#rosa-managing-objects-cli[Managing objects with the rosa CLI]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-1830

This content has been migrated from the old repo from the old PR that will now be closed: https://github.com/openshift/managed-openshift-docs/pull/35

Use this new PR for all comments going forward. Thank you.