### PR TITLE
OSSMDOC-280 Add note to clarify supported ES version.

### DIFF
--- a/modules/jaeger-install-elasticsearch.adoc
+++ b/modules/jaeger-install-elasticsearch.adoc
@@ -44,7 +44,13 @@ If you have already installed the Elasticsearch Operator as part of OpenShift Lo
 The Elasticsearch installation requires the *openshift-operators-redhat* namespace for the Elasticsearch operator.  The other {ProductName} operators are installed in the `openshift-operators` namespace.
 ====
 +
-. Select the *Update Channel* that matches your {product-title} installation.  For example, if you are installing on {product-title} version 4.7, select the 4.7 update channel.
+. Select the *Update Channel* that matches your {product-title} installation.  For example, if you are installing on {product-title} version 4.6, select the 4.6 update channel.
++
+[NOTE]
+====
+For {product-title} version 4.7 select the 4.6 update channel.
+====
++
 
 . Select the *Automatic* Approval Strategy.
 +


### PR DESCRIPTION
The current release streams for the ES operator are
4.6
5.0
stable (which is 5.0)
Currently the 5.0 version has not been tested for Jaeger.

Add note to specify that customers should use the 4.6 channel.