### PR TITLE
[enterprise-4.8] Documentation indicates OpenShiftSDN is a (preferred) supported default network CNI Provider

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -95,7 +95,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -71,7 +71,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -107,7 +107,12 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14 <7>
     hostPrefix: 23 <8>
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork: <9>
   - 172.30.0.0/16
 platform:

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -281,10 +281,10 @@ You cannot modify parameters specified by the `networking` object after installa
 
 |`networking.networkType`
 |The default Container Network Interface (CNI) network provider plug-in to install.
-ifdef::openshift-origin[]
+ifndef::openshift-origin[]
 Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OVNKubernetes`.
 endif::openshift-origin[]
-ifndef::openshift-origin[]
+ifdef::openshift-origin[]
 Either `OpenShiftSDN` or `OVNKubernetes`. The default value is `OpenShiftSDN`.
 endif::openshift-origin[]
 |String

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -84,7 +84,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -44,7 +44,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -58,7 +58,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 endif::network[]

--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -37,7 +37,12 @@ networking:
   - cidr: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
 platform:
   openstack:
     cloud: mycloud

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -37,7 +37,12 @@ networking:
   machineCIDR: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
 platform:
   openstack:
     region: region1

--- a/modules/installing-rhv-example-install-config-yaml.adoc
+++ b/modules/installing-rhv-example-install-config-yaml.adoc
@@ -50,7 +50,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -105,6 +105,13 @@ NOTE: Because of performance improvements introduced in {product-title} 4.3 and 
 <6> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
 
+ifdef::openshift-origin[]
+[NOTE]
+====
+{product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
+====
+endif::openshift-origin[]
+
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
 == Configuration parameters for the OpenShift SDN CNI cluster network provider
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/29158