### PR TITLE
Corrected syntax of migration limit examples

### DIFF
--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -34,9 +34,9 @@ metadata:
 data:
   feature-gates: "LiveMigration"
   migrations: |-
-    parallelMigrationsPerCluster: 5
-    parallelOutboundMigrationsPerNode: 2
-    bandwidthPerMigration: 64Mi
-    completionTimeoutPerGiB: 800
-    progressTimeout: 150
+    parallelMigrationsPerCluster: "5"
+    parallelOutboundMigrationsPerNode: "2"
+    bandwidthPerMigration: "64Mi"
+    completionTimeoutPerGiB: "800"
+    progressTimeout: "150"
 ----


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1906607
4.6, 4.7, 4.8

Preview: https://deploy-preview-30577--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits.html