### PR TITLE
Fixed broken link by correcting typo in advisory name

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2543,7 +2543,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-02-08
 
-{product-title} release 4.6.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0308[RHSA-2021:0308] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0309[RHSA-2021:0309] advisory.
+{product-title} release 4.6.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0308[RHSA-2021:0308] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0309[RHBA-2021:0309] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
This pull request fixes a broken link the 4.6 release notes.

[RHSA-2021:0308 - OpenShift Container Platform 4.6.16 bug fix and security update](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-16)

Preview link: https://deploy-preview-31661--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-16

The advisory for the RPM packages starts with RHBA, not RHSA.

*broken link: https://access.redhat.com/errata/RHSA-2021:0309
*correct link: https://access.redhat.com/errata/RHBA-2021:0309


