### PR TITLE
[enterprise-4.5] Refresh cluster network configuration

### DIFF
--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -50,6 +50,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+include::modules/nw-network-config.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -64,6 +66,7 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 // include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
+include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -49,6 +49,7 @@ include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 // include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
+include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -50,7 +50,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
-
+include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -52,6 +52,7 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 // include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
+include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -49,6 +49,7 @@ include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 // begin network customization
+include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 // end network customization

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -55,7 +55,7 @@ include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 include::modules/nw-install-config-parameters.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
-
+include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
 

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -16,15 +16,10 @@ ifeval::["{context}" == "installing-vsphere-network-customizations"]
 endif::[]
 
 [id="modifying-nwoperator-config-startup_{context}"]
-= Modifying advanced network configuration parameters
+= Specifying advanced network configuration
 
-You can modify the advanced network configuration parameters only before you
-install the cluster. Advanced configuration customization lets you integrate
-your cluster into your existing network environment by specifying an MTU or
-VXLAN port, by allowing customization of
-link:https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/[kube-proxy]
-settings, and by specifying a different `mode` for the `openshiftSDNConfig`
-parameter.
+You can use advanced configuration customization to integrate your cluster into your existing network environment by specifying additional configuration for your cluster network provider.
+You can specify advanced network configuration only before you install the cluster.
 
 [IMPORTANT]
 ====
