### PR TITLE
RN for Pipelines 1.4 GA

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1312,6 +1312,8 @@ Topics:
   Dir: pipelines
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: OpenShift Pipelines release notes
+    File: op-release-notes
   - Name: Understanding OpenShift Pipelines
     File: understanding-openshift-pipelines
   - Name: Installing OpenShift Pipelines
@@ -1322,8 +1324,6 @@ Topics:
     File: creating-applications-with-cicd-pipelines
   - Name: Working with Pipelines using the Developer perspective
     File: working-with-pipelines-using-the-developer-perspective
-  - Name: OpenShift Pipelines release notes
-    File: op-release-notes
 - Name: GitOps
   Dir: gitops
   Distros: openshift-enterprise,openshift-origin

--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -21,7 +21,6 @@ For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understandin
 [id="getting-support"]
 == Pipelines support
 
-////
 The following compatibility matrix shows the support status and compatible versions for the various {pipelines-title} components:
 
 |===
@@ -41,14 +40,12 @@ The following compatibility matrix shows the support status and compatible versi
 |4.7
 
 |===
-////
-
-If you experience difficulty with a procedure described in this documentation,
-visit the Red Hat Customer Portal to learn more about link:https://access.redhat.com/support/offerings/techpreview/[Red Hat Technology Preview features support scope].
 
 For questions and feedback, you can send an email to the product team at pipelines-interest@redhat.com.
 
 // Modules included, most to least recent
