### PR TITLE
Fixed indentation in sample proxy certificate. Closes #31018

### DIFF
--- a/security/certificate_types_descriptions/proxy-certificates.adoc
+++ b/security/certificate_types_descriptions/proxy-certificates.adoc
@@ -22,9 +22,9 @@ metadata:
   namespace: openshift-config
 data:
   ca-bundle.crt: |
-  -----BEGIN CERTIFICATE-----
-  Custom CA certificate bundle.
-  -----END CERTIFICATE-----
+    -----BEGIN CERTIFICATE-----
+    Custom CA certificate bundle.
+    -----END CERTIFICATE-----
 ----
 
 [discrete]


### PR DESCRIPTION
This PR adds spaces to a few lines in a sample proxy certificate that weren't indented enough.

* Closes [GitHub Issue #31018](https://github.com/openshift/openshift-docs/issues/31018)
* Applies to 4.5, 4.6, 4.7, and 4.8+
* Needs QE review @xiaojiey 
* [Direct preview link here](https://deploy-preview-31355--osdocs.netlify.app/openshift-enterprise/latest/security/certificate_types_descriptions/proxy-certificates.html#purpose)


