### PR TITLE
Jira OSDOCS-2048 Fix kebab image

### DIFF
--- a/modules/attributes-openshift-dedicated.adoc
+++ b/modules/attributes-openshift-dedicated.adoc
@@ -9,3 +9,4 @@
 :cloud-redhat-com: link:https://cloud.redhat.com/openshift[OpenShift Cluster Manager (OCM)]
 :AWS: Amazon Web Services (AWS)
 :GCP: Google Cloud Platform (GCP)
+:kebab: image:kebab.png[title="Options menu"]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSDOCS-2048

Added the kebab image to the common attributes file. The image is now fixed in these two sections:
Direct link:
https://deploy-preview-31643--osdocs.netlify.app/openshift-rosa/latest/monitoring/osd-managing-metrics.html#querying-metrics-for-all-projects-as-an-administrator_managing-metrics
https://deploy-preview-31643--osdocs.netlify.app/openshift-rosa/latest/monitoring/osd-managing-metrics.html#exploring-the-visualized-metrics_managing-metrics