### PR TITLE
BZ185249 - Added the `\A` parameter to the templates documentation.

### DIFF
--- a/modules/templates-writing-parameters.adoc
+++ b/modules/templates-writing-parameters.adoc
@@ -63,13 +63,44 @@ characters long consisting of all upper and lowercase alphabet letters
 and numbers.
 
 The syntax available is not a full regular expression syntax. However, you can
-use `\w`, `\d`, and `\a` modifiers:
+use `\w`, `\d`, `\a`, and `\A` modifiers:
 
 - `[\w]{10}` produces 10 alphabet characters, numbers, and underscores. This
 follows the PCRE standard and is equal to `[a-zA-Z0-9_]{10}`.
 - `[\d]{10}` produces 10 numbers. This is equal to `[0-9]{10}`.
 - `[\a]{10}` produces 10 alphabetical characters. This is equal to
 `[a-zA-Z]{10}`.
+- `[\A]{10}` produces 10 punctuation or symbol characters. This is equal to ``[~!@#$%^&*()-_+={}[]\|<,>.?/"';:`]{10}``.
+
+[NOTE]
+====
+Depending on if the template is written in YAML or JSON, and the type of string that the modifier is embedded within, you might need to escape the backslash with a second backslash. The following examples are equivalent:
+
+.Example YAML template with a modifier
+[source,yaml]
+----
+  parameters:
+  - name: singlequoted_example
+    generate: expression
+    from: '[\A]{10}'
+  - name: doublequoted_example
+    generate: expression
+    from: "[\\A]{10}"
+----
+
+.Example JSON template with a modifier
+[source,json]
+----
+{
+    "parameters": [
+       {"name": "json_example",
+        "generate": "expression",
+        "from": "[\\A]{10}"
+       }
+    ]
+}
+----
+====
 
 Here is an example of a full template with parameter definitions and references:
 


### PR DESCRIPTION
This PR addresses the referenced BZ ticket (https://bugzilla.redhat.com/show_bug.cgi?id=1858240). There is also a Customer Portal ticket as well (https://access.redhat.com/solutions/5231811). Fixes https://github.com/openshift/openshift-docs/issues/23903

This change affects versions OCP 4.5+.

Added the `\A` parameter to the "Writing Template Parameters" section of the Images documentation: https://deploy-preview-30790--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/using-templates.html#templates-writing-parameters_using-templates

