### PR TITLE
OSDOCS-2034Moved rosa login step to earlier in the procedure 

### DIFF
--- a/modules/rosa-setting-up-environment.adoc
+++ b/modules/rosa-setting-up-environment.adoc
@@ -31,7 +31,7 @@ This user has `Programmatic` access enabled and the `AdministratorAccess` policy
 +
 . Enable the ROSA service in the AWS Console.
 .. Sign in to your link:https://console.aws.amazon.com/rosa/home[AWS account].
-.. To enable ROSA, go to the link:https://console.aws.amazon.com/rosa/[ROSA service] and select *Enable*.
+.. To enable ROSA, go to the link:https://console.aws.amazon.com/rosa/[ROSA service] and select *Enable OpenShift*.
 
 . Install and configure the AWS CLI.
 .. Follow the AWS command-line interface documentation to link:https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html[install] and link:https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html[configure] the AWS CLI for your operating system.
@@ -122,7 +122,7 @@ Add this file to the correct location for your operating system. For example, on
 $ source /etc/bash_completion.d/rosa
 ----
 
-. Enter the following command to verify that your AWS account has the necessary permissions:
+. Enter the following command to verify that your AWS account has the necessary permissions.
 +
 [source,terminal]
 ----
@@ -134,6 +134,30 @@ $ rosa verify permissions
 ----
 I: Validating SCP policies...
 I: AWS SCP policies ok
+----
+
+. Log in to your Red Hat account with `rosa`.
++
+.. Enter the following command.
++
+[source,terminal]
+----
+$ rosa login
+----
++
+.. Replace `<my_offline_access_token>` with your token.
++
+.Example output
+[source,terminal]
+----
+To login to your Red Hat account, get an offline access token at https://cloud.redhat.com/openshift/token/rosa
+? Copy the token and paste it here: <my-offline-access-token>
+----
++
+.Example output continued
+[source,terminal]
+----
+I: Logged in as 'rh-rosa-user' on 'https://api.openshift.com'
 ----
 
 . Verify that your AWS account has the necessary quota to deploy an {product-title} cluster.
@@ -160,28 +184,6 @@ If you need to increase your quota, go to your link:https://aws.amazon.com/conso
 After both the permissions and quota checks pass, proceed to the next step.
 +
 . Prepare your AWS account for cluster deployment:
-+
-.. Enter the following command to log in to your Red Hat account with `rosa`.
-+
-[source,terminal]
-----
-$ rosa login
-----
-+
-Replace `<my_offline_access_token>` with your token.
-+
-.Example output
-[source,terminal]
-----
-To login to your Red Hat account, get an offline access token at https://cloud.redhat.com/openshift/token/rosa
-? Copy the token and paste it here: <my-offline-access-token>
-----
-+
-.Example output continued
-[source,terminal]
-----
-I: Logged in as 'rh-rosa-user' on 'https://api.openshift.com'
-----
 +
 .. Run the following command to verify your Red Hat and AWS credentials are setup correctly.  Check that your AWS Account ID, Default Region and ARN match what you expect. You can safely ignore the rows beginning with OCM for now (OCM stands for OpenShift Cluster Manager).
 +


### PR DESCRIPTION
to match Engineering change that now requires login before checking the AWS quota. This has been moved up and is now step 6. I also fixed the name of the button in step 2.

JIRA: https://issues.redhat.com/browse/OSDOCS-2034

Preview: https://deploy-preview-31459--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-setting-up-environment.html

QE shouldn't be needed, this is a minor, iterative change. Peer reviewer: Please merge to branch/dedicated.