### PR TITLE
[enterprise-4.5] CNV-9975 [1913948] Clarify size of pvc specification when uploading t…

### DIFF
--- a/modules/virt-uploading-local-disk-image-dv.adoc
+++ b/modules/virt-uploading-local-disk-image-dv.adoc
@@ -49,7 +49,7 @@ $ virtctl image-upload dv <datavolume_name> \ <1>
 ====
 * If you do not want to create a new DataVolume, omit the `--size` parameter and
 include the `--no-create` flag.
-
+* When uploading a disk image to a PVC, the PVC size must be larger than the size of the uncompressed virtual disk.
 * To allow insecure server connections when using HTTPS, use the `--insecure`
 parameter. Be aware that when you use the `--insecure` flag, the authenticity of
 the upload endpoint is *not* verified.


### PR DESCRIPTION
…o PVC/DV

Cherry picked from commit 347e6cbf0e5ae9dac0812503a558af94424bbc66 in https://github.com/openshift/openshift-docs/pull/31442

This is a manual cherry-pick to resolve `git cherry-pick` errors. Removed the `virt-uploading-image-web.adoc` file from the commit because it does not exist in this branch.

cc: @bgaydosrh 