### PR TITLE
vsphere, baremetal, platform none vmxnet3 bz

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -45,6 +45,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-platform-agnostic"]
+:agnostic:
+endif::[]
 
 [id="installation-requirements-user-infra_{context}"]
 = Machine requirements for a cluster with user-provisioned infrastructure
@@ -85,6 +88,13 @@ endif::ibm-z[]
 ====
 
 The bootstrap and control plane machines must use {op-system-first} as the operating system.
+
+ifdef::bare-metal,agnostic[]
+[IMPORTANT]
+====
+If the `platform: none` field is defined in the `install-config.yaml` file, virtual machines (VMs) configured to use virtual hardware version 14 or greater might result in a failed installation. It is recommended to configure VMs with virtual hardware version 13. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1935539[BZ#1935539].
+====
+endif::bare-metal,agnostic[]
 
 ifndef::openshift-origin[]
 Note that {op-system} is based on {op-system-base-full} 8 and inherits all of its hardware certifications and requirements.
@@ -369,4 +379,7 @@ ifeval::["{context}" == "installing-bare-metal-network-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!bare-metal:
+endif::[]
+ifeval::["{context}" == "installing-platform-agnostic"]
+:!agnostic:
 endif::[]


### PR DESCRIPTION
A customer running on ESXi with or without vCenter
may hit the vmxnet3 v4 bug even when using `platform: none`.

Add an important note that was added to vSphere doc section
to baremetal.

Preview: https://deploy-preview-31965--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#machine-requirements_installing-bare-metal