### PR TITLE
[Serverless] Fixing examples to support response Hello Serverless!

### DIFF
--- a/modules/creating-serverless-apps-kn.adoc
+++ b/modules/creating-serverless-apps-kn.adoc
@@ -24,21 +24,22 @@ $ kn service create <service-name> --image <image> --env <key=value>
 [source,terminal]
 [source,terminal]
 ----
-$ kn service create event-display \
-    --image quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+$ kn service create hello \
+    --env RESPONSE='Hello Serverless!' \
+    --image docker.io/openshift/hello-openshift
 ----
 +
 .Example output
 [source,terminal]
 ----
-Creating service 'event-display' in namespace 'default':
+Creating service 'hello' in namespace 'default':
 
   0.271s The Route is still working to reflect the latest desired specification.
-  0.580s Configuration "event-display" is waiting for a Revision to become ready.
+  0.580s Configuration "hello" is waiting for a Revision to become ready.
   3.857s ...
   3.861s Ingress has not yet been reconciled.
   4.270s Ready to serve.
 
-Service 'event-display' created with latest revision 'event-display-bxshg-1' and URL:
-http://event-display-default.apps-crc.testing
+Service 'hello' created with latest revision 'hello-bxshg-1' and URL:
+http://hello-default.apps-crc.testing
 ----

--- a/modules/creating-serverless-apps-yaml.adoc
+++ b/modules/creating-serverless-apps-yaml.adoc
@@ -16,13 +16,13 @@ To create a serverless application by using YAML, you must create a YAML file th
 apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
-  name: event-delivery
+  name: hello
   namespace: default
 spec:
   template:
     spec:
       containers:
-        - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+        - image: docker.io/openshift/hello-openshift
           env:
             - name: RESPONSE
               value: "Hello Serverless!"

--- a/modules/interacting-serverless-apps-http2-gRPC.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC.adoc
@@ -30,7 +30,7 @@ $ oc -n knative-serving-ingress get svc kourier
 
 [source,terminal]
 ----
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                                             PORT(S)                                                                                                                                      AGE
+NAME      TYPE           CLUSTER-IP      EXTERNAL-IP                                                             PORT(S)                      AGE
 kourier   LoadBalancer   172.30.51.103   a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com   80:31380/TCP,443:31390/TCP   67m
 ----
 
@@ -42,7 +42,8 @@ The public address is surfaced in the `EXTERNAL-IP` field, and in this case is `
 
 [source,terminal]
 ----
-$ curl -H "Host: hello-default.example.com" a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com
+$ curl -H "Host: hello-default.example.com" \
+  a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com
 ----
 
 +

--- a/modules/verifying-serverless-app-deployment.adoc
+++ b/modules/verifying-serverless-app-deployment.adoc
@@ -24,21 +24,21 @@ $ oc get ksvc <service_name>
 .Example output
 [source,terminal]
 ----
-NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
-event-delivery   http://event-delivery-default.example.com   event-delivery-4wsd2   event-delivery-4wsd2   True
+NAME   URL                               LATESTCREATED  LATESTREADY  READY  REASON
+hello  http://hello-default.example.com  hello-4wsd2    hello-4wsd2  True
 ----
 . Make a request to your cluster and observe the output.
 +
 .Example HTTP request
 [source,terminal]
 ----
-$ curl http://event-delivery-default.example.com
+$ curl http://hello-default.example.com
 ----
 +
 .Example HTTPS request
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com
+$ curl https://hello-default.example.com
 ----
 +
 .Example output
@@ -50,7 +50,7 @@ Hello Serverless!
 +
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com --insecure
+$ curl https://hello-default.example.com --insecure
 ----
 +
 .Example output
@@ -68,7 +68,7 @@ The path to the certificate can be passed to the curl command by using the `--ca
 +
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com --cacert <file>
+$ curl https://hello-default.example.com --cacert <file>
 ----
 +
 .Example output


### PR DESCRIPTION
While creating example knative services in https://docs.openshift.com/container-platform/4.7/serverless/serving-creating-managing-apps.html an image that respond is required. 

`quay.io/openshift-knative/knative-eventing-sources-event-display:latest` will not respond to general request, and it will just print cloud event (if received one with POST) in it's logs.

In this doc page it makes much more sense to rely on the standard Openshift image of `docker.io/openshift/hello-openshift` as it will respond to simple request, and respect `RESPONSE` env variable that changes the response.