### PR TITLE
[enterprise-4.6] Add module for manual CSV annotations

### DIFF
--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-generating-csvs.adoc
+
+[id="osdk-csv-manual-annotations_{context}"]
+= Operator metadata annotations
+
+Operator developers can manually define certain annotations in the metadata of a cluster service version (CSV) to enable features or highlight capabilities in user interfaces (UIs), such as OperatorHub.
+
+The following table lists Operator metadata annotations that can be manually defined using `metadata.annotations` fields.
+
+.Annotations
+[cols="5a,5a",options="header"]
+|===
+|Field |Description
+
+|`alm-examples`
+|Provide custom resource definition (CRD) templates with a minimum set of configuration. Compatible UIs pre-fill this template for users to further customize.
+
+|`operatorframework.io/initialization-resource`
+|Specify a single required custom resource that must be created at the time that the Operator is installed. Must include a template that contains a complete YAML definition.
+
+|`operatorframework.io/suggested-namespace`
+|Set a suggested namespace where the Operator should be deployed.
+
+|`operators.openshift.io/infrastructure-features`
+|Infrastructure features supported by the Operator. Users can view and filter by these features when discovering Operators through OperatorHub in the web console. Valid, case-sensitive values:
+
+- `disconnected`: Operator supports being mirrored into disconnected catalogs, including all dependencies, and does not require Internet access. All related images required for mirroring are listed by the Operator.
+- `cnf`: Operator provides a Cloud-native Network Functions (CNF) Kubernetes plug-in.
+- `cni`: Operator provides a Container Network Interface (CNI) Kubernetes plug-in.
+- `csi`: Operator provides a Container Storage Interface (CSI) Kubernetes plug-in.
+- `fips`: Operator accepts the FIPS mode of the underlying platform and works on nodes that are booted into FIPS mode.
+- `proxy-aware`: Operator supports running on a cluster behind a proxy. Operator accepts the standard proxy environment variables  `HTTP_PROXY` and `HTTPS_PROXY`, which Operator Lifecycle Manager (OLM) provides to the Operator automatically when the cluster is configured to use a proxy. Required environment variables are passed down to Operands for managed workloads.
+
+|`operators.openshift.io/valid-subscription`
+|Free-form array for listing any specific subscriptions that are required to use the Operator. For example, `'["3Scale Commercial License", "Red Hat Managed Integration"]'`.
+
+|`operators.operatorframework.io/internal-objects`
+|Hides CRDs in the UI that are not meant for user manipulation.
+
+|===
+
+[discrete]
+[id="osdk-csv-manual-annotations-examples_{context}"]
+== Example use cases
+
+.Operator supports disconnected and proxy-aware
+[source,terminal]
+----
+operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+----
+
+.Operator requires an OpenShift Container Platform license
+[source,terminal]
+----
+operators.openshift.io/valid-subscription: '["OpenShift Container Platform"]'
+----
+
+.Operator requires a 3scale license
+[source,terminal]
+----
+operators.openshift.io/valid-subscription: '["3Scale Commercial License", "Red Hat Managed Integration"]'
+----
+
+.Operator supports disconnected and proxy-aware, and requires an OpenShift Container Platform license
+[source,terminal]
+----
+operators.openshift.io/infrastructure-features: '["disconnected", "proxy-aware"]'
+operators.openshift.io/valid-subscription: '["OpenShift Container Platform"]'
+----

--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -5,9 +5,11 @@
 [id="osdk-manually-defined-csv-fields_{context}"]
 = Manually-defined CSV fields
 
-Many CSV fields cannot be populated using generated, generic manifests that are not specific to Operator SDK. These fields are mostly human-written, English metadata about the Operator and various custom resource definitions (CRDs).
+Many CSV fields cannot be populated using generated, generic manifests that are not specific to Operator SDK. These fields are mostly human-written metadata about the Operator and various custom resource definitions (CRDs).
 
 Operator authors must directly modify their cluster service version (CSV) YAML file, adding personalized data to the following required fields. The Operator SDK gives a warning during CSV generation when a lack of data in any of the required fields is detected.
+
+The following tables detail which manually-defined CSV fields are required and which are optional.
 
 .Required
 [cols="2a,8a",options="header"]

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -27,6 +27,16 @@ include::modules/osdk-manually-defined-csv-fields.adoc[leveloffset=+1]
 
 - xref:../../operators/understanding/olm-what-operators-are.adoc#olm-maturity-model_olm-what-operators-are[Operator maturity model]
 
+include::modules/osdk-csv-manual-annotations.adoc[leveloffset=+2]
+.Additional resources
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-crds-templates_osdk-generating-csvs[CRD templates]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-init-resource_osdk-generating-csvs[Initializing required custom resources
+]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace_osdk-generating-csvs[Setting a suggested namespace]
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments] (disconnected mode)
+- xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-hiding-internal-objects_osdk-generating-csvs[Hiding internal objects]
+- xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS crytography]
+
 include::modules/osdk-generating-a-csv.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-restricted-network.adoc[leveloffset=+1]
 include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]


### PR DESCRIPTION
Manually incorporates 4.6-relevant changes from https://github.com/openshift/openshift-docs/pull/29065 and its follow-up https://github.com/openshift/openshift-docs/pull/29511.