### PR TITLE
OSDOCS-1807: SRIOV Intel XL710

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -8,6 +8,7 @@
 {product-title} supports the following network interface controller (NIC) models:
 
 * Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
+* Intel XL710 40GbE SFP+ with vendor ID `0x8086` and device ID `0x1583`
 * Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
 * Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
 * Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`


### PR DESCRIPTION
* Add Intel XL710 to the list of supported hw

-----
@openshift/team-documentation  PTAL.

Applies to branch enterprise-4.8 and milestone Future Release.