### PR TITLE
Fix supported images for all OSDK tutorials

### DIFF
--- a/modules/osdk-prepare-supported-images.adoc
+++ b/modules/osdk-prepare-supported-images.adoc
@@ -1,45 +1,46 @@
 // Module included in the following assemblies:
 //
 // * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+// * operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+// * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+
+:osdk_ver: v1.3.0
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:golang:
+:type: Go
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:ansible:
+:type: Ansible
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:helm:
+:type: Helm
+endif::[]
 
 [id="osdk-prepare-supported-images_{context}"]
-= Preparing your Operator use supported images
+= Preparing your Operator to use supported images
 
-Before running your Go-based Operator on {product-title}, update your project to use supported images.
+Before running your {type}-based Operator on {product-title}, update your project to use supported images.
 
 .Procedure
 
-. Update the following lines in the project root-level Dockerfile to use supported images.
-
-.. Change the default builder image reference from:
+ifdef::golang[]
+. Update the project root-level Dockerfile to use supported images. Change the default runner image reference from:
 +
 [source,terminal]
 ----
-golang:1.15
+FROM gcr.io/distroless/static:nonroot
 ----
 +
 to:
 +
 [source,terminal]
 ----
-registry.redhat.io/openshift4/builder:rhel-8-golang-1.15-openshift-4.7
+FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ----
 
-.. Change the default runner image reference from:
-+
-[source,terminal]
-----
-gcr.io/distroless/static:nonroot
-----
-+
-to:
-+
-[source,terminal]
-----
-registry.access.redhat.com/ubi8/ubi-minimal:latest
-----
-
-.. Remove the `USER: nonroot:nonroot` directive, as it is not required by the supported image.
+. Depending on the Go project version, your Dockerfile might contain a `USER 65532:65532` or `USER nonroot:nonroot` directive. In either case, remove the line, as it is not required by the supported runner image.
 
 . In the `config/default/manager_auth_proxy_patch.yaml` file, change the `image` value from:
 +
@@ -54,3 +55,60 @@ to use the supported image:
 ----
 registry.redhat.io/openshift4/ose-kube-rbac-proxy:v{product-version}
 ----
+endif::[]
+
+ifdef::ansible[]
+* Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
++
+[source,terminal,subs="attributes+"]
+----
+FROM quay.io/operator-framework/ansible-operator:{osdk_ver}
+----
++
+to:
++
+[source,terminal,subs="attributes+"]
+----
+FROM registry.redhat.io/openshift4/ose-ansible-operator:v{product-version}
+----
++
+[IMPORTANT]
+====
+Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
+====
+endif::[]
+
+ifdef::helm[]
+* Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
++
+[source,terminal,subs="attributes+"]
+----
+FROM quay.io/operator-framework/helm-operator:{osdk_ver}
+----
++
+to:
++
+[source,terminal,subs="attributes+"]
+----
+FROM registry.redhat.io/openshift4/ose-helm-operator:v{product-version}
+----
++
+[IMPORTANT]
+====
+Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
+====
+endif::[]
+
+:!osdk_ver:
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:!golang:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:!ansible:
+:!type:
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:!helm:
+:!type:
+endif::[]

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -32,6 +32,7 @@ include::modules/osdk-ansible-modify-manager.adoc[leveloffset=+1]
 
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
+include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+2]
 

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -34,6 +34,7 @@ include::modules/osdk-helm-modify-cr.adoc[leveloffset=+2]
 
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
+include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1940225
https://bugzilla.redhat.com/show_bug.cgi?id=1940221

Preview builds:

* [Ansible tutorial](https://deploy-preview-30624--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-prepare-supported-images_osdk-ansible-tutorial)
* [Helm tutorial](https://deploy-preview-30624--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-prepare-supported-images_osdk-helm-tutorial)
* [Go tutorial](https://deploy-preview-30624--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-prepare-supported-images_osdk-golang-tutorial)