### PR TITLE
Update instructions for configuring `kdump` on CoreOS

### DIFF
--- a/modules/investigating-kernel-crashes.adoc
+++ b/modules/investigating-kernel-crashes.adoc
@@ -74,7 +74,14 @@ endif::[]
 . Ensure that `kdump` has loaded a crash kernel by checking that the `kdump.service` has started and exited successfully and that `cat /sys/kernel/kexec_crash_loaded` prints `1`.
 
 == Enabling kdump on day-1
-The `kdump` service is intended to be enabled per-node to debug kernel problems. It is not recommended to enable `kdump` on all of your nodes in the cluster. Although machine-specific machine configs are not yet supported, you can perform the previous steps through a `systemd` unit in a `MachineConfig` object on day-1 and have kdump enabled on all nodes in the cluster. You can create a machine config object and inject that object into the set of manifest files used by Ignition during cluster setup. See "Customizing nodes" in the _Installing -> Installation configuration_ section for more information and examples on how to use Ignition configs.
+The `kdump` service is intended to be enabled per node to debug kernel problems. Because there are costs to having `kdump` enabled, and these costs accumulate with each additional `kdump`-enabled node, it is recommended that `kdump` only be enabled on each node as needed. Potential costs of enabling `kdump` on each node include:
+
+* Less available RAM due to memory being reserved for the crash kernel.
+* Node unavailability while the kernel is dumping the core.
+* Additional storage space being used to store the crash dumps.
+* Not being production-ready because the `kdump` service is in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview].
+
+If you are aware of the downsides and trade-offs of having the `kdump` service enabled, it is possible to enable `kdump` in a cluster-wide fashion. Although machine-specific machine configs are not yet supported, you can perform the previous steps through a `systemd` unit in a `MachineConfig` object on day-1 and have kdump enabled on all nodes in the cluster. You can create a `MachineConfig` object and inject that object into the set of manifest files used by Ignition during cluster setup. See "Customizing nodes" in the _Installing -> Installation configuration_ section for more information and examples on how to use Ignition configs.
 
 == Testing the kdump configuration
 


### PR DESCRIPTION
In the "Enabling `kdump` on day-1" section, the wording around
"it is not recommended to enable `kdump` on all nodes in the
cluster" is misleading. There is nothing particularly bad about
enabling `kdump` on e.g. 10/10 v.s. 9/10 nodes, but rather `kdump`
should only be enabled on as many nodes as necessary.
Emphasize this point and include some information regarding the
costs of enabling `kdump` on each additional node.