### PR TITLE
Fix setting cookie name example

### DIFF
--- a/modules/nw-annotating-a-route-with-a-cookie-name.adoc
+++ b/modules/nw-annotating-a-route-with-a-cookie-name.adoc
@@ -9,32 +9,54 @@
 [id="nw-annotating-a-route-with-a-cookie-name_{context}"]
 = Annotating a route with a cookie
 
-You can set a cookie name to overwrite the default, auto-generated one for the
-route. This allows the application receiving route traffic to know the cookie
-name. By deleting the cookie it can force the next request to re-choose an
-endpoint. So, if a server was overloaded it tries to remove the requests from the
-client and redistribute them.
+You can set a cookie name to overwrite the default, auto-generated one for the route. This allows the application receiving route traffic to know the cookie name. By deleting the cookie it can force the next request to re-choose an endpoint. So, if a server was overloaded it tries to remove the requests from the client and redistribute them.
 
 .Procedure
 
-. Annotate the route with the desired cookie name:
+. Annotate the route with the specified cookie name:
 +
 [source,terminal]
 ----
-$ oc annotate route <route_name> router.openshift.io/<cookie_name>="-<cookie_annotation>"
+$ oc annotate route <route_name> router.openshift.io/cookie_name="<cookie_name>"
 ----
 +
-For example, to annotate the cookie name of `my_cookie` to the `my_route` with
-the annotation of `my_cookie_annotation`:
+--
+where:
+
+`<route_name>`:: Specifies the name of the route.
+`<cookie_name>`:: Specifies the name for the cookie.
+--
++
+For example, to annotate the route `my_route` with the cookie name `my_cookie`:
 +
 [source,terminal]
 ----
-$ oc annotate route my_route router.openshift.io/my_cookie="-my_cookie_annotation"
+$ oc annotate route my_route router.openshift.io/cookie_name="my_cookie"
 ----
 
-. Save the cookie, and access the route:
+. Capture the route host name in a variable:
 +
 [source,terminal]
 ----
-$ curl $my_route -k -c /tmp/my_cookie
+$ ROUTE_NAME=$(oc get route <route_name> -o jsonpath='{.spec.host}')
+----
++
+--
+where:
+
+`<route_name>`:: Specifies the name of the route.
+--
+
+. Save the cookie, and then access the route:
++
+[source,terminal]
+----
+$ curl $ROUTE_NAME -k -c /tmp/cookie_jar
+----
++
+Use the cookie saved by the previous command when connecting to the route:
++
+[source,terminal]
+----
+$ curl $ROUTE_NAME -k -b /tmp/cookie_jar
 ----


### PR DESCRIPTION
This patch needs to be applied to all 4.x branches.

Preview: [Annotating a route with a cookie](https://deploy-preview-31530--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-annotating-a-route-with-a-cookie-name_route-configuration)