### PR TITLE
BZ1942895 change note for ibm z

### DIFF
--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -93,7 +93,7 @@ Each cluster virtual machine must meet the following minimum requirements:
 
 |Virtual Machine
 |Operating System
-|vCPU
+|vCPU ^[1]^
 |Virtual RAM
 |Storage
 
@@ -116,6 +116,9 @@ Each cluster virtual machine must meet the following minimum requirements:
 |120 GB
 
 |===
+--
+^[1]^ 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
+--
 
 [id="preferred-ibm-z-system-requirements_{context}"]
 == Preferred IBM Z system environment

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -112,7 +112,7 @@ Each cluster machine must meet the following minimum requirements:
 
 |Machine
 |Operating System
-|vCPU^1^
+|vCPU ^[1]^
 |Virtual RAM
 |Storage
 
@@ -134,8 +134,6 @@ ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
 ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.8 - 7.9]
-ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.6]
 |2
 |8 GB
 |120 GB
@@ -143,17 +141,21 @@ endif::openshift-origin[]
 
 ifdef::openshift-origin[]
 |Compute
-ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system}]
+|{op-system}
 |2
 |8 GB
 |120 GB
 endif::openshift-origin[]
 
-5+a|
-^1^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.
-
 |===
+--
+ifdef::ibm-z[]
+^[1]^ 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
+endif::ibm-z[]
+ifndef::ibm-z[]
+^[1]^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.
+endif::ibm-z[]
+--
 
 ifdef::ibm-z[]
 [id="minimum-ibm-z-system-requirements_{context}"]


### PR DESCRIPTION
The new note in min resource reqs table doesn't fit for IBM Z added a extra note 
See https://bugzilla.redhat.com/show_bug.cgi?id=1942895

Preview IBM Z: https://deploy-preview-31155--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#minimum-resource-requirements_installing-ibm-z

Preview bare metal: https://deploy-preview-31155--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal

Preview KVM on IBM Z:  https://deploy-preview-31155--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#minimum-resource-requirements_installing-ibm-z-kvm