### PR TITLE
BZ-1798741 Modify note for manual cleanup of S3 bucket data used for metering

### DIFF
--- a/modules/metering-store-data-in-s3.adoc
+++ b/modules/metering-store-data-in-s3.adoc
@@ -9,7 +9,7 @@ Metering can use an existing Amazon S3 bucket or create a bucket for storage.
 
 [NOTE]
 ====
-Metering does not manage or delete any S3 bucket data. When uninstalling metering, any S3 buckets used to store metering data must be manually cleaned up.
+Metering does not manage or delete any S3 bucket data. You must manually clean up S3 buckets that are used to store metering data.
 ====
 
 To use Amazon S3 for storage, edit the `spec.storage` section in the example `s3-storage.yaml` file below.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1798741
Small update to a note in the Metering docs regarding S3 bucket data management to make the note more general and not specific to uninstalling metering.

Preview:

**Side Note:** There is a similar note in [Uninstalling metering](https://docs.openshift.com/container-platform/4.7/metering/metering-uninstall.html) that also mentions manual clean up of S3 bucket data after uninstalling metering.