### PR TITLE
[enterprise-4.5] Added "ec2:DeleteTags" to EC2 permissions table per BZ1926543

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -28,6 +28,7 @@ cluster, the IAM user requires the following permissions:
 * `ec2:CreateVolume`
 * `ec2:DeleteSecurityGroup`
 * `ec2:DeleteSnapshot`
+* `ec2:DeleteTags`
 * `ec2:DeregisterImage`
 * `ec2:DescribeAccountAttributes`
 * `ec2:DescribeAddresses`


### PR DESCRIPTION
Cherrypick of 6a2ab8d0e7c8c1d005688db13675a35743b58a03 (https://github.com/openshift/openshift-docs/pull/31323)

(Conflict was a result of changes in https://github.com/openshift/openshift-docs/pull/30320 specifically, this [added collapsible menu item](https://github.com/openshift/openshift-docs/pull/30320/files#diff-12455161a2958903b9035de54de2ec75ab37fa38d4480a500e4c84ff0123a22eR256-R262) showing up in 4.5, though it wouldn't be needed until 4.6.