+include::modules/op-release-notes-1-4.adoc[leveloffset=+1]
+
 include::modules/op-release-notes-1-3.adoc[leveloffset=+1]
 
 include::modules/op-release-notes-1-2.adoc[leveloffset=+1]

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -1,0 +1,162 @@
+// Module included in the following assembly:
+//
+// * cicd/pipelines/op-release-notes.adoc
+
+[id="op-release-notes-1-4_{context}"]
+= Release notes for {pipelines-title} General Availability 1.4
+
+
+[id="new-features-1-4_{context}"]
+== New features
+{pipelines-title} General Availability (GA) 1.4 is now available on {product-title} 4.7.
+
+[NOTE]
+====
+In addition to the stable/preview Operator channel for OCP 4.7, the general availability of Pipelines 1.4 comes with the deprecated channels such as `ocp-4.6` and `ocp-4.5`. However, these deprecated channels and support for them will be removed in the following release of {pipelines-title}.
+====
+
+In addition to the fixes and stability improvements, the following sections highlight what is new in {pipelines-title} 1.4.
+
+* The custom tasks have the following enhancements:
+** Pipeline results can now refer to results produced by custom tasks.
+** Custom tasks can now use workspaces, service accounts, and pod templates to build more complex custom tasks.
+
+* The `finally` task has the following enhancements:
+** The `when` expressions are supported in `finally` tasks, which provides efficient guarded execution and improved reusability of tasks.
+** A `finally` task can be configured to consume the results of any task within the same pipeline.
++
+[NOTE]
+====
+Support for `when` expressions and `finally` tasks are unavailable in the {product-title} 4.7 web console.
+====
+
+* Support for multiple secrets of the type `dockercfg` or `dockerconfigjson` is added for authentication at runtime.
+
+* Functionality to support sparse-checkout with the `git-clone` task is added. This enables you to clone only a subset of the repository as your local copy, and helps you to restrict the size of the cloned repositories.
+
+* You can create pipeline runs in a pending state without actually starting them. In clusters that are under heavy load, this allows Operators to have control over the start time of the pipeline runs.
+
+* Ensure that you set the `SYSTEM_NAMESPACE` environment variable manually for the controller; this was previously set by default.
+
+* A non-root user is now added to the build-base image of pipelines so that `git-init` can clone repositories as a non-root user.
+
+* Support to validate dependencies between resolved resources before a pipeline run starts is added. All result variables in the pipeline must be valid, and optional workspaces from a pipeline can only be passed to tasks expecting it for the pipeline to start running.
+
+* The controller and webhook runs as a non-root group, and their superfluous capabilities have been removed to make them more secure.
+
+* You can use the `tkn pr logs` command to see the log streams for retried task runs.
+
+* You can use the `--clustertask` option in the `tkn tr delete` command to delete all the task runs associated with a particular cluster task.
+
+* Support for using Knative service with the `EventListener` resource is added by introducing a new `customResource` field.
+
+* An error message is displayed when an event payload does not use the JSON format.
+
+* The source control interceptors such as GitLab, BitBucket, and GitHub, now use the new `InterceptorRequest` or `InterceptorResponse` type interface.
+
+* A new CEL function `marshalJSON` is implemented so that you can encode a JSON object or an array to a string.
+
+* An HTTP handler for serving the CEL and the source control core interceptors is added. It packages four core interceptors into a single HTTP server that is deployed in the `tekton-pipelines` namespace. The `EventListener` object forwards events over the HTTP server to the interceptor. Each interceptor is available at a different path. For example, the CEL interceptor is available on the `/cel` path.
+
+* The `pipelines-scc` Security Context Constraint (SCC) is used with the default `pipeline` service account for pipelines. This new service account is similar to `anyuid`, but with a minor difference as defined in the YAML for SCC of {product-title} 4.7:
++
+[source, YAML]
+----
+fsGroup:
+  type: MustRunAs
+----
+
+
+[id="deprecated-features-1-4_{context}"]
+== Deprecated features
+
+* The `build-gcs` sub-type in the pipeline resource storage, and the `gcs-fetcher` image, are not supported.
+
+* In the `taskRun` field of cluster tasks, the label `tekton.dev/task` is removed.
+
+* For webhooks, the value `v1beta1` corresponding to the field `admissionReviewVersions` is removed.
+
+* The `creds-init` helper image for building and deploying is removed.
+
+* In the triggers spec and binding, the deprecated field `template.Name` is removed in favor of `template.Ref`.
+
+* For `EventListener` custom resources/objects, the fields `PodTemplate` and `ServiceType` are deprecated in favor of `Resource`.
+
+* The deprecated spec style embedded bindings is removed.
+
+* The `spec` field is removed from the `triggerSpecBinding`.
+
+* The event ID representation is changed from a five-character random string to a UUID.
+
+
+[id="known-issues-1-4_{context}"]
+== Known issues
+
+* In the **Developer** perspective, Pipeline Metrics and Triggers are available only on {product-title} 4.7.6 or later versions.
+
+* On IBM Power Systems, IBM Z, and LinuxONE, the `tkn hub` command is not supported.
+
+* When you run Maven and Jib Maven cluster tasks on an IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters, set the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
+
+* On IBM Power Systems, IBM Z, and LinuxONE, a Jib Maven cluster task fails.
+
+* Triggers throw error resulting from bad handling of the JSON format, if you have the following configuration in the trigger binding:
++
+[source, YAML]
+----
+params:
+  - name: github_json
+    value: $(body)
+----
+To resolve the issue:
+** If you are using triggers v0.11.0 and above, use the `marshalJSON` CEL function, which takes a JSON object or array and returns the JSON encoding of that object or array as a string.
+** If you are using older triggers version, add the following annotation in the trigger template:
++
+[source, YAML]
+----
+annotations:
+  triggers.tekton.dev/old-escape-quotes: "true"
+----
+
+[id="fixed-issues-1-4_{context}"]
+== Fixed issues
+
+* Previously, the `tekton.dev/task` label was removed from the task runs of cluster tasks, and the `tekton.dev/clusterTask` label was introduced. The problems resulting from that change is resolved by fixing the `clustertask describe` and  `delete` commands. In addition, the `lastrun` function for tasks is modified, to fix the issue of the `tekton.dev/task` label being applied to the task runs of both tasks and cluster tasks in older versions of pipelines.
+
+* When doing an interactive `tkn pipeline start pipelinename`, a `PipelineResource` is created interactively. The `tkn p start` command prints the resource status if the resource status is not `nil`.
+
+* Previously, the `tekton.dev/task=name` label was removed from the task runs created from cluster tasks. This fix modifies the `tkn clustertask start` command with the `--last` flag to check for the `tekton.dev/task=name` label in the created task runs.
+
+* When a task uses an inline task specification, the corresponding task run now gets embedded in the pipeline when you run the `tkn pipeline describe` command, and the task name is returned as embedded.
+
+* The `tkn version` command is fixed to display the version of the installed Tekton CLI tool, without a configured `kubeConfiguration namespace` or access to a cluster.
+
+* If an argument is unexpected or more than one arguments are used, the `tkn completion` command gives an error.
+
+* Previously, pipeline runs with the `finally` tasks nested in a pipeline specification would lose those `finally` tasks, when converted to the `v1alpha1` version and restored back to the `v1beta1` version. This error occurring during conversion is fixed to avoid potential data loss. Pipeline runs with the `finally` tasks nested in a pipeline specification is now serialized and stored on the alpha version, only to be deserialized later.
+
+* Previously, there was an error in the pod generation when a service account had the `secrets` field as `{}`. The task runs failed with `CouldntGetTask` because the GET request with an empty secret name returned an error, indicating that the resource name may not be empty. This issue is fixed by avoiding an empty secret name in the `kubeclient` GET request.
+
+* Pipelines with the `v1beta1` API versions can now be requested along with the `v1alpha1` version, without losing the `finally` tasks. Applying the returned `v1alpha1` version will store the resource as `v1beta1`, with the `finally` section restored to its original state.
+
+* Previously, an unset `selfLink` field in the controller caused an error in the Kubernetes v1.20 clusters. As a temporary fix, the `CloudEvent` source field is set to a value that matches the current source URI, without the value of the auto-populated `selfLink` field.
+
+* Previously, a secret name with dots such as `gcr.io` led to a task run creation failure. This happened because of the secret name being used internally as part of a volume mount name. The volume mount name conforms to the RFC1123 DNS label and disallows dots as part of the name. This issue is fixed by replacing the dot with a dash that results in a readable name.
+
+* Context variables are now validated in the `finally` tasks.
+
+* Previously, when the task run reconciler was passed a task run that did not have a previous status update containing the name of the pod it created, the task run reconciler listed the pods associated with the task run. The task run reconciler used the labels of the task run, which were propagated to the pod, to find the pod. Changing these labels while the task run was running, caused the code to not find the existing pod. As a result, duplicate pods were created. This issue is fixed by changing the task run reconciler to only use the `tekton.dev/taskRun` Tekton-controlled label when finding the pod.
+
+* Previously, when a pipeline accepted an optional workspace and passed it to a pipeline task, the pipeline run reconciler stopped with an error if the workspace was not provided, even if a missing workspace binding is a valid state for an optional workspace. This issue is fixed by ensuring that the pipeline run reconciler does not fail to create a task run, even if an optional workspace is not provided.
+
+* The sorted order of step statuses matches the order of step containers.
+
+* Previously, the task run status was set to `unknown` when a pod encountered the `CreateContainerConfigError` reason, which meant that the task and the pipeline ran until the pod timed out. This issue is fixed by setting the task run status to `false`, so that the task is set as failed when the pod encounters the `CreateContainerConfigError` reason.
+
+* Previously, pipeline results were resolved on the first reconciliation, after a pipeline run was completed. This could fail the resolution resulting in the `Succeeded` condition of the pipeline run being overwritten. As a result, the final status information was lost, potentially confusing any services watching the pipeline run conditions. This issue is fixed by moving the resolution of pipeline results to the end of a reconciliation, when the pipeline run is put into a `Succeeded` or `True` condition.
+
+* Execution status variable is now validated. This avoids validating task results while validating context variables to access execution status.
+
+* Previously, a pipeline result that contained an invalid variable would be added to the pipeline run with the literal expression of the variable intact. Therefore, it was difficult to assess whether the results were populated correctly. This issue is fixed by filtering out the pipeline run results that reference failed task runs. Now, a pipeline result that contains an invalid variable will not be emitted by the pipeline run at all.
+
+* The `tkn eventlistener describe` command is fixed to avoid crashing without a template. It also displays the details about trigger references.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `4.7`, `4.8`
- **JIRA issues**:  [RHDEVDOCS-2721 Release Notes, Known Issues, and Bug Fixes for Pipelines GA 1.4](https://issues.redhat.com/browse/RHDEVDOCS-2721) and its sub-tasks.
- **Preview pages**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.4](https://deploy-preview-31605--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-4_op-release-notes)
- **Reviewer**: Pavol Pitonak, Vincent Demeester
- **G-doc draft**: [Release notes for Red Hat OpenShift Pipelines GA 1.4](https://docs.google.com/document/d/1Qb0zDPhxbxWsiA-CTeQ00HKmSCFxjtHMnrl8etlqung/edit?usp=sharing)