### PR TITLE
OSDOCS-1807: sr-iov supp x710

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -5,8 +5,9 @@
 [id="supported-devices_{context}"]
 = Supported devices
 
-{product-title} supports the following Network Interface Card (NIC) models:
+{product-title} supports the following network interface controller (NIC) models:
 
+* Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
 * Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
 * Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
 * Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`


### PR DESCRIPTION
Preview link: https://deploy-preview-31255--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

The update is in the first bullet.

--------------------
@openshift/team-documention PTAL.

Applies to enterprise-4.8 and milestone Future Release. // Thanks Jeana. Some day, I'll be able to do this job.  I promise.