### PR TITLE
GH#30718: Modify code block options in RHV playbooks module

### DIFF
--- a/modules/installation-rhv-downloading-ansible-playbooks.adoc
+++ b/modules/installation-rhv-downloading-ansible-playbooks.adoc
@@ -11,11 +11,11 @@ Download the Ansible playbooks for installing {product-title} version {product-v
 
 . On your installation machine, run the following commands:
 +
-[source,terminal]
+[source,terminal,subs=attributes+]
 ----
 $ mkdir playbooks
 $ cd playbooks
-$ curl -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt\?ref\=$release-{product-version} |
+$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-{product-version}  |
 grep 'download_url.*\.yml' |
 awk '{ print $2 }' | sed -r 's/("|",)//g' |
 xargs -n 1 curl -O


### PR DESCRIPTION
This change adds "subs=attributes+" to code block options.
As a result, attributes within the code block should render correctly.
Commit resolves #30718. 

@rolfedh Could you verify this and +1/-1 after the preview? Not sure if you'd also want QE to take a look. 