### PR TITLE
BZ1884750 - Add instructions for adding more compute machines in vSphere

### DIFF
--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -11,6 +11,13 @@ You can add more compute machines to your {product-title} cluster on VMware vSph
 
 * You xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[installed a cluster on vSphere].
 
+* You have installation media and {op-system-first} images that you used to create your cluster. If you do not have these files, you must obtain them by following the instructions in the xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[installation procedure].
+
+[IMPORTANT]
+====
+If you do not have access to the {op-system-first} images that were used to create your cluster, you can add more compute machines to your {product-title} cluster with newer versions of {op-system-first} images. For instructions, see link:https://access.redhat.com/solutions/5514051[Adding new nodes to UPI cluster fails after upgrading to OpenShift 4.6+].
+====
+
 include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]


### PR DESCRIPTION
In BZ#1884750[0], it was requested that the OCP documents be updated to be more clear about adding additional compute machines to bare metal clusters. A previous PR[1] provided the additional information requested. This is a follow-up PR on a request to also add the information to the vSphere docs.

[0] https://bugzilla.redhat.com/show_bug.cgi?id=1884750
[1] https://github.com/openshift/openshift-docs/pull/29506


**PREVIEW LINK:** https://deploy-preview-31756--osdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-vsphere-compute-user-infra.html#prerequisites