### PR TITLE
OSDOCS-2005: Fixed --cluster and --user command syntax.

### DIFF
--- a/modules/rosa-accessing-your-cluster-quick.adoc
+++ b/modules/rosa-accessing-your-cluster-quick.adoc
@@ -5,9 +5,9 @@
 
 
 [id="rosa-accessing-your-cluster-quick_{context}"]
-= Accessing your cluster
+= Accessing your cluster quickly
 
-To log in to your cluster, you can use this quick access procedure.
+You can use this quick access procedure to log in to your cluster.
 
 [NOTE]
 ====
@@ -16,13 +16,11 @@ As a best practice, access your cluster with an IDP account instead.
 
 .Procedure
 
-To access your cluster:
-
 . Enter the following command:
 +
 [source,terminal]
 ----
-$ rosa create admin -c <cluster_name>
+$ rosa create admin --cluster=<cluster_name>
 ----
 +
 .Example output

--- a/modules/rosa-accessing-your-cluster.adoc
+++ b/modules/rosa-accessing-your-cluster.adoc
@@ -23,15 +23,15 @@ To access your cluster using an IDP account:
 +
 [source, terminal]
 ----
-$ rosa create idp --cluster=rh-rosa-test-cluster --interactive
+$ rosa create idp --cluster=<cluster_name> --interactive
 ----
 +
 .. Enter the following values:
 +
 --
 * Type of identity provider: `github`
-* Restrict to members of: `organizations` (if you do not have a GitHub Organization, you can create one now.)
-* GitHub organizations: `rh-test-org` (enter the name of your org)
+* Restrict to members of: `organizations` (if you do not have a GitHub Organization, you can create one now)
+* GitHub organizations: `rh-test-org` (enter the name of your organization)
 --
 +
 .Example output
@@ -77,7 +77,7 @@ The IDP can take 1-2 minutes to be configured within your cluster.
 +
 [source,terminal]
 ----
-$ rosa list idps --cluster rh-rosa-test-cluster1
+$ rosa list idps --cluster=<cluster_name>
 ----
 +
 .Example output
@@ -92,7 +92,7 @@ github-1    GitHub    https://oauth-openshift.apps.rh-rosa-test-cluster1.j9n4.s1
 +
 [source,terminal]
 ----
-$ rosa describe cluster rh-rosa-test-cluster1
+$ rosa describe cluster --cluster=<cluster_name>
 ----
 +
 .Example output

--- a/modules/rosa-create-cluster-admins.adoc
+++ b/modules/rosa-create-cluster-admins.adoc
@@ -23,14 +23,14 @@ Additionally, only the user who created the cluster can grant cluster access to 
 +
 [source,terminal]
 ----
-$ rosa grant user cluster-admin --user <idp_user_name> --cluster <cluster_name>
+$ rosa grant user cluster-admin --user=<idp_user_name> --cluster=<cluster_name>
 ----
 +
 . Verify your user is listed as a cluster administrator:
 +
 [source,terminal]
 ----
-$ rosa list users --cluster <cluster_name>
+$ rosa list users --cluster=<cluster_name>
 ----
 +
 .Example output

--- a/modules/rosa-create-dedicated-cluster-admins.adoc
+++ b/modules/rosa-create-dedicated-cluster-admins.adoc
@@ -20,7 +20,7 @@ Only the user who created the cluster can grant cluster access to other `cluster
 +
 [source,terminal]
 ----
-$ rosa grant user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
+$ rosa grant user dedicated-admin --user=<idp_user_name> --cluster=<cluster_name>
 ----
 +
 . Enter the following command to verify that your user now has `dedicated-admin` access:

--- a/modules/rosa-delete-cluster-admins.adoc
+++ b/modules/rosa-delete-cluster-admins.adoc
@@ -20,12 +20,12 @@ Only the user who created the cluster can revoke access for `cluster-admin` user
 +
 [source,terminal]
 ----
-$ rosa revoke user --cluster <cluster_name> --cluster-admins <idp_user_name>
+$ rosa revoke user --cluster=<cluster_name> --cluster-admins=<idp_user_name>
 ----
 +
 . Verify your user is no longer listed as a `cluster-admin`:
 +
 [source,terminal]
 ----
-$ rosa list users --cluster <cluster_name>
+$ rosa list users --cluster=<cluster_name>
 ----

--- a/modules/rosa-delete-dedicated-admins.adoc
+++ b/modules/rosa-delete-dedicated-admins.adoc
@@ -20,7 +20,7 @@ Only the user who created the cluster can revoke access for a `dedicated-admin` 
 +
 [source,terminal]
 ----
-$ rosa revoke user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
+$ rosa revoke user dedicated-admin --user=<idp_user_name> --cluster=<cluster_name>
 ----
 +
 . Enter the following command to verify that your user no longer has `dedicated-admin` access. The user will not be listed in the output.

--- a/modules/rosa-quickstart-instructions.adoc
+++ b/modules/rosa-quickstart-instructions.adoc
@@ -15,15 +15,15 @@ If you have already installed the required prerequisites, here are the commands 
 $ rosa init
 
 ## Starts the cluster creation process (~30-40minutes)
-$ rosa create cluster --cluster-name <cluster_name>
+$ rosa create cluster --cluster-name=<cluster_name>
 
 ## Connect your IDP to your cluster
-$ rosa create idp --cluster <cluster_name> --interactive
+$ rosa create idp --cluster=<cluster_name> --interactive
 
 ## Promotes a user from your IDP to dedicated-admin level
-$ rosa grant user dedicated-admin --user <idp_user_name> --cluster <cluster_name>
+$ rosa grant user dedicated-admin --user=<idp_user_name> --cluster=<cluster_name>
 
 ## Checks if your install is ready (look for State: Ready),
 ## and provides your Console URL to login to the web console.
-$ rosa describe cluster <cluster_name>
+$ rosa describe cluster --cluster=<cluster_name>
 ----

--- a/rosa_getting_started/rosa-quickstart.adoc
+++ b/rosa_getting_started/rosa-quickstart.adoc
@@ -4,11 +4,8 @@ include::modules/attributes-openshift-dedicated.adoc[]
 = Getting started with {product-title}
 :context: rosa-quickstart
 
-
-A list of quick start commands for creating a {product-title} (ROSA) cluster after the prerequisites have been met.
-
 toc::[]
 
-This chapter walks you through setting up your first {product-title} cluster using the `rosa` command-line utility (CLI).
+This document walks you through setting up your first {product-title} cluster using the `rosa` command-line utility (CLI).
 
 include::modules/rosa-quickstart-instructions.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2005

Previews for fixed topics:

https://deploy-preview-31078--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart.html

https://deploy-preview-31078--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-accessing-cluster.html

https://deploy-preview-31078--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-deleting-access-cluster.html