### PR TITLE
CCO-21: Support AWS Security Token Service (4.8 GA)

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -2,7 +2,6 @@
 = About the Cloud Credential Operator
 include::modules/common-attributes.adoc[]
 :context: about-cloud-credential-operator
-:FeatureName: Support for Amazon Web Services Secure Token Service (AWS STS)
 
 toc::[]
 
@@ -10,6 +9,7 @@ The Cloud Credential Operator (CCO) manages cloud provider credentials as  custo
 
 By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in several different modes. If no mode is specified, or the `credentialsMode` parameter is set to an empty string (`""`), the CCO operates in its default mode.
 
+[id="about-cloud-credential-operator-modes"]
 == Modes
 
 By setting different values for the `credentialsMode` parameter in the `install-config.yaml` file, the CCO can be configured to operate in _mint_, _passthrough_, or _manual_ mode. These options provide transparency and flexibility in how the CCO uses cloud credentials to process `CredentialsRequest` CRs in the cluster, and allow the CCO to be configured to suit the security requirements of your organization. Not all CCO modes are supported for all cloud providers.
@@ -26,9 +26,6 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 * **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual]**: In manual mode, a user manages cloud credentials instead of the CCO.
 
 ** **xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Manual with AWS STS]**: In manual mode, you can configure an AWS cluster to use Amazon Web Services Secure Token Service (AWS STS). With this configuration, the CCO uses temporary credentials for different components.
-//Tech Preview only in 4.7, needs disclaimer. Move after mint when feature is GA
-+
-include::modules/technology-preview.adoc[leveloffset=+0]
 
 .CCO mode support matrix
 [cols="<.^2,^.^1,^.^1,^.^1"]
@@ -68,6 +65,7 @@ include::modules/technology-preview.adoc[leveloffset=+0]
 
 |====
 
+[id="about-cloud-credential-operator-default"]
 == Default behavior
 For platforms on which multiple modes are supported (AWS, Azure, and GCP), when the CCO operates in its default mode, it checks the provided credentials dynamically to determine for which mode they are sufficient to process `CredentialsRequest` CRs.
 
@@ -84,6 +82,7 @@ If the credentials are changed after a successful installation and the CCO deter
 
 To resolve insufficient credentials issues, provide a credential with sufficient permissions. If an error occurred during installation, try installing again. For issues with new `CredentialsRequest` CRs, wait for the CCO to try to process the CR again. As an alternative, you can manually create IAM for xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[AWS], xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Azure], and xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[GCP].
 
+[id="additional-resources_about-cloud-credential-operator"]
 == Additional resources
 
 * xref:../../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Red Hat Operators reference page for the Cloud Credential Operator]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
@@ -2,7 +2,6 @@
 = Using manual mode
 include::modules/common-attributes.adoc[]
 :context: cco-mode-manual
-:FeatureName: Support for Amazon Web Services Secure Token Service (AWS STS)
 
 toc::[]
 
@@ -14,15 +13,14 @@ Using manual mode allows each cluster component to have only the permissions it 
 
 For information about configuring your cloud provider to use manual mode, see _Manually creating IAM_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[AWS], xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[Azure], or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[GCP].
 
-include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
-
 [id="manual-mode-sts-blurb"]
 == Manual mode with AWS STS
 
 You can configure an AWS cluster in manual mode to use xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Amazon Web Services Secure Token Service (AWS STS)]. With this configuration, the CCO uses temporary credentials for different components.
 
-include::modules/technology-preview.adoc[leveloffset=+0]
+include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 
+[id="additional-resources_cco-mode-manual"]
 == Additional resources
 
 * xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -5,10 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Manual mode with STS is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS).
-
-:FeatureName: Support for AWS Secure Token Service (STS)
-include::modules/technology-preview.adoc[leveloffset=+0]
+Manual mode with STS is supported for Amazon Web Services (AWS).
 
 In manual mode with STS, the individual {product-title} cluster components use AWS Secure Token Service (STS) to assign components IAM roles that provide short-term, limited-privilege security credentials. These credentials are associated with IAM roles that are specific to each component that makes AWS API calls.
 
