### PR TITLE
CNV-5268 virtctl vnc proxy

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -52,8 +52,14 @@ the specified port of the node.
 |`virtctl console <vmi_name>`
 |Connect to a serial console of a virtual machine instance.
 
-|`virtctl vnc <vmi_name>`
-|Open a VNC connection to a virtual machine instance.
+|`virtctl vnc --kubeconfig=$KUBECONFIG <vmi_name>`
+|Open a VNC (Virtual Network Client) connection to a virtual machine instance. Access the graphical console of a virtual machine instance through a VNC which requires a remote viewer on your local machine.
+
+|`virtctl vnc --kubeconfig=$KUBECONFIG --proxy-only=true <vmi-name>`
+|Display the port number and connect manually to the virtual machine instance by using any viewer through the VNC connection.
+
+|`virtctl vnc --kubeconfig=$KUBECONFIG --port=<port-number> <vmi-name>`
+|Specify a port number to run the proxy on the specified port, if that port is available. If a port number is not specified, the proxy runs on a random port.
 
 |`virtctl image-upload dv <datavolume_name> --image-path=</path/to/image> --no-create`
 |Upload a virtual machine image to a data volume that already exists.


### PR DESCRIPTION
This PR is associated with [CNV-5268](https://issues.redhat.com/browse/CNV-5268):
https://issues.redhat.com/browse/CNV-5268?filter=-1

The table with virtctl client commands has been updated to reflect the virtctl command with and without the proxy.

This PR applies to OpenShift Virtualization 4.8 release.
