### PR TITLE
BZ#1927841: host network routers and OVN-K

### DIFF
--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -31,7 +31,12 @@ configured for your cluster. The default template name is `project-request`.
 
 . In the template, add each `NetworkPolicy` object as an element to the `objects` parameter. The `objects` parameter accepts a collection of one or more objects.
 +
-In the following example, the `objects` parameter collection includes several `NetworkPolicy` objects:
+In the following example, the `objects` parameter collection includes several `NetworkPolicy` objects.
++
+[IMPORTANT]
+====
+For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
+====
 +
 [source,yaml]
 ----


### PR DESCRIPTION
This is a followup request from Andrew. We
overlooked this page for the admonition.

Click and scroll for the pink box: https://deploy-preview-31358--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/default-network-policy.html#nw-networkpolicy-project-defaults_default-network-policy

----
Applies to enterprise-4.6 through 4.8.  Milestone Next Release.

@openshift/team-documention PTAL.