### PR TITLE
[Enterprise-4.7] Manual CP of PR#30945

### DIFF
--- a/modules/quotas-sample-resource-quotas-def.adoc
+++ b/modules/quotas-sample-resource-quotas-def.adoc
@@ -121,11 +121,11 @@ spec:
   scopes:
   - Terminating <5>
 ----
-<1> The total number of pods in a non-terminal state.
-<2> Across all pods in a non-terminal state, the sum of CPU limits cannot exceed this value.
-<3> Across all pods in a non-terminal state, the sum of memory limits cannot exceed this value.
-<4> Across all pods in a non-terminal state, the sum of ephemeral storage limits cannot exceed this value.
-<5> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds >=0`.  For example, this quota would charge for build or deployer pods, but not long running pods like a web server or database.
+<1> The total number of pods in a terminating state.
+<2> Across all pods in a terminating state, the sum of CPU limits cannot exceed this value.
+<3> Across all pods in a terminating state, the sum of memory limits cannot exceed this value.
+<4> Across all pods in a terminating state, the sum of ephemeral storage limits cannot exceed this value.
+<5> Restricts the quota to only matching pods where `spec.activeDeadlineSeconds >=0`. For example, this quota would charge for build or deployer pods, but not long running pods like a web server or database.
 
 .`storage-consumption.yaml`
 [source,yaml]


### PR DESCRIPTION
For some reason the auto-CP https://github.com/openshift/openshift-docs/pull/31168 for `enterprise-4.7`(based on PR #30945) never kicked off a build. This is a new PR to add the same identical changes to `modules/quotas-sample-resource-quotas-def.adoc` and see if it passes so I can merge and close 31168.

Preview build: https://deploy-preview-31190--osdocs.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-per-project.html#quotas-sample-resource-quota-definitions_quotas-setting-per-project