### PR TITLE
GH#31508 - Fix Debian package extension typo

### DIFF
--- a/modules/olm-csv.adoc
+++ b/modules/olm-csv.adoc
@@ -7,7 +7,7 @@
 
 A _cluster service version_ (CSV) represents a specific version of a running Operator on an {product-title} cluster. It is a YAML manifest created from Operator metadata that assists Operator Lifecycle Manager (OLM) in running the Operator in the cluster.
 
-OLM requires this metadata about an Operator to ensure that it can be kept running safely on a cluster, and to provide information about how updates should be applied as new versions of the Operator are published. This is similar to packaging software for a traditional operating system; think of the packaging step for OLM as the stage at which you make your `rpm`, `dep`, or `apk` bundle.
+OLM requires this metadata about an Operator to ensure that it can be kept running safely on a cluster, and to provide information about how updates should be applied as new versions of the Operator are published. This is similar to packaging software for a traditional operating system; think of the packaging step for OLM as the stage at which you make your `rpm`, `deb`, or `apk` bundle.
 
 A CSV includes the metadata that accompanies an Operator container image, used to populate user interfaces with information such as its name, version, description, labels, repository link, and logo.
 


### PR DESCRIPTION
Applies to master, branch/enterprise-4.5, branch/enterprise-4.6, branch/enterprise-4.7 and branch/enterprise-4.8.

This relates to https://github.com/openshift/openshift-docs/issues/31508.