### PR TITLE
Replaced obsolete URL https://mirror.openshift.com/pub/openshift-v4/o…

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -60,7 +60,7 @@ You can install the OpenShift CLI (`oc`) binary on Linux by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/ and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
@@ -98,7 +98,7 @@ You can install the OpenShift CLI (`oc`) binary on Windows by using the followin
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/ and choose the folder for your operating system and architecture.
 . Download `oc.zip`.
 endif::[]
 ifndef::openshift-origin[]
@@ -131,7 +131,7 @@ You can install the OpenShift CLI (`oc`) binary on macOS by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/ and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]


### PR DESCRIPTION
…c/latest with the new URL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/

Per: 
https://github.com/openshift/openshift-docs/issues/30745#issuecomment-804882784