### PR TITLE
Bug 1939230 - "Custom image builds with Buildah" instructions incorrect

### DIFF
--- a/modules/builds-create-custom-build-artifacts.adoc
+++ b/modules/builds-create-custom-build-artifacts.adoc
@@ -10,16 +10,16 @@ You must create the image you want to use as your custom build image.
 
 .Procedure
 
-. Starting with an empty directory, create a file named `dockerfile` with the following content:
+. Starting with an empty directory, create a file named `Dockerfile` with the following content:
 +
 [source,terminal]
 ----
-FROM docker.io/centos:7
+FROM registry.centos.org/centos:7
 RUN yum install -y buildah
 # In this example, `/tmp/build` contains the inputs that build when this
 # custom builder image is run. Normally the custom builder image fetches
 # this content from some location at build time, by using git clone as an example.
-ADD dockerfile.sample /tmp/input/dockerfile
+ADD dockerfile.sample /tmp/input/Dockerfile
 ADD build.sh /usr/bin
 RUN chmod a+x /usr/bin/build.sh
 # /usr/bin/build.sh contains the actual custom build logic that will be run when
@@ -31,7 +31,7 @@ ENTRYPOINT ["/usr/bin/build.sh"]
 +
 [source,terminal]
 ----
-FROM docker.io/centos:7
+FROM registry.centos.org/centos:7
 RUN touch /tmp/built
 ----
 


### PR DESCRIPTION
- For versions 4.5+
- https://bugzilla.redhat.com/show_bug.cgi?id=1939230
- Direct link to doc preview: https://deploy-preview-30499--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/custom-builds-buildah.html#builds-create-custom-build-artifacts_custom-builds-buildah
- Ready for Peer Review and Merge. 