### PR TITLE
Jira:OSDOCS-2001:Fix formatting issues in autoscaling topics

### DIFF
--- a/modules/rosa-about-autoscaling-nodes.adoc
+++ b/modules/rosa-about-autoscaling-nodes.adoc
@@ -2,7 +2,7 @@
 //
 // rosa-nodes/rosa-enabling-autoscaling-nodes.adoc
 
-[id="rosa-enabling-autoscaling_{context}"]
+[id="rosa-about-autoscaling-nodes_{context}"]
 = About autoscaling nodes in a cluster
 
 The cluster autoscaler increases the size of the cluster when there are pods that failed to schedule on any of the current nodes due to insufficient resources or when another node is necessary to meet deployment needs. The cluster autoscaler does not increase the cluster resources beyond the limits that you specify.

--- a/modules/rosa-adding-instance-types.adoc
+++ b/modules/rosa-adding-instance-types.adoc
@@ -46,3 +46,4 @@ ID                  AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS             
 default             No            2           m5.xlarge                                      us-east-1a
 db-nodes-mp         No            2           m5.xlarge      app=db, tier=backend            us-east-1a
 db-nodes-large-mp   No            2           m5.2xlarge     app=db, tier=backend            us-east-1a
+----

--- a/modules/rosa-disabling-autoscaling-nodes.adoc
+++ b/modules/rosa-disabling-autoscaling-nodes.adoc
@@ -1,3 +1,4 @@
+
 // Module included in the following assemblies:
 //
 // rosa-nodes/rosa-disabling-autoscaling-nodes.adoc
@@ -5,11 +6,12 @@
 [id="rosa-disabling-autoscaling_{context}"]
 = Disabling autoscaling nodes in an existing cluster
 
+
 Disable autoscaling for worker nodes in the machine pool definition.
 
 .Procedure
 
-Enter the following command:
+. Enter the following command:
 +
 [source,terminal]
 ----

--- a/modules/rosa-enabling-autoscaling-nodes.adoc
+++ b/modules/rosa-enabling-autoscaling-nodes.adoc
@@ -3,7 +3,7 @@
 //
 // rosa-nodes/rosa-enabling-autoscaling-nodes.adoc
 
-[id="rosa-enabling-autoscaling_{context}"]
+[id="rosa-enabling-autoscaling-nodes_{context}"]
 = Enabling autoscaling nodes in an existing cluster
 
 


### PR DESCRIPTION
JIra: https://issues.redhat.com/browse/OSDOCS-2001

1) Fixed Code Block - Added termination characters to the end of the Example output block "----":
https://deploy-preview-31129--osdocs.netlify.app/openshift-rosa/latest/nodes/nodes/rosa-managing-worker-nodes.html#rosa-adding-instance-types_rosa-managing-worker-nodes

2) Create unique Id to the About autoscaling nodes in a cluster section. 
https://deploy-preview-31129--osdocs.netlify.app/openshift-rosa/latest/nodes/nodes/rosa-enabling-autoscaling-nodes.html#rosa-enabling-cluster-autoscaling_rosa-enabling-autoscaling-nodes

3) Fix format issues in disabling autoscaling - Add missing "." at the beginning of the first step in the Procedure:
https://deploy-preview-31129--osdocs.netlify.app/openshift-rosa/latest/nodes/nodes/rosa-disabling-autoscaling-nodes.html#rosa-disabling-autoscaling_rosa-autoscaling-nodes