### PR TITLE
s390x: add notes to prevent usage of 'newlines' in zVM's parmfiles

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -58,17 +58,23 @@ Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 +
 [source,terminal]
 ----
-rd.neednet=1 dfltcc=off console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
-cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
-ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
-rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
-!condev rd.dasd=0.0.3490
+
+rd.neednet=1 \
+dfltcc=off \
+console=ttysclp0 \
+coreos.inst.install_dev=dasda \
+coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign \
+ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \
+rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 \
+zfcp.allow_lun_scan=0 cio_ignore=all,!condev \
+rd.dasd=0.0.3490
 ----
 +
 [NOTE]
 ====
 `dfltcc=off` is required for IBM z15 and LinuxONE III.
+Write all options in the parameter file as a single line and make sure you have no newline characters.
 ====
 
 ** For installations on FCP-type disks, complete the following tasks:
@@ -96,21 +102,27 @@ The following is an example parameter file `worker-1.parm` for a worker node wit
 +
 [source,terminal]
 ----
-rd.neednet=1 dfltcc=off console=ttysclp0 coreos.inst.install_dev=sda
-coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign
-ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
-rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
-!condev
-rd.zfcp=0.0.1987,0x50050763070bc5e3,0x4008400B00000000
-rd.zfcp=0.0.19C7,0x50050763070bc5e3,0x4008400B00000000
-rd.zfcp=0.0.1987,0x50050763071bc5e3,0x4008400B00000000
+
+rd.neednet=1 \
+dfltcc=off \
+console=ttysclp0 \
+coreos.inst.install_dev=sda \
+coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign \
+ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \
+rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 \
+zfcp.allow_lun_scan=0 \
+cio_ignore=all,!condev \
+rd.zfcp=0.0.1987,0x50050763070bc5e3,0x4008400B00000000 \
+rd.zfcp=0.0.19C7,0x50050763070bc5e3,0x4008400B00000000 \
+rd.zfcp=0.0.1987,0x50050763071bc5e3,0x4008400B00000000 \
 rd.zfcp=0.0.19C7,0x50050763071bc5e3,0x4008400B00000000
 ----
 +
 [NOTE]
 ====
 `dfltcc=off` is required for IBM z15 and LinuxONE III.
+Write all options in the parameter file as a single line and make sure you have no newline characters.
 ====
 
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to z/VM, for example with FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-installing-zvm-s390[Installing under Z/VM].


### PR DESCRIPTION
Users often copy-paste example configs (with newlines) and end up with
an issue descibed here:
https://bugzilla.redhat.com/show_bug.cgi?id=1941302

Signed-off-by: Nikita Dubrovskii <nikita@linux.ibm.com>