### PR TITLE
Removes back ticks in headings

### DIFF
--- a/applications/deployments/managing-deployment-processes.adoc
+++ b/applications/deployments/managing-deployment-processes.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [id="deploymentconfig-operations"]
-== Managing `DeploymentConfig` objects
+== Managing DeploymentConfig objects
 
 `DeploymentConfig` objects can be managed from the {product-title} web console's *Workloads* page or using the `oc` CLI. The following procedures show CLI usage unless otherwise stated.
 

--- a/applications/deployments/what-deployments-are.adoc
+++ b/applications/deployments/what-deployments-are.adoc
@@ -1,5 +1,5 @@
 [id="what-deployments-are"]
-= Understanding `Deployment` and `DeploymentConfig` objects
+= Understanding Deployment and DeploymentConfig objects
 include::modules/common-attributes.adoc[]
 :context: what-deployments-are
 

--- a/authentication/impersonating-system-admin.adoc
+++ b/authentication/impersonating-system-admin.adoc
@@ -1,5 +1,5 @@
 [id="impersonating-system-admin"]
-= Impersonating the `system:admin` user
+= Impersonating the system:admin user
 include::modules/common-attributes.adoc[]
 :context: impersonating-system-admin
 

--- a/cli_reference/developer_cli_odo/creating_and_deploying_applications_with_odo/creating-a-single-component-application-with-odo.adoc
+++ b/cli_reference/developer_cli_odo/creating_and_deploying_applications_with_odo/creating-a-single-component-application-with-odo.adoc
@@ -1,5 +1,5 @@
 [id='creating-a-single-component-application-with-odo']
-= Creating a single-component application with `{odo-title}`
+= Creating a single-component application with {odo-title}
 include::modules/developer-cli-odo-attributes.adoc[]
 include::modules/common-attributes.adoc[]
 :context: creating-a-single-component-application-with-odo

--- a/cli_reference/developer_cli_odo/understanding-odo.adoc
+++ b/cli_reference/developer_cli_odo/understanding-odo.adoc
@@ -1,5 +1,5 @@
 [id="understanding-odo"]
-= Understanding `odo`
+= Understanding odo
 include::modules/developer-cli-odo-attributes.adoc[]
 include::modules/common-attributes.adoc[]
 :context: understanding-odo

--- a/cli_reference/kn-cli-tools.adoc
+++ b/cli_reference/kn-cli-tools.adoc
@@ -1,6 +1,6 @@
 include::modules/serverless-document-attributes.adoc[]
 [id="kn-cli-tools"]
-= Knative CLI (`kn`) for use with OpenShift Serverless
+= Knative CLI (kn) for use with OpenShift Serverless
 :context: kn-cli-tools
 include::modules/common-attributes.adoc[]
 

--- a/cli_reference/tkn_cli/op-configuring-tkn.adoc
+++ b/cli_reference/tkn_cli/op-configuring-tkn.adoc
@@ -1,5 +1,5 @@
 [id="op-configuring-tkn"]
-= Configuring the OpenShift Pipelines `tkn` CLI
+= Configuring the OpenShift Pipelines tkn CLI
 include::modules/common-attributes.adoc[]
 include::modules/pipelines-document-attributes.adoc[]
 :context: configuring-tkn

--- a/cli_reference/tkn_cli/op-tkn-reference.adoc
+++ b/cli_reference/tkn_cli/op-tkn-reference.adoc
@@ -1,5 +1,5 @@
 [id='op-tkn-reference']
-= OpenShift Pipelines `tkn` reference
+= OpenShift Pipelines tkn reference
 include::modules/common-attributes.adoc[]
 include::modules/pipelines-document-attributes.adoc[]
 :context: op-tkn-reference

--- a/modules/about-sosreport.adoc
+++ b/modules/about-sosreport.adoc
@@ -3,7 +3,7 @@
 // * support/gathering-cluster-data.adoc
 
 [id="about-sosreport_{context}"]
-= About `sosreport`
+= About sosreport
 
 `sosreport` is a tool that collects configuration details, system information, and diagnostic data from {op-system-base-full} and {op-system-first} systems. `sosreport` provides a standardized way to collect diagnostic information relating to a node, which can then be provided to Red Hat Support for issue diagnosis.
 

--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -4,7 +4,7 @@
 // * post_installation_configuration/cluster-tasks.adoc
 
 [id="cluster-autoscaler-cr_{context}"]
-= `ClusterAutoscaler` resource definition
+= ClusterAutoscaler resource definition
 
 This `ClusterAutoscaler` resource definition shows the parameters and sample values for the cluster autoscaler.
 

--- a/modules/cluster-logging-about-crd.adoc
+++ b/modules/cluster-logging-about-crd.adoc
@@ -3,7 +3,7 @@
 // * logging/cluster-logging.adoc
 
 [id="cluster-logging-configuring-crd_{context}"]
-= About the `ClusterLogging` custom resource
+= About the ClusterLogging custom resource
 
 To make changes to your OpenShift Logging environment, create and modify the `ClusterLogging` custom resource (CR).
 

