### PR TITLE
BZ-1950023 4.5 Fix link to prometheus storage requirements

### DIFF
--- a/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/cluster_monitoring/configuring-the-monitoring-stack.adoc
@@ -52,7 +52,7 @@ See xref:../../scalability_and_performance/optimizing-storage.adoc#recommended-c
 
 == Prerequisites
 
-* Dedicate sufficient local persistent storage to ensure that the disk does not become full. How much storage you need depends on the number of pods. For information on system requirements for persistent storage, see xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#prometheus-database-storage-requirements[Prometheus database storage requirements].
+* Dedicate sufficient local persistent storage to ensure that the disk does not become full. How much storage you need depends on the number of pods. For information on system requirements for persistent storage, see xref:../../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#prometheus-database-storage-requirements_cluster-monitoring-operator[Prometheus database storage requirements].
 * Make sure you have a persistent volume (PV) ready to be claimed by the persistent volume claim (PVC), one PV for each replica. Because Prometheus has two replicas and Alertmanager has three replicas, you need five PVs to support the entire monitoring stack. The PVs should be available from the Local Storage Operator. This does not apply if you enable dynamically provisioned storage.
 * Use the block type of storage.
 * xref:../../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-using-local-volume[Configure local persistent storage.]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1950023

In Cluster monitoring > Configuring the monitoring stack > Configuring persistent storage > Prerequisites, extend link to "Prometheus database storage requirements" section to include the specific assembly _{context}. Existing link does not take you directly to the right section in the assembly, which is especially confusing on the Customer Portal.

Preview: https://deploy-preview-31918--osdocs.netlify.app/openshift-enterprise/latest/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html#prerequisites-2

