### PR TITLE
fixes issue 30978

### DIFF
--- a/modules/compliance-deploying.adoc
+++ b/modules/compliance-deploying.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-deploying.adoc
+
+[id="compliance_deploying_{context}"]
+= Deploying the Compliance Operator
+
+Before you can actually use the operator, you need to make sure it is deployed in the cluster.
+First, become kubeadmin, either with oc login or by exporting KUBECONFIG.
+
+You can deploy the Compliance Operator via the Operator Hub available in the OpenShift GUI.
+
+By default, the operator runs in the openshift-compliance namespace, so make sure all namespaced resources like the deployment or the custom resources the operator consumes are created there. However, it is possible for the operator to be deployed in other namespaces as well.
+
+As kubeadmin, select the Compliance Operator in Operator Hub and click install.
+
+To verify the installation. Run below commands:
+
+[source,terminal]
+----
+$ oc get sub -nopenshift-compliance
+$ oc get ip -nopenshift-compliance
+$ oc get csv -nopenshift-compliance
+----
+
+.Example output
+[source,terminal]
+----
+$ oc get sub -nopenshift-compliance
+NAME                  PACKAGE               SOURCE             CHANNEL
+compliance-operator   compliance-operator   redhat-operators   4.7
+
+$ oc get ip -nopenshift-compliance
+NAME            CSV                           APPROVAL    APPROVED
+install-s2trr   compliance-operator.v0.1.26   Automatic   true
+
+$ oc get csv -nopenshift-compliance
+NAME                          DISPLAY               VERSION   REPLACES   PHASE
+compliance-operator.v0.1.26   Compliance Operator   0.1.26               Succeeded
+----
+
+At this point, the operator should be up and running and you can verify it by running:
+
+[source,terminal]
+----
+$ oc get deploy -nopenshift-compliance
+$ oc get pods -nopenshift-compliance
+----
+
+.Example output
+[source,terminal]
+----
+$ oc get deploy -nopenshift-compliance
+NAME                             READY   UP-TO-DATE   AVAILABLE   AGE
+compliance-operator              1/1     1            1           22m
+ocp4-openshift-compliance-pp     1/1     1            1           21m
+rhcos4-openshift-compliance-pp   1/1     1            1           21m
+
+$ oc get pods -nopenshift-compliance
+NAME                                             READY   STATUS    RESTARTS   AGE
+compliance-operator-65b9d8b9cc-wc9zp             1/1     Running   0          22m
+ocp4-openshift-compliance-pp-7cb966898-r7q8c     1/1     Running   0          21m
+rhcos4-openshift-compliance-pp-cfc9f4b9d-rs8zt   1/1     Running   0          21m
+----

--- a/security/compliance_operator/compliance-operator-deploying.adoc
+++ b/security/compliance_operator/compliance-operator-deploying.adoc
@@ -1,0 +1,19 @@
+[id="deploying-compliance-operator"]
+= Deploying the Compliance Operator
+include::modules/common-attributes.adoc[]
+:context: understanding-compliance
+
+toc::[]
+
+The compliance-operator is a OpenShift Operator that allows an administrator to run compliance scans and provide remediations for the issues found. The operator leverages OpenSCAP under the hood to perform the scans.
+
+By default, the operator runs in the openshift-compliance namespace, so make sure all namespaced resources like the deployment or the custom resources the operator consumes are created there. However, it is possible for the operator to be deployed in other namespaces as well.
+
+You can install the Compliance Operator from Operator Hub from within the OpenShift GUI. The operator is called Compliance Operator.
+
+[IMPORTANT]
+====
+The Compliance Operator is available for {op-system-first} deployments only.
+====
+
+include::modules/compliance-deploying.adoc[leveloffset=+1]


### PR DESCRIPTION
Basics in place for installing the compliance operator. Documentation can start with this and continue with: https://docs.openshift.com/container-platform/4.7/security/compliance_operator/compliance-operator-understanding.html

Fix for https://github.com/openshift/openshift-docs/issues/30978