### PR TITLE
Bz1933918

### DIFF
--- a/modules/nw-ingress-creating-a-passthrough-route.adoc
+++ b/modules/nw-ingress-creating-a-passthrough-route.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * ingress/routes.adoc
+
+[id="nw-ingress-creating-a-passthrough-route_{context}"]
+= Creating a passthrough route
+
+You can configure a secure route using passthrough termination by using the `oc create route` command. With passthrough termination, encrypted traffic is sent straight to the destination without the router providing TLS termination. Therefore no key or certificate is required on the route.
+
+.Prerequisites
+
+* You must have a service that you want to expose.
+
+.Procedure
+
+* Create a `Route` resource:
++
+[source,terminal]
+----
+$ oc create route passthrough route-passthrough-secured --service=frontend --port=8080
+----
++
+If you examine the resulting `Route` resource, it should look similar to the following:
++
+.A Secured Route Using Passthrough Termination
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: route-passthrough-secured <1>
+spec:
+  host: www.example.com
+  port:
+    targetPort: 8080
+  tls:
+    termination: passthrough <2>
+    insecureEdgeTerminationPolicy: None <3>
+  to:
+    kind: Service
+    name: frontend
+----
+<1> The name of the object, which is limited to 63 characters.
+<2> The `*termination*` field is set to `passthrough`. This is the only required `tls` field.
+<3> Optional `insecureEdgeTerminationPolicy`. The only valid values are are `None`, `Redirect`, or empty for disabled.
++
+The destination pod is responsible for serving certificates for the
+traffic at the endpoint. This is currently the only method that can support requiring client certificates, also known as two-way authentication.

--- a/networking/routes/secured-routes.adoc
+++ b/networking/routes/secured-routes.adoc
@@ -5,8 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The following sections describe how to create re-encrypt and edge routes with
-custom certificates.
+Secure routes provide the ability to use several types of TLS termination to serve certificates to the client. The following sections describe how to create re-encrypt, edge, and passthrough routes with custom certificates.
 
 [IMPORTANT]
 ====
@@ -20,3 +19,5 @@ in the Azure documentation.
 include::modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-creating-an-edge-route-with-a-custom-certificate.adoc[leveloffset=+1]
+
+include::modules/nw-ingress-creating-a-passthrough-route.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds a module for passthrough routes to the Routes assembly. 

For 4.5+

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1933918

Preview at https://deploy-preview-30957--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/secured-routes.html#nw-ingress-creating-a-passthrough-route_secured-routes

@zhaozhanqi Please review. Thank you. 