### PR TITLE
Jira: OSDOCS-1950 - Remove the --watch argument from create cluster

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -127,9 +127,6 @@ $ rosa create cluster --cluster=<cluster_name> [arguments]
 
 |--version
 |The version (string) of OpenShift Container Platform that will be used to install the cluster. Example: `4.3.10`
-
-|--watch
-|Watches the cluster installation logs.
 |===
 
 .Optional arguments inherited from parent commands

--- a/modules/rosa-quickstart-instructions.adoc
+++ b/modules/rosa-quickstart-instructions.adoc
@@ -14,8 +14,8 @@ If you have already installed the required prerequisites, here are the commands 
 ## Configures your AWS account and ensures everything is setup correctly
 $ rosa init
 
-## Starts the cluster creation process (~30-40minutes) and watches the logs
-$ rosa create cluster --cluster-name <cluster_name> --watch
+## Starts the cluster creation process (~30-40minutes)
+$ rosa create cluster --cluster-name <cluster_name>
 
 ## Connect your IDP to your cluster
 $ rosa create idp --cluster <cluster_name> --interactive

--- a/modules/rosa-using-bash-script.adoc
+++ b/modules/rosa-using-bash-script.adoc
@@ -28,7 +28,7 @@ $ rosa init --token=<token>
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name=<cluster_name> --watch
+$ rosa create cluster --cluster-name=<cluster_name>
 ----
 
 . Add an identity provider (IDP):


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSDOCS-1950

Removed the --watch argument from the create cluster command CLI, ROSA Quickstart topic and Using a Bash script.

Links to updated content:
https://deploy-preview-30578--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart.html
https://deploy-preview-30578--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-cluster_rosa-managing-objects-cli
https://deploy-preview-30578--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-get-started-cli.html#rosa-using-bash-script_rosa-getting-started-cli

