### PR TITLE
Match lowercase for disconnected annotation

### DIFF
--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -100,13 +100,13 @@ spec:
 <2> Specify each image by a digest (SHA), not by an image tag.
 <3> Also reference the Operator container image by a digest (SHA), not by an image tag.
 
-. Add the `Disconnected` annotation, which indicates that the Operator works in a disconnected environment:
+. Add the `disconnected` annotation, which indicates that the Operator works in a disconnected environment:
 +
 [source,yaml]
 ----
 metadata:
   annotations:
-    operators.openshift.io/infrastructure-features: '["Disconnected"]'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
 ----
 +
 Operators can be filtered in OperatorHub by this infrastructure feature.


### PR DESCRIPTION
Fixing what is now a typo, thanks to https://github.com/openshift/openshift-docs/pull/29511.