--- a/modules/cluster-logging-deploying-about.adoc
+++ b/modules/cluster-logging-deploying-about.adoc
@@ -145,7 +145,7 @@ You specify the schedule for Curator in the link:https://en.wikipedia.org/wiki/C
 ----
 
 [id="cluster-logging-deploy-about-sample_{context}"]
-== Sample modified `ClusterLogging` custom resource
+== Sample modified ClusterLogging custom resource
 
 The following is an example of a `ClusterLogging` custom resource modified using the options previously described.
 
@@ -210,4 +210,3 @@ spec:
             cpu: 200m
             memory: 1Gi
 ----
-

--- a/modules/cluster-logging-exported-fields-systemd.adoc
+++ b/modules/cluster-logging-exported-fields-systemd.adoc
@@ -3,7 +3,7 @@
 // * logging/cluster-logging-exported-fields.adoc
 
 [id="cluster-logging-exported-fields-systemd_{context}"]
-= `systemd` exported fields
+= systemd exported fields
 
 These are the `systemd` fields exported by OpenShift Logging available for searching
 from Elasticsearch and Kibana.

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -3,14 +3,14 @@
 // * post_installation_configuration/machine-configuration-tasks.adoc
 
 [id="create-a-containerruntimeconfig_{context}"]
-= Creating a `ContainerRuntimeConfig` CR to edit CRI-O parameters
+= Creating a ContainerRuntimeConfig CR to edit CRI-O parameters
 
 You can change some of the settings associated with the {product-title} CRI-O runtime for the nodes associated with a specific machine config pool (MCP). Using a `ContainerRuntimeConfig` custom resource (CR), you set the configuration values and add a label to match the MCP. The MCO then rebuilds the `crio.conf` and `storage.conf` configuration files on the associated nodes with the updated values.
 
 [NOTE]
 ====
 To revert the changes implemented by using a `ContainerRuntimeConfig` CR, you must delete the CR. Removing the label from the machine config pool does not revert the changes.
-==== 
+====
 
 You can modify the following settings by using a `ContainerRuntimeConfig` CR:
 
@@ -24,7 +24,7 @@ You can create multiple `ContainerRuntimeConfig` CRs, as needed, with a limit of
 
 You can also edit an existing `ContainerRuntimeConfig` CRs to edit existing settings or add new settings instead of creating a new CR. It is recommended to create a new CR to modify a different machine config pool, rather than add additional labels to an existing CR.
 
-If you want to delete the machine configs, you should delete them in reverse order to avoid exceeding the limit. For example, you should delete the `containerruntime-3` machine config before deleting the `containerruntime-2` machine config. 
+If you want to delete the machine configs, you should delete them in reverse order to avoid exceeding the limit. For example, you should delete the `containerruntime-3` machine config before deleting the `containerruntime-2` machine config.
 
 [NOTE]
 ====
@@ -88,9 +88,9 @@ spec:
 <1> Specifies the machine config pool label.
 <2> Optional: Specifies the level of verbosity for log messages.
 <3> Optional: Specifies the maximum size allowed for the container log file. If set to a positive number, it must be at least `8192`.
-<4> Optional: Specifies the maximum size of a container image. 
+<4> Optional: Specifies the maximum size of a container image.
 <5> Optional: Specifies the maximum number of processes allowed in a container.
-	
+
 .Procedure
 
 To change CRI-O settings using the `ContainerRuntimeConfig` CR:
@@ -114,7 +114,7 @@ spec:
    logSizeMax: "-1"
 ----
 <1> Specify a label for the machine config pool that you want you want to modify.
-<2> Set the parameters as needed.  
+<2> Set the parameters as needed.
 
 . Create the `ContainerRuntimeConfig` CR:
 +

--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -5,7 +5,7 @@
 // * post_installation_configuration/machine-configuration-tasks.adoc
 
 [id="create-a-kubeletconfig-crd-to-edit-kubelet-parameters_{context}"]
-= Creating a `KubeletConfig` CRD to edit kubelet parameters
+= Creating a KubeletConfig CRD to edit kubelet parameters
 
 The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new
 `kubelet-config-controller` added to the Machine Config Controller (MCC). This allows you to create a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.

--- a/modules/creating-runtimeclass.adoc
+++ b/modules/creating-runtimeclass.adoc
@@ -3,7 +3,7 @@
 // * windows_containers/scheduling-windows-workloads.adoc
 
 [id="creating-runtimeclass_{context}"]
-= Creating a `RuntimeClass` object to encapsulate scheduling mechanisms
+= Creating a RuntimeClass object to encapsulate scheduling mechanisms
 
 Using a `RuntimeClass` object simplifies the use of scheduling mechanisms like taints and tolerations; you deploy a runtime class that encapsulates your taints and tolerations and then apply it to your pods to schedule them to the appropriate node. Creating a runtime class is also necessary in clusters that support multiple operating system variants.
 

--- a/modules/delete-kn-trigger.adoc
+++ b/modules/delete-kn-trigger.adoc
@@ -3,7 +3,7 @@
 // * /serverless/event_workflows/serverless-using-brokers.adoc
 
 [id="delete-kn-trigger_{context}"]
-= Deleting a trigger using `kn`
+= Deleting a trigger using kn
 
 .Procedure
 

