### PR TITLE
[enterprise-4.5] Documentation indicates OpenShiftSDN is a preferred supported default network CNI Provider

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -77,7 +77,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -68,7 +68,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -54,7 +54,12 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14 <7>
     hostPrefix: 23 <8>
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork: <9>
   - 172.30.0.0/16
 platform:

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -267,9 +267,17 @@ If you are using Azure File storage, you cannot enable FIPS mode.
 |Required if you use `networking.machineNetwork`. The IP block address pool. The default is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default is `192.168.126.0/24`.
 |IP network. IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the forward slash (/) character, followed by a decimal value between 0 and 32 that describes the number of significant bits. For example, `10.0.0.0/16` represents IP addresses `10.0.0.0` through `10.0.255.255`.
 
+ifndef::openshift-origin[]
 |`networking.networkType`
 |The type of network to install. The default is `OpenShiftSDN`.
 |String
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+|`networking.networkType`
+|The type of network to install. The default is `OVNKubernetes`.
+|String
+endif::openshift-origin[]
 
 |`networking.serviceNetwork`
 |The IP address pools for services. The default is 172.30.0.0/16.

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -65,7 +65,12 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -44,7 +44,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -53,7 +53,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 endif::network[]

--- a/modules/installation-osp-config-yaml.adoc
+++ b/modules/installation-osp-config-yaml.adoc
@@ -38,7 +38,12 @@ networking:
   - cidr: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
 platform:
   openstack:
     cloud: mycloud

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -38,7 +38,12 @@ networking:
   machineCIDR: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
 platform:
   openstack:
     region: region1

--- a/modules/installing-rhv-config-yaml.adoc
+++ b/modules/installing-rhv-config-yaml.adoc
@@ -50,7 +50,12 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
+ifndef::openshift-origin[]
   networkType: OpenShiftSDN
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+  networkType: OVNKubernetes
+endif::openshift-origin[]
   serviceNetwork:
   - 172.30.0.0/16
 platform:

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -115,6 +115,13 @@ NOTE: Because of performance improvements introduced in {product-title} 4.3 and 
 <6> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
 endif::operator[]
 
+ifdef::openshift-origin[]
+[NOTE]
+====
+{product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
+====
+endif::openshift-origin[]
+
 [id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
 == Configuration parameters for the OpenShift SDN default CNI network provider
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/29158