### PR TITLE
OSDOCS-1806: add Intel E810 NICs

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -9,6 +9,9 @@
 
 * Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
 * Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
+* Intel E810-CQDA2 100GbE dual-port QSPF28 and E810-2CQDA2 100GbE dual-port QSPF28 with vendor ID `0x8086` and device ID `0x1592`
+* Intel E810-XXVDA2 25GbE dual-port SPF28 with vendor ID `0x8086` and device ID `0x159b`
+* Intel E810-XXVDA4 25GbE quad-port SPF28 with vendor ID `0x8086` and device ID `0x1593`
 * Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
 * Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`
 * Mellanox MT27800 Family [ConnectX-5] 100GbE with vendor ID `0x15b3` and device ID `0x1017`


### PR DESCRIPTION
Added bullets 2, 3, and 4 at https://deploy-preview-31415--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

----

* Add the four NICs from SDN-1496.

* Peek at the api/v1/helper.go file in sriov-network-operator repo.

* Add GbE speed, SPF, and no. of ports info from Intel web sites:

CQDA2: <https://www.intel.com/content/www/us/en/products/network-io/ethernet/ethernet-adapters/ethernet-800-series-network-adapters/e810-cqda2-ocp-3.html>

2CQDA2: <https://ark.intel.com/content/www/us/en/ark/products/210969/intel-ethernet-network-adapter-e810-2cqda2.html>

XXVDA2: <https://www.intel.com/content/www/us/en/products/network-io/ethernet/ethernet-adapters/ethernet-800-series-network-adapters/e810-xxvda2.html>

XXVDA4: <https://www.intel.com/content/www/us/en/products/network-io/ethernet/ethernet-adapters/ethernet-800-series-network-adapters/e810-xxvda4.html>

----
@openshift/team-documentation PTAL.

Applies to branch enterprise-4.8 and milestone Future Release.