### PR TITLE
BZ 1927378: cdrom readonly

### DIFF
--- a/virt/virt-2-6-release-notes.adoc
+++ b/virt/virt-2-6-release-notes.adoc
@@ -98,6 +98,9 @@ The SVVP Certification applies to:
 [id="virt-2-6-known-issues"]
 == Known issues
 
+* A virtual machine instance (VMI) fails to migrate if the `cdrom` drive is set to `readonly: true` in the VMI spec. The following message is displayed: `Operation not supported: Cannot migrate empty or read-only disk sdb`.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1927378[*BZ#1927378*])
+
 * Some Containerized Data Importer (CDI) operations are currently not xref:../virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[preallocated] when requested. These include:
 ** Creating blank block disks
 ** Importing VMWare disk images


### PR DESCRIPTION
Doc BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1928666
regarding
Eng BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1927378
also tracked in [CNV-10451](https://issues.redhat.com/browse/CNV-10451)

[Preview build](https://deploy-preview-30484--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-2-6-release-notes.html#virt-2-6-known-issues)

(no cherrypick)