### PR TITLE
GH#27901 - Remove default custom certificate for Ingress Controller

### DIFF
--- a/modules/nw-ingress-custom-default-certificate-remove.adoc
+++ b/modules/nw-ingress-custom-default-certificate-remove.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+[id="nw-ingress-custom-default-certificate-remove_{context}"]
+= Removing a custom default certificate
+
+As an administrator, you can remove a custom certificate that you configured an Ingress Controller to use.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
+* You previously configured a custom default certificate for the Ingress Controller.
+
+.Procedure
+
+* To remove the custom certificate and restore the certificate that ships with {product-title}, enter the following command:
++
+[source,terminal]
+----
+$ oc patch -n openshift-ingress-operator ingresscontrollers/default \
+  --type json -p $'- op: remove\n  path: /spec/defaultCertificate'
+----
++
+There can be a delay while the cluster reconciles the new certificate configuration.
+
+.Verification
+
+* To confirm that the original cluster certificate is restored, enter the following command:
++
+[source,terminal]
+----
+$ echo Q | \
+  openssl s_client -connect console-openshift-console.apps.<domain>:443 -showcerts 2>/dev/null | \
+  openssl x509 -noout -subject -issuer -enddate
+----
++
+where:
++
+--
+`<domain>`:: Specifies the base domain name for your cluster.
+--
++
+.Example output
+[source,text]
+----
+subject=CN = *.apps.<domain>
+issuer=CN = ingress-operator@1620633373
+notAfter=May 10 10:44:36 2023 GMT
+----

--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -76,19 +76,29 @@ $ oc patch --type=merge --namespace openshift-ingress-operator ingresscontroller
 +
 [source,terminal]
 ----
-$ oc get --namespace openshift-ingress-operator ingresscontrollers/default \
-  --output jsonpath='{.spec.defaultCertificate}'
+$ echo Q |\
+  openssl s_client -connect console-openshift-console.apps.<domain>:443 -showcerts 2>/dev/null |\
+  openssl x509 -noout -subject -issuer -enddate
 ----
 +
+where:
++
+--
+`<domain>`:: Specifies the base domain name for your cluster.
+--
++
 .Example output
-[source,terminal]
+[source,text]
 ----
-map[name:custom-certs-default]
+subject=C = US, ST = NC, L = Raleigh, O = RH, OU = OCP4, CN = *.apps.example.com
+issuer=C = US, ST = NC, L = Raleigh, O = RH, OU = OCP4, CN = example.com
+notAfter=May 10 08:32:45 2022 GM
 ----
 +
 [TIP]
 ====
 You can alternatively apply the following YAML to set a custom default certificate:
+
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -43,6 +43,8 @@ include::modules/nw-ingress-controller-status.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-setting-a-custom-default-certificate.adoc[leveloffset=+2]
 
+include::modules/nw-ingress-custom-default-certificate-remove.adoc[leveloffset=+2]
+
 include::modules/nw-scaling-ingress-controller.adoc[leveloffset=+2]
 
 include::modules/nw-configure-ingress-access-logging.adoc[leveloffset=+2]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/27901

Preview: https://deploy-preview-30633--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-ingress-custom-default-certificate-remove_configuring-ingress