### PR TITLE
[enterprise-4.7] Fix for v4-7 to PR31675

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -58,6 +58,14 @@ endif::openshift-origin[]
 ifndef::openshift-origin[]
 [discrete]
 == stable-{product-version} channel
+While the `fast-{product-version}` channel contains releases as soon as their errata are published, releases are added to the `stable-{product-version}` channel after a delay. During this delay, data is collected from Red Hat SRE teams, Red Hat support services, and pre-production and production environments that participate in connected customer program about the stability of the release.
+
+You can use the `stable-{product-version}` channel to upgrade from a previous minor version of {product-title}.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+[discrete]
+== stable-4 channel
+Releases are added to the `stable-4` channel after passing all tests.
 
 While the `fast-{product-version}` channel contains releases as soon as their errata are published, releases are added to the `stable-{product-version}` channel after a delay. During this delay, data is collected from Red Hat SRE teams, Red Hat support services, and pre-production and production environments that participate in connected customer program about the stability of the release. You can use the `stable-{product-version}` channel to upgrade from a previous minor version of {product-title}.
 endif::openshift-origin[]
@@ -110,11 +118,7 @@ Red Hat will eventually provide supported update paths from any supported releas
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-The presence of an update recommendation in the `stable-4`
-channel is a declaration that the update is fully supported while it is in the
-channel. While releases will never be removed from the channel, update recommendations
-that exhibit serious issues will be removed from the channel. Updates initiated
-after the update recommendation has been removed might not be supported.
+The presence of an update recommendation in the `stable-4` channel is a declaration that the update is fully supported while it is in the channel. While releases will never be removed from the channel, update recommendations that exhibit serious issues will be removed from the channel. Updates initiated after the update recommendation has been removed might not be supported.
 endif::openshift-origin[]
 
 ifndef::openshift-origin[]
@@ -124,6 +128,7 @@ ifndef::openshift-origin[]
 The `fast-{product-version}` and `stable-{product-version}` channels present a choice between receiving general availability releases as soon as they are available or allowing Red Hat to control the rollout of those updates. If issues are detected during rollout or at a later time, upgrades to that version might be blocked in both the `fast-{product-version}` and `stable-{product-version}` channels, and a new version might be introduced that becomes the new preferred upgrade target.
 
 Customers can improve this process by configuring pre-production systems on the `fast-{product-version}` channel, configuring production systems on the `stable-{product-version}` channel, and participating in the Red Hat connected customer program. Red Hat uses this program to observe the impact of updates on your specific hardware and software configurations. Future releases might improve or alter the pace at which updates move from the `fast-{product-version}` to the `stable-{product-version}` channel.
+endif::openshift-origin[]
 
 [discrete]
 == Restricted network clusters
@@ -136,4 +141,3 @@ ifndef::openshift-origin[]
 
 Your cluster is still supported if you change from the `stable-{product-version}` channel to the `fast-{product-version}` channel. Although you can switch to the `candidate-{product-version}` channel at any time, some releases in that channel might be unsupported release candidates. You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release. You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel, although if the current release was recently promoted to `fast-{product-version}` there can be a delay of up to a day for the release to be promoted to `stable-{product-version}`. If you change to a channel that does not include your current release, an alert displays and no updates can be recommended, but you can safely change back to your original channel at any point.
 endif::openshift-origin[]
-


### PR DESCRIPTION
New fix for xref: https://github.com/openshift/openshift-docs/pull/31685 and parent PR xref: #31675 - this adds the ifdefs/ifndefs

Preview: https://deploy-preview-31696--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor