### PR TITLE
Descheduler: create namespace with openshift.io/cluster-monitoring=true label set

### DIFF
--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -22,7 +22,7 @@ endif::[]
 . Log in to the {product-title} web console.
 . Create the required namespace for the Kube Descheduler Operator.
 .. Navigate to *Administration* -> *Namespaces* and click *Create Namespace*.
-.. Enter `openshift-kube-descheduler-operator` in the *Name* field and click *Create*.
+.. Enter `openshift-kube-descheduler-operator` in the *Name* field, enter `openshift.io/cluster-monitoring=true` in the *Labels* field to enable descheduler metrics, and click *Create*.
 . Install the Kube Descheduler Operator.
 .. Navigate to *Operators* -> *OperatorHub*.
 .. Type *Kube Descheduler Operator* into the filter box.


### PR DESCRIPTION
So the Prometheus can collect metrics from descheduler namespace.