### PR TITLE
Document OSDK compatibility

### DIFF
--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -25,9 +25,39 @@ The Operator SDK is a framework that uses the link:https://github.com/kubernetes
 
 Operator authors with cluster administrator access to a Kubernetes-based cluster (such as {product-title}) can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
 
-[NOTE]
+[id="osdk-compatibility-matrix"]
+== Operator SDK compatibility matrix
+
+
+[WARNING]
 ====
-{product-title} 4.7 supports Operator SDK v1.3.0 or later.
+The compatibility asserts the compatibility of the operator SDK itself, it does not take into consideration the API calls done by your code.
+These must be asserted by the developer of the operator.
+====
+
+**Helm-based and Ansible-based operators compatibility**
+
+Operators based in Helm and Ansible must follow a predefined project layout. There are breaking changes between Operator SDK 0.19 and 1.3
+
+[options="header"]
+|===============================================================================================================
+|Operator SDK version | Builder image version | Compatible OpenShift version | Compatible Kubernetes API version 
+| 0.19                | 4.6                   | 4.6 and 4.7                  | 1.18, 1.19
+| 1.3                 | 4.7                   | 4.6 - 4.8                    | 1.18 - 1.20
+|===============================================================================================================
+
+**Go operators compatibility**
+
+[options="header"]
+|===================================================================================================================
+|Operator SDK version | Go version | K8s version | Compatible OpenShift versions | Compatible Kubernetes API version 
+| 0.19                | 1.13       | 1.18        | 4.6 and 4.7                   | 1.18, 1.19
+| 1.3                 | 1.15       | 1.19        | 4.6 - 4.8                     | 1.18 - 1.20
+|===================================================================================================================
+
+[WARNING]
+====
+Compatibility depends mostly on the k8s.io/apimachinery and k8s.io/client-go version. This documentation assumes these have not been modified in go.mod or go.sum.
 ====
 
 [id="osdk-about-what-are-operators"]


### PR DESCRIPTION
Needs backport all the way back to 4.6.

In copy @jmrodri who is the lead of the operator SDK and @tikeller and @meissnerim who raised concerns about the current state of the documentation.

It's worth noting that per [client-go's compatibility matrix](https://github.com/kubernetes/client-go/tree/master#compatibility-matrix) I may have been far too conservative. Perhaps should we add more versions @jmrodri?