### PR TITLE
Update mtc-version-z (MTC 1.4.3)

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -36,4 +36,4 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.4
-:mtc-version-z: 1.4.2
+:mtc-version-z: 1.4.3


### PR DESCRIPTION
4.5+

No QE or peer review required.