### PR TITLE
GitHub-29586: Added missing label from command

### DIFF
--- a/modules/deployments-ab-testing-lb.adoc
+++ b/modules/deployments-ab-testing-lb.adoc
@@ -214,7 +214,7 @@ The application is deployed and a service is created. This is the first shard.
 +
 [source,terminal]
 ----
-$ oc expose svc/ab-example-a --name=ab-example
+$ oc expose svc/ab-example-a --name=ab-example --labels=ab-example=true
 ----
 
 . Browse to the application at `ab-example-<project>.<router_domain>` to verify you see the `v1` image.


### PR DESCRIPTION
Fixes #29586

Preview: https://deploy-preview-30762--osdocs.netlify.app/openshift-enterprise/latest/applications/deployments/route-based-deployment-strategies.html#deployments-ab-one-service-multi-dc_route-based-deployment-strategies