### PR TITLE
CNV-11213: bumping HCO version for 2.4.8 release

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.4
 :KubeVirtVersion: v0.30.5
-:HCOVersion: 2.4.7
+:HCOVersion: 2.4.8
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]


### PR DESCRIPTION
- https://issues.redhat.com/browse/CNV-11213
- no cherrypick