### PR TITLE
GitHub Issue #29523: Removed -$VERSION from code for getting the oc binary.

### DIFF
--- a/modules/ipi-install-extracting-the-openshift-installer.adoc
+++ b/modules/ipi-install-extracting-the-openshift-installer.adoc
@@ -22,7 +22,7 @@ $ export extract_dir=$(pwd)
 +
 [source,terminal]
 ----
-$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux-$VERSION.tar.gz | tar zxvf - oc
+$ curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/openshift-client-linux.tar.gz | tar zxvf - oc
 ----
 
 . Extract the installer:


### PR DESCRIPTION
Git Hub Issue burndown: Issue #29523 

For version 4.5+
Direct link to doc preview: https://deploy-preview-30956--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#extracting-the-openshift-installer_ipi-install-installation-workflow
