### PR TITLE
BZ1859731: removed sudo now that podman supports rootless execution.

### DIFF
--- a/modules/installing-cluster-loader.adoc
+++ b/modules/installing-cluster-loader.adoc
@@ -11,5 +11,5 @@
 +
 [source,terminal]
 ----
-$ sudo podman pull quay.io/openshift/origin-tests:4.7
+$ podman pull quay.io/openshift/origin-tests:4.7
 ----

--- a/modules/running-cluster-loader.adoc
+++ b/modules/running-cluster-loader.adoc
@@ -18,7 +18,7 @@ template builds and waits for them to complete:
 +
 [source,terminal]
 ----
-$ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z -i \
+$ podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z -i \
 quay.io/openshift/origin-tests:4.7 /bin/bash -c 'export KUBECONFIG=/root/.kube/config && \
 openshift-tests run-test "[sig-scalability][Feature:Performance] Load cluster \
 should populate the cluster [Slow][Serial] [Suite:openshift]"'
@@ -29,7 +29,7 @@ setting the environment variable for `VIPERCONFIG`:
 +
 [source,terminal]
 ----
-$ sudo podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z \
+$ podman run -v ${LOCAL_KUBECONFIG}:/root/.kube/config:z \
 -v ${LOCAL_CONFIG_FILE_PATH}:/root/configs/:z \
 -i quay.io/openshift/origin-tests:4.7 \
 /bin/bash -c 'KUBECONFIG=/root/.kube/config VIPERCONFIG=/root/configs/test.yaml \


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1859731

for 4.5+

I verified with Sebastian Jug that it is ok to remove sudo.

Direct link: https://deploy-preview-31417--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-cluster-loader.html