### PR TITLE
Release notes for Node and MCO

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -284,6 +284,25 @@ For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.a
 
 When running machines in vSphere, you can now set the `minReplicas` value to `0` in the `MachineAutoscaler` resource definition. When this value is set to `0`, the cluster autoscaler scales the machine set to and from zero depending on if the machines are in use. For more information, see the xref:../machine_management/applying-autoscaling.html#machine-autoscaler-cr_applying-autoscaling[MachineAutoscaler resource definition].
 
+[id="ocp-4-8-mco-upgrade-complete"]
+==== MCO waits for all machine config pools to update before reporting the update is complete
+
+When updating, the Machine Config Operator (MCO) now reports an `Upgradeable=False` status to the Cluster Version Operator (CVO) if any machine config pool has not completed updating. This status blocks future minor updates, but does not block future patch updates, or the current update. Previously, the MCO reported the `Upgradeable` status based only on the state of the master machine config pool, even if the worker pools were not done updating.   
+
+[id="ocp-4-8-mco-no-reboot-cert"]
+==== Automatic rotation of kubelet-ca.crt does not require node draining or reboot
+
+The automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) no longer requires the Machine Config Operator (MCO) to drain nodes or reboot the cluster.
+
+As part of this change, the following modifications do not require the MCO to drain nodes: 
+
+** changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config
+** changes to the global pull secret or pull secret in the `openshift-config` namespace
+
+When the MCO detects any of these changes, it applies the changes and uncordons the node.
+
+For more information, see xref:../architecture/control-plane.adoc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+
 [id="ocp-4-8-nodes"]
 === Nodes
 
@@ -319,6 +338,52 @@ The Node Feature Discovery (NFD) Operator detects hardware features available on
 - `pstate scaling_governor`: When the Intel `pstate` driver status is `active`, the `pstate scaling_governor` label reflects the scaling governor algorithm. The algorithm is either `powersave` or `performance`.
 
 - `cstate status`: If the `intel_idle` driver has C-states or idle states, the `cstate status` label is `true`. Otherwise, it is `false`.
+
+[id="ocp-4-8-nodes-no-reboot-cert"]
+==== Automatic rotation of kubelet-ca.crt does not require reboot
+
+The automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) no longer requires the Machine Config Operator (MCO) to drain nodes or reboot the cluster.
+
+As part of this change, the following modifications do not require the MCO to drain nodes: 
+
+** changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config
+** changes to the global pull secret or pull secret in the `openshift-config` namespace
+
+When the MCO detects any of these changes, it applies the changes and uncordons the node.
+
+For more information, see xref:../architecture/control-plane.adoc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+
+[id="ocp-4-8-nodes-vpa-ga"]
+==== Vertical pod autoscaling is generally available
+
+The {product-title} vertical pod autoscaler (VPA) is now generally available. The VPA automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns.
+
+You can also use the VPA with pods that require only one replica by modifying the `VerticalPodAutoscalerController` object as described below. Previously, the VPA worked only with pods that required two or more replicas.
+
+For more information, see xref:../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler[Automatically adjust pod resource levels with the vertical pod autoscaler].
+
+[id="ocp-4-8-nodes-vpa-replicas"]
+==== Vertical pod autoscaling minimum can be configured
+
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically update pods. As a result, workload objects that specify fewer than two replicas are not acted upon by the VPA. You can change this cluster-wide minimum value by modifying the `VerticalPodAutoscalerController` object to add the `minReplicas` parameter.
+
+For more information, see xref:../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vertical-autoscaler[Automatically adjust pod resource levels with the vertical pod autoscaler].
+
+[id="ocp-4-8-nodes-resources-configuring-auto_{context}"]
+==== Automatically allocate CPU and memory resources for nodes
+
+{product-title} can automatically determine the optimal sizing value of the `system-reserved` setting when a node starts. Previously, the CPU and memory allocations in the `system-reserved` setting were fixed limits that you needed to manually determine and set.
+
+When automatic resource allocation is enabled, a script on each node calculates the optimal values for the respective reserved resources based on the installed CPU and memory capacity on the node. 
+
+For more information, see xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring[Automatically allocating resources for nodes].
+
+[id="ocp-4-8-nodes-registry-allowed-repo_{context}"]
+==== Adding specific repositories to pull images
+
+You can now specify an individual repository within a registry when creating lists of allowed and blocked registries for pulling and pushing images. Previously, you could specify only a registry.
+
+For more information, see xref:../openshift_images/image-configuration.adoc#images-configuration-allowed_image-configuration[Adding specific registries] and xref:../openshift_images/image-configuration.adoc#images-configuration-blocked_image-configuration[Blocking specific registries].
 
 [id="ocp-4-8-logging"]
 === Cluster logging
@@ -679,7 +744,7 @@ In the table below, features are marked with the following statuses:
 |Vertical Pod Autoscaler
 |TP
 |TP
-|
+|GA
 
 |Operator API
 |GA


### PR DESCRIPTION
Release notes for:

* https://issues.redhat.com/browse/OSDOCS-1841
* https://issues.redhat.com/browse/OSDOCS-1842
* https://issues.redhat.com/browse/OSDOCS-1843
* https://issues.redhat.com/browse/OSDOCS-1845
* https://issues.redhat.com/browse/OSDOCS-1846
* https://issues.redhat.com/browse/OSDOCS-1849
* https://issues.redhat.com/browse/OSDOCS-1850
* https://issues.redhat.com/browse/OSDOCS-1851
* https://issues.redhat.com/browse/OSDOCS-2020

Previews:
**Machine API**
[MCO waits for all machine config pools to update before reporting the update is complete
](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-mco-upgrade-complete)
[Automatic rotation of kubelet-ca.crt does not require node draining or reboot](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-mco-no-reboot-cert)
**Nodes**
[Automatic rotation of kubelet-ca.crt does not require reboot](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-no-reboot-cert) ([Repeated intentionally](https://github.com/openshift/openshift-docs/pull/31237/files#r653028834))
[Vertical pod autoscaling is generally available](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-vpa-ga)
[Vertical pod autoscaling minimum can be configured](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-vpa-replicas)
[Automatically allocate CPU and memory resources for nodes](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-resources-configuring-auto_release-notes)
[Adding specific repositories to pull images](https://deploy-preview-31237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-registry-allowed-repo_release-notes)