### PR TITLE
BZ-1862278: Added changes as requested in the bug

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -126,6 +126,11 @@ The cluster requires several firewall rules. If you do not use a shared VPC, the
 
 If you choose to create each rule based on events, you must create firewall rules after you provision the cluster and during the life of the cluster when the console notifies you that rules are missing. Events that are similar to the following event are displayed, and you must add the firewall rules that are required:
 
+[source,terminal]
+----
+$ oc get events -n openshift-ingress --field-selector="reason=LoadBalancerManualChange"
+----
+
 .Example output
 [source,terminal]
 ----

--- a/modules/installation-deployment-manager-int-lb.adoc
+++ b/modules/installation-deployment-manager-int-lb.adoc
@@ -15,3 +15,5 @@ You can use the following Deployment Manager template to deploy the internal loa
 include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/02_lb_int.py[]
 ----
 ====
+
+You will need this template in addition to the `02_lb_ext.py` template when you create an external cluster.

--- a/modules/installation-gcp-user-infra-adding-ingress.adoc
+++ b/modules/installation-gcp-user-infra-adding-ingress.adoc
@@ -16,11 +16,13 @@ ifdef::shared-vpc[]
 = Adding the ingress DNS records
 endif::shared-vpc[]
 
-If you removed the DNS Zone configuration when creating Kubernetes manifests and
-generating Ignition configs, you must manually create DNS records that point at
-the ingress load balancer. You can create either a wildcard
-`*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other
-records per your requirements.
+ifndef::shared-vpc[]
+If you removed the DNS zone configuration when creating Kubernetes manifests and generating Ignition configs, you must manually create DNS records that point at the ingress load balancer. You can create either a wildcard `*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+endif::[]
+ifdef::shared-vpc[]
+DNS zone configuration is removed when creating Kubernetes manifests and generating Ignition configs. You must manually create DNS records that point at the ingress load balancer. You can create either a wildcard
+`*.apps.{baseDomain}.` or specific records. You can use A, CNAME, and other records per your requirements.
+endif::[]
 
 .Prerequisites
 

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -54,17 +54,17 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   gcp:
-    projectID: openshift-production
-    region: us-central1 <5>
+    projectID: openshift-production <5>
+    region: us-central1 <6>
 pullSecret: '{"auths": ...}'
 ifndef::openshift-origin[]
-fips: false <6>
-sshKey: ssh-ed25519 AAAA... <7>
-publish: Internal <8>
+fips: false <7>
+sshKey: ssh-ed25519 AAAA... <8>
+publish: Internal <9>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <6>
-publish: Internal <7>
+sshKey: ssh-ed25519 AAAA... <7>
+publish: Internal <8>
 endif::openshift-origin[]
 ----
 <1> Specify the public DNS on the host project.
@@ -76,13 +76,14 @@ endif::openshift-origin[]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Specify the region that your VPC network is in.
+<5> Specify the main project where the VM instances reside. 
+<6> Specify the region that your VPC network is in.
 ifndef::openshift-origin[]
-<6> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -90,10 +91,10 @@ endif::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifndef::openshift-origin[]
-<8> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+<9> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
 To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<7> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+<8> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
 To use a shared VPC in a cluster that uses infrastructure that you provision, you must set `publish` to `Internal`. The installation program will no longer be able to access the public DNS zone for the base domain in the host project.
 endif::openshift-origin[]


### PR DESCRIPTION
Applies to 4.5+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1862278 [Please see the BZ Link as the requested changes are in Comment 0]
Preview Links:

- https://deploy-preview-31942--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-shared-vpc-config-yaml_installing-gcp-user-infra-vpc [#5 on the install-config.yaml file]

- https://deploy-preview-31942--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-deployment-manager-int-lb_installing-gcp-user-infra-vpc [After the 02_lb_int.py template file. Added a paragraph]

- https://deploy-preview-31942--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-worker_installing-gcp-user-infra-vpc [Step 2a]

- https://deploy-preview-31942--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-adding-ingress_installing-gcp-user-infra-vpc [First paragraph + new note]

- https://deploy-preview-31942--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-vpc-adding-firewall-rules [Example Output]

Pending QE Approval: @tsze-redhat 