### PR TITLE
Fix emphasis and tokens in table

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -31,7 +31,7 @@ Clients access the {product-title} cluster nodes over the `baremetal` network.
 A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
 
 ----
-<cluster-name>.<domain-name>
+<cluster_name>.<domain-name>
 ----
 
 For example:
@@ -80,21 +80,21 @@ endif::[]
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The host names of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
-[width="100%", cols="3,5e,2e", frame="topbot",options="header"]
+[width="100%",cols="3,5,2",frame="topbot",options="header"]
 |=====
 | Usage | Host Name | IP
-| API | api.<cluster-name>.<domain> | <ip>
-| Ingress LB (apps) |  *.apps.<cluster-name>.<domain>  | <ip>
+| API | api.<cluster_name>.<domain> | <ip>
+| Ingress LB (apps) |  *.apps.<cluster_name>.<domain>  | <ip>
 ifeval::[{release} <= 4.5]
-| Nameserver | ns1.<cluster-name>.<domain> | <ip>
+| Nameserver | ns1.<cluster_name>.<domain> | <ip>
 endif::[]
-| Provisioner node | provisioner.<cluster-name>.<domain> | <ip>
-| Master-0 | openshift-master-0.<cluster-name>.<domain> | <ip>
-| Master-1 | openshift-master-1.<cluster-name>-.<domain> | <ip>
-| Master-2 | openshift-master-2.<cluster-name>.<domain> | <ip>
-| Worker-0 | openshift-worker-0.<cluster-name>.<domain> | <ip>
-| Worker-1 | openshift-worker-1.<cluster-name>.<domain> | <ip>
-| Worker-n | openshift-worker-n.<cluster-name>.<domain> | <ip>
+| Provisioner node | provisioner.<cluster_name>.<domain> | <ip>
+| Master-0 | openshift-master-0.<cluster_name>.<domain> | <ip>
+| Master-1 | openshift-master-1.<cluster_name>.<domain> | <ip>
+| Master-2 | openshift-master-2.<cluster_name>.<domain> | <ip>
+| Worker-0 | openshift-worker-0.<cluster_name>.<domain> | <ip>
+| Worker-1 | openshift-worker-1.<cluster_name>.<domain> | <ip>
+| Worker-n | openshift-worker-n.<cluster_name>.<domain> | <ip>
 |=====
 
 ifdef::upstream[]


### PR DESCRIPTION
We don't use `e` in a table. We're using `_` in tokens.