### PR TITLE
Warning regarding HW14 and higher on 4.7.x failing

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -37,3 +37,8 @@ you install {product-title}.
 ====
 You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-8756D419-A878-4AE0-9183-C6D5A91A8FB1.html[Edit Time Configuration for a Host] in the VMware documentation.
 ====
+
+[IMPORTANT]
+====
+Virtual machines (VMs) configured to use virtual hardware version 14 or greater might result in a failed installation. It is recommended to configure VMs with virtual hardware version 13. This is a known issue that is being addressed in link:https://bugzilla.redhat.com/show_bug.cgi?id=1935539[BZ#1935539].
+====


### PR DESCRIPTION
Customers are encountering failed installations on 4.7.x when installing with VMs configured to use virtual hardware versions greater than 13.  This issue is being actively worked in https://bugzilla.redhat.com/show_bug.cgi?id=1935539 .  Due to the high likelihood of running in to this issue, the intent of this change is to inform installers up-front that they will likely not be able to successfully install 4.7.x on HW version 14 or later.  

Furthermore, this issue is unique to 4.7 and as such this PR was written directly against 4.7.  A workaround and further background on this issue is documented here: https://access.redhat.com/solutions/5896081