### PR TITLE
OSDOCS-1808: Huge pages and Downward API

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -72,6 +72,13 @@ This release adds improvements related to the following components and concepts.
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].
 
+[id="ocp-4-8-enhancements-sriov-network-operator"]
+==== Enhancements to the SR-IOV Network Operator
+
+The Network Resources Injector that is deployed with the Operator is enhanced to expose information about huge pages requests and limits with the Downward API. When a pod specification includes a huge pages request or limit, the information is exposed in the `/etc/podnetinfo` path.
+
+For more information, see xref:../networking/hardware_networks/about-sriov.adoc#nw-sriov-hugepages_about-sriov[Huge pages resource injection for Downward API].
+
 [id="ocp-4-8-storage"]
 === Storage
 
@@ -104,6 +111,13 @@ The following descheduler metrics are available:
 
 * `descheduler_build_info` - Provides build information about the descheduler.
 * `descheduler_pods_evicted` - Provides the number of pods that have been evicted for each combination of strategy, namespace, and result. There must be at least one evicted pod for this metric to appear.
+
+[id="ocp-4-8-nodes-huge-pages-downward-api"]
+==== Support for huge pages with the Downward API
+
+With this release, when you set requests and limits for huge pages in a pod specification, you can use the Downward API to view the allocation for the pod from within a container. This enhancements relies on the `DownwardAPIHugePages` feature gate. {product-title} {product-version} enables the feature gate.
+
+For more information, see xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#consuming-huge-pages-resource-using-the-downward-api_huge-pages[Consuming huge pages resources using the Downward API].
 
 [id="ocp-4-8-logging"]
 === Cluster logging


### PR DESCRIPTION
One update, but in two parts:

* 4.8 enables the feature gate in k8s 1.21.  This helps
vanilla pods use Downward API with huge pages. This is mentioned in the Nodes area under heading [Support for huge pages with the Downward API](https://deploy-preview-31851--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-nodes-huge-pages-downward-api)

* SR-IOV Network Resource Injector automatically injects
pod specification fields to make use of the first bullet. This work is mentioned in the Networking area under heading [Enhancements to the SR-IOV Network Operator](https://deploy-preview-31851--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-enhancements-sriov-network-operator)

---
Applies to branch enterprise-4.8 and milestone Future Release.