### PR TITLE
Bug 1911481 include module with procedure for creating mirror registry

### DIFF
--- a/installing/install_config/installing-restricted-networks-preparations.adoc
+++ b/installing/install_config/installing-restricted-networks-preparations.adoc
@@ -26,6 +26,8 @@ and push it to the remote location.
 
 include::modules/cli-installing-cli.adoc[leveloffset=+2]
 
+include::modules/installation-creating-mirror-registry.adoc[leveloffset=+1]
+
 include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]
 
 //This command seems out of place. Where should it really go?


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1911481

Preview: https://deploy-preview-31489--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-restricted-networks-preparations.html#installation-creating-mirror-registry_installing-restricted-networks-preparations