### PR TITLE
Changed text regarding modification of manifest files. BZ1904138

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -28,7 +28,7 @@ parameter.
 
 [IMPORTANT]
 ====
-Modifying the {product-title} manifest files directly is not supported.
+Modifying the {product-title} manifest files created by the installation program is not supported. Applying a manifest file that you create, as in the following procedure, is supported.
 ====
 
 .Prerequisites


### PR DESCRIPTION
…BZ1904138.

https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-network-customizations.html#modifying-nwoperator-config-startup_installing-aws-network-customizations (also in 4.4, 4.5 and 4.6)

Text change in modules/nw-modifying-operator-install-config.adoc in the "IMPORTANT" box:

"Modifying the OpenShift Container Platform manifest files directly is not supported."

Changed to:
"Modify the OpenShift Container Platform manifest files only after installation completes."
