### PR TITLE
RHDEVDOCS-2942-dep-es-curator

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -19,6 +19,19 @@ The following advisories are available for {ProductName} 5.0:
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
 
+// Release Notes by version
 include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
+
+[id="openshift-logging-5-0-deprecated-removed-features"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+[id="openshift-logging-5-0-elasticsearch-curator"]
+=== Elasticsearch Curator
+
+The Elasticsearch Curator is deprecated in OpenShift Logging 5.0 and will be removed in OpenShift Logging 5.1. Elasticsearch Curator helps you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator,  xref:../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[configure the log retention time].


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: master, enterprise-4.7, enterprise-4.8
- https://issues.redhat.com/browse/RHDEVDOCS-2942
- Doc preview of changed topic: https://deploy-preview-31850--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-0-deprecated-removed-features
- SME review: Approved by @jcantrill 
- QE review: Approved by @kabirbhartiRH 
- Peer review: Approved by @jc-berger 
- Please merge