### PR TITLE
Jira CNV10449 Correcting description of operating system in VM Wizard fields

### DIFF
--- a/modules/virt-vm-wizard-fields-web.adoc
+++ b/modules/virt-vm-wizard-fields-web.adoc
@@ -51,10 +51,10 @@ endif::[]
 |Operating System
 |
 ifdef::virtualmachine[]
-|The primary operating system that is selected for the virtual machine in the template. You cannot edit this field when creating a virtual machine from a template.
+|The operating system that is selected for the virtual machine in the template. You cannot edit this field when creating a virtual machine from a template.
 endif::[]
 ifdef::vmtemplate[]
-|The primary operating system that is selected for the virtual machine. Selecting an operating system automatically selects the default *Flavor* and *Workload Type* for that operating system.
+|The operating system that is selected for the virtual machine. Selecting an operating system automatically selects the default *Flavor* and *Workload Type* for that operating system.
 endif::[]
 
 .4+|Boot Source


### PR DESCRIPTION
This PR addresses JIRA story ( https://issues.redhat.com/browse/CNV-10449 ) and Bug 1927733 ( https://bugzilla.redhat.com/show_bug.cgi?id=1927733 ).

The story/bug deals with altering the description of "Operating System" in the VM Wizard fields table in "Creating virtual machines." The change is to remove the word "primary" to clear up confusion about the nature of the OS involved in the VM.

Preview: https://deploy-preview-31211--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-vm-wizard-fields-web_virt-create-vms 