### PR TITLE
OSSMDOC-177 Missing removal steps.

### DIFF
--- a/modules/ossm-remove-cleanup-1x.adoc
+++ b/modules/ossm-remove-cleanup-1x.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v1x/installing-ossm.adoc
+
+
+[id="ossm-remove-cleanup-1x_{context}"]
+= Clean up Operator resources
+
+Follow this procedure to manually remove resources left behind after removing the {ProductName} Operator using the OpenShift console.
+
+.Prerequisites
+
+* An account with cluster administration access.
+* Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
+
+.Procedure
+
+. Log in to the {product-title} CLI as a cluster administrator.
+
+. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using Jaeger as a stand alone service without service mesh, do not delete the Jaeger resources.
++
+[NOTE]
+====
+The Operators are installed in the `openshift-operators` namespace by default.  If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
+====
++
+[source,terminal]
+----
+$ oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io
+----
++
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfigurations/openshift-operators.servicemesh-resources.maistra.io
+----
++
+[source,terminal]
+----
+$ oc delete -n openshift-operators daemonset/istio-node
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
+----
+// needs a slash?  What is the format here?
++
+[source,terminal]
+----
+$ oc delete clusterrole istio-view istio-edit
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole jaegers.jaegertracing.io-v1-admin jaegers.jaegertracing.io-v1-crdview jaegers.jaegertracing.io-v1-edit jaegers.jaegertracing.io-v1-view
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.istio\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.maistra\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.kiali\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc delete crds jaegers.jaegertracing.io
+----
++
+[source,terminal]
+----
+$ oc delete svc admission-controller -n <operator-project>
+----
++
+[source,terminal]
+----
+$ oc delete project <istio-system-project>
+----

--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/installing-ossm.adoc
+
+
+[id="ossm-remove-cleanup_{context}"]
+= Clean up Operator resources
+
+Follow this procedure to manually remove resources left behind after removing the {ProductName} Operator using the OpenShift console.
+
+.Prerequisites
+
+* An account with cluster administration access.
+* Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
+
+.Procedure
+
+. Log in to the {product-title} CLI as a cluster administrator.
+
+. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using Jaeger as a stand alone service without service mesh, do not delete the Jaeger resources.
++
+[NOTE]
+====
+The Operators are installed in the `openshift-operators` namespace by default.  If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
+====
++
+[source,terminal]
+----
+$ oc delete validatingwebhookconfiguration/openshift-operators.servicemesh-resources.maistra.io
+----
++
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfigurations/openshift-operators.servicemesh-resources.maistra.io
+----
++
+[source,terminal]
+----
+$ oc delete svc maistra-admission-controller -n openshift-operators
+----
++
+[source,terminal]
+----
+$ oc delete -n openshift-operators daemonset/istio-node
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole istio-view istio-edit
+----
++
+[source,terminal]
+----
+$ oc delete clusterrole jaegers.jaegertracing.io-v1-admin jaegers.jaegertracing.io-v1-crdview jaegers.jaegertracing.io-v1-edit jaegers.jaegertracing.io-v1-view
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.istio\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.maistra\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc get crds -o name | grep '.*\.kiali\.io' | xargs -r -n 1 oc delete
+----
++
+[source,terminal]
+----
+$ oc delete crds jaegers.jaegertracing.io
+----
++
+[source,terminal]
+----
+$ oc delete secret -n openshift-operators maistra-operator-serving-cert
+----
++
+[source,terminal]
+----
+$ oc delete cm -n openshift-operators maistra-operator-cabundle
+----

--- a/modules/ossm-remove-operators.adoc
+++ b/modules/ossm-remove-operators.adoc
@@ -3,12 +3,10 @@
 // * service_mesh/v1x/installing-ossm.adoc
 // * service_mesh/v2x/installing-ossm.adoc
 
-[id="ossm-operatorhub-remove_{context}"]
+[id="ossm-operatorhub-remove-operators_{context}"]
 = Removing the installed Operators
 
-You must remove the Operators to successfully remove {ProductName}. Once you
-remove the {ProductName} Operator, you must remove the Jaeger Operator, Kiali
-Operator, and the Elasticsearch Operator.
+You must remove the Operators to successfully remove {ProductName}. Once you remove the {ProductName} Operator, you must remove the Kiali Operator, the Jaeger Operator,  and the Elasticsearch Operator.
 
 [id="ossm-remove-operator-servicemesh_{context}"]
 == Removing the {ProductName} Operator
@@ -24,44 +22,14 @@ Follow this procedure to remove the {ProductName} Operator.
 
 . Log in to the {product-title} web console.
 
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the {ProductName} Operator. Then, click on it.
+. From the *Operators* → *Installed Operators* page, scroll or type a keyword into the *Filter by name* to find the {ProductName} Operator. Then, click on it.
 
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
+. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
 
 . When prompted by the *Remove Operator Subscription* window, optionally select the
 *Also completely remove the Operator from the selected namespace*
 check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
