### PR TITLE
Clarify channel name usage in Operator install via CLI

### DIFF
--- a/modules/olm-changing-update-channel.adoc
+++ b/modules/olm-changing-update-channel.adoc
@@ -7,7 +7,7 @@
 
 The subscription of an installed Operator specifies an update channel, which is used to track and receive updates for the Operator. To upgrade the Operator to start tracking and receiving updates from a newer channel, you can change the update channel in the subscription.
 
-The names of update channels in a subscription can differ between Operators, but the naming scheme should follow a common convention within a given Operator. For example, channel names might follow a minor release update stream for the application provided by the Operator (`1.2`, `1.3`) or a simple release frequency (`stable`, `fast`).
+The names of update channels in a subscription can differ between Operators, but the naming scheme should follow a common convention within a given Operator. For example, channel names might follow a minor release update stream for the application provided by the Operator (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
 
 [NOTE]
 ====

--- a/modules/olm-dependency-resolution-preferences.adoc
+++ b/modules/olm-dependency-resolution-preferences.adoc
@@ -37,7 +37,7 @@ There are two rules that govern catalog preference:
 [id="olm-dependency-catalog-ordering_{context}"]
 == Channel ordering
 
-An Operator package in a catalog is a collection of update channels that a user can subscribe to in a {product-title} cluster. Channels can be used to provide a particular stream of updates for a minor release (`1.2`, `1.3`) or a simple release frequency (`stable`, `fast`).
+An Operator package in a catalog is a collection of update channels that a user can subscribe to in a {product-title} cluster. Channels can be used to provide a particular stream of updates for a minor release (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
 
 It is likely that a dependency might be satisfied by Operators in the same package, but different channels. For example, version `1.2` of an Operator might exist in both the `stable` and `fast` channels.
 

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -114,15 +114,16 @@ metadata:
   name: <subscription_name>
   namespace: openshift-operators <1>
 spec:
-  channel: alpha
-  name: <operator_name> <2>
-  source: redhat-operators <3>
-  sourceNamespace: openshift-marketplace <4>
+  channel: <channel_name> <2>
+  name: <operator_name> <3>
+  source: redhat-operators <4>
+  sourceNamespace: openshift-marketplace <5>
 ----
 <1> For `AllNamespaces` install mode usage, specify the `openshift-operators` namespace. Otherwise, specify the relevant single namespace for `SingleNamespace` install mode usage.
-<2> Name of the Operator to subscribe to.
-<3> Name of the catalog source that provides the Operator.
-<4> Namespace of the catalog source. Use `openshift-marketplace` for the default OperatorHub catalog sources.
+<2> Name of the channel to subscribe to.
+<3> Name of the Operator to subscribe to.
+<4> Name of the catalog source that provides the Operator.
+<5> Namespace of the catalog source. Use `openshift-marketplace` for the default OperatorHub catalog sources.
 
 . Create the `Subscription` object:
 +

--- a/modules/olm-subscription.adoc
+++ b/modules/olm-subscription.adoc
@@ -26,4 +26,6 @@ spec:
 
 This `Subscription` object defines the name and namespace of the Operator, as well as the catalog from which the Operator data can be found. The channel, such as `alpha`, `beta`, or `stable`, helps determine which Operator stream should be installed from the catalog source.
 
+The names of channels in a subscription can differ between Operators, but the naming scheme should follow a common convention within a given Operator. For example, channel names might follow a minor release update stream for the application provided by the Operator (`1.2`, `1.3`) or a release frequency (`stable`, `fast`).
+
 In addition to being easily visible from the {product-title} web console, it is possible to identify when there is a newer version of an Operator available by inspecting the status of the related subscription. The value associated with the `currentCSV` field is the newest version that is known to OLM, and `installedCSV` is the version that is installed on the cluster.

--- a/operators/user/olm-installing-operators-in-namespace.adoc
+++ b/operators/user/olm-installing-operators-in-namespace.adoc
@@ -26,7 +26,8 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+1]
 .Additional resources
 
-* xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-about_olm-understanding-operatorgroups[About Operator groups]
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-operatorgroups-about_olm-understanding-olm[Operator groups]
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-subscription_olm-understanding-olm[Channel names]
 
 include::modules/olm-installing-specific-version-cli.adoc[leveloffset=+1]
 .Additional resources


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/28402.

Preview build:

* [Installing from OperatorHub using the CLI](https://deploy-preview-30901--osdocs.netlify.app/openshift-enterprise/latest/operators/user/olm-installing-operators-in-namespace.html#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace)