### PR TITLE
TP update for triggers

### DIFF
--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -31,7 +31,7 @@ The following compatibility matrix shows the support status and compatible versi
 
 |0.22
 
-|0.12
+|0.12 Technology Preview (TP)
 
 |0.17
 

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -10,6 +10,20 @@
 == New features
 {pipelines-title} General Availability (GA) 1.4 is now available on {product-title} 4.7.
 
+[IMPORTANT]
+====
+The Triggers feature is currently a Technology Preview feature.
+
+Technology Preview features are not supported with Red Hat production service
+level agreements (SLAs), might not be functionally complete, and Red Hat does
+not recommend to use them for production. These features provide early access to
+upcoming product features, enabling customers to test functionality and provide
+feedback during the development process.
+
+See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
+Technology Preview features support scope] for more information.
+====
+
 [NOTE]
 ====
 In addition to the stable/preview Operator channel for OCP 4.7, the general availability of Pipelines 1.4 comes with the deprecated channels such as `ocp-4.6` and `ocp-4.5`. However, these deprecated channels and support for them will be removed in the following release of {pipelines-title}.


### PR DESCRIPTION
This PR updates the P status of the Triggers feature in Pipelines alongwith the requisite TP note. 
This applies to both 4.7 and 4.8
SME Review done: Savita
Direct Preview: https://deploy-preview-31934--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#getting-support