### PR TITLE
Fixing TOC build issue

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -1,6 +1,8 @@
+{product-author}
 // The {product-title} attribute provides the context-sensitive name of the relevant OpenShift distribution, for example, "OpenShift Container Platform" or "OKD". The {product-version} attribute provides the product version relative to the distribution, for example "4.8".
 // {product-title} and {product-version} are parsed when AsciiBinder queries the _distro_map.yml file in relation to the base branch of a pull request.
 // See https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#product-name-version for more information on this topic.
+{product-version}
 // Other common attributes are defined in the following lines:
 :data-uri:
 :icons:


### PR DESCRIPTION
This PR reverts the removal of `{product-author}` and `{product-version}` from the `modules/common-attributes.adoc` file. Those were removed as part of https://github.com/openshift/openshift-docs/pull/30291.

The removal of those attributes causes TOC entries that were not preceded by a blank line not to show in the docs build. 