### PR TITLE
Play commit to show json-doc codebloc lang

### DIFF
--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -45,7 +45,7 @@ plug-in:
 
 // containernetworking/plugins/.../host-device.go#L50
 .host-device CNI plug-in JSON configuration object
-[source,json]
+[source,json-doc]
 ----
 {
   "cniVersion": "0.3.1",


### PR DESCRIPTION
If we can add a test to confirm that the foll markup
works, we can avoid showing ellipses in JSON as
an error.

```asciidoc
[source,json-doc]
----
{
  ...
}
```

/hold