### PR TITLE
OSDOCS-1809: Update the SDN migration procedure for release 4.8

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -7,7 +7,7 @@
 
 Migrating to the OVN-Kubernetes Container Network Interface (CNI) cluster network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
 
-A migration to the OVN-Kubernetes cluster network provider is supported on installer-provisioned clusters on the following platforms:
+A migration to the OVN-Kubernetes cluster network provider is supported on the following platforms:
 
 * Bare metal hardware
 * Amazon Web Services (AWS)
@@ -15,11 +15,6 @@ A migration to the OVN-Kubernetes cluster network provider is supported on insta
 * Microsoft Azure
 * {rh-openstack-first}
 * VMware vSphere
-
-[NOTE]
-====
-Performing a migration on a user-provisioned cluster is not supported.
-====
 
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
 == Considerations for migrating to the OVN-Kubernetes network provider
@@ -130,14 +125,71 @@ OVN-Kubernetes fully supports the Kubernetes `NetworkPolicy` API in the `network
 [id="how-the-migration-process-works_{context}"]
 == How the migration process works
 
-The migration process works as follows:
+The following table summarizes the migration process by segmenting between the user-initiated steps in the process and the actions that the migration performs in response.
 
-. Set a temporary annotation set on the Cluster Network Operator (CNO) configuration object. This annotation triggers the CNO to watch for a change to the `defaultNetwork` field.
+.Migrating to OVN-Kubernetes from OpenShift SDN
+[cols="1,1a",options="header"]
+|===
 
-. Suspend the Machine Config Operator (MCO) to ensure that it does not interrupt the migration.
+|User-initiated steps|Migration activity
 
-. Update the `defaultNetwork` field. The update causes the CNO to destroy the OpenShift SDN control plane pods and deploy the OVN-Kubernetes control plane pods. Additionally, it updates the Multus objects to reflect the new cluster network provider.
+|
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Make sure the `migration` field is `null` before setting it to a value.
+|
+Cluster Network Operator (CNO):: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
+Machine Config Operator (MCO):: Rolls out an update to the systemd configuration necessary for OVN-Kubernetes; The MCO updates a single machine per pool at a time by default, causing the total time the migration takes to increase with the size of the cluster.
 
-. Reboot each node in the cluster. Because the existing pods in the cluster are unaware of the change to the cluster network provider, rebooting each node ensures that each node is drained of pods. New pods are attached to the new cluster network provided by OVN-Kubernetes.
+|Update the `networkType` field of the `Network.config.openshift.io` CR.
+|
+CNO:: Performs the following actions:
++
+--
+* Destroys the OpenShift SDN control plane pods.
+* Deploys the OVN-Kubernetes control plane pods.
+* Updates the Multus objects to reflect the new cluster network provider.
+--
 
-. Enable the MCO after all nodes in the cluster reboot. The MCO rolls out an update to the systemd configuration necessary to complete the migration. The MCO updates a single machine per pool at a time by default, so the total time the migration takes increases with the size of the cluster.
+|
+Reboot each node in the cluster.
+|
+Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-Kubernetes cluster network.
+
+|===
+
+If a rollback to OpenShift SDN is required, the following table describes the process.
+
+.Performing a rollback to OpenShift SDN
+[cols="1,1a",options="header"]
+|===
+
+|User-initiated steps|Migration activity
+
+|Suspend the MCO to ensure that it does not interrupt the migration.
+|The MCO stops.
+
+|
+Set the `migration` field of the `Network.operator.openshift.io` custom resource (CR) named `cluster` to `OVNKubernetes`. Make sure the `migration` field is `null` before setting it to a value.
+|
+CNO:: Updates the status of the `Network.config.openshift.io` CR named `cluster` accordingly.
+
+|Update the `networkType` field.
+|
+CNO:: Performs the following actions:
++
+--
+* Destroys the OpenShift SDN control plane pods.
+* Deploys the OVN-Kubernetes control plane pods.
+* Updates the Multus objects to reflect the new cluster network provider.
+--
+
+|
+Reboot each node in the cluster.
+|
+Cluster:: As nodes reboot, the cluster assigns IP addresses to pods on the OVN-Kubernetes cluster network.
+
+|
+Enable the MCO after all nodes in the cluster reboot.
+|
+MCO:: Rolls out an update to the systemd configuration necessary for OpenShift SDN; The MCO updates a single machine per pool at a time by default, so the total time the migration takes increases with the size of the cluster.
+
+|===

--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -16,12 +16,12 @@ Perform the migration only when an interruption in service is acceptable.
 
 .Prerequisites
 
-* A cluster installed on installer-provisioned infrastructure and configured with the OpenShift SDN default CNI network provider in the network policy isolation mode.
+* A cluster configured with the OpenShift SDN CNI cluster network provider in the network policy isolation mode.
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
 * A recent backup of the etcd database is available.
-* The cluster is in a known good state, without any errors.
 * A reboot can be triggered manually for each node.
+* The cluster is in a known good state, without any errors.
 
 .Procedure
 
@@ -32,63 +32,18 @@ Perform the migration only when an interruption in service is acceptable.
 $ oc get Network.config.openshift.io cluster -o yaml > cluster-openshift-sdn.yaml
 ----
 
-. To enable the migration, set an annotation on the Cluster Network Operator configuration object by entering the following command:
+. To prepare all the nodes for the migration, set the `migration` field on the Cluster Network Operator configuration object by entering the following command:
 +
 [source,terminal]
 ----
-$ oc annotate Network.operator.openshift.io cluster \
-  'networkoperator.openshift.io/network-migration'=""
-----
-
-. Stop all of the machine configuration pools managed by the Machine Config Operator (MCO):
-
-** Stop the master configuration pool:
-+
-[source,terminal]
-----
-$ oc patch MachineConfigPool master --type='merge' --patch \
-  '{ "spec": { "paused": true } }'
-----
-
-** Stop the worker configuration pool:
-+
-[source,terminal]
-----
-$ oc patch MachineConfigPool worker --type='merge' --patch \
-  '{ "spec":{ "paused" :true } }'
-----
-
-. Configure the OVN-Kubernetes cluster network provider by using one of the following commands:
-
-** To specify the network provider without changing the cluster network IP address block, enter the following command:
-+
-[source,terminal]
-----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
-----
-
-** To specify a different cluster network IP address block, enter the following command:
-+
-[source,terminal]
-----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{
-    "spec": {
-      "clusterNetwork": [
-        {
-          "cidr": "<cidr>",
-          "hostPrefix": "<prefix>"
-        }        
-      ],
-      "networkType": "OVNKubernetes"
-    } 
-  }'
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": {"networkType": "OVNKubernetes" } } }'
 ----
 +
-where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster. You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block, because the OVN-Kubernetes network provider uses this block internally.
-+
-IMPORTANT: You cannot change the service network address block during the migration.
+[NOTE]
+====
+This step does not deploy OVN-Kubernetes immediately. Instead, specifying the `migration` field triggers the Machine Config Operator (MCO) to apply new machine configs to all the nodes in the cluster in preparation for the OVN-Kubernetes deployment.
+====
 
 . Optional: You can customize the following settings for OVN-Kubernetes to meet your network infrastructure requirements:
 +
@@ -130,64 +85,22 @@ $ oc patch Network.operator.openshift.io cluster --type=merge \
     }}}}'
 ----
 
-. Wait until the Multus daemon set rollout completes.
+. As the MCO updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated. Check the machine config pool status by entering the following command:
 +
 [source,terminal]
 ----
-$ oc -n openshift-multus rollout status daemonset/multus
+$ oc get mcp
 ----
 +
-The name of the Multus pods is in form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
+A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
 +
-.Example output
-[source,text]
-----
-Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
-...
-Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
-daemon set "multus" successfully rolled out
-----
-
-. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
-+
-[source,bash]
-----
-#!/bin/bash
-
-for ip in $(oc get nodes  -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
-do
-   echo "reboot node $ip"
-   ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
-done
-----
-+
-If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
-
-. After the nodes in your cluster have rebooted, start all of the machine configuration pools:
-+
---
-* Start the master configuration pool:
-+
-[source,terminal]
-----
-$ oc patch MachineConfigPool master --type='merge' --patch \
-  '{ "spec": { "paused": false } }'
-----
-
-* Start the worker configuration pool:
-+
-[source,terminal]
-----
-$ oc patch MachineConfigPool worker --type='merge' --patch \
-  '{ "spec": { "paused": false } }'
-----
---
-+
-As the MCO updates machines in each config pool, it reboots each node.
-+
-By default the MCO updates a single machine per pool at a time, so the time that the migration requires to complete grows with the size of the cluster.
+[NOTE]
+====
+By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+====
 
 . Confirm the status of the new machine configuration on the hosts:
+
 .. To list the machine configuration state and the name of the applied machine configuration, enter the following command:
 +
 [source,terminal]
@@ -226,22 +139,6 @@ The machine config must include the following update to the systemd configuratio
 [source,plain]
 ----
 ExecStart=/usr/local/bin/configure-ovs.sh OVNKubernetes
-----
-
-. Confirm that the migration succeeded:
-
-.. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
-+
-[source,terminal]
-----
-$ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
-----
-
-.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
-+
-[source,terminal]
-----
-$ oc get nodes
 ----
 
 .. If a node is stuck in the `NotReady` state, investigate the machine config daemon pod logs and resolve any errors.
@@ -283,6 +180,90 @@ where `pod` is the name of a machine config daemon pod.
 
 ... Resolve any errors in the logs shown by the output from the previous command.
 
+. To start the migration, configure the OVN-Kubernetes cluster network provider by using one of the following commands:
+
+** To specify the network provider without changing the cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
+----
+
+** To specify a different cluster network IP address block, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.config.openshift.io cluster \
+  --type='merge' --patch '{
+    "spec": {
+      "clusterNetwork": [
+        {
+          "cidr": "<cidr>",
+          "hostPrefix": "<prefix>"
+        }
+      ]
+      "networkType": "OVNKubernetes"
+    } 
+  }'
+----
++
+where `cidr` is a CIDR block and `prefix` is the slice of the CIDR block apportioned to each node in your cluster. You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
++
+[IMPORTANT]
+====
+You cannot change the service network address block during the migration.
+====
+
+. Verify that the Multus daemon set rollout is complete before continuing with subsequent steps:
++
+[source,terminal]
+----
+$ oc -n openshift-multus rollout status daemonset/multus
+----
++
+The name of the Multus pods is in the form of `multus-<xxxxx>` where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
++
+.Example output
+[source,text]
+----
+Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
+...
+Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
+daemon set "multus" successfully rolled out
+----
+
+. To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password.
++
+[source,bash]
+----
+#!/bin/bash
+
+for ip in $(oc get nodes  -o jsonpath='{.items[*].status.addresses[?(@.type=="InternalIP")].address}')
+do
+   echo "reboot node $ip"
+   ssh -o StrictHostKeyChecking=no core@$ip sudo shutdown -r -t 3
+done
+----
++
+If ssh access is not available, you might be able to reboot each node through the management portal for your infrastructure provider.
+
+. Confirm that the migration succeeded:
+
+.. To confirm that the CNI cluster network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OVNKubernetes`.
++
+[source,terminal]
+----
+$ oc get network.config/cluster -o jsonpath='{.status.networkType}{"\n"}'
+----
+
+.. To confirm that the cluster nodes are in the `Ready` state, enter the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
+
 .. To confirm that your pods are not in an error state, enter the following command:
 +
 [source,terminal]
