### PR TITLE
Use 20% column width for CNO tables

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -47,7 +47,7 @@ You can specify the cluster network provider configuration for your cluster by s
 The fields for the Cluster Network Operator (CNO) are described in the following table:
 
 .Cluster Network Operator configuration object
-[cols=".^2,.^1,.^7a",options="header"]
+[cols=".^2,.^2,.^6a",options="header"]
 |====
 |Field|Type|Description
 
@@ -114,7 +114,7 @@ If you are using the OVN-Kubernetes cluster network provider, the kube-proxy con
 The values for the `defaultNetwork` object are defined in the following table:
 
 .`defaultNetwork` object
-[cols=".^3,.^1,.^6a",options="header"]
+[cols=".^3,.^2,.^5a",options="header"]
 |====
 |Field|Type|Description
 
@@ -283,7 +283,7 @@ defaultNetwork:
 The values for the `kubeProxyConfig` object are defined in the following table:
 
 .`kubeProxyConfig` object
-[cols=".^3,.^1,.^6a",options="header"]
+[cols=".^3,.^2,.^5a",options="header"]
 |====
 |Field|Type|Description
 


### PR DESCRIPTION
This looks terrible otherwise:

https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/networking/cluster-network-operator#nw-operator-cr_cluster-network-operator