### PR TITLE
Add min replicas note to VPA docs

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-about.adoc
@@ -5,15 +5,15 @@
 [id="nodes-pods-vertical-autoscaler-about_{context}"]
 = About the Vertical Pod Autoscaler Operator
 
-The Vertical Pod Autoscaler Operator (VPA) is implemented as an API resource and a custom resource (CR). The CR determines the actions the Vertical Pod Autoscaler Operator should take with the pods associated with a specific workload object, such as a daemon set, replication controller, and so forth.
+The Vertical Pod Autoscaler Operator (VPA) is implemented as an API resource and a custom resource (CR). The CR determines the actions the Vertical Pod Autoscaler Operator should take with the pods associated with a specific workload object, such as a daemon set, replication controller, and so forth, in a project.
 
-The VPA automatically computes historic and current CPU and memory usage for the containers in those pods and can use this data to automatically re-deploy pods with optimized resource limits and requests to ensure that these pods are operating efficiently at all times. When re-deploying pods, the VPA honors any Pod Disruption Budget set for applications. If you do not want the VPA to automatically re-deploy pods, you can use this resource information to manually update the pods as needed.
+The VPA automatically computes historic and current CPU and memory usage for the containers in those pods and uses this data to determine optimized resource limits and requests to ensure that these pods are operating efficiently at all times. For example, the VPA reduces resources for pods that are requesting more resources than they are using and increases resources for pods that are not requesting enough.
 
-When configured to update pods automatically, the VPA reduces resources for pods that are requesting more resources then they are using and increase resources for pods that are not requesting enough.
+The VPA automatically deletes any pods that are out of alignment with its recommendations one at a time, so that your applications can continue to serve requests with no downtime. The workload objects then re-deploy the pods with the original resource limits and requests. The VPA uses a mutating admission webhook to update the pods with optimized resource limits and requests before the pods are admitted to a node. If you do not want the VPA to delete pods, you can view the VPA resource limits and requests and manually update the pods as needed.
 
-For example, if you have a pod that uses 50% of the CPU but only requests 10%, the VPA determines that the pod is consuming more CPU than requested and restarts the pods with higher resources.
+For example, if you have a pod that uses 50% of the CPU but only requests 10%, the VPA determines that the pod is consuming more CPU than requested and deletes the pod. The workload object, such as replica set, restarts the pods and the VPA updates the new pod with its recommended resources.
 
-For developers, the VPA helps ensure their pods stay up during periods of high demand by scheduling pods onto nodes so that appropriate resources are available for each pod.
+For developers, you can use the VPA to help ensure your pods stay up during periods of high demand by scheduling pods onto nodes that have appropriate resources for each pod.
 
 Administrators can use the VPA to better utilize cluster resources, such as preventing pods from reserving more CPU resources than needed. The VPA monitors the resources that workloads are actually using and adjusts the resource requirements so capacity is available to other workloads. The VPA also maintains the ratios between limits and requests that are specified in initial container configuration.
 

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -9,7 +9,7 @@ To use the Vertical Pod Autoscaler Operator (VPA), you create a VPA custom resou
 
 You use the VPA CR to associate a workload object and specify which mode the VPA operates in:
 
-* The `Auto` and `Recreate` modes automatically apply the VPA CPU and memory recommendations throughout the pod lifetime.
+* The `Auto` and `Recreate` modes automatically apply the VPA CPU and memory recommendations throughout the pod lifetime. The VPA deletes any pods in the project that are out of alignment with its recommendations. When redeployed by the workload object, the VPA updates the new pods with its recommendations.
 * The `Initial` mode automatically applies VPA recommendations only at pod creation.
 * The `Off` mode only provides recommended resource limits and requests, allowing you to manually apply the recommendations. The `off` mode does not update pods.
 
@@ -28,7 +28,7 @@ resources:
     memory: 100Mi
 ----
 
-After creating a VPA that is set to `auto`, the VPA learns the resource usage and terminates and recreates the pod with new resource limits and requests:
+After creating a VPA that is set to `auto`, the VPA learns the resource usage and deletes the pod. When redeployed, the pod uses the new resource limits and requests:
 
 [source,yaml]
 ----
@@ -48,16 +48,14 @@ You can view the VPA recommendations using the following command:
 $ oc get vpa <vpa-name> --output yaml
 ----
 
-The output shows the recommendations for CPU and memory requests, similar to the following:
+After a few minutes, the output shows the recommendations for CPU and memory requests, similar to the following:
 
 .Example output
 [source,yaml]
 ----
 ...
 status:
-
 ...
-
   recommendation:
     containerRecommendations:
     - containerName: frontend
@@ -86,7 +84,6 @@ status:
       upperBound:
         cpu: 476m
         memory: "498558823"
-
 ...
 ----
 