-associated with the Operator.
-
-
-[id="ossm-remove-operator-jaeger_{context}"]
-== Removing the Jaeger Operator
-
-Follow this procedure to remove the Jaeger Operator.
-
-.Prerequisites
-
-* Access to the {product-title} web console.
-* The Jaeger Operator must be installed.
-
-.Procedure
-
-. Log in to the {product-title} web console.
-
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the Jaeger Operator. Then, click on it.
-
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
-
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
-associated with the Operator.
+This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs associated with the Operator.
 
 [id="ossm-remove-operator-kiali_{context}"]
 == Removing the Kiali Operator
@@ -79,6 +47,32 @@ Follow this procedure to remove the Kiali Operator.
 
 . From the *Operators* → *Installed Operators* page, scroll or type a keyword into
 the *Filter by name* to find the Kiali Operator. Then, click on it.
+
+. On the right-hand side of the *Operator Details* page, select *Uninstall
+Operator* from the *Actions* drop-down menu.
+
+. When prompted by the *Remove Operator Subscription* window, optionally select the
+*Also completely remove the Operator from the selected namespace*
+check box if you want all components related to the installation to be removed.
+This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
+associated with the Operator.
+
+[id="ossm-remove-operator-jaeger_{context}"]
+== Removing the Jaeger Operator
+
+Follow this procedure to remove the Jaeger Operator.
+
+.Prerequisites
+
+* Access to the {product-title} web console.
+* The Jaeger Operator must be installed.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
+the *Filter by name* to find the Jaeger Operator. Then, click on it.
 
 . On the right-hand side of the *Operator Details* page, select *Uninstall
 Operator* from the *Actions* drop-down menu.
@@ -114,59 +108,3 @@ Operator* from the *Actions* drop-down menu.
 check box if you want all components related to the installation to be removed.
 This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
 associated with the Operator.
-
-[id="ossm-remove-cleanup_{context}"]
-== Clean up Operator resources
-
-Follow this procedure to manually remove resources left behind after removing the {ProductName} Operator by using the OperatorHub interface.
-
-.Prerequisites
-
-* An account with cluster administration access.
-* Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
-
-.Procedure
-
-. Log in to the {product-title} CLI as a cluster administrator.
-
-. Run the following commands to clean up resources after uninstalling the Operators:
-+
-[NOTE]
-====
-Replace `<operator-project>` with the name of the project where the {ProductName} Operator was installed. This is typically `openshift-operators`.
-====
-+
-[source,terminal]
-----
-$ oc delete validatingwebhookconfiguration/<operator-project>.servicemesh-resources.maistra.io
-----
-+
-[source,terminal]
-----
-$ oc delete mutatingwebhookconfigurations/<operator-project>.servicemesh-resources.maistra.io
-----
-+
-[source,terminal]
-----
-$ oc delete -n <operator-project> daemonset/istio-node
-----
-+
-[source,terminal]
-----
-$ oc delete clusterrole/istio-admin clusterrole/istio-cni clusterrolebinding/istio-cni
-----
-+
-[source,terminal]
-----
-$ oc get crds -o name | grep '.*\.istio\.io' | xargs -r -n 1 oc delete
-----
-+
-[source,terminal]
-----
-$ oc get crds -o name | grep '.*\.maistra\.io' | xargs -r -n 1 oc delete
-----
-+
-[source,terminal]
-----
-$ oc get crds -o name | grep '.*\.kiali\.io' | xargs -r -n 1 oc delete
-----

--- a/service_mesh/v1x/removing-ossm.adoc
+++ b/service_mesh/v1x/removing-ossm.adoc
@@ -11,4 +11,6 @@ include::modules/ossm-member-roll-delete.adoc[leveloffset=+1]
 
 include::modules/ossm-control-plane-remove.adoc[leveloffset=+1]
 
-include::modules/ossm-operatorhub-remove.adoc[leveloffset=+1]
+include::modules/ossm-remove-operators.adoc[leveloffset=+1]
+
+include::modules/ossm-remove-cleanup-1x.adoc[leveloffset=+2]

--- a/service_mesh/v2x/removing-ossm.adoc
+++ b/service_mesh/v2x/removing-ossm.adoc
@@ -11,4 +11,6 @@ include::modules/ossm-member-roll-delete.adoc[leveloffset=+1]
 
 include::modules/ossm-control-plane-remove.adoc[leveloffset=+1]
 
-include::modules/ossm-operatorhub-remove.adoc[leveloffset=+1]
+include::modules/ossm-remove-operators.adoc[leveloffset=+1]
+
+include::modules/ossm-remove-cleanup.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR updates the steps for removing Service Mesh, resolving [OSSMDOC-177](https://issues.redhat.com/browse/OSSMDOC-177) and OSSMDOC-164.
 - Splits the ossm-operatorhub-remove module into two new files, ossm-remove-operators (common) and ossm-remove-cleanup (V1 and V2)
 - Updates the assembly files to point to the new modules.

(4.5 branch only needs V1 files and will be a manual cherry pick)