### PR TITLE
OSSMDOC-308: Uninstall reorg

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2612,7 +2612,7 @@ Topics:
     File: ossm-deploy-production
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
-  - Name: Removing Service Mesh
+  - Name: Uninstalling Service Mesh
     File: removing-ossm
   - Name: Configuration reference
     File: ossm-reference

--- a/modules/ossm-control-plane-remove.adoc
+++ b/modules/ossm-control-plane-remove.adoc
@@ -6,17 +6,12 @@
 [id="ossm-control-plane-remove_{context}"]
 = Removing the {ProductName} control plane
 
-You can remove the {ProductShortName} control plane by using the {product-title} web console or the CLI.
-
+To uninstall {ProductShortName} from an existing {product-title} instance, you must first delete the control plane and the Operators. Then, you must run commands to manually remove residual resources.
 
 [id="ossm-control-plane-remove-operatorhub_{context}"]
 == Removing the control plane with the web console
 
 You can remove the {ProductName} control plane by using the web console.
-
-.Prerequisites
-
-* The {ProductName} control plane must be deployed.
 
 .Procedure
 
@@ -34,28 +29,12 @@ You can remove the {ProductName} control plane by using the web console.
 
 . Click *Delete* on the confirmation dialog window to remove the `ServiceMeshControlPlane`.
 
-
-
 [id="ossm-control-plane-remove-cli_{context}"]
 == Removing the control plane from the CLI
 
 You can remove the {ProductName} control plane by using the CLI.
 
-.Prerequisites
-* The {ProductName} control plane must be deployed.
-* Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
-
 .Procedure
-
-[NOTE]
-====
-When you remove the `ServiceMeshControlPlane`, {ProductShortName} tells the Operator to begin uninstalling everything it installed.
-====
-
-[TIP]
-====
-You can use the shortened `smcp` alias in place of `servicemeshcontrolplane`.
-====
 
 . Log in to the {product-title} CLI.
 
@@ -63,13 +42,12 @@ You can use the shortened `smcp` alias in place of `servicemeshcontrolplane`.
 +
 [source,terminal]
 ----
-$ oc get servicemeshcontrolplanes -n istio-system
+$ oc get smcp -n istio-system
 ----
 
-+
 . Replace `<name_of_custom_resource>` with the output from the previous command, and run this command to remove the custom resource:
 +
 [source,terminal]
 ----
-$ oc delete servicemeshcontrolplanes -n istio-system <name_of_custom_resource>
+$ oc delete smcp -n istio-system <name_of_custom_resource>
 ----

--- a/modules/ossm-member-roll-delete.adoc
+++ b/modules/ossm-member-roll-delete.adoc
@@ -1,9 +1,0 @@
-// Module included in the following assemblies:
-//
-// * service_mesh/v1x/installing-ossm.adoc
-// * service_mesh/v2x/installing-ossm.adoc
-
-[id="ossm-member-roll-delete_{context}"]
-= Removing the {ProductName} member roll
-
-The `ServiceMeshMemberRoll` resource is automatically deleted when you delete the `ServiceMeshControlPlane` resource it is associated with.

--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -6,12 +6,7 @@
 [id="ossm-remove-cleanup_{context}"]
 = Clean up Operator resources
 
-You can manually remove resources left behind after removing the {ProductName} Operator using the OpenShift console.
-
-.Prerequisites
-
-* An account with cluster administration access.
-* Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
+Follow this procedure to manually remove resources left behind after removing the {ProductName} Operator by using the OpenShift console.
 
 .Procedure
 
@@ -21,7 +16,7 @@ You can manually remove resources left behind after removing the {ProductName} O
 +
 [NOTE]
 ====
-The Operators are installed in the `openshift-operators` namespace by default.  If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
+The Openshift Elasticsearch operator is installed in `openshift-operators-redhat` by default. The other Operators are installed in the `openshift-operators` namespace by default. If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
 ====
 +
 [source,terminal]

--- a/modules/ossm-remove-operators.adoc
+++ b/modules/ossm-remove-operators.adoc
@@ -6,105 +6,22 @@
 [id="ossm-operatorhub-remove-operators_{context}"]
 = Removing the installed Operators
 
-You must remove the Operators to successfully remove {ProductName}. Once you remove the {ProductName} Operator, you must remove the Kiali Operator, the Jaeger Operator,  and the OpenShift Elasticsearch Operator.
+You must remove the Operators to successfully remove {ProductName}. Once you remove the {ProductName} Operator, you must remove the Kiali Operator, the Jaeger Operator, and the OpenShift Elasticsearch Operator.
 
 [id="ossm-remove-operator-servicemesh_{context}"]
-== Removing the {ProductName} Operator
+== Removing the Operators
 
