### PR TITLE
BZ-1937617 Setting log level - remove Alertmanager and add Thanos Querier

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -5,7 +5,7 @@
 [id="setting-log-levels-for-monitoring-components_{context}"]
 = Setting log levels for monitoring components
 
-You can configure the log level for Prometheus Operator, Prometheus, Alertmanager and Thanos Ruler.
+You can configure the log level for Prometheus Operator, Prometheus, Thanos Querier, and Thanos Ruler.
 
 The following log levels can be applied to each of those components in the `cluster-monitoring-config` and `user-workload-monitoring-config` `ConfigMap` objects:
 
@@ -18,7 +18,7 @@ The default log level is `info`.
 
 .Prerequisites
 
-* *If you are setting a log level for Prometheus Operator or Prometheus in the `openshift-monitoring` project*:
+* *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Querier in the `openshift-monitoring` project*:
 ** You have access to the cluster as a user with the `cluster-admin` role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Ruler in the `openshift-user-workload-monitoring` project*:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1937617

Removes Alertmanager reference from the [Setting log levels for monitoring components](https://docs.openshift.com/container-platform/4.7/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack) section and adds Thanos Querier. `logLevel` capability for Thanos Querier was added in 4.7, but the update was reflected only in the Release Notes.

Preview: https://deploy-preview-30606--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack

**Note:** I don't see `logLevel` mentioned in the 4.5 docs. A separate PR will be created to remove mention of Alertmanager from 4.6.