### PR TITLE
NTO 4.8 changes.

### DIFF
--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -3,62 +3,29 @@
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
 [id="verifying-tuned-profiles-are-applied_{context}"]
-=  Verifying that the Tuned profiles are applied
+=  Verifying that the TuneD profiles are applied
 
-Use this procedure to check which Tuned profiles are applied on every node.
+Starting with {product-title} 4.8, it is no longer necessary to check the TuneD pod logs
+to find which TuneD profiles are applied on cluster nodes.
 
-.Procedure
-
-. Check which Tuned pods are running on each node:
-+
 [source,terminal]
 ----
-$ oc get pods -n openshift-cluster-node-tuning-operator -o wide
+$ oc get profile -n openshift-cluster-node-tuning-operator
 ----
-+
+
 .Example output
 [source,terminal]
 ----
-NAME                                            READY   STATUS    RESTARTS   AGE    IP             NODE                                         NOMINATED NODE   READINESS GATES
-cluster-node-tuning-operator-599489d4f7-k4hw4   1/1     Running   0          6d2h   10.129.0.76    ip-10-0-145-113.eu-west-3.compute.internal   <none>           <none>
-tuned-2jkzp                                     1/1     Running   1          6d3h   10.0.145.113   ip-10-0-145-113.eu-west-3.compute.internal   <none>           <none>
-tuned-g9mkx                                     1/1     Running   1          6d3h   10.0.147.108   ip-10-0-147-108.eu-west-3.compute.internal   <none>           <none>
-tuned-kbxsh                                     1/1     Running   1          6d3h   10.0.132.143   ip-10-0-132-143.eu-west-3.compute.internal   <none>           <none>
-tuned-kn9x6                                     1/1     Running   1          6d3h   10.0.163.177   ip-10-0-163-177.eu-west-3.compute.internal   <none>           <none>
-tuned-vvxwx                                     1/1     Running   1          6d3h   10.0.131.87    ip-10-0-131-87.eu-west-3.compute.internal    <none>           <none>
-tuned-zqrwq                                     1/1     Running   1          6d3h   10.0.161.51    ip-10-0-161-51.eu-west-3.compute.internal    <none>           <none>
+NAME             TUNED                     APPLIED   DEGRADED   AGE
+master-0         openshift-control-plane   True      False      6h33m
+master-1         openshift-control-plane   True      False      6h33m
+master-2         openshift-control-plane   True      False      6h33m
+worker-a         openshift-node            True      False      6h28m
+worker-b         openshift-node            True      False      6h28m
 ----
 
-. Extract the profile applied from each pod and match them against the previous list:
-+
-[source,terminal]
-----
-$ for p in `oc get pods -n openshift-cluster-node-tuning-operator -l openshift-app=tuned -o=jsonpath='{range .items[*]}{.metadata.name} {end}'`; do printf "\n*** $p ***\n" ; oc logs pod/$p -n openshift-cluster-node-tuning-operator | grep applied; done
-----
-+
-.Example output
-[source,terminal]
-----
-*** tuned-2jkzp ***
-2020-07-10 13:53:35,368 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-control-plane' applied
-
-*** tuned-g9mkx ***
-2020-07-10 14:07:17,089 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node' applied
-2020-07-10 15:56:29,005 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node-es' applied
-2020-07-10 16:00:19,006 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node' applied
-2020-07-10 16:00:48,989 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node-es' applied
-
-*** tuned-kbxsh ***
-2020-07-10 13:53:30,565 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node' applied
-2020-07-10 15:56:30,199 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node-es' applied
-
-*** tuned-kn9x6 ***
-2020-07-10 14:10:57,123 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node' applied
-2020-07-10 15:56:28,757 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-node-es' applied
-
-*** tuned-vvxwx ***
-2020-07-10 14:11:44,932 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-control-plane' applied
-
-*** tuned-zqrwq ***
-2020-07-10 14:07:40,246 INFO     tuned.daemon.daemon: static tuning from profile 'openshift-control-plane' applied
-----
+* `NAME`: Name of the Profile object. There is one Profile object per node and their names match.
+* `TUNED`: Name of the desired TuneD profile to apply.
+* `APPLIED`: `True` if the TuneD daemon applied the desired profile. (`True/False/Unknown`).
+* `DEGRADED`: `True` if any errors were reported during application of the TuneD profile (`True/False/Unknown`).
+* `AGE`: Time elapsed since the creation of Profile object.

