### PR TITLE
OSDOCS#1860 - OpenShift SDN egress IPs are balanced equally

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -193,7 +193,9 @@ When using the automatic assignment approach for egress IP addresses the followi
 
 - You set the `egressCIDRs` parameter of each node's `HostSubnet` resource to indicate the range of egress IP addresses that can be hosted by a node.
 {product-title} sets the `egressIPs` parameter of the `HostSubnet` resource based on the IP address range you specify.
+ifeval::[{product-version} < 4.8]
 - Only a single egress IP address per namespace is supported when using the automatic assignment mode.
+endif::[]
 
 If the node hosting the namespace's egress IP address is unreachable, {product-title} will reassign the egress IP address to another node with a compatible egress IP address range.
 The automatic assignment approach works best for clusters installed in environments with flexibility in associating additional IP addresses with nodes.
@@ -201,14 +203,17 @@ The automatic assignment approach works best for clusters installed in environme
 [id="considerations-manual-egress-ips"]
 == Considerations when using manually assigned egress IP addresses
 
+This approach is recommended for clusters installed in public cloud environments, where there can be limitations on associating additional IP addresses with nodes.
+
 When using the manual assignment approach for egress IP addresses the following considerations apply:
 
 - You set the `egressIPs` parameter of each node's `HostSubnet` resource to indicate the IP addresses that can be hosted by a node.
 - Multiple egress IP addresses per namespace are supported.
 
-When a namespace has multiple egress IP addresses, if the node hosting the first egress IP address is unreachable, {product-title} will automatically switch to using the next available egress IP address until the first egress IP address is reachable again.
+If a namespace has multiple egress IP addresses and those addresses are hosted on multiple nodes, the following additional considerations apply:
 
-This approach is recommended for clusters installed in public cloud environments, where there can be limitations on associating additional IP addresses with nodes.
+- If a pod is on a node that is hosting an egress IP address, that pod always uses the egress IP address on the node.
+- If a pod is not on a node that is hosting an egress IP address, that pod uses an egress IP address at random.
 endif::openshift-sdn[]
 
 ifdef::openshift-sdn[]

--- a/modules/nw-egress-ips-automatic.adoc
+++ b/modules/nw-egress-ips-automatic.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/assigning-egress-ips.adoc
+// * networking/openshift_sdn/assigning-egress-ips.adoc
 
 [id="nw-egress-ips-automatic_{context}"]
 = Configuring automatically assigned egress IP addresses for a namespace
@@ -20,16 +20,20 @@ following JSON:
 +
 [source,terminal]
 ----
- $ oc patch netnamespace <project_name> --type=merge -p \ <1>
+ $ oc patch netnamespace <project_name> --type=merge -p \
   '{
     "egressIPs": [
-      "<ip_address>" <2>
+      "<ip_address>"
     ]
   }'
 ----
-<1> Specify the name of the project.
-<2> Specify a single egress IP address. Using multiple IP addresses is not
-supported.
++
+--
+where:
+
+`<project_name>`:: Specifies the name of the project.
+`<ip_address>`:: Specifies one or more egress IP addresses for the `egressIPs` array.
+--
 +
 For example, to assign `project1` to an IP address of 192.168.1.100 and
 `project2` to an IP address of 192.168.1.101:
@@ -47,15 +51,20 @@ parameter for each host using the following JSON:
 +
 [source,terminal]
 ----
-$ oc patch hostsubnet <node_name> --type=merge -p \ <1>
+$ oc patch hostsubnet <node_name> --type=merge -p \
   '{
     "egressCIDRs": [
-      "<ip_address_range_1>", "<ip_address_range_2>" <2>
+      "<ip_address_range>", "<ip_address_range>"
     ]
   }'
 ----
-<1> Specify a node name.
-<2> Specify one or more IP address ranges in CIDR format.
++
+--
+where:
+
+`<node_name>`:: Specifies a node name.
+`<ip_address_range>`:: Specifies an IP address range in CIDR format. You can specify more than one address range for the `egressCIDRs` array.
+--
 +
 For example, to set `node1` and `node2` to host egress IP addresses
 in the range 192.168.1.0 to 192.168.1.255:

