### PR TITLE
[enterprise-4.x]Fix callouts typo in sample install-config.yaml file for bare metal

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -63,8 +63,8 @@ parameters.
 ----
 apiVersion: v1
 baseDomain: example.com <1>
-compute:
-- hyperthreading: Enabled <2> <3>
+compute: <2>
+- hyperthreading: Enabled <3>
   name: worker
   replicas: 0 <4>
 ifeval::["{context}" == "installing-ibm-z"]
@@ -82,9 +82,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
   architecture : ppc64le
 endif::[]
-controlPlane:
-  hyperthreading: Enabled <2> <3>
-  name: master <3>
+controlPlane: <2>
+  hyperthreading: Enabled <3>
+  name: master
   replicas: 3 <5>
 ifeval::["{context}" == "installing-ibm-z"]
   architecture : s390x
@@ -195,7 +195,7 @@ endif::restricted[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this
 base and include the cluster name.
-<2> The `controlPlane` section is a single mapping, but the compute section is a
+<2> The `controlPlane` section is a single mapping, but the `compute` section is a
 sequence of mappings. To meet the requirements of the different data structures,
 the first line of the `compute` section must begin with a hyphen, `-`, and the
 first line of the `controlPlane` section must not. Although both sections


### PR DESCRIPTION
@vikram-redhat I found some callouts typo in sample install-config.yaml file for bare metal, minimum version that the change applies to should be 4.1 in my opinion, could you review them? Thanks.