### PR TITLE
Replace the Fluentd DeploymentConfig and DaemonSet note to EFK upgrade

### DIFF
--- a/upgrading/automated_upgrades.adoc
+++ b/upgrading/automated_upgrades.adoc
@@ -872,6 +872,23 @@ You can set the `openshift_logging_elasticsearch_replace_configmap` parameter to
 `logging-elasticsearch` ConfigMap  with the current default values. In some cases, using an older
 ConfigMap can cause the upgrade to fail. The default is set to `false`. For more information, see the parameter
 in xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[specify logging Ansible variables].
++
+[NOTE]
+====
+If your Fluentd `*DeploymentConfig*` object and `*DaemonSet*` object for the EFK components are
+already set with:
+
+----
+        image: <image_name>:<vX.Y>
+        imagePullPolicy: IfNotPresent
+----
+
+The latest version `<image_name>` might not be pulled if there is already one with the same 
+`<image_name:vX.Y>` stored locally on the node where the pod is being re-deployed. 
+If your image version is v3.11, and you want to upgrade to the latest version using the playbook, 
+set the `openshift_image_tag=v3.11.<Z>` or 
+`oreg_url=registry.access.redhat.com/openshift3/ose-${component}:v3.11.<Z>` Ansible parameter.
+====
 
 . Dechedule your Fluentd pods to stop data ingestion and ensure the cluster state does not change.
 +
@@ -881,7 +898,7 @@ For example, you can change the node selector in Fluentd pods to one that does n
 oc patch daemonset logging-fluentd -p '{"spec": {"template": {"spec": {"nodeSelector": {"non-existing": "true"}}}}}'
 ----
 
-. Perform an link: https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-flush.html[Elasticsearch Index flush] on all relevant indices. The flush process persists all logs from memory to disk, which prevents log loss when Elasticsearch is shutdown during the upgrade.
+. Perform an link:https://www.elastic.co/guide/en/elasticsearch/reference/2.4/indices-flush.html[Elasticsearch Index flush] on all relevant indices. The flush process persists all logs from memory to disk, which prevents log loss when Elasticsearch is shutdown during the upgrade.
 
 . Perform an online or offline backup:
 
@@ -915,6 +932,44 @@ logging deployment.
 ==== Upgrading if fields do not have dots
 
 If the xref:upgrading-efk-logging-stack-script[script above] indicates your indices do not contain fields with a dot in the name, use the following steps to upgrade.
+
+. Review how to
+xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[specify logging Ansible variables]
+and update your Ansible inventory file to at least set the
+following required variable in the `[OSEv3:vars]` section:
++
+----
+[OSEv3:vars]
+
+openshift_logging_install_logging=true <1>
+----
+<1> Enables the ability to upgrade the logging stack.
+
+. Update any other `openshift_logging_*` variables that you want to override the
+default values for, as described in
+xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Specifying Logging Ansible Variables].
++
+You can set the `openshift_logging_elasticsearch_replace_configmap` parameter to `true` to replace your
+`logging-elasticsearch` ConfigMap  with the current default values. In some cases, using an older
+ConfigMap can cause the upgrade to fail. The default is set to `false`. For more information, see the parameter
+in xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[specify logging Ansible variables].
++
+[NOTE]
+====
+If your Fluentd `*DeploymentConfig*` object and `*DaemonSet*` object for the EFK components are
+already set with:
+
+----
+        image: <image_name>:<vX.Y>
+        imagePullPolicy: IfNotPresent
+----
+
+The latest version <image_name> might not be pulled if there is already one with the same 
+`<image_name:vX.Y>` stored locally on the node where the pod is being re-deployed. 
+If your image version is v3.11, and you want to upgrade to the latest version using the playbook, 
+set the `openshift_image_tag=v3.11.<Z>` or 
+`oreg_url=registry.access.redhat.com/openshift3/ose-${component}:v3.11.<Z>` Ansible parameter.
+====
 
 . Optionally, dechedule your Fluentd pods and scale down your Elasticsearch pods to stop data ingestion and ensure the cluster state does not change.
 +


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/21638

Do we need this note in the 3.11 EFK upgrade? 
```

If your Fluentd DeploymentConfig and DaemonSet for the EFK components are already set with: 

image: <image_name>:<vX.Y>         
imagePullPolicy: IfNotPresent    

The latest version <image_name> might not be pulled if there is already one with the same 
<image_name:vX.Y> stored locally on the node where the pod is being re-deployed. If so, manually 
change the DeploymentConfig and DaemonSet to imagePullPolicy: Always to make sure it is re-pulled.
```

Preview: 
https://deploy-preview-30755--osdocs.netlify.app/openshift-enterprise/latest/upgrading/automated_upgrades.html#upgrading-efk-logging-stack-dots
https://deploy-preview-30755--osdocs.netlify.app/openshift-enterprise/latest/upgrading/automated_upgrades.html#upgrading-efk-logging-stack-nodots