### PR TITLE
drop virtctl rename

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -38,9 +38,6 @@ in memory.
 |`virtctl migrate <vm_name>`
 |Migrate a virtual machine.
 
-|`virtctl rename <vm_name> <new_vm_name>`
-|Rename a stopped virtual machine.
-
 |`virtctl restart <vm_name>`
 |Restart a virtual machine.
 


### PR DESCRIPTION
We never supported `virtctl rename` so we should not document them.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>