### PR TITLE
modules/understanding-upgrade-channels: Mention 4.(y-1) in 4.y channels

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -10,14 +10,21 @@
 = {product-title} upgrade channels and releases
 
 In {product-title} 4.1, Red Hat introduced the concept of channels for
-recommending the appropriate release versions for cluster upgrade. By controlling
-the pace of upgrades, these upgrade channels allow you to choose an upgrade
-strategy. Upgrade channels are tied to a minor version of
-{product-title}. For instance, {product-title} 4.7
-upgrade channels will never include an upgrade to a 4.8 release. This strategy ensures that
-administrators explicitly decide to upgrade to the next minor version of
-{product-title}. Upgrade channels control only release selection and do not impact the version of the cluster that you install; the `openshift-install`
-binary file for a specific version of {product-title} always installs that version.
+recommending the appropriate release versions for cluster upgrade. By
+controlling the pace of upgrades, these upgrade channels allow you to
+choose an upgrade strategy. Upgrade channels are tied to a minor
+version of {product-title}. For instance, {product-title} 4.8 upgrade
+channels will recommend upgrades to 4.8 and upgrades within 4.8. They
+will also recommend upgrades within 4.7 and from 4.7 to 4.8, to allow
+clusters on 4.7 to eventually upgrade to 4.8. They will not recommend
+upgrades to 4.9 or later releases. This strategy ensures that
+administrators explicitly decide to upgrade to the next minor version
+of {product-title}.
+
+Upgrade channels control only release selection and do not impact the
+version of the cluster that you install; the `openshift-install`
+binary file for a specific version of {product-title} always installs
+that version.
 
 ifndef::openshift-origin[]
 {product-title} {product-version} offers the following upgrade channels:
@@ -40,7 +47,7 @@ ifndef::openshift-origin[]
 == candidate-{product-version} channel
 
 The `candidate-{product-version}` channel contains candidate builds for a z-stream
-({product-version}.z) release.
+({product-version}.z) and previous minor version releases.
 Release candidates contain all the features of the product but are not supported. Use release candidate versions to test feature acceptance and assist in qualifying the next version
 of {product-title}.
 A release candidate is any build that is available in the candidate channel, including ones that do not contain link:https://semver.org/spec/v2.0.0.html#spec-item-9[a pre-release version] such as `-rc` in their names.
@@ -72,7 +79,7 @@ for more build information.
 == fast-{product-version} channel
 
 The `fast-{product-version}` channel is updated with new {product-version}
-versions as soon as Red Hat declares the given version as a general availability
+and previous minor versions as soon as Red Hat declares the given version as a general availability
 release. As such, these releases are fully supported, are production quality, and have
 performed well while available as a release candidate in the `candidate-{product-version}`
 channel from where they were promoted. Some time after a release appears in the


### PR DESCRIPTION
This should help address user confusion about why there are 4.5.z in 4.6 channels and so on.

Lean on the existing "previous minor" language.  At some point we may stretch this back further, e.g. including 4.6.z in 4.8 channels, so folks who want to go from their current 4.6 to 4.8 (but not further to 4.9) can do that with a single channel tweak, and be gradually hopped along from 4.6.z through 4.7.z to 4.8.z.  But we can replace "previous" with "earlier" or some such throughout if/when we decide to do that.

It's unfortunate that we don't have `{next-product-version}` and `{previous-product-version}` variables, but we already had hard-coded versions in this paragraph, so adding a few more hard-coded versions there doesn't seem like a huge maintenance burden bump.  I have moved this up to target 4.8, since that's our next release target.

Now that the update portion of the paragraph is more involved, I've also split the install portion off into its own, separate paragraph.