### PR TITLE
RHDEVDOCS-2847 publish release notes for OpenShift Logging 5.0.1

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -10,7 +10,8 @@ toc::[]
 
 The following advisories are available for {ProductName} 5.0:
 
-* link:https://errata.devel.redhat.com/docs/show/66974[RHBA-2020:66974-04 Errata Advisory for Openshift Logging 5.0.0]
+* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Errata Advisory for Openshift Logging 5.0.0]
+* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)]
 
 [id="openshift-logging-5-0-inclusive-language"]
 == Making open source more inclusive
@@ -18,4 +19,5 @@ The following advisories are available for {ProductName} 5.0:
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
 
 include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
-//include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
+// include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]

--- a/modules/cluster-logging-release-notes-5.0.0.adoc
+++ b/modules/cluster-logging-release-notes-5.0.0.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-0"]
 = OpenShift Logging 5.0.0
 
-This release includes Red Hat Bug Advisory, link:https://errata.devel.redhat.com/docs/show/66974[RHBA-2020:66974-04 Errata Advisory for Openshift Logging 5.0.0].
+This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Errata Advisory for Openshift Logging 5.0.0].
 
 [id="openshift-logging-5-0-new-features-and-enhancements"]
 == New features and enhancements
@@ -172,8 +172,6 @@ The current release fixes this issue. Now, when a rollover occurs in the `indexm
 * Previously, in some cases, the {ProductName}/Elasticsearch dashboard was missing from the {product-title} monitoring dashboard because the dashboard configuration resource referred to a different namespace owner and caused the {product-title} to garbage-collect that resource. Now, the ownership reference is removed from the Elasticsearch Operator reconciler configuration, and the logging dashboard appears in the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910259[*BZ#1910259*])
 
 * Previously, the code that uses environment variables to replace values in the Kibana configuration file did not consider commented lines. This prevented users from overriding the default value of server.maxPayloadBytes. The current release fixes this issue by uncommenting the default value of server.maxPayloadByteswithin. Now, users can override the value by using environment variables, as documented. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918876[*BZ#1918876*])
-
-* Previously, logs were not sent to managed storage when legacy log forwarding was enabled. This happened because the internal generation of the `logforwarding` configuration improperly made a decision for  either `logforwarding` or legacy `logforwarding`. The current release fixes this issue:  Logs are sent to managed storage when the logstore is defined in the `clusterlogging` instance.  Additionally, logs are sent to legacy `logforwarding` when enabled regardless of whether a managed logstore is enabled or not. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921263[*1921263*])
 
 * Previously, the Kibana log level was increased not to suppress instructions to delete indices that failed to migrate, which also caused the display of GET requests at the INFO level that contained the Kibana user's email address and OAuth token. The current release fixes this issue by masking these fields, so the Kibana logs do not display them. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925081[*BZ#1925081*])
 

--- a/modules/cluster-logging-release-notes-5.0.1.adoc
+++ b/modules/cluster-logging-release-notes-5.0.1.adoc
@@ -1,9 +1,18 @@
 [id="cluster-logging-release-notes-5-0-1"]
 = OpenShift Logging 5.0.1
 
-This release includes Red Hat Bug Advisory, link:https://errata.devel.redhat.com/docs/show/TBD[RHBA-TBD Errata Advisory for Openshift Logging 5.0.TBD].
+This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)].
 
 [id="openshift-logging-5-0-1-bug-fixes"]
 == Bug fixes
 
-* If you did not set `.proxy` in the cluster installation configuration, and then configured a global proxy on the installed cluster, a bug prevented Fluentd from forwarding logs to Elasticsearch. To work around this issue, in the proxy/cluster configuration, set `no_proxy` to `.svc.cluster.local` so it skips internal traffic. The current release fixes the proxy configuration issue. Now, if you configure the global proxy after installing an OpenShift cluster, Fluentd forwards logs to Elasticsearch. (link:https://issues.redhat.com/browse/LOG-1187[*LOG-1187*])
+* Previously, if you enabled legacy log forwarding, logs were not sent to managed storage. This issue occurred because the generated log forwarding configuration improperly chose between either log forwarding or legacy log forwarding. The current release fixes this issue. If the `ClusterLogging` CR defines a `logstore`, logs are sent to managed storage. Additionally, if legacy log forwarding is enabled, logs are sent to legacy log forwarding regardless of whether managed storage is enabled.
+(link:https://issues.redhat.com/browse/LOG-1172[*LOG-1172*])
+
+* Previously, while under load, Elasticsearch responded to some requests with an HTTP 500 error, even though there was nothing wrong with the cluster. Retrying the request was successful. This release fixes the issue by updating the cron jobs to be more resilient when encountering temporary HTTP 500 errors. Now, they will retry a request multiple times first before failing.
+(link:https://issues.redhat.com/browse/LOG-1215[*LOG-1215*])
+
+// Other bugs in this release that do not have release notes:
+//
+// * link:https://issues.redhat.com/browse/LOG-1169[*LOG-1169*] No icon for CLO and EO 5.0 on Operator hub
+// * https://issues.redhat.com/browse/LOG-1182[*LOG-1182*] Fix EO upgrade tests for 5.0

--- a/modules/cluster-logging-release-notes-5.0.2.adoc
+++ b/modules/cluster-logging-release-notes-5.0.2.adoc
@@ -1,0 +1,9 @@
+[id="cluster-logging-release-notes-5-0-2"]
+= OpenShift Logging 5.0.2
+
+This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)].
+
+[id="openshift-logging-5-0-2-bug-fixes"]
+== Bug fixes
+
+* If you did not set `.proxy` in the cluster installation configuration and then configured a global proxy on the installed cluster, a bug prevented Fluentd from forwarding logs to Elasticsearch. To work around this issue, in the proxy/cluster configuration, set `no_proxy` to `.svc.cluster.local` so it skips internal traffic. The current release fixes the proxy configuration issue. Now, if you configure the global proxy after installing an {product-title} cluster, Fluentd forwards logs to Elasticsearch. (link:https://issues.redhat.com/browse/LOG-1187[*LOG-1187*])


### PR DESCRIPTION
and begin staging 5.0.2

- For versions 4.7+
- https://issues.redhat.com/browse/RHDEVDOCS-2847
- Direct link to doc preview: https://deploy-preview-30741--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html
- Ready for peer review and merge