### PR TITLE
[Bug 1952167] Add `initrd=` karg to iPXE instructions; fix live kernel/initrd filenames

### DIFF
--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -106,18 +106,19 @@ This configuration does not enable serial console access on machines with a grap
 ** For iPXE:
 +
 ----
-kernel  http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
-initrd http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img
+kernel http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> initrd=main coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
+initrd --name main http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img <3>
 boot
 ----
 <1> Specify locations of the {op-system} files that you uploaded to your
 HTTP server. The `kernel` parameter value is the location of the `kernel` file,
-the `initrd` parameter value is the location of the `initramfs` file.
-The `coreos.live.rootfs_url` parameter value is the location of the `rootfs` file,
+the `initrd=main` argument is needed for booting on UEFI systems,
+the `coreos.live.rootfs_url` parameter value is the location of the `rootfs` file,
 and the `coreos.inst.ignition_url` parameter value is the
 location of the bootstrap Ignition config file.
 <2> If you use multiple NICs, specify a single interface in the `ip` option.
 For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
+<3> Specify the location of the `initramfs` file that you uploaded to your HTTP server.
 +
 [NOTE]
 ====

--- a/modules/machine-user-infra-machines-pxe.adoc
+++ b/modules/machine-user-infra-machines-pxe.adoc
@@ -26,8 +26,8 @@ DEFAULT pxeboot
 TIMEOUT 20
 PROMPT 0
 LABEL pxeboot
-    KERNEL http://<HTTP_server>/rhcos-<version>-installer-live-kernel-<architecture> <1>
-    APPEND initrd=http://<HTTP_server>/rhcos-<version>-installer-live-initramfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/worker.ign coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-installer-live-rootfs.<architecture>.img <2>
+    KERNEL http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> <1>
+    APPEND initrd=http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/worker.ign coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img <2>
 ----
 <1> Specify the location of the live `kernel` file that you uploaded to your HTTP server.
 <2> Specify locations of the {op-system} files that you uploaded to your HTTP server. The `initrd` parameter value is the location of the live `initramfs` file, the `coreos.inst.ignition_url` parameter value is the location of the worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is the location of the live `rootfs` file. The `coreos.inst.ignition_url` and `coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
@@ -41,10 +41,10 @@ This configuration does not enable serial console access on machines with a grap
 ** For iPXE:
 +
 ----
-kernel http://<HTTP_server>/rhcos-<version>-installer-kernel-<architecture> coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/worker.ign coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-installer-live-rootfs.<architecture>.img <1>
-initrd=http://<HTTP_server>/rhcos-<version>-installer-live-initramfs.<architecture>.img <2>
+kernel http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> initrd=main coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/worker.ign coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img <1>
+initrd --name main http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img <2>
 ----
-<1> Specify locations of the {op-system} files that you uploaded to your HTTP server. The `kernel` parameter value is the location of the `kernel` file, the `coreos.inst.ignition_url` parameter value is the location of the worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is the location of the live `rootfs` file. The `coreos.inst.ignition_url` and `coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
+<1> Specify locations of the {op-system} files that you uploaded to your HTTP server. The `kernel` parameter value is the location of the `kernel` file, the `initrd=main` argument is needed for booting on UEFI systems, the `coreos.inst.ignition_url` parameter value is the location of the worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is the location of the live `rootfs` file. The `coreos.inst.ignition_url` and `coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
 <2> Specify the location of the `initramfs` file that you uploaded to your HTTP server.
 +
 +


### PR DESCRIPTION
With iPXE on UEFI, the `initrd` _directive_ specifies where to fetch the initrd image, and the `initrd` _kernel argument_ tells the kernel where to find that image after iPXE has written it into the UEFI virtual filesystem.  The `initrd=` argument isn't needed on BIOS but is harmless there.

Also fix some mangled filenames.  `-installer-` is a relic of the old pre-4.6 images.

Needs backport to 4.6, 4.7, and 4.8.

Fixes: https://github.com/openshift/openshift-docs/issues/30974
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1952167
See also: https://ipxe.org/appnote/debian_preseed