### PR TITLE
search: add ROSA search support

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -188,7 +188,8 @@
     'openshift-dedicated': ['docs_dedicated', version],
     'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version],
-    'openshift-aro' : ['docs_aro']
+    'openshift-aro' : ['docs_aro', version],
+    'openshift-rosa' : ['docs_rosa']
   };
 
   distros[dk] ? hcSearchCategory.apply(null, distros[dk]) : hcSearchCategory("docs");


### PR DESCRIPTION
* Adds the new ROSA documentation search label.
* Adds the current version value for the ARO search label so that v3
  results are not returned when searching the almost empty ARO 4 docs.

---
@vikram-redhat, this should be included with the ROSA docs release; the search server is going to expect the `docs_rosa` label  (without any version number) in order to search for ROSA only.