### PR TITLE
RHV IPI restricted network table mark

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -141,7 +141,7 @@ endif::openshift-origin[]
 |
 |
 |xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
-|
+|xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
 |
 |
 |

--- a/installing/installing_rhv/installing-rhv-restricted-network.adoc
+++ b/installing/installing_rhv/installing-rhv-restricted-network.adoc
@@ -1,4 +1,4 @@
-[id="installing-rhv-restricted-network_{context}"]
+[id="installing-rhv-restricted-network"]
 = Installing a cluster on {rh-virtualization} in a restricted network
 include::modules/common-attributes.adoc[]
 :context: installing-rhv-restricted-network


### PR DESCRIPTION
Marking support table now that RHV IPI restricted network docs are available (#28522).

Preview: https://deploy-preview-30580--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms