### PR TITLE
OSDOCS-1855: Egress router for OVN-K

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -439,6 +439,13 @@ In {product-title} 4.8, you can configure an external load balancer to handle `a
 
 {product-title} 4.8 adds OVN-Kubernetes IPsec support for clusters that are configured to use dual-stack networking.
 
+[id="ocp-4-8-egress-router-ovn-kubernetes"]
+==== Egress router CNI for OVN-Kubernetes
+
+The egress router CNI plug-in is generally available. The Cluster Network Operator is enhanced to support an `EgressRouter` API object. The process for adding an egress router on a cluster that uses OVN-Kubernetes is simplified. When you create an egress router object, the Operator automatically adds a network attachment definition and a deployment. The pod for the deployment acts as the egress router.
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/using-an-egress-router-ovn.adoc[Considerations for the use of an egress router pod].
+
 [id="ocp-4-8-storage"]
 === Storage
 [id="ocp-4-8-storage-gcp-pd-csi-ga"]
@@ -1162,7 +1169,7 @@ In the table below, features are marked with the following statuses:
 |Egress router CNI plug-in
 |-
 |TP
-|
+|GA
 
 |Scheduler profiles
 |-


### PR DESCRIPTION
The [Egress router](https://deploy-preview-31964--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-egress-router-ovn-kubernetes) heading is the new information.

PTAL.

/assign @danielmellado 
/assign @weliang1

----
Applies to branch enterprise-4.8 and milestone Future-Release.