### PR TITLE
OSDOCS-998 declarative configs for networking

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -854,6 +854,8 @@ Topics:
     File: remove-additional-network
   - Name: Assigning a secondary network to a VRF
     File: assigning-a-secondary-network-to-a-vrf
+  - Name: Networking and GitOps
+    File: networking-gitops
 - Name: Hardware networks
   Dir: hardware_networks
   Distros: openshift-enterprise,openshift-origin

--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -5,8 +5,8 @@
 [id="nw-multus-advanced-annotations_{context}"]
 = Specifying pod-specific addressing and routing options
 
-When attaching a pod to an additional network, you may want to specify further properties
-about that network in a particular pod. This allows you to change some aspects of routing, as well
+When attaching a pod to an additional network, you might want to specify additional properties
+about that network for a particular pod. This allows you to change some aspects of routing, as well
 as specify static IP addresses and MAC addresses. To accomplish this, you can use the JSON formatted annotations.
 
 .Prerequisites
@@ -22,19 +22,9 @@ endif::sriov[]
 
 To add a pod to an additional network while specifying addressing and/or routing options, complete the following steps:
 
-. Edit the `Pod` resource definition. If you are editing an existing `Pod` resource, run the
-following command to edit its definition in the default editor. Replace `<name>`
-with the name of the `Pod` resource to edit.
-+
-[source,terminal]
-----
-$ oc edit pod <name>
-----
-
-. In the `Pod` resource definition, add the `k8s.v1.cni.cncf.io/networks`
+. Modify the pod resource definition by adding the `k8s.v1.cni.cncf.io/networks`
 parameter to the pod `metadata` mapping. The `k8s.v1.cni.cncf.io/networks`
-accepts a JSON string of a list of objects that reference the name of `NetworkAttachmentDefinition` custom resource (CR) names
-in addition to specifying additional properties.
+annotation accepts a JSON string. In the JSON string, specify a list of objects that reference network attachment definition names and additional properties.
 +
 [source,yaml]
 ----
@@ -44,7 +34,7 @@ metadata:
 ----
 <1> Replace `<network>` with a JSON object as shown in the following examples. The single quotes are required.
 
-. In the following example the annotation specifies which network attachment will have the default route,
+. In the following example, the annotation specifies which network attachment will have the default route,
 using the `default-route` parameter.
 +
 [source,yaml]
@@ -71,18 +61,17 @@ spec:
 <1> The `name` key is the name of the additional network to associate
 with the pod.
 <2> The `default-route` key specifies a value of a gateway for traffic to be routed over if no other
-routing entry is present in the routing table. If more than one `default-route` key is specified,
-this will cause the pod to fail to become active.
+routing entry is present in the routing table. If more than one `default-route` key is specified, the pod fails to become active.
 
-The default route will cause any traffic that is not specified in other routes to be routed to the gateway.
+The default route causes any traffic that is not specified in other routes to be routed to the gateway.
 
 [IMPORTANT]
 ====
 Setting the default route to an interface other than the default network interface for {product-title}
-may cause traffic that is anticipated for pod-to-pod traffic to be routed over another interface.
+might cause traffic that is anticipated for pod-to-pod traffic to be routed over another interface.
 ====
 
-To verify the routing properties of a pod, the `oc` command may be used to execute the `ip` command within a pod.
+To verify the routing properties of a pod, you can use the `oc` command to execute the `ip` command within a pod.
 
 [source,terminal]
 ----
@@ -91,11 +80,11 @@ $ oc exec -it <pod_name> -- ip route
 
 [NOTE]
 ====
-You may also reference the pod's `k8s.v1.cni.cncf.io/networks-status` to see which additional network has been
-assigned the default route, by the presence of the `default-route` key in the JSON-formatted list of objects.
+You can also reference the `k8s.v1.cni.cncf.io/networks-status` annotation for a pod to see which additional network is assigned the default route.
+The network interface with the default route has a `default-route` key in the JSON-formatted list of objects.
 ====
 
-To set a static IP address or MAC address for a pod you can use the JSON formatted annotations. This requires you create networks that specifically allow for this functionality. This can be specified in a rawCNIConfig for the CNO.
+To set a static IP address or MAC address for a pod, you can use the JSON formatted annotations. This requires you create networks that specifically allow for this functionality. This can be specified in a rawCNIConfig for the CNO.
 
 . Edit the CNO CR by running the following command:
 +
@@ -116,17 +105,16 @@ rawCNIConfig: '{ <3>
 }'
 type: Raw
 ----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
+<1> Specify a name for the additional network attachment definition to add.
+The name must be unique within the specified namespace.
 
 <2> Specify the namespace to create the network attachment in. If
 you do not specify a value, then the `default` namespace is used.
 
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+<3> Specify the CNI plug-in configuration in JSON format. The configuration is based on the following template.
 
