### PR TITLE
BZ#1929230 - Clarify network policy multitenant is not multitenant mode

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -4,6 +4,10 @@
 // * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
+ifeval::[{product-version} >= 4.6]
+:ovn:
+endif::[]
+
 [id="nw-networkpolicy-multitenant-isolation_{context}"]
 = Configuring multitenant isolation by using network policy
 
@@ -12,7 +16,14 @@ project namespaces.
 
 .Prerequisites
 
-* Your cluster is using a default CNI network provider that supports `NetworkPolicy` objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+* Your cluster is using a cluster network provider that supports `NetworkPolicy` objects, such as
+ifndef::ovn[]
+the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+ifdef::ovn[]
+the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 
@@ -134,3 +145,7 @@ spec:
   policyTypes:
   - Ingress
 ----
+
+ifdef::ovn[]
+:!ovn:
+endif::ovn[]

--- a/modules/nw-openshift-sdn-modes.adoc
+++ b/modules/nw-openshift-sdn-modes.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * networking/openshift_sdn/about-openshift-sdn.adoc
+
+[id="nw-openshift-sdn-modes_{context}"]
+= OpenShift SDN network isolation modes
+
+OpenShift SDN provides three SDN modes for configuring the pod network:
+
+* _Network policy_ mode allows project administrators to configure their own
+isolation policies using `NetworkPolicy` objects. Network policy is the default mode in {product-title} {product-version}.
+
+* _Multitenant_ mode provides project-level isolation for pods and services. Pods from different projects cannot send packets to or receive packets from pods and services of a different project. You can disable isolation for a project, allowing it to send network traffic to all pods and services in the entire cluster and receive network traffic from those pods and services.
+
+* _Subnet_ mode provides a flat pod network where every pod can communicate with every other pod and service. The network policy mode provides the same functionality as subnet mode.

--- a/networking/network_policy/multitenant-network-policy.adoc
+++ b/networking/network_policy/multitenant-network-policy.adoc
@@ -1,5 +1,5 @@
 [id="multitenant-network-policy"]
-= Configuring multitenant mode with network policy
+= Configuring multitenant isolation with network policy
 include::modules/common-attributes.adoc[]
 :context: multitenant-network-policy
 
@@ -7,9 +7,19 @@ toc::[]
 
 As a cluster administrator, you can configure your network policies to provide multitenant network isolation.
 
+[NOTE]
+====
+If you are using the OpenShift SDN cluster network provider, configuring network policies as described in this section provides network isolation similar to multitenant mode but with network policy mode set.
+====
+
 include::modules/nw-networkpolicy-multitenant-isolation.adoc[leveloffset=+1]
 
 [id="multitenant-network-policy-next-steps"]
 == Next steps
 
 * xref:../../networking/network_policy/default-network-policy.adoc#default-network-policy[Defining a default network policy]
+
+[id="multitenant-network-policy-additional-resources"]
+== Additional resources
+
+* xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#nw-openshift-sdn-modes_about-openshift-sdn[OpenShift SDN network isolation modes]

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -11,21 +11,7 @@ unified cluster network that enables communication between pods across the
 OpenShift SDN, which configures an overlay network using Open vSwitch (OVS).
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-OpenShift SDN provides three SDN modes for configuring the pod network:
-
-* The _network policy_ mode allows project administrators to configure their own
-isolation policies using xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[NetworkPolicy objects].
-Network policy is the default mode in {product-title} {product-version}.
-
-* The _multitenant_ mode provides project-level isolation for pods and services.
-pods from different projects cannot send packets to or receive packets from pods
-and services of a different project. You can disable isolation for a project,
-allowing it to send network traffic to all pods and services in the entire
-cluster and receive network traffic from those pods and services.
-
-* The _subnet_ mode provides a flat pod network where every pod can
-communicate with every other pod and service. The network policy mode provides
-the same functionality as the subnet mode.
+include::modules/nw-openshift-sdn-modes.adoc[leveloffset=+1]
 
 ifdef::openshift-origin[]
 [NOTE]
@@ -33,8 +19,8 @@ ifdef::openshift-origin[]
 {product-title} uses the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes Container Network Interface (CNI) plug-in] by default.
 ====
 endif::openshift-origin[]
-
 endif::[]
+
 ifdef::openshift-dedicated[]
 OpenShift SDN supports only the _network policy_ mode, which allows project
 administrators to configure their own isolation policies by using


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1929230

This clarifies that multitenant mode is completely distinct from network policy, however it might be configured.

Previews:
- [Configuring multitenant isolation with network policy](https://deploy-preview-30507--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html)
- [OpenShift SDN network isolation modes](https://deploy-preview-30507--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/about-openshift-sdn.html#nw-openshift-sdn-modes_about-openshift-sdn)