--- a/modules/nw-egress-ips-static.adoc
+++ b/modules/nw-egress-ips-static.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/assigning-egress-ips.adoc
+// * networking/openshift_sdn/assigning-egress-ips.adoc
 
 [id="nw-egress-ips-static_{context}"]
 = Configuring manually assigned egress IP addresses for a namespace
@@ -19,47 +19,52 @@ object with the desired IP addresses:
 +
 [source,terminal]
 ----
-$ oc patch netnamespace <project> --type=merge -p \ <1>
+ $ oc patch netnamespace <project_name> --type=merge -p \
   '{
-    "egressIPs": [ <2>
+    "egressIPs": [
       "<ip_address>"
-      ]
+    ]
   }'
 ----
-<1> Specify the name of the project.
-<2> Specify one or more egress IP addresses. The `egressIPs` parameter is an
-array.
 +
-For example, to assign the `project1` project to an IP address of
-`192.168.1.100`:
+--
+where:
+
+`<project_name>`:: Specifies the name of the project.
+`<ip_address>`:: Specifies one or more egress IP addresses for the `egressIPs` array.
+--
++
+For example, to assign the `project1` project to the IP addresses `192.168.1.100` and `192.168.1.101`:
 +
 [source,terminal]
 ----
 $ oc patch netnamespace project1 --type=merge \
-  -p '{"egressIPs": ["192.168.1.100"]}'
+  -p '{"egressIPs": ["192.168.1.100","192.168.1.101"]}'
 ----
 +
-You can set `egressIPs` to two or more IP addresses on different nodes to
-provide high availability. If multiple egress IP addresses are set, pods use the
-first IP in the list for egress, but if the node hosting that IP address fails,
-pods switch to using the next IP in the list after a short delay.
+To provide high availability, set the `egressIPs` value to two or more IP addresses on different nodes. If multiple egress IP addresses are set, then pods use all egress IP addresses roughly equally.
 
 . Manually assign the egress IP to the node hosts. Set the `egressIPs` parameter
 on the `HostSubnet` object on the node host. Using the following JSON, include
-as many IPs as you want to assign to that node host:
+as many IP addresses as you want to assign to that node host:
 +
 [source,terminal]
 ----
-$ oc patch hostsubnet <node_name> --type=merge -p \ <1>
+$ oc patch hostsubnet <node_name> --type=merge -p \
   '{
-    "egressIPs": [ <2>
-      "<ip_address_1>",
-      "<ip_address_N>"
+    "egressIPs": [
+      "<ip_address>",
+      "<ip_address>"
       ]
   }'
 ----
-<1> Specify the name of the node.
-<2> Specify one or more egress IP addresses. The `egressIPs` field is an array.
++
+--
+where:
+
+`<node_name>`:: Specifies a node name.
+`<ip_address>`:: Specifies an IP address. You can specify more than one IP address for the `egressIPs` array.
+--
 +
 For example, to specify that `node1` should have the egress IPs `192.168.1.100`,
 `192.168.1.101`, and `192.168.1.102`:
@@ -70,6 +75,4 @@ $ oc patch hostsubnet node1 --type=merge -p \
   '{"egressIPs": ["192.168.1.100", "192.168.1.101", "192.168.1.102"]}'
 ----
 +
-In the previous example, all egress traffic for `project1` will be routed to the
-node hosting the specified egress IP, and then connected (using NAT) to that IP
-address.
+In the previous example, all egress traffic for `project1` will be routed to the node hosting the specified egress IP, and then connected through Network Address Translation (NAT) to that IP address.


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1860

TODO: squash commits

Previews:
- [Considerations when using manually assigned egress IP addresses](https://deploy-preview-31142--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#considerations-manual-egress-ips)
- [Considerations when using automatically assigned egress IP addresses](https://deploy-preview-31142--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#considerations-automatic-egress-ips)
- [Configuring automatically assigned egress IP addresses for a namespace](https://deploy-preview-31142--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-automatic_egress-ips)
- [Configuring manually assigned egress IP addresses for a namespace](https://deploy-preview-31142--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-static_egress-ips)