### PR TITLE
Jira: 1876 - Remove step for enabling cluster admin

### DIFF
--- a/modules/rosa-create-cluster-admins.adoc
+++ b/modules/rosa-create-cluster-admins.adoc
@@ -19,13 +19,6 @@ Additionally, only the user who created the cluster can grant cluster access to 
 
 .Procedure
 
-. Enable `cluster-admin` capability on the cluster:
-+
-[source,terminal]
-----
-$ rosa edit cluster <cluster_name> --enable-cluster-admins
-----
-+
 . Give your user `cluster-admin` privileges:
 +
 [source,terminal]


### PR DESCRIPTION
In topic,  Granting cluster-admin access, removed Step 1  "Enable cluster-admin capability on the cluster"  per this Jira: (https://issues.redhat.com/browse/OSDOCS-1876)

Here's a link to the updated section: 
https://deploy-preview-30471--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-accessing-cluster.html#rosa-create-cluster-admins