### PR TITLE
WIP CNF-1498_RN: Documenting support for n3000 and ACC100 in 4.8 

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -120,6 +120,19 @@ The following descheduler metrics are available:
 
 [id="ocp-4-8-scale"]
 === Scale
+==== Support for the OpenNESS operator for Intel® FPGA PAC N3000
+{product-title} 4.8 supports the OpenNESS operator for Intel® FPGA PAC N3000. The operator:
+
+* Orchestrates and manages the resources/devices exposed by the Intel® FPGA PAC N3000 card within OpenShift.
+* Provides functionality to load the necessary drivers.
+* Allows the user to program the Intel® FPGA PAC N3000 user image.
+* Enables the update of the Intel® XL710 NICs (Network Interface Cards) firmware.
+
+For vRAN use-cases the operator is used alongside the additionally supported OpenNESS Operator for Intel Wireless FEC Accelerator.
+This operator is a common operator for FEC device/resource management for a range of accelerator cards for example:
+
+* Intel® FPGA PAC N3000
+* Intel® vRAN dedicated accelerator ACC100 (Mount Bryce)
 
 
 [id="ocp-4-8-dev-exp"]


### PR DESCRIPTION
Create the first draft of [CNF-1498](https://issues.redhat.com/browse/CNF-1498) new features section in release notes for 4.8. Issue updated to reflect support for ACC100. Tracking support for both ACC100 and N3000 in https://github.com/openshift/openshift-docs/pull/33328

Preview: https://deploy-preview-32006--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-scale