### PR TITLE
BZ1943465 Explained the difference between latest and fast channels

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -11,6 +11,10 @@ include::modules/ipi-install-preparing-the-provisioner-node-for-openshift-instal
 
 include::modules/ipi-install-retrieving-the-openshift-installer.adoc[leveloffset=+1]
 
+.Additional resources
+
+* See xref:../../updating/updating-cluster-between-minor.adoc#understanding-upgrade-channels_updating-cluster-between-minor[{product-title} upgrade channels and releases] for an explanation of the different release channels.
+
 include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset=+1]
 
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1943465. To resolve this issue, I added a note to the bare metal installation topic that describes how the `stable` channel differences from the `latest/fast`. I also link to the documentation that includes all the different channels.

The note may be found at: https://deploy-preview-31058--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#retrieving-the-openshift-installer_ipi-install-installation-workflow