### PR TITLE
Update cluster logging from Viewing Logs topics

### DIFF
--- a/logging/viewing-resource-logs.adoc
+++ b/logging/viewing-resource-logs.adoc
@@ -9,7 +9,7 @@ You can view the logs for various resources, such as builds, deployments, and po
 
 [NOTE]
 ====
-Resource logs are a default feature that provides limited log viewing capability. To enhance your log retrieving and viewing experience, it is recommended that you install xref:../logging/cluster-logging.adoc#cluster-logging[{product-title} cluster logging]. Cluster logging aggregates all the logs from your {product-title} cluster, such as node system audit logs, application container logs, and infrastructure logs, into a dedicated log store.  You can then query, discover, and visualize your log data through the xref:../logging/cluster-logging-visualizer.adoc#cluster-logging-visualizer-using[Kibana interface]. Resource logs do not access the cluster logging log store. 
+Resource logs are a default feature that provides limited log viewing capability. To enhance your log retrieving and viewing experience, it is recommended that you install xref:../logging/cluster-logging.adoc#cluster-logging[OpenShift Logging]. OpenShift Logging aggregates all the logs from your {product-title} cluster, such as node system audit logs, application container logs, and infrastructure logs, into a dedicated log store.  You can then query, discover, and visualize your log data through the xref:../logging/cluster-logging-visualizer.adoc#cluster-logging-visualizer-using[Kibana interface]. Resource logs do not access the OpenShift Logging log store. 
 ====
 
 include::modules/viewing-resource-logs-cli-console.adoc[leveloffset=+1]

--- a/modules/gathering-application-diagnostic-data.adoc
+++ b/modules/gathering-application-diagnostic-data.adoc
@@ -8,7 +8,7 @@
 Application failures can occur within running application pods. In these situations, you can retrieve diagnostic information with these strategies:
 
 * Review events relating to the application pods.
-* Review the logs from the application pods, including application-specific log files that are not collected by the {product-title} logging framework.
+* Review the logs from the application pods, including application-specific log files that are not collected by the OpenShift Logging framework.
 * Test application functionality interactively and run diagnostic tools in an application container.
 
 .Prerequisites
@@ -32,7 +32,7 @@ $ oc describe pod/my-app-1-akdlg
 $ oc logs -f pod/my-app-1-akdlg
 ----
 
-. Query specific logs within a running application pod. Logs that are sent to stdout are collected by the {product-title} logging framework and are included in the output of the preceding command. The following query is only required for logs that are not sent to stdout.
+. Query specific logs within a running application pod. Logs that are sent to stdout are collected by the OpenShift Logging framework and are included in the output of the preceding command. The following query is only required for logs that are not sent to stdout.
 +
 .. If an application log can be accessed without root privileges within a pod, concatenate the log file as follows:
 +


### PR DESCRIPTION
Updated the term {product-title} cluster logging_ to _OpenShift Logging_ in 4.7+ files affected by https://github.com/openshift/openshift-docs/pull/30366 and two stray files I found.