### PR TITLE
Update links to Rosa CLI download

### DIFF
--- a/modules/rosa-setting-up-cli.adoc
+++ b/modules/rosa-setting-up-cli.adoc
@@ -12,35 +12,15 @@ To set up the `rosa` CLI, download the latest release, then configure and initia
 
 .Procedure
 
-. Download the latest release of `rosa` for your operating system from the link:https://github.com/openshift/rosa/releases/latest[`rosa` releases page on GitHub].
+. Download the latest release of the `rosa` CLI for your operating system from the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[{product-title}] product page.
 +
-. Optional: After downloading a release, you can rename the executable file that you downloaded to `rosa`, and then add `rosa` to your path.
+. It is recommended that after you download the release, you rename the executable file that you downloaded to `rosa`, and then add `rosa` to your path.
 +
-. After downloading `rosa`, enable Bash completion for `rosa`. Bash completion helps to automatically complete commands and suggest options when you press `Tab`. The command generates a Bash completion file for `rosa` and sources it to your current shell session.
+. Optional: After downloading `rosa`, enable Bash completion for `rosa`. Bash completion helps to automatically complete commands and suggest options when you press `Tab`. The command generates a Bash completion file for `rosa` and sources it to your current shell session.
 +
 To configure your Bash shell to load `rosa` completions for each session, add the following command to your `Bashrc` file (`~/.Bashrc` or `~/.profile`).
 +
 [source,terminal]
 ----
 $ . <(rosa completion)
-----
-+
-. Enter the following command in the Bash terminal to verify that your user now has `cluster-admin` access. A cluster administrator can run this command without errors, but a dedicated administrator cannot.
-+
-[source,terminal]
-----
-$ oc get all -n openshift-apiserver
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                  READY   STATUS    RESTARTS   AGE
-pod/apiserver-6ndg2   1/1     Running   0          17h
-pod/apiserver-lrmxs   1/1     Running   0          17h
-pod/apiserver-tsqhz   1/1     Running   0          17h
-NAME          TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)   AGE
-service/api   ClusterIP   172.30.23.241   <none>        443/TCP   18h
-NAME                       DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
-daemonset.apps/apiserver   3         3         3       3            3           node-role.kubernetes.io/master=   18h
 ----

--- a/modules/rosa-setting-up-environment.adoc
+++ b/modules/rosa-setting-up-environment.adoc
@@ -63,7 +63,7 @@ $ aws sts get-caller-identity
 ----
 +
 . Install `rosa`, the {product-title} command-line interface (CLI).
-.. Download the link:https://github.com/openshift/moactl/releases[latest release] of `rosa` for your operating system.
+.. Download the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[latest release] of the `rosa` CLI for your operating system.
 .. Optional: Rename the executable file you downloaded to `rosa`. This documentation uses `rosa` to refer to the executable file.
 .. Optional: Add `rosa` to your path.
 .. Enter the following command to verify your installation:


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSDOCS-1951

Here are direct links to the preview:
See Step 1 in Setting up the rosa CLI
https://deploy-preview-30695--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-get-started-cli.html#rosa-setting-up-cli_rosa-getting-started-cli

See Step 4 in Setting up the environment:
https://deploy-preview-30695--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-setting-up-environment.html#rosa-setting-up-environment_rosa-setting-up-environment