@@ -60,17 +57,38 @@ data:
 [id="sts-mode-installing"]
 == Installing an {product-title} cluster configured for manual mode with STS
 
-To install a cluster that is configured to use the CCO in manual mode with STS in {product-title} version 4.7:
+To install a cluster that is configured to use the Cloud Credential Operator (CCO) in manual mode with STS:
 
-. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-config_cco-mode-sts[Create the required AWS resources]
-. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-run-installer_cco-mode-sts[Run the {product-title} installer]
-. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-verifying_cco-mode-sts[Verify that the cluster is using short-lived credentials]
+//[pre-4.8]. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-config_cco-mode-sts[Create the required AWS resources]
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configure the Cloud Credential Operator utility].
+. Create the required AWS resources xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-individually_cco-mode-sts[individually], or xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-at-once_cco-mode-sts[with a single command].
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-run-installer_cco-mode-sts[Run the {product-title} installer].
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-verifying_cco-mode-sts[Verify that the cluster is using short-lived credentials].
 
-//Task part 1: Creating AWS resources manually
-include::modules/sts-mode-installing-manual-config.adoc[leveloffset=+2]
+[NOTE]
+====
+Because the cluster is operating in manual mode when using STS, it is not able to create new credentials for components with the permissions that they require. When upgrading to a different minor version of {product-title}, there are often new AWS permission requirements. Before upgrading a cluster that is using STS, the cluster administrator must manually ensure that the AWS permissions are sufficient for existing components and available to any new components.
+====
 
-//Task part 2: Run the OCP installer
+//[pre-4.8]Task part 1: Creating AWS resources manually
+//include::modules/sts-mode-installing-manual-config.adoc[leveloffset=+2]
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+[id="sts-mode-create-aws-resources-ccoctl"]
+=== Creating AWS resources with the Cloud Credential Operator utility
+
+You can use the CCO utility (`ccoctl`) to create the required AWS resources xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-individually_cco-mode-sts[individually], or xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-at-once_cco-mode-sts[with a single command].
+
+//Task part 2a: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
+
+//Task part 2b: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Run the OCP installer
 include::modules/sts-mode-installing-manual-run-installer.adoc[leveloffset=+2]
 
