### PR TITLE
[enterprise-4.x] Updated the documentation to explain the fields in the SCC to control…

### DIFF
--- a/modules/nodes-containers-sysctls-unsafe.adoc
+++ b/modules/nodes-containers-sysctls-unsafe.adoc
@@ -6,10 +6,15 @@
 = Enabling unsafe sysctls
 
 A cluster administrator can allow certain unsafe sysctls for very special
-situations such as high-performance or real-time application tuning.
+situations such as high performance or real-time application tuning.
 
 If you want to use unsafe sysctls, a cluster administrator must enable them
 individually for a specific type of node. The sysctls must be namespaced.
+
+You can further control which sysctls can be set in pods by specifying lists of sysctls or sysctl patterns in the `forbiddenSysctls` and `allowedUnsafeSysctls` fields of the Security Context Constraints.
+
+- The `forbiddenSysctls` option excludes specific sysctls.
+- The `allowedUnsafeSysctls` option controls specific needs such as high performance or real-time application tuning.
 
 [WARNING]
 ====
@@ -20,7 +25,7 @@ containers, resource shortage, or breaking a node.
 
 .Procedure
 
-. Add a label to the machine config pool where the containers where containers 
+. Add a label to the machine config pool where the containers where containers
 with the unsafe sysctls will run:
 +
 [source,terminal]
@@ -59,7 +64,7 @@ spec:
 ----
 <1> Specify the label from the machine config pool.
 <2> List the unsafe sysctls you want to allow.
- 
+
 . Create the object:
 +
 [source,terminal]
@@ -119,4 +124,3 @@ $ oc get machineconfig 99-worker-XXXXXX-XXXXX-XXXX-XXXXX-kubelet -o json | grep 
 ----
 +
 You can now add unsafe sysctls to pods as needed.
- 


### PR DESCRIPTION
Fixes #15234. This burn down ticket requested information in the documentation about the forbidden and unsafe sysctls options. For this update, explains the two fields that control the sysctrls in the SCC,

For the 3.11 documentation update, see #30944 

Link to section: https://deploy-preview-31158--osdocs.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-sysctls.html#nodes-containers-sysctls-unsafe_nodes-containers-using

I add the statement and the two bullets on the two fields for Unsafe sysctls.