### PR TITLE
Tweak bottom margins for collapsed/expanded blocks

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -193,13 +193,14 @@ details {
   box-shadow: 2px 2px 2px #8a8a8a;
   cursor: pointer;
   margin-top: 0.8em;
+  margin-bottom: 1.5em;
   display: list-item;
 }
  details > div {
   border-radius: 0 0 5px 5px;
   background-color: #f9f9f9;
   padding: 4px 6px;
-  margin: 0.5em 0.7em;
+  margin: 0.5em 0.7em 1.5em 0.7em;
   box-shadow: 2px 2px 2px #8a8a8a;
 }
 #collapsibleButtonDiv {


### PR DESCRIPTION
The bottom margin of collapsible blocks (both when expanded and collapsed) looked a little close to the next line of text. This gives it a little more room. Based on discussion with @lbarbeevargas.

Before (collapsed):

![before-collapse](https://user-images.githubusercontent.com/3442316/116449976-fe5aa680-a817-11eb-9451-171545c26028.png)

After (collapsed):

![after-collapse](https://user-images.githubusercontent.com/3442316/116449997-031f5a80-a818-11eb-9dc7-b7b0946220ce.png)

Before (expanded):

![before-expand](https://user-images.githubusercontent.com/3442316/116450008-06b2e180-a818-11eb-921e-ebafa01e14ce.png)

After (expanded):

![after-expand](https://user-images.githubusercontent.com/3442316/116450036-0e728600-a818-11eb-9e7b-56b2f95c3bf3.png)

This is hard to showcase in a live preview because of the `docs.css` target, but here's an internal build that works on certain levels of assemblies (third-level nested topics in this build, specifically). In particular, here's an example with a lot of collapsible content (CTRL+F for "Collapse" to find): 

https://deploy-preview-32029--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html