### PR TITLE
BZ: 1538917 Adds Persistent storage + mount propagation section to 3.11

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -456,6 +456,8 @@ Topics:
     File: enabling_controller_attach_detach
   - Name: Persistent Volume Snapshots
     File: persistent_volume_snapshots
+  - Name: Persistent Storage Using hostPath
+    File: persistent_storage_hostpath
 - Name: Persistent Storage Examples
   Dir: storage_examples
   Distros: openshift-origin,openshift-enterprise
@@ -474,6 +476,8 @@ Topics:
     File: gluster_dynamic_example
   - Name: Mounting Volumes To Privileged Pods
     File: privileged_pod_storage
+  - Name: Mount Propagation
+    File: mount_propagation
   - Name: Switching an Integrated OpenShift Container Registry to GlusterFS
     File: gluster_backed_registry
   - Name: Binding Persistent Volumes by Label

--- a/architecture/additional_concepts/storage.adoc
+++ b/architecture/additional_concepts/storage.adoc
@@ -236,7 +236,7 @@ ifdef::openshift-enterprise,openshift-origin[]
 {product-title} supports the following `PersistentVolume` plug-ins:
 
 - xref:../../install_config/persistent_storage/persistent_storage_nfs.adoc#install-config-persistent-storage-persistent-storage-nfs[NFS]
-- HostPath
+- xref:../../install_config/persistent_storage/persistent_storage_hostpath.adoc#persistent_storage_using_hostpath[hostPath]
 - xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#overview-volumes[GlusterFS]
 - xref:../../install_config/persistent_storage/persistent_storage_glusterfs.adoc#overview-block-volumes[gluster-block]
 - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/3.11/html/operations_guide/chap-documentation-red_hat_gluster_storage_container_native_with_openshift_platform-openshift_creating_persistent_volumes#File_Storage[OpenShift Container Storage (OCS) File]

--- a/install_config/persistent_storage/persistent_storage_hostpath.adoc
+++ b/install_config/persistent_storage/persistent_storage_hostpath.adoc
@@ -1,0 +1,28 @@
+[[persistent-storage-using-hostpath]]
+= Persistent Storage Using hostPath
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+:context: persistent-storage-using-hostpath
+
+toc::[]
+
+A `hostPath` volume in an {product-title} cluster mounts a file or directory from the host node’s file system into your pod. Most pods do not need a `hostPath` volume, but it does offer a quick option for testing should an application require it.
+
+[IMPORTANT]
+====
+The cluster administrator must configure pods to run as privileged. This grants access to pods in the same node.
+====
+
+include::modules/persistent-storage-hostpath-about.adoc[leveloffset=+1]
+include::modules/persistent-storage-hostpath-static-provisioning.adoc[leveloffset=+1]
+include::modules/persistent-storage-hostpath-pod.adoc[leveloffset=+1]
+
+[id="additional-resources_mount-provisioning"]
+== Additional resources
+* xref:../../install_config/storage_examples/mount_propagation.adoc#mount-propagation[Mount Propagation]

--- a/install_config/storage_examples/mount_propagation.adoc
+++ b/install_config/storage_examples/mount_propagation.adoc
@@ -1,0 +1,55 @@
+[[mount-propagation]]
+= Mount Propagation
+{product-author}
+{product-version}
+:data-uri:
+:icons:
+:experimental:
+:toc: macro
+:toc-title:
+:prewrap!:
+
+toc::[]
+
+[[mount-propagation-overview]]
+== Overview
+Mount propagation allows for sharing volumes mounted by a container to other containers in the same pod, or even to other pods on the same node.
+
+[[mount-propagation-values]]
+== Values
+
+Mount propagation of a volume is controlled by the `mountPropagation` field in `Container.volumeMounts`. Its values are:
+
+* `none` - This volume mount does not receive any subsequent mounts that are mounted to this volume or any of its subdirectories by the host. In similar fashion, no mounts created by the container are visible on the host. This is the default mode, and is equal to `private` mount propagation in Linux kernels.
+
+* `HostToContainer` - This volume mount receives all subsequent mounts that are mounted to this volume or any of its subdirectories. In other words, if the host mounts anything inside the volume mount, the container acknowledges it mounted there. This mode is equal to `rslave` mount propagation in Linux kernels.
+
+* `Bidirectional` - This volume mount behaves the same as the `HostToContainer` mount. In addition, all volume mounts created by the container are propagated back to the host and to all containers of all pods that use the same volume. A typical use case for this mode is a Pod with a FlexVolume or CSI driver or a Pod that needs to mount something on the host using a `hostPath` volume. This mode is equal to `rshared` mount propagation in Linux kernels.
+
+[IMPORTANT]
+====
+`Bidirectional` mount propagation can be dangerous. It can damage the host operating system and therefore it is allowed only in privileged containers. Familiarity with Linux kernel behavior is strongly recommended. In addition, any volume mounts created by containers in pods must be destroyed, or unmounted, by the containers on termination.
+====
+
+[[mount-propagation-configuration]]
+== Configuration
+Before mount propagation can work properly on some deployments, such as CoreOS, Red Hat Enterprise Linux/Centos, or Ubuntu, the mount share must be configured correctly in Docker.
+
+.Procedure
+
+. Edit your Docker's systemd service file. Set `MountFlags` as follows:
++
+[source,terminal]
+----
+MountFlags=shared
+----
++
+Alternatively, remove `MountFlags=slave`, if present.
+
+. Restart the Docker daemon:
++
+[source,terminal]
+----
+$ sudo systemctl daemon-reload
+$ sudo systemctl restart docker
+----

