### PR TITLE
BZ1861066: added general SSH step and GCP-dspecific step to SSH module

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -56,6 +56,21 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :user-infra:
 endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-default"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:gcp:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :user-infra:
 endif::[]
@@ -148,7 +163,7 @@ following command:
 $ ssh-keygen -t ed25519 -N '' \
     -f <path>/<file_name> <1>
 ----
-<1> Specify the path and file name, such as `~/.ssh/id_rsa`, of the new SSH key.
+<1> Specify the path and file name, such as `~/.ssh/id_rsa`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your ``~/.ssh` directory.
 +
 Running this command generates an SSH key that does not require a password in
 the location that you specified.
@@ -180,6 +195,20 @@ Identity added: /home/<you>/<path>/<file_name> (<computer_name>)
 ----
 <1> Specify the path and file name for your SSH private key, such as `~/.ssh/id_rsa`
 
+ifdef::gcp[]
+. Set the `GOOGLE_APPLICATION_CREDENTIALS` environment variable to the full path to your service account private key file.
++
+[source,terminal]
+----
+$ export GOOGLE_APPLICATION_CREDENTIALS="<your_service_account_file>"
+----
+. Verify that the credentials were applied.
++
+[source,terminal]
+----
+$ gcloud auth list
+----
+endif::gcp[]
 
 .Next steps
 
@@ -199,6 +228,21 @@ ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :!user-infra:
+endif::[]
+ifeval::["{context}" == "installing-gcp-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-default"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-network-customizations"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-private"]
+:!gcp:
+endif::[]
+ifeval::["{context}" == "installing-gcp-vpc"]
+:!gcp:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!user-infra:


### PR DESCRIPTION
I added the requested info, but only added item 2 to GCP-related topics.

https://bugzilla.redhat.com/show_bug.cgi?id=1861066

Link to doc preview: https://deploy-preview-31723--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-default.html#ssh-agent-using_installing-gcp-default

for 4.5+