### PR TITLE
GH30902: Added --cluster=<cluster_name> flag to correct the example.

### DIFF
--- a/modules/rosa-accessing-your-cluster.adoc
+++ b/modules/rosa-accessing-your-cluster.adoc
@@ -23,7 +23,7 @@ To access your cluster using an IDP account:
 +
 [source, terminal]
 ----
-$ rosa create idp --cluster=rh-rosa-test-cluster --interactive
+$ rosa create idp --cluster=<cluster_name> --interactive
 ----
 +
 .. Enter the following values:
@@ -77,7 +77,7 @@ The IDP can take 1-2 minutes to be configured within your cluster.
 +
 [source,terminal]
 ----
-$ rosa list idps --cluster rh-rosa-test-cluster1
+$ rosa list idps --cluster=<cluster_name>
 ----
 +
 .Example output
@@ -92,7 +92,7 @@ github-1    GitHub    https://oauth-openshift.apps.rh-rosa-test-cluster1.j9n4.s1
 +
 [source,terminal]
 ----
-$ rosa describe cluster rh-rosa-test-cluster1
+$ rosa describe cluster --cluster=<cluster_name>
 ----
 +
 .Example output


### PR DESCRIPTION
#https://github.com/openshift/openshift-docs/issues/30902

Also fixed the other examples to make them clearer and match the actual syntax.