### PR TITLE
Added new documentation about verifying container image signatures.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -639,6 +639,8 @@ Topics:
   - Name: Hardening Red Hat Enterprise Linux CoreOS
     File: security-hardening
     Distros: openshift-enterprise,openshift-aro
+  - Name: Container image signatures
+    File: security-container-signature
   - Name: Hardening Fedora CoreOS
     File: security-hardening
     Distros: openshift-origin

--- a/modules/containers-signature-verify-application.adoc
+++ b/modules/containers-signature-verify-application.adoc
@@ -1,0 +1,258 @@
+// Module included in the following assemblies:
+//
+// * security/container_security/security-container-signature.adoc
+
+[id="containers-signature-verify-application_{context}"]
+= Verifying the signature verification configuration
+After you apply the machine configs to the cluster, the Machine Config Controller detects the new `MachineConfig` object and generates a new `rendered-worker-<hash>` version.
+
+.Prerequisites
+* You enabled signature verification by using a machine config file.
+
+.Procedure
+
+. On the command line, run the following command to display information about a desired worker:
++
+[source,terminal]
+----
+$ oc describe machineconfigpool/worker
+----
++
+.Example output of initial worker monitoring
++
+[source,terminal]
+----
+Name:         worker
+Namespace:
+Labels:       machineconfiguration.openshift.io/mco-built-in=
+Annotations:  <none>
+API Version:  machineconfiguration.openshift.io/v1
+Kind:         MachineConfigPool
+Metadata:
+  Creation Timestamp:  2019-12-19T02:02:12Z
+  Generation:          3
+  Resource Version:    16229
+  Self Link:           /apis/machineconfiguration.openshift.io/v1/machineconfigpools/worker
+  UID:                 92697796-2203-11ea-b48c-fa163e3940e5
+Spec:
+  Configuration:
+    Name:  rendered-worker-f6819366eb455a401c42f8d96ab25c02
+    Source:
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         00-worker
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         01-worker-container-runtime
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         01-worker-kubelet
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         51-worker-rh-registry-trust
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         99-worker-92697796-2203-11ea-b48c-fa163e3940e5-registries
+      API Version:  machineconfiguration.openshift.io/v1
+      Kind:         MachineConfig
+      Name:         99-worker-ssh
+  Machine Config Selector:
+    Match Labels:
+      machineconfiguration.openshift.io/role:  worker
+  Node Selector:
+    Match Labels:
+      node-role.kubernetes.io/worker:
+  Paused:                              false
+Status:
+  Conditions:
+    Last Transition Time:  2019-12-19T02:03:27Z
+    Message:
+    Reason:
+    Status:                False
+    Type:                  RenderDegraded
+    Last Transition Time:  2019-12-19T02:03:43Z
+    Message:
+    Reason:
+    Status:                False
+    Type:                  NodeDegraded
+    Last Transition Time:  2019-12-19T02:03:43Z
+    Message:
+    Reason:
+    Status:                False
+    Type:                  Degraded
+    Last Transition Time:  2019-12-19T02:28:23Z
+    Message:
+    Reason:
+    Status:                False
+    Type:                  Updated
+    Last Transition Time:  2019-12-19T02:28:23Z
+    Message:               All nodes are updating to rendered-worker-f6819366eb455a401c42f8d96ab25c02
+    Reason:
+    Status:                True
+    Type:                  Updating
+  Configuration:
+    Name:  rendered-worker-d9b3f4ffcfd65c30dcf591a0e8cf9b2e
+    Source:
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   00-worker
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   01-worker-container-runtime
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   01-worker-kubelet
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   99-worker-92697796-2203-11ea-b48c-fa163e3940e5-registries
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   99-worker-ssh
+  Degraded Machine Count:     0
+  Machine Count:              1
+  Observed Generation:        3
+  Ready Machine Count:        0
+  Unavailable Machine Count:  1
+  Updated Machine Count:      0
+Events:                       <none>
+----
+
+. Run the `oc describe` command again:
++
+[source,terminal]
+----
+$ oc describe machineconfigpool/worker
+----
++
+.Example output after the worker is updated
++
+[source,terminal]
+----
+...
+    Last Transition Time:  2019-12-19T04:53:09Z
+    Message:               All nodes are updated with rendered-worker-f6819366eb455a401c42f8d96ab25c02
+    Reason:
+    Status:                True
+    Type:                  Updated
+    Last Transition Time:  2019-12-19T04:53:09Z
+    Message:
+    Reason:
+    Status:                False
+    Type:                  Updating
+  Configuration:
+    Name:  rendered-worker-f6819366eb455a401c42f8d96ab25c02
+    Source:
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   00-worker
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   01-worker-container-runtime
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   01-worker-kubelet
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   51-worker-rh-registry-trust
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   99-worker-92697796-2203-11ea-b48c-fa163e3940e5-registries
+      API Version:            machineconfiguration.openshift.io/v1
+      Kind:                   MachineConfig
+      Name:                   99-worker-ssh
+  Degraded Machine Count:     0
+  Machine Count:              3
+  Observed Generation:        4
+  Ready Machine Count:        3
+  Unavailable Machine Count:  0
+  Updated Machine Count:      3
+...
+----
++
+[NOTE]
+====
+The `Observed Generation` parameter shows an increased count based on the generation of the controller-produced configuration. This controller updates this value even if it fails to process the specification and generate a revision. The `Configuration Source` value points to the `51-worker-rh-registry-trust` configuration.
+====
+
+. Confirm that the `policy.json` file exists with the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node> -- chroot /host cat /etc/containers/policy.json
+----
++
+.Example output
++
+[source,terminal]
+----
+Starting pod/<node>-debug ...
+To use host binaries, run `chroot /host`
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker": {
+      "registry.access.redhat.com": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ],
+      "registry.redhat.io": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ]
+    },
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    }
+  }
+}
+----
+
+. Confirm that the `registry.redhat.io.yaml` file exists with the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node> -- chroot /host cat /etc/containers/registries.d/registry.redhat.io.yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+Starting pod/<node>-debug ...
+To use host binaries, run `chroot /host`
+docker:
+     registry.redhat.io:
+         sigstore: https://registry.redhat.io/containers/sigstore
+----
+
+. Confirm that the `registry.access.redhat.com.yaml` file exists with the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node> -- chroot /host cat /etc/containers/registries.d/registry.access.redhat.com.yaml
+----
++
+.Example output
++
+[source,terminal]
+----
+Starting pod/<node>-debug ...
+To use host binaries, run `chroot /host`
+docker:
+     registry.access.redhat.com:
+         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
+----

