### PR TITLE
BZ#1852105 No longer a short char limit for GCP cluster name

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -260,11 +260,6 @@ link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-mana
 in the Azure documentation.
 ====
 endif::azure[]
-ifdef::gcp[]
-If you provide a name that is longer
-than 6 characters, only the first 6 characters will be used in the infrastructure
-ID that is generated from the cluster name.
-endif::gcp[]
 ifdef::rhv[]
 .. Respond to the installation program prompts.
 ... For `SSH Public Key`, select a password-less public key, such as `~/.ssh/id_rsa.pub`. This key authenticates connections with the new {product-title} cluster.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1852105

Preview: https://deploy-preview-31213--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-initializing_installing-gcp-user-infra