### PR TITLE
Add .small class to version headers

### DIFF
--- a/modules/life-cycle-major-versions.adoc
+++ b/modules/life-cycle-major-versions.adoc
@@ -3,7 +3,7 @@
 // * rosa_policy/rosa-life-cycle.adoc
 
 [id="rosa-major-versions_{context}"]
-= Major versions (X.y.z)
+= Major versions [.small]#X.y.z#
 
 Major versions of {product-title}, for example version 4, are supported for one year following the release of a subsequent major version or the retirement of the product.
 

--- a/modules/life-cycle-minor-versions.adoc
+++ b/modules/life-cycle-minor-versions.adoc
@@ -3,7 +3,7 @@
 // * rosa_policy/rosa-life-cycle.adoc
 
 [id="rosa-minor-versions_{context}"]
-= Minor versions (x.Y.z)
+= Minor versions [.small]#x.Y.z#
 
 Red Hat supports two minor versions of the major release.
 

--- a/modules/life-cycle-patch-versions.adoc
+++ b/modules/life-cycle-patch-versions.adoc
@@ -3,7 +3,7 @@
 // * rosa_policy/rosa-life-cycle.adoc
 
 [id="rosa-patch-versions_{context}"]
-= Patch versions (x.y.Z)
+= Patch versions [.small]#x.y.Z#
 
 During the period in which a minor release is supported, all OpenShift Container Platform patch releases will be supported unless otherwise specified.
 


### PR DESCRIPTION
Provide better visual formatting. The `(X.y.z)` stuff isn't _important_, more of just a hint.