### PR TITLE
CNV-11417: RHV and VM import deprecated in 4.8

### DIFF
--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can import a single Red Hat Virtualization (RHV) virtual machine into {VirtProductName} by using the VM Import wizard or the CLI.
 
+:FeatureName: Importing a RHV VM
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
 include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
 include::modules/virt-importing-vm-wizard.adoc[leveloffset=+1]

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can import a VMware vSphere 6.5, 6.7, or 7.0 VM or VM template into {VirtProductName} by using the VM Import wizard.
 
+:FeatureName: Importing a VMware VM
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
 
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/CNV-11417

4.5+

Previews:

https://deploy-preview-31736--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html

https://deploy-preview-31736--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html

No QE required.