### PR TITLE
OSDOCS-1789: Noting new descheduler v1 API group and v1beta1 deprecation

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -95,6 +95,11 @@ For more information, see the xref:../networking/hardware_networks/about-sriov.a
 [id="ocp-4-8-nodes"]
 === Nodes
 
+[id="ocp-4-8-nodes-descheduler-apigroup"]
+==== Descheduler operator.openshift.io/v1 API group is now available
+
+The `operator.openshift.io/v1` API group is now available for the descheduler. Support for the `operator.openshift.io/v1beta1` API group for the descheduler might be removed in a future release.
+
 [id="ocp-4-8-nodes-descheduler-metrics"]
 ==== Prometheus metrics for the descheduler
 
@@ -205,6 +210,11 @@ In the table, features are marked with the following statuses:
 
 [id="ocp-4-8-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-8-descheduler-apigroup-deprecated"]
+==== Descheduler operator.openshift.io/v1beta1 API group is deprecated
+
+The `operator.openshift.io/v1beta1` API group for the descheduler is deprecated and might be removed in a future release. Use the `operator.openshift.io/v1` API group instead.
 
 [id="ocp-4-8-removed-features"]
 === Removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1789

Preview:
* https://deploy-preview-31800--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-nodes-descheduler-apigroup
* https://deploy-preview-31800--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-descheduler-apigroup-deprecated