### PR TITLE
CNV-11391 Removed wording that says SR-IOV network does not support live migr…

### DIFF
--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -41,8 +41,7 @@ upgrade.
 [IMPORTANT]
 ====
 If you have virtual machines running that cannot be live migrated, they might block an {product-title} cluster upgrade.
-This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces.
+This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces that have the `sriovLiveMigration` feature gate disabled.
 
-As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster upgrade. Remove the `evictionStrategy: LiveMigrate` field and
-set the `runStrategy` field to `Always`.
+As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster upgrade. Remove the `evictionStrategy: LiveMigrate` field and set the `runStrategy` field to `Always`.
 ====

--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -102,7 +102,7 @@ ifdef::virt-features-for-storage[]
 You cannot live migrate virtual machines that use:
 
 * A storage class with ReadWriteOnce (RWO) access mode
-* Passthrough features such as SR-IOV and GPU
+* Passthrough features such as GPUs or SR-IOV network interfaces that have the `sriovLiveMigration` feature gate disabled 
 
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====

--- a/modules/virt-understanding-live-migration.adoc
+++ b/modules/virt-understanding-live-migration.adoc
@@ -15,7 +15,6 @@ Virtual machines must have a persistent volume claim (PVC) with a shared
 ReadWriteMany (RWX) access mode to be live migrated.
 
 [NOTE]
-==== 
-Live migration is not supported for virtual machines that are
-attached to an SR-IOV network interface.
+====
+Live migration is supported for virtual machines that are attached to an SR-IOV network interface only if the `sriovLiveMigration` feature gate is enabled in the HyperConverged Cluster custom resource (CR). When the `spec.featureGates.sriovLiveMigration` field is set to `true`, the `virt-launcher` pod runs with the `SYS_RESOURCE` capability. This might degrade its security.
 ====

--- a/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
+++ b/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
@@ -10,7 +10,7 @@ This process is similar but not identical to configuring an SR-IOV device for {p
 
 [NOTE]
 ====
-Live migration is not supported for virtual machines that are attached to an SR-IOV network interface.
+Live migration is supported for virtual machines that are attached to an SR-IOV network interface only if the `sriovLiveMigration` feature gate is enabled in the HyperConverged Cluster custom resource (CR). When the `spec.featureGates.sriovLiveMigration` field is set to `true`, the `virt-launcher` pod runs with the `SYS_RESOURCE` capability. This might degrade its security.
 ====
 
 == Prerequisites
@@ -24,4 +24,3 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../../virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc#virt-defining-an-sriov-network[Configuring an SR-IOV network attachment for virtual machines]
-


### PR DESCRIPTION
…ation.

Addresses [CNV-11391](https://issues.redhat.com/browse/CNV-11391)

OpenShift Virtualization 4.8 will support live migration on SR-IOV network connections if the `sriovLiveMigration` feature gate is enabled in the HCO CR. Changed existing note text, which said SR-IOV prevents live migration, in the following modules:

[How OpenShift Virtualization upgrades affect your cluster](https://deploy-preview-31757--osdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#how-openshift-virtualization-upgrades-affect-your-cluster)

[Storage feature matrix](https://deploy-preview-31757--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-features-for-storage.html#virt-features-for-storage-matrix_virt-features-for-storage)

[Understanding live migration](https://deploy-preview-31757--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration.html#virt-understanding-live-migration_virt-live-migration)

[Configuring SR-IOV device for VMs](https://deploy-preview-31757--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.html)

