### PR TITLE
Fix absolute path for images-configuration

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -56,13 +56,13 @@ status:
 Either the `allowedRegistries` parameter or the `blockedRegistries` parameter can be set, but not both.
 ====
 +
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/host/etc/containers/policy.json` file on each node.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/etc/containers/policy.json` file on each node.
 
 . To check that the registries have been added to the policy file, use the following command on a node:
 +
 [source,terminal]
 ----
-$ cat /host/etc/containers/policy.json
+$ cat /etc/containers/policy.json
 ----
 +
 The following policy indicates that only images from the example.com, quay.io, and registry.redhat.io registries are permitted for image pulls and pushes:

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -55,7 +55,7 @@ The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster
 +
 [source,terminal]
 ----
-$ cat /host/etc/containers/registries.conf
+$ cat /etc/containers/registries.conf
 ----
 +
 The following example indicates that images from the `untrusted.com` registry are prevented for image pulls and pushes:

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -66,7 +66,7 @@ The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster
 +
 [source,terminal]
 ----
-$ cat /host/etc/containers/registries.conf
+$ cat /etc/containers/registries.conf
 ----
 +
 The following example indicates that images from the `insecure.com` registry is insecure and is allowed for image pulls and pushes.

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -21,7 +21,7 @@ Using image short names with public registries is strongly discouraged. You shou
 If you list public registries under the `containerRuntimeSearchRegistries` parameter, you expose your credentials to all the registries on the list and you risk network and registry attacks. You should always use fully-qualified image names with public registries.
 ====
 
-The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/host/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
+The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.
 
 The `containerRuntimeSearchRegistries` parameter works only with the Podman and CRI-O container engines. The registries in the list can be used only in pod specs, not in builds and image streams.
 
@@ -83,7 +83,7 @@ When the `allowedRegistries` parameter is defined, all registries including the 
 +
 [source,terminal]
 ----
-$ cat /host/etc/containers/registries.conf.d/01-image-searchRegistries.conf
+$ cat /etc/containers/registries.conf.d/01-image-searchRegistries.conf
 ----
 +
 .Example output


### PR DESCRIPTION
@vikram-redhat I found one absolute path issue for images-configuration, minimum version that the change applies to might be 4.1, but I only verified on OCP v4.5/4.6/4.7 environment, could you review them? Thanks.

Changes on my commit: From `/host/etc/containers` to `/etc/containers`, because there is no absolute path `/host/etc/containers` on each node after checking OCP v4.5/4.6/4.7 environment.
