### PR TITLE
BZ1878471: Removed requirement that's no longer needed

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -4,6 +4,16 @@
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
 
+ifeval::["{context}" == "installing-azure-government-region"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:azure-private:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:azure:
+endif::[]
+
 [id="installation-about-custom-azure-vnet_{context}"]
 = About reusing a VNet for your {product-title} cluster
 
@@ -41,7 +51,10 @@ To ensure that the subnets that you provide are suitable, the installation progr
 
 * All the subnets that you specify exist.
 * You provide two private subnets, one for the control plane machines and one for the compute machines.
-* The subnet CIDRs belong to the machine CIDR that you specified. Machines are not provisioned in availability zones that you do not provide private subnets for. If required, the installation program creates public load balancers that manage the control plane and worker nodes, and Azure allocates a public IP address to them.
+* The subnet CIDRs belong to the machine CIDR that you specified. Machines are not provisioned in availability zones that you do not provide private subnets for.
+ifdef::azure[]
+If required, the installation program creates public load balancers that manage the control plane and worker nodes, and Azure allocates a public IP address to them.
+endif::[]
 
 If you destroy a cluster that uses an existing VNet, the VNet is not deleted.
 


### PR DESCRIPTION
The enhancement of user-defined outbound routing starting in OCP-4.6 makes public IP addresses and the public load balancer a non-requirement for Vnet in private cluster installs on Azure. However, public IP addresses and public load balancers are still required in other types of Azure installs, like "Installing a cluster on Azure into a Government Region" and "Installing a cluster on Azure into an existing VNet"

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1878471

Direct link to doc preview: https://deploy-preview-31938--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private.html#installation-about-custom-azure-vnet-requirements_installing-azure-private

For 4.6+


