### PR TITLE
BZ#1904295 Added `sudo` to a shell command that needs superuser privileges.

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -92,7 +92,7 @@ location of the disk you are installing to. Here is an example:
 +
 [source,terminal]
 ----
-$ coreos-installer install \
+$ sudo coreos-installer install \
      --ignition-url=https://host/worker.ign /dev/sda
 ----
 


### PR DESCRIPTION
A shell command that writes into `/dev/sda` needs superuser privileges to work.

* For versions 4.6+.
* https://bugzilla.redhat.com/show_bug.cgi?id=1904295
* Direct links to doc preview [see Step 6]: https://deploy-preview-30515--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-iso_installing-bare-metal

@miabbott --Can you take a look? 