### PR TITLE
ISSUE-27987 - add ordering note and disable dhcp example

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -24,6 +24,11 @@ When adding networking arguments, you must also add the `rd.neednet=1` kernel ar
 
 The following table describes how to use `ip=`, `nameserver=`, and `bond=` kernel arguments for live ISO installs.
 
+[NOTE]
+====
+Ordering is important when adding kernel arguments: `ip=`, `nameserver=`, and then `bond=`.
+====
+
 .Routing and bonding options for ISO
 |===
 |Description |Examples
@@ -47,6 +52,13 @@ a|
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
+----
+
+a|Disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used.
+a|
+----
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
+ip=::::core0.example.com:enp2s0:none
 ----
 
 a|You can combine DHCP


### PR DESCRIPTION
Proposed fix for https://github.com/openshift/openshift-docs/issues/27987
Adds note about importance of karg ordering, as well as a suggested example for disabling dhcp. Current doc: [Routing and bonding options at RHCOS boot prompt](https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-static-network_installing-bare-metal) - section was added in OCP 4.6, so this applies to 4.6+.

PREVIEW BUILD: https://deploy-preview-30773--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-static-network_installing-bare-metal