### PR TITLE
RHDEVDOCS-2937 Tracker for curator Issue #31475 in file logging/confi…

### DIFF
--- a/logging/config/cluster-logging-curator.adoc
+++ b/logging/config/cluster-logging-curator.adoc
@@ -5,14 +5,20 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} {product-version}, log curation is performed by Elasticsearch Curator, based on a xref:../../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[retention policy] that you define.
+You can configure log retention time. That is, you can specify how long the default Elasticsearch log store keeps indices by configuring a separate retention policy for each of the three log sources: infrastructure logs, application logs, and audit logs. For instructions, see xref:../../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[Configuring log retention time].
 
-The Elasticsearch Curator tool removes Elasticsearch indices that use the data model prior to {product-title} 4.5. You can modify the Curator index retention policy for your old data.
+[NOTE]
+====
+Configuring log retention time is recommended method for curating log data: It works with both the current data model and the previous data model from {product-title} 4.4 and earlier.
+====
 
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
+Optionally, to remove Elasticsearch indices that use the data model from {product-title} 4.4 and earlier, you can also use the Elasticsearch Curator. The following sections explain how to use the Elasticsearch Curator.
+
+[IMPORTANT]
+====
+The Elasticsearch Curator is deprecated in {product-title} 4.7 (OpenShift Logging 5.0) and will be removed in OpenShift Logging 5.1.
+====
+
 
 include::modules/cluster-logging-curator-schedule.adoc[leveloffset=+1]
 

--- a/modules/cluster-logging-about-curator.adoc
+++ b/modules/cluster-logging-about-curator.adoc
@@ -1,8 +1,0 @@
-// Module included in the following assemblies:
-//
-// * logging/cluster-logging.adoc
-
-[id="cluster-logging-about-curator_{context}"]
-= About logging curation
-
-In {product-title} {product-version}, log curation is performed by Elasticsearch based on a xref:../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[retention policy] that you define. The Elasticsearch Curator tool removes Elasticsearch indices that use the data model prior to {product-title} 4.5. 

--- a/modules/cluster-logging-curator-delete-index.adoc
+++ b/modules/cluster-logging-curator-delete-index.adoc
@@ -9,8 +9,13 @@
 This file can be expanded when more functions are supported. Only delete_indices currently. When more functions are added, we can use include::modules/cluster-logging-curator-actions.adoc[leveloffset=+1] for a strict delete index files topic, if needed
 ////
 
-You can configure Curator to delete Elasticsearch data that uses the data model prior to {product-title} 4.5. You can configure per-project and global settings. Global settings apply to any project not specified. Per-project settings override global settings.
+You can configure Elasticsearch Curator to delete Elasticsearch data that uses the data model prior to {product-title} version 4.5. You can configure per-project and global settings. Global settings apply to any project not specified. Per-project settings override global settings.
 // Preserve the hard-coded "4.5" in the preceding paragraph. Do not replace it with a product version attribute.
+
+[IMPORTANT]
+====
+The Elasticsearch Curator is deprecated in {product-title} 4.7 (OpenShift Logging 5.0) and will be removed in OpenShift Logging 5.1.
+====
 
 .Prerequisites
 
@@ -65,15 +70,13 @@ The available parameters are:
 |Description
 
 |`.defaults`
-|Use `.defaults` as the `project_name` to set the defaults for projects that are
-not specified.
+|Use `.defaults` as the `project_name` to set the defaults for projects that are not specified.
 
 |`.regex`
 |The list of regular expressions that match project names.
 
 |`pattern`
-|The valid and properly escaped regular expression pattern enclosed by single
-quotation marks.
+|The valid and properly escaped regular expression pattern enclosed by single quotation marks.
 
 |===
 
@@ -118,12 +121,5 @@ Use:
 
 [IMPORTANT]
 ====
-When you use `months` as the `$UNIT` for an operation, Curator starts counting at
-the first day of the current month, not the current day of the current month.
-For example, if today is April 15, and you want to delete indices that are 2 months
-older than today (delete: months: 2), Curator does not delete indices that are dated
-older than February 15; it deletes indices older than February 1. That is, it
-goes back to the first day of the current month, then goes back two whole months
-from that date. If you want to be exact with Curator, it is best to use days
-(for example, `delete: days: 30`).
+When you use `months` as the `$UNIT` for an operation, Curator starts counting at the first day of the current month, not the current day of the current month. For example, if today is April 15, and you want to delete indices that are 2 months older than today (delete: months: 2), Curator does not delete indices that are dated older than February 15; it deletes indices older than February 1. That is, it goes back to the first day of the current month, then goes back two whole months from that date. If you want to be exact with Curator, it is best to use days (for example, `delete: days: 30`).
 ====

--- a/modules/cluster-logging-curator-schedule.adoc
+++ b/modules/cluster-logging-curator-schedule.adoc
@@ -5,8 +5,12 @@
 [id="cluster-logging-curator-schedule_{context}"]
 = Configuring the Curator schedule
 
-You can specify the schedule for Curator using the `Cluster Logging` custom resource
-created by the OpenShift Logging installation.
+You can specify the schedule for Curator using the `Cluster Logging` custom resource created by the OpenShift Logging installation.
+
+[IMPORTANT]
+====
+The Elasticsearch Curator is deprecated in {product-title} 4.7 (OpenShift Logging 5.0) and will be removed in OpenShift Logging 5.1.
+====
 
 .Prerequisites
 


### PR DESCRIPTION
…g/cluster-logging-curator.adoc

- Aligned team: Dev Tools
- For versions 4.5, 4.6, and 4.7 (not 4.8)
- https://issues.redhat.com/browse/RHDEVDOCS-2937, tracker for https://github.com/openshift/openshift-docs/issues/31475
- Direct link to doc preview: https://deploy-preview-31739--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-curator.html
- SME review: Waiting for review (https://coreos.slack.com/archives/GGUR75P60/p1619008519165000)
- QE review: Waiting for review by @kabirbhartiRH 
- Peer review: Waiting for review (https://coreos.slack.com/archives/G01Q6LPP04S/p1619008861157700)
- Merge: waiting for approvals