### PR TITLE
Add installation configuration parameters

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -45,6 +45,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 // Network Operator specific configuration

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -52,6 +52,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -65,6 +65,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -327,7 +327,21 @@ networking:
 
 |`publish`
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
-|`Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
+|
+ifdef::aws,azure,gcp[]
+`Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
+endif::[]
+ifndef::aws,azure,gcp[]
+`Internal` or `External`. The default value is `External`.
+
+Setting this field to `Internal` is not supported on non-cloud platforms.
+ifeval::[{product-version} <= 4.7]
+[IMPORTANT]
+====
+If the value of the field is set to `Internal`, the cluster will become non-functional. For more information, refer to link:https://bugzilla.redhat.com/show_bug.cgi?id=1953035[BZ#1953035].
+====
+endif::[]
+endif::[]
 
 |`sshKey`
 | The SSH key or keys to authenticate access your cluster machines.


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1952277

So the list of installation parameters was never included with the bare metal installation documentation. I'm not sure why this is, but it would be useful to include this, particularly when exposing information about dual-stack support.

Before: https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal/installing-bare-metal.html#installation-initializing-manual_installing-bare-metal
After: https://deploy-preview-31990--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters_installing-bare-metal