### PR TITLE
BZ1941073 Rel Notes 4_5

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -430,6 +430,10 @@ You can now use CSI to specify volumes directly in the pod specification, rather
 
 Volume cloning using CSI, previously in Technology Preview, is now fully supported in {product-title} 4.5. For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-cloning.adoc#persistent-storage-csi-cloning[CSI volume cloning].
 
+[id="ocp-4-5-aws-efs-tp-removed-1st"]
+==== External provisioner for AWS EFS (Technology Preview) feature has been removed
+The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
+
 [id="ocp-4-5-operators"]
 === Operators
 
@@ -782,6 +786,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|External provisioner for AWS EFS (Technology Preview)
+|REM
+|REM
+|REM
+
 |====
 
 [id="ocp-4-5-deprecated-features"]
@@ -931,6 +940,10 @@ registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.5.0
 registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.5.1
 registry.redhat.io/rhscl/ruby-23-rhel7
 ----
+
+[id="ocp-4-5-aws-efs-tp-removed-2nd"]
+==== External provisioner for AWS EFS (Technology Preview) feature has been removed
+The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
 
 [id="ocp-4-5-bug-fixes"]
 == Bug fixes
@@ -1616,11 +1629,6 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |Raw Block with Cinder
-|TP
-|TP
-|TP
-
-|External provisioner for AWS EFS
 |TP
 |TP
 |TP


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1941073

This PR addresses the changes for the 4.5 RN only: Added to "Deprecated and removed features table", "Removed features" section, "New Features and enhancements" > "Storage" section; Deleted from "Technology Preview Features"

PTAL @jsafrane, @qinpingli, @xltian, @sferich888, @vikram-redhat

I will send out a change notification email when I get your acks. Thanks!

Book:https://github.com/openshift/openshift-docs/pull/31446
RN 4.5: https://github.com/openshift/openshift-docs/pull/31449
RN 4.6: https://github.com/openshift/openshift-docs/pull/31448
RN 4.7: https://github.com/openshift/openshift-docs/pull/31447
RN 4.8: Coming later. Will incorporate the same changes as the other rel notes listed above.