### PR TITLE
BZ#1943601 | Fixed typo in two sample config YAML files

### DIFF
--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -94,7 +94,7 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   gcp:
-    ProjectID: openshift-production <1>
+    projectID: openshift-production <1>
     region: us-central1 <1>
 ifdef::vpc[]
     network: existing_vpc <6>

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -54,7 +54,7 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   gcp:
-    ProjectID: openshift-production
+    projectID: openshift-production
     region: us-central1 <5>
 pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]


### PR DESCRIPTION
This PR fixes typos that were identified in [BZ 1943601](https://bugzilla.redhat.com/show_bug.cgi?id=1943601).

In both cases, I changed `ProjectID` to `projectID`.

Direct preview links:
* [direct link 1](https://deploy-preview-31154--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations)
* [direct link 2](https://deploy-preview-31154--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-shared-vpc-config-yaml_installing-gcp-user-infra-vpc)

QE Review: @gpei 
