### PR TITLE
GitHub-26681: Noted new flag for JDK 11+

### DIFF
--- a/modules/nodes-cluster-resource-configure-jdk.adoc
+++ b/modules/nodes-cluster-resource-configure-jdk.adoc
@@ -39,6 +39,11 @@ There are at least two ways the above can be achieved:
    supported by the JVM, set `-XX:+UnlockExperimentalVMOptions
    -XX:+UseCGroupMemoryLimitForHeap`.
 +
+[NOTE]
+====
+The `UseCGroupMemoryLimitForHeap` option has been removed in JDK 11. Use `-XX:+UseContainerSupport` instead.
+====
++
 This sets `-XX:MaxRAM` to the container memory limit, and the maximum heap size
 (`-XX:MaxHeapSize` / `-Xmx`) to 1/`-XX:MaxRAMFraction` (1/4 by default).
 
@@ -101,6 +106,11 @@ maven slave image sets:
 JAVA_TOOL_OPTIONS="-XX:+UnlockExperimentalVMOptions
 -XX:+UseCGroupMemoryLimitForHeap -Dsun.zip.disableMemoryMapping=true"
 ----
+
+[NOTE]
+====
+The `UseCGroupMemoryLimitForHeap` option has been removed in JDK 11. Use `-XX:+UseContainerSupport` instead.
+====
 
 This does not guarantee that additional options are not required, but is
 intended to be a helpful starting point.


### PR DESCRIPTION
Fixes #26681

Preview: https://deploy-preview-30784--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure.html#nodes-cluster-resource-configure-jdk-heap_nodes-cluster-resource-configure