### PR TITLE
Added "ec2:DeleteTags" to EC2 permissions table per BZ1926543

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -26,6 +26,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:CreateVolume`
 * `ec2:DeleteSecurityGroup`
 * `ec2:DeleteSnapshot`
+* `ec2:DeleteTags`
 * `ec2:DeregisterImage`
 * `ec2:DescribeAccountAttributes`
 * `ec2:DescribeAddresses`


### PR DESCRIPTION
BZ1926543: https://bugzilla.redhat.com/show_bug.cgi?id=1926543

Document URL: 
https://docs.openshift.com/container-platform/4.6/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account

Section Number and Name:
Required AWS permissions

Describe the issue:
When a private cluster is deployed over AWS using existing resources such as VPC, subnets, etc, then the tag OpenShift tag such as "kubernetes.io/cluster/aygarg-lkcdg: shared" gets added to the existing subnets. At the time of cluster destroy, this tag remains added to the subnets instead of getting removed.

Applicable Document Versions:
4.5, 4.6, 4.7 and 4.8

Suggestions for improvement:
Add the following permission in the documentation so the installer can remove the tag.
--> "ec2:DeleteTags"