### PR TITLE
bz1941073_RN_4_6

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -742,6 +742,10 @@ The Local Storage Operator now has the ability to:
 
 For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#local-storage-discovery_persistent-storage-local[Automating discovery and provisioning for local storage devices].
 
+[id="ocp-4-6-aws-efs-tp-removed-1st"]
+==== External provisioner for AWS EFS (Technology Preview) feature has been removed
+The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
+
 [id="ocp-4-6-registry"]
 === Registry
 
@@ -1368,6 +1372,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|External provisioner for AWS EFS
+|REM
+|REM
+|REM
+
 |====
 
 [id="ocp-4-6-deprecated-features"]
@@ -1400,6 +1409,10 @@ The `OperatorSource` resource, part of the Marketplace API for the Operator Fram
 ==== MongoDB templates removed
 
 All MongoDB-based samples have been replaced, deprecated, or removed.
+
+[id="ocp-4-6-aws-efs-tp-removed-2nd"]
+==== External provisioner for AWS EFS (Technology Preview) feature has been removed
+The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
 
 [id="ocp-4-6-bug-fixes"]
 == Bug fixes
@@ -2021,11 +2034,6 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |Raw Block with Cinder
-|TP
-|TP
-|TP
-
-|External provisioner for AWS EFS
 |TP
 |TP
 |TP


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1941073

This PR addresses the changes for the 4.6 RN only: Added to "Deprecated and removed features table", "Removed features" section, "New Features and enhancements" > "Storage" section; Deleted from "Technology Preview Features"

PTAL @jsafrane, @qinpingli, @xltian, @sferich888, @vikram-redhat

I will send out a change notification email when I get your acks. Thanks!

Book:https://github.com/openshift/openshift-docs/pull/31446
RN 4.5: https://github.com/openshift/openshift-docs/pull/31449
RN 4.6: https://github.com/openshift/openshift-docs/pull/31448
RN 4.7: https://github.com/openshift/openshift-docs/pull/31447
RN 4.8: Coming later. Will incorporate the same changes as the other rel notes listed above.