@@ -98,7 +95,12 @@ The VPA uses the `lowerBound` and `upperBound` values to determine if a pod need
 == Automatically applying VPA recommendations
 To use the VPA to automatically update pods, create a VPA CR for a specific workload object with `updateMode` set to `Auto` or `Recreate`.
 
-When the pods are created for the workload object, the VPA constantly monitors the containers to analyze their CPU and memory needs. The VPA deletes and redeploys pods with new container resource limits and requests to meet those needs, honoring any Pod Disruption Budget set for your applications. The recommendations are added to the `status` field of the VPA CR for reference.
+When the pods are created for the workload object, the VPA constantly monitors the containers to analyze their CPU and memory needs. The VPA deletes any pods that do not meet the VPA recommendations for CPU and memory. When redeployed, the pods use the new resource limits and requests based on the VPA recommendations, honoring any pod disruption budget set for your applications. The recommendations are added to the `status` field of the VPA CR for reference.
+
+[NOTE]
+====
+The workload object must specify a minimum of two replicas in order for the VPA to monitor and update the pods. If the workload object specifies one replica, the VPA does not delete the pod to prevent application downtime. You can manually delete the pod to use the recommended resources.
+====
 
 .Example VPA CR for the `Auto` mode
 [source,yaml]
@@ -116,7 +118,7 @@ spec:
     updateMode: "Auto" <3>
 ----
 <1> The type of workload object you want this VPA CR to manage.
-<2> The name of workload object you want this VPA CR to manage.
+<2> The name of the workload object you want this VPA CR to manage.
 <3> Set the mode to `Auto` or `Recreate`:
 * `Auto`. The VPA assigns resource requests on pod creation and updates the existing pods by terminating them when the requested resources differ significantly from the new recommendation.
 * `Recreate`. The VPA assigns resource requests on pod creation and updates the existing pods by terminating them when the requested resources differ significantly from the new recommendation. This mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
@@ -130,7 +132,7 @@ There must be operating pods in the project before the VPA can determine recomme
 == Automatically applying VPA recommendations on pod creation
 To use the VPA to apply the recommended resources only when a pod is first deployed, create a VPA CR for a specific workload object with `updateMode` set to `Initial`.
 
-When the pods are created for that workload object, the VPA analyzes the CPU and memory needs of the containers and assigns the recommended container resource limits and requests. The VPA does not update the pods as it learns new resource recommendations.
+Then, manually delete any pods associated with the workload object that you want to use the VPA recommendations. In the `Initial` mode, the VPA does not delete pods and does not update the pods as it learns new resource recommendations.
 
 .Example VPA CR for the `Initial` mode
 [source,yaml]
@@ -148,7 +150,7 @@ spec:
     updateMode: "Initial" <3>
 ----
 <1> The type of workload object you want this VPA CR to manage.
-<2> The name of workload object you want this VPA CR to manage.
+<2> The name of the workload object you want this VPA CR to manage.
 <3> Set the mode to `Initial`. The VPA assigns resources when pods are created and does not change the resources during the lifetime of the pod.
 
 [NOTE]
@@ -179,7 +181,7 @@ spec:
     updateMode: "Off" <3>
 ----
 <1> The type of workload object you want this VPA CR to manage.
-<2> The name of workload object you want this VPA CR to manage.
+<2> The name of the workload object you want this VPA CR to manage.
 <3> Set the mode to `Off`.
 
 You can view the recommendations using the following command.
@@ -222,7 +224,7 @@ spec:
       mode: "Off"
 ----
 <1> The type of workload object you want this VPA CR to manage.
-<2> The name of workload object you want this VPA CR to manage.
+<2> The name of the workload object you want this VPA CR to manage.
 <3> Set the mode to `Auto`, `Recreate`, or `Off`. The `Recreate` mode should be used rarely, only if you need to ensure that the pods are restarted whenever the resource request changes.
 <4> Specify the containers you want to opt-out and set `mode` to `Off`.
 

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 
 
-The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns. The VPA uses individual custom resources (CR) to update all of the pods associated with a workload object, such as a `Deployment`, `Deployment Config`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`.
+The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns. The VPA uses individual custom resources (CR) to update all of the pods associated with a workload object, such as a `Deployment`, `DeploymentConfig`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`, in a project.
 
 The VPA helps you to understand the optimal CPU and memory usage for your pods and can automatically maintain pod resources through the pod lifecycle.
  


### PR DESCRIPTION
Based on a comment in the [OCPNODE-452 ](https://issues.redhat.com/browse/OCPNODE-452?focusedCommentId=16026816&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-16026816), I added a note about the min replicas. 
Based on [a private slack conversation](https://coreos.slack.com/archives/C01UL5DNCGZ/p1618351950002500), I re-worded the topic to reflect that the VPA does not re-deploy the pods, the controlling object does that. 

Preview:  https://deploy-preview-31563--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html