### PR TITLE
BZ1862279: Corrected syntax for export commands

### DIFF
--- a/modules/installation-creating-gcp-bootstrap.adoc
+++ b/modules/installation-creating-gcp-bootstrap.adoc
@@ -41,7 +41,7 @@ template describes the bootstrap machine that your cluster requires.
 +
 [source,terminal]
 ----
-$ export CLUSTER_IMAGE=`gcloud compute images describe ${INFRA_ID}-rhcos-image --format json | jq -r .selfLink`
+$ export CLUSTER_IMAGE=(`gcloud compute images describe ${INFRA_ID}-rhcos-image --format json | jq -r .selfLink`)
 ----
 
 . Create a bucket and upload the `bootstrap.ign` file:

--- a/modules/installation-creating-gcp-control-plane.adoc
+++ b/modules/installation-creating-gcp-control-plane.adoc
@@ -94,9 +94,9 @@ Manager, so you must add the etcd entries manually.
 +
 [source,terminal]
 ----
-$ export MASTER0_IP=`gcloud compute instances describe ${INFRA_ID}-master-0 --zone ${ZONE_0} --format json | jq -r .networkInterfaces[0].networkIP`
-$ export MASTER1_IP=`gcloud compute instances describe ${INFRA_ID}-master-1 --zone ${ZONE_1} --format json | jq -r .networkInterfaces[0].networkIP`
-$ export MASTER2_IP=`gcloud compute instances describe ${INFRA_ID}-master-2 --zone ${ZONE_2} --format json | jq -r .networkInterfaces[0].networkIP`
+$ export MASTER0_IP=(`gcloud compute instances describe ${INFRA_ID}-master-0 --zone ${ZONE_0} --format json | jq -r .networkInterfaces[0].networkIP`)
+$ export MASTER1_IP=(`gcloud compute instances describe ${INFRA_ID}-master-1 --zone ${ZONE_1} --format json | jq -r .networkInterfaces[0].networkIP`)
+$ export MASTER2_IP=(`gcloud compute instances describe ${INFRA_ID}-master-2 --zone ${ZONE_2} --format json | jq -r .networkInterfaces[0].networkIP`)
 ----
 .. Add the DNS entries for the control plane etcd entries:
 +

--- a/modules/installation-creating-gcp-iam-shared-vpc.adoc
+++ b/modules/installation-creating-gcp-iam-shared-vpc.adoc
@@ -62,14 +62,14 @@ $ gcloud deployment-manager deployments create ${INFRA_ID}-iam --config 03_iam.y
 +
 [source,terminal]
 ----
-$ export MASTER_SERVICE_ACCOUNT=`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-m@${PROJECT_NAME}." --format json | jq -r '.[0].email'`
+$ export MASTER_SERVICE_ACCOUNT=(`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-m@${PROJECT_NAME}." --format json | jq -r '.[0].email'`)
 ----
 
 . Export the variable for the worker service account:
 +
 [source,terminal]
 ----
-$ export WORKER_SERVICE_ACCOUNT=`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-w@${PROJECT_NAME}." --format json | jq -r '.[0].email'`
+$ export WORKER_SERVICE_ACCOUNT=(`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-w@${PROJECT_NAME}." --format json | jq -r '.[0].email'`)
 ----
 
 ifndef::shared-vpc[]
@@ -77,7 +77,7 @@ ifndef::shared-vpc[]
 +
 [source,terminal]
 ----
