### PR TITLE
Bug 1835001: added a note about viewing ChargeBack report

### DIFF
--- a/modules/metering-install-operator.adoc
+++ b/modules/metering-install-operator.adoc
@@ -12,6 +12,11 @@ You can install metering by deploying the Metering Operator. The Metering Operat
 You cannot create a Project starting with `openshift-` using the web console or by using the `oc new-project` command in the CLI.
 ====
 
+[NOTE]
+====
+If the Metering Operator is installed using a namespace other than `openshift-metering`, the Metering reports are only viewable using the CLI. It is strongly suggested throughout the installation steps to use the `openshift-metering` namespace.
+====
+
 [id="metering-install-web-console_{context}"]
 == Installing metering using the web console
 You can use the {product-title} web console to install the Metering Operator.


### PR DESCRIPTION
**This PR takes the place of  #29819 since I need to update 4.5-4.8 and 29819 was opened only in enterprise4.5. QA ACK'd**

Added a note about viewing ChargeBack report if namespace is other than openshift-metering