--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -51,7 +51,7 @@ spec:
 <3> Note the order of parameters is important as some platforms support huge pages of various sizes.
 <4> Enable machine config pool based matching.
 
-. Create the Tuned `hugepages` profile
+. Create the Tuned `hugepages` object
 +
 [source,terminal]
 ----
@@ -94,7 +94,7 @@ $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages
 
 [WARNING]
 ====
-This functionality is currently only supported on {op-system-first} 8.x worker nodes. On {op-system-base-full} 7.x worker nodes the Tuned `[bootloader]` plug-in is currently not supported.
+This functionality is currently only supported on {op-system-first} 8.x worker nodes. On {op-system-base-full} 7.x worker nodes the TuneD `[bootloader]` plug-in is currently not supported.
 ====
 
 ////

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -39,7 +39,7 @@ _EOF_
 
 [IMPORTANT]
 ====
-Custom profile writers are strongly encouraged to include the default Tuned
+Custom profile writers are strongly encouraged to include the default TuneD
 daemon profiles shipped within the default Tuned CR. The example above uses the
 default `openshift-control-plane` profile to accomplish this.
 ====

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -6,9 +6,9 @@
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
 
-The custom resource (CR) for the Operator has two major sections. The first section, `profile:`, is a list of Tuned profiles and their names. The second, `recommend:`, defines the profile selection logic.
+The custom resource (CR) for the Operator has two major sections. The first section, `profile:`, is a list of TuneD profiles and their names. The second, `recommend:`, defines the profile selection logic.
 
-Multiple custom tuning specifications can co-exist as multiple CRs in the Operator's namespace. The existence of new CRs or the deletion of old CRs is detected by the Operator. All existing custom tuning specifications are merged and appropriate objects for the containerized Tuned daemons are updated.
+Multiple custom tuning specifications can co-exist as multiple CRs in the Operator's namespace. The existence of new CRs or the deletion of old CRs is detected by the Operator. All existing custom tuning specifications are merged and appropriate objects for the containerized TuneD daemons are updated.
 
 *Management state*
 
@@ -20,26 +20,26 @@ The Operator Management state is set by adjusting the default Tuned CR. By defau
 
 *Profile data*
 
-The `profile:` section lists Tuned profiles and their names.
+The `profile:` section lists TuneD profiles and their names.
 
 [source,yaml]
 ----
 profile:
 - name: tuned_profile_1
   data: |
-    # Tuned profile specification
+    # TuneD profile specification
     [main]
     summary=Description of tuned_profile_1 profile
 
     [sysctl]
     net.ipv4.ip_forward=1
-    # ... other sysctl's or other Tuned daemon plugins supported by the containerized Tuned
+    # ... other sysctl's or other TuneD daemon plugins supported by the containerized TuneD
 
 # ...
 
 - name: tuned_profile_n
   data: |
-    # Tuned profile specification
+    # TuneD profile specification
     [main]
     summary=Description of tuned_profile_n profile
 
@@ -74,7 +74,7 @@ The individual items of the list:
 <3> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
 <4> An optional list.
 <5> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<6> A Tuned profile to apply on a match. For example `tuned_profile_1`.
+<6> A TuneD profile to apply on a match. For example `tuned_profile_1`.
 
 `<match>` is an optional list recursively defined as follows:
 
@@ -98,7 +98,7 @@ The list items `match` and `machineConfigLabels` are connected by the logical OR
 
 [IMPORTANT]
 ====