-$ export COMPUTE_SUBNET=`gcloud compute networks subnets describe ${INFRA_ID}-worker-subnet --region=${REGION} --format json | jq -r .selfLink`
+$ export COMPUTE_SUBNET=(`gcloud compute networks subnets describe ${INFRA_ID}-worker-subnet --region=${REGION} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 

--- a/modules/installation-creating-gcp-lb.adoc
+++ b/modules/installation-creating-gcp-lb.adoc
@@ -47,13 +47,13 @@ requires.
 ifdef::shared-vpc[]
 [source,terminal]
 ----
-$ export CLUSTER_NETWORK=`gcloud compute networks describe ${HOST_PROJECT_NETWORK} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
+$ export CLUSTER_NETWORK=(`gcloud compute networks describe ${HOST_PROJECT_NETWORK} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 ifndef::shared-vpc[]
 [source,terminal]
 ----
-$ export CLUSTER_NETWORK=`gcloud compute networks describe ${INFRA_ID}-network --format json | jq -r .selfLink`
+$ export CLUSTER_NETWORK=(`gcloud compute networks describe ${INFRA_ID}-network --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 
@@ -62,13 +62,13 @@ endif::shared-vpc[]
 ifdef::shared-vpc[]
 [source,terminal]
 ----
-$ export CONTROL_SUBNET=`gcloud compute networks subnets describe ${HOST_PROJECT_CONTROL_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
+$ export CONTROL_SUBNET=(`gcloud compute networks subnets describe ${HOST_PROJECT_CONTROL_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 ifndef::shared-vpc[]
 [source,terminal]
 ----
-$ export CONTROL_SUBNET=`gcloud compute networks subnets describe ${INFRA_ID}-master-subnet --region=${REGION} --format json | jq -r .selfLink`
+$ export CONTROL_SUBNET=(`gcloud compute networks subnets describe ${INFRA_ID}-master-subnet --region=${REGION} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 
@@ -76,17 +76,17 @@ endif::shared-vpc[]
 +
 [source,terminal]
 ----
-$ export ZONE_0=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[0] | cut -d "/" -f9`
+$ export ZONE_0=(`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[0] | cut -d "/" -f9`)
 ----
 +
 [source,terminal]
 ----
-$ export ZONE_1=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[1] | cut -d "/" -f9`
+$ export ZONE_1=(`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[1] | cut -d "/" -f9`)
 ----
 +
 [source,terminal]
 ----
-$ export ZONE_2=`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[2] | cut -d "/" -f9`
+$ export ZONE_2=(`gcloud compute regions describe ${REGION} --format=json | jq -r .zones[2] | cut -d "/" -f9`)
 ----
 
 . Create a `02_infra.yaml` resource definition file:
@@ -133,14 +133,14 @@ $ gcloud deployment-manager deployments create ${INFRA_ID}-infra --config 02_inf
 +
 [source,terminal]
 ----
-$ export CLUSTER_IP=`gcloud compute addresses describe ${INFRA_ID}-cluster-ip --region=${REGION} --format json | jq -r .address`
+$ export CLUSTER_IP=(`gcloud compute addresses describe ${INFRA_ID}-cluster-ip --region=${REGION} --format json | jq -r .address`)
 ----
 
 . For an external cluster, also export the cluster public IP address:
 +
 [source,terminal]
 ----
-$ export CLUSTER_PUBLIC_IP=`gcloud compute addresses describe ${INFRA_ID}-cluster-public-ip --region=${REGION} --format json | jq -r .address`
+$ export CLUSTER_PUBLIC_IP=(`gcloud compute addresses describe ${INFRA_ID}-cluster-public-ip --region=${REGION} --format json | jq -r .address`)
 ----
 
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]

--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -49,13 +49,13 @@ template describes the worker machines that your cluster requires.
 ifndef::shared-vpc[]
 [source,terminal]
 ----
-$ export COMPUTE_SUBNET=`gcloud compute networks subnets describe ${INFRA_ID}-worker-subnet --region=${REGION} --format json | jq -r .selfLink`
+$ export COMPUTE_SUBNET=(`gcloud compute networks subnets describe ${INFRA_ID}-worker-subnet --region=${REGION} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 ifdef::shared-vpc[]
 [source,terminal]
 ----
-$ export COMPUTE_SUBNET=`gcloud compute networks subnets describe ${HOST_PROJECT_COMPUTE_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`
+$ export COMPUTE_SUBNET=(`gcloud compute networks subnets describe ${HOST_PROJECT_COMPUTE_SUBNET} --region=${REGION} --project ${HOST_PROJECT} --account ${HOST_PROJECT_ACCOUNT} --format json | jq -r .selfLink`)
 ----
 endif::shared-vpc[]
 
@@ -63,7 +63,7 @@ endif::shared-vpc[]
 +
 [source,terminal]
 ----
-$ export WORKER_SERVICE_ACCOUNT=`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-w@${PROJECT_NAME}." --format json | jq -r '.[0].email'`
+$ export WORKER_SERVICE_ACCOUNT=(`gcloud iam service-accounts list --filter "email~^${INFRA_ID}-w@${PROJECT_NAME}." --format json | jq -r '.[0].email'`)
 ----
 
 .. Export the location of the compute machine Ignition config file:


### PR DESCRIPTION
Applies 4.5+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1862279
QE Approval Needed: @tsze-redhat 
Preview Links: 
- https://deploy-preview-31313--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-lb_installing-gcp-user-infra
- https://deploy-preview-31313--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-iam-shared-vpc_installing-gcp-user-infra
- https://deploy-preview-31313--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-bootstrap_installing-gcp-user-infra
- https://deploy-preview-31313--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-control-plane_installing-gcp-user-infra
- https://deploy-preview-31313--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-worker_installing-gcp-user-infra