### PR TITLE
[enterprise-4.6] BZ1846542: add NTP config info to restricted network install content

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -31,6 +31,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -38,6 +38,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -51,6 +51,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -40,6 +40,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -48,6 +48,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -52,6 +52,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -56,6 +56,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+++ b/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
@@ -37,6 +37,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -49,6 +49,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -38,6 +38,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -40,6 +40,10 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
+.Additional resources
+
+* xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
+
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -256,6 +256,11 @@ ifdef::vsphere[]
 :!vsphere:
 endif::[]
 
+[discrete]
+== NTP configuration
+
+An {product-title} cluster that is installed in a restricted network is configured to use a public Network Time Protocol (NTP) server by default. To avoid clock skew, reconfigure the cluster to use a private NTP server instead. For more information, see the documentation for _Configuring chrony time service_.
+
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]


### PR DESCRIPTION
Cherrypicked from ad892c93e57aeb9b6431901f6366daf68aaba3f3 xref:https://github.com/openshift/openshift-docs/pull/27809