### PR TITLE
OSDOCS-1952 Document clarification OCP 4.6 bare metal clusters do not support applying network policy to ingress router pods

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -46,7 +46,9 @@ To make a project allow only connections from the {product-title} Ingress Contro
 +
 [IMPORTANT]
 ====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+For the OVN-Kubernetes cluster network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+
+For bare metal OVN-Kubernetes cluster network provider installs, the Ingress Controller pods default to using the `HostNetwork` endpoint publishing strategy. There is no way to track host-networked pods within OVN. And there is no way to define any kind of network policy, which includes allow all ingress traffic with network policy on bare metal clusters.
 ====
 +
 [source,yaml]

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -23,7 +23,9 @@ project namespaces.
 +
 [IMPORTANT]
 ====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+For the OVN-Kubernetes cluster network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+
+For bare metal OVN-Kubernetes cluster network provider installs, the Ingress Controller pods default to using the `HostNetwork` endpoint publishing strategy. There is no way to track host-networked pods within OVN. And there is no way to define any kind of network policy, which includes allow all ingress traffic with network policy on bare metal clusters.
 ====
 +
 [source,terminal]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1952

Previews: 
https://deploy-preview-30556--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html
https://deploy-preview-30556--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html