### PR TITLE
BZ#1954008: RHV import to CNV with insufficient storage

### DIFF
--- a/modules/virt-importing-vm-prerequisites.adoc
+++ b/modules/virt-importing-vm-prerequisites.adoc
@@ -9,7 +9,7 @@ Importing a virtual machine from Red Hat Virtualization (RHV) into {VirtProductN
 * You must have admin user privileges.
 * Storage:
 ** The {VirtProductName} local and shared persistent storage classes must support VM import.
-** If you are using Ceph RBD block-mode volumes, the storage must be large enough to accommodate the virtual disk. If the disk is too large for the available storage, the import process fails and the PV that is used to copy the virtual disk is not released.
+** If you are using Ceph RBD block-mode volumes and the available storage space is too small for the virtual disk, the import process bar stops at 75% for more than 20 minutes and the migration does not succeed. No error message is displayed in the web console. link:https://bugzilla.redhat.com/show_bug.cgi?id=1910019[*BZ#1910019*]
 ** If you are using NFS storage, you must run the following command because of a known issue (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946177[*BZ#1946177*]):
 +
 [source,terminal]

--- a/modules/virt-troubleshooting-vm-import.adoc
+++ b/modules/virt-troubleshooting-vm-import.adoc
@@ -76,9 +76,7 @@ Failed to bind volumes: provisioning failed for PVC
 ----
 +
 You must use a compatible storage class. The Cinder storage class is not supported.
-
 endif::[]
-
 ifdef::virt-importing-vmware-vm[]
 The following error messages might appear:
 
@@ -98,4 +96,12 @@ Restricted Access: configmaps "vmware-to-kubevirt-os" is forbidden: User cannot 
 ----
 +
 Only an admin user can import a VM.
+endif::[]
+
+ifdef::virt-importing-rhv-vm[]
+[id="known-issues_{context}"]
+== Known issues
+
+* If you are using Ceph RBD block-mode volumes and the available storage space is too small for the virtual disk, the import process bar stops at 75% for more than 20 minutes and the migration does not succeed. No error message is displayed in the web console. link:https://bugzilla.redhat.com/show_bug.cgi?id=1910019[*BZ#1910019*]
+
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1954008

4.5+

Import fails without warning if Ceph block storage is too small for RHV disk.

Change previews:

https://deploy-preview-31955--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-importing-vm-prerequisites_virt-importing-rhv-vm (storage prerequisites) 

https://deploy-preview-31955--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#known-issues_virt-importing-rhv-vm (known issues)

Verified by QE

