### PR TITLE
BZ:1771730 Add IPAM to host-device example

### DIFF
--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -111,7 +111,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23/24"
+            "address": "192.168.1.23/24"
           }
         ]
       }
@@ -134,7 +134,15 @@ spec:
       "cniVersion": "0.3.1",
       "name": "test-network-1",
       "type": "{plugin}",
-      "device": "eth1"
+      "device": "eth1",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "192.168.1.23/24"
+          }
+        ]
+      }
     }'
 ----
 endif::[]
@@ -160,7 +168,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23/24"
+            "address": "192.168.1.23/24"
           }
         ]
       }
@@ -188,7 +196,7 @@ spec:
         "type": "static",
         "addresses": [
           {
-            "address": "191.168.1.23/24"
+            "address": "192.168.1.23/24"
           }
         ]
       }

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -24,7 +24,7 @@ The following YAML describes the configuration parameters for the CNO:
 name: <name> <1>
 namespace: <namespace> <2>
 rawCNIConfig: '{ <3>
-  ...  
+  ...
 }'
 type: Raw
 ----
@@ -32,7 +32,7 @@ type: Raw
 creating. The name must be unique within the specified `namespace`.
 
 <2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
+you do not specify a value, the `default` namespace is used.
 
 <3> Specify the CNI plug-in configuration in JSON format, which
 is based on the following template.
@@ -43,6 +43,7 @@ following parameters: `device`, `hwaddr`, `kernelpath`, or `pciBusID`.
 The following object describes the configuration parameters for the host-device CNI
 plug-in:
 
+// containernetworking/plugins/.../host-device.go#L50
 .host-device CNI plug-in JSON configuration object
 [source,json]
 ----
@@ -54,7 +55,7 @@ plug-in:
   "hwaddr": "<hwaddr>", <3>
   "kernelpath": "<kernelpath>", <4>
   "pciBusID": "<pciBusID>", <5>
-    "ipam": { <6>
+  "ipam": { <6>
     ...
   }
 }
@@ -88,7 +89,10 @@ rawCNIConfig: '{ <1>
   "cniVersion": "0.3.1",
   "name": "work-network",
   "type": "host-device",
-  "device": "eth1"
+  "device": "eth1",
+  "ipam": {
+    "type": "dhcp"
+  }
 }'
 ----
 <1> The CNI configuration object is specified as a YAML string.

--- a/networking/multiple_networks/configuring-host-device.adoc
+++ b/networking/multiple_networks/configuring-host-device.adoc
@@ -5,10 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure an additional network for your
-cluster by using the host-device Container Network Interface (CNI) plug-in. The
-plug-in allows you to move the specified network device from the host's network
-namespace into the Pod's network namespace.
+As a cluster administrator, you can configure an additional network for your cluster by using the host-device Container Network Interface (CNI) plug-in. The plug-in moves the specified network device from the network namespace of the host into the network namespace of the pod.
 
 include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1771730

In step 2 in procedure "Creating an additional network attachment with the host-device CNI plug-in", I added an "ipam" field in the JSON: https://deploy-preview-30598--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-host-device.html#nw-multus-create-network_configuring-host-device

Further down on that page under heading "host-device configuration example", I added the same "ipam" field in the JSON: https://deploy-preview-30598--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-host-device.html#nw-multus-hostdev-config-example_configuring-host-device

@openshift/team-documentation PTAL

Applies to enterprise-4.5 through 4.8, and milestone Next-Release.