### PR TITLE
Remove link Ansible inv doc link

### DIFF
--- a/install_config/topics/configuring_azure_using_ansible.adoc
+++ b/install_config/topics/configuring_azure_using_ansible.adoc
@@ -5,11 +5,9 @@ install_config/configuring_azure.adoc
 ////
 
 [id='azure-configuring-ansible_{context}']
-= Configuring {product-title} for Azure using Ansible
+= Configuring {product-title} for Azure by using Ansible
 
-You can configure {product-title} for Azure at installation time or by running
-the xref:../install/configuring_inventory_file.adoc#configuring-ansible[Ansible
-inventory file] after installation.
+You can configure {product-title} for Azure at installation time.
 
 Add the following to the Ansible inventory file located at
 *_/etc/ansible/hosts_* by default to configure your {product-title} environment


### PR DESCRIPTION
Fix to https://github.com/openshift/openshift-docs/issues/27643
Removes xref to Ansible inventory file customization doc. As the reporter states, the wording removed in this PR "leads to believe Azure File can be run as day-2 operation by running the Ansible inventory file".

Preview link: https://deploy-preview-31243--osdocs.netlify.app/openshift-enterprise/latest/install_config/configuring_azure.html#azure-configuring-ansible_configuring-for-azure