### PR TITLE
Network fields for install-config edited for brevity

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -294,36 +294,52 @@ endif::openshift-origin[]
 |String
 
 |`networking.clusterNetwork`
-|The IP address pools for pods. The default is `10.128.0.0/14` with a host prefix of `/23`.
+|The IP address blocks for pods. The default is `10.128.0.0/14` with a host prefix of `/23`. If you specify multiple IP address blocks, the blocks must not overlap.
 |Array of objects. For example:
 
 [source,yaml]
 ----
 networking:
-  clusterNetworking:
+  clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
 ----
 
 |`networking.clusterNetwork.cidr`
-|Required if you use `networking.clusterNetwork`. The IP block address pool.
-|IP network. IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the forward slash (`/`) character, followed by a decimal value between `0` and `32` that describes the number of significant bits. For example, `10.0.0.0/16` represents IP addresses `10.0.0.0` through `10.0.255.255`.
+|Required if you use `networking.clusterNetwork`. An IP address block.
+|IP network in Classless Inter-Domain Routing (CIDR) notation. For example, `10.128.0.0/14`.
 
 |`networking.clusterNetwork.hostPrefix`
-|Required if you use `networking.clusterNetwork`. The prefix size to allocate to each node from the CIDR. For example, `24` would allocate `2^8=256` addresses to each node.
-|Integer
+|The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, allowing for 510 (2^(32 - 23) - 2) pod IP addresses.
+|A subnet prefix. The default value is `23`.
 
 |`networking.serviceNetwork`
-|The IP address pools for services. The default is `172.30.0.0/16`.
-|Array of IP networks. IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the forward slash (`/`) character, followed by a decimal value between `0` and `32` that describes the number of significant bits. For example, `10.0.0.0/16` represents IP addresses `10.0.0.0` through `10.0.255.255`.
+|The IP address block for services. The default is `172.30.0.0/16`.
+
+The OpenShift SDN and OVN-Kubernetes Container Network Interface (CNI) network providers support only a single IP address block for the service network.
+|An IP address block in CIDR format. For example, `172.30.0.0/16`.
+
+[source,yaml]
+----
+networking:
+  serviceNetwork:
+   - 172.30.0.0/16
+----
 
 |`networking.machineNetwork`
-|The IP address pools for machines.
+|The IP address blocks for machines.
 |Array of objects
 
+[source,yaml]
+----
+networking:
+  machineNetwork:
+  - cidr: 10.0.0.0/16
+----
+
 |`networking.machineNetwork.cidr`
-|Required if you use `networking.machineNetwork`. The IP block address pool. The default is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default is `192.168.126.0/24`.
-|IP network. IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the forward slash (`/`) character, followed by a decimal value between `0` and `32` that describes the number of significant bits. For example, `10.0.0.0/16` represents IP addresses `10.0.0.0` through `10.0.255.255`.
+|Required if you use `networking.machineNetwork`. An IP address block. The default is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default is `192.168.126.0/24`.
+|IP network in Classless Inter-Domain Routing (CIDR) notation. For example, `10.0.0.0/16`.
 
 |`publish`
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.


### PR DESCRIPTION
Somehow, this seems too verbose. If someone isn't sure what CIDR is, a successful cluster install is probably not on the horizon anyway.

Necessary for additional IPv6 content necessary for bare metal only.

And need to state that the service network only supports a single IP address block.