--- a/modules/deployments-accessing-private-repos.adoc
+++ b/modules/deployments-accessing-private-repos.adoc
@@ -3,7 +3,7 @@
 // * applications/deployments/managing-deployment-processes.adoc
 
 [id="deployments-accessing-private-repos_{context}"]
-= Accessing private repositories from `DeploymentConfig` objects
+= Accessing private repositories from DeploymentConfig objects
 
 You can add a secret to your `DeploymentConfig` object so that it can access images from a private repository. This procedure shows the {product-title} web console method.
 

--- a/modules/deployments-comparing-deploymentconfigs.adoc
+++ b/modules/deployments-comparing-deploymentconfigs.adoc
@@ -3,7 +3,7 @@
 // * applications/deployments/what-deployments-are.adoc
 
 [id="deployments-comparing-deploymentconfigs_{context}"]
-= Comparing `Deployment` and `DeploymentConfig` objects
+= Comparing Deployment and DeploymentConfig objects
 
 Both Kubernetes `Deployment` objects and {product-title}-provided `DeploymentConfig` objects are supported in {product-title}; however, it is recommended to use `Deployment` objects unless you need a specific feature or behavior provided by `DeploymentConfig` objects.
 
@@ -19,7 +19,7 @@ For `DeploymentConfig` objects, if a node running a deployer pod goes down, it w
 However, deployment rollouts are driven from a controller manager. The controller manager runs in high availability mode on masters and uses leader election algorithms to value availability over consistency. During a failure it is possible for other masters to act on the same deployment at the same time, but this issue will be reconciled shortly after the failure occurs.
 
 [id="delpoymentconfigs-specific-features_{context}"]
-== `DeploymentConfig` object-specific features
+== DeploymentConfig object-specific features
 
 [discrete]
 ==== Automatic rollbacks

--- a/modules/deployments-deploymentconfigs.adoc
+++ b/modules/deployments-deploymentconfigs.adoc
@@ -3,7 +3,7 @@
 // * applications/deployments/what-deployments-are.adoc
 
 [id="deployments-and-deploymentconfigs_{context}"]
-= `DeploymentConfig` objects
+= DeploymentConfig objects
 
 Building on replication controllers, {product-title} adds expanded support for the software development and deployment lifecycle with the concept of `DeploymentConfig` objects. In the simplest case, a `DeploymentConfig` object creates a new replication controller and lets it start up pods.
 

--- a/modules/developer-cli-odo-about-devfiles-in-odo.adoc
+++ b/modules/developer-cli-odo-about-devfiles-in-odo.adoc
@@ -1,10 +1,10 @@
 [id="about-the-devfile-in-odo"]
-= About the devfile in `{odo-title}`
+= About the devfile in {odo-title}
 
 The devfile is a portable file that describes your development environment.
 With the devfile, you can define a portable developmental environment without the need for reconfiguration.
 
 With the devfile, you can describe your development environment, such as the source code, IDE tools, application runtimes, and predefined commands. To learn more about the devfile, see link:https://redhat-developer.github.io/devfile/[the devfile documentation].
 
-With `{odo-title}`, you can create components from the devfiles. When creating a component by using a devfile, `{odo-title}` transforms the devfile into a workspace consisting of multiple containers that run on {product-title}, Kubernetes, or Docker. 
-`{odo-title}` automatically uses the default devfile registry but users can add their own registries. 
+With `{odo-title}`, you can create components from the devfiles. When creating a component by using a devfile, `{odo-title}` transforms the devfile into a workspace consisting of multiple containers that run on {product-title}, Kubernetes, or Docker.
+`{odo-title}` automatically uses the default devfile registry but users can add their own registries.

--- a/modules/developer-cli-odo-openshift-cluster-objects.adoc
+++ b/modules/developer-cli-odo-openshift-cluster-objects.adoc
@@ -70,7 +70,7 @@ The naming convention of the persistent volume is <component_name>-s2idata.
 | `/opt/app-root`
 |===
 
-== `emptyDir` volume
+== emptyDir volume
 An `emptyDir` volume is created when a pod is assigned to a node, and exists as long as that pod is running on the node. If the container is restarted or moved, the content of the `emptyDir` is removed, Init container restores the data back to the `emptyDir`. `emptyDir` is initially empty.
 
 The `copy-supervisord` Init container copies necessary files onto the `emptyDir` volume. These files are then utilized by the main application container at runtime for execution.

--- a/modules/developer-cli-odo-push-workflow.adoc
+++ b/modules/developer-cli-odo-push-workflow.adoc
@@ -4,12 +4,12 @@
 
 [id="odo-push-workflow_{context}"]
 
-= `{odo-title} push` workflow
+= {odo-title} push workflow
 This section describes `{odo-title} push` workflow. {odo-title} push deploys user code on an {product-title} cluster with all the necessary {product-title} resources.
 
 . Creating resources
 +
-If not already created, `{odo-title} push` creates the following {product-title} resources:
+If not already created, `{odo-title}` push creates the following {product-title} resources:
 +
 * `DeploymentConfig` object:
 ** Two init containers are executed: `copy-supervisord` and `copy-files-to-volume`. The init containers copy files onto the `emptyDir` and the `PersistentVolume` type of volumes respectively.

