### PR TITLE
Bug 1886229: Clarify multipath support in release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -53,8 +53,7 @@ This release adds improvements related to the following components and concepts.
 * Native Ignition support for LUKS disk encryption provides additional configurability for encrypted root filesystems, as well as support for encryption of additional data filesystems.
 * {op-system} now supports boot disk mirroring, except on s390x, providing redundancy in the case of disk failure. For more information, see xref:../installing/install_config/installing-customizing.adoc#installation-special-config-mirrored-disk_installing-customizing[Mirroring disks during installation].
 * {op-system} on s390x can be installed onto fixed-block architecture (FBA)-type direct access storage device (DASD) disks.
-
-* Multipathing is now supported during initial deployment and early boot for storage devices when attached to clusters that are created using {product-title} 4.7 or higher.
+* {op-system} now supports the primary disk being multipathed.
 
 [NOTE]
 ====
@@ -92,6 +91,13 @@ Previously, {op-system} DHCP kernel parameters were not working as expected beca
 ==== {op-system} supports multipath
 
 {op-system} now supports multipath on the primary disk, allowing stronger resilience to hardware failure so that you can set up {op-system} on top of multipath to achieve higher host availability. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1886229[*BZ#1886229*] for more information.
+
+[IMPORTANT]
+====
+Only enable multipathing with kernel arguments within a machine config as documented. Do not enable multipathing during installation.
+
+For more information, see "Enabling multipath with kernel arguments" in xref:../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Post-installation machine configuration tasks].
+====
 
 [id="ocp-4-7-rhcos-fetching-aws-from-imdsv2"]
 ==== Fetching configs on AWS from Instance Metadata Service Version 2 (IMDSv2)
@@ -2336,4 +2342,4 @@ link:https://access.redhat.com/solutions/6001181[{product-title} 4.7.9 container
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 
-the operator could modify 
+the operator could modify


### PR DESCRIPTION
Make it clearer that multipathing is only supported when activated using
the documented MachineConfig and that it must not be enabled before
this.