### PR TITLE
1.2 RN updates in OCP 4.6 version

### DIFF
--- a/modules/op-release-notes-1-2.adoc
+++ b/modules/op-release-notes-1-2.adoc
@@ -66,7 +66,7 @@ Installations in restricted environments are currently not supported on IBM Powe
 [id="deprecated-features-1-2_{context}"]
 == Deprecated features
 
-* `$(params)` are now deprecated and replaced by `$(tt.params)` to avoid confusion between the `resourcetemplate` and `triggertemplate` parameters.
+* `$(params)` are now removed and replaced by `$(tt.params)` to avoid confusion between the `resourcetemplate` and `triggertemplate` parameters.
 * The `ServiceAccount` reference of the optional `EventListenerTrigger`-based authentication level has changed from an object reference to a `ServiceAccountName` string. This ensures that the `ServiceAccount` reference is in the same namespace as the `EventListenerTrigger` object.
 * The `Conditions` custom resource definition (CRD) is now deprecated; use the `WhenExpressions` CRD instead.
 * The `PipelineRun.Spec.ServiceAccountNames` object is being deprecated and replaced by the `PipelineRun.Spec.TaskRunSpec[].ServiceAccountName` object.
@@ -108,7 +108,7 @@ $ oc patch crd/eventlisteners.triggers.tekton.dev -p '{"metadata":{"finalizers":
 Error executing command: fork/exec /bin/bash: exec format error
 ----
 +
-As a workaround, use an architecture specific container image or specify the sha256 digest to point to the correct architecture. 
+As a workaround, use an architecture specific container image or specify the sha256 digest to point to the correct architecture.
 To get the sha256 digest enter:
 +
 [source,terminal]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.6
JIRA issues: [RHDEVDOCS-2736](https://issues.redhat.com/browse/RHDEVDOCS-2736)
Preview pages: [Deprecated Features](https://deploy-preview-30565--osdocs.netlify.app/openshift-enterprise/latest/pipelines/op-release-notes.html#deprecated-features-1-2_op-release-notes)
This pull request has been reviewed and approved by SME/QE: @praveen4g0 