### PR TITLE
Small typo in 'Routes' module

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -104,7 +104,7 @@ directed to different servers. This algorithm is generally
 used with passthrough routes.
 
 The `ROUTER_TCP_BALANCE_SCHEME` xref:env-variables[environment variable] sets the default
-strategy for passthorugh routes. The `ROUTER_LOAD_BALANCE_ALGORITHM` xref:env-variables[environment
+strategy for passthrough routes. The `ROUTER_LOAD_BALANCE_ALGORITHM` xref:env-variables[environment
 variable] sets the default strategy for the router for the remaining routes.
 A xref:route-specific-annotations[route specific annotation],
 `*haproxy.router.openshift.io/balance*`, can be used to control specific routes.


### PR DESCRIPTION
Fixes a small typo in the 'Routes' module. No BZ. 

Preview available at https://deploy-preview-30854--osdocs.netlify.app/openshift-enterprise/latest/architecture/networking/routes.html