### PR TITLE
Updating 4.7 release notes link to be 1.20-specific

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-{product-title} (link:https://access.redhat.com/errata/RHSA-2020:5633[RHSA-2020:5633]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.20] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2020:5633[RHSA-2020:5633]) is now available. This release uses link:https://v1-20.docs.kubernetes.io/docs/setup/release/notes/[Kubernetes 1.20] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.7.0 as the GA version and, instead, is releasing {product-title} 4.7.z as the GA version.
 


### PR DESCRIPTION
FYI @jeana-redhat @stevsmit 

When a Kubernetes release first comes out, they haven't been making a version-specific URL for it. It is just https://kubernetes.io/docs/setup/release/notes/ for the latest version, and that's what we include in our RNs.

However, once the next kube version comes out, the contents at that link's location get updated to hold the newest version. So this link in our 4.7 release notes would be wrong, in that it would point to 1.21 instead of 1.20.

Kubernetes 1.21 is being released today, so now they've created a version-specific URL for 1.20. So this is me updating the release note for 4.7 to use that one that is specific to 1.20.

I opened an issue with Kubernetes a few months ago on this, but they haven't yet done anything about it. So we'll just need to keep remembering to come back and adjust the previous version's link.

Preview: https://deploy-preview-31416--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-about-this-release