### PR TITLE
[enterprise-4.4] Add description/displayName to OSDK CSV

### DIFF
--- a/modules/managing-memcached-operator-using-olm.adoc
+++ b/modules/managing-memcached-operator-using-olm.adoc
@@ -48,7 +48,6 @@ for more information on manually defining a manifest file.
 target. Create the following OperatorGroup in the namespace where you will
 create the CSV. In this example, the `default` namespace is used:
 +
-[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
@@ -63,7 +62,25 @@ spec:
 . *Deploy the Operator.* Use the files that were generated into the `deploy/`
 directory by the Operator SDK when you built the Memcached Operator.
 
-.. Apply the Operator's CSV manifest to the specified namespace in the cluster:
+.. Edit the generated CSV manifest file by adding `description` and `displayName` fields for each custom resource definition (CRD) `kind` in the `spec.customresourcedefinitions.owned` section:
++
+.deploy/olm-catalog/memcached-operator/0.0.1/memcached-operator.v0.0.1.clusterserviceversion.yaml file
+----
+...
+spec:
+  customresourcedefinitions:
+    owned:
+    - kind: Memcached
+      name: memcacheds.cache.example.com
+      version: v1alpha1
+      description: <crd_description> <1>
+      displayName: Memcached <2>
+...
+----
+<1> Specify a description for the CRD.
+<2> Specify a display name for the CRD.
+
+.. Apply the CSV manifest to the specified namespace in the cluster:
 +
 ----
 $ oc apply -f deploy/olm-catalog/memcached-operator/0.0.1/memcached-operator.v0.0.1.clusterserviceversion.yaml


### PR DESCRIPTION
4.4 version of https://github.com/openshift/openshift-docs/pull/31137.

Preview build: https://deploy-preview-31193--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-getting-started.html#managing-memcached-operator-using-olm_osdk-getting-started