### PR TITLE
BZ1806511 - Add local volume provisioning to Storage docs

### DIFF
--- a/modules/persistent-storage-local-create-cr-manual.adoc
+++ b/modules/persistent-storage-local-create-cr-manual.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-local.adoc
+
+[id="local-create-cr-manual_{context}"]
+= Provisioning local volumes without the Local Storage Operator
+
+Local volumes cannot be created by dynamic provisioning. Instead, persistent volumes can be created by defining the persistent volume (PV) in an object definition. The local volume provisioner looks for any file system or block volume devices at the paths specified in the defined resource.
+
+[IMPORTANT]
+====
+Manual provisioning of PVs includes the risk of potential data leaks across PV reuse when PVCs are deleted.
+The Local Storage Operator is recommmended for automating the life cycle of devices when provisioning local PVs.
+====
+
+.Prerequisites
+
+* Local disks are attached to the {product-title} nodes.
+
+.Procedure
+
+. Define the PV. Create a file, such as `example-pv-filesystem.yaml` or `example-pv-block.yaml`, with the `PersistentVolume` object definition. This resource must define the nodes and paths to the local volumes.
++
+[NOTE]
+====
+Do not use different storage class names for the same device. Doing so will create multiple PVs.
+====
++
+.example-pv-filesystem.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: example-pv-filesystem
+spec:
+  capacity:
+    storage: 100Gi
+  volumeMode: Filesystem <1>
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage <2>
+  local:
+    path: /dev/xvdf <3>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - example-node
+----
+<1> The volume mode, either `Filesystem` or `Block`, that defines the type of PVs.
+<2> The name of the storage class to use when creating PV resources. Use a storage class that uniquely identifies this set of PVs.
+<3> The path containing a list of local storage devices to choose from.
++
+[NOTE]
+====
+A raw block volume (`volumeMode: block`) is not formatted with a file system. Use this mode only if any application running on the pod can use raw block devices.
+====
++
+.example-pv-block.yaml
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: example-pv-block
+spec:
+  capacity:
+    storage: 100Gi
+  volumeMode: Block <1>
+  accessModes:
+  - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage <2>
+  local:
+    path: /dev/xvdf <3>
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - example-node
+----
+<1> The volume mode, either `Filesystem` or `Block`, that defines the type of PVs.
+<2> The name of the storage class to use when creating PV resources. Be sure to use a storage class that uniquely identifies this set of PVs.
+<3> The path containing a list of local storage devices to choose from.
+
+. Create the PV resource in your {product-title} cluster. Specify the file you just created:
++
+[source,terminal]
+----
+$ oc create -f <example-pv>.yaml
+----
+
+. Verify that the local PV was created:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM                STORAGECLASS    REASON   AGE
+example-pv-filesystem   100Gi      RWO            Delete           Available                        local-storage            3m47s
+example-pv1             1Gi        RWO            Delete           Bound       local-storage/pvc1   local-storage            12h
+example-pv2             1Gi        RWO            Delete           Bound       local-storage/pvc2   local-storage            12h
+example-pv3             1Gi        RWO            Delete           Bound       local-storage/pvc3   local-storage            12h
+----

--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -3,9 +3,9 @@
 // * storage/persistent_storage/persistent-storage-local.adoc
 
 [id="local-volume-cr_{context}"]
-= Provisioning the local volumes
+= Provisioning local volumes by using the Local Storage Operator
 
-Local volumes cannot be created by dynamic provisioning. Instead, persistent volumes must be created by the Local Storage Operator. This provisioner looks for any file system or block volume devices at the paths specified in defined resource.
+Local volumes cannot be created by dynamic provisioning. Instead, persistent volumes can be created by the Local Storage Operator. The local volume provisioner looks for any file system or block volume devices at the paths specified in the defined resource.
 
 .Prerequisites
 

--- a/storage/persistent_storage/persistent-storage-local.adoc
+++ b/storage/persistent_storage/persistent-storage-local.adoc
@@ -24,6 +24,8 @@ include::modules/persistent-storage-local-install.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-local-create-cr.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-local-create-cr-manual.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-local-pvc.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-local-pod.adoc[leveloffset=+1]


### PR DESCRIPTION
[BZ1806511](https://bugzilla.redhat.com/show_bug.cgi?id=1806511) - adds a procedure for provisioning local storage volumes without using the Local Storage Operator. This is not currently documented in OCP but should be, as confirmed by Storage eng.

**Preview build link:** https://deploy-preview-31398--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local.html#local-create-cr-manual_persistent-storage-local