@@ -292,14 +273,31 @@ $ oc get pods --all-namespaces -o wide --sort-by='{.spec.nodeName}'
 +
 If pods on a node are in an error state, reboot that node.
 
-. Complete the following steps only if the migration succeeds and your cluster is in a good state:
-
-.. To remove the migration annotation from the Cluster Network Operator configuration object, enter the following command:
+.. To confirm that all of the cluster Operators are not in an abnormal state, enter the following command:
 +
 [source,terminal]
 ----
-$ oc annotate Network.operator.openshift.io cluster \
-  networkoperator.openshift.io/network-migration-
+$ oc get co
+----
++
+The status of every cluster Operator must be the following: `AVAILABLE="True"`, `PROGRESSING="False"`, `DEGRADED="False"`. If a cluster Operator is not available or degraded, check the logs for the cluster Operator for more information.
+
+. Complete the following steps only if the migration succeeds and your cluster is in a good state:
+
+.. To remove the migration configuration from the CNO configuration object, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": null } }'
+----
+
+.. To remove custom configuration for the OpenShift SDN network provider, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "defaultNetwork": { "openshiftSDNConfig": null } } }'
 ----
 
 .. To remove the OpenShift SDN network provider namespace, enter the following command:

--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -5,7 +5,7 @@
 [id="nw-ovn-kubernetes-rollback_{context}"]
 = Rolling back the default CNI network provider to OpenShift SDN
 
