### PR TITLE
[enterprise-4.8] BZ#1943150: Fix opm prune -i registry image

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -7,7 +7,7 @@
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 
 ifdef::openshift-origin[]
-:index-image: upstream-community-operators
+:index-image: catalog
 :tag: latest
 endif::[]
 ifndef::openshift-origin[]

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -6,8 +6,8 @@
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 
 ifdef::openshift-origin[]
-:index-image-pullspec: quay.io/operator-framework/upstream-community-operators:latest
-:index-image: upstream-community-operators
+:index-image-pullspec: quay.io/operatorhubio/catalog:latest
+:index-image: catalog
 :example-registry: example.com
 endif::[]
 ifndef::openshift-origin[]

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -10,6 +10,7 @@ ifdef::openshift-origin[]
 :catalog-name: upstream-community-operators
 :index-image-pullspec: quay.io/operator-framework/upstream-community-operators:latest
 :index-image: upstream-community-operators:latest
+:registry-image: quay.io/openshift/origin-operator-registry:4.8.0
 :package1: couchdb-operator
 :package2: eclipse-che
 :package3: etcd
@@ -18,6 +19,7 @@ ifndef::openshift-origin[]
 :catalog-name: redhat-operators
 :index-image-pullspec: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
 :index-image: redhat-operator-index:v{product-version}
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v4.8
 :package1: advanced-cluster-management
 :package2: jaeger-product
 :package3: quay-operator
@@ -122,13 +124,13 @@ $ grpcurl -plaintext localhost:50051 api.Registry/ListPackages > packages.out
 $ opm index prune \
     -f {index-image-pullspec} \// <1>
     -p {package1},{package2},{package3} \// <2>
-    -t <target_registry>:<port>/<namespace>/{index-image} \// <3>
-    -i registry.redhat.io/openshift4/ose-operator-registry/{index-image} <4>
+    [-i {registry-image}] \// <3>
+    -t <target_registry>:<port>/<namespace>/{index-image} <4>
 ----
 <1> Index to prune.
 <2> Comma-separated list of packages to keep.
-<3> Custom tag for new index image being built.
-<4> For IBM Power Systems and IBM Z images only, you must add the `-i` entry to the command.
+<3> Required only for IBM Power Systems and IBM Z images: Operator Registry base image with the tag that matches the target {product-title} cluster major and minor version.
+<4> Custom tag for new index image being built.
 
 . Run the following command to push the new index image to your target registry:
 +
@@ -145,6 +147,7 @@ endif::[]
 :!catalog-name:
 :!index-image-pullspec:
 :!index-image:
+:!registry-image:
 :!package1:
 :!package2:
 :!package3:

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -7,9 +7,9 @@
 // * migration/migrating_4_2_4/deploying-cam-4-2-4.adoc
 
 ifdef::openshift-origin[]
-:catalog-name: upstream-community-operators
-:index-image-pullspec: quay.io/operator-framework/upstream-community-operators:latest
-:index-image: upstream-community-operators:latest
+:catalog-name: catalog
+:index-image-pullspec: quay.io/operatorhubio/catalog:latest
+:index-image: catalog:latest
 :registry-image: quay.io/openshift/origin-operator-registry:4.8.0
 :package1: couchdb-operator
 :package2: eclipse-che

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -4,7 +4,7 @@
 // * operators/admin/olm-restricted-network.adoc
 
 ifdef::openshift-origin[]
-:index-image: upstream-community-operators
+:index-image: catalog
 endif::[]
 ifndef::openshift-origin[]
 :index-image: redhat-operator-index


### PR DESCRIPTION
4.8 version of https://github.com/openshift/openshift-docs/pull/31013.