--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -1,0 +1,185 @@
+// Module included in the following assemblies:
+//
+// * security/container_security/security-container-signature.adoc
+
+[id="containers-signature-verify-enable_{context}"]
+= Enabling signature verification for Red Hat Container Registries
+Enabling container signature validation requires files that link the registry URLs to the sigstore and then specifies the keys which verify the images.
+
+.Procedure
+. Create the files that link the registry URLs to the sigstore and that specifies the key to verify the image.
+
+** Create the `policy.json` file:
++
+[source,terminal]
+----
+$ cat > policy.json <<EOF
+{
+  "default": [
+    {
+      "type": "insecureAcceptAnything"
+    }
+  ],
+  "transports": {
+    "docker": {
+      "registry.access.redhat.com": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ],
+      "registry.redhat.io": [
+        {
+          "type": "signedBy",
+          "keyType": "GPGKeys",
+          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+        }
+      ]
+    },
+    "docker-daemon": {
+      "": [
+        {
+          "type": "insecureAcceptAnything"
+        }
+      ]
+    }
+  }
+}
+EOF
+----
+
+** Create the `registry.access.redhat.com.yaml` file:
++
+[source,terminal]
+----
+$ cat <<EOF > registry.access.redhat.com.yaml
+docker:
+     registry.access.redhat.com:
+         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
+EOF
+----
+
+** Create the `registry.redhat.io.yaml` file:
++
+[source,terminal]
+----
+$ cat <<EOF > registry.redhat.io.yaml
+docker:
+     registry.redhat.io:
+         sigstore: https://registry.redhat.io/containers/sigstore
+EOF
+----
+
+. Set the files with a `base64` encode format that will be used for the machine config template:
++
+[source,terminal]
+----
+$ export ARC_REG=$( cat registry.access.redhat.com.yaml | base64 -w0 )
+$ export RIO_REG=$( cat registry.redhat.io.yaml | base64 -w0 )
+$ export POLICY_CONFIG=$( cat policy.json | base64 -w0 )
+----
+
+. Create a machine config that writes the exported files to disk on the worker nodes:
++
+[source,terminal]
+----
+$ cat > 51-worker-rh-registry-trust.yaml <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 51-worker-rh-registry-trust
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${ARC_REG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.d/registry.access.redhat.com.yaml
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${RIO_REG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.d/registry.redhat.io.yaml
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${POLICY_CONFIG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/policy.json
+  osImageURL: ""
+EOF
+----
+
+. Apply the created machine config:
++
+[source,terminal]
+----
+$ oc apply -f 51-worker-rh-registry-trust.yaml
+----
+
+. Create a machine config, which writes the exported files to disk on the master nodes:
++
+[source,terminal]
+----
+$ cat > 51-master-rh-registry-trust.yaml <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 51-master-rh-registry-trust
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 2.2.0
+    networkd: {}
+    passwd: {}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${ARC_REG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.d/registry.access.redhat.com.yaml
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${RIO_REG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/registries.d/registry.redhat.io.yaml
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,${POLICY_CONFIG}
+          verification: {}
+        filesystem: root
+        mode: 420
+        path: /etc/containers/policy.json
+  osImageURL: ""
+EOF
+----
+
+. Apply the master machine config changes to the cluster:
++
+[source,terminal]
+----
+$ oc apply -f 51-master-rh-registry-trust.yaml
+----

--- a/security/container_security/security-container-signature.adoc
+++ b/security/container_security/security-container-signature.adoc
@@ -1,0 +1,22 @@
+[id="security-container-signature"]
+= Container image signatures
+include::modules/common-attributes.adoc[]
+:context: security-container-signature
+
+toc::[]
+
+Red Hat delivers signatures for the images in the Red Hat Container Registries. Those signatures can be automatically verified when being pulled to {product-title} 4 clusters by using the Machine Config Operator (MCO).
+
+link:https://quay.io/[Quay.io] serves most of the images that make up {product-title}, and only the release image is signed. Release images refer to the approved {product-title} images, offering a degree of protection against supply chain attacks. However, some extensions to {product-title}, such as logging, monitoring, and service mesh, are shipped as Operators from the Operator Lifecycle Manager (OLM). Those images ship from the link:https://catalog.redhat.com/software/containers/explore[Red Hat Ecosystem Catalog Container images] registry.
+
+To verify the integrity of those images between Red Hat registries and your infrastructure, enable signature verification.
+
+//Enabling Signature Verification in OCP
+include::modules/containers-signature-verify-enable.adoc[leveloffset=+1]
+
+//Verifying that the enable signature verification is active
+include::modules/containers-signature-verify-application.adoc[leveloffset=+1]
+
+[id="additional-resources_security-container-signature"]
+== Additional resources
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine Config Overview]


### PR DESCRIPTION
This pull request adds new documentation around verifying signatures in OCP. This information comes from the customer portal: https://access.redhat.com/verify-images-ocp4

Applicable Versions: 4.5+

JIRA Ticket: https://issues.redhat.com/browse/OSDOCS-2130

Preview: https://deploy-preview-31906--osdocs.netlify.app/openshift-enterprise/latest/security/container_security/security-container-signature.html