--- a/modules/persistent-storage-hostpath-about.adoc
+++ b/modules/persistent-storage-hostpath-about.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-hostpath.adoc
+
+[id="persistent-storage-hostpath-about_{context}"]
+= Overview
+
+{product-title} supports `hostPath` mounting for development and testing on a single-node cluster.
+
+In a production cluster, you would not use `hostPath`. Instead, a cluster administrator provisions a network resource, such as a GCE Persistent Disk volume or an Amazon EBS volume. Network resources support the use of storage classes to set up dynamic provisioning.
+
+A `hostPath` volume must be provisioned statically.

--- a/modules/persistent-storage-hostpath-pod.adoc
+++ b/modules/persistent-storage-hostpath-pod.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-hostpath.adoc
+
+[id="persistent-storage-hostpath-pod_{context}"]
+= Mounting the hostPath share in a privileged pod
+
+After the persistent volume claim has been created, it can be used inside of a pod by an application. The following example demonstrates mounting this share inside of a pod.
+
+.Prerequisites
+* A persistent volume claim exists that is mapped to the underlying `hostPath` share.
+
+.Procedure
+
+* Create a privileged pod that mounts the existing persistent volume claim:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod-name <1>
+spec:
+  containers:
+    ...
+    securityContext:
+      privileged: true <2>
+    volumeMounts:
+    - mountPath: /data <3>
+      name: hostpath-privileged
+  ...
+  securityContext: {}
+  volumes:
+    - name: hostpath-privileged
+      persistentVolumeClaim:
+        claimName: task-pvc-volume <4>
+----
+<1> The name of the pod.
+<2> The pod must run as privileged to access the node's storage.
+<3> The path to mount the hostPath share inside the privileged pod.
+<4> The name of the `PersistentVolumeClaim` object that has been previously created.

--- a/modules/persistent-storage-hostpath-static-provisioning.adoc
+++ b/modules/persistent-storage-hostpath-static-provisioning.adoc
@@ -1,0 +1,66 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-hostpath.adoc
+
+[id="hostpath-static-provisioning_{context}"]
+= Statically provisioning hostPath volumes
+
+A pod that uses a `hostPath` volume must be referenced by manual, or static, provisioning.
+
+.Procedure
+
+. Define the persistent volume (PV). Create a `pv.yaml` file with the `PersistentVolume` object definition:
++
+[source,yaml]
+----
+  apiVersion: v1
+  kind: PersistentVolume
+  metadata:
+    name: task-pv-volume <1>
+    labels:
+      type: local
+  spec:
+    storageClassName: manual <2>
+    capacity:
+      storage: 5Gi
+    accessModes:
+      - ReadWriteOnce <3>
+    persistentVolumeReclaimPolicy: Retain
+    hostPath:
+      path: "/mnt/data" <4>
+----
+<1> The name of the volume. This name is how it is identified by persistent volume claims or pods.
+<2> Used to bind persistent volume claim requests to this persistent volume.
+<3> The volume can be mounted as `read-write` by a single node.
+<4> The configuration file specifies that the volume is at `/mnt/data` on the cluster’s node.
+
+. Create the PV from the file:
++
+[source,terminal]
+----
+$ oc create -f pv.yaml
+----
+
+. Define the persistent volume claim (PVC). Create a `pvc.yaml` file with the `PersistentVolumeClaim` object definition:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: task-pvc-volume
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: manual
+----
+
+. Create the PVC from the file:
++
+[source,terminal]
+----
+$ oc create -f pvc.yaml
+----


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1538917

I had to add a section on persistent storage because it is related to mount propagation; because of this, I updated the topic_map.yaml file. Also updated an xref to hostPath under Additional Concepts - Persistent Storage. 

Previews: hostPath link in Additional Concepts: https://deploy-preview-31435--osdocs.netlify.app/openshift-enterprise/latest/architecture/additional_concepts/storage.html#types-of-persistent-volumes

Persistent Storage section preview: https://deploy-preview-31435--osdocs.netlify.app/openshift-enterprise/latest/install_config/persistent_storage/persistent_storage_hostpath.html#persistent_storage_using_hostpath

Mount Propagation: https://deploy-preview-31435--osdocs.netlify.app/openshift-enterprise/latest/install_config/storage_examples/mount_propagation.html#mount-propagation

For 3.11

@gpei please review. Thank you! 