### PR TITLE
BZ1871798 - Revised a sentence explaining how hyperthreaded CPUs relate to vCPUs

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -166,14 +166,14 @@ ifdef::openshift-origin[]
 |8 GB
 |120 GB
 endif::openshift-origin[]
-
 |===
+[.small]
 --
 ifdef::ibm-z[]
-^[1]^ 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
+1. 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
 endif::ibm-z[]
 ifndef::ibm-z[]
-^[1]^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.
+1. 1 vCPU is equivalent to 1 physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
 endif::ibm-z[]
 --
 


### PR DESCRIPTION
This PR solves the request of BZ1871798 by rephrasing the note under a table to explicitly state how hyperthreaded CPUs relate to a vCPU.

BZ Ticket: https://bugzilla.redhat.com/show_bug.cgi?id=1871798

Preview: https://deploy-preview-31467--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal