### PR TITLE
OSSMDOC-311 values for CPU and memory switched.

### DIFF
--- a/modules/jaeger-config-storage.adoc
+++ b/modules/jaeger-config-storage.adoc
@@ -89,7 +89,7 @@ The following configuration parameters are for a _self-provisioned_ Elasticsearc
 |Number of Elasticsearch nodes. For high availability use at least 3 nodes. Do not use 2 nodes as “split brain” problem can happen.
 |Integer value. For example, Proof of concept = 1,
 Minimum deployment =3
-|1
+|3
 
 |elasticsearch:
   resources:
@@ -98,7 +98,7 @@ Minimum deployment =3
 |Number of central processing units for requests, based on your environment’s configuration.
 |Specified in cores or millicores (for example, 200m, 0.5, 1). For example, Proof of concept = 500m,
 Minimum deployment =1
-|1Gi
+|1
 
 |elasticsearch:
   resources:
@@ -107,7 +107,7 @@ Minimum deployment =1
 |Available memory for requests, based on your environment’s configuration.
 |Specified in bytes (for example, 200Ki, 50Mi, 5Gi). For example, Proof of concept = 1Gi,
 Minimum deployment = 16Gi*
-|500m
+|16Gi
 
 |elasticsearch:
   resources:


### PR DESCRIPTION
The elasticsearch cpu and memory values present in the table somehow got swapped.

The example YAML is correct, but this needed to be fixed in parameter table 7.
QE review - approved by Jkandasa
Peer review - Approved by neal-timpe