### PR TITLE
Added errata for 4.7.7

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2264,3 +2264,31 @@ This update adds new capabilities to the cluster API provider BareMetal (CAPBM) 
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-7"]
+=== RHSA-2021:1150 - {product-title} 4.7.7 bug fix and security update
+
+Issued: 2021-04-20
+
+{product-title} release 4.7.7, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1149[RHBA-2021:1149] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1150[RHSA-2021:1150]  advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/5972041[{product-title} 4.7.7 container image list]
+
+[id="ocp-4-7-7-bug-fixes"]
+==== Bug fixes
+
+* Previously, and for unknown reasons, a kubelet could register the wrong IP address for a node. As a consequence, the node would be in a `NotReady` state until it was rebooted. Now, the systemd manager configuration is reloaded with the valid IP address as an environment variable, meaning that nodes no longer enter a `NotReady` state because a kubelet registered the wrong IP address.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1944394[*BZ#1944394*])
+
+* Previously, after link:https://access.redhat.com/security/cve/cve-2021-3344[CVE-2021-3344] was fixed, builds did not automatically mount entitlement keys on the node. The fix minimized the amount of data copied from a pod's `/run/secrets` directory to the build container, causing the `/run/secrets/etc-pki-entitlements` file to be ommitted. As a result, the fix prevented entitled builds from working seamlessly when the entitlement certificates were stored on the OpenShift host or node.
++
+Now, the OpenShift build image and associated pod mount all entitlement-related files from `/run/secrets` into the build container. Entitled builds cannot pick up the certificates stored on the OpenShift host/node. Note that you can ignore warning messages like `level=warning msg="Path \"/run/secrets/etc-pki-entitlement\" from \"/etc/containers/mounts.conf\" doesn't exist, skipping` when running {product-title} builds on {op-system-first} nodes.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1945692[*BZ#1945692*])
+
+[id="ocp-4-7-7-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
I added the errata update for version 4.7.7.

* Applies to 4.7
* Preview: [_RHSA-2021:1150 - OpenShift Container Platform 4.7.7 bug fix and security update._](https://deploy-preview-31655--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-7)
