### PR TITLE
Various updates to `kdump` configuration

### DIFF
--- a/modules/investigating-kernel-crashes.adoc
+++ b/modules/investigating-kernel-crashes.adoc
@@ -27,34 +27,16 @@ Perform the following steps to enable `kdump` on {op-system}.
 # rpm-ostree kargs --append='crashkernel=256M'
 ----
 
-. By default, the path in which the vmcore will be saved is `/var/crash`. It is also possible to write the dump over the network or to some other location on the local system by editing `/etc/kdump.conf`. For example, assuming `/var/usrlocal/cores` exists, enter the following command to edit `/etc/kdump.conf` to save the vmcore to `/var/usrlocal/cores`:
+. Optional: To write the crash dump over the network or to some other location, rather than to the default local `/var/crash` location, edit the `/etc/kdump.conf` configuration file. 
 +
-[source, terminal]
-----
-# sed -i "s/^path.*/path \/var\/usrlocal\/cores/" /etc/kdump.conf
-----
+[NOTE]
+====
+Network dumps are required when using LUKS. `kdump` does not support local crash dumps on LUKS-encrypted devices.
+====
 +
-For additional information, see `kdump.conf`, a manual page for the `/etc/kdump.conf` configuration file containing the full documentation of available options, and note the comments in `/etc/kdump.conf` and `/etc/sysconfig/kdump`.
+For details on configuring the `kdump` service, see the comments in `/etc/sysconfig/kdump`, `/etc/kdump.conf`, and the `kdump.conf` manual page.
 ifdef::openshift-enterprise[]
 Also refer to the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/system_design_guide/installing-and-configuring-kdump_system-design-guide#configuring-the-kdump-target_configuring-kdump-on-the-command-line[RHEL `kdump` documentation] for further information on configuring the dump target.
-endif::[]
-+
-
-ifdef::openshift-enterprise[]
-. Because `kdump` has trouble finding the correct bootimage location on {op-system}, the `KDUMP_BOOTDIR` variable must be manually set in `/etc/kdump.conf`. You can use `/proc/cmdline` to figure out the `ostree` boot location. For example:
-+
-[source, terminal]
-----
-# BOOT_LOC=/boot$(cat /proc/cmdline | egrep -o "/ostree/.*/vmlinuz" | sed -e "s|/vmlinuz||g")
-# sed -i "s|^#KDUMP_BOOTDIR=\"/boot\"|KDUMP_BOOTDIR=\"${BOOT_LOC}\"|" /etc/sysconfig/kdump
-----
-
-. Configure `/etc/sysconfig/kdump` to not use the default link:https://man7.org/linux/man-pages/man2/kexec_file_load.2.html[file-based `kexec` syscall] for loading the crash kernel.
-+
-[source, terminal]
-----
-# sed -i "s|^KEXEC_ARGS=\"-s\"|KEXEC_ARGS=\"\"|" /etc/sysconfig/kdump
-----
 endif::[]
 
 . Enable the `kdump` systemd service.


### PR DESCRIPTION
### Remove `kdump` crash dump location example

The precise location on the filesystem likely does not matter, so
we should remove this example of an uncommon use case.
We have observed that users skimming through the docs may have
mistaken this example for a required step, and unnecessarily
configuring their crash dump location to `/var/usrlocal/cores`.

### Remove unnecessary bootimage location configuration

Fix in `kexec-tools` is in RHEL 8.4 and also backported to 8.3.

xref: https://bugzilla.redhat.com/show_bug.cgi?id=1866611

### Remove instruction to use `kexec_load()` over `kexec_file_load()`

The default `kexec_file_load()` appears to be working fine in
RHCOS.

### Add note about `kdump` on LUKS

Currently, `kdump` does not support saving the crash dump on the
local filesystem if it is encrypted by LUKS. Add a note that
manual configuration to use a remote dump is required if using LUKS.