### PR TITLE
[SRVKS-724] Update serving.knative.dev/visibility to networking.knative.dev/visibility

### DIFF
--- a/modules/knative-service-cluster-local.adoc
+++ b/modules/knative-service-cluster-local.adoc
@@ -12,16 +12,16 @@ Publicly accessible URLs are accessible from outside of the cluster.
 However, developers may need to build back-end services that are only be accessible from inside the cluster, known as _private services_.
 // Cluster administrators can configure private services for the cluster so that all services are private by default.
 // Need to add additional details about editing the configmap for admins
-Developers can label individual services in the cluster with the `serving.knative.dev/visibility=cluster-local` label to make them private.
+Developers can label individual services in the cluster with the `networking.knative.dev/visibility=cluster-local` label to make them private.
 
 .Procedure
 
-* Set the visibility for your service by adding the `serving.knative.dev/visibility=cluster-local` label:
+* Set the visibility for your service by adding the `networking.knative.dev/visibility=cluster-local` label:
 +
 
 [source,terminal]
 ----
-$ oc label ksvc <service_name> serving.knative.dev/visibility=cluster-local
+$ oc label ksvc <service_name> networking.knative.dev/visibility=cluster-local
 ----
 
 .Verification


### PR DESCRIPTION
This patch updates the label to `networking.knative.dev/visibility`.

Both `networking.knative.dev/visibility` and `serving.knative.dev/visibility` are available on serverless v1.14 or before but Serving v0.21+ (serverless v1.15) supports only `networking.knative.dev/visibility`.

Reference: https://github.com/knative/serving/commit/e402e8ec9acb6a5af79ebbec8d1ed11f5a7e3ff0 

/cc @abrennan89 