### PR TITLE
The patch command was incomplete for unapplying the remediation.

### DIFF
--- a/modules/compliance-unapplying.adoc
+++ b/modules/compliance-unapplying.adoc
@@ -11,7 +11,7 @@ It might be required to unapply a remediation that was previously applied.
 +
 [source,terminal]
 ----
-$ oc patch complianceremediations/<scan_name>-sysctl-net-ipv4-conf-all-accept-redirects
+$ oc patch complianceremediations/<scan_name>-sysctl-net-ipv4-conf-all-accept-redirects --patch '{"spec":{"apply":false}}' --type=merge
 ----
 
 . The remediation status will change to `NotApplied` and the composite `MachineConfig` object would be re-rendered to not include the remediation.


### PR DESCRIPTION
Team,

The patch command mentioned for unapplying the remediation in compliance operator, is not referring to the false flag. By, looking into the doc for applying remediation, it gives better understanding : https://docs.openshift.com/container-platform/4.7/security/compliance_operator/compliance-operator-remediation.html

@vikram-redhat Can you please review. Let me know if any changes required.