### PR TITLE
[SRVKS-713] Add explanation about rewriteAppHTTPProbers annotation in ServiceMesh integration

### DIFF
--- a/modules/serverless-service-mesh-enable-sidecar-injection.adoc
+++ b/modules/serverless-service-mesh-enable-sidecar-injection.adoc
@@ -23,12 +23,14 @@ spec:
     metadata:
       annotations:
         sidecar.istio.io/inject: "true" <1>
+        sidecar.istio.io/rewriteAppHTTPProbers: "true" <2>
     spec:
       containers:
       - image: docker.io/openshift/hello-openshift
         name: container
 ----
 <1> Add the `sidecar.istio.io/inject="true"` annotation.
+<2> Optional: Add the `sidecar.istio.io/rewriteAppHTTPProbers="true"` annotation if you have enabled JSON Web Token (JWT) authentication.
 
 . Apply the Service resource YAML file:
 +

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -21,5 +21,10 @@ You can enable JSON Web Token (JWT) authentication for Knative services.
 Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
 
+[IMPORTANT]
+====
+You must set the annotation `sidecar.istio.io/rewriteAppHTTPProbers: "true"` in your Knative service as {ServerlessProductName} versions 1.14.0 and later use a HTTP probe as the readiness probe for Knative services by default.
+====
+
 include::modules/serverless-ossm-v2x-jwt.adoc[leveloffset=+1]
 include::modules/serverless-ossm-v1x-jwt.adoc[leveloffset=+1]


### PR DESCRIPTION
Serverlss 1.14+ starts using HTTP probe for the readiness probe of
Knative Service, users have to set rewriteAppHTTPProbers annotation.

This patch adds the explanation.

/cc @abrennan89 