### PR TITLE
Rel Notes doc text for 4.6.25 release

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -442,7 +442,7 @@ The `cluster-backup.sh` and `cluster-restore.sh` scripts were updated to provide
 [id="ocp-4-6-machine-api-multiple-block-device-mappings"]
 ==== Support for multiple block device mappings
 
-The Machine API now supports multiple block device mappings for machines running on AWS. If more than one block device is given, you can now store logs, data in empty directory pods, and docker images in block devices that are separate from the root device on a machine.
+The Machine API now supports multiple block device mappings for machines running on AWS. If more than one block device is given, you can now store logs, data in empty directory pods, and Docker images in block devices that are separate from the root device on a machine.
 
 [id="ocp-4-6-default-validation-providerspec-apis"]
 ==== Defaults and validation for the Machine API `providerSpec`
@@ -714,7 +714,7 @@ See xref:../installing/installing_aws/installing-aws-account.html#nw-endpoint-ro
 
 Configuring an Ingress Controller to inject an HTTP header with a uniquely defined request ID is now supported. This can be used to trace cluster traffic.
 
-For more information, see the xref:../rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#specification[`IngressController` specification]. 
+For more information, see the xref:../rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#specification[`IngressController` specification].
 
 [id="ocp-4-6-storage"]
 === Storage
@@ -2733,6 +2733,77 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/5909931[{product-title} 4.6.23 container image list]
 
 [id="ocp-4-6-23-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-25"]
+=== RHBA-2021:1153 - {product-title} 4.6.25 bug fix update
+
+Issued: 2021-04-20
+
+{product-title} release 4.6.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1153[RHBA-2021:1153] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1154[RHBA-2021:1154] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/5920851[{product-title} 4.6.25 container image list]
+
+[id="ocp-4-6-25-features"]
+==== Features
+
+[id="ocp-4-6-25-installing-cluster-on-vmc-on-aws"]
+===== Installing a cluster on VMC on AWS
+You can now install an {product-title} cluster on VMware vSphere infrastructure by deploying it to VMware Cloud (VMC) on AWS. For more information, see xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[deploying a cluster to VMC].
+
+[id="ocp-4-6-25-gathering-sap-backport"]
+===== Insights Operator enhancement for unhealthy SAP pods
+The Insights Operator can now gather data for unhealthy SAP pods. When the SDI installation fails, it is possible to detect the problem by looking at which of the initialization pods have failed. The Insights Operator now gathers  information about failed pods in the SAP/SDI namespaces. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1935775[*BZ#1935775*].
+
+[id="ocp-4-6-25-SAP-license-management-enhancement"]
+===== SAP license management enhancement
+With this update, you can now use the following command to detect failure in the license management pod:
+
+[source,terminal]
+----
+# oc logs deploy/license-management-l4rvh
+----
+
+.Example output
+[source,terminal]
+----
+Found 2 pods, using pod/license-management-l4rvh-74595f8c9b-flgz9
++ iptables -D PREROUTING -t nat -j VSYSTEM-AGENT-PREROUTING
++ true
++ iptables -F VSYSTEM-AGENT-PREROUTING -t nat
++ true
++ iptables -X VSYSTEM-AGENT-PREROUTING -t nat
++ true
++ iptables -N VSYSTEM-AGENT-PREROUTING -t nat
+iptables v1.6.2: can't initialize iptables table `nat': Permission denied
+----
+
+If results return `Permission denied`, iptables or your kernal might need to be upgraded. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1939059[*BZ#1939059*].
+
+[id="ocp-4-6-25-adding-memory-and-uptime-metadata-to-insights-operator-archive"]
+===== Adding memory and uptime metadata to the Insights Operator archive
+This update adds `uptime` and `memory alloc` metadata to the Insights Operator archive so that small memory leaks can be investigated properly. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1942457[*BZ#1942457*].
+
+[id="ocp-4-6-25-bug-fixes"]
+==== Bug fixes
+
+* Previously, the host name from the VMware vSphere metadata was not set before NetworkManager started, and this metadata was ignored when the host name was set later. With this release, the host name is now set by `vsphere-hostname.service` before NetworkManager starts if this information is available in the vSphere metadata. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904825[*BZ#1904825*])
+
+* Previously, the automatically generated Docker config secret did not include credentials for integrated internal registry routes. Because no credentials for accessing the registry through any of its routes were present, pods that attempted to reach the registry failed due to lack of authentication. With this release, all configured registry routes to the default Docker credential secret are included, and pods can reach the integrated registry by any of its routes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1931857[*BZ#1931857*])
+
+* Previously, the file `/etc/pki/ca-trust/extracted` could become unwritable, preventing the Image Registry Operator from adding CA certificates to the pod's trust store. With this release, an emptyDir volume is mounted into `/etc/pki/ca-trust/extracted` and the volume is now always writable by the pod. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1936984[*BZ#1936984*])
+
+* Previously, a misconfigured `nodeip-configuration` service for vSphere on user-provisioned infrastructure was fixed in the Machine Config Operator (MCO) for {product-title} 4.7, but not for {product-title} 4.6. As a result, when upgrading {product-title} from a version 4.6.z to a different 4.6.z and then to 4.7, the 4.7 version of the MCO stopped the entire upgrade if the control plane completed the 4.7 upgrade before the compute machines completed the 4.6.z upgrade. This release fixes the misconfigured `nodeip-configuration` service so that upgrades can complete successfully. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1940585[*BZ#1940585*])
+
+* Previously, HTTP requests were not closed when they were no longer needed, causing Go routine leaks, which increase memory usage over time. With this release, HTTP requests are always closed when they are no longer needed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941563[*BZ#1941563*])
+
+* Previously, link:https://bugzilla.redhat.com/show_bug.cgi?id=1936587[*BZ#1936587*] set the global CoreDNS cache max TTL to 900 seconds. As a result, NXDOMAIN records received from upstream resolvers were cached for 900 seconds. This update explicitly caches negative DNS response records for a maximum of 30 seconds. As a result, resolving NXDOMAINs records are no longer cached for 900 seconds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944245[*BZ#1944245*])
+
+[id="ocp-4-6-25-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
4.6.24 was dropped, repurposing this PR for 4.6.25 which is largely the same

For release 20 April 2021
Preview: https://deploy-preview-31192--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-25