### PR TITLE
[enterprise-4.7] Include namespace referring to image stream # 31225 : security/compliance_operator/compliance-operator-manage.adoc 

### DIFF
--- a/modules/compliance-imagestreams.adoc
+++ b/modules/compliance-imagestreams.adoc
@@ -15,7 +15,7 @@ The `contentImage` reference points to a valid `ImageStreamTag`, and the Complia
 .Example image stream
 [source,terminal]
 ----
-$ oc get is
+$ oc get is -n openshift-compliance
 ----
 
 .Example output
@@ -34,13 +34,14 @@ $ oc patch is openscap-ocp4-ds \
     -p '{"spec":{"lookupPolicy":{"local":true}}}' \
     --type=merge
     imagestream.image.openshift.io/openscap-ocp4-ds patched
+    -n openshift-compliance
 ----
 
 . Use the name of the `ImageStreamTag` for the `ProfileBundle` by retrieving the `istag` name:
 +
 [source,terminal]
 ----
-$ oc get istag
+$ oc get istag -n openshift-compliance
 ----
 +
 .Example output


### PR DESCRIPTION
Documentation reference: https://docs.openshift.com/container-platform/4.7/security/compliance_operator/compliance-operator-manage.html

Added namespace "openshift-compliance" for image stream for better clarity. The commands mentioned in doc against the imagestreams are not indicating the namespace. If a user is in different namespace than would not get the required image which would be referring to the image repository ""image-registry.openshift-image-registry.svc:5000/openshift-compliance" for "openshift-compliance" namespace.

@vikram-redhat  @ahardin-rh . Please have a look at PR. Thank you.