@@ -44,64 +39,51 @@ endif::ignition-config[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir=<installation_directory>
 ----
-<1> For `<installation_directory>`, specify the name of the directory that
-contains the `install-config.yaml` file for your cluster.
++
+--
+where:
 
-. Create a file that is named `cluster-network-03-config.yml` in the
-`<installation_directory>/manifests/` directory:
+`<installation_directory>`:: Specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
+--
+
+. Create a stub manifest file for the advanced network configuration that is named `cluster-network-03-config.yml` in the `<installation_directory>/manifests/` directory:
 +
 [source,terminal]
 ----
-$ touch <installation_directory>/manifests/cluster-network-03-config.yml <1>
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+EOF
 ----
-<1> For `<installation_directory>`, specify the directory name that contains the
++
+--
+where:
+
+`<installation_directory>`:: Specifies the directory name that contains the
 `manifests/` directory for your cluster.
-+
-After creating the file, several network configuration files are in the
-`manifests/` directory, as shown:
-+
-[source,terminal]
-----
-$ ls <installation_directory>/manifests/cluster-network-*
-----
-+
-.Example output
-[source,terminal]
-----
-cluster-network-01-crd.yml
-cluster-network-02-config.yml
-cluster-network-03-config.yml
-----
+--
 
-. Open the `cluster-network-03-config.yml` file in an editor and enter a CR that
-describes the Operator configuration you want:
+. Open the `cluster-network-03-config.yml` file in an editor and specify the advanced network configuration for your cluster, such as in the following example:
 +
+--
+.Specify a different VXLAN port for the OpenShift SDN network provider
 [source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
 kind: Network
 metadata:
   name: cluster
-spec: <1>
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  serviceNetwork:
-  - 172.30.0.0/16
+spec:
   defaultNetwork:
-    type: OpenShiftSDN
     openshiftSDNConfig:
-      mode: NetworkPolicy
-      mtu: 1450
-      vxlanPort: 4789
+      vxlanPort: 4800
 ----
-<1> The parameters for the `spec` parameter are only an example. Specify your
-configuration for the Cluster Network Operator in the CR.
-+
-The CNO provides default values for the parameters in the CR, so you must
-specify only the parameters that you want to change.
+--
 
 . Save the `cluster-network-03-config.yml` file and quit the text editor.
 . Optional: Back up the `manifests/cluster-network-03-config.yml` file. The

--- a/modules/nw-network-config.adoc
+++ b/modules/nw-network-config.adoc
@@ -1,0 +1,30 @@
+// TODO -  possibly delete this file
+// Or does it add actual value?
+
+// Module included in the following assemblies:
+//
+// * networking/cluster-network-operator.adoc
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+
+[id="nw-network-config_{context}"]
+= Network configuration phases
+
+When specifying a cluster configuration prior to installation, there are several phases in the installation procedures when you can modify the network configuration:
+
+Phase 1:: After entering the `openshift-install create install-config` command. In the `install-config.yaml` file, you can customize the following network-related fields:
++
+* `networking.networkType`
+* `networking.clusterNetwork`
+* `networking.serviceNetwork`
+* `networking.machineNetwork`
++
+For more information on these fields, refer to "Installation configuration parameters".
+
+Phase 2:: After entering the `openshift-install create manifests` command. If you must specify advanced network configuration, during this phase you can define a customized Cluster Network Operator manifest with only the fields you want to modify.
+
+You cannot override the values specified in phase 1 in the `install-config.yaml` file during phase 2. However, you can further customize the cluster network provider during phase 2.

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -33,20 +33,290 @@ endif::[]
 [id="nw-operator-cr_{context}"]
 = Cluster Network Operator configuration
 
-The configuration for the cluster network is specified as part of the Cluster Network Operator (CNO) configuration and stored in a CR object that is named `cluster`. The CR specifies the parameters for the `Network` API in the `operator.openshift.io` API group.
+The configuration for the cluster network is specified as part of the Cluster Network Operator (CNO) configuration and stored in a custom resource (CR) object that is named `cluster`. The CR specifies the fields for the `Network` API in the `operator.openshift.io` API group.
 
-ifdef::post-install-network-configuration[]
+The CNO configuration inherits the following fields during cluster installation from the `Network` API in the `Network.config.openshift.io` API group and these fields cannot be changed:
+
+`clusterNetwork`:: IP address pools from which pod IP addresses are allocated.
+`serviceNetwork`:: IP address pool for services.
+`defaultNetwork.type`:: Cluster network provider, such as OpenShift SDN or OVN-Kubernetes.
+
+// For the post installation assembly, no further content is provided.
+ifdef::post-install-network-configuration,operator[]
 [NOTE]
 ====
-After cluster installation, you cannot modify the configuration for the cluster network provider.
+After cluster installation, you cannot modify the fields listed in the previous section.
 ====
-endif::post-install-network-configuration[]
+endif::[]
 ifndef::post-install-network-configuration[]
-You can specify the cluster network configuration for your {product-title} cluster by setting the parameter values for the `defaultNetwork` parameter in the CNO CR. The following CR displays the default configuration for the CNO and explains both the parameters you can configure and the valid parameter values:
+You can specify the cluster network provider configuration for your cluster by setting the fields for the `defaultNetwork` object in the CNO object named `cluster`.
 
-.Cluster Network Operator CR
+[id="nw-operator-cr-cno-object_{context}"]
+== Cluster Network Operator configuration object
+
+The fields for the Cluster Network Operator (CNO) are described in the following table:
+
+.Cluster Network Operator configuration object
+[cols=".^2,.^1,.^7a",options="header"]
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|The name of the CNO object. This name is always `cluster`.
+
+|`spec.clusterNetwork`
+|`array`
+|A list specifying the blocks of IP addresses from which pod IP addresses are
+allocated and the subnet prefix length assigned to each individual node in the cluster. For example:
+
 [source,yaml]
+----
+spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/19
+    hostPrefix: 23
+  - cidr: 10.128.32.0/19
+    hostPrefix: 23
+----
+
+ifdef::operator[]
+This value is ready-only and inherited from the `Network.config.openshift.io` object named `cluster` during cluster installation.
+endif::operator[]
 ifndef::operator[]
+This value is ready-only and specified in the `install-config.yaml` file.
+endif::operator[]
+
+|`spec.serviceNetwork`
+|`array`
+|A block of IP addresses for services. The OpenShift SDN and OVN-Kubernetes Container Network Interface (CNI) network providers support only a single IP address block for the service network. For example:
+
+[source,yaml]
+----
+spec:
+  serviceNetwork:
+  - 172.30.0.0/14
+----
+
+ifdef::operator[]
+This value is ready-only and inherited from the `Network.config.openshift.io` object named `cluster` during cluster installation.
+endif::operator[]
+ifndef::operator[]
+This value is ready-only and specified in the `install-config.yaml` file.
+endif::operator[]
+
+|`spec.defaultNetwork`
+|`object`
+|Configures the Container Network Interface (CNI) cluster network provider for the cluster network.
+
+|`spec.kubeProxyConfig`
+|`object`
+|
+The fields for this object specify the kube-proxy configuration.
+If you are using the OVN-Kubernetes cluster network provider, the kube-proxy configuration has no effect.
+
+|====
+
+[discrete]
+[id="nw-operator-cr-defaultnetwork_{context}"]
+=== defaultNetwork object configuration
+
+The values for the `defaultNetwork` object are defined in the following table:
+
+.`defaultNetwork` object
+[cols=".^3,.^1,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`type`
+|`string`
+|Either `OpenShiftSDN` or `OVNKubernetes`. The cluster network provider is selected during installation. This value cannot be changed after cluster installation.
+[NOTE]
+====
+ifdef::openshift-origin[]
+{product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
+endif::openshift-origin[]
+ifndef::openshift-origin[]
+{product-title} uses the OpenShift SDN Container Network Interface (CNI) cluster network provider by default.
+endif::openshift-origin[]
+====
+
+|`openshiftSDNConfig`
+|`object`
+|This object is only valid for the OpenShift SDN cluster network provider.
+
+|`ovnKubernetesConfig`
+|`object`
+|This object is only valid for the OVN-Kubernetes cluster network provider.
+
+|====
+
+[discrete]
+[id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
+==== Configuration for the OpenShift SDN CNI cluster network provider
+
+The following table describes the configuration fields for the OpenShift SDN Container Network Interface (CNI) cluster network provider.
+
+.`openshiftSDNConfig` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`mode`
+|`string`
+|
+ifndef::operator[]
+Configures the network isolation mode for OpenShift SDN. The default value is `NetworkPolicy`.
+
+The values `Multitenant` and `Subnet` are available for backwards compatibility with {product-title} 3.x but are not recommended. This value cannot be changed after cluster installation.
+endif::operator[]
+ifdef::operator[]
+The network isolation mode for OpenShift SDN.
+endif::operator[]
+
+|`mtu`
+|`integer`
+|
+ifndef::operator[]
+The maximum transmission unit (MTU) for the VXLAN overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
+
+If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
+
+If your cluster requires different MTU values for different nodes, you must set this value to `50` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1450`.
+
+This value cannot be changed after cluster installation.
+endif::operator[]
+ifdef::operator[]
+The maximum transmission unit (MTU) for the VXLAN overlay network. This value is normally configured automatically.
+endif::operator[]
+
+|`vxlanPort`
+|`integer`
+|
+ifndef::operator[]
+The port to use for all VXLAN packets. The default value is `4789`. This value cannot be changed after cluster installation.
+
+If you are running in a virtualized environment with existing nodes that are part of another VXLAN network, then you might be required to change this. For example, when running an OpenShift SDN overlay on top of VMware NSX-T, you must select an alternate port for the VXLAN, because both SDNs use the same default VXLAN port number.
+
+On Amazon Web Services (AWS), you can select an alternate port for the VXLAN between port `9000` and port `9999`.
+endif::operator[]
+ifdef::operator[]
+The port to use for all VXLAN packets. The default value is `4789`.
+endif::operator[]
+
+|====
+
+ifdef::operator[]
+NOTE: You can only change the configuration for your cluster network provider during cluster installation.
+endif::operator[]
+
+.Example OpenShift SDN configuration
+[source,yaml]
+----
+defaultNetwork:
+  type: OpenShiftSDN
+  openshiftSDNConfig:
+    mode: NetworkPolicy
+    mtu: 1450
+    vxlanPort: 4789
+----
+
+[discrete]
+[id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
+==== Configuration for the OVN-Kubernetes CNI cluster network provider
+
+The following table describes the configuration fields for the OVN-Kubernetes CNI cluster network provider.
+
+.`ovnKubernetesConfig` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`mtu`
+|`integer`
+|
+ifndef::operator[]
+The maximum transmission unit (MTU) for the Geneve (Generic Network Virtualization Encapsulation) overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
+
+If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
+
+If your cluster requires different MTU values for different nodes, you must set this value to `100` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
+
+This value cannot be changed after cluster installation.
+endif::operator[]
+ifdef::operator[]
+The maximum transmission unit (MTU) for the Geneve (Generic Network Virtualization Encapsulation) overlay network. This value is normally configured automatically.
+endif::operator[]
+
+|`genevePort`
+|`integer`
+|
+ifndef::operator[]
+The port to use for all Geneve packets. The default value is `6081`. This value cannot be changed after cluster installation.
+endif::operator[]
+ifdef::operator[]
+The UDP port for the Geneve overlay network.
+endif::operator[]
+
+|====
+
+ifdef::operator[]
+NOTE: You can only change the configuration for your cluster network provider during cluster installation.
+endif::operator[]
+
+.Example OVN-Kubernetes configuration
+[source,yaml]
+----
+defaultNetwork:
+  type: OVNKubernetes
+  ovnKubernetesConfig:
+    mtu: 1400
+    genevePort: 6081
+----
+
+[discrete]
+[id="nw-operator-cr-kubeproxyconfig_{context}"]
+=== kubeProxyConfig object configuration
+
+The values for the `kubeProxyConfig` object are defined in the following table:
+
+.`kubeProxyConfig` object
+[cols=".^3,.^1,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`iptablesSyncPeriod`
+|`string`
+|
+The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go `time` package] documentation.
+
+[NOTE]
+====
+Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
+====
+
+|`proxyArguments.iptables-min-sync-period`
+|`array`
+|
+The minimum duration before refreshing `iptables` rules. This field ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go `time` package]. The default value is:
+
+[source,yaml]
+----
+kubeProxyConfig:
+  proxyArguments:
+    iptables-min-sync-period:
+    - 0s
+----
+|====
+
+ifdef::operator[]
+[id="nw-operator-example-cr_{context}"]
+== Cluster Network Operator example configuration
+
+A complete CNO configuration is specified in the following example:
+
+.Example Cluster Network Operator object
+[source,yaml]
 ----
 apiVersion: operator.openshift.io/v1
 kind: Network
@@ -58,207 +328,7 @@ spec:
     hostPrefix: 23
   serviceNetwork: <1>
   - 172.30.0.0/16
-  defaultNetwork: <2>
-    ...
-  kubeProxyConfig: <3>
-    iptablesSyncPeriod: 30s <4>
-    proxyArguments:
-      iptables-min-sync-period: <5>
-      - 0s
-----
-<1> Specified in the `install-config.yaml` file.
-
-<2> Configures the default Container Network Interface (CNI) network provider for the cluster network.
-
-<3> The parameters for this object specify the `kube-proxy` configuration. If you do not specify the parameter values, the Cluster Network Operator applies the displayed default parameter values. If you are using the OVN-Kubernetes default CNI network provider, the kube-proxy configuration has no effect.
-
-<4> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
-+
-NOTE: Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
-
-<5> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
-endif::operator[]
-
-ifdef::operator[]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  clusterNetwork: <1>
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  serviceNetwork: <2>
-  - 172.30.0.0/16
-  defaultNetwork: <3>
-    ...
-  kubeProxyConfig: <4>
-    iptablesSyncPeriod: 30s <5>
-    proxyArguments:
-      iptables-min-sync-period: <6>
-      - 0s
-----
-<1> A list specifying the blocks of IP addresses from which pod IP addresses are
-allocated and the subnet prefix length assigned to each individual node.
-
-<2> A block of IP addresses for services. The OpenShift SDN Container Network Interface (CNI) network provider supports only a single IP address block for the service network.
-
-<3> Configures the default CNI network provider for the cluster network.
-
-<4> The parameters for this object specify the Kubernetes network proxy (kube-proxy) configuration. If you are using the OVN-Kubernetes default CNI network provider, the kube-proxy configuration has no effect.
-
-<5> The refresh period for `iptables` rules. The default value is `30s`. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package] documentation.
-+
-NOTE: Because of performance improvements introduced in {product-title} 4.3 and greater, adjusting the `iptablesSyncPeriod` parameter is no longer necessary.
-
-<6> The minimum duration before refreshing `iptables` rules. This parameter ensures that the refresh does not happen too frequently. Valid suffixes include `s`, `m`, and `h` and are described in the link:https://golang.org/pkg/time/#ParseDuration[Go time package].
-endif::operator[]
-
-ifdef::openshift-origin[]
-[NOTE]
-====
-{product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
-====
-endif::openshift-origin[]
-
-[id="nw-operator-configuration-parameters-for-openshift-sdn_{context}"]
-== Configuration parameters for the OpenShift SDN default CNI network provider
-
-The following YAML object describes the configuration parameters for
-the OpenShift SDN default Container Network Interface (CNI) network provider.
-
-ifdef::operator[]
-NOTE: You can only change the configuration for your default CNI network provider during cluster installation.
-endif::operator[]
-
-[source,yaml]
-ifndef::operator[]
-----
-defaultNetwork:
-  type: OpenShiftSDN <1>
-  openshiftSDNConfig: <2>
-    mode: NetworkPolicy <3>
-    mtu: 1450 <4>
-    vxlanPort: 4789 <5>
-----
-<1> Specified in the `install-config.yaml` file.
-
-<2> Specify only if you want to override part of the OpenShift SDN
-configuration.
-
-<3> Configures the network isolation mode for OpenShift SDN. The allowed values
-are `Multitenant`, `Subnet`, or `NetworkPolicy`. The default value is
-`NetworkPolicy`.
-
-<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
-+
-If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
-+
-If your cluster requires different MTU values for different nodes, you must set this value to `50` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1450`.
-
-<5> The port to use for all VXLAN packets. The default value is `4789`. If you
-are running in a virtualized environment with existing nodes that are part of
-another VXLAN network, then you might be required to change this. For example,
-when running an OpenShift SDN overlay on top of VMware NSX-T, you must select an
-alternate port for VXLAN, since both SDNs use the same default VXLAN port
-number.
-+
-On Amazon Web Services (AWS), you can select an alternate port for the VXLAN
-between port `9000` and port `9999`.
-endif::operator[]
-
-ifdef::operator[]
-----
-defaultNetwork:
-  type: OpenShiftSDN <1>
-  openshiftSDNConfig: <2>
-    mode: NetworkPolicy <3>
-    mtu: 1450 <4>
-    vxlanPort: 4789 <5>
-----
-<1> The default CNI network provider plug-in that is used.
-
-<2> OpenShift SDN specific configuration parameters.
-
-<3> The network isolation mode for OpenShift SDN.
-
-<4> The maximum transmission unit (MTU) for the VXLAN overlay network. This
-value is normally configured automatically.
-
-<5> The port to use for all VXLAN packets. The default value is `4789`.
-endif::operator[]
-
-ifdef::ovn-preview[]
-[id="nw-operator-configuration-parameters-for-ovn-sdn_{context}"]
-== Configuration parameters for the OVN-Kubernetes default CNI network provider
-
-The following YAML object describes the configuration parameters for the OVN-Kubernetes default CNI network provider.
-
-ifdef::operator[]
-NOTE: You can only change the configuration for your default CNI network provider during cluster installation.
-endif::operator[]
-
-[source,yaml]
-----
-defaultNetwork:
-  type: OVNKubernetes <1>
-  ovnKubernetesConfig: <2>
-    mtu: 1400 <3>
-    genevePort: 6081 <4>
-----
-ifndef::operator[]
-<1> Specified in the `install-config.yaml` file.
-endif::operator[]
-
-ifdef::operator[]
-<1> The default CNI network provider plug-in that is used.
-endif::operator[]
-
-ifndef::operator[]
-<2> Specify only if you want to override part of the OVN-Kubernetes configuration.
-endif::operator[]
-
-ifdef::operator[]
-<2> OVN-Kubernetes specific configuration parameters.
-endif::operator[]
-
-ifndef::operator[]
-<3> The maximum transmission unit (MTU) for the Geneve (Generic Network Virtualization Encapsulation) overlay network. This is detected automatically based on the MTU of the primary network interface. You do not normally need to override the detected MTU.
-+
-If the auto-detected value is not what you expected it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
-+
-If your cluster requires different MTU values for different nodes, you must set this value to `100` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
-endif::operator[]
-
-ifdef::operator[]
-<3> The MTU for the Geneve (Generic Network Virtualization Encapsulation)
-overlay network. This value is normally configured automatically.
-endif::operator[]
-
-<4> The UDP port for the Geneve overlay network.
-
-endif::ovn-preview[]
-
-[id="nw-operator-example-cr_{context}"]
-== Cluster Network Operator example configuration
-
-A complete CR object for the CNO is displayed in the following example:
-
-.Cluster Network Operator example CR
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  clusterNetwork:
-  - cidr: 10.128.0.0/14
-    hostPrefix: 23
-  serviceNetwork:
-  - 172.30.0.0/16
-  defaultNetwork:
+  defaultNetwork: <1>
     type: OpenShiftSDN
     openshiftSDNConfig:
       mode: NetworkPolicy
@@ -270,6 +340,8 @@ spec:
       iptables-min-sync-period:
       - 0s
 ----
+<1> Configured only during cluster installation.
+endif::operator[]
 endif::post-install-network-configuration[]
 
 ifeval::["{context}" == "cluster-network-operator"]

--- a/networking/cluster-network-operator.adoc
+++ b/networking/cluster-network-operator.adoc
@@ -18,3 +18,8 @@ include::modules/nw-cno-logs.adoc[leveloffset=+1]
 include::modules/nw-ovn-technology-preview.adoc[leveloffset=+1]
 
 include::modules/nw-operator-cr.adoc[leveloffset=+1]
+
+[id="cluster-network-operator-additional-resources"]
+== Additional resources
+
+* xref:../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[`Network` API in the `operator.openshift.io` API group]


### PR DESCRIPTION
ovn-k8s is is TP in 4.5, so this needs more rework.

The configuration for this is unwieldy. As additional fields are
added, this becomes increasingly difficult to maintain. And the
installation procedure is needlessly confusing. So this introduces:

- An updated procedure for creating a manifest
- A table-based presentation of the CNO object
- Ancillary materials as might be necessary