### PR TITLE
OSDOCS-1860: Add release note entry for OpenShift SDN egress IPs

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -94,6 +94,12 @@ For `console` and `downloads` routes, custom routes functionally is now implemen
 
 An OpenShift SDN cluster network provider migration to the OVN-Kubernetes cluster network provider is supported for user-provisioned clusters. For more information, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#nw-ovn-kubernetes-migration-about_migrate-from-openshift-sdn[Migrate from the OpenShift SDN cluster network provider].
 
+[id="ocp-4-8-openshift-sdn-egress-ips-balance"]
+==== OpenShift SDN cluster network provider egress IP feature balances across nodes
+
+The egress IP feature of OpenShift SDN now balances network traffic roughly equally across nodes for a given namespace, if that namespace is assigned multiple egress IP addresses. Each IP address must reside on a different node.
+For more information, refer to xref:../networking/openshift_sdn/assigning-egress-ips.adoc#assigning-egress-ips[Configuring egress IPs for a project] for OpenShift SDN.
+
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1860

The egress IP capability now load balances across multiple configured
egress IPs.

Preview:
- [OpenShift SDN cluster network provider egress IP feature balances across nodes](https://deploy-preview-31200--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-openshift-sdn-egress-ips-balance)