### PR TITLE
ISSUE-3055 Minor change

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -16,4 +16,4 @@ include::modules/understanding-machine-config-operator.adoc[leveloffset=+3]
 
 .Additional information
 
-For information on preventing the control plane machines from after the Machine Config Operator makes changes to the machine config, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].
+For information on preventing the control plane machines from rebooting after the Machine Config Operator makes changes to the machine config, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling Machine Config Operator from automatically rebooting].


### PR DESCRIPTION
Applies to 4.7+
Link to Issue: https://github.com/openshift/openshift-docs/issues/30555
Minor change, no QE needed. It was a grammar issue in the sentence. 
Preview Link: https://deploy-preview-30768--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#understanding-machine-config-operator_control-plane (Additional Information section). 