### PR TITLE
Add procedure for removing custom Operator catalogs

### DIFF
--- a/modules/olm-removing-catalogs.adoc
+++ b/modules/olm-removing-catalogs.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-custom-catalogs.adoc
+
+[id="olm-removing-catalogs_{context}"]
+= Removing custom catalogs
+
+As a cluster administrator, you can remove custom Operator catalogs that have been previously added to your cluster by deleting the related catalog source.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Administration* -> *Cluster Settings*.
+
+. Click the *Global Configuration* tab, and then click *OperatorHub*.
+
+. Click the *Sources* tab.
+
+. Select the *Options* menu {kebab} for the catalog that you want to remove, and then click *Delete CatalogSource*.

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -6,10 +6,23 @@
 // * migration/migrating_4_1_4/deploying-cam-4-1-4.adoc
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 
+ifeval::["{context}" == "olm-restricted-networks"]
+:olm-restricted-networks:
+endif::[]
+ifeval::["{context}" == "olm-managing-custom-catalogs"]
+:olm-managing-custom-catalogs:
+endif::[]
+
 [id="olm-restricted-networks-operatorhub_{context}"]
 = Disabling the default OperatorHub sources
 
-Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation. Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs as a cluster administrator.
+Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation.
+ifdef::olm-restricted-networks[]
+Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs as a cluster administrator.
+endif::[]
+ifdef::olm-managing-custom-catalogs[]
+As a cluster administrator, you can disable the set of default catalogs.
+endif::[]
 
 .Procedure
 
@@ -25,3 +38,10 @@ $ oc patch OperatorHub cluster --type json \
 ====
 Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Global Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, delete, disable, and enable individual sources.
 ====
+
+ifeval::["{context}" == "olm-restricted-networks"]
+:!olm-restricted-networks:
+endif::[]
+ifeval::["{context}" == "olm-managing-custom-catalogs"]
+:!olm-managing-custom-catalogs:
+endif::[]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -53,3 +53,6 @@ include::modules/olm-accessing-images-private-registries.adoc[leveloffset=+1]
 * See xref:../../cicd/builds/creating-build-inputs.adoc#builds-secrets-overview_creating-build-inputs[What is a secret?] for more information on the types of secrets, including those used for registry credentials.
 * See xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret] for more details on the impact of changing this secret.
 * See xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries] for more details on linking pull secrets to service accounts per namespace.
+
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+include::modules/olm-removing-catalogs.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/28108.

Preview build:

* [Disabling the default OperatorHub sources](https://deploy-preview-30884--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs) (existing section now shared in the "Managing custom catalogs" topic)
* [Removing custom catalogs](https://deploy-preview-30884--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-removing-catalogs_olm-managing-custom-catalogs) (new)

