### PR TITLE
[virt] fixing xref in node placement docs

### DIFF
--- a/virt/install/virt-specifying-nodes-for-virtualization-components.adoc
+++ b/virt/install/virt-specifying-nodes-for-virtualization-components.adoc
@@ -20,7 +20,7 @@ include::modules/virt-about-node-placement-virtualization-components.adoc[levelo
 
 [id="node-placement-resources_{context}"]
 ==== Node placement rules
-* xref:../../nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
+* xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
 * xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity rules]
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 


### PR DESCRIPTION
- Just fixing an xref that somehow wound up with `.html` instead of `.adoc`
- CP to 4.7 and 4.8
- [Preview build](https://deploy-preview-31910--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#additional-resources_virt-specifying-nodes-for-virtualization-components)