### PR TITLE
RHOSDOC-37 Ember-CSI

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1057,6 +1057,8 @@ Topics:
     File: persistent-storage-csi-cloning
   - Name: AWS Elastic Block Store CSI Driver Operator
     File: persistent-storage-csi-ebs
+  - Name: Ember-CSI Driver Operator
+    File: persistent-storage-csi-ember
   - Name: GCP PD CSI Driver Operator
     File: persistent-storage-csi-gcp-pd
   - Name: OpenStack Cinder CSI Driver Operator

--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -17,6 +17,7 @@ The following table describes the CSI drivers that are installed with {product-t
 |CSI driver  |CSI volume snapshots  |CSI cloning  |CSI resize
 
 |AWS EBS (Tech Preview) | ✅ | - | ✅
+|Ember-CSI (Tech Preview)| ✅ | - | - 
 |Google Cloud Platform (GCP) persistent disk (PD) (Tech Preview)| ✅ | - | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅
 |OpenStack Manila | ✅ | ✅ | ✅

--- a/storage/container_storage_interface/persistent-storage-csi-ember.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ember.adoc
@@ -1,0 +1,29 @@
+[id="persistent-storage-csi-ember"]
+= Ember-CSI Driver Operator
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-csi-ember
+
+toc::[]
+
+== Overview
+
+{product-title} is capable of provisioning persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for Ember-CSI.
+
+:FeatureName: Ember-CSI Driver Operator
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+The Ember-CSI Operator provides a GUI to configure and deploy supported storage drivers, as well as a CSI storage class that you can use to create PVs.
+
+With each Ember-CSI back end deployed by the Operator, you can create and mount Ember-CSI PVs.
+
+Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+
+To create CSI-provisioned PVs that mount to Ember-CSI storage assets, {product-title} installs the Ember-CSI Driver Operator and the Ember-CSI driver in the `openshift-cluster-csi-drivers` namespace.
+
+include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+For more information about installing Ember-CSI, see https://access.redhat.com/documentation/en-us/ember-csi/0/html-single/installing_ember-csi_on_openshift_container_platform/index[Installing Ember-CSI on OpenShift Container Platform].
+
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
+* https://access.redhat.com/documentation/en-us/ember-csi/0/html-single/installing_ember-csi_on_openshift_container_platform/index[Installing Ember-CSI on OpenShift Container Platform]


### PR DESCRIPTION
Add Ember-CSI info to OCP docs for https://issues.redhat.com/browse/RHOSPDOC-37.

The changes include (1) new topic for Ember-CSI under "Using CSI", and (2) revised "CSI drivers supported by OCP" in "Configuring CSI Volumes" topic "Using CSI".

PTAL: @bobfuru, @jsafrane, @qinpingli @duanwei33 

How far back does this go for support? I'm tagging it to 4.7, 4.8, but might it go back to 4.5?

FYI:
Chapter 2. Installing Ember-CSI on OpenShift Container Platform
Use the Ember-CSI operator to deploy Ember-CSI on OpenShift Container Platform.
Prerequisites
OpenShift Container Platform version **4.4 or later**.