### PR TITLE
BZ-1877344: Added pod phases and statuses

### DIFF
--- a/modules/odc-interacting-with-applications-and-components.adoc
+++ b/modules/odc-interacting-with-applications-and-components.adoc
@@ -16,8 +16,16 @@ This feature is available only when you create applications using the *From Git*
 ====
 +
 * Hover your cursor over the lower left icon on the Pod to see the name of the latest build and its status. The status of the application build is indicated as *New* (image:odc_build_new.png[title="New Build"]), *Pending* (image:odc_build_pending.png[title="Pending Build"]), *Running* (image:odc_build_running.png[title="Running Build"]), *Completed* (image:odc_build_completed.png[title="Completed Build"]), *Failed* (image:odc_build_failed.png[title="Failed Build"]), and *Canceled* (image:odc_build_canceled.png[title="Canceled Build"]).
-* The status or phase of the pod is indicated by different colors and tooltips as *Running* (image:odc_pod_running.png[title="Pod Running"]), *Not Ready* (image:odc_pod_not_ready.png[title="Pod Not Ready"]), *Warning*(image:odc_pod_warning.png[title="Pod Warning"]), *Failed*(image:odc_pod_failed.png[title="Pod Failed"]), *Pending*(image:odc_pod_pending.png[title="Pod Pending"]), *Succeeded*(image:odc_pod_succeeded.png[title="Pod Succeeded"]), *Terminating*(image:odc_pod_terminating.png[title="Pod Terminating"]), or *Unknown*(image:odc_pod_unknown.png[title="Pod Unknown"]).
-For more information about pod status, see the link:https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-phase[Kubernetes documentation].
+* The status or phase of the pod is indicated by different colors and tooltips as:
+** *Running* (image:odc_pod_running.png[title="Pod Running"]): The pod is bound to a node and all of the containers are created. At least one container is still running or is in the process of starting or restarting.
+** *Not Ready* (image:odc_pod_not_ready.png[title="Pod Not Ready"]): The pods which are running multiple containers, not all containers are ready.
+** *Warning*(image:odc_pod_warning.png[title="Pod Warning"]): Containers in pods are being terminated, however termination did not succeed. Some containers may be other states.
+** *Failed*(image:odc_pod_failed.png[title="Pod Failed"]): All containers in the pod terminated but least one container has terminated in failure. That is, the container either exited with non-zero status or was terminated by the system.
+** *Pending*(image:odc_pod_pending.png[title="Pod Pending"]): The pod is accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. This includes time a pod spends waiting to be scheduled as well as the time spent downloading container images over the network.
+** *Succeeded*(image:odc_pod_succeeded.png[title="Pod Succeeded"]): All containers in the pod terminated successfully and will not be restarted.
+** *Terminating*(image:odc_pod_terminating.png[title="Pod Terminating"]): When a pod is being deleted, it is shown as *Terminating* by some kubectl commands. *Terminating* status is not one of the pod phases. A pod is granted a graceful termination period, which defaults to 30 seconds.
+** *Unknown*(image:odc_pod_unknown.png[title="Pod Unknown"]): The state of the pod could not be obtained. This phase typically occurs due to an error in communicating with the node where the pod should be running.
+
 * After you create an application and an image is deployed, the status is shown as *Pending*. After the application is built, it is displayed as *Running*.
 +
 .Application topology


### PR DESCRIPTION
Applies to 4.5+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1877344
QE approval needed: @skordas 
Preview Link: https://deploy-preview-31920--osdocs.netlify.app/openshift-enterprise/latest/applications/application_life_cycle_management/odc-viewing-application-composition-using-topology-view.html#odc-interacting-with-applications-and-components_viewing-application-composition-using-topology-view