### PR TITLE
fixed YAMLLoadWarning

### DIFF
--- a/build.py
+++ b/build.py
@@ -164,7 +164,7 @@ def parse_build_config(config):
     """
     config = os.path.expanduser(config)
     with open(config, "r") as f:
-        data = list(yaml.load_all(f))
+        data = list(yaml.load_all(f,Loader=yaml.FullLoader))
 
     for book in data:
         book_name = book['Name']

--- a/build_for_portal.py
+++ b/build_for_portal.py
@@ -157,7 +157,7 @@ def parse_build_config(config):
     """
     config = os.path.expanduser(config)
     with open(config, "r") as f:
-        data = list(yaml.load_all(f))
+        data = list(yaml.load_all(f,Loader=yaml.FullLoader))
 
     for book in data:
         book_name = book['Name']


### PR DESCRIPTION
Based on https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

- Fixes Travis CI build warning https://travis-ci.com/github/openshift/openshift-docs/builds/223249927#L256
  ```
  build.py:167: YAMLLoadWarning: calling yaml.load_all() without Loader=... is deprecated, 
  as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  ```