--- a/modules/developer-cli-odo-pushing-the-odo-init-image-to-a-mirror-registry.adoc
+++ b/modules/developer-cli-odo-pushing-the-odo-init-image-to-a-mirror-registry.adoc
@@ -9,7 +9,7 @@ Depending on your operating system, you can push the `odo` init image to a clust
 
 [id="pushing-the-init-image-to-a-mirror-registry-on-linux_{context}"]
 
-== Pushing the `init` image to a mirror registry on Linux
+== Pushing the init image to a mirror registry on Linux
 
 .Procedure
 
@@ -51,7 +51,7 @@ $ export ODO_BOOTSTRAPPER_IMAGE=<mirror-registry>:5000/openshiftdo/odo-init-imag
 
 [id="pushing-the-init-image-to-a-mirror-registry-on-macos_{context}"]
 
-== Pushing the `init` image to a mirror registry on MacOS
+== Pushing the init image to a mirror registry on MacOS
 
 .Procedure
 
@@ -89,7 +89,7 @@ $ export ODO_BOOTSTRAPPER_IMAGE=<mirror-registry>:5000/openshiftdo/odo-init-imag
 
 [id="pushing-the-init-image-to-a-mirror-registry-on-windows_{context}"]
 
-== Pushing the `init` image to a mirror registry on Windows
+== Pushing the init image to a mirror registry on Windows
 
 .Procedure
 

--- a/modules/developer-cli-odo-pushing-the-odo-init-image-to-an-internal-registry-directly.adoc
+++ b/modules/developer-cli-odo-pushing-the-odo-init-image-to-an-internal-registry-directly.adoc
@@ -9,7 +9,7 @@ If your cluster allows images to be pushed to the internal registry directly, pu
 
 [id="pushing-the-init-image-directly-on-linux_{context}"]
 
-== Pushing the `init` image directly on Linux
+== Pushing the init image directly on Linux
 
 .Procedure
 
@@ -86,7 +86,7 @@ $ export ODO_BOOTSTRAPPER_IMAGE=<registry_path>/openshiftdo/odo-init-image-rhel7
 
 [id="pushing-the-init-image-directly-on-macos_{context}"]
 
-== Pushing the `init` image directly on MacOS
+== Pushing the init image directly on MacOS
 
 .Procedure
 
@@ -163,7 +163,7 @@ $ export ODO_BOOTSTRAPPER_IMAGE=<registry_path>/openshiftdo/odo-init-image-rhel7
 
 [id="pushing-the-init-image-directly-on-windows_{context}"]
 
-== Pushing the `init` image directly on Windows
+== Pushing the init image directly on Windows
 
 .Procedure
 

--- a/modules/dynamic-provisioning-storage-class-definition.adoc
+++ b/modules/dynamic-provisioning-storage-class-definition.adoc
@@ -4,7 +4,7 @@
 // * post_installation_configuration/storage-configuration.adoc
 
 [id="basic-storage-class-definition_{context}"]
-= Basic `StorageClass` object definition
+= Basic StorageClass object definition
 
 The following resource shows the parameters and default values that you
 use to configure a storage class. This example uses the AWS

--- a/modules/ephemeral-storage-csi-inline-pod.adoc
+++ b/modules/ephemeral-storage-csi-inline-pod.adoc
@@ -3,7 +3,7 @@
 // * storage/container_storage_interface/ephemeral-storage-csi-inline-pod-scheduling.adoc
 
 [id="ephemeral-storage-csi-inline-pod_{context}"]
-= Embedding a CSI inline ephemeral volume in the `Pod` specification
+= Embedding a CSI inline ephemeral volume in the Pod specification
 
 You can embed a CSI inline ephemeral volume in the `Pod` specification in {product-title}. At runtime, nested inline volumes follow the ephemeral lifecycle of their associated pods so that the CSI driver handles all phases of volume operations as pods are created and destroyed.
 

--- a/modules/impersonation-system-admin-group.adoc
+++ b/modules/impersonation-system-admin-group.adoc
@@ -3,7 +3,7 @@
 // * users_and_roles/impersonating-system-admin.adoc
 
 [id="impersonation-system-admin-group_{context}"]
-= Impersonating the `system:admin` group
+= Impersonating the system:admin group
 
 
 When a `system:admin` user is granted cluster administration permissions through a group, you must include the

--- a/modules/impersonation-system-admin-user.adoc
+++ b/modules/impersonation-system-admin-user.adoc
@@ -3,7 +3,7 @@
 // * users_and_roles/impersonating-system-admin.adoc
 
 [id="impersonation-system-admin-user_{context}"]
-= Impersonating the `system:admin` user
+= Impersonating the system:admin user
 
 You can grant a user permission to impersonate `system:admin`, which grants them
 cluster administrator permissions.

--- a/modules/kn-trigger-describe.adoc
+++ b/modules/kn-trigger-describe.adoc
@@ -3,7 +3,7 @@
 // * serverless/event_workflows/serverless-using-brokers.adoc
 
 [id="kn-trigger-describe_{context}"]
-= Describing a trigger using `kn`
+= Describing a trigger using kn
 
 You can use the `kn trigger describe` command to print information about a trigger.
 

