### PR TITLE
Fix OSDK version typo

### DIFF
--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -27,7 +27,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} 4.7 supports Operator SDK v1.4.0 or later.
+{product-title} 4.7 supports Operator SDK v1.3.0 or later.
 ====
 
 [id="osdk-about-what-are-operators"]


### PR DESCRIPTION
Typo of `v1.4.0` should be `v1.3.0` for the supported version of OSDK in OCP 4.7.