### PR TITLE
Adding note related to FIPS compliant ciphers.

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -138,6 +138,11 @@ $ ssh-keygen -t ed25519 -N '' \
 Running this command generates an SSH key that does not require a password in
 the location that you specified.
 
+[NOTE]
+====
+FIPS compliant machines have a restricted set of ciphers and will not support `ed25519`.  You may use `ecdsa` or `rsa` as your key generation cipher. 
+====
+
 . Start the `ssh-agent` process as a background task:
 +
 [source,terminal]


### PR DESCRIPTION
A note should be introduced into all sections related to ssh-keygen and FIPS compliant machines.

https://access.redhat.com/solutions/3643252