### PR TITLE
BZ#1929240 Adds warning label to Operator catalog image

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -72,8 +72,13 @@ $ oc adm catalog mirror \
 <1> Specify your Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> This flag is currently required due to a known issue with multiple architecture support. If unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
+<4> This flag is currently required due to a known issue with multiple architecture support.
 <5> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
++
+[WARNING]
+====
+If the `filter-by-os` remains unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
+====
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
For 4.5

https://bugzilla.redhat.com/show_bug.cgi?id=1929240

The BZ log suggests that this should be changed in 4.5 and 4.6, however this issue has already been changed in 4.6. Please see https://github.com/openshift/oc/pull/673 if confirmation is needed. 

Direct link to doc preview: https://deploy-preview-30678--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html

No QA needed. 