### PR TITLE
Removed unlimited memory wording from limit range topic

### DIFF
--- a/modules/nodes-cluster-limit-ranges-limits.adoc
+++ b/modules/nodes-cluster-limit-ranges-limits.adoc
@@ -74,11 +74,7 @@ spec:
 <2> The maximum amount of CPU that a single container in a pod can request.
 <3> The maximum amount of memory that a single container in a pod can request.
 <4> The minimum amount of CPU that a single container in a pod can request.
-Not setting a `min` value or setting `0` is unlimited, allowing the
-Pod to consume more than the `max` CPU value.
 <5> The minimum amount of memory that a single container in a pod can request.
-Not setting a `min` value or setting `0` is unlimited, allowing the
-Pod to consume more than the `max` memory value.
 <6> The default amount of CPU that a container can use if not specified in the `Pod` spec.
 <7> The default amount of memory that a container can use if not specified in the `Pod` spec.
 <8> The default amount of CPU that a container can request if not specified in the `Pod` spec.
@@ -92,7 +88,11 @@ Pod to consume more than the `max` memory value.
 A limit range allows you to specify the minimum and maximum CPU and memory limits for all containers
 across a pod in a given project. To create a container in the project, the container CPU and memory
 requests in the `Pod` spec must comply with the values set in the `LimitRange` object. If not,
-the pod does not get created.
+the pod does not get created. 
+
+If the `Pod` spec does not specify a container resource memory or limit,
+the `default` or `defaultRequest` CPU and memory values for containers
+specified in the limit range object are assigned to the container.
 
 Across all containers in a pod, the following must hold true:
 
@@ -129,11 +129,7 @@ spec:
 <2> The maximum amount of CPU that a pod can request across all containers.
 <3> The maximum amount of memory that a pod can request across all containers.
 <4> The minimum amount of CPU that a pod can request across all containers.
-Not setting a `min` value or setting `0` is unlimited, allowing the pod to
-consume more than the `max` CPU value.
 <5> The minimum amount of memory that a pod can request across all containers.
-Not setting a `min` value or setting `0` is unlimited, allowing the pod to
-consume more than the `max` memory value.
 <6> The maximum limit-to-request ratio for a container.
 
 [id="nodes-cluster-limit-image-limits"]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/31354

Removed incorrect information about default behavior from call-outs in the _Container limits_ and _Pod limits_ sections. The default behavior is stated before the code block in the _Container limits_ section. Copied this sentence to the _Pod limits_ section.

Preview: https://deploy-preview-31501--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges.html#nodes-cluster-limit-container-limits