### PR TITLE
Added release notes for 4.7.8, fixed advisory number in 4.7.7 title

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2270,7 +2270,7 @@ This update adds new capabilities to the cluster API provider BareMetal (CAPBM) 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-7"]
-=== RHSA-2021:1150 - {product-title} 4.7.7 bug fix and security update
+=== RHBA-2021:1149 - {product-title} 4.7.7 bug fix and security update
 
 Issued: 2021-04-20
 
@@ -2296,3 +2296,19 @@ Now, the OpenShift build image and associated pod mount all entitlement-related 
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-8"]
+=== RHSA-2021:1225 - {product-title} 4.7.8 bug fix and security update
+
+Issued: 2021-04-26
+
+{product-title} release 4.7.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:1225[RHSA-2021:1225] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1226[RHBA-2021:1226]  advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/5982961[{product-title} 4.7.8 container image list]
+
+[id="ocp-4-7-8-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions


### PR DESCRIPTION
This PR includes:
* the 4.7.8 release notes
* a fix to the advisory number in the 4.7.7 release notes title

Applies to 4.7 only.

[Direct preview link](https://deploy-preview-31864--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-8)