### PR TITLE
JIRA2110: OSDOCS-2110 Fix ID metadata for files.

### DIFF
--- a/monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
+++ b/monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc
@@ -1,7 +1,7 @@
-[id="accessing-monitoring-for-user-defined-projects"]
+[id="osd-accessing-monitoring-for-user-defined-projects"]
 = Accessing monitoring for user-defined projects
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: accessing-monitoring-for-user-defined-projects
+:context: osd-accessing-monitoring-for-user-defined-projects
 
 toc::[]
 
@@ -19,4 +19,4 @@ Custom Prometheus instances and the Prometheus Operator installed through Operat
 [id="accessing-user-defined-monitoring-next-steps"]
 == Next steps
 
-* xref:../monitoring/osd-managing-metrics.adoc#managing-metrics[Managing metrics]
+* xref:../monitoring/osd-managing-metrics.adoc#osd-managing-metrics[Managing metrics]

--- a/monitoring/osd-configuring-the-monitoring-stack.adoc
+++ b/monitoring/osd-configuring-the-monitoring-stack.adoc
@@ -1,7 +1,7 @@
-[id="configuring-the-monitoring-stack"]
+[id="osd-configuring-the-monitoring-stack"]
 = Configuring the monitoring stack
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: configuring-the-monitoring-stack
+:context: osd-configuring-the-monitoring-stack
 
 toc::[]
 
@@ -72,4 +72,4 @@ include::modules/osd-monitoring-setting-log-levels-for-monitoring-components.ado
 [id="configuring-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]

--- a/monitoring/osd-managing-alerts.adoc
+++ b/monitoring/osd-managing-alerts.adoc
@@ -1,7 +1,7 @@
-[id="alerts"]
+[id="osd-managing-alerts"]
 = Alerts
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: alerts
+:context: osd-managing-alerts
 
 toc::[]
 
@@ -9,4 +9,4 @@ Alerts for monitoring workloads in user-defined projects are not currently suppo
 
 [id="alerts-next-steps"]
 .Next steps
-* xref:../monitoring/osd-reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]
+* xref:../monitoring/osd-reviewing-monitoring-dashboards.adoc#osd-reviewing-monitoring-dashboards[Reviewing monitoring dashboards]

--- a/monitoring/osd-managing-metrics.adoc
+++ b/monitoring/osd-managing-metrics.adoc
@@ -1,7 +1,7 @@
-[id="managing-metrics"]
+[id="osd-managing-metrics"]
 = Managing metrics
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: managing-metrics
+:context: osd-managing-metrics
 
 toc::[]
 
@@ -15,7 +15,7 @@ include::modules/osd-monitoring-setting-up-metrics-collection-for-user-defined-p
 include::modules/osd-monitoring-deploying-a-sample-service.adoc[leveloffset=+2]
 include::modules/osd-monitoring-specifying-how-a-service-is-monitored.adoc[leveloffset=+2]
 
-* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
 
 // Querying metrics
 include::modules/osd-monitoring-querying-metrics.adoc[leveloffset=+1]
@@ -24,15 +24,15 @@ include::modules/osd-monitoring-querying-metrics-for-user-defined-projects-as-a-
 
 .Additional resources
 
-* See the xref:../monitoring/osd-managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user
+* See the xref:../monitoring/osd-managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_osd-managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user
 
 include::modules/osd-monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2]
 
 .Additional resources
 
-* See the xref:../monitoring/osd-managing-metrics.adoc#querying-metrics_managing-metrics[Querying metrics] section on using the PromQL interface
-* xref:../monitoring/osd-troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[Troubleshooting monitoring issues]
+* See the xref:../monitoring/osd-managing-metrics.adoc#querying-metrics_osd-managing-metrics[Querying metrics] section on using the PromQL interface
+* xref:../monitoring/osd-troubleshooting-monitoring-issues.adoc#osd-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]
 
 [id="managing-metrics-next-steps"]
 .Next steps
-xref:../monitoring/osd-managing-alerts.adoc#alerts[Alerts]
+xref:../monitoring/osd-managing-alerts.adoc#osd-managing-alerts[Alerts]

--- a/monitoring/osd-reviewing-monitoring-dashboards.adoc
+++ b/monitoring/osd-reviewing-monitoring-dashboards.adoc
@@ -1,7 +1,7 @@
-[id="reviewing-monitoring-dashboards"]
+[id="osd-reviewing-monitoring-dashboards"]
 = Reviewing monitoring dashboards
 include::modules/common-attributes.adoc[]
-:context: reviewing-monitoring-dashboards
+:context: osd-reviewing-monitoring-dashboards
 
 toc::[]
 
@@ -27,4 +27,4 @@ include::modules/osd-monitoring-reviewing-monitoring-dashboards-developer.adoc[l
 
 [id="monitoring-dashboards-next-steps"]
 .Next steps
-* xref:../monitoring/osd-troubleshooting-monitoring-issues.adoc#troubleshooting-monitoring-issues[Troubleshooting monitoring issues]
+* xref:../monitoring/osd-troubleshooting-monitoring-issues.adoc#osd-troubleshooting-monitoring-issues[Troubleshooting monitoring issues]

--- a/monitoring/osd-troubleshooting-monitoring-issues.adoc
+++ b/monitoring/osd-troubleshooting-monitoring-issues.adoc
@@ -1,7 +1,7 @@
-[id="troubleshooting-monitoring-issues"]
+[id="osd-troubleshooting-monitoring-issues"]
 = Troubleshooting monitoring issues
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: troubleshooting-monitoring-issues
+:context: osd-troubleshooting-monitoring-issues
 
 toc::[]
 

--- a/monitoring/osd-understanding-the-monitoring-stack.adoc
+++ b/monitoring/osd-understanding-the-monitoring-stack.adoc
@@ -1,7 +1,7 @@
-[id="understanding-the-monitoring-stack"]
+[id="osd-understanding-the-monitoring-stack"]
 = Understanding the monitoring stack
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: understanding-the-monitoring-stack
+:context: osd-understanding-the-monitoring-stack
 
 toc::[]
 
@@ -20,11 +20,11 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 [id="understanding-the-monitoring-stack-additional-resources"]
 == Additional resources
 
-* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
+* xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
 * link:https://docs.openshift.com/container-platform/4.7/monitoring/understanding-the-monitoring-stack.html#default-monitoring-components_understanding-the-monitoring-stack[Default monitoring components]
 * link:https://docs.openshift.com/container-platform/4.7/monitoring/understanding-the-monitoring-stack.html#default-monitoring-targets_understanding-the-monitoring-stack[Default monitoring targets]
 
 [id="understanding-the-monitoring-stack-next-steps"]
 == Next steps
 
-* xref:../monitoring/osd-configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[Configuring the monitoring stack]
+* xref:../monitoring/osd-configuring-the-monitoring-stack.adoc#osd-configuring-the-monitoring-stack[Configuring the monitoring stack]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2110
Fixing metadata for monitoring files.

Direct link to monitoring section:
https://deploy-preview-31670--osdocs.netlify.app/openshift-rosa/latest/monitoring/osd-understanding-the-monitoring-stack.html