### PR TITLE
Jira:OSDOCS-1992 Add instances types to ROSA service definition

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -17,7 +17,7 @@ This is an overview of the provisioned Amazon Web Services (AWS) components on a
 AWS EC2 instances are required for deploying the control plane and data plane functions of ROSA in the AWS public cloud.
 
 - Three m5.xlarge minimum (control plane nodes)
-- Two m5.xlarge minimum (infrastructure nodes)
+- Two r5.xlarge minimum (infrastructure nodes)
 - Two m5.xlarge minimum but highly variable (worker nodes)
 
 [id="rosa-ebs-storage_{context}"]

--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -60,17 +60,30 @@ General purpose
 - M5.xlarge (4 vCPU, 16 GiB)
 - M5.2xlarge (8 vCPU, 32 GiB)
 - M5.4xlarge (16 vCPU, 64 GiB)
+- M5.8xlarge (32 vCPU, 128 GiB)
+- M5.12xlarge (48 vCPU, 192 GiB)
+- M5.16xlarge (64 vCPU, 256 GiB)
+- M5.24xlarge (96 vCPU, 384 GiB)
 
 Memory-optimized
 
 - R5.xlarge (4 vCPU, 32 GiB)
 - R5.2xlarge (8 vCPU, 64 GiB)
 - R5.4xlarge (16 vCPU, 128 GiB)
+- R5.8xlarge (32 vCPU, 256 GiB)
+- R5.12xlarge (48 vCPU, 384 GiB)
+- R5.16xlarge (64 vCPU, 512 GiB)
+- R5.24xlarge (96 vCPU, 768 GiB)
 
 Compute-optimized
 
 - C5.2xlarge (8 vCPU, 16 GiB)
 - C5.4xlarge (16 vCPU, 32 GiB)
+- C5.9xlarge (36 vCPU, 72 GiB)
+- C5.12xlarge (48 vCPU, 96 GiB)
+- C5.18xlarge (72 vCPU, 144 GiB)
+- C5.24xlarge (96 vCPU, 192 GiB)
+
 
 [id="rosa-sdpolicy-regions-az_{context}"]
 == Regions and availability zones


### PR DESCRIPTION
Jira [OSDOCS-1992](https://issues.redhat.com/browse/OSDOCS-1992): https://issues.redhat.com/browse/OSDOCS-1992

Direct links to changes:
Add extra instance types to the ROSA service definition:
https://deploy-preview-31316--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-aws-compute-types_rosa-service-definition

Change EC2 instance types to r5.xlarge for infrastructure nodes:
https://deploy-preview-31316--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#rosa-ec2-instances_prerequisites