### PR TITLE
Fixed the example to have the correct escaped values.

### DIFF
--- a/modules/templates-writing-parameters.adoc
+++ b/modules/templates-writing-parameters.adoc
@@ -70,7 +70,7 @@ follows the PCRE standard and is equal to `[a-zA-Z0-9_]{10}`.
 - `[\d]{10}` produces 10 numbers. This is equal to `[0-9]{10}`.
 - `[\a]{10}` produces 10 alphabetical characters. This is equal to
 `[a-zA-Z]{10}`.
-- `[\A]{10}` produces 10 punctuation or symbol characters. This is equal to ``[~!@#$%^&*()-_+={}[]\|<,>.?/"';:`]{10}``.
+- `[\A]{10}` produces 10 punctuation or symbol characters. This is equal to ``[~!@#$%\^&*()\-_+={}\[\]\\|<,>.?/"';:`]{10}``.
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR is an update to #30790 to include the necessary escape syntax for the example.

Preview: https://deploy-preview-31431--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/using-templates.html#templates-writing-parameters_using-templates