### PR TITLE
JIRA CNV-10760 Adding information about referencing NAD definitions in different namespaces

### DIFF
--- a/modules/virt-attaching-vm-secondary-network-cli.adoc
+++ b/modules/virt-attaching-vm-secondary-network-cli.adoc
@@ -39,7 +39,7 @@ spec:
           pod: {}
         - name: bridge-net <1>
           multus:
-            networkName: <a-bridge-network> <2>
+            networkName: <network-namespace/a-bridge-network> <2>
 ...
 ----
 <1> The name of the bridge interface. This value must match the `name` value of the corresponding `spec.template.spec.networks` entry.
@@ -47,7 +47,7 @@ spec:
 +
 [NOTE]
 ====
-The example virtual machine is connected to both the `default` pod network and `bridge-net`, which is defined by a network attachment definition named `a-bridge-network`.
+The example virtual machine is connected to both the `default` pod network and `bridge-net`, which is defined by a network attachment definition named `a-bridge-network`. If the network attachment definition is not in the same namespace as the VM, you must combine the namespace and the network name to create the network attachment definition name.
 ====
 
 . Apply the configuration:


### PR DESCRIPTION
This PR addresses JIRA story [CNV-10760](https://issues.redhat.com/browse/CNV-10760) ( https://issues.redhat.com/browse/CNV-10760 ) and Bug 1935549 ( https://bugzilla.redhat.com/show_bug.cgi?id=1935549 ).

The story/bug deals with adding information about being able to reference NAD definitions in a different namespace of a VM.

CP: 4.8

Preview: https://deploy-preview-31951--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-attaching-vm-secondary-network-cli_virt-attaching-multiple-networks