### PR TITLE
OSDOCS-2074, convert KCS article on accessing metrics from outside the cluster for custom apps

### DIFF
--- a/modules/accessing-metrics-outside-cluster.adoc
+++ b/modules/accessing-metrics-outside-cluster.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+
+[id="accessing-metrics-from-outside-cluster_{context}"]
+= Accessing metrics from outside the cluster for custom applications
+
+Learn how to query Prometheus statistics from the command line when monitoring your own services. You can access monitoring data from outside the cluster with the `thanos-querier` route.
+
+.Prerequisites
+
+* You deployed your own service, following the _Enabling monitoring for user-defined projects_ procedure.
+
+.Procedure
+
+. Extract a token to connect to Prometheus:
++
+[source,terminal]
+----
+$ SECRET=`oc get secret -n openshift-user-workload-monitoring | grep  prometheus-user-workload-token | head -n 1 | awk '{print $1 }'`
+----
++
+[source,terminal]
+----
+$ TOKEN=`echo $(oc get secret $SECRET -n openshift-user-workload-monitoring -o json | jq -r '.data.token') | base64 -d`
+----
+
+. Extract your route host:
++
+[source,terminal]
+----
+$ THANOS_QUERIER_HOST=`oc get route thanos-querier -n openshift-monitoring -o json | jq -r '.spec.host'`
+----
+
+. Query the metrics of your own services in the command line. For example:
++
+[source,terminal]
+----
+$ NAMESPACE=ns1
+----
++
+[source,terminal]
+----
+$ curl -X GET -kG "https://$THANOS_QUERIER_HOST/api/v1/query?" --data-urlencode "query=up{namespace='$NAMESPACE'}" -H "Authorization: Bearer $TOKEN"
+----
++
+The output will show you the duration that your application pods have been up.
++
+.Example output
+[source,terminal]
+----
+{"status":"success","data":{"resultType":"vector","result":[{"metric":{"__name__":"up","endpoint":"web","instance":"10.129.0.46:8080","job":"prometheus-example-app","namespace":"ns1","pod":"prometheus-example-app-68d47c4fb6-jztp2","service":"prometheus-example-app"},"value":[1591881154.748,"1"]}]}}
+----

--- a/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -29,6 +29,9 @@ include::modules/monitoring-granting-user-permissions-using-the-cli.adoc[levelof
 // Granting users permission to configure monitoring for user-defined projects
 include::modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc[leveloffset=+1]
 
+// Accessing metrics from outside the cluster for custom applications
+include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
+
 // Disabling monitoring for user-defined projects
 include::modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2074

Original content: https://access.redhat.com/solutions/5151831

Preview build: https://deploy-preview-31500--osdocs.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects.html#accessing-metrics-from-outside-cluster_enabling-monitoring-for-user-defined-projects