### PR TITLE
Jira:1986 - Fix link in ROSA Service Definition

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -94,7 +94,7 @@ The following AWS regions are supported by Red Hat OpenShift 4 and are supported
 - us-west-1 (N. California)
 - us-west-2 (Oregon)
 
-Multiple availability zone clusters can only be deployed in regions with at least 3 availability clouds. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.
+Multiple availability zone clusters can only be deployed in regions with at least 3 availability zones. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.
 
 Each new {product-title} cluster is installed within an installer-created or preexisting Virtual Private Cloud (VPC) in a single region, with the option to deploy into a single availability zone (Single-AZ) or across multiple availability zones (Multi-AZ). This provides cluster-level network and resource isolation, and enables cloud-provider VPC settings, such as VPN connections and VPC Peering. Persistent volumes (PVs) are backed by AWS Elastic Block Storage (EBS), and are specific to the availability zone in which they are provisioned. Persistent volume claims (PVCs) do not bind to a volume until the associated pod resource is assigned into a specific availability zone to prevent unschedulable pods. Availability zone-specific resources are only usable by resources in the same availability zone.
 

--- a/modules/rosa-sdpolicy-security.adoc
+++ b/modules/rosa-sdpolicy-security.adoc
@@ -53,7 +53,7 @@ $ oc adm policy add-cluster-role-to-group self-provisioner system:authenticated:
 
 [id="rosa-sdpolicy-regulatory-compliance_{context}"]
 == Regulatory compliance
-See link:https://www.openshift.com/products/dedicated/process-and-security#compliance[OpenShift Dedicated Process and Security Overview] for the latest compliance information.
+See Understanding process and security for ROSA for the latest compliance information.
 
 [id="rosa-sdpolicy-network-security_{context}"]
 == Network security

--- a/rosa_policy/rosa-service-definition.adoc
+++ b/rosa_policy/rosa-service-definition.adoc
@@ -13,3 +13,8 @@ include::modules/rosa-sdpolicy-networking.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-storage.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-platform.adoc[leveloffset=+1]
 include::modules/rosa-sdpolicy-security.adoc[leveloffset=+1]
+
+
+== Additional resources
+
+* See xref:../rosa_policy/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding process and security for ROSA] for the latest compliance information.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSDOCS-1986

Direct links to changes:
Wording change: clouds changed to zones:
https://deploy-preview-30949--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition

Update Regulatory compliance section. Add requested cross reference link to new Additional resources section.
https://deploy-preview-30949--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-regulatory-compliance_rosa-service-definition
