### PR TITLE
Add rbac-proxy step to Ansible/Helm OSDK tutorials

### DIFF
--- a/modules/osdk-prepare-supported-images.adoc
+++ b/modules/osdk-prepare-supported-images.adoc
@@ -12,10 +12,12 @@ endif::[]
 ifeval::["{context}" == "osdk-ansible-tutorial"]
 :ansible:
 :type: Ansible
+:type_lc: ansible
 endif::[]
 ifeval::["{context}" == "osdk-helm-tutorial"]
 :helm:
 :type: Helm
+:type_lc: helm
 endif::[]
 
 [id="osdk-prepare-supported-images_{context}"]
@@ -41,6 +43,28 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 ----
 
 . Depending on the Go project version, your Dockerfile might contain a `USER 65532:65532` or `USER nonroot:nonroot` directive. In either case, remove the line, as it is not required by the supported runner image.
+endif::[]
+
+ifdef::ansible,helm[]
+. Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
++
+[source,terminal,subs="attributes+"]
+----
+FROM quay.io/operator-framework/{type_lc}-operator:{osdk_ver}
+----
++
+to:
++
+[source,terminal,subs="attributes+"]
+----
+FROM registry.redhat.io/openshift4/ose-{type_lc}-operator:v{product-version}
+----
++
+[IMPORTANT]
+====
+Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
+====
+endif::[]
 
 . In the `config/default/manager_auth_proxy_patch.yaml` file, change the `image` value from:
 +
@@ -55,49 +79,6 @@ to use the supported image:
 ----
 registry.redhat.io/openshift4/ose-kube-rbac-proxy:v{product-version}
 ----
-endif::[]
-
-ifdef::ansible[]
-* Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM quay.io/operator-framework/ansible-operator:{osdk_ver}
-----
-+
-to:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM registry.redhat.io/openshift4/ose-ansible-operator:v{product-version}
-----
-+
-[IMPORTANT]
-====
-Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
-====
-endif::[]
-
-ifdef::helm[]
-* Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM quay.io/operator-framework/helm-operator:{osdk_ver}
-----
-+
-to:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM registry.redhat.io/openshift4/ose-helm-operator:v{product-version}
-----
-+
-[IMPORTANT]
-====
-Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
-====
-endif::[]
 
 :!osdk_ver:
 ifeval::["{context}" == "osdk-golang-tutorial"]
@@ -107,8 +88,10 @@ endif::[]
 ifeval::["{context}" == "osdk-ansible-tutorial"]
 :!ansible:
 :!type:
+:!type_lc:
 endif::[]
 ifeval::["{context}" == "osdk-helm-tutorial"]
 :!helm:
 :!type:
+:!type_lc:
 endif::[]


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/30624.

* The step about updating the rbac-proxy image was previously only in the Go version of the tutorial. This change makes the step visible for all 3 tutorials (Go, Ansible, Helm).
* Combined the Ansible/Helm-relevant steps about updating the builder image into a single step that uses ifdefs + attributes to reduce redundancy.

Preview build:

* [Go](https://deploy-preview-30702--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-prepare-supported-images_osdk-golang-tutorial)
* [Ansible](https://deploy-preview-30702--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-prepare-supported-images_osdk-ansible-tutorial)
* [Helm](https://deploy-preview-30702--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-prepare-supported-images_osdk-helm-tutorial)