### PR TITLE
Pipelines 1.14.0 cli download link version bump

### DIFF
--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -45,9 +45,25 @@ For {op-system-base-full} version 8, you can install the {pipelines-title} CLI (
 
 . Enable the repositories required by {pipelines-title}:
 +
+* Linux (x86_64, amd64)
++
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.3-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="pipelines-1.4-for-rhel-8-x86_64-rpms"
+----
++
+* Linux on IBM Z and LinuxONE (s390x)
++
+[source,terminal]
+----
+# subscription-manager repos --enable="pipelines-1.4-for-rhel-8-s390x-rpms"
+----
++
+* Linux on IBM Power Systems (ppc64le)
++
+[source,terminal]
+----
+# subscription-manager repos --enable="pipelines-1.4-for-rhel-8-ppc64le-rpms"
 ----
 
 . Install the `openshift-pipelines-client` package:

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -12,11 +12,11 @@ For Linux distributions, you can download the CLI directly as a `tar.gz` archive
 
 . Download the relevant CLI.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.15.0/tkn-linux-amd64-0.15.0.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-amd64-0.17.2.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.15.0/tkn-linux-s390x-0.15.0.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-s390x-0.17.2.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.15.0/tkn-linux-ppc64le-0.15.0.tar.gz[Linux on IBM Power Systems (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-linux-ppc64le-0.17.2.tar.gz[Linux on IBM Power Systems (ppc64le)]
 
 . Unpack the archive:
 +

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -10,7 +10,7 @@ For macOS, the `tkn` CLI is provided as a `tar.gz` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.15.0/tkn-macos-amd64-0.15.0.tar.gz[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-macos-amd64-0.17.2.tar.gz[CLI].
 
 . Unpack and unzip the archive.
 

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -10,7 +10,7 @@ For Windows, the `tkn` CLI is provided as a `zip` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.15.0/tkn-windows-amd64-0.15.0.zip[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.17.2/tkn-windows-amd64-0.17.2.zip[CLI].
 
 . Unzip the archive with a ZIP program.
 


### PR DESCRIPTION
This is for the upcoming Pipelines 1.14.0 GA 

Preview https://deploy-preview-31552--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/installing-tkn.html

@ppitonak Can you QE review please. Thanks!

cc @Preeticp @