### PR TITLE
RHDEVDOCS-2858 Users are no longer forced to choose between the internal OR external log store

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-fluentd_{context}"]
 = Forwarding logs using the legacy Fluentd method
 
-You can use the Fluentd *forward* protocol to send logs to destinations outside of your {product-title} cluster instead of the default Elasticsearch log store by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the Fluentd *forward* protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 [IMPORTANT]
 ====

--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-syslog_{context}"]
 = Forwarding logs using the legacy syslog method
 
-You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster instead of the default Elasticsearch log store by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
- For versions 4.5+
- https://issues.redhat.com/browse/RHDEVDOCS-2858
- Direct link to doc preview: https://deploy-preview-30832--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-legacy-fluentd_cluster-logging-external
- Direct link to doc preview: https://deploy-preview-30832--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-legacy-syslog_cluster-logging-external
- Ready for peer review and merge