### PR TITLE
 Bug 1788733: Simplified procedure for cluster-wide proxy setup and asciidoc updates

### DIFF
--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -26,9 +26,11 @@ status:
 A cluster administrator can configure the proxy for {product-title} by modifying
 this `cluster` Proxy object.
 
-NOTE: Only the Proxy object named `cluster` is supported, and no additional
+[NOTE]
+====
+Only the Proxy object named `cluster` is supported, and no additional
 proxies can be created.
-
+====
 .Prerequisites
 
 * Cluster administrator permissions
@@ -39,10 +41,18 @@ proxies can be created.
 . Create a ConfigMap that contains any additional CA certificates required for
 proxying HTTPS connections.
 +
-NOTE: You can skip this step if the proxy’s identity certificate is signed by an
+[NOTE]
+====
+You can skip this step if the proxy’s identity certificate is signed by an
 authority from the RHCOS trust bundle.
-
-.. Create a file called `user-ca-bundle.yaml` with the following contents, and provide the values of your PEM-encoded certificates:
+====
++
+[source,terminal]
+----
+$ oc create configmap user-ca-bundle --from-file=ca-bundle.crt=/path/to/my-ca.crt -n openshift-config
+----
++
+.. Alternatively, you can create a file called `user-ca-bundle.yaml` with the following contents, and provide the values of your PEM-encoded certificates:
 +
 [source,yaml]
 ----
@@ -60,8 +70,8 @@ metadata:
 identity certificate.
 <3> The ConfigMap name that will be referenced from the Proxy object.
 <4> The ConfigMap must be in the `openshift-config` namespace.
-
-.. Create the ConfigMap from this file:
++
+.. Then create the ConfigMap from this file:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1788733

Simplified procedure for cluster-wide proxy setup and applied asciidoc formatting updates to note admonitions 
 Direct link to doc: https://deploy-preview-31265--osdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html#nw-proxy-configure-object_config-cluster-wide-proxy

for 4.5+

