### PR TITLE
modules/*imagestream*: Set 'created' back to match 'generation' order

### DIFF
--- a/modules/images-imagestream-configure.adoc
+++ b/modules/images-imagestream-configure.adoc
@@ -16,7 +16,7 @@ kind: ImageStream
 metadata:
   annotations:
     openshift.io/generated-by: OpenShiftNewApp
-  creationTimestamp: 2017-09-29T13:33:49Z
+  creationTimestamp: 2017-09-01T13:40:00Z
   generation: 1
   labels:
     app: ruby-sample-build
@@ -35,7 +35,7 @@ status:
       dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d <3>
       generation: 2
       image: sha256:909de62d1f609a717ec433cc25ca5cf00941545c83a01fb31527771e1fab3fc5 <4>
-    - created: 2017-09-29T13:40:11Z
+    - created: 2017-09-01T13:40:11Z
       dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:909de62d1f609a717ec433cc25ca5cf00941545c83a01fb31527771e1fab3fc5
       generation: 1
       image: sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d

--- a/modules/images-using-imagestream-tags.adoc
+++ b/modules/images-using-imagestream-tags.adoc
@@ -20,7 +20,7 @@ The following image stream tag is from an `ImageStream` object:
       dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d
       generation: 2
       image: sha256:909de62d1f609a717ec433cc25ca5cf00941545c83a01fb31527771e1fab3fc5
-    - created: 2017-09-29T13:40:11Z
+    - created: 2017-09-01T13:40:11Z
       dockerImageReference: 172.30.56.218:5000/test/origin-ruby-sample@sha256:909de62d1f609a717ec433cc25ca5cf00941545c83a01fb31527771e1fab3fc5
       generation: 1
       image: sha256:47463d94eb5c049b2d23b03a9530bf944f8f967a0fe79147dd6b9135bf7dd13d


### PR DESCRIPTION
I was confused about whether the first entry was the most recent (it is) because, while the generation was larger, the created timestamp was smaller.  This commit makes the creation timestamp larger to match the generation change.