### PR TITLE
CNV-10094: bumping HCO version for 2.5.5

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.5
 :KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.4
+:HCOVersion: 2.5.5
 // :LastHCOVersion: 2.4.4
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- [CNV-10094](https://issues.redhat.com/browse/CNV-10094)
- [Usage example](https://deploy-preview-30819--osdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-upgrade-pathways-2.4.4_upgrading-virt): the heading "Upgrading from 2.4.4 or 2.4.5 to 2.5.5" uses the `{HCOVersion}` attribute.
- Bumping HCO version due to minor release
- No cherrypick