### PR TITLE
GitHub-27506: Removing the page history link from the ARO docs

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -83,7 +83,7 @@
         <%= breadcrumb_topic %>
       </li>
 
-      <% if (distro_key != "openshift-origin") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro") %>
       <span text-align="right" style="float: right !important">
         <a href="https://github.com/openshift/openshift-docs/commits/enterprise-<%= (distro_key == "openshift-enterprise") ? version : ((distro_key == "openshift-dedicated") ? ((version == "4") ? "4.3" : "3.11") : "3.11") %>/<%= repo_path %>">
           Page history


### PR DESCRIPTION
This relates to GitHub issue https://github.com/openshift/openshift-docs/issues/27506.

The PR removes the "Page history" link from the ARO documentation.