### PR TITLE
BZ1949528: Add --filter-by-os to oc image mirror in Package Manifest doc

### DIFF
--- a/modules/olm-mirroring-package-manifest-catalog.adoc
+++ b/modules/olm-mirroring-package-manifest-catalog.adoc
@@ -112,8 +112,14 @@ In this example, if you only want to mirror these images, you would then remove 
 ----
 $ oc image mirror \
     [-a ${REG_CREDS}] \
+    --filter-by-os='.*' \
     -f ./manifests-redhat-operators-<random_number>/mapping.txt
 ----
++
+[WARNING]
+====
+If the `--filter-by-os` flag remains unset or set to any value other than `.*`, the command filters out different architectures, which changes the digest of the manifest list, also known as a _multi-arch image_. The incorrect digest causes deployments of those images and Operators on disconnected clusters to fail.
+====
 
 . Create the `ImageContentSourcePolicy` object:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1949528

Preview: [Mirroring a Package Manifest Format catalog image](https://deploy-preview-31591--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-mirroring-package-manifest-catalog_olm-managing-custom-catalogs) (step 2b)