### PR TITLE
Commenting out content that was merged before GA

### DIFF
--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -21,6 +21,7 @@ For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understandin
 [id="getting-support"]
 == Pipelines support
 
+////
 The following compatibility matrix shows the support status and compatible versions for the various {pipelines-title} components:
 
 |===
@@ -40,6 +41,7 @@ The following compatibility matrix shows the support status and compatible versi
 |4.7
 
 |===
+////
 
 If you experience difficulty with a procedure described in this documentation,
 visit the Red Hat Customer Portal to learn more about link:https://access.redhat.com/support/offerings/techpreview/[Red Hat Technology Preview features support scope].


### PR DESCRIPTION
Content for 1.4 GA of Pipelines was inadvertently merged before GA. Commenting out those sections to prevent confusion.
Doc Epic: https://issues.redhat.com/browse/RHDEVDOCS-2387?focusedCommentId=16011881&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-16011881
Aligned team: Dev Tools
Versions: 4.7 and 4.8
Preview link: https://deploy-preview-31117--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#getting-support