### PR TITLE
GitHub-27741: Removing additional fields from new machine config

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -183,7 +183,7 @@ $ oc get machine clustername-8qw5l-master-0 \ <1>
 ----
 <1> Specify the name of the master machine for the unhealthy node.
 
-.. Edit the `new-master-machine.yaml` file that was created in the previous step.
+.. Edit the `new-master-machine.yaml` file that was created in the previous step to assign a new name and remove unnecessary fields.
 
 ... Remove the entire `status` section:
 +
@@ -217,14 +217,7 @@ status:
     kind: AWSMachineProviderStatus
 ----
 
-... Remove the `providerID` field:
-+
-[source,yaml]
-----
-  providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
-----
-
-... Change the `name` field to a new name.
+... Change the `metadata.name` field to a new name.
 +
 It is recommended to keep the same base name as the old machine and change the ending number to the next available number. In this example, `clustername-8qw5l-master-0` is changed to `clustername-8qw5l-master-3`.
 +
@@ -240,7 +233,7 @@ metadata:
   ...
 ----
 
-... Update the `selfLink` field to use the new machine name from the previous step.
+... Update the `metadata.selfLink` field to use the new machine name from the previous step.
 +
 [source,yaml]
 ----
@@ -250,6 +243,31 @@ metadata:
   ...
   selfLink: /apis/machine.openshift.io/v1beta1/namespaces/openshift-machine-api/machines/clustername-8qw5l-master-3
   ...
+----
+
+... Remove the `spec.providerID` field:
++
+[source,yaml]
+----
+  providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
+----
+
+... Remove the `metadata.annotations` and `metadata.generation` fields:
++
+[source,yaml]
+----
+  annotations:
+    machine.openshift.io/instance-state: running
+  ...
+  generation: 2
+----
+
+... Remove the `metadata.resourceVersion` and `metadata.uid` fields:
++
+[source,yaml]
+----
+  resourceVersion: "13291"
+  uid: a282eb70-40a2-4e89-8009-d05dd420d31a
 ----
 
 .. Delete the machine of the unhealthy member:


### PR DESCRIPTION
Fixes #27741.

Preview: https://deploy-preview-30922--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member