### PR TITLE
BZ#1894650 - Avoid overlap with OVN-Kubernetes join range

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -28,13 +28,17 @@ The subnets assigned to nodes and the IP addresses assigned to individual pods a
 
 While the OVN-Kubernetes network provider implements many of the capabilities present in the OpenShift SDN network provider, the configuration is not the same.
 
-If your cluster uses any of the following OpenShift SDN capabilities, you must manually configure the same capability in OVN-Kubernetes:
-
+* If your cluster uses any of the following OpenShift SDN capabilities, you must manually configure the same capability in OVN-Kubernetes:
++
+--
 * Namespace isolation
 * Egress IP addresses
 * Egress network policies
 * Egress router pods
 * Multicast
+--
+
+* If your cluster uses any part of the `100.64.0.0/16` IP address range, you cannot migrate to OVN-Kubernetes because it uses this IP address range internally.
 
 The following sections highlight the differences in configuration between the aforementioned capabilities in OVN-Kubernetes and OpenShift SDN.
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1894650
- https://bugzilla.redhat.com/show_bug.cgi?id=1894268

Preview:
- [Considerations for migrating to the OVN-Kubernetes network provider](https://deploy-preview-31503--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn)