### PR TITLE
GH#30879: Adding a note about SSH keys and FIPS-enabled clusters

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -198,15 +198,11 @@ $ eval "$(ssh-agent -s)"
 ----
 Agent pid 31874
 ----
-+
-.. List the public keys of the identities that are managed by the SSH agent:
-+
-[source,terminal]
-----
-$ ssh-add -L
-----
-+
-.. If the SSH public key that you are passing to the {product-title} installation program is not listed in the output of the preceding command, add your private key identity to the `ssh-agent`:
+[NOTE]
+====
+If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate the SSH key. The key must be either RSA or ECDSA.
+====
+. Add your SSH private key to the `ssh-agent`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
GitHub Issue burndown Issue #30879

For 4.5+

Direct link to doc preview: https://deploy-preview-30932--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#ssh-agent-using_installing-restricted-networks-vsphere