### PR TITLE
[enterprise-4.5] BZ1949528: Add --filter-by-os to oc image mirror in Package Manifest doc

### DIFF
--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -77,7 +77,7 @@ $ oc adm catalog mirror \
 +
 [WARNING]
 ====
-If the `--filter-by-os` flag remains unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
+If the `--filter-by-os` flag remains unset or set to any value other than `.*`, the command filters out different architectures, which changes the digest of the manifest list, also known as a _multi-arch image_. The incorrect digest causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
 ====
 +
 .Example output
@@ -143,8 +143,14 @@ In this example, if you only want to mirror these images, you would then remove 
 ----
 $ oc image mirror \
     [-a ${REG_CREDS}] \
+    --filter-by-os='.*' \
     -f ./redhat-operators-manifests/mapping.txt
 ----
++
+[WARNING]
+====
+If the `--filter-by-os` flag remains unset or set to any value other than `.*`, the command filters out different architectures, which changes the digest of the manifest list, also known as a _multi-arch image_. The incorrect digest causes deployments of those images and Operators on disconnected clusters to fail.
+====
 
 . Apply the `ImageContentSourcePolicy` object:
 +

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -102,7 +102,7 @@ $ oc adm catalog mirror \
 <1> Specify your new Operator catalog image.
 <2> Optional: If required, specify the location of your registry credentials file.
 <3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> This flag is currently required due to a known issue with multiple architecture support. If unset or set to any value other than `.*`, filtering out different architectures changes the digest of the manifest list, also known as a "multi-arch image", which causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
+<4> This flag is currently required due to a known issue with multiple architecture support. If the `--filter-by-os` flag remains unset or set to any value other than `.*`, the command filters out different architectures, which changes the digest of the manifest list, also known as a _multi-arch image_. The incorrect digest causes deployments of those images and Operators on disconnected clusters to fail. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1890951[BZ#1890951].
 
 . Apply the newly generated manifests:
 +


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/31591 because the file name for the module was different after 4.5. Also syncing up the other 2 instances of this note with the more clear, updated description.