### PR TITLE
OSDOCS-2039: SR-IOV hw support

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -35,9 +35,9 @@ spec:
 ----
 <1> The name for the custom resource object.
 
-<2> The namespace where the SR-IOV Operator is installed.
+<2> The namespace where the SR-IOV Network Operator is installed.
 
-<3> The resource name of the SR-IOV device plug-in. You can create multiple SR-IOV network node policies for a resource name.
+<3> The resource name of the SR-IOV network device plug-in. You can create multiple SR-IOV network node policies for a resource name.
 
 <4> The node selector specifies the nodes to configure. Only SR-IOV network devices on the selected nodes are configured. The SR-IOV Container Network Interface (CNI) plug-in and device plug-in are deployed on selected nodes only.
 
@@ -53,7 +53,7 @@ If you specify `rootDevices`, you must also specify a value for `vendor`, `devic
 
 <9> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
 
-<10> Optional: The device hexadecimal code of the SR-IOV network device. The only allowed values are `158b`, `1015`, and `1017`.
+<10> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
 
 <11> Optional: An array of one or more physical function (PF) names for the device.
 


### PR DESCRIPTION
Several devices are supported as of 4.8 and the statement
of support for three specific devices is misleading.

See callout desc #10 at https://deploy-preview-31698--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-networknodepolicy-object_configuring-sriov-device

----
@openshift/team-documentation  PTAL.

Applies to branch enterprise-4.8 and milestone Future Release