### PR TITLE
Manual CP of #31141 to 4.6 RHDEVDOCS-2829 Explain how to "only deploy collector section"

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1525,7 +1525,7 @@ Topics:
   Dir: config
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
   Topics:
-  - Name: About the Cluster Logging Custom Resource
+  - Name: About the Cluster Logging custom resource
     File: cluster-logging-configuring-cr
   - Name: Configuring the logging collector
     File: cluster-logging-collector
@@ -2296,7 +2296,7 @@ Topics:
   - Name: Customizing the installation
     File: customizing-installation-ossm
   - Name: Performance and scalability
-    File: ossm-performance-scalability 
+    File: ossm-performance-scalability
   - Name: Deploying applications on Service Mesh
     File: prepare-to-deploy-applications-ossm
   - Name: Data visualization and observability

--- a/logging/config/cluster-logging-collector.adoc
+++ b/logging/config/cluster-logging-collector.adoc
@@ -22,3 +22,8 @@ include::modules/cluster-logging-collector-limits.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-tuning.adoc[leveloffset=+1]
 
+include::modules/cluster-logging-removing-unused-components-if-no-elasticsearch.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third party systems]

--- a/modules/cluster-logging-about-crd.adoc
+++ b/modules/cluster-logging-about-crd.adoc
@@ -11,7 +11,7 @@ Instructions for creating or modifying a CR are provided in this documentation a
 The following is an example of a typical custom resource for cluster logging.
 
 [id="efk-logging-configuring-about-sample_{context}"]
-.Sample `ClusterLogging` CR
+.Sample `ClusterLogging` custom resource (CR)
 ifdef::openshift-dedicated[]
 [source,yaml]
 ----

--- a/modules/cluster-logging-removing-unused-components-if-no-elasticsearch.adoc
+++ b/modules/cluster-logging-removing-unused-components-if-no-elasticsearch.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-collector.adoc
+
+[id="cluster-logging-removing-unused-components-if-no-elasticsearch_{context}"]
+= Removing unused components if you do not use the default Elasticsearch log store
+
+As an administrator, in the rare case that you forward logs to a third-party log store and do not use the default Elasticsearch log store, you can remove several unused components from your logging cluster.
+
+In other words, if you do not use the default Elasticsearch log store, you can remove the internal Elasticsearch `logStore`, Kibana `visualization`, and log `curation` components from the `ClusterLogging` custom resource (CR). Removing these components is optional but saves resources.
+
+.Prerequisites
+
+* Verify that your log forwarder does not send log data to the default internal Elasticsearch cluster. Inspect the `ClusterLogForwarder` CR YAML file that you used to configure log forwarding. Verify that it _does not_ have an `outputRefs` element that specifies `default`. For example:
++
+[source,yaml]
+----
+outputRefs:
+- default
+----
+
+[WARNING]
+====
+Suppose the `ClusterLogForwarder` CR forwards log data to the internal Elasticsearch cluster, and you remove the `logStore` component from the `ClusterLogging` CR. In that case, the internal Elasticsearch cluster will not be present to store the log data. This absence can cause data loss.
+====
+
+.Procedure
+
+. Edit the `ClusterLogging` custom resource (CR) in the `openshift-logging` project:
++
+[source,terminal]
+----
+$ oc edit ClusterLogging instance
+----
+
+. If they are present, remove the `logStore`, `visualization`, `curation`  stanzas from the `ClusterLogging` CR.
+
+. Preserve the `collection` stanza of the `ClusterLogging` CR. The result should look similar to the following example:
++
+[source,yaml]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: "ClusterLogging"
+metadata:
+  name: "instance"
+  namespace: "openshift-logging"
+spec:
+  managementState: "Managed"
+  collection:
+    logs:
+      type: "fluentd"
+      fluentd: {}
+----
+
+. Verify that the Fluentd pods are redeployed:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-logging
+----


### PR DESCRIPTION
- For version 4.6
- https://issues.redhat.com/browse/RHDEVDOCS-2829
- Direct link to doc preview: https://deploy-preview-31252--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-collector.html#cluster-logging-collecting-and-forwarding-logs-only_cluster-logging-collector
- Completed SME, QE, and peer reviews.
- **Ready for merge**.