### PR TITLE
BZ:1924176 v2-del URL to KCS with probs

### DIFF
--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -22,7 +22,7 @@ include::modules/checking-mco-status.adoc[leveloffset=+2]
 
 Tasks in this section let you create `MachineConfig` objects to modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see
  content related to link:https://access.redhat.com/solutions/5307301[changing MTU network settings], link:https://access.redhat.com/solutions/5096731[adding] or
-link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys, link:https://access.redhat.com/solutions/4518671[replacing DNS nameservers], link:https://access.redhat.com/verify-images-ocp4[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
+link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys, link:https://access.redhat.com/verify-images-ocp4[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
 
 {product-title} version 4.7 supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2].  All new machine configs you create going forward should be based on Ignition specification version 3.2.  If you are upgrading your {product-title} cluster, any existing Ignition specification version 2.x machine configs will be translated automatically to specification version 3.2.
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1924176

This is an urgent BZ and this "second swing" at the BZ is
to remove the link to the KCS article that is steering
customers into trouble.

In the para that follows the heading, I removed the link to the KCS article that described how to modify the name servers.
https://deploy-preview-30616--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#using-machineconfigs-to-change-machines

Applies to branches enterprise-4.6 to enterprise-4.8 and milestone Next Release.