### PR TITLE
Correcting path for cert location

### DIFF
--- a/modules/ossm-security-cert-manage.adoc
+++ b/modules/ossm-security-cert-manage.adoc
@@ -70,7 +70,7 @@ $ RATINGSPOD=`oc get pods -l app=ratings -o jsonpath='{.items[0].metadata.name}'
 +
 [source,terminal]
 ----
-$ oc exec -it $RATINGSPOD -c istio-proxy -- /bin/cat /etc/certs/root-cert.pem > /tmp/pod-root-cert.pem
+$ oc exec -it $RATINGSPOD -c istio-proxy -- /bin/cat /var/run/secrets/istio/root-cert.pem > /tmp/pod-root-cert.pem
 ----
 +
 The file `/tmp/pod-root-cert.pem` contains the root certificate propagated to the pod.


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/27619
Preview: https://deploy-preview-30936--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-security.html#ossm-cert-manage-verify-cert_ossm-security