### PR TITLE
GH#29832 Compute machines can use RHEL too

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -72,8 +72,7 @@ these cluster machines.
 endif::ibm-z[]
 ====
 
-The bootstrap, control plane, and compute machines must use the {op-system-first} as the
-operating system.
+The bootstrap and control plane machines must use {op-system-first} as the operating system.
 
 ifndef::openshift-origin[]
 Note that {op-system} is based on {op-system-base-full} 8 and inherits all of its hardware certifications and requirements.


### PR DESCRIPTION
Resolves #29832

Preview: https://deploy-preview-30782--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#machine-requirements_installing-restricted-networks-vsphere