### PR TITLE
BZ1946177: RHV VM import fails for NFS target storage class (CNV 2.6.1)

### DIFF
--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -43,12 +43,7 @@ ifdef::virt-features-for-storage[]
 |Yes
 endif::[]
 ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
-ifeval::["{VirtVersion}" >= "2.5"]
 |Yes
-endif::[]
-ifeval::["{VirtVersion}" < "2.5"]
-|No
-endif::[]
 endif::[]
 
 |{VirtProductName} hostpath provisioner
@@ -62,12 +57,7 @@ ifdef::virt-importing-rhv-vm[]
 |No
 endif::[]
 ifdef::virt-importing-vmware-vm[]
-ifeval::["{VirtVersion}" < "2.5"]
-|Yes ^[1]^
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
 |Yes
-endif::[]
 endif::[]
 
 |Other multi-node writable storage
@@ -77,16 +67,8 @@ ifdef::virt-features-for-storage[]
 |Yes ^[2]^
 |Yes ^[2]^
 endif::[]
-ifdef::virt-importing-rhv-vm[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
 |Yes ^[1]^
-endif::[]
-ifdef::virt-importing-vmware-vm[]
-ifeval::["{VirtVersion}" < "2.5"]
-|Yes ^[2]^
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
-|Yes ^[1]^
-endif::[]
 endif::[]
 
 |Other single-node writable storage
@@ -96,42 +78,21 @@ ifdef::virt-features-for-storage[]
 |Yes ^[2]^
 |Yes ^[2]^
 endif::[]
-ifdef::virt-importing-rhv-vm[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
 |Yes ^[2]^
-endif::[]
-ifdef::virt-importing-vmware-vm[]
-ifeval::["{VirtVersion}" < "2.5"]
-|Yes ^[3]^
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
-|Yes ^[2]^
-endif::[]
 endif::[]
 |===
 [.small]
-ifdef::virt-importing-vmware-vm[]
+ifdef::virt-importing-rhv-vm,virt-importing-vmware-vm[]
 --
-ifeval::["{VirtVersion}" < "2.5"]
-1. The `v2v-conversion-template` disk must use {VirtProductName} hostpath provisioner storage if the VM disks use NFS storage.
-2. PVCs must request a ReadWriteMany access mode.
-3. PVCs must request a ReadWriteOnce access mode.
-endif::[]
-ifeval::["{VirtVersion}" >= "2.5"]
 1. PVCs must request a ReadWriteMany access mode.
 2. PVCs must request a ReadWriteOnce access mode.
-endif::[]
 --
 endif::[]
 ifdef::virt-features-for-storage[]
 --
 1. PVCs must request a ReadWriteMany access mode.
 2. Storage provider must support both Kubernetes and CSI snapshot APIs
---
-endif::[]
-ifdef::virt-importing-rhv-vm[]
---
-1. PVCs must request a ReadWriteMany access mode.
-2. PVCs must request a ReadWriteOnce access mode.
 --
 endif::[]
 

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -80,6 +80,13 @@ EOF
 <4> Specify the RHV storage domain.
 <5> Specify `nfs` or `ocs-storagecluster-ceph-rbd`.
 <6> If you specified the `ocs-storagecluster-ceph-rbd` storage class, you must specify `Block` as the volume mode.
+// For CNV 2.6.1 only. Will be fixed in CNV 2.6.2.
+. If you specified NFS as the target storage class, you must run the following command because of a known issue (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946177[*BZ#1946177*]):
++
+[source,terminal]
+----
+$ oc patch cdi cdi-kubevirt-hyperconverged --type merge -p '{"spec": {"config": {"filesystemOverhead": {"global": "0"}}}}'
+----
 
 . Create the `VirtualMachineImport` CR by running the following command:
 +

--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -10,6 +10,13 @@ Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductN
 * Storage:
 ** The {VirtProductName} local and shared persistent storage classes must support VM import.
 ** If you are using Ceph RBD block-mode volumes, the storage must be large enough to accommodate the virtual disk. If the disk is too large for the available storage, the import process fails and the PV that is used to copy the virtual disk is not released.
+** If you are using NFS storage, you must run the following command because of a known issue (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946177[*BZ#1946177*]):
++
+[source,terminal]
+----
+$ oc patch cdi cdi-kubevirt-hyperconverged --type merge -p '{"spec": {"config": {"filesystemOverhead": {"global": "0"}}}}'
+----
+// remove for CNV 2.6.2
 
 * Networks:
 ** The RHV and {VirtProductName} networks must either have the same name or be mapped to each other.
@@ -30,4 +37,3 @@ Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductN
 ** The VM must not have been created with {product-title} and subsequently added to RHV.
 ** The VM must not be configured for USB devices.
 ** The watchdog model must not be `diag288`.
-

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -101,13 +101,21 @@ endif::[]
 ifdef::virt-importing-rhv-vm[]
 * *General* -> *Name*: The VM name is limited to 63 characters.
 * *General* -> *Description*: Optional description of the VM.
-* *Storage*:
 ** *Storage Class*: Select *NFS* or *ocs-storagecluster-ceph-rbd*.
 +
 If you select *ocs-storagecluster-ceph-rbd*, you must set the *Volume Mode* of the disk to *Block*.
++
+If you select *NFS*, you must run the following command on the CLI because of a known issue (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946177[*BZ#1946177*]):
++
+[source,terminal]
+----
+$ oc patch cdi cdi-kubevirt-hyperconverged --type merge -p '{"spec": {"config": {"filesystemOverhead": {"global": "0"}}}}'
+----
+// remove this step for CNV 2.6.2
 
 ** *Advanced* -> *Volume Mode*: Select *Block*.
-* *Networking* -> *Network*: You can select a network from a list of available `NetworkAttachmentDefinition` objects.
+* *Advanced* -> *Volume Mode*: Select *Block*.
+* *Networking* -> *Network*: You can select a network from a list of available network attachment definition objects.
 endif::[]
 ifdef::virt-importing-vmware-vm[]
 * *General*:

--- a/modules/virt-troubleshooting-vm-import.adoc
+++ b/modules/virt-troubleshooting-vm-import.adoc
@@ -66,60 +66,28 @@ endif::[]
 == Error messages
 
 ifdef::virt-importing-rhv-vm[]
-The following error messages might appear:
-
-* The following error message is displayed in the VM Import Controller pod log if the target VM name exceeds 63 characters link:https://bugzilla.redhat.com/show_bug.cgi?id=1857165[(*BZ#1857165*)]:
-+
-----
-Message:               Error while importing disk image
-Reason:                ProcessingFailed
-----
+The following error message might appear:
 
 * The following error message is displayed in the VM Import Controller pod log and the progress bar stops at 10% if the {VirtProductName} storage PV is not suitable:
 +
+[source,terminal]
 ----
 Failed to bind volumes: provisioning failed for PVC
 ----
 +
-You must use the NFS storage class. Cinder storage is not supported. link:https://bugzilla.redhat.com/show_bug.cgi?id=1857784[(*BZ#1857784*)]
+You must use a compatible storage class. The Cinder storage class is not supported.
 
-ifeval::["{HCOVersion}" == "2.4.1"]
-* The following error message is displayed in the *Virtual Machines* tab of the *Virtualization* screen in the {VirtProductName} console if the `vm-import-controller` cannot find a matching template for the RHV VM operating system:
-+
-----
-The virtual machine could not be imported.
-VMTemplateMatchingFailed: Couldn't find matching template
-----
-+
-You can perform the following actions to fix this problem:
-
-** Change the RHV VM operating system to an operating system that exists in the default `vm-import-controller` config map.
-** If you created a custom config map, check the config map to verify that the RHV VM operating system is mapped to a matching {VirtProductName} common template.
-** If there is no matching {VirtProductName} common template, create an appropriate VM template in the {VirtProductName} console and then create a custom config map to map the RHV VM operating system to the new template.
-
-* The migration will hang at the *Starting Red Hat Virtualization (RHV) controller* message in the {VirtProductName} console if a non-admin user tries to import a VM. Only an admin user has permission to import a VM.
-endif::[]
 endif::[]
 
 ifdef::virt-importing-vmware-vm[]
-The following error message might appear:
+The following error messages might appear:
 
 * If the VMware VM is not shut down before import, the imported virtual machine displays the error message, `Readiness probe failed` in the {product-title} console and the V2V Conversion pod log displays the following error message:
 +
+[source,terminal]
 ----
 INFO - have error: ('virt-v2v error: internal error: invalid argument: libvirt domain ‘v2v_migration_vm_1’ is running or paused. It must be shut down in order to perform virt-v2v conversion',)"
 ----
-
-ifeval::["{VirtVersion}" == "2.4"]
-* When you select the VMware provider, the following warning message is displayed:
-+
-----
-Warning alert:Could not load config map vmware-to-kubevirt-os in kube-public namespace
-Configmaps "vmware-to-kubevirt-os" not found
-----
-+
-This warning does not affect the VMware virtual machine import.
-endif::[]
 
 * The following error message is displayed in the {product-title} console if a non-admin user tries to import a VM:
 +
@@ -130,15 +98,4 @@ Restricted Access: configmaps "vmware-to-kubevirt-os" is forbidden: User cannot 
 ----
 +
 Only an admin user can import a VM.
-endif::[]
-
-ifdef::virt-importing-vmware-vm[]
-[id='known-issues_{context}']
-== Known issues
-
-The following are known issues:
-
-* You must have sufficient storage space for the imported disk.
-+
-If you try to import a virtual machine with a disk that is larger than the available storage space, the operation cannot complete. You will not be able to import another virtual machine or to clean up the storage because there are insufficient resources to support object deletion. To resolve this situation, you must add more object storage devices to the storage backend. link:https://bugzilla.redhat.com/show_bug.cgi?id=1721504[(*BZ#1721504*)]
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1946177
Importing RHV VM to NFS storage only works with a CLI workaround. This bug will be fixed in 2.6.2.

Changes to storage matrix were general cleanup, not related to this bug.

CP for 4.5+

Preview build:
https://deploy-preview-31229--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-prerequisites_virt-importing-rhv-vm

https://deploy-preview-31229--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-wizard_virt-importing-rhv-vm

https://deploy-preview-31229--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-cli_virt-importing-rhv-vm

Ready for peer review and QE.