### PR TITLE
BZ1852798: Removed etcd instructions

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -154,10 +154,6 @@ within the cluster.
 |`AWS::Route53::HostedZone`
 |The hosted zone for your internal DNS.
 
-|etcd record sets
-|`AWS::Route53::RecordSet`
-|The registration records for etcd for your control plane machines.
-
 |Public load balancer
 |`AWS::ElasticLoadBalancingV2::LoadBalancer`
 |The load balancer for your public subnets.


### PR DESCRIPTION
Applies to 4.4+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1852798
QE Approval Needed: @pamoedom 
Preview Link: https://deploy-preview-30950--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-other-infrastructure_installing-aws-user-infra (Required DNS and load balancing components table)