### PR TITLE
Bz1869637

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -525,16 +525,9 @@ ifdef::azure[]
 |====
 |Parameter|Description|Values
 
-|`machines.platform.azure.type`
-|The Azure VM instance type.
-|VMs that use Windows or Linux as the operating system. See the
-link:https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-supported-os?view=azs-1908[Guest operating systems supported on Azure Stack]
-in the Azure documentation.
-
-|`machines.platform.azure.osDisk.diskSizeGB`
+|`controlPlane.platform.azure.osDisk.diskSizeGB`
 |The Azure disk size for the VM.
-|Integer that represents the size of the disk in GB, for example `512`. The
-minimum supported disk size is `120`.
+|Integer that represents the size of the disk in GB. The minimum supported disk size is `1024`.
 
 |`platform.azure.baseDomainResourceGroupName`
 |The name of the resource group that contains the DNS zone for your base domain.


### PR DESCRIPTION
This is a follow-on PR to the original PR owned by Andrew Taylor at https://github.com/openshift/openshift-docs/pull/26719

This update satisfies https://bugzilla.redhat.com/show_bug.cgi?id=1869637
document URL is:
https://docs.openshift.com/container-platform/4.3/installing/installing_azure/installing-azure-customizations.html#installation-azure-config-yaml_installing-azure-customizations

The change is in the module:

modules/installation-configuration-parameters.adoc "machines.platform.azure.osDisk.diskSizeGB" changed to "controlPlane.platform.azure.osDisk.diskSizeGB"