### PR TITLE
OSSMDOC-316: Release notes reorg

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2505,8 +2505,12 @@ Topics:
 - Name: Service Mesh 2.x
   Dir: v2x
   Topics:
+  - Name: About OpenShift Service Mesh
+    File: ossm-about
   - Name: Service Mesh 2.x release notes
     File: servicemesh-release-notes
+  - Name: Service Mesh support
+    File: ossm-support
   - Name: Service Mesh architecture
     File: ossm-architecture
   - Name: Service Mesh and Istio differences

--- a/modules/ossm-servicemesh-overview.adoc
+++ b/modules/ossm-servicemesh-overview.adoc
@@ -1,21 +1,16 @@
 ////
 Module included in the following assemblies:
-* service_mesh/v1x/ossm-architecture.adoc
-* service_mesh/v2x/ossm-architecture.adoc
-* service_mesh/v1x/servicemesh-release-notes.adoc
-* service_mesh/v2x/servicemesh-release-notes.adoc
+* service_mesh/v2x/ossm-about.adoc
 ////
 
 [id="ossm-servicemesh-overview_{context}"]
-= {ProductName} overview
+= Introduction to {ProductName}
 
-{ProductName} is a platform that provides behavioral insight and operational control over the service mesh, providing a uniform way to connect, secure, and monitor microservice applications.
+{ProductName} addresses a variety of problems in a microservice architecture by creating a centralized point of control in an application. It adds a transparent layer on existing distributed applications without requiring any changes to the application code.
 
-The term _service mesh_ describes the network of microservices that make up applications in a distributed microservice architecture and the interactions between those microservices. As a service mesh grows in size and complexity, it can become harder to understand and manage.
+Microservice architectures split the work of enterprise applications into modular services, which can make scaling and maintenance easier. However, as an enterprise application built on a microservice architecture grows in size and complexity, it becomes difficult to understand and manage. {ProductShortName} can address those architecture problems by capturing or intercepting traffic between services and can modify, redirect, or create new requests to other services.
 
-Based on the open source link:https://istio.io/[Istio] project, {ProductName} adds a transparent layer on existing distributed applications without requiring any changes to the service code. You add {ProductName} support to services by deploying a special sidecar proxy throughout your environment that intercepts all network communication between microservices. You configure and manage the service mesh using the control plane features.
-
-{ProductName} provides an easy way to create a network of deployed services that provides discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring. A service mesh also provides more complex operational functionality, including A/B testing, canary releases, rate limiting, access control, and end-to-end authentication.
+{ProductShortName}, which is based on the open source link:https://istio.io/[Istio project], provides an easy way to create a network of deployed services that provides discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring. A service mesh also provides more complex operational functionality, including A/B testing, canary releases, rate limiting, access control, and end-to-end authentication.
 
 == Making open source more inclusive
 

--- a/service_mesh/v2x/ossm-about.adoc
+++ b/service_mesh/v2x/ossm-about.adoc
@@ -1,0 +1,8 @@
+[id="ossm-about"]
+= About OpenShift Service Mesh
+include::modules/ossm-document-attributes.adoc[]
+:context: ossm-about
+
+toc::[]
+
+include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]

--- a/service_mesh/v2x/ossm-support.adoc
+++ b/service_mesh/v2x/ossm-support.adoc
@@ -1,0 +1,22 @@
+[id="ossm-support"]
+= Getting support
+include::modules/ossm-document-attributes.adoc[]
+:context: ossm-support
+
+toc::[]
+
+include::modules/support.adoc[leveloffset=+1]
+
+The `must-gather` tool enables you to collect diagnostic information about your
+{product-title} cluster, including virtual machines and other data related to
+{ProductName}. You can send that diagnostic information to support for both {product-title} and {ProductName}.
+
+include::modules/about-must-gather.adoc[leveloffset=+1]
+
+=== Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+
+* The {product-title} CLI (`oc`) installed.
+
+include::modules/ossm-about-collecting-ossm-data.adoc[leveloffset=+1]

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -7,32 +7,6 @@ toc::[]
 
 // The following include statements pull in the module files that comprise 2.x release notes.
 
-include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]
-
-include::modules/support.adoc[leveloffset=+1]
-
-When opening a support case, it is helpful to provide debugging
-information about your cluster to Red Hat Support.
-
-The `must-gather` tool enables you to collect diagnostic information about your
-{product-title} cluster, including virtual machines and other data related to
-{ProductName}.
-
-For prompt support, supply diagnostic information for both {product-title}
-and {ProductName}.
-
-include::modules/about-must-gather.adoc[leveloffset=+2]
-
-=== Prerequisites
-
-* Access to the cluster as a user with the `cluster-admin` role.
-
-* The {product-title} CLI (`oc`) installed.
-
-include::modules/ossm-about-collecting-ossm-data.adoc[leveloffset=+2]
-
-include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
-
 include::modules/ossm-rn-new-features.adoc[leveloffset=+1]
 
 include::modules/ossm-rn-technology-preview.adoc[leveloffset=+1]


### PR DESCRIPTION
- Aligned team: Service Mesh
- For branches: 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/OSSMDOC-316

- Splits release notes assembly into three:
- [About](https://deploy-preview-32037--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-about.html) - rewrites about content
- [Release notes](https://deploy-preview-32037--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html)
- [Support](https://deploy-preview-32037--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-support.html)
- SME review: knrc, rcernich, brian-avery
- QE review: gbaufake
- Peer review: hjoy, jc-berger, rolfedh

All reviews done, ready to merge.