### PR TITLE
OSDOCS-2133 Release note for HAProxy 2.2

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -180,7 +180,7 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/tra
 
 {product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. Once the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
 
-[id="ocp-4-8-preparation-HAProxy-2.2"]
+[id="ocp-4-8-preparation-haproxy-2.2"]
 ==== Converting HTTP header names to support upgrading to {product-title} 4.8
 
 {product-title} updated to HAProxy 2.2, which changes HTTP header names to lowercase by default, for example, changing `Host: xyz.com` to `host: xyz.com`. For legacy applications that are sensitive to the capitalization of HTTP header names, use the Ingress Controller `spec.httpHeaders.headerNameCaseAdjustments` API field to accommodate legacy applications until they can be fixed. Make sure to add the necessary configuration by using `spec.httpHeaders.headerNameCaseAdjustments` before upgrading {product-title} now that HAProxy 2.2 is available.
@@ -380,6 +380,12 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 ==== The Federal Risk and Authorization Management Program (FedRAMP) moderate controls
 
 In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4-moderate` profile will be completed in a future release.
+
+[discrete]
+[id="ocp-4-8-haproxy-2.2.13-upgrade"]
+==== Ingress Controller upgraded to HAProxy 2.2.13
+
+The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.13.
 
 [id="ocp-4-8-coreDNS-version-update"]
 ==== CoreDNS update to version 1.8.1


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2133

Preview: https://deploy-preview-31902--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-notable-technical-changes