### PR TITLE
Added optional AWS fields for OpenShift 4.5 AWS Install docs per BZ1865758

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -309,6 +309,14 @@ ifdef::aws[]
 |====
 |Parameter|Description|Values
 
+|`compute.platform.aws.amiID`
+|The The AWS AMI used to boot compute machines for the cluster. This is required for regions that require a custom RCOS AMI
+|Any published or custom RCOS AMI that belongs to the set AWS region.
+
+|`compute.platform.aws.rootVolume.kmsKeyARN`
+|The KMS key that will be used to encrypt the EBS volume. If no key is provided, the default KMS key for the account will be used.
+|Valid link:https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_GetEbsDefaultKmsKeyId.html[AWS KMS key type]
+
 |`compute.platform.aws.rootVolume.iops`
 |The Input/Output Operations Per Second (IOPS) that is reserved for the root volume.
 |Integer, for example `4000`.
@@ -334,6 +342,10 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |`compute.aws.region`
 |The AWS region that the installation program creates compute resources in.
 |Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
+
+|`controlPlane.platform.aws.amiID`
+|The AWS AMI used to boot control plane machines for the cluster. This is required for regions that require a custom RHCOS AMI.
+|Any published or custom RHCOS AMI that belongs to the set AWS region.
 
 |`controlPlane.platform.aws.type`
 |The EC2 instance type for the control plane machines.


### PR DESCRIPTION
For Version 4.5 Only.

https://bugzilla.redhat.com/show_bug.cgi?id=1865758

Original Document URL:
https://docs.openshift.com/container-platform/4.5/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters_installing-aws-customizations

Direct Link to doc preview:
https://deploy-preview-31856--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters_installing-aws-customizations

Section Number and Name:
Installation configuration parameters - Table 3. Optional AWS parameters

Ready for QA: @yuhuijiang , @staebler 