### PR TITLE
[enterprise-4.5] Clarified how hyperthreaded CPUs relate to vCPUs.

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -128,7 +128,7 @@ Each cluster machine must meet the following minimum requirements:
 
 |Machine
 |Operating System
-|vCPU^1^
+|vCPU ^[1]^
 |Virtual RAM
 |Storage
 
@@ -163,11 +163,11 @@ ifndef::ibm-z,ibm-power[|{op-system}]
 |8 GB
 |120 GB
 endif::openshift-origin[]
-
-5+a|
-^1^ 1 physical core provides 2 vCPUs when hyper-threading is enabled. 1 physical core provides 1 vCPU when hyper-threading is not enabled.
-
 |===
+[.small]
+--
+1. 1 vCPU is equivalent to 1 physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
+--
 
 ifdef::ibm-z[]
 [id="minimum-ibm-z-system-requirements_{context}"]


### PR DESCRIPTION
For this fix, the footnote to a table was rewritten to clarify how to figure out vCPUs with hyperthreaded CPUs.

Cherry Picked from 091d3485a4011b7bc1c10e5621f6695001da7c9c xref: #31467 

Preview: https://deploy-preview-31540--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal