### PR TITLE
OSDOCS-2095: Added release note for descheduler metrics

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -85,6 +85,15 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-8-nodes"]
 === Nodes
 
+[id="ocp-4-8-nodes-descheduler-metrics"]
+==== Prometheus metrics for the descheduler
+
+You can now enable Prometheus metrics for the descheduler by adding the `openshift.io/cluster-monitoring=true` label to the `openshift-kube-descheduler-operator` namespace where you installed the descheduler.
+
+The following descheduler metrics are available:
+
+* `descheduler_build_info` - Provides build information about the descheduler.
+* `descheduler_pods_evicted` - Provides the number of pods that have been evicted for each combination of strategy, namespace, and result. There must be at least one evicted pod for this metric to appear.
 
 [id="ocp-4-8-logging"]
 === Cluster logging


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2095

Preview: https://deploy-preview-31583--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-nodes-descheduler-metrics