-//Task part 3: Verify that the cluster is using short-lived credentials
+//Task part 4: Verify that the cluster is using short-lived credentials
 include::modules/sts-mode-installing-verifying.adoc[leveloffset=+2]

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+
+[id="cco-ccoctl-configuring_{context}"]
+= Configuring the Cloud Credential Operator utility
+
+To create and manage cloud credentials from outside of the cluster when the Cloud Credential Operator (CCO) is operating in manual mode with STS, extract and prepare the CCO utility (`ccoctl`) binary.
+
+[NOTE]
+====
+The `ccoctl` is a Linux binary that must run in a Linux environment.
+====
+
+.Prerequisites
+
+* Obtain the {product-title} release image.
+
+.Procedure
+
+. Get the CCO container image from the {product-title} release image:
++
+[source,terminal]
+----
+$ CCO_IMAGE=$(oc adm release info --image-for='cloud-credential-operator' $RELEASE_IMAGE)
+----
+
+. Extract the `ccoctl` binary from the CCO container image within the {product-title} release image:
++
+[source,terminal]
+----
+$ oc image extract $CCO_IMAGE --file="/usr/bin/ccoctl" -a ~/.pull-secret
+----
+
+. Change the permissions to make `ccoctl` executable:
++
+[source,terminal]
+----
+$ chmod 775 ccoctl
+----
+
+.Verification
+
+* To verify that `ccoctl` is ready to use, display the help file:
++
+[source,terminal]
+----
+$ ccoctl aws --help
+----
++
+.Output of `ccoctl aws --help`:
++
+[source,terminal]
+----
+Creating/updating/deleting cloud credentials objects for AWS cloud
+
+
+Usage:
+  ccoctl aws [command]
+
+
+Available Commands:
+  create-all               Create all the required credentials objects
+  create-iam-roles         Create IAM roles
+  create-identity-provider Create IAM identity provider
+  create-key-pair          Create a key pair
+  delete                   Delete credentials objects
+
+Flags:
+  -h, --help   help for aws
+
+Use "ccoctl aws [command] --help" for more information about a command.
+----

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+
+[id="cco-ccoctl-creating-at-once_{context}"]
+= Creating AWS resources with a single command
+
+If you do not need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, and if the process the `ccoctl` tool uses to create AWS resources automatically meets the requirements of your organization, you can use the `ccoctl aws create-all` command to automate the creation of AWS resources.
+
+Otherwise, you can create the AWS resources individually.
+
+//to-do if possible: xref to modules/cco-ccoctl-creating-individually.adoc for `create the AWS resources individually`
+
+[NOTE]
+====
+By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+====
+
+.Prerequisites
+
+* Extract and prepare the `ccoctl` binary.
+
+.Procedure
+
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/openshift-release:__<version>__
+----
+
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
++
+[source,terminal,subs="+quotes"]
+----
+$ ccoctl aws create-all --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests
+----
+
+.Verification
+
+* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
++
+[source,terminal,subs="+quotes"]
+----
+$ ll __<path_to_ccoctl_output_dir>__/manifests
+----
++
+.Example output:
++
+[source,terminal,subs="+quotes"]
+----
+total 24
+-rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
+-rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+----
+
+You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+
+[id="cco-ccoctl-creating-individually_{context}"]
+= Creating AWS resources individually
+
+If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. For example, this option might be useful for an organization that shares the responsibility for creating these resources among different users or departments.
+
+Otherwise, you can use the `ccoctl aws create-all` command to create the AWS resources automatically.
+
+//to-do if possible: xref to modules/cco-ccoctl-creating-at-once.adoc for `create the AWS resources automatically`
+
+[NOTE]
+====
+By default, `ccoctl` creates objects in the directory in which the commands are run. To specify a directory, use the `--output-dir` flag. This procedure uses `_<path_to_ccoctl_output_dir>_` to refer to this location.
+
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To place JSON files on the local file system instead, use the `--dry-run` flag. These JSON files can be reviewed or modified and then applied with the AWS CLI tool using the `--cli-input-json` parameters.
+====
+
+.Prerequisites
+
+* Extract and prepare the `ccoctl` binary.
+
+.Procedure
+
+. Generate the public and private RSA key files that are used to set up the OpenID Connect provider for the cluster:
++
+[source,terminal]
+----
+$ ccoctl aws create key-pair
+----
++
+.Example output:
++
+[source,terminal,subs="+quotes"]
+----
+2021/04/13 11:01:02 Generating RSA keypair
+2021/04/13 11:01:03 Writing private key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.private
+2021/04/13 11:01:03 Writing public key to /__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+2021/04/13 11:01:03 Copying signing key for use by installer
+----
++
+Where `serviceaccount-signer.private` and `serviceaccount-signer.public` are the generated key files.
++
+This command also creates a private key that the cluster requires during installation in `/_<path_to_ccoctl_output_dir>_/tls/bound-service-account-signing-key.key`.
+
+. Create an OpenID Connect identity provider and S3 bucket on AWS:
++
+[source,terminal,subs="+quotes"]
+----
+$ ccoctl aws create-identity-provider --name=__<name>__ --region=__<aws_region>__ --public-key-file=__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
+----
++
+Where:
++
+** `_<name>_` is the name used to tag any cloud resources that are created for tracking.
+** `_<aws-region>_` is the AWS region in which cloud resources will be created.
+** `_<path_to_ccoctl_output_dir>_` is the path to the public key file that the `ccoctl aws create key-pair` command generated.
++
+.Example output:
++
+[source,terminal,subs="+quotes"]
+----
+2021/04/13 11:16:09 Bucket __<name>__-oidc created
+2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket __<name>__-oidc at .well-known/openid-configuration updated
+2021/04/13 11:16:10 Reading public key
+2021/04/13 11:16:10 JSON web key set (JWKS) in the S3 bucket __<name>__-oidc at keys.json updated
+2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+----
++
+Where `02-openid-configuration` is a discovery document and `03-keys.json` is a JSON web key set file.
++
+This command also creates a YAML configuration file in `/_<path_to_ccoctl_output_dir>_/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
+
+. Create IAM roles for each component in the cluster.
+
+.. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
++
+[source,terminal,subs="+quotes"]
+----
+$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/openshift-release:__<version>__
+----
+
+.. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
++
+[source,terminal,subs="+quotes"]
+----
+$ ccoctl aws create-iam-roles --name=__<name>__ --region=__<aws_region>__ --credentials-requests-dir=__<path_to_directory_with_list_of_credentials_requests>__/credrequests --identity-provider-arn=arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
+----
++
+[NOTE]
+====
+For AWS environments that use alternative IAM API endpoints, such as GovCloud, you must also specify your region with the `--region` parameter.
+====
++
+For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust policy that is tied to the specified OIDC identity provider, and a permissions policy as defined in each `CredentialsRequest` object from the {product-title} release image.
+
+.Verification
+
+* To verify that the {product-title} secrets are created, list the files in the `_<path_to_ccoctl_output_dir>_/manifests` directory:
++
+[source,terminal,subs="+quotes"]
+----
+$ ll __<path_to_ccoctl_output_dir>__/manifests
+----
++
+.Example output:
++
+[source,terminal,subs="+quotes"]
+----
+total 24
+-rw-------. 1 __<user>__ __<user>__ 161 Apr 13 11:42 cluster-authentication-02-config.yaml
+-rw-------. 1 __<user>__ __<user>__ 379 Apr 13 11:59 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 353 Apr 13 11:59 openshift-cluster-csi-drivers-ebs-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 355 Apr 13 11:59 openshift-image-registry-installer-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 339 Apr 13 11:59 openshift-ingress-operator-cloud-credentials-credentials.yaml
+-rw-------. 1 __<user>__ __<user>__ 337 Apr 13 11:59 openshift-machine-api-aws-cloud-credentials-credentials.yaml
+----
+
+You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.

--- a/modules/sts-mode-installing-manual-run-installer.adoc
+++ b/modules/sts-mode-installing-manual-run-installer.adoc
@@ -5,7 +5,41 @@
 [id="sts-mode-installing-manual-run-installer_{context}"]
 = Running the installer
 
-* Run the {product-title} installer:
+.Prerequisites
+
+* Create the `install-config.yaml` file for your installation.
+
+.Procedure
+
+. From the installation directory that contains your `install-config.yaml` file, configure the  Cloud Credential Operator (CCO) to run in manual mode:
++
+[source,terminal]
+----
+$ echo “credentialsMode: Manual” >> install-config.yaml
+----
+
+. Create the required {product-title} installation manifests:
++
+[source,terminal]
+----
+$ openshift-install create manifests
+----
+
+. Copy the manifests that `ccoctl` generated to the manifests directory that the installation program created:
++
+[source,terminal,subs="+quotes"]
+----
+$ cp /__<path_to_ccoctl_output_dir>__/manifests/* ./manifests/
+----
+
+. Copy the private key that the `ccoctl` generated in the `tls` directory to the installation directory:
++
+[source,terminal,subs="+quotes"]
+----
+$ cp -a /__<path_to_ccoctl_output_dir>__/tls .
+----
+
+. Run the {product-title} installer:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2196 (as part of https://issues.redhat.com/browse/OSDOCS-1953)
Preview: https://deploy-preview-31136--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#sts-mode-installing