### PR TITLE
New deprecated-feature module and added to Metering assemblies

### DIFF
--- a/metering/configuring_metering/metering-about-configuring.adoc
+++ b/metering/configuring_metering/metering-about-configuring.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 The `MeteringConfig` custom resource specifies all the configuration details for your metering installation. When you first install the metering stack, a default `MeteringConfig` custom resource is generated. Use the examples in the documentation to modify this default file. Keep in mind the following key points:
 
 * At a minimum, you need to xref:../../metering/configuring_metering/metering-configure-persistent-storage.adoc#metering-configure-persistent-storage[configure persistent storage] and xref:../../metering/configuring_metering/metering-configure-hive-metastore.adoc#metering-configure-hive-metastore[configure the Hive metastore].

--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 == Resource requests and limits
 You can adjust the CPU, memory, or storage resource requests and/or limits for pods and volumes. The `default-resource-limits.yaml` below provides an example of setting resource request and limits for each component.
 

--- a/metering/configuring_metering/metering-configure-aws-billing-correlation.adoc
+++ b/metering/configuring_metering/metering-configure-aws-billing-correlation.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Metering can correlate cluster usage information with https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/billing-reports-costusage.html[AWS detailed billing information], attaching a dollar amount to resource usage. For clusters running in EC2, you can enable this by modifying the example `aws-billing.yaml` file below.
 
 [source,yaml]

--- a/metering/configuring_metering/metering-configure-hive-metastore.adoc
+++ b/metering/configuring_metering/metering-configure-hive-metastore.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Hive metastore is responsible for storing all the metadata about the database tables created in Presto and Hive. By default, the metastore stores this information in a local embedded Derby database in a persistent volume attached to the pod.
 
 Generally, the default configuration of the Hive metastore works for small clusters, but users may wish to improve performance or move storage requirements out of cluster by using a dedicated SQL database for storing the Hive metastore data.

--- a/metering/configuring_metering/metering-configure-persistent-storage.adoc
+++ b/metering/configuring_metering/metering-configure-persistent-storage.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Metering requires persistent storage to persist data collected by the Metering Operator and to store the results of reports. A number of different storage providers and storage formats are supported. Select your storage provider and modify the example configuration files to configure persistent storage for your metering installation.
 
 include::modules/metering-store-data-in-s3.adoc[leveloffset=+1]

--- a/metering/configuring_metering/metering-configure-reporting-operator.adoc
+++ b/metering/configuring_metering/metering-configure-reporting-operator.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 The Reporting Operator is responsible for collecting data from Prometheus, storing the metrics in Presto, running report queries against Presto, and exposing their results via an HTTP API. Configuring the Reporting Operator is primarily done in your `MeteringConfig` custom resource.
 
 include::modules/metering-prometheus-connection.adoc[leveloffset=+1]

--- a/metering/metering-about-metering.adoc
+++ b/metering/metering-about-metering.adoc
@@ -5,4 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 include::modules/metering-overview.adoc[leveloffset=+1]

--- a/metering/metering-installing-metering.adoc
+++ b/metering/metering-installing-metering.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Review the following sections before installing metering into your cluster.
 
 To get started installing metering, first install the Metering Operator from OperatorHub. Next, configure your instance of metering by creating a `MeteringConfig` custom resource (CR). Installing the Metering Operator creates a default `MeteringConfig` resource that you can modify using the examples in the documentation. After creating your `MeteringConfig` resource, install the metering stack. Last, verify your installation.

--- a/metering/metering-troubleshooting-debugging.adoc
+++ b/metering/metering-troubleshooting-debugging.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Use the following sections to help troubleshoot and debug specific issues with metering.
 
 In addition to the information in this section, be sure to review the following topics:

--- a/metering/metering-uninstall.adoc
+++ b/metering/metering-uninstall.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 You can remove metering from your {product-title} cluster.
 
 [NOTE]

--- a/metering/metering-upgrading-metering.adoc
+++ b/metering/metering-upgrading-metering.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 You can upgrade metering to {product-version} by updating the Metering Operator subscription.
 
 == Prerequisites

--- a/metering/metering-usage-examples.adoc
+++ b/metering/metering-usage-examples.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 Use the following example reports to get started measuring capacity, usage, and utilization in your cluster. These examples showcase the various types of reports metering offers, along with a selection of the predefined queries.
 
 == Prerequisites

--- a/metering/metering-using-metering.adoc
+++ b/metering/metering-using-metering.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 == Prerequisites
 
 * xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Install Metering]

--- a/metering/reports/metering-about-reports.adoc
+++ b/metering/reports/metering-about-reports.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 A `Report` custom resource provides a method to manage periodic Extract Transform and Load (ETL) jobs using SQL queries. Reports are composed from other metering resources, such as `ReportQuery` resources that provide the actual SQL query to run, and `ReportDataSource` resources that define the data available to the `ReportQuery` and `Report` resources.
 
 Many use cases are addressed by the predefined `ReportQuery` and `ReportDataSource` resources that come installed with metering. Therefore, you do not need to define your own unless you have a use case that is not covered by these predefined resources.

--- a/metering/reports/metering-storage-locations.adoc
+++ b/metering/reports/metering-storage-locations.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 A `StorageLocation` custom resource configures where data will be stored by the Reporting Operator. This includes the data collected from Prometheus, and the results produced by generating a `Report` custom resource.
 
 You only need to configure a `StorageLocation` custom resource if you want to store data in multiple locations, like multiple S3 buckets or both S3 and HDFS, or if you wish to access a database in Hive and Presto that was not created by metering. For most users this is not a requirement, and the xref:../../metering/configuring_metering/metering-about-configuring.adoc#metering-about-configuring[documentation on configuring metering] is sufficient to configure all necessary storage components.

--- a/modules/deprecated-feature.adoc
+++ b/modules/deprecated-feature.adoc
@@ -1,0 +1,11 @@
+// When including this file, ensure that {FeatureName} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+{FeatureName} is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:


### PR DESCRIPTION
This PR adds a new `deprecated-feature.adoc` module that is based off of the [tech preview module](https://github.com/openshift/openshift-docs/blob/master/modules/technology-preview.adoc) and existing wording in the [Deprecated and removed features](https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-deprecated-removed-features) section of the release notes. 

In this PR, the new module is also added to the top of each Metering assembly. 

A subsequent PR will add information on this new `deprecated-feature.adoc` module to the OCP doc guidelines.

Preview: https://deploy-preview-31776--osdocs.netlify.app/openshift-enterprise/latest/metering/metering-about-metering.html