### PR TITLE
BZ1688564 small formatting changes to Configuring Custom Certificates

### DIFF
--- a/install_config/certificate_customization.adoc
+++ b/install_config/certificate_customization.adoc
@@ -376,13 +376,12 @@ You can retrofit custom master and custom router certificates into an existing
 [[configuring-custom-certificates-retrofit-master]]
 === Retrofit Custom Master Certificates into a Cluster
 
-To retrofit custom certificates:
+To retrofit xref:../install_config/certificate_customization.adoc#overview[custom certificates]:
 
 . Edit the Ansible inventory file to set the `openshift_master_overwrite_named_certificates=true`.
 
 . Specify the path to the certificate using the `openshift_master_named_certificates` parameter.
 +
-[source,yaml]
 ----
 openshift_master_overwrite_named_certificates=true
 openshift_master_named_certificates=[{"certfile": "/path/on/host/to/crt-file", "keyfile": "/path/on/host/to/key-file", "names": ["public-master-host.com"], "cafile": "/path/on/host/to/ca-file"}] <1>
@@ -396,9 +395,8 @@ openshift_master_named_certificates=[{"certfile": "/path/on/host/to/crt-file", "
 ansible-playbook /usr/share/ansible/openshift-ansible/playbooks/redeploy-certificates.yml
 ----
 
-. If you use xref:configuring-custom-certificates[named certificates]:
-.. Update the certificate parameters in the  *_master-config.yaml_* file on each
-master node.
+. If you use named certificates:
+.. Update the xref:configuring-custom-certificates[certificate parameters] in the  *_master-config.yaml_* file on each master node.
 .. Restart the {product-title} master service to apply the changes.
 +
 ----


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1688564

Preview: https://deploy-preview-31645--osdocs.netlify.app/openshift-enterprise/latest/install_config/certificate_customization.html#configuring-custom-certificates-retrofit-master

For 3.11

@gpei `openshift_master_overwrite_name_certificates` and `openshift_master_name_certificates` are Ansible inventory variables and not parameters of the master config file. All parameters of the master config file (master-config.yaml) can be found here: https://docs.openshift.com/container-platform/3.11/install_config/master_node_configuration.html#master-configuration-files

Can you tell me which parameters I need to add to 4a? The two listed there are not correct. I've not been able to find this information.  