### PR TITLE
BZ-1937617 Remove Alertmanager mention from setting log level

### DIFF
--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -5,7 +5,7 @@
 [id="setting-log-levels-for-monitoring-components_{context}"]
 = Setting log levels for monitoring components
 
-You can configure the log level for Prometheus Operator, Prometheus, Alertmanager and Thanos Ruler.
+You can configure the log level for Prometheus Operator, Prometheus, and Thanos Ruler.
 
 The following log levels can be applied to each of those components in the `cluster-monitoring-config` and `user-workload-monitoring-config` `ConfigMap` objects:
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1937617

Removes Alertmanager reference from the [Setting log levels for monitoring components](https://docs.openshift.com/container-platform/4.6/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack) section.

**Preview:** https://deploy-preview-30618--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#setting-log-levels-for-monitoring-components_configuring-the-monitoring-stack

[Separate PR](https://github.com/openshift/openshift-docs/pull/30606) to remove Alertmanager mention from 4.7+.