### PR TITLE
OSDOC-1983 - Move CSI Operator for GCE from TP to GA

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
@@ -10,7 +10,6 @@ toc::[]
 {product-title} can provision persistent volumes (PVs) using the Container Storage Interface (CSI) driver for Google Cloud Platform (GCP) persistent disk (PD) storage.
 
 :FeatureName: GCP PD CSI Driver Operator
-include::modules/technology-preview.adoc[leveloffset=+1]
 
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a Container Storage Interface (CSI) Operator and driver.
 


### PR DESCRIPTION
Moves GCE CSI Operator feature from TP to GA for 4.8.

OSDOCS: https://issues.redhat.com/browse/OSDOCS-1983
JIRA epic: https://issues.redhat.com/browse/STOR-255
Preview: https://deploy-preview-30740--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-gcp-pd.html

@qinpingli @bertinatto PTAL.