### PR TITLE
OSDOCS-1991: Removed Accessing AWS Infrastructure assembly from ROSA

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -59,8 +59,6 @@ Distros: openshift-rosa
 Topics:
 - Name: Understanding cloud infrastructure access
   File: rosa-understanding-aws
-- Name: Accessing AWS infrastructure
-  File: dedicated-aws-access
 - Name: Configuring AWS VPC peering
   File: dedicated-aws-peering
 - Name: Configuring AWS VPN

--- a/cloud_infrastructure_access/dedicated-aws-dc.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-dc.adoc
@@ -2,6 +2,7 @@
 = Configuring AWS Direct Connect
 include::modules/common-attributes.adoc[]
 :context: dedicated-aws-direct-connect
+
 toc::[]
 
 This process describes accepting an AWS Direct Connect virtual interface with

--- a/cloud_infrastructure_access/dedicated-aws-peering.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-peering.adoc
@@ -2,6 +2,7 @@
 = Configuring AWS VPC peering
 include::modules/common-attributes.adoc[]
 :context: dedicated-aws-peering
+
 toc::[]
 
 This sample process configures an Amazon Web Services (AWS) VPC containing an
@@ -13,9 +14,12 @@ guide.
 
 include::modules/dedicated-aws-vpc-peering-terms.adoc[leveloffset=+1]
 include::modules/dedicated-aws-vpc-initiating-peering.adoc[leveloffset=+1]
+
+ifdef::openshift-dedicated[]
 .Additional resources
 
-* xref:../cloud_infrastructure_access/dedicated-aws-access.adoc#dedicated-aws-ocm-iam-role[Logging into the Web Console for the OSD AWS Account]
+* xref:../cloud_infrastructure_access/dedicated-aws-access.adoc#dedicated-aws-ocm-iam-role[Logging into the Web Console for the AWS Account]
+endif::[]
 
 include::modules/dedicated-aws-vpc-accepting-peering.adoc[leveloffset=+1]
 include::modules/dedicated-aws-vpc-configuring-routing-tables.adoc[leveloffset=+1]

--- a/cloud_infrastructure_access/dedicated-aws-vpn.adoc
+++ b/cloud_infrastructure_access/dedicated-aws-vpn.adoc
@@ -2,6 +2,7 @@
 = Configuring AWS VPN
 include::modules/common-attributes.adoc[]
 :context: dedicated-aws-vpn
+
 toc::[]
 
 This sample process configures an Amazon Web Services (AWS) {product-title}

--- a/cloud_infrastructure_access/rosa-private-cluster.adoc
+++ b/cloud_infrastructure_access/rosa-private-cluster.adoc
@@ -1,9 +1,9 @@
-include::modules/attributes-openshift-dedicated.adoc[]
 [id="rosa-private-cluster"]
-:context: rosa-private-cluster
-toc::[]
-
 = Configuring a private cluster
+include::modules/attributes-openshift-dedicated.adoc[]
+:context: rosa-private-cluster
+
+toc::[]
 
 An {product-title} cluster can be made private so that internal applications can be hosted inside a corporate network. In addition, private clusters can be configured to have only internal API endpoints for increased security.
 

--- a/cloud_infrastructure_access/rosa-understanding-aws.adoc
+++ b/cloud_infrastructure_access/rosa-understanding-aws.adoc
@@ -1,18 +1,18 @@
-:context: dedicated-understanding-aws
-[id="welcome-index"]
+[id="rosa-understanding-cloud-infra-access"]
 = Understanding cloud infrastructure access
-include::modules/common-attributes.adoc[]
+include::modules/attributes-openshift-dedicated.adoc[]
+:context: rosa-understanding-aws
+
+toc::[]
 
 Amazon Web Services (AWS) infrastructure access permits link:https://access.redhat.com/node/3610411[Customer Portal Organization Administrators] and cluster owners to enable AWS Identity and Access Management (IAM) users to
 have federated access to the AWS Management Console for their {product-title} (ROSA) cluster.
 
-[id="enabling-aws-access"]
-== Enabling AWS access
-AWS access can be granted for customer AWS users, and private cluster access can be implemented to suit the needs of your ROSA environment.
+[id="establishing-private-connecton-aws"]
+== Establishing a private connection
+Private cluster access can be implemented to suit the needs of your ROSA environment.
 
-Get started with xref:../cloud_infrastructure_access/dedicated-aws-access.adoc#dedicated-aws-access[Accessing AWS infrastructure] for your ROSA cluster. By creating an AWS user and account and providing that user with access to the ROSA AWS account.
-
-After you have access to the ROSA AWS account, use one or more of the following methods to establish a private connection to your cluster:
+Access your ROSA AWS account and use one or more of the following methods to establish a private connection to your cluster:
 
 - xref:../cloud_infrastructure_access/dedicated-aws-peering.adoc#dedicated-aws-peering[Configuring AWS VPC peering]: Enable VPC peering to route network traffic between two private IP addresses.
 
@@ -20,4 +20,4 @@ After you have access to the ROSA AWS account, use one or more of the following 
 
 - xref:../cloud_infrastructure_access/dedicated-aws-dc.adoc#dedicated-aws-dc[Configuring AWS Direct Connect]: Configure AWS Direct Connect to establish a dedicated network connection between your private network and an AWS Direct Connect location.
 
-After configuring your cloud infrastructure access, learn more about xref:../cloud_infrastructure_access/rosa-private-cluster.adoc[Configuring a private cluster].
+After configuring your cloud infrastructure access, learn more about xref:../cloud_infrastructure_access/rosa-private-cluster.adoc#rosa-private-cluster[Configuring a private cluster].


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-1991

No QE needed. Removed the assembly per SME request because it does not apply to ROSA.