### PR TITLE
Remove outdated module from assembly

### DIFF
--- a/openshift_images/samples-operator-alt-registry.adoc
+++ b/openshift_images/samples-operator-alt-registry.adoc
@@ -21,8 +21,6 @@ Before you create the mirror registry, you must prepare the mirror host.
 
 include::modules/cli-installing-cli.adoc[leveloffset=+2]
 
-include::modules/installation-creating-mirror-registry.adoc[leveloffset=+1]
-
 //include::modules/installation-local-registry-pull-secret.adoc[leveloffset=+1]
 
 include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+1]


### PR DESCRIPTION
This module is outdated and unsupported. It was pulled from another assembly several releases back, and should be pulled from this assembly as well.  

@kalexand-rh, @pneedle-rh, and @sferich888 FYI.

We might also need an exception to remove it from 4.3 and 4.4 for consistency. 