### PR TITLE
Rel Notes doc text for 4.6.26 release

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2828,3 +2828,27 @@ This update adds `uptime` and `memory alloc` metadata to the Insights Operator a
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-26"]
+=== RHBA-2021:1232 - {product-title} 4.6.26 bug fix update
+
+Issued: 2021-04-27
+
+{product-title} release 4.6.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1232[RHBA-2021:1232] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1229[RHBA-2021:1229] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/5990161[{product-title} 4.6.26 container image list]
+
+[id="ocp-4-6-26-features"]
+==== Features
+
+[id="ocp-4-6-26-gathering-sap-datahubs-backport"]
+===== Insights Operator enhancement for gathering SAP pod data
+
+The Insights Operator can now gather `Datahubs` resources from SAP clusters. This data allows SAP clusters to be distinguished from non-SAP clusters in the Insights Operator archives, even in situations in which all of the data gathered exclusively from SAP clusters is missing and it would otherwise be impossible to determine if a cluster has an SDI installation. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1942907[*BZ#1942907*].
+
+[id="ocp-4-6-26-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
For release 27 April
Preview: https://deploy-preview-31881--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-26