### PR TITLE
BZ1941998: Update ocp3 image versions (MTC 1.4.3)

### DIFF
--- a/migration/migrating_3_4/deploying-cam-3-4.adoc
+++ b/migration/migrating_3_4/deploying-cam-3-4.adoc
@@ -17,8 +17,6 @@ You can configure the {mtc-full} Operator to install the {mtc-short} link:https:
 
 In a restricted environment, you can install the {mtc-full} Operator from a local mirror registry.
 
-After you have installed the {mtc-full} Operator on your clusters, you can launch the {mtc-short} console.
-
 [id='installing-cam-operator_{context}']
 == Installing the {mtc-full} Operator
 
@@ -26,7 +24,7 @@ You can install the {mtc-full} Operator with the Operator Lifecycle Manager (OLM
 
 [IMPORTANT]
 ====
-You must ensure that the same Operator version is installed on the source and target clusters.
+You must install the same Operator version on all clusters.
 ====
 
 include::modules/migration-installing-cam-operator-ocp-4.adoc[leveloffset=+2]

--- a/modules/migration-about-migration-hooks.adoc
+++ b/modules/migration-about-migration-hooks.adoc
@@ -23,7 +23,7 @@ You can create a hook by using an Ansible playbook or a custom hook container.
 
 The Ansible playbook is mounted on a hook container as a config map. The hook container runs as a job, using the cluster, service account, and namespace specified in the `MigPlan` custom resource (CR). The job continues to run until it reaches the the default limit of 6 retries or a successful completion. This continues even if the initial pod is evicted or killed.
 
-The default Ansible runtime image is `registry.redhat.io/rhmtc/openshift-migration-hook-runner-rhel7:latest`. This image is based on the Ansible Runner image and includes `python-openshift` for Ansible Kubernetes resources and an updated `oc` binary.
+The default Ansible runtime image is `registry.redhat.io/rhmtc/openshift-migration-hook-runner-rhel7:{mtc-version}`. This image is based on the Ansible Runner image and includes `python-openshift` for Ansible Kubernetes resources and an updated `oc` binary.
 
 Optional: You can use a custom Ansible runtime image containing additional Ansible modules or tools instead of the default image.
 

--- a/modules/migration-installing-cam-operator-ocp-3.adoc
+++ b/modules/migration-installing-cam-operator-ocp-3.adoc
@@ -16,7 +16,7 @@ endif::[]
 
 [IMPORTANT]
 ====
-You must install the same {mtc-short} version on the {product-title} 3 and 4 clusters. The {mtc-full} Operator on the {product-title} 4 cluster is updated automatically by Operator Lifecycle Manager.
+You must install the same {mtc-short} version on all clusters.
 
 To ensure that you have the latest version on the {product-title} 3 cluster, download the `operator.yml` and `controller-3.yml` files when you are ready to create and run the migration plan.
 ====
@@ -26,7 +26,7 @@ To ensure that you have the latest version on the {product-title} 3 cluster, dow
 * Access to `registry.redhat.io`
 * Podman installed
 ifdef::migrating-3-4[]
-* {product-title} 3 cluster configured to pull images from `registry.redhat.io`
+* Source cluster configured to pull images from `registry.redhat.io`
 +
 To pull images, you must link:https://access.redhat.com/solutions/3772061[create an image stream secret] and copy it to each node in your cluster.
 endif::[]
@@ -54,14 +54,16 @@ $ sudo podman login registry.redhat.io
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version-z}):/operator.yml ./
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version}):/operator.yml ./
 ----
 
 . Download the `controller-3.yml` file:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version-z}):/controller-3.yml ./
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version}):/controller-3.yml ./
 ----
 
 ifdef::disconnected-3-4[]
@@ -80,7 +82,7 @@ The output shows the mapping between the `registry.redhat.io` image and your mir
 registry.redhat.io/rhmtc/openshift-migration-rhel7-operator@sha256:468a6126f73b1ee12085ca53a312d1f96ef5a2ca03442bcb63724af5e2614e8a=<registry.apps.example.com>/rhmtc/openshift-migration-rhel7-operator
 ----
 
-. Update the `image` and `REGISTRY` values in the `operator.yml` file:
+. Update the `image` and `REGISTRY` values in the Operator configuration file:
 +
 [source,yaml]
 ----

--- a/modules/migration-upgrading-migration-tool-3.adoc
+++ b/modules/migration-upgrading-migration-tool-3.adoc
@@ -25,8 +25,10 @@ $ sudo podman login registry.redhat.io
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version-z}):/operator.yml ./
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version}):/operator.yml ./ <1>
 ----
+<1> You can specify a z-stream release, if necessary.
 
 . Replace the {mtc-full} Operator:
 +
@@ -56,7 +58,7 @@ $ oc scale -n openshift-migration --replicas=0 deployment/migration-operator
 $ oc scale -n openshift-migration --replicas=1 deployment/migration-operator
 ----
 
-. Verify that the `migration-operator` was upgraded to {mtc-version-z}:
+. Verify that the `migration-operator` was upgraded:
 +
 [source,terminal]
 ----
@@ -67,7 +69,8 @@ $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep ima
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version-z}):/controller-3.yml ./
+$ sudo podman cp $(sudo podman create \
+  registry.redhat.io/rhmtc/openshift-migration-rhel7-operator:v{mtc-version}):/controller-3.yml ./
 ----
 
 . Create the `migration-controller` object:
@@ -91,7 +94,7 @@ $ oc adm policy add-scc-to-user anyuid -z migration-controller -n openshift-migr
 $ oc get pods -n openshift-migration
 ----
 
-. If you have already added your {product-title} 3 source cluster to the {mtc-short} console, you must update the service account token because the upgrade deletes and restores the `openshift-migration` namespace:
+. If you have already added your {product-title} 3 source cluster to the {mtc-short} web console, you must update the service account token because the upgrade process deletes and restores the `openshift-migration` namespace:
 
 .. Obtain the service account token:
 +

--- a/modules/migration-using-must-gather.adoc
+++ b/modules/migration-using-must-gather.adoc
@@ -18,7 +18,7 @@ The `openshift-migration-must-gather-rhel8` image for {mtc-short} collects migra
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=openshift-migration-must-gather-rhel8:v{mtc-version-z}
+$ oc adm must-gather --image=openshift-migration-must-gather-rhel8:v{mtc-version}
 ----
 
 . Remove authentication keys and other sensitive information.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1951998

4.5+

Update MTC images for ocp3 to point to y-stream instead of z-stream. 
Applies to operator, controller-3, must-gather, and hook-runner.

Change previews:

https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/migrating-application-workloads-3-4.html#migration-about-migration-hooks_migrating-3-4

https://deploy-preview-31738--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/deploying-cam-3-4.html#migration-installing-cam-operator-ocp-3_migrating-3-4 (steps 2 and 3)

https://deploy-preview-31738--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/upgrading-migration-tool-3-4.html#migration-upgrading-migration-tool-3_migrating-3-4 (steps 2 and 8)

https://docs.openshift.com/container-platform/4.7/migration/migrating_3_4/troubleshooting-3-4.html#migration-using-must-gather_migrating-3-4

