### PR TITLE
Only global pull secrets can be configured in clusters where ImageContentSourcePolicy is set

### DIFF
--- a/modules/builds-image-source.adoc
+++ b/modules/builds-image-source.adoc
@@ -39,6 +39,11 @@ source:
 <4> The directory relative to the build root where the build process can access the file.
 <5> The location of the file to be copied out of the referenced image.
 <6> An optional secret provided if credentials are needed to access the input image.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 
 Optionally, if an input image requires a pull secret, you can link the pull secret to the service account used by the build. By default, builds use the `builder` service account. The pull secret is automatically added to the build if the secret contains a credential that matches the repository hosting the input image. To link a pull secret to the service account used by the build, run:
 

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -30,10 +30,16 @@ By pulling container images needed by {product-title} and then bringing those im
 Even if you don't configure mirroring during {product-title} installation, you can do so later using the `ImageContentSourcePolicy` object.
 
 The following procedure provides a post-installation mirror configuration, where you create an `ImageContentSourcePolicy` object that identifies:
-
+--
 * The source of the container image repository you want to mirror.
 * A separate entry for each mirror repository you want to offer the content
 requested from the source repository.
+--
+
+[NOTE]
+====
+You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project. 
+====
 
 .Prerequisites
 * Access to the cluster as a user with the `cluster-admin` role.

--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -175,6 +175,11 @@ The manifests directory contains the following files, some of which might requir
 If you mirrored the content to local files, you must modify your `catalogSource.yaml` file to remove any backslash (`/`) characters from the `metadata.name` field. Otherwise, when you attempt to create the object, it fails with an "invalid resource name" error.
 ====
 * The `imageContentSourcePolicy.yaml` file defines an `ImageContentSourcePolicy` object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 * The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
 +
 [IMPORTANT]
@@ -191,6 +196,7 @@ $ oc create -f <path/to/manifests/dir>/imageContentSourcePolicy.yaml
 ----
 +
 where `<path/to/manifests/dir>` is the path to the manifests directory for your mirrored content.
+
 
 You can now create a `CatalogSource` object to reference your mirrored index image and Operator content.
 

--- a/modules/olm-mirroring-package-manifest-catalog.adoc
+++ b/modules/olm-mirroring-package-manifest-catalog.adoc
@@ -63,6 +63,11 @@ After running the command, a `manifests-<index_image_name>-<random_number>/` dir
 --
 * The `catalogSource.yaml` file is a basic definition for a `CatalogSource` object that is pre-populated with your catalog image tag and other relevant metadata. This file can be used as is or modified to add the catalog source to your cluster.
 * The `imageContentSourcePolicy.yaml` file defines an `ImageContentSourcePolicy` object that can configure nodes to translate between the image references stored in Operator manifests and the mirrored registry.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 * The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
 --
 

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -59,6 +59,11 @@ $ LOCAL_SECRET_JSON='<path_to_pull_secret>'
 ----
 +
 For `<path_to_pull_secret>`, specify the absolute path to and file name of the pull secret for your mirror registry that you created.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 
 .. Export the release mirror:
 +

--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -25,3 +25,8 @@ $ oc adm upgrade --allow-explicit-upgrade --to-image ${LOCAL_REGISTRY}/${LOCAL_R
 <1> The `<sha256_sum_value>` value is the sha256 sum value for the release from the image signature ConfigMap, for example, `@sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
 +
 If you use an `ImageContentSourcePolicy` for the mirror registry, you can use the canonical registry name instead of `LOCAL_REGISTRY`.
++
+[NOTE]
+====
+You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project. 
+====

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -22,3 +22,7 @@ include::modules/images-configuration-shortname.adoc[leveloffset=+2]
 include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
+
+.Additional resources
+
+For more information about global pull secrets, see xref:../openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1889413

Added the same note in multiple locations.
Previews:
[Configuring image registry repository mirroring](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration). The new link is at the bottom of this file.
[Mirroring an Operator catalog](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks)
[Mirroring a Package Manifest Format catalog image](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-mirroring-package-manifest-catalog_olm-managing-custom-catalogs)
[Mirroring the OpenShift Container Platform image repository](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html#update-mirror-repository_updating-restricted-network-cluster)
[Upgrading the restricted network cluster](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html#update-restricted_updating-restricted-network-cluster)
[Image source](https://deploy-preview-31968--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs.html#builds-image-source_creating-build-inputs)