### PR TITLE
[Enterprise-3.11] Added a new section to sysctls to mention how to handle unsafe sysctls

### DIFF
--- a/admin_guide/sysctls.adoc
+++ b/admin_guide/sysctls.adoc
@@ -113,10 +113,15 @@ launch.
 == Enabling unsafe sysctls
 
 The cluster administrator can allow certain unsafe sysctls for very special
-situations such as high-performance or real-time application tuning.
+situations such as high performance or real-time application tuning.
 
 If you want to use unsafe sysctls, cluster administrators must enable them
 individually on nodes. They can enable only namespaced sysctls.
+
+You can further control which sysctls can be set in pods by specifying lists of sysctls or sysctl patterns in the `forbiddenSysctls` and `allowedUnsafeSysctls` fields of the Security Context Constraints.
+
+- The `forbiddenSysctls` option excludes specific sysctls.
+- The `allowedUnsafeSysctls` option controls specific needs such as high performance or real-time application tuning.
 
 [WARNING]
 ====
@@ -162,7 +167,7 @@ allowedUnsafeSysctls: <1>
 metadata:
   name: restricted-sysctls <2>
 ...
----- 
+----
 <1> Add the unsafe sysctls you want to use.
 <2> Specify a new name for the SCC.
 
@@ -222,7 +227,7 @@ the specification.
 
 [WARNING]
 ====
-To avoid destabilizing your operating system, modify sysctl parameters only 
+To avoid destabilizing your operating system, modify sysctl parameters only
 after you understand their effects.
 ====
 


### PR DESCRIPTION
Fixes #15234. This burn down ticket requested information in the documentation about the forbidden and unsafe sysctls options. For this update, I added the two options to the 3.11 documentation. A separate ticket will be needed for 4.5+ documentation.

Link to section: https://deploy-preview-30944--osdocs.netlify.app/openshift-enterprise/latest/admin_guide/sysctls.html#enabling-unsafe-sysctls

I add the statement and the two bullets on the two options for Unsafe sysctls.