### PR TITLE
CNV-BZ-1904228 Added prereq to dedicated resources procedure

### DIFF
--- a/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.adoc
@@ -5,16 +5,14 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-Virtual machines can have resources of a node, such as CPU,
-dedicated to them in order to improve performance.
+To improve performance, you can dedicate node resources, such as CPU, to a virtual machine.
 
 include::modules/virt-about-dedicated-resources.adoc[leveloffset=+1]
 
 == Prerequisites
 
-* The
-xref:../../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must
-be configured on the node. Verify that the node has the `cpumanager` = `true`
-label before scheduling virtual machine workloads.
+* The xref:../../../scalability_and_performance/using-cpu-manager.adoc[CPU Manager]  must be configured on the node. Verify that the node has the `cpumanager = true` label before scheduling virtual machine workloads.
+
+* The virtual machine must be powered off.
 
 include::modules/virt-enabling-dedicated-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1904228

The VM must be powered down before the user can enable dedicated resources. Added this prereq to the Enabling dedicated resources for virtual machines assembly.

Also removed hard wraps

Preview: https://deploy-preview-30650--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-dedicated-resources-vm.html#prerequisites

SME review requested from Yaacov Zamir
QE review requested from Israel Pinto; QE ack provided by Kedar Bidarkar