### PR TITLE
RHDEVDOCS-2931 Build 4.8: Release note images removed

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -190,6 +190,25 @@ In the table, features are marked with the following statuses:
 [id="ocp-4-8-removed-features"]
 === Removed features
 
+[id="ocp-4-8-images-removed-from-samples-imagestreams"]
+==== Images removed from samples imagestreams
+
+The following images are no longer included in the samples imagestreams provided with {product-title}:
+
+----
+registry.redhat.io/rhscl/nodejs-10-rhel7
+registry.redhat.io/ubi7/nodejs-10
+registry.redhat.io/rhscl/perl-526-rhel7
+registry.redhat.io/rhscl/postgresql-10-rhel7
+registry.redhat.io/rhscl/ruby-25-rhel7
+registry.redhat.io/ubi7/ruby-25
+registry.redhat.io/rhdm-7/rhdm-decisioncentral-rhel8:7.9.0
+registry.redhat.io/rhdm-7/rhdm-kieserver-rhel8:7.9.0
+registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.9.0
+registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.9.0
+registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.9.0
+----
+
 [id="ocp-4-8-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
[RHDEVDOCS-2931](https://issues.redhat.com/browse/RHDEVDOCS-2931) Build 4.8: Release note images removed

- For version 4.8 only.
- https://issues.redhat.com/browse/RHDEVDOCS-2931
- Direct link to doc preview: https://deploy-preview-31525--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-removed-features
- SME review: Completed
- QE review: Requested
- Peer review: Requested
- Please merge when ready