-The following object describes the configuration parameters for utilizing static MAC address
-and IP address using the macvlan CNI plug-in:
+The following object describes the configuration parameters for a static MAC address
+and an IP address that uses the macvlan CNI plug-in:
 
 .macvlan CNI plug-in JSON configuration object using static IP and MAC address
 [source,json]
@@ -150,24 +138,16 @@ and IP address using the macvlan CNI plug-in:
 
 <1> The `plugins` field specifies a configuration list of CNI configurations.
 
-<2> The `capabilities` key denotes that a request is being made to enable the static IP functionality of a CNI plug-ins runtime configuration capabilities.
+<2> The first `capabilities` key specifies a request to a CNI plug-in to enable the static IP functionality in the runtime configuration capabilities of the plug-in.
 
 <3> The `master` field is specific to the macvlan plug-in.
 
-<4> Here the `capabilities` key denotes that a request is made to enable the static MAC address functionality of a CNI plug-in.
+<4> The second `capabilities` key specifies a request to a CNI plug-in to enable the static MAC address functionality.
 
-The above network attachment may then be referenced in a JSON formatted annotation, along with keys to specify which
-static IP and MAC address will be assigned to a given pod.
-
-Edit the desired pod with:
-
-[source,terminal]
-----
-$ oc edit pod <name>
-----
+After you create the preceding network attachment definition, you can reference  it in a JSON-formatted annotation and specify which
+static IP and MAC address to assign to a pod.
 
 .macvlan CNI plug-in JSON configuration object using static IP and MAC address
-
 [source,yaml]
 ----
 apiVersion: v1
@@ -184,19 +164,19 @@ metadata:
     ]'
 ----
 
-<1> Use the `<name>` as provided when creating the `rawCNIConfig` above.
+<1> Specify the `<name>` from the network attachment definition.
 
-<2> Provide the desired IP address.
+<2> Specify the IP address.
 
-<3> Provide the desired MAC address.
+<3> Specify the MAC address.
 
 [NOTE]
 ====
-Static IP addresses and MAC addresses do not have to be used at the same time, you may use them
-individually, or together.
+You do not need to specify static IP addresses and MAC addresses at the same time.
+You can specify them individually or together.
 ====
 
-To verify the IP address and MAC properties of a pod with additional networks, use the `oc` command to execute the ip command within a pod.
+To verify the IP address and MAC properties of a pod with additional networks, use the `oc` command to execute the `ip a` command within a pod.
 
 [source,terminal]
 ----

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -37,6 +37,7 @@ you do not specify a value, then the `default` namespace is used.
 <3> Specify the CNI plug-in configuration in JSON format, which
 is based on the following template.
 
+// tag::json-ref[]
 The following object describes the configuration parameters for the bridge CNI
 plug-in:
 
@@ -101,6 +102,7 @@ no VLAN tag is assigned.
 
 <11> Set the maximum transmission unit (MTU) to the specified value. The
 default value is automatically set by the kernel.
+// end::json-ref[]
 
 [id="nw-multus-bridge-config-example_{context}"]
 == bridge configuration example

--- a/modules/nw-multus-create-network-decl.adoc
+++ b/modules/nw-multus-create-network-decl.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/networking-gitops.adoc
+
+[id="nw-multus-create-network-decl_{context}"]
+= Create an additional network declaratively
+
+:net-def-name: network-bridge-static
+
+To create an additional network declaratively in support of GitOps, complete the following steps.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a file, such as `{net-def-name}.yaml`, with contents that are similar to the following example:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: {net-def-name} <.>
+spec:
+  config: |- <.>
+    {
+      "cniVersion": "0.4.0",
+      "name": "{net-def-name}",
+      "type": "bridge",
+      "bridge": "mynet1",
+      "ipam": { <.>
+        "type": "static",
+        "addresses":[
+          {
+            "address": "192.168.12.99/24",
+            "gateway": "192.168.12.1"
+          },
+          {
+            "address": "3ffe:ffff:0:01ff::1/64",
+            "gateway": "3ffe:ffff:0::1"
+          }
+        ],
+        "routes": [
+          { "dst": "0.0.0.0/0" },
+          { "dst": "192.168.0.0/16", "gw": "192.168.12.1" }
+        ]
+      }
+    }
+----
+<.> Specify a name for the network attachment definition. This is the name that a pod specification must reference in the `k8s.v1.cni.cncf.io/networks` annotation.
+<.> Specify the configuration for the additional network attachment definition.
+<.> Specify the configuration for the IP address management (IPAM) CNI plug-in. The plug-in manages IP address assignment for the network attachment definition.
+
+. Apply the manifest:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc create -n <namespace> -f <{net-def-name}.yaml>
+----
++
+.Example output
+[source,terminal,subs="attributes+"]
+----
+networkattachementdefinition.k8s.cni.cncf.io/{net-def-name} created
+----
+
+.Verification steps
+
+* Confirm that the network attachment definition exists by running the following command. Replace `<namespace>` with the namespace that you specified when you applied the manifest.
++
+[source,terminal,subs="attributes+"]
+----
+NAME                   AGE
+{net-def-name}  14m
+----

