### PR TITLE
Add Win/Mac disclaimer for oc adm catalog build usage

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -16,10 +16,15 @@ Cluster administrators can build a custom Operator catalog image based on the Pa
 
 For this example, the procedure assumes use of a mirror registry that has access to both your network and the Internet.
 
+[NOTE]
+====
+Only the Linux version of the `oc` client can be used for this procedure, because the Windows and macOS versions do not provide the `oc adm catalog build` command. 
+====
+
 .Prerequisites
 
 * Workstation with unrestricted network access
-* `oc` version 4.3.5+
+* `oc` version 4.3.5+ Linux client
 * `podman` version 1.9.3+
 * Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -16,10 +16,15 @@ After a cluster administrator has configured OperatorHub to use custom Operator 
 
 For this example, the procedure assumes a custom `redhat-operators` catalog image is already configured for use with OperatorHub.
 
+[NOTE]
+====
+Only the Linux version of the `oc` client can be used for this procedure, because the Windows and macOS versions do not provide the `oc adm catalog build` command.
+====
+
 .Prerequisites
 
 * Workstation with unrestricted network access
-* `oc` version 4.3.5+
+* `oc` version 4.3.5+ Linux client
 * `podman` version 1.9.3+
 * Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 * OperatorHub configured to use custom catalog images


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/27696.

Preview build:

* [Building a Package Manifest Format catalog image](https://deploy-preview-30802--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-building-operator-catalog-image_olm-managing-custom-catalogs)
* [Updating a Package Manifest Format catalog image](https://deploy-preview-30802--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-updating-operator-catalog-image_olm-managing-custom-catalogs)

The note will also appear in the 4.5 version of [Using Operator Lifecycle Manager on restricted networks](https://docs.openshift.com/container-platform/4.5/operators/admin/olm-restricted-networks.html) after this has been cherrypicked to the `enterprise-4.5` branch.