### PR TITLE
GitHub issue#31057 add haproxy.router.openshift.io/set-forwarded-headers to annotation table

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -41,6 +41,17 @@ and "-". The default is the hashed internal key name for the route. |
 `None`: cookies are restricted to the visited site.
 
 This value is applicable to re-encrypt and edge routes only. For more information, see the link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite cookies documentation].|
+
+|`haproxy.router.openshift.io/set-forwarded-headers` | Sets the policy for handling the `Forwarded` and `X-Forwarded-For` HTTP headers per route. The values are:
+
+`append`: appends the header, preserving any existing header. This is the default value.
+
+`replace`: sets the header, removing any existing header.
+
+`never`: never sets the header, but preserves any existing header.
+
+`if-none`: sets the header if it is not already set.| `ROUTER_SET_FORWARDED_HEADERS`
+
 |===
 
 [NOTE]


### PR DESCRIPTION
Resolves https://github.com/openshift/openshift-docs/issues/31057.

Direct preview link: https://deploy-preview-31191--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration