### PR TITLE
CNF 1483 RN: Describing the net queues feature in the 4.8 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -275,6 +275,15 @@ The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled 
 [id="ocp-4-8-scale"]
 === Scale
 
+[id="ocp-4-8-reducing-nic-queues-using-the-performance-addon-operator"]
+==== Reducing NIC using the Performance Addon Operator
+
+The Performance Addon Operator allows you to adjust the Network Interface Card (NIC) queue count for each network device by configuring the performance profile. Device network queues allow packets to be distributed among different physical queues, and each queue gets a separate thread for packet processing.
+
+For Data Plane Development Kit (DPDK) based workloads, it is important to reduce the NIC queues to only the number of reserved or housekeeping CPUs to ensure the desired low latency is achieved.
+
+For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#reducing-nic-queues-using-the-performance-addon-operator_cnf-master[Reducing NIC queues using the Performance Addon Operator].
+
 [id="ocp-4-8-scale-cluster-maximums"]
 ==== Cluster maximums
 


### PR DESCRIPTION
Release notes for 4.8 describing net queues feature CNF 1483
Preview Link: https://deploy-preview-31016--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-scale