### PR TITLE
BZ-1952805 oc login is no longer interactive

### DIFF
--- a/modules/cli-developer-basic.adoc
+++ b/modules/cli-developer-basic.adoc
@@ -20,12 +20,6 @@ $ oc explain pods
 Log in to the {product-title} server and save login information for subsequent
 use.
 
-.Example: Interactive login
-[source,terminal]
-----
-$ oc login
-----
-
 .Example: Log in specifying a user name
 [source,terminal]
 ----


### PR DESCRIPTION
Related to https://bugzilla.redhat.com/show_bug.cgi?id=1952805 & https://bugzilla.redhat.com/show_bug.cgi?id=1920427