### PR TITLE
ISSUE-29590 - Clarify wording for compute-resources-time-bound example

### DIFF
--- a/modules/quotas-sample-resource-quotas-def.adoc
+++ b/modules/quotas-sample-resource-quotas-def.adoc
@@ -121,11 +121,11 @@ spec:
   scopes:
   - Terminating <5>
 ----
-<1> The total number of pods in a non-terminal state.
-<2> Across all pods in a non-terminal state, the sum of CPU limits cannot exceed this value.
-<3> Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value.
-<4> Across all pods in a non-terminal state, the sum of ephemeral storage limits cannot exceed this value.
-<5> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds >=0`.  For example, this quota would charge for build or deployer pods, but not long running pods like a web server or database.
+<1> The total number of pods in a terminating state.
+<2> Across all pods in a terminating state, the sum of CPU limits cannot exceed this value.
+<3> Across all pods in a terminating state, the sum of memory limits cannot exceed this value.
+<4> Across all pods in a terminating state, the sum of ephemeral storage limits cannot exceed this value.
+<5> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds >=0`. For example, this quota would charge for build or deployer pods, but not long running pods like a web server or database.
 
 .`storage-consumption.yaml`
 [source,yaml]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/29590 - the request is to update the example for `compute-resources-time-bound.yaml` to reflect the resource quotas for a `Terminating` scope by changing the wording from "non-terminal state" to "Terminating state". I'm unfamiliar with this area but in also looking at upstream docs (https://kubernetes.io/docs/concepts/policy/resource-quotas/), I see a distinction between `Terminating` and `NotTerminating`, which are scopes, and `terminal` and `non-terminal`, which are states.

This PR updates the wording based on the Issue suggestion, although I'm not certain we need to make this change at all. From my perspective, the `Terminating` scope is still not "terminated" and therefore can be classified still as "non-terminal". 

But I will defer to QE for their thoughts.

**PREVIEW LINK:** https://deploy-preview-30945--osdocs.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-per-project.html#quotas-sample-resource-quota-definitions_quotas-setting-per-project