--- a/modules/kn-trigger-list.adoc
+++ b/modules/kn-trigger-list.adoc
@@ -3,7 +3,7 @@
 // * /serverless/event_workflows/serverless-using-brokers.adoc
 
 [id="kn-trigger-list_{context}"]
-= Listing triggers using `kn`
+= Listing triggers using kn
 
 The `kn trigger list` command prints a list of available triggers.
 

--- a/modules/kn-trigger-update.adoc
+++ b/modules/kn-trigger-update.adoc
@@ -3,7 +3,7 @@
 // * serverless/event_workflows/serverless-using-brokers.adoc
 
 [id="kn-trigger-update_{context}"]
-= Updating a trigger using `kn`
+= Updating a trigger using kn
 
 You can use the `kn trigger update` command with certain flags to update attributes for a trigger.
 

--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -4,7 +4,7 @@
 // * post_installation_configuration/cluster-tasks.adoc
 
 [id="machine-autoscaler-cr_{context}"]
-= `MachineAutoscaler` resource definition
+= MachineAutoscaler resource definition
 
 This `MachineAutoscaler` resource definition shows the parameters and sample values for the machine autoscaler.
 

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -4,7 +4,7 @@
 // * post_installation_configuration/node-tasks.adoc
 
 [id="machine-health-checks-creating_{context}"]
-= Creating a `MachineHealthCheck` resource
+= Creating a MachineHealthCheck resource
 
 You can create a `MachineHealthCheck` resource for all `MachineSets` in your cluster.
 You should not create a `MachineHealthCheck` resource that targets control plane machines.

--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -5,7 +5,7 @@
 
 
 [id="machine-health-checks-resource_{context}"]
-= Sample `MachineHealthCheck` resource
+= Sample MachineHealthCheck resource
 
 The `MachineHealthCheck` resource resembles one of the following YAML files:
 

--- a/modules/migration-error-messages.adoc
+++ b/modules/migration-error-messages.adoc
@@ -40,7 +40,7 @@ $ oc logs <MigrationUI_Pod> -n openshift-migration
 ----
 
 [id='podvolumebackups-timeout-error-in-velero-log_{context}']
-== `PodVolumeBackups` timeout error in `Velero` pod log
+== PodVolumeBackups timeout error in Velero pod log
 
 If a migration fails because Restic times out, the following error is displayed in the `Velero` pod log.
 
@@ -69,7 +69,7 @@ spec:
 . Click *Save*.
 
 [id='resticverifyerrors-in-the-migmigration-custom-resource_{context}']
-== `ResticVerifyErrors` in the `MigMigration` custom resource
+== ResticVerifyErrors in the MigMigration custom resource
 
 If data verification fails when migrating a persistent volume with the file system data copy method, the following error is displayed in the `MigMigration` CR.
 

--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -5,7 +5,7 @@
 // * migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
 
 [id="migration-using-must-gather_{context}"]
-= Using `must-gather` to collect data
+= Using must-gather to collect data
 
 You must run the `must-gather` tool if you open a customer support case on the link:https://access.redhat.com[Red Hat Customer Portal] for the {mtc-full} ({mtc-short}).
 

--- a/modules/nodes-containers-projected-volumes-about.adoc
+++ b/modules/nodes-containers-projected-volumes-about.adoc
@@ -30,7 +30,7 @@ Projected volumes allow you to use a secret as a public key to encrypt the names
 This example allows the Operator to use the application to deliver the namespace information securely without using an encrypted transport.
 
 [id="projected-volumes-examples_{context}"]
-== Example `Pod` specs
+== Example Pod specs
 
 The following are examples of `Pod` specs for creating projected volumes.
 

--- a/modules/nw-sriov-device-discovery.adoc
+++ b/modules/nw-sriov-device-discovery.adoc
@@ -19,7 +19,7 @@ The Operator creates and manages these resources automatically.
 ====
 
 [id="example-sriovnetworknodestate_{context}"]
-== Example `SriovNetworkNodeState` object
+== Example SriovNetworkNodeState object
 
 The following YAML is an example of a `SriovNetworkNodeState` object created by the SR-IOV Network Operator:
 

--- a/modules/ossm-cr-parameters.adoc
+++ b/modules/ossm-cr-parameters.adoc
@@ -4,7 +4,7 @@
 // * service_mesh/v2x/customizing-installation-ossm.adoc
 
 [id="ossm-cr-parameters_{context}"]
-= `ServiceMeshControlPlane` parameters
+= ServiceMeshControlPlane parameters
 
 The following examples illustrate use of the `ServiceMeshControlPlane` parameters and the tables provide additional information about supported parameters.
 

--- a/modules/ossm-updating-smcp.adoc
+++ b/modules/ossm-updating-smcp.adoc
@@ -9,7 +9,7 @@
 Configure {ProductName} to work with your app by creating and configuring a `ServiceMeshControlPlane`. The `ServiceMeshControlPlane` resource defines the configuration to be used during installation. You can deploy the default configuration provided by Red Hat or customize the `ServiceMeshControlPlane` resource for your microservices and workflows.
 
 [id="ossm-control-plane-deploy-operatorhub_{context}"]
