### PR TITLE
Modified command snippets and YAML samples according to RHDEVDOCS - 2625, 2626, and 2638

### DIFF
--- a/logging/config/cluster-logging-tolerations.adoc
+++ b/logging/config/cluster-logging-tolerations.adoc
@@ -5,11 +5,11 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can use taints and tolerations to ensure that OpenShift Logging pods run 
+You can use taints and tolerations to ensure that OpenShift Logging pods run
 on specific nodes and that no other workload can run on those nodes.
 
-Taints and tolerations are simple `key:value` pair.  A taint on a node 
-instructs the node to repel all pods that do not tolerate the taint.	
+Taints and tolerations are simple `key:value` pair.  A taint on a node
+instructs the node to repel all pods that do not tolerate the taint.
 
 The `key` is any string, up to 253 characters and the `value` is any string up to 63 characters.
 The string must begin with a letter or number, and may contain letters, numbers, hyphens, dots, and underscores.
@@ -22,12 +22,15 @@ kind: "ClusterLogging"
 metadata:
   name: "instance"
   namespace: openshift-logging
+
+...
+
 spec:
   managementState: "Managed"
   logStore:
     type: "elasticsearch"
     elasticsearch:
-      nodeCount: 1
+      nodeCount: 3
       tolerations: <1>
       - key: "logging"
         operator: "Exists"
@@ -35,10 +38,10 @@ spec:
         tolerationSeconds: 6000
       resources:
         limits:
-          memory: 8Gi
+          memory: 16Gi
         requests:
-          cpu: 100m
-          memory: 1Gi
+          cpu: 200m
+          memory: 16Gi
       storage: {}
       redundancyPolicy: "ZeroRedundancy"
   visualization:
@@ -59,7 +62,7 @@ spec:
   collection:
     logs:
       type: "fluentd"
-      fluentd: 
+      fluentd:
         tolerations: <3>
         - key: "logging"
           operator: "Exists"
@@ -91,5 +94,5 @@ include::modules/cluster-logging-collector-tolerations.adoc[leveloffset=+1]
 [id="cluster-logging-tolerations-addtl-resources"]
 == Additional resources
 
-For more information about taints and tolerations, see 
+For more information about taints and tolerations, see
 xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].

--- a/modules/cluster-logging-collector-limits.adoc
+++ b/modules/cluster-logging-collector-limits.adoc
@@ -5,15 +5,15 @@
 [id="cluster-logging-collector-limits_{context}"]
 = Configure log collector CPU and memory limits
 
-The log collector allows for adjustments to both the CPU and memory limits. 
+The log collector allows for adjustments to both the CPU and memory limits.
 
 .Procedure
 
-. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project: 
+. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
 +
 [source,terminal]
 ----
-$ oc edit ClusterLogging instance
+$ oc -n openshift-logging edit ClusterLogging instance
 ----
 +
 [source,yaml]
@@ -22,8 +22,9 @@ apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
   name: "instance"
+  namespace: openshift-logging
 
-....
+...
 
 spec:
   collection:

--- a/modules/cluster-logging-cpu-memory.adoc
+++ b/modules/cluster-logging-cpu-memory.adoc
@@ -5,15 +5,15 @@
 [id="cluster-logging-memory-limits_{context}"]
 = Configuring CPU and memory limits
 
-The OpenShift Logging components allow for adjustments to both the CPU and memory limits. 
+The OpenShift Logging components allow for adjustments to both the CPU and memory limits.
 
 .Procedure
 
-. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project: 
+. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
 +
 [source,terminal]
 ----
-$ oc edit ClusterLogging instance -n openshift-logging
+$ oc -n openshift-logging edit ClusterLogging instance
 ----
 +
 [source,yaml]
@@ -22,21 +22,22 @@ apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
   name: "instance"
+  namespace: openshift-logging
 
-....
+...
 
 spec:
   managementState: "Managed"
   logStore:
     type: "elasticsearch"
     elasticsearch:
-      nodeCount: 2
+      nodeCount: 3
       resources: <1>
         limits:
-          memory: 2Gi
+          memory: 16Gi
         requests:
           cpu: 200m
-          memory: 2Gi
+          memory: 16Gi
       storage:
         storageClassName: "gp2"
         size: "200G"


### PR DESCRIPTION
**Aligned team**: Dev Tools

**OCP version for cherry-picking**: `4.7`, `4.8`

**JIRA issues**:
- [RHDEVDOCS-2625](https://issues.redhat.com/browse/RHDEVDOCS-2625)
- [RHDEVDOCS-2626](https://issues.redhat.com/browse/RHDEVDOCS-2626)
- [RHDEVDOCS-2628](https://issues.redhat.com/browse/RHDEVDOCS-2628)

**Preview pages**: Command snippets and YAML samples in the following pages:
- [Configuring CPU and memory limits](https://deploy-preview-30943--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-memory.html#cluster-logging-memory-limits_cluster-logging-memory)
- [Using tolerations to control OpenShift Logging pod placement](https://deploy-preview-30943--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-tolerations.html)
- [Configure log collector CPU and memory limits](https://deploy-preview-30943--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-collector.html#cluster-logging-collector-limits_cluster-logging-collector)

**Reviewer SME/QE**: Oscar Casal Sanchez (@r2d2rnd)