### PR TITLE
RHDEVDOCS-2600 Manage info about supported Elasticsearch versions to …

### DIFF
--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-es_{context}"]
 = Forwarding logs to an external Elasticsearch instance
 
-You can optionally forward logs to an external Elasticsearch v5.x or v6.x instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can optionally forward logs to an external Elasticsearch instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 To configure log forwarding to an external Elasticsearch instance, create a `ClusterLogForwarder` custom resource (CR) with an output to that instance and a pipeline that uses the output. The external Elasticsearch output can use the HTTP (insecure) or HTTPS (secure HTTP) connection.
 

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -10,7 +10,7 @@ Forwarding cluster logs to external third-party systems requires a combination o
 * An _output_ is the destination for log data that you define, or where you want the logs sent. An output can be one of the following types:
 +
 --
-* `elasticsearch`. An external Elasticsearch v5.x or v6.x instance. The `elasticsearch` output can use a TLS connection.
+* `elasticsearch`. An external Elasticsearch instance. The `elasticsearch` output can use a TLS connection.
 
 * `fluentdForward`. An external log aggregation solution that supports Fluentd. This option uses the Fluentd *forward* protocols.  The `fluentForward` output can use a TCP or TLS connection and supports shared-key authentication by providing a *shared_key* field in a secret. Shared-key authentication can be used with or without TLS.
 


### PR DESCRIPTION
- For versions 4.7+
- https://issues.redhat.com/browse/RHDEVDOCS-2600
- Direct link to doc preview: 
  - https://deploy-preview-30906--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-es_cluster-logging-external
  - https://deploy-preview-30906--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forwarding-about_cluster-logging-external
- Ready for peer review and merge
- Please merge when ready