### PR TITLE
Bug 1947093: Update OSP versions when listing Kuryr limitations

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -33,10 +33,10 @@ services can cause you to run out of resources.
 Deployments of later versions of {rh-openstack} that have the OVN Octavia driver disabled also
 use the Amphora driver. They are subject to the same resource concerns as earlier versions of {rh-openstack}.
 
-* Octavia {rh-openstack} versions before 16 do not support UDP listeners. Therefore,
+* Octavia {rh-openstack} versions before 13.0.13 do not support UDP listeners. Therefore,
 {product-title} UDP services are not supported.
 
-* Octavia {rh-openstack} versions before 16 cannot listen to multiple protocols on the
+* Octavia {rh-openstack} versions before 13.0.13 cannot listen to multiple protocols on the
 same port. Services that expose the same port to different protocols, like TCP
 and UDP, are not supported.
 
@@ -46,7 +46,7 @@ and UDP, are not supported.
 
 There are limitations when using Kuryr SDN that depend on your deployment environment.
 
-Because of Octavia's lack of support for the UDP protocol and multiple listeners, if the {rh-openstack} version is earlier than 16, Kuryr forces pods to use TCP for DNS resolution.
+Because of Octavia's lack of support for the UDP protocol and multiple listeners, if the {rh-openstack} version is earlier than 13.0.13, Kuryr forces pods to use TCP for DNS resolution.
 
 In Go versions 1.12 and earlier, applications that are compiled with CGO support disabled use UDP only. In this case,
 the native Go resolver does not recognize the `use-vc` option in `resolv.conf`, which controls whether TCP is forced for DNS resolution.
@@ -71,7 +71,7 @@ You can address API changes on an individual basis.
 
 If the Amphora image is upgraded, the {rh-openstack} operator can handle existing load balancer VMs in two ways:
 
-* Upgrade each VM by triggering a triggering a link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/networking_guide/sec-octavia#update-running-amphora-instances[load balancer failover].
+* Upgrade each VM by triggering a link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/networking_guide/sec-octavia#update-running-amphora-instances[load balancer failover].
 
 * Leave responsibility for upgrading the VMs to users.
 

--- a/modules/installation-osp-kuryr-octavia-configuration.adoc
+++ b/modules/installation-osp-kuryr-octavia-configuration.adoc
@@ -91,7 +91,7 @@ parameter_defaults:
 +
 [NOTE]
 ====
-This is not needed for {rh-openstack} 14+.
+This is not needed for {rh-openstack} 13.0.13+.
 ====
 
 . Install or update your Overcloud environment with Octavia:
@@ -121,7 +121,7 @@ backend is ML2/OVS. There is no need for modifications if the backend is
 ML2/OVN.
 ====
 
-. In {rh-openstack} versions 13 and 15, add the project ID
+. In {rh-openstack} versions earlier than 13.0.13, add the project ID
 to the `octavia.conf` configuration file after you create the project.
 * To enforce
 network policies across services, like when traffic goes through
@@ -133,7 +133,7 @@ and that they can be updated to enforce services isolation.
 +
 [NOTE]
 ====
-This task is unnecessary in {rh-openstack} version 16 or later.
+This task is unnecessary in {rh-openstack} version 13.0.13 or later.
 
 Octavia implements a new ACL API that restricts access to the load
 balancers VIP.
@@ -224,7 +224,7 @@ controller-0$ sudo docker restart octavia_worker
 [NOTE]
 ====
 Depending on your {rh-openstack} environment, Octavia might not support UDP
-listeners. If you use Kuryr SDN on {rh-openstack} version 15 or earlier, UDP services are not supported.
+listeners. If you use Kuryr SDN on {rh-openstack} version 13.0.13 or earlier, UDP services are not supported.
 {rh-openstack} version 16 or later support UDP.
 ====
 


### PR DESCRIPTION
In OSP 13.0.13 we've got an Octavia backport - i.e. Octavia from OSP 16
was backported to OSP13. This means we need to update some of the
Kuryr limitations that depend on the OSP version. This commit does so.