-Follow this procedure to remove the {ProductName} Operator.
+Follow this procedure to remove the Operators that make up {ProductName}. Repeat the steps for each of the following Operators.
 
-.Prerequisites
-
-* Access to the {product-title} web console.
-* The {ProductName} Operator must be installed.
-
-.Procedure
-
-. Log in to the {product-title} web console.
-
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into the *Filter by name* to find the {ProductName} Operator. Then, click on it.
-
-. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
-
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs associated with the Operator.
-
-[id="ossm-remove-operator-kiali_{context}"]
-== Removing the Kiali Operator
-
-Follow this procedure to remove the Kiali Operator.
-
-.Prerequisites
-
-* Access to the {product-title} web console.
-* The Kiali Operator must be installed.
+* {ProductName}
+* Kiali
+* Jaeger
+* OpenShift Elasticsearch
 
 .Procedure
 
 . Log in to the {product-title} web console.
 
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the Kiali Operator. Then, click on it.
+. From the *Operators* → *Installed Operators* page, scroll or type a keyword into the *Filter by name* to find each Operator. Then, click the Operator name.
 
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
-
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
-associated with the Operator.
-
-[id="ossm-remove-operator-jaeger_{context}"]
-== Removing the Jaeger Operator
-
-Follow this procedure to remove the Jaeger Operator.
-
-.Prerequisites
-
-* Access to the {product-title} web console.
-* The Jaeger Operator must be installed.
-
-.Procedure
-
-. Log in to the {product-title} web console.
-
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the Jaeger Operator. Then, click on it.
-
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
-
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
-associated with the Operator.
-
-[id="ossm-remove-operator-elasticsearch_{context}"]
-== Removing the OpenShift Elasticsearch Operator
-
-Follow this procedure to remove the OpenShift Elasticsearch Operator.
-
-.Prerequisites
-
-* Access to the {product-title} web console.
-* The OpenShift Elasticsearch Operator must be installed.
-
-.Procedure
-
-. Log in to the {product-title} web console.
-
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into
-the *Filter by name* to find the OpenShift Elasticsearch Operator. Then, click on it.
-
-. On the right-hand side of the *Operator Details* page, select *Uninstall
-Operator* from the *Actions* drop-down menu.
-
-. When prompted by the *Remove Operator Subscription* window, optionally select the
-*Also completely remove the Operator from the selected namespace*
-check box if you want all components related to the installation to be removed.
-This removes the CSV, which in turn removes the pods, Deployments, CRDs, and CRs
-associated with the Operator.
+. On the the *Operator Details* page, select *Uninstall Operator* from the *Actions* menu. Follow the prompts to uninstall each Operator.

--- a/service_mesh/v1x/removing-ossm.adoc
+++ b/service_mesh/v1x/removing-ossm.adoc
@@ -5,9 +5,7 @@ include::modules/ossm-document-attributes-1x.adoc[]
 
 toc::[]
 
-This process allows you to remove {ProductName} from an existing {product-title} instance. Remove the control plane before removing the operators.
-
-include::modules/ossm-member-roll-delete.adoc[leveloffset=+1]
+To remove {ProductName} from an existing {product-title} instance, remove the control plane before removing the operators.
 
 include::modules/ossm-control-plane-remove.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/removing-ossm.adoc
+++ b/service_mesh/v2x/removing-ossm.adoc
@@ -1,16 +1,14 @@
 [id="removing-ossm"]
-= Removing {ProductName}
+= Uninstalling {ProductName}
 include::modules/ossm-document-attributes.adoc[]
 :context: removing-ossm
 
 toc::[]
 
-This process allows you to remove {ProductName} from an existing {product-title} instance. Remove the control plane before removing the operators.
-
-include::modules/ossm-member-roll-delete.adoc[leveloffset=+1]
+To uninstall {ProductName} from an existing {product-title} instance and remove its resources, you must delete the control plane, delete the Operators, and run commands to manually remove some resources.
 
 include::modules/ossm-control-plane-remove.adoc[leveloffset=+1]
 
 include::modules/ossm-remove-operators.adoc[leveloffset=+1]
 
-include::modules/ossm-remove-cleanup.adoc[leveloffset=+2]
+include::modules/ossm-remove-cleanup.adoc[leveloffset=+1]


### PR DESCRIPTION
- Aligned team: Service mesh
- For branches: 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/OSSMDOC-308
- After testing the [remove docs](https://deploy-preview-31939--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/removing-ossm.html), I've condensed the instructions.
- I also rewrote the short description and removed the servicemeshmemberoll module.  
- https://deploy-preview-31939--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/removing-ossm.html

- SME review: rcernich, brian-avery
- QE review: gbaufake
- Peer review: hjoy, mikemckiernan