-== Editing the `ServiceMeshControlPlane` from the web console
+== Editing the ServiceMeshControlPlane from the web console
 
 Follow this procedure to edit the `ServiceMeshControlPlane` with the {product-title} web console.
 
@@ -26,7 +26,7 @@ Follow this procedure to edit the `ServiceMeshControlPlane` with the {product-ti
 . Click *Save*.
 
 [id="ossm-control-plane-deploy-cli_{context}"]
-== Editing the `ServiceMeshControlPlane` from the CLI
+== Editing the ServiceMeshControlPlane from the CLI
 
 Follow this procedure to create or edit the `ServiceMeshControlPlane` with the command line.
 
@@ -68,4 +68,3 @@ The installation has finished successfully when the READY column is true.
 NAME            READY   STATUS              TEMPLATE   VERSION   AGE
 basic-install   9/9     InstallSuccessful   default    v2.0      4m25s
 ----
-

--- a/modules/pruning-deployments.adoc
+++ b/modules/pruning-deployments.adoc
@@ -3,7 +3,7 @@
 // * applications/pruning-objects.adoc
 
 [id="pruning-deployments_{context}"]
-= Pruning `DeploymentConfig` objects
+= Pruning DeploymentConfig objects
 
 To prune `DeploymentConfig` objects that are no longer required by the system due to age and status, administrators can run the following command:
 

--- a/modules/serverless-create-kn-trigger.adoc
+++ b/modules/serverless-create-kn-trigger.adoc
@@ -3,7 +3,7 @@
 // * serverless/event_workflows/serverless-using-brokers.adoc
 
 [id="serverless-create-kn-trigger_{context}"]
-= Creating a trigger using `kn`
+= Creating a trigger using kn
 
 You can create a trigger by using the `kn trigger create` command.
 

--- a/modules/serverless-installing-cli-linux-rpm.adoc
+++ b/modules/serverless-installing-cli-linux-rpm.adoc
@@ -3,7 +3,7 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-linux-rpm_{context}"]
-= Installing the `kn` CLI for Linux using an RPM
+= Installing the kn CLI for Linux using an RPM
 
 For Red Hat Enterprise Linux (RHEL), you can install `kn` as an RPM if you have an active {product-title} subscription on your Red Hat account.
 

--- a/modules/serverless-installing-cli-linux.adoc
+++ b/modules/serverless-installing-cli-linux.adoc
@@ -3,7 +3,7 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-linux_{context}"]
-= Installing the `kn` CLI for Linux
+= Installing the kn CLI for Linux
 
 For Linux distributions, you can download the CLI directly as a `tar.gz` archive.
 

--- a/modules/serverless-installing-cli-macos.adoc
+++ b/modules/serverless-installing-cli-macos.adoc
@@ -3,7 +3,7 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-macosx_{context}"]
-= Installing the `kn` CLI for macOS
+= Installing the kn CLI for macOS
 
 `kn` for macOS is provided as a `tar.gz` archive.
 

--- a/modules/serverless-installing-cli-web-console.adoc
+++ b/modules/serverless-installing-cli-web-console.adoc
@@ -3,7 +3,7 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-web-console_{context}"]
-= Installing the `kn` CLI using the {product-title} web console
+= Installing the kn CLI using the {product-title} web console
 
 Once the {ServerlessOperatorName} is installed, you will see a link to download the `kn` CLI for Linux, macOS and Windows from the *Command Line Tools* page in the {product-title} web console.
 

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -3,7 +3,7 @@
 // serverless/installing-knative-client.adoc
 
 [id="installing-cli-windows_{context}"]
-= Installing the `kn` CLI for Windows
+= Installing the kn CLI for Windows
 
 The CLI for Windows is provided as a zip archive.
 

--- a/modules/support-generating-a-sosreport-archive.adoc
+++ b/modules/support-generating-a-sosreport-archive.adoc
@@ -3,7 +3,7 @@
 // * support/gathering-cluster-data.adoc
 
 [id="support-generating-a-sosreport-archive_{context}"]
-= Generating a `sosreport` archive for an {product-title} cluster node
+= Generating a sosreport archive for an {product-title} cluster node
 
 The recommended way to generate a `sosreport` for an {product-title} {product-version} cluster node is through a debug pod.
 

--- a/modules/traffic-splitting-kn.adoc
+++ b/modules/traffic-splitting-kn.adoc
@@ -3,7 +3,7 @@
 // serverless/knative_serving/splitting-traffic-between-revisions-knative.adoc
 
 [id="traffic-splitting-kn_{context}"]
-= Traffic mapping and splitting using `kn`
+= Traffic mapping and splitting using kn
 
 `kn` provides commands that help you to control traffic mapping and how traffic is split between revisions.
 

--- a/modules/troubleshooting-openshift-install-command-issues.adoc
+++ b/modules/troubleshooting-openshift-install-command-issues.adoc
@@ -3,7 +3,7 @@
 // * support/troubleshooting/troubleshooting-installations.adoc
 
 [id="troubleshooting-openshift-install-command-issues_{context}"]
-= Troubleshooting `openshift-install` command issues
+= Troubleshooting openshift-install command issues
 
 If you experience issues running the `openshift-install` command, check the following:
 

--- a/modules/virt-additional-scc-for-kubevirt-controller.adoc
+++ b/modules/virt-additional-scc-for-kubevirt-controller.adoc
@@ -3,13 +3,13 @@
 // * virt/virt-additional-security-privileges-controller-and-launcher.adoc
 
 [id="virt-additional-scc-for-kubevirt-controller_{context}"]
-= Additional {product-title} security context constraints and Linux capabilities for the `kubevirt-controller` service account
+= Additional {product-title} security context constraints and Linux capabilities for the kubevirt-controller service account
 
 Security context constraints (SCCs) control permissions for pods. These permissions include actions that a pod, a collection of containers, can perform and what resources it can access. You can use SCCs to define a set of conditions that a pod must run with to be accepted into the system.
 
 The `kubevirt-controller` is a cluster controller that creates the virt-launcher pods for virtual machines in the cluster. These virt-launcher pods are granted permissions by the `kubevirt-controller` service account.
 
-== Additional SCCs granted to the `kubevirt-controller` service account
+== Additional SCCs granted to the kubevirt-controller service account
 
 The `kubevirt-controller` service account is granted additional SCCs and Linux capabilities so that it can create virt-launcher pods with the appropriate permissions. These extended permissions allow virtual machines to take advantage of {VirtProductName} features that are beyond the scope of typical pods.
 
@@ -27,7 +27,7 @@ This provides the following additional Linux capabilities
 `NET_RAW`, and
 `SYS_NICE`.
 
-== Viewing the SCC and RBAC definitions for the `kubevirt-controller`
+== Viewing the SCC and RBAC definitions for the kubevirt-controller
 
 You can view the `SecurityContextConstraints` definition for the `kubevirt-controller` by using the `oc` tool:
 

--- a/modules/virt-configuring-vm-live-migration-cli.adoc
+++ b/modules/virt-configuring-vm-live-migration-cli.adoc
@@ -3,7 +3,7 @@
 // * virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc
 
 [id="virt-configuring-vm-live-migration-cli_{context}"]
-= Configuring custom virtual machines with the `LiveMigration` eviction strategy
+= Configuring custom virtual machines with the LiveMigration eviction strategy
 
 You only need to configure the `LiveMigration` eviction strategy on custom
 virtual machines. Common templates have this eviction strategy

--- a/modules/virt-editing-kubevirtstorageclassdefaults-cli.adoc
+++ b/modules/virt-editing-kubevirtstorageclassdefaults-cli.adoc
@@ -3,7 +3,7 @@
 // * virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc
 
 [id="virt-editing-kubevirtstorageclassdefaults-cli_{context}"]
-= Editing the `kubevirt-storage-class-defaults` config map in the CLI
+= Editing the kubevirt-storage-class-defaults config map in the CLI
 
 Modify the storage settings for data volumes by editing the `kubevirt-storage-class-defaults` config map in the `openshift-cnv` namespace.
 You can also add settings for other storage classes to create data volumes in the web console for different storage types.
@@ -39,4 +39,3 @@ data:
 <4> If you add a volume mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
 
 . Save and exit the editor to update the config map.
-

--- a/modules/virt-editing-kubevirtstorageclassdefaults-web.adoc
+++ b/modules/virt-editing-kubevirtstorageclassdefaults-web.adoc
@@ -3,7 +3,7 @@
 // * virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc
 
 [id="virt-editing-kubevirtstorageclassdefaults-web_{context}"]
-= Editing the `kubevirt-storage-class-defaults` config map in the web console
+= Editing the kubevirt-storage-class-defaults config map in the web console
 
 Modify the storage settings for data volumes by editing the `kubevirt-storage-class-defaults` config map in the `openshift-cnv` namespace.
 You can also add settings for other storage classes to create data volumes in the web console for different storage types.
@@ -15,7 +15,7 @@ You must configure storage settings that are supported by the underlying storage
 
 .Procedure
 
-. Click *Workloads* -> *Config Maps* from the side menu. 
+. Click *Workloads* -> *Config Maps* from the side menu.
 . In the *Project* list, select *openshift-cnv*.
 . Click *kubevirt-storage-class-defaults* to open the *Config Map Overview*.
 . Click the *YAML* tab to display the editable configuration.
@@ -31,11 +31,8 @@ data:
   <new>.volumeMode: Block <4>
 ----
 <1> The default accessMode is `ReadWriteOnce`.
-<2> The default volumeMode is `Filesystem`. 
+<2> The default volumeMode is `Filesystem`.
 <3> If you add an access mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
 <4> If you add a volume mode for a storage class, replace the `<new>` part of the parameter with the storage class name.
 
-. Click *Save* to update the config map. 
-
-
-
+. Click *Save* to update the config map.

--- a/modules/virt-installing-virtctl-client-web.adoc
+++ b/modules/virt-installing-virtctl-client-web.adoc
@@ -3,17 +3,17 @@
 // virt/install/virt-installing-virtctl.adoc
 
 [id="virt-installing-virtctl-client-web_{context}"]
-= Installing the `virtctl` client from the web console
+= Installing the virtctl client from the web console
 
 You can download the `virtctl` client from the Red Hat Customer Portal, which is linked to in your {VirtProductName} web console in the *Command Line Tools* page.
 
 .Prerequisites
 
-* You must have an activated {product-title} subscription to access the download page on the Customer Portal. 
+* You must have an activated {product-title} subscription to access the download page on the Customer Portal.
 
 .Procedure
 
-. Access the Customer Portal by clicking the image:question-circle.png[title="Help"] icon, which is in the upper-right corner of the web console, and selecting *Command Line Tools*. 
+. Access the Customer Portal by clicking the image:question-circle.png[title="Help"] icon, which is in the upper-right corner of the web console, and selecting *Command Line Tools*.
 
 . Ensure you have the appropriate version for your cluster selected from the *Version:* list.
 
@@ -23,7 +23,7 @@ You can download the `virtctl` client from the Red Hat Customer Portal, which is
 +
 [source,terminal]
 ----
-$ tar -xvf <virtctl-version-distribution.arch>.tar.gz 
+$ tar -xvf <virtctl-version-distribution.arch>.tar.gz
 ----
 
 . For Linux and macOS:

--- a/modules/virt-installing-virtctl-client.adoc
+++ b/modules/virt-installing-virtctl-client.adoc
@@ -3,7 +3,7 @@
 // virt/install/virt-installing-virtctl.adoc
 
 [id="virt-installing-virtctl-client_{context}"]
-= Installing the `virtctl` client
+= Installing the virtctl client
 
 Install the `virtctl` client from the `kubevirt-virtctl` package.
 

--- a/modules/windows-machineset-aws.adoc
+++ b/modules/windows-machineset-aws.adoc
@@ -3,7 +3,7 @@
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
 
 [id="windows-machineset-aws_{context}"]
-= Sample YAML for a Windows `MachineSet` object on AWS
+= Sample YAML for a Windows MachineSet object on AWS
 
 This sample YAML defines a Windows `MachineSet` object running on Amazon Web Services (AWS) that the Windows Machine Config Operator (WMCO) can react upon.
 

--- a/modules/windows-machineset-azure.adoc
+++ b/modules/windows-machineset-azure.adoc
@@ -3,7 +3,7 @@
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
 
 [id="windows-machineset-azure_{context}"]
-= Sample YAML for a Windows `MachineSet` object on Azure
+= Sample YAML for a Windows MachineSet object on Azure
 
 This sample YAML defines a Windows `MachineSet` object running on Microsoft Azure that the Windows Machine Config Operator (WMCO) can react upon.
 

--- a/service_mesh/v1x/customizing-installation-ossm.adoc
+++ b/service_mesh/v1x/customizing-installation-ossm.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 After your default `ServiceMeshControlPlane` resource is deployed, you can configure the resource to suit your environment.
 
-== Resources for configuring your `ServiceMeshControlPlane` resource
+== Resources for configuring your ServiceMeshControlPlane resource
 
 Read more about how to configure your `ServiceMeshControlPlane` resource further, or skip ahead to Updating the `ServiceMeshControlPlane`.
 

--- a/service_mesh/v2x/customizing-installation-ossm.adoc
+++ b/service_mesh/v2x/customizing-installation-ossm.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 After your default `ServiceMeshControlPlane` resource is deployed, you must configure the resource to suit your environment.  Note that the default Jaeger deployment must be changed, as the default `allinone` deployment does not supply persistent memory.
 
-== Resources for configuring your `ServiceMeshControlPlane` resource
+== Resources for configuring your ServiceMeshControlPlane resource
 
 Read more about how to configure your `ServiceMeshControlPlane` resource further, or skip ahead to Updating the `ServiceMeshControlPlane`.
 

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -102,7 +102,7 @@ Alternatively, you can use the console to create the control plane. In the {prod
 .. Click *Create*.
 
 [id="ossm-upgrading-differences_{context}"]
-== Configuring the 2.0 `ServiceMeshControlPlane`
+== Configuring the 2.0 ServiceMeshControlPlane
 
 The `ServiceMeshControlPlane` resource has been changed for {ProductName} version 2.0. After you created a v2 version of the `ServiceMeshControlPlane` resource, modify it to take advantage of the new features and to fit your deployment. Consider the following changes to the specification and behavior of {ProductName} 2.0 as you're modifying your `ServiceMeshControlPlane` resource. You can also refer to the {ProductName} 2.0 product documentation for new information to features you use. The v2 resource must be used for {ProductName} 2.0 installations.
 

--- a/virt/install/virt-installing-virtctl.adoc
+++ b/virt/install/virt-installing-virtctl.adoc
@@ -1,5 +1,5 @@
 [id="virt-installing-virtctl"]
-= Installing the `virtctl` client
+= Installing the virtctl client
 include::modules/virt-document-attributes.adoc[]
 :context: virt-installing-virtctl
 


### PR DESCRIPTION
No BZ.

In accordance with https://github.com/openshift/openshift-docs/blob/master/contributing_to_docs/doc_guidelines.adoc#assemblymodule-titles-and-section-headings.

Preview at https://deploy-preview-31486--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html

For versions 4.5+.