### PR TITLE
Removes MTU network link

### DIFF
--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -19,10 +19,9 @@ include::modules/machine-config-overview.adoc[leveloffset=+2]
 include::modules/checking-mco-status.adoc[leveloffset=+2]
 
 [id="using-machineconfigs-to-change-machines"]
-== Using `MachineConfig` objects to configure nodes
+== Using MachineConfig objects to configure nodes
 
-Tasks in this section let you create `MachineConfig` objects to modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see
- content related to link:https://access.redhat.com/solutions/5307301[changing MTU network settings], link:https://access.redhat.com/solutions/5096731[adding] or
+You can use the tasks in this section to create `MachineConfig` objects that modify files, systemd unit files, and other operating system features running on {product-title} nodes. For more ideas on working with machine configs, see content related to link:https://access.redhat.com/solutions/5096731[adding] or
 link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys, link:https://access.redhat.com/verify-images-ocp4[verifying image signatures], link:https://access.redhat.com/solutions/4727321[enabling SCTP], and link:https://access.redhat.com/solutions/5170251[configuring iSCSI initiatornames] for {product-title}.
 
 {product-title} version 4.7 supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2].  All new machine configs you create going forward should be based on Ignition specification version 3.2.  If you are upgrading your {product-title} cluster, any existing Ignition specification version 2.x machine configs will be translated automatically to specification version 3.2.


### PR DESCRIPTION
No BZ. Vikram requested I remove the MTU network link. Below is his message: 

https://docs.openshift.com/container-platform/4.6/post_installation_configuration/machine-configuration-tasks.html#using-machineco[…]change-machines links to https://access.redhat.com/solutions/5307301 in the text “changing MTU network settings”. That link to changing MTU network settings needs to be removed. I guess we need to remove the the whole “see content related to changing MTU network settings, adding or updating SSH” to “see content related to adding or updating SSH” or however you want to reword it.

This is for 4.6+ 

Preview: https://deploy-preview-31210--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#using-machineconfigs-to-change-machines

No QA needed. 