### PR TITLE
BZ: 1666515 Adds Master Events section to 3.11

### DIFF
--- a/install_config/aggregate_logging_sizing.adoc
+++ b/install_config/aggregate_logging_sizing.adoc
@@ -39,7 +39,7 @@ $ oc adm new-project logging --node-selector=""
 ----
 
 In conjunction with node labeling, which is done later, this controls pod
-placement across the logging project.  
+placement across the logging project.
 
 Elasticsearch (ES) should be deployed with a cluster size of at least three for
 resiliency to node failures. This is specified by setting the
@@ -49,10 +49,10 @@ Refer to
 xref:../install_config/aggregate_logging.adoc#aggregate-logging-ansible-variables[Ansible
 Variables] for a full list of parameters.
 
-Kibana requires a hostname that can be resolved from wherever the browser will be used to access it.  
-For example, you might need to add a DNS alias for Kibana to your corporate name service in order to access Kibana 
-from the web browser running on your laptop.  Logging deployment creates a Route to Kibana on one of your "infra" nodes 
-or wherever the OpenShift router is running.  The Kibana hostname alias should point to this machine.  
+Kibana requires a host name that can be resolved from wherever the browser will be used to access it.
+For example, you might need to add a DNS alias for Kibana to your corporate name service in order to access Kibana
+from the web browser running on your laptop.  Logging deployment creates a Route to Kibana on one of your "infra" nodes
+or wherever the OpenShift router is running.  The Kibana hostname alias should point to this machine.
 This hostname is specified as the Ansible `openshift_logging_kibana_hostname` variable.
 
 Installation can take some time depending on whether the images were already
@@ -168,7 +168,7 @@ In Red Hat Enterprise Linux (RHEL) 7 the *systemd-journald.socket* unit creates
 *_/dev/log_* during the boot process, and then passes input to
 *systemd-journald.service*. Every *syslog()* call goes to the journal.
 
-The default rate limiting for *systemd-journald* causes some system logs to be dropped before 
+The default rate limiting for *systemd-journald* causes some system logs to be dropped before
 Fluentd can read them. To prevent this add the following to the *_/etc/systemd/journald.conf_* file:
 
 ----
@@ -205,10 +205,22 @@ Administrative Elasticsearch Operations] section for more in-depth information.
 
 include::install_config/aggregate_logging.adoc[tag=elasticsearch-ha]
 
+[[master-events-aggregated-to-efk-as-logs]]
+=== Master Events are Aggregated to EFK as Logs
+
+The *eventrouter* pod scrapes the events from kubernetes API and and outputs to
+*STDOUT*. The *fluentd* plug-in transforms the log message and sends it to
+Elasticsearch (ES).
+
+Enable `openshift_logging_install_eventrouter` by setting it to `true`. It is
+off by default. *Eventrouter* is deployed to the default namespace. Collected
+information is in operation indices of ES and only cluster administrators have
+visual access.
+
 [[install-config-aggregate-logging-sizing-guidelines-storage]]
 == Storage Considerations
 
-An Elasticsearch index is a collection of shards and their corresponding replicas. 
+An Elasticsearch index is a collection of shards and their corresponding replicas.
 This is how ES implements high availability internally, so there
 is little need to use hardware based mirroring RAID variants. RAID 0 can still
 be used to increase overall disk performance.


### PR DESCRIPTION
BZ https://bugzilla.redhat.com/show_bug.cgi?id=1666515

Preview at https://deploy-preview-31589--osdocs.netlify.app/openshift-enterprise/latest/install_config/aggregate_logging_sizing.html#master-events-aggregated-to-efk-as-logs

I thought it worked best in this section, but if you have any advice I'll gladly change it around. 

@gpei please review :) Thank you 

For 3.11