### PR TITLE
Removing `the` from `the CDI` as needed

### DIFF
--- a/modules/virt-about-preallocation.adoc
+++ b/modules/virt-about-preallocation.adoc
@@ -7,7 +7,7 @@
 
 The Containerized Data Importer (CDI) can use the QEMU preallocate mode for data volumes to improve write performance. You can use preallocation mode for importing and uploading operations and when creating blank data volumes.
 
-If preallocation is enabled, the CDI uses the better preallocation method depending on the underlying file system and device type:
+If preallocation is enabled, CDI uses the better preallocation method depending on the underlying file system and device type:
 
 `fallocate`::
 If the file system supports it, CDI uses the operating system's `fallocate` call to preallocate space by using the `posix_fallocate` function, which allocates blocks and marks them as uninitialized. 

--- a/modules/virt-how-fs-overhead-affects-space-vm-disks.adoc
+++ b/modules/virt-how-fs-overhead-affects-space-vm-disks.adoc
@@ -10,6 +10,6 @@ When you add a virtual machine disk to a persistent volume claim (PVC) that uses
 * The virtual machine disk.
 * The space that the Containerized Data Importer (CDI) reserves for file system overhead, such as metadata.
 
-By default, the CDI reserves 5.5% of the PVC space for overhead, reducing the space available for virtual machine disks by that amount.
+By default, CDI reserves 5.5% of the PVC space for overhead, reducing the space available for virtual machine disks by that amount.
 
 If a different value works better for your use case, you can configure the overhead value by editing the `CDI` object. You can change the value globally and you can specify values for specific storage classes.

--- a/modules/virt-operations-requiring-scratch-space.adoc
+++ b/modules/virt-operations-requiring-scratch-space.adoc
@@ -10,7 +10,7 @@
 | Type | Reason
 
 | Registry imports 
-| The CDI must download the image to a scratch space and extract the layers to find the image file. The image file is then passed to QEMU-IMG for conversion to a raw disk.
+| CDI must download the image to a scratch space and extract the layers to find the image file. The image file is then passed to QEMU-IMG for conversion to a raw disk.
 
 | Upload image 
 | QEMU-IMG does not accept input from STDIN. Instead, the image to upload is saved in scratch space before it can be passed to QEMU-IMG for conversion. 
@@ -22,5 +22,5 @@
 | QEMU-IMG inadequately handles authentication. Instead, the image is saved to scratch space and authenticated before it is passed to QEMU-IMG.
 
 | HTTP imports of custom certificates 
-| QEMU-IMG inadequately handles custom certificates of HTTPS endpoints. Instead, the CDI downloads the image to scratch space before passing the file to QEMU-IMG.
+| QEMU-IMG inadequately handles custom certificates of HTTPS endpoints. Instead, CDI downloads the image to scratch space before passing the file to QEMU-IMG.
 |===

--- a/modules/virt-understanding-scratch-space.adoc
+++ b/modules/virt-understanding-scratch-space.adoc
@@ -6,7 +6,7 @@
 = Understanding scratch space
 
 The Containerized Data Importer (CDI) requires scratch space (temporary storage) to complete some operations, such as importing and uploading virtual machine images.
-During this process, the CDI provisions a scratch space PVC equal to the size of the PVC backing the destination data volume (DV).
+During this process, CDI provisions a scratch space PVC equal to the size of the PVC backing the destination data volume (DV).
 The scratch space PVC is deleted after the operation completes or aborts.
 
 You can define the storage class that is used to bind the scratch space PVC in the `spec.config.scratchSpaceStorageClass` field of the `CDI` object.
@@ -16,12 +16,12 @@ If there is no default storage class defined in the cluster, the storage class u
 
 [NOTE]
 ====
-The CDI requires requesting scratch space with a `file` volume mode, regardless of the PVC backing the origin data volume.
+CDI requires requesting scratch space with a `file` volume mode, regardless of the PVC backing the origin data volume.
 If the origin PVC is backed by `block` volume mode, you must define a storage class capable of provisioning `file` volume mode PVCs.
 ====
 
 [discrete]
 == Manual provisioning
 
-If there are no storage classes, the CDI will use any PVCs in the project that match the size requirements for the image.
-If there are no PVCs that match these requirements, the CDI import pod will remain in a *Pending* state until an appropriate PVC is made available or until a timeout function kills the pod.
+If there are no storage classes, CDI uses any PVCs in the project that match the size requirements for the image.
+If there are no PVCs that match these requirements, the CDI import pod remains in a *Pending* state until an appropriate PVC is made available or until a timeout function kills the pod.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/21699

We have multiple uses of `the CDI`, where the preferred/proper terminology doesn't use `the`. See: https://kubevirt.io/2018/containerized-data-importer.html