-When using machine config pool based matching, it is advised to group nodes with the same hardware configuration into the same machine config pool. Not following this practice might result in Tuned operands calculating conflicting kernel parameters for two or more nodes sharing the same machine config pool.
+When using machine config pool based matching, it is advised to group nodes with the same hardware configuration into the same machine config pool. Not following this practice might result in TuneD operands calculating conflicting kernel parameters for two or more nodes sharing the same machine config pool.
 ====
 
 .Example: node or pod label based matching
@@ -121,10 +121,10 @@ When using machine config pool based matching, it is advised to group nodes with
   profile: openshift-node
 ----
 
-The CR above is translated for the containerized Tuned daemon into its `recommend.conf` file based on the profile priorities. The profile with the
-highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized Tuned daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
+The CR above is translated for the containerized TuneD daemon into its `recommend.conf` file based on the profile priorities. The profile with the
+highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized TuneD daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
-If the labels for the profile with priority `10` matched, `openshift-control-plane-es` profile is applied and no other profile is considered. If the node/pod label combination did not match, the second highest priority profile (`openshift-control-plane`) is considered. This profile is applied if the containerized Tuned pod runs on a node with labels `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
+If the labels for the profile with priority `10` matched, `openshift-control-plane-es` profile is applied and no other profile is considered. If the node/pod label combination did not match, the second highest priority profile (`openshift-control-plane`) is considered. This profile is applied if the containerized TuneD pod runs on a node with labels `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
 Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks the `<match>` section and, therefore, will always match. It acts as a profile catch-all to set `openshift-node` profile, if no other profile with higher priority matches on a given node.
 

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -4,9 +4,9 @@
 // * post_installation_configuration/node-tasks.adoc
 
 [id="supported-tuned-daemon-plug-ins_{context}"]
-= Supported Tuned daemon plug-ins
+= Supported TuneD daemon plug-ins
 
-Excluding the `[main]` section, the following Tuned plug-ins are supported when
+Excluding the `[main]` section, the following TuneD plug-ins are supported when
 using custom profiles defined in the `profile:` section of the Tuned CR:
 
 * audio
@@ -26,7 +26,7 @@ using custom profiles defined in the `profile:` section of the Tuned CR:
 * vm
 
 There is some dynamic tuning functionality provided by some of these plug-ins
-that is not supported. The following Tuned plug-ins are currently not supported:
+that is not supported. The following TuneD plug-ins are currently not supported:
 
 * bootloader
 * script
@@ -35,6 +35,6 @@ that is not supported. The following Tuned plug-ins are currently not supported:
 
 See
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance#available-tuned-plug-ins_customizing-tuned-profiles[Available
-Tuned Plug-ins] and
+TuneD Plug-ins] and
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance[Getting
-Started with Tuned] for more information.
+Started with TuneD] for more information.

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -22,11 +22,11 @@ ifdef::operators[]
 [discrete]
 == Purpose
 endif::operators[]
-The Node Tuning Operator helps you manage node-level tuning by orchestrating the Tuned daemon. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
+The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
 
-The Operator manages the containerized Tuned daemon for {product-title} as a Kubernetes daemon set. It ensures the custom tuning specification is passed to all containerized Tuned daemons running in the cluster in the format that the daemons understand. The daemons run on all nodes in the cluster, one per node.
+The Operator manages the containerized TuneD daemon for {product-title} as a Kubernetes daemon set. It ensures the custom tuning specification is passed to all containerized TuneD daemons running in the cluster in the format that the daemons understand. The daemons run on all nodes in the cluster, one per node.
 
-Node-level settings applied by the containerized Tuned daemon are rolled back on an event that triggers a profile change or when the containerized Tuned daemon is terminated gracefully by receiving and handling a termination signal.
+Node-level settings applied by the containerized TuneD daemon are rolled back on an event that triggers a profile change or when the containerized TuneD daemon is terminated gracefully by receiving and handling a termination signal.
 
 The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
 ifdef::operators[]


### PR DESCRIPTION
Changes:
  - Verification that the TuneD profiles are applied; all the user needs to do now is
    `oc get profile -n openshift-cluster-node-tuning-operator`
  - TuneD daemon is being renamed officially to TuneD; see: https://github.com/redhat-performance/tuned/pull/334