### PR TITLE
BZ1848738 - Remove volume claim template name

### DIFF
--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -35,8 +35,6 @@ data:
   config.yaml: |
     <component>:
       volumeClaimTemplate:
-        metadata:
-          name: <PVC_name_prefix>
         spec:
           storageClassName: <storage_class>
           resources:
@@ -59,8 +57,6 @@ data:
   config.yaml: |
     *prometheusK8s*:
       volumeClaimTemplate:
-        metadata:
-          name: *localpvc*
         spec:
           storageClassName: *local-storage*
           resources:
@@ -83,8 +79,6 @@ data:
   config.yaml: |
     *alertmanagerMain*:
       volumeClaimTemplate:
-        metadata:
-          name: *localpvc*
         spec:
           storageClassName: *local-storage*
           resources:


### PR DESCRIPTION
This applies to branch/enterprise-4.5 only. The volume claim template name has been removed from the examples in the equivalent section for 4.6 onward already.

This relates to https://bugzilla.redhat.com/show_bug.cgi?id=1848738.

The preview is [here](https://deploy-preview-32016--osdocs.netlify.app/openshift-enterprise/latest/monitoring/cluster_monitoring/configuring-the-monitoring-stack.html#configuring-a-local-persistent-volume-claim_configuring-monitoring).