-As a cluster administrator, you can rollback your cluster to the OpenShift SDN default Container Network Interface (CNI) network provider.
+As a cluster administrator, you can rollback your cluster to the OpenShift SDN Container Network Interface (CNI) cluster network provider.
 During the rollback, you must reboot every node in your cluster.
 
 [IMPORTANT]
@@ -17,17 +17,9 @@ Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 
 * Install the OpenShift CLI (`oc`).
 * Access to the cluster as a user with the `cluster-admin` role.
-* A cluster installed on infrastructure configured with the OVN-Kubernetes default CNI network provider.
+* A cluster installed on infrastructure configured with the OVN-Kubernetes CNI cluster network provider.
 
 .Procedure
-
-. To enable the migration, set an annotation on the Cluster Network Operator configuration object by entering the following command:
-+
-[source,terminal]
-----
-$ oc annotate Network.operator.openshift.io cluster \
-  'networkoperator.openshift.io/network-migration'=""
-----
 
 . Stop all of the machine configuration pools managed by the Machine Config Operator (MCO):
 
@@ -39,7 +31,7 @@ $ oc patch MachineConfigPool master --type='merge' --patch \
   '{ "spec": { "paused": true } }'
 ----
 
-** Stop the worker configuration pool:
+** Stop the worker machine configuration pool:
 +
 [source,terminal]
 ----
