### PR TITLE
Add WWID to PV def

### DIFF
--- a/install_config/persistent_storage/persistent_storage_fibre_channel.adoc
+++ b/install_config/persistent_storage/persistent_storage_fibre_channel.adoc
@@ -12,32 +12,21 @@
 toc::[]
 
 == Overview
-You can provision your {product-title} cluster with
-xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent storage] using
-link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-fibrechanel.html[Fibre Channel].
-Some familiarity with Kubernetes and Fibre Channel is assumed.
+You can provision your {product-title} cluster with xref:../../architecture/additional_concepts/storage.adoc#architecture-additional-concepts-storage[persistent storage] using link:https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/Storage_Administration_Guide/ch-fibrechanel.html[Fibre Channel] (FC). Some familiarity with Kubernetes and FC is assumed.
 
-The Kubernetes xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent volume]
-framework allows administrators to provision a cluster with persistent storage
-and gives users a way to request those resources without having any knowledge of
-the underlying infrastructure.
+The Kubernetes xref:../../dev_guide/persistent_volumes.adoc#dev-guide-persistent-volumes[persistent volume] framework allows administrators to provision a cluster with persistent storage and gives users a way to request those resources without having any knowledge of the underlying infrastructure.
 
 [IMPORTANT]
 ====
-High-availability of storage in the infrastructure is left to the underlying
-storage provider.
+High-availability of storage in the infrastructure is left to the underlying storage provider.
 ====
 
 [[provisioning-fibre]]
 
 == Provisioning
-Storage must exist in the underlying infrastructure before it can be mounted as
-a volume in {product-title}. All that is required for Fibre Channel persistent
-storage is the *targetWWNs* (array of Fibre Channel target's World Wide
-Names), a valid *LUN* number, filesystem type, and the `*PersistentVolume*`
-API. Persistent volume and a LUN have one-to-one mapping between them.
+Storage must exist in the underlying infrastructure before it can be mounted as a volume in {product-title}. All that is required for FC persistent storage is the `*PersistentVolume*` API,  the `*wwids*` or the `*targetWWNs*` with a valid `*lun*` number, and the `*fsType*`. Persistent volume and a LUN have one-to-one mapping between them.
 
-.Persistent Volumes Object Definition
+.Persistent Volume Object Definition
 
 [source,yaml]
 ----
@@ -51,34 +40,29 @@ spec:
   accessModes:
     - ReadWriteOnce
   fc:
-    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <1>
-    lun: 2
+    wwids: [scsi-3600508b400105e210000900000490000] <1>
+    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <2>
+    lun: 2 <2>
     fsType: ext4
 ----
-<1> Fibre Channel WWNs are identified as `/dev/disk/by-path/pci-<IDENTIFIER>-fc-0x<WWN>-lun-<LUN#>`, but you do not need to provide any part of the path leading up to the `WWN`, including the `0x`, and anything after, including the `-` (hyphen).
+<1> Optional: World wide identifiers (WWIDs). Either FC `*wwids*` or a combination of FC `*targetWWNs*` and `*lun*` must be set, but not both simultaneously. The FC WWID identifier is recommended over the WWNs target because it is guaranteed to be unique for every storage device, and independent of the path that is used to access the device. The WWID identifier can be obtained by issuing a SCSI Inquiry to retrieve the Device Identification Vital Product Data (`*page 0x83*`) or Unit Serial Number (`*page 0x80*`). FC WWIDs are identified as `*/dev/disk/by-id/*` to reference the data on the disk, even if the path to the device changes and even when accessing the device from different systems.
+<2> Optional: World wide names (WWNs). Either FC `*wwids*` or a combination of FC `*targetWWNs*` and `*lun*` must be set, but not both simultaneously. The FC WWID identifier is recommended over the WWNs target because it is guaranteed to be unique for every storage device, and independent of the path that is used to access the device. FC WWNs are identified as `*/dev/disk/by-path/pci-<identifier>-fc-0x<wwn>-lun-<lun_#>*`, but you do not need to provide any part of the path leading up to the `*<wwn>*`, including the `0x`, and anything after, including the `-` (hyphen).
 
 [IMPORTANT]
 ====
-Changing the value of the `*fstype*` parameter after the volume has been
-formatted and provisioned can result in data loss and pod failure.
+Changing the value of the `*fstype*` parameter after the volume has been formatted and provisioned can result in data loss and pod failure.
 ====
 
 [[enforcing-disk-quotas-fibre]]
 
 === Enforcing Disk Quotas
-Use LUN partitions to enforce disk quotas and size constraints. Each LUN is one persistent volume. Kubernetes enforces
-unique names for persistent volumes.
+Use LUN partitions to enforce disk quotas and size constraints. Each LUN is one persistent volume. Kubernetes enforces unique names for persistent volumes.
 
-Enforcing quotas in this way allows the end user to request persistent storage
-by a specific amount (e.g, 10Gi) and be matched with a corresponding volume of
-equal or greater capacity.
+Enforcing quotas in this way allows the end user to request persistent storage by a specific amount, such as 10 Gi, and be matched with a corresponding volume of equal or greater capacity.
 
 [[volume-security-fibre]]
 
 === Fibre Channel Volume Security
-Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in
-the user's namespace and can only be referenced by a pod within that same
-namespace. Any attempt to access a persistent volume across a namespace causes
-the pod to fail.
+Users request storage with a `*PersistentVolumeClaim*`. This claim only lives in the namespace of the user and can only be referenced by a pod within that same namespace. Any attempt to access a persistent volume claim across a namespace causes the pod to fail.
 
-Each Fibre Channel LUN must be accessible by all nodes in the cluster.
+Each FC LUN must be accessible by all nodes in the cluster.


### PR DESCRIPTION
[BZ1598285](https://bugzilla.redhat.com/show_bug.cgi?id=1598285) - Adds examples for WWIDs in PV object definition YAML, with note that either WWID or targetWWN and lun can be used but not simultaneously, as described in k8s [ISSUE-48639](https://github.com/kubernetes/kubernetes/issues/48639).

**PREVIEW LINK:** https://deploy-preview-31966--osdocs.netlify.app/openshift-enterprise/latest/install_config/persistent_storage/persistent_storage_fibre_channel.html#provisioning-fibre