### PR TITLE
make it clear what the default namespace is

### DIFF
--- a/modules/compliance-profiles.adoc
+++ b/modules/compliance-profiles.adoc
@@ -6,6 +6,7 @@
 = Compliance Operator profiles
 
 There are several profiles available as part of the Compliance Operator installation.
+The default namespace in which the Compliance Operator is installed into is openshift-compliance.
 
 View the available profiles:
 


### PR DESCRIPTION
Prevents users from having to go on a discovery journey regarding default namespace.
Fixes https://github.com/openshift/openshift-docs/issues/30996