### PR TITLE
RHDEVDOCS-2918 Add 5.0.2 release notes to Logging docs

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -12,6 +12,7 @@ The following advisories are available for {ProductName} 5.0:
 
 * link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Errata Advisory for Openshift Logging 5.0.0]
 * link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)]
+* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 for OpenShift Logging Bug Fix Release (5.0.2)]
 
 [id="openshift-logging-5-0-inclusive-language"]
 == Making open source more inclusive
@@ -20,4 +21,4 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 
 include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
-// include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]

--- a/modules/cluster-logging-release-notes-5.0.2.adoc
+++ b/modules/cluster-logging-release-notes-5.0.2.adoc
@@ -1,9 +1,29 @@
 [id="cluster-logging-release-notes-5-0-2"]
 = OpenShift Logging 5.0.2
 
-This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)].
+This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 for OpenShift Logging Bug Fix Release (5.0.2)].
 
 [id="openshift-logging-5-0-2-bug-fixes"]
 == Bug fixes
 
-* If you did not set `.proxy` in the cluster installation configuration and then configured a global proxy on the installed cluster, a bug prevented Fluentd from forwarding logs to Elasticsearch. To work around this issue, in the proxy/cluster configuration, set `no_proxy` to `.svc.cluster.local` so it skips internal traffic. The current release fixes the proxy configuration issue. Now, if you configure the global proxy after installing an {product-title} cluster, Fluentd forwards logs to Elasticsearch. (link:https://issues.redhat.com/browse/LOG-1187[*LOG-1187*])
+* If you did not set `.proxy` in the cluster installation configuration,
+and then configured a global proxy on the installed cluster, a bug
+prevented Fluentd from forwarding logs to Elasticsearch. To work around
+this issue, in the proxy/cluster configuration, set `no_proxy` to
+`.svc.cluster.local` so it skips internal traffic. The current release
+fixes the proxy configuration issue. Now, if you configure the global proxy
+after installing an OpenShift cluster, Fluentd forwards logs to
+Elasticsearch. (link:https://issues.redhat.com/browse/LOG-1187[*LOG-1187*])
+
+* Previously, forwarding logs to Kafka using chained certificates failed
+with error "state=error: certificate verify failed (unable to get local
+issuer certificate)." Logs could not be forwarded to a Kafka broker with a
+certificate signed by an intermediate CA. This happened because fluentd
+Kafka plugin could only handle a single CA certificate supplied in the
+ca-bundle.crt entry of the corresponding secret. The current release fixes
+this issue by enabling the fluentd Kafka plugin to handle multiple CA
+certificates supplied in the ca-bundle.crt entry of the corresponding
+secret. Now, logs can be forwarded to a Kafka broker with a certificate
+signed by an intermediate CA. (link:https://issues.redhat.com/browse/LOG-1216[*LOG-1216*], link:https://issues.redhat.com/browse/LOG-1218[*LOG-1218*])
+
+* Previously, an update in the cluster service version (CSV) accidentally introduced resources and limits for the OpenShift Elasticsearch operator container. Under specific conditions, this caused an out-of-memory condition that terminated the Elasticsearch operator pod. The current release fixes this issue by removing the CSV resources and limits for the operator container. Now, the operator gets scheduled without issues. (link:https://issues.redhat.com/browse/LOG-1254[*LOG-1254*])


### PR DESCRIPTION
- For versions 4.7+
- https://issues.redhat.com/browse/RHDEVDOCS-2918
- Direct link to doc preview: https://deploy-preview-31485--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-0-2
- SME review: Approved by @ewolinetz 
- QE review: Approved by @kabirbhartiRH 
- Peer review: Completed. @Srivaralakshmi 
- Please merge now.