### PR TITLE
[virt] HCO bump for 2.6.1

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.0
+:HCOVersion: 2.6.1
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- https://issues.redhat.com/browse/CNV-11063
- Just bumping the HCO version for 2.6.1, to be merged upon release (~April 7)
- No cherrypick, direct to 4.7
- Examples:
[Subscription object YAML](https://deploy-preview-31312--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components)
and
[must-gather command](https://deploy-preview-31312--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data.html#gathering-data-specific-features_virt-collecting-virt-data)