### PR TITLE
Mig-615: Deprecated APIs in 4.x migration

### DIFF
--- a/migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
+++ b/migration/migrating_4_1_4/troubleshooting-4-1-4.adoc
@@ -18,6 +18,7 @@ Manual rollback is not required if the application was not stopped during migrat
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+1]
 include::modules/migration-using-mig-log-reader.adoc[leveloffset=+1]
 include::modules/migration-downloading-logs.adoc[leveloffset=+1]
+include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+1]
 include::modules/migration-error-messages.adoc[leveloffset=+1]
 include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+1]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]

--- a/migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
+++ b/migration/migrating_4_2_4/troubleshooting-4-2-4.adoc
@@ -18,6 +18,7 @@ Manual rollback is not required if the application was not stopped during migrat
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+1]
 include::modules/migration-using-mig-log-reader.adoc[leveloffset=+1]
 include::modules/migration-downloading-logs.adoc[leveloffset=+1]
+include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+1]
 include::modules/migration-error-messages.adoc[leveloffset=+1]
 include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+1]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]

--- a/modules/migration-updating-deprecated-gvks.adoc
+++ b/modules/migration-updating-deprecated-gvks.adoc
@@ -5,9 +5,7 @@
 [id='migration-gvk-incompatibility_{context}']
 = Updating deprecated APIs
 
-In {product-title} {product-version}, some APIs that are used by {product-title} 3.x are link:https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/[deprecated].
-
-If your source cluster uses deprecated APIs, the following warning message is displayed when you create a migration plan in the {mtc-full} ({mtc-short}):
+If your source cluster uses deprecated APIs, the following warning message is displayed when you create a migration plan in the {mtc-full} ({mtc-short}) web console:
 
 [source,terminal]
 ----
@@ -22,13 +20,13 @@ During migration with the {mtc-full} ({mtc-short}), the deprecated APIs are save
 
 . Run the migration plan.
 
-. View the `MigPlan` CR:
+. View the `MigPlan` custom resource (CR):
 +
 [source,terminal]
 ----
 $ oc describe migplan <migplan_name> -n openshift-migration <1>
 ----
-<1> Specify the name of the migration plan.
+<1> Specify the name of the `MigPlan` CR.
 +
 The output is similar to the following:
 +
@@ -55,7 +53,7 @@ status:
       kind: scheduledjobs
       version: v2alpha1
 ----
-<1> Record the `MigPlan` UID.
+<1> Record the `MigPlan` CR UID.
 <2> Record the deprecated APIs listed in the `gvks` section.
 
 . Get the `MigMigration` name associated with the `MigPlan` UID:
@@ -64,7 +62,7 @@ status:
 ----
 $ oc get migmigration -o json | jq -r '.items[] | select(.metadata.ownerReferences[].uid=="<migplan_uid>") | .metadata.name' <1>
 ----
-<1> Specify the `MigPlan` UID.
+<1> Specify the `MigPlan` CR UID.
 
 . Get the `MigMigration` UID associated with the `MigMigration` name:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-615

"Updating deprecated APIs" module added to Troubleshooting assembly of 4.1 and 4.2 migration docs. QE not required because an existing module is being added.

4.5+

Previews: 

https://deploy-preview-31506--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/troubleshooting-4-1-4.html#migration-gvk-incompatibility_migrating-4-1-4

https://deploy-preview-31506--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_2_4/troubleshooting-4-2-4.html#migration-gvk-incompatibility_migrating-4-2-4