### PR TITLE
 BZ1648088 Clarifies OCP does not support multiple LDAP servers for same identity provider 

### DIFF
--- a/install_config/configuring_authentication.adoc
+++ b/install_config/configuring_authentication.adoc
@@ -127,7 +127,7 @@ provider to existing users by setting the `mappingMethod` parameter to
 [[identity-providers-configuring]]
 == Configuring identity providers
 
-{product-title} supports configuring only a single identity provider. However,
+{product-title} does not support configuring multiple LDAP servers for the same identity provider. However,
 you can extend the basic authentication for more complex
 configurations such as xref:../install_config/sssd_for_ldap_failover.adoc#setting-up-for-ldap-failover[LDAP failover].
 


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1648088

Preview: https://deploy-preview-31984--osdocs.netlify.app/openshift-enterprise/latest/install_config/configuring_authentication.html#identity-providers-configuring

For 3.11. 

@barleyer please review. Thanks! 