@@ -47,12 +39,15 @@ $ oc patch MachineConfigPool worker --type='merge' --patch \
   '{ "spec":{ "paused" :true } }'
 ----
 
-. To configure the OpenShift SDN cluster network provider, enter the following command:
+. To start the migration, set the cluster network provider back to OpenShift SDN by entering the following commands:
 +
 [source,terminal]
 ----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{ "spec": { "networkType": "OpenShiftSDN" } }'
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": { "networkType": "OpenShiftSDN" } } }'
+
+$ oc patch Network.config.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "networkType": "OpenShiftSDN" } }'
 ----
 
 . Optional: You can customize the following settings for OpenShift SDN to meet your network infrastructure requirements:
@@ -252,12 +247,20 @@ If pods on a node are in an error state, reboot that node.
 
 . Complete the following steps only if the migration succeeds and your cluster is in a good state:
 
-.. To remove the migration annotation from the Cluster Network Operator configuration object, enter the following command:
+.. To remove the migration configuration from the Cluster Network Operator configuration object, enter the following command:
 +
 [source,terminal]
 ----
-$ oc annotate Network.operator.openshift.io cluster \
-  networkoperator.openshift.io/network-migration-
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "migration": null } }'
+----
+
+.. To remove the OVN-Kubernetes configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc patch Network.operator.openshift.io cluster --type='merge' \
+  --patch '{ "spec": { "defaultNetwork": { "ovnKubernetesConfig":null } } }'
 ----
 
 .. To remove the OVN-Kubernetes network provider namespace, enter the following command:


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1809

Preview:
- [Migrate from the OpenShift SDN cluster network provider](https://deploy-preview-31089--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html)