### PR TITLE
OSDOCS-2039: SRIOV support MT2880 cx-5 ex

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -14,5 +14,6 @@
 * Mellanox MT27800 Family [ConnectX-5] 100GbE with vendor ID `0x15b3` and device ID `0x1017`
 * Mellanox MT27700 Family [ConnectX-4] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1013`
 * Mellanox MT27800 Family [ConnectX-5] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1017`
+* Mellanox MT28880 Family [ConnectX-5 Ex] Ethernet controller, 100Gb/s, dual-port QSPF28 with vendor ID `0x15b3` and device ID `0x1019`
 * Mellanox MT28908 Family [ConnectX-6] VPI adapter card, 100Gb/s (HDR100, EDR IB), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`
 * Mellanox MT28908 Family [ConnectX-6] VPI adapter card, HDR200 IB (200Gb/s), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`


### PR DESCRIPTION
Preview: Click and Ctrl+F for "MT28880"
https://deploy-preview-31428--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov

----

Fixes SDN-1740.

Desc hacked together from the foll.

* <https://mellanox.com/related-docs/oem/dell/PB_ConnectX-5_Ex_Card_dell.pdf>

* <https://store.mellanox.com/products/nvidia-mcx556a-edat-connectx-5-ex-vpi-adapter-card-edr-infiniband-and-100gbe-dual-port-qsfp28-pcie4-0-x16-tall-bracket-rohs-r6.html>

----
@openshift/team-documentation  PTAL.

Applies to enterprise-4.8 and milestone Future Release.