### PR TITLE
Adds additional resources section

### DIFF
--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -53,17 +53,17 @@ The upstream Istio community installation includes options to perform exact head
 ----
 apiVersion: security.istio.io/v1beta1
 kind: AuthorizationPolicy
-metadata: 
+metadata:
   name: httpbin-usernamepolicy
-spec: 
+spec:
   action: ALLOW
-  rules: 
-    - when: 
+  rules:
+    - when:
         - key: 'request.regex.headers[username]'
-          values: 
+          values:
             - "allowed.*"
-  selector: 
-    matchLabels: 
+  selector:
+    matchLabels:
       app: httpbin
 ----
 

--- a/service_mesh/v1x/ossm-vs-community.adoc
+++ b/service_mesh/v1x/ossm-vs-community.adoc
@@ -14,6 +14,11 @@ The current release of {ProductName} differs from the current upstream Istio com
 include::modules/ossm-multitenant.adoc[leveloffset=+1]
 
 include::modules/ossm-vs-istio-1x.adoc[leveloffset=+1]
+[discrete]
+[id="additional-resources_ossm-vs-istio-v1x"]
+==== Additional resources
+
+* xref:../../service_mesh/v1x/ossm-traffic-manage.html#ossm-auto-route_routing-traffic-v1x[Automatic route creation]
 
 include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-vs-community.adoc
+++ b/service_mesh/v2x/ossm-vs-community.adoc
@@ -14,8 +14,12 @@ The current release of {ProductName} differs from the current upstream Istio com
 include::modules/ossm-multitenant.adoc[leveloffset=+1]
 
 include::modules/ossm-vs-istio.adoc[leveloffset=+1]
+[discrete]
+[id="additional-resources_ossm-vs-istio-v2x"]
+==== Additional resources
 
-include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+2]
+* xref:../../service_mesh/v2x/ossm-traffic-manage.html#ossm-auto-route_routing-traffic[Automatic route creation]
 
-include::modules/ossm-jaeger-service-mesh.adoc[leveloffset=+2]
+include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]
 
+include::modules/ossm-jaeger-service-mesh.adoc[leveloffset=+1]


### PR DESCRIPTION
GH Issue #28322 (https://github.com/openshift/openshift-docs/issues/28322) for 4.6+

Preview: 

v2x: https://deploy-preview-31128--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-vs-community.html#additional-resources

v1x: https://deploy-preview-31128--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/ossm-vs-community.html#additional-resources

I added an Additional Resources section to v1x and v2x Service Mesh assemblies. The original text alluded to a link, however we cannot put links in modules. It was suggested I add the Additional Resources section in its place. 