### PR TITLE
Added release notes for 4.6 ZStream

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1533,8 +1533,29 @@ All MongoDB-based samples have been replaced, deprecated, or removed.
 
 * The Che Workspace Operator removed support for the `Workspace` resource and replaced it with the `DevWorkspace` CRD. As a result, the command line terminal was not enabled with the latest Che Workspace Operator. With this fix, the OpenShift command line terminal was moved to use the `DevWorkspace` resource. The command line terminal will now be enabled in the OpenShift Console when the Che Workspace Operator is installed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1844938[*BZ#1844938*])
 
-* Previously, the route decorator for Knative services redirected users to a revision specific route if traffic was distributed across multiple revisions. The route decorator has been updated to always point to the Knative base service route.
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1860768[*BZ#1860768*])"
+* Previously, the route decorator for Knative services redirected users to a revision specific route if traffic was distributed across multiple revisions. The route decorator has been updated to always point to the Knative base service route. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1860768[*BZ#1860768*])
+
+* Previously, the pod did not start when the user added a secret for an external private container registry and imported the container image from the registry. As a result, the deployment was stuck until the service account or the deployment was updated manually. This bug fix allows the new deployments to use the internal container registry to start their pods. With this bug fix, the user can import a container image from an external private container registry without additional changes on the service account or the deployment. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926340[*BZ#1926340*])
+
+* The console used a prior version of the `KafkaSource` object that used the `resources` and `serviceAccountName` fields in their specification. The v1beta1 version of the `KafkaSource` object removed these fields, due to which the user was unable to create the `KafkaSource` object with the v1beta1 version. This issue has been fixed now and the user is able to create the `KafkaSource` object with the v1beta1 version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1892695[*BZ#1892695*])
+
+* Previously, the relative chart URL for downloading the chart to instantiate a helm release was unreachable. This happened because the `index.yaml` file from the remote repository, referenced in the Helm chart repository, was fetched and used as is. Some of these index files contained relative chart URLs. This issue is fixed by translating relative chart URLs to absolute URLs, which makes the chart URL reachable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1916406[*BZ#1916406*])
+
+* Previously, the users were not able to see any Knative services and sources on the *Topology* view. This was because the triggers had both a Knative service and an In-Memory Channel as subscribers due to a Null Pointer Exception (NPE). This issue is resolved by fixing the Null Pointer Exception, so that the Knative data model returns proper data and the Knative resources are properly shown on the *Topology* view. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1907827[*BZ#1907827*])
+
+* Previously, the API server could fail to create a resource and return a 409 status code due to a conflict while updating a resource quota resource. This issue is fixed and the {product title} web console will attempt to retry the request while receiving a 409 status code. At most three attempts are made which is often sufficient to complete the request. In the event that a 409 continues to occur, an error will be displayed in the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1928230[*BZ#1928230*])
+
+* Previously, no helm charts were displayed in the developer catalog because the chart repository `httpClient()` did not consider any proxy environment variable. This issue is fixed and the helm charts are now being displayed in the developer catalog. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1919138[*BZ#1919138*])
+
+* Technology preview badges are being displayed on the *Eventing* user interface although it would be going for a GA release. The Technology preview badges are now removed from *Eventing* user interface. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1899382[*BZ#1899382*])
+
+* Previously, the application crashed when the correlated pod data was not available for the deployment config. This was because the console deployment fetched two sets of data with the pod status donut shown as soon as deployment config is loaded. If the API returns more than 250 pods, some of the information is skipped and is not available. This issue is fixed and the pod data is available even when the project contains more than 250 pods, thus ensuring that the *DeploymentConfig* detail page does not crash anymore. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921603[*BZ#1921603*])
+
+* Previously, the static models corresponding to the trigger, subscription, channel, and IMC eventing sources used the beta API version. With the Serverless 0.10 release, the latest supported versions for eventing sources were updated to the v1 version. This bug fix updates the user interface models to point to the latest supported version. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1896625[*BZ#1896625*])
+
+* Previously, when conditional tasks failed, the completed pipeline runs showed a permanent pending task for each failed conditional task. This issue has been fixed by disabling the failed conditional tasks and by adding skipped icons to them. This gives a better picture of the state of the pipeline run. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1916378[*BZ#1916378*])
+
+* Previously, the user was denied access to pull images from other projects due to insufficient user permissions. This bug fix removes all the user interface checks for role bindings and shows the `oc` command alert to help users use the command line. With this bug fix, the user is no longer blocked from creating images from different namespaces and is now able to deploy images from other projects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1933727[*BZ#1933727*])
 
 *DNS*
 


### PR DESCRIPTION
JIRA ID: [RHDEVDOCS-2789](https://issues.redhat.com/browse/RHDEVDOCS-2789) 

This PR is for OCP 4.6 ZStream. 

Direct Preview Link: https://deploy-preview-31404--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html