### PR TITLE
[enterprise-4.6] GH#31545 Additional AWS permissions

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -138,6 +138,11 @@ If you use an existing VPC, your account does not require these permissions for 
 * `iam:RemoveRoleFromInstanceProfile`
 * `iam:SimulatePrincipalPolicy`
 * `iam:TagRole`
+
+[NOTE]
+=====
+If you have not created an elastic load balancer (ELB) in your AWS account, the IAM user also requires the `iam:CreateServiceLinkedRole` permission.
+=====
 ====
 
 .Required Route 53 permissions for installation


### PR DESCRIPTION
Manual cherrypick of #31629

Removed permission from that PR only applicable to OCP 4.7+