### PR TITLE
Allow min-replicas=1 for the Vertical Pod Autoscaler

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-about.adoc
@@ -11,6 +11,11 @@ The VPA automatically computes historic and current CPU and memory usage for the
 
 The VPA automatically deletes any pods that are out of alignment with its recommendations one at a time, so that your applications can continue to serve requests with no downtime. The workload objects then re-deploy the pods with the original resource limits and requests. The VPA uses a mutating admission webhook to update the pods with optimized resource limits and requests before the pods are admitted to a node. If you do not want the VPA to delete pods, you can view the VPA resource limits and requests and manually update the pods as needed.
 
+[NOTE]
+====
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown shown in _Changing the VPA minimum value_.
+====
+
 For example, if you have a pod that uses 50% of the CPU but only requests 10%, the VPA determines that the pod is consuming more CPU than requested and deletes the pod. The workload object, such as replica set, restarts the pods and the VPA updates the new pod with its recommended resources.
 
 For developers, you can use the VPA to help ensure your pods stay up during periods of high demand by scheduling pods onto nodes that have appropriate resources for each pod.

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -91,6 +91,40 @@ The output shows the recommended resources, `target`, the minimum recommended re
 
 The VPA uses the `lowerBound` and `upperBound` values to determine if a pod needs to be updated. If a pod has resource requests below the `lowerBound` values or above the `upperBound` values, the VPA terminates and recreates the pod with the `target` values.
 
+[id="nodes-pods-vertical-autoscaler-using-one-pod_{context}"]
+== Changing the VPA minimum value
+
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete and update their pods. As a result, workload objects that specify fewer than two replicas are not automatically acted upon by the VPA. The VPA does update new pods from these workload objects if the pods are restarted by some process external to the VPA.  You can change this cluster-wide minimum value by modifying the `minReplicas` parameter in the `VerticalPodAutoscalerController` custom resource (CR).
+
+For example, if you set `minReplicas` to `3`, the VPA does not delete and update pods for workload objects that specify fewer than three replicas.  
+
+[NOTE]
+====
+If you set `minReplicas` to `1`, the VPA can delete the only pod for a workload object that specifies only one replica. You should use this setting with one-replica objects only if your workload can tolerate downtime whenever the VPA deletes a pod to adjust its resources. To avoid unwanted downtime with one-replica objects, configure the VPA CRs with the `podUpdatePolicy` set to `Initial`, which automatically updates the pod only when it is restarted by some process external to the VPA, or `Off`, which allows you to update the pod manually at an appropriate time for your application. 
+====
+
+.Example `VerticalPodAutoscalerController` object
+[source,yaml]
+----
+apiVersion: autoscaling.openshift.io/v1
+kind: VerticalPodAutoscalerController
+metadata:
+  creationTimestamp: "2021-04-21T19:29:49Z"
+  generation: 2
+  name: default
+  namespace: openshift-vertical-pod-autoscaler
+  resourceVersion: "142172"
+  uid: 180e17e9-03cc-427f-9955-3b4d7aeb2d59
+spec:
+  minReplicas: 3 <1>
+  podMinCPUMillicores: 25
+  podMinMemoryMb: 250
+  recommendationOnly: false
+  safetyMarginFraction: 0.15
+----
+
+<1> Specify the minimum number of replicas in a workload object for the VPA to act on. Any objects with replicas fewer than the minimum are not automatically deleted by the VPA.
+
 [id="nodes-pods-vertical-autoscaler-using-auto_{context}"]
 == Automatically applying VPA recommendations
 To use the VPA to automatically update pods, create a VPA CR for a specific workload object with `updateMode` set to `Auto` or `Recreate`.
@@ -99,7 +133,7 @@ When the pods are created for the workload object, the VPA constantly monitors t
 
 [NOTE]
 ====
-The workload object must specify a minimum of two replicas in order for the VPA to monitor and update the pods. If the workload object specifies one replica, the VPA does not delete the pod to prevent application downtime. You can manually delete the pod to use the recommended resources.
+By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete their pods. Workload objects that specify fewer replicas than this minimum are not deleted. If you manually delete these pods, when the workload object redeploys the pods, the VPA does update the new pods with its recommendations. You can change this minimum by modifying the `VerticalPodAutoscalerController` object as shown shown in _Changing the VPA minimum value_.
 ====
 
 .Example VPA CR for the `Auto` mode


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1851

Preview of new section: https://deploy-preview-31849--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-one-pod_nodes-pods-vertical-autoscaler
New note: https://deploy-preview-31849--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-about_nodes-pods-vertical-autoscaler