--- a/modules/nw-multus-gitops.adoc
+++ b/modules/nw-multus-gitops.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/networking-gitops.adoc
+
+[id="nw-multus-gitops_{context}"]
+= Multiple networks and GitOps
+
+Typically, managing an additional network is performed imperatively by editing the `cluster` object for the Cluster Network Operator with the `oc edit networks.operator.openshift.io cluster` command and adding a `.spec.additionalNetworks` field.
+
+To support GitOps, the best practice is to begin by creating a network attachment definition object instead of modifying the `cluster` object.
+
+== Limitations
+
+* After you add a network attachment definition and a pod uses the network attachment, modifying the network attachment definition does not trigger the pod to restart. As a result, the pod continues to run with the previous definition.

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -40,6 +40,7 @@ is based on the following template.
 IMPORTANT: Specify your network device by setting only one of the
 following parameters: `device`, `hwaddr`, `kernelpath`, or `pciBusID`.
 
+// tag::json-ref[]
 The following object describes the configuration parameters for the host-device CNI
 plug-in:
 
@@ -74,6 +75,7 @@ the CNO configuration.
 
 <6> Specify a configuration object for the ipam CNI plug-in. The plug-in
 manages IP address assignment for the attachment definition.
+// end::json-ref[]
 
 [id="nw-multus-hostdev-config-example_{context}"]
 == host-device configuration example

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -37,6 +37,7 @@ you do not specify a value, then the `default` namespace is used.
 <3> Specify the CNI plug-in configuration in JSON format, which
 is based on the following template.
 
+// tag::json-ref[]
 The following object describes the configuration parameters for the ipvlan CNI
 plug-in:
 
@@ -70,6 +71,7 @@ default value is automatically set by the kernel.
 
 <5> Specify a configuration object for the ipam CNI plug-in. The plug-in
 manages IP address assignment for the attachment definition.
+// end::json-ref[]
 
 [id="nw-multus-ipvlan-config-example_{context}"]
 == ipvlan configuration example

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -50,6 +50,7 @@ you do not specify a value, then the `default` namespace is used.
 <3> Specify the CNI plug-in configuration in JSON format, which
 is based on the following template.
 
+// tag::json-ref[]
 The following object describes the configuration parameters for the macvlan CNI
 plug-in:
 
@@ -77,6 +78,7 @@ plug-in:
 <4> Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 <5> Specify a configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+// end::json-ref[]
 endif::json[]
 
 ifdef::yaml[]

--- a/modules/nw-multus-network-json.adoc
+++ b/modules/nw-multus-network-json.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_newtorks/networking-gitops.adoc
+
+[id="nw-multus-network-json_{context}"]
+= Configuration for network attachment definition
+
+The following sections provide reference information about the network plugins that you can use when you create a JSON-formatted network attachment definition.
+
+== Configuration for bridge
+
+include::nw-multus-bridge-object.adoc[tag=json-ref]
+
+== Configuration for host-device
+
+include::nw-multus-host-device-object.adoc[tag=json-ref]
+
+== Configuration for ipvlan
+
+include::nw-multus-ipvlan-object.adoc[tag=json-ref]
+
+== Configuration for macvlan
+
+include::nw-multus-macvlan-object.adoc[tag=json-ref]

--- a/networking/multiple_networks/networking-gitops.adoc
+++ b/networking/multiple_networks/networking-gitops.adoc
@@ -1,0 +1,20 @@
+[id="networking-gitops"]
+= Networking and GitOps
+include::modules/common-attributes.adoc[]
+:context: networking-gitops
+
+toc::[]
+
+As a cluster administrator, you can manage networking in {product-title} declaratively to meet your GitOps goals.
+
+include::modules/nw-multus-gitops.adoc[leveloffset=+1]
+
+include::modules/nw-multus-create-network-decl.adoc[leveloffset=+1]
+
+include::modules/nw-multus-network-json.adoc[leveloffset=+1]
+
+include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
+
+== Next steps
+
+* xref:../../networking/multiple_networks/attaching-pod.adoc#attaching-pod[Attach a pod to an additional network].


### PR DESCRIPTION
/hold

This is a "feeler PR" to provoke ideas.  I started with Multus because that is an area that is currently documented as imperative with `oc edit`.

This is in the wrong loc for a broad title like "Networking and GitOps"--either the title needs to change or the loc and breadth need to increase.

https://deploy-preview-31207--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/networking-gitops.html