### PR TITLE
RN update with 1.4 GA Support status table

### DIFF
--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -19,7 +19,27 @@ toc::[]
 For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding OpenShift Pipelines].
 
 [id="getting-support"]
-== Getting support
+== Pipelines support
+
+The following compatibility matrix shows the support status and compatible versions for the various {pipelines-title} components:
+
+|===
+|{pipelines-title} | Support status | Pipelines | Triggers | CLI | Catalog | {product-title}
+
+| 1.4
+|General Availability (GA)
+
+|0.22
+
+|0.12
+
+|0.17
+
+|0.22
+
+|4.7
+
+|===
 
 If you experience difficulty with a procedure described in this documentation,
 visit the Red Hat Customer Portal to learn more about link:https://access.redhat.com/support/offerings/techpreview/[Red Hat Technology Preview features support scope].


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.7 and enterprise-4.8
JIRA issues: [RHDEVDOCS-2387](https://issues.redhat.com/browse/RHDEVDOCS-2387)
Preview pages: [Pipelines support](https://deploy-preview-30586--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#getting-support)
This PR has been reviewed by the SMEs and QEs.