### PR TITLE
Update guidance to allow use of markup or backticks in a Title for a block

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -106,7 +106,7 @@ use a gerund form in headings, such as:
 
 Do not use "Overview" as a heading.
 
-Do not use backticks or other markup in headings.
+Do not use backticks or other markup in assembly or module headings.
 
 === Discrete headings
 
@@ -607,6 +607,11 @@ For all of the system blocks including table delimiters, use four characters. Fo
 |=== for tables
 ---- for code blocks
 ....
+
+[NOTE]
+====
+You can use backticks or other markup in the title for a block, such as a code block `.Example` or a table `.Description` title.
+====
 
 === Code blocks, command syntax, and example output
 
@@ -1165,7 +1170,7 @@ When referring to actual instances of API objects, use link:https://en.wikipedia
 
 [NOTE]
 ====
-Do not use backticks or other markup in headings.
+Do not use backticks or other markup in assembly or module headings. You can use backticks or other markup in the title for a block, such as a code block `.Example` or a table `.Description` title.
 ====
 
 Be sure to match the proper object type (or `kind` in Kubernetes terms); for example, do not add an "s" to make it plural. *Only follow this guidance if you are explicitly referring to the API object (for example, when editing an object in the CLI or viewing an object in the web console).*


### PR DESCRIPTION
Updates guidelines to include guidance to allow use of markup or backticks in the title (.Title) for a block, such as a code block or table.

@openshift/team-documentation PTAL. This is based on the conversation/agenda item from the team meeting on 12 April.