### PR TITLE
BZ-1875931 Update wording for cluster autoscaler memory resource limits

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -43,8 +43,8 @@ spec:
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.
 <3> Specify the minimum number of cores to deploy.
 <4> Specify the maximum number of cores to deploy.
-<5> Specify the minimum amount of memory, in GiB, per node.
-<6> Specify the maximum amount of memory, in GiB, per node.
+<5> Specify the minimum amount of memory, in GiB, in the cluster.
+<6> Specify the maximum amount of memory, in GiB, in the cluster.
 <7> Optionally, specify the type of GPU node to deploy. Only `nvidia.com/gpu` and `amd.com/gpu` are valid types.
 <8> Specify the minimum number of GPUs to deploy.
 <9> Specify the maximum number of GPUs to deploy.
@@ -54,3 +54,8 @@ spec:
 <13> Specify the period to wait before deleting a node after a node has recently been _deleted_. If you do not specify a value, the default value of `10s` is used.
 <14> Specify the period to wait before deleting a node after a scale down failure occurred. If you do not specify a value, the default value of `3m` is used.
 <15> Specify the period before an unnecessary node is eligible for deletion. If you do not specify a value, the default value of `10m` is used.
+
+[NOTE]
+====
+When performing a scaling operation, the cluster autoscaler remains within the ranges set in the `ClusterAutoscaler` resource definition, such as the minimum and maximum number of cores to deploy or the amount of memory in the cluster. However, the cluster autoscaler does not correct the current values in your cluster to be within those ranges.
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1875931

Update wording in the `ClusterAutoscaler` resource definition for the `resourceLimits:memory:min` and `resourceLimits:memory:max`.

Preview: https://deploy-preview-31982--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-cr_applying-autoscaling