### PR TITLE
4.7: Remove release note on BZ 1904131

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1513,8 +1513,6 @@ This bug fix ensures Kubernetes is used as the source of truth. OVN-Kubernetes n
 
 * Previously, under certain circumstances, pods did not terminate due to an error condition with Multus. Multus includes the message `failed to destroy network for pod sandbox` in logs when the problem occurs. This bug fix makes Multus tolerate a deleted cache file and pods can terminate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1900835[*BZ#1900835*])
 
-* Previously, when using the Kuryr SDN network provider with network policies, any update to a network policy caused the Kuryr controller to recreate security group rules. This bug fix corrects how the Kuryr controller compares security group rules after a network policy is updated. Rules are preserved when possible and added or removed when necessary. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904131[*BZ#1904131*])
-
 * Previously, when using the OpenShift SDN network provider with network policies, it was possible for for pods to experience network connectivity problems even in namespaces that do not use network policies. This bug fix ensures that the underlying Open vSwitch (OVS) flows that implement the network policy are valid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1914284[*BZ#1914284*])
 
 * Previously, when using the OVN-Kubernetes network provider and using multiple pods to serve as external gateways, scaling down the pods prevented other pods in the namespace from routing traffic to the remaining external gateways. Instead, traffic was routed to the default gateway of the node. This bug fix enables the pods to continue routing traffic to the remaining external gateways. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917605[*BZ#1917605*])


### PR DESCRIPTION
BZ 1904131 was only created for procedural reasons and that problem was
already fixed in both 4.7 and 4.6. The bug only affected 4.5 so it
shouldn't be included in 4.7 release notes. This commit removes mention
of that bug from the release notes.