### PR TITLE
Update ignition spec version on the MachineConfig examples

### DIFF
--- a/modules/checking-mco-status.adoc
+++ b/modules/checking-mco-status.adoc
@@ -26,13 +26,13 @@ In the previous output, there are three master and three worker nodes. All machi
 ----
 $ oc get machineconfigs
 NAME                             GENERATEDBYCONTROLLER          IGNITIONVERSION  AGE
-00-master                        2c9371fbb673b97a6fe8b1c52...   3.1.0            5h18m
-00-worker                        2c9371fbb673b97a6fe8b1c52...   3.1.0            5h18m
-01-master-container-runtime      2c9371fbb673b97a6fe8b1c52...   3.1.0            5h18m
-01-master-kubelet                2c9371fbb673b97a6fe8b1c52…     3.1.0            5h18m
+00-master                        2c9371fbb673b97a6fe8b1c52...   3.2.0            5h18m
+00-worker                        2c9371fbb673b97a6fe8b1c52...   3.2.0            5h18m
+01-master-container-runtime      2c9371fbb673b97a6fe8b1c52...   3.2.0            5h18m
+01-master-kubelet                2c9371fbb673b97a6fe8b1c52…     3.2.0            5h18m
 ...
-rendered-master-dde...           2c9371fbb673b97a6fe8b1c52...   3.1.0            5h18m
-rendered-worker-fde...           2c9371fbb673b97a6fe8b1c52...   3.1.0            5h18m
+rendered-master-dde...           2c9371fbb673b97a6fe8b1c52...   3.2.0            5h18m
+rendered-worker-fde...           2c9371fbb673b97a6fe8b1c52...   3.2.0            5h18m
 ----
 +
 Note that the `machineconfigs` listed as `rendered` are not meant to be changed or deleted. Expect them to be hidden at some point in the future.
@@ -63,7 +63,7 @@ Name:         01-master-kubelet
 Spec:
   Config:
     Ignition:
-      Version:  3.1.0
+      Version:  3.2.0
     Storage:
       Files:
         Contents:

--- a/modules/cnf-installing-the-operators.adoc
+++ b/modules/cnf-installing-the-operators.adoc
@@ -157,7 +157,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
         - path: /etc/modprobe.d/sctp-blacklist.conf

--- a/modules/compliance-anatomy.adoc
+++ b/modules/compliance-anatomy.adoc
@@ -269,7 +269,7 @@ $ oc get mc | grep 75-
 .Example output
 [source,terminal]
 ----
-75-rhcos4-e8-worker-my-companys-compliance-requirements                                                2.2.0             2m46s
+75-rhcos4-e8-worker-my-companys-compliance-requirements                                                3.2.0             2m46s
 ----
 
 The remediations the `mc` currently consists of are listed in the machine config's annotations:

--- a/modules/compliance-review.adoc
+++ b/modules/compliance-review.adoc
@@ -20,7 +20,7 @@ spec:
     spec:
       config:
         ignition:
-          version: 3.1.0
+          version: 3.2.0
         storage:
           files:
             - path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_accept_redirects.conf

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -149,7 +149,7 @@ $ oc get machineconfigs | grep containerrun
 .Example output
 [source,terminal]
 ----
-99-worker-generated-containerruntime   2c9371fbb673b97a6fe8b1c52691999ed3a1bfc2  3.1.0  31s
+99-worker-generated-containerruntime   2c9371fbb673b97a6fe8b1c52691999ed3a1bfc2  3.2.0  31s
 ----
 
 . Monitor the machine config pool until all are shown as ready:

--- a/modules/creating-infra-machines.adoc
+++ b/modules/creating-infra-machines.adoc
@@ -70,29 +70,29 @@ $ oc get machineconfig
 [source,terminal]
 ----
 NAME                                                        GENERATEDBYCONTROLLER                      IGNITIONVERSION   CREATED
-00-master                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-00-worker                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-01-master-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-01-master-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-01-worker-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-01-worker-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-99-master-1ae2a1e0-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-99-master-ssh                                                                                          2.2.0             31d
-99-worker-1ae64748-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             31d
-99-worker-ssh                                                                                          2.2.0             31d
-rendered-infra-4e48906dca84ee702959c71a53ee80e7             365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             19s
-rendered-master-072d4b2da7f88162636902b074e9e28e            5b6fb8349a29735e48446d435962dec4547d3090   2.2.0             31d
-rendered-master-3e88ec72aed3886dec061df60d16d1af            02c07496ba0417b3e12b78fb32baf6293d314f79   2.2.0             31d
-rendered-master-419bee7de96134963a15fdf9dd473b25            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             17d
-rendered-master-53f5c91c7661708adce18739cc0f40fb            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             13d
-rendered-master-a6a357ec18e5bce7f5ac426fc7c5ffcd            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             7d3h
-rendered-master-dc7f874ec77fc4b969674204332da037            5b6fb8349a29735e48446d435962dec4547d3090   2.2.0             31d
-rendered-worker-1a75960c52ad18ff5dfa6674eb7e533d            5b6fb8349a29735e48446d435962dec4547d3090   2.2.0             31d
-rendered-worker-2640531be11ba43c61d72e82dc634ce6            5b6fb8349a29735e48446d435962dec4547d3090   2.2.0             31d
-rendered-worker-4e48906dca84ee702959c71a53ee80e7            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             7d3h
-rendered-worker-4f110718fe88e5f349987854a1147755            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             17d
-rendered-worker-afc758e194d6188677eb837842d3b379            02c07496ba0417b3e12b78fb32baf6293d314f79   2.2.0             31d
-rendered-worker-daa08cc1e8f5fcdeba24de60cd955cc3            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   2.2.0             13d
+00-master                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+00-worker                                                   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+01-master-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+01-master-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+01-worker-container-runtime                                 365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+01-worker-kubelet                                           365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+99-master-1ae2a1e0-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+99-master-ssh                                                                                          3.2.0             31d
+99-worker-1ae64748-a115-11e9-8f14-005056899d54-registries   365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             31d
+99-worker-ssh                                                                                          3.2.0             31d
+rendered-infra-4e48906dca84ee702959c71a53ee80e7             365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             23m
+rendered-master-072d4b2da7f88162636902b074e9e28e            5b6fb8349a29735e48446d435962dec4547d3090   3.2.0             31d
+rendered-master-3e88ec72aed3886dec061df60d16d1af            02c07496ba0417b3e12b78fb32baf6293d314f79   3.2.0             31d
+rendered-master-419bee7de96134963a15fdf9dd473b25            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             17d
+rendered-master-53f5c91c7661708adce18739cc0f40fb            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             13d
+rendered-master-a6a357ec18e5bce7f5ac426fc7c5ffcd            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             7d3h
+rendered-master-dc7f874ec77fc4b969674204332da037            5b6fb8349a29735e48446d435962dec4547d3090   3.2.0             31d
+rendered-worker-1a75960c52ad18ff5dfa6674eb7e533d            5b6fb8349a29735e48446d435962dec4547d3090   3.2.0             31d
+rendered-worker-2640531be11ba43c61d72e82dc634ce6            5b6fb8349a29735e48446d435962dec4547d3090   3.2.0             31d
+rendered-worker-4e48906dca84ee702959c71a53ee80e7            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             7d3h
+rendered-worker-4f110718fe88e5f349987854a1147755            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             17d
+rendered-worker-afc758e194d6188677eb837842d3b379            02c07496ba0417b3e12b78fb32baf6293d314f79   3.2.0             31d
+rendered-worker-daa08cc1e8f5fcdeba24de60cd955cc3            365c1cfd14de5b0e3b85e0fc815b0060f36ab955   3.2.0             13d
 ----
 +
 You should see a new machine config, with the `rendered-infra-*` prefix.
@@ -123,7 +123,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
       - path: /etc/infratest

--- a/modules/digging-into-machine-config.adoc
+++ b/modules/digging-into-machine-config.adoc
@@ -34,14 +34,14 @@ $ oc get machineconfig
 ----
 NAME                                      GENERATEDBYCONTROLLER   IGNITIONVERSION   CREATED   OSIMAGEURL
 
-00-master                                 4.0.0-0.150.0.0-dirty   3.1.0             16m
+00-master                                 4.0.0-0.150.0.0-dirty   3.2.0             16m
 00-master-ssh                             4.0.0-0.150.0.0-dirty                     16m
-00-worker                                 4.0.0-0.150.0.0-dirty   3.1.0             16m
+00-worker                                 4.0.0-0.150.0.0-dirty   3.2.0             16m
 00-worker-ssh                             4.0.0-0.150.0.0-dirty                     16m
-01-master-kubelet                         4.0.0-0.150.0.0-dirty   3.1.0             16m
-01-worker-kubelet                         4.0.0-0.150.0.0-dirty   3.1.0             16m
-master-1638c1aea398413bb918e76632f20799   4.0.0-0.150.0.0-dirty   3.1.0             16m
-worker-2feef4f8288936489a5a832ca8efe953   4.0.0-0.150.0.0-dirty   3.1.0             16m
+01-master-kubelet                         4.0.0-0.150.0.0-dirty   3.2.0             16m
+01-worker-kubelet                         4.0.0-0.150.0.0-dirty   3.2.0             16m
+master-1638c1aea398413bb918e76632f20799   4.0.0-0.150.0.0-dirty   3.2.0             16m
+worker-2feef4f8288936489a5a832ca8efe953   4.0.0-0.150.0.0-dirty   3.2.0             16m
 ----
 
 The Machine Config Operator acts somewhat differently than Ignition when it

--- a/modules/installation-creating-azure-bootstrap.adoc
+++ b/modules/installation-creating-azure-bootstrap.adoc
@@ -36,7 +36,7 @@ describes the bootstrap machine that your cluster requires.
 [source,terminal]
 ----
 $ export BOOTSTRAP_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --account-key ${ACCOUNT_KEY} -c "files" -n "bootstrap.ign" -o tsv`
-$ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.1.0" --arg url ${BOOTSTRAP_URL} '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 | tr -d '\n'`
+$ export BOOTSTRAP_IGNITION=`jq -rcnM --arg v "3.2.0" --arg url ${BOOTSTRAP_URL} '{ignition:{version:$v,config:{replace:{source:$url}}}}' | base64 | tr -d '\n'`
 ----
 
 . Create the deployment by using the `az` CLI:

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -53,7 +53,7 @@ If you follow the steps to create a separate `/var` partition in this procedure,
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       disks:
         - device: /dev/sdb
@@ -117,7 +117,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       disks:
       - device: /dev/<device_name> <1>

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -66,7 +66,7 @@ preparation phases of an {product-title} installation.
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       disks:
         - device: /dev/sdb
@@ -133,7 +133,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       disks:
       - device: /dev/<device_name> <1>

--- a/modules/installation-osp-converting-ignition-resources.adoc
+++ b/modules/installation-osp-converting-ignition-resources.adoc
@@ -122,7 +122,7 @@ $ openstack token issue -c id -f value
         }]
       }
     },
-    "version": "3.1.0"
+    "version": "3.2.0"
   }
 }
 ----

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -132,7 +132,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       disks:
       - device: /dev/<device_name> <1>

--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -43,7 +43,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     systemd:
       units:
       - name: nodeip-configuration.service

--- a/modules/networking-osp-enabling-metadata.adoc
+++ b/modules/networking-osp-enabling-metadata.adoc
@@ -29,7 +29,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     systemd:
       units:
         - name: create-mountpoint-var-config.service

--- a/modules/networking-osp-enabling-vfio-noiommu.adoc
+++ b/modules/networking-osp-enabling-vfio-noiommu.adoc
@@ -24,7 +24,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
       - path: /etc/modprobe.d/vfio-noiommu.conf

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -63,9 +63,9 @@ NAME                                               GENERATEDBYCONTROLLER        
 01-worker-container-runtime                        52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 99-master-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-99-master-ssh                                                                                 3.1.0             40m
+99-master-ssh                                                                                 3.2.0             40m
 99-worker-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-99-worker-ssh                                                                                 3.1.0             40m
+99-worker-ssh                                                                                 3.2.0             40m
 rendered-master-23e785de7587df95a4b517e0647e5ab7   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 rendered-worker-5d596d9293ca3ea80c896a1191735bb1   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 ----
@@ -83,7 +83,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
   kernelArguments:
     - enforcing=0<3>
 ----
@@ -117,13 +117,11 @@ NAME                                               GENERATEDBYCONTROLLER        
 01-master-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-container-runtime                        52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-
-05-worker-kernelarg-selinuxpermissive                                                         3.1.0             105s
-
+05-worker-kernelarg-selinuxpermissive                                                         3.2.0             105s
 99-master-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-99-master-ssh                                                                                 3.1.0             40m
+99-master-ssh                                                                                 3.2.0             40m
 99-worker-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
-99-worker-ssh                                                                                 3.1.0             40m
+99-worker-ssh                                                                                 3.2.0             40m
 rendered-master-23e785de7587df95a4b517e0647e5ab7   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 rendered-worker-5d596d9293ca3ea80c896a1191735bb1   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 ----

--- a/modules/nw-sctp-enabling.adoc
+++ b/modules/nw-sctp-enabling.adoc
@@ -27,7 +27,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     storage:
       files:
         - path: /etc/modprobe.d/sctp-blacklist.conf

--- a/modules/persistent-kubelet-log-level-configuration.adoc
+++ b/modules/persistent-kubelet-log-level-configuration.adoc
@@ -16,7 +16,7 @@ kind: MachineConfig
  spec:
    config:
      ignition:
-       version: 3.1.0
+       version: 3.2.0
      systemd:
        units:
          - name: kubelet.service

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -33,7 +33,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
   extensions:
     - usbguard
 EOF
@@ -60,7 +60,7 @@ $ oc get machineconfig 80-worker-extensions
 [source,terminal]
 ----
 NAME                 GENERATEDBYCONTROLLER IGNITIONVERSION AGE
-80-worker-extensions                       3.1.0           57s
+80-worker-extensions                       3.2.0           57s
 ----
 
 . Check that the new machine config is now applied and that the nodes are not in a degraded state. It may take a few minutes. The worker pool will show the updates in progress, as each machine successfully has the new machine config applied:

--- a/modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc
+++ b/modules/set-the-default-max-container-root-partition-size-for-overlay-with-crio.adoc
@@ -67,8 +67,8 @@ New `99-worker-generated-containerruntime` and `rendered-worker-xyz` objects are
 .Example output
 [source,terminal]
 ----
-99-worker-generated-containerruntime  4173030d89fbf4a7a0976d1665491a4d9a6e54f1   2.2.0             7m42s
-rendered-worker-xyz                   4173030d89fbf4a7a0976d1665491a4d9a6e54f1   2.2.0             7m36s
+99-worker-generated-containerruntime  4173030d89fbf4a7a0976d1665491a4d9a6e54f1   3.2.0             7m42s
+rendered-worker-xyz                   4173030d89fbf4a7a0976d1665491a4d9a6e54f1   3.2.0             7m36s
 ----
 
 . After those objects are created, monitor the machine config pool for the changes to be applied:

--- a/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
@@ -40,7 +40,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 3.1.0
+      version: 3.2.0
     systemd:
       units:
         - contents: |


### PR DESCRIPTION
@vikram-redhat There are two issues on the examples of machineconfig, minimum version that the change applies to should be 4.7 in my opinion, could you arrange someone to review them? Thanks.

1. post_installation_configuration/machine-configuration-tasks.adoc

    The ignition version should be 3.2.0 for OCP 4.7, except 99-master-ssh and 99-worker-ssh which should be 3.1.0. Provided the real outputs on an OCP 4.7.3 environment as below:
    ```
    # date; oc get clusterversions
    Thu Apr 29 11:20:13 CST 2021
    NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
    version   4.7.3     True        False         34d     Cluster version is 4.7.3
    # date; oc get mc
    Thu Apr 29 11:20:20 CST 2021
    NAME                                               GENERATEDBYCONTROLLER                      IGNITIONVERSION   AGE
    00-master                                          39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    00-worker                                          39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    01-master-container-runtime                        39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    01-master-kubelet                                  39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    01-worker-container-runtime                        39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    01-worker-kubelet                                  39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    99-master-generated-registries                     39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    99-master-ssh                                                                                 3.1.0             35d
    99-worker-generated-registries                     39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    99-worker-ssh                                                                                 3.1.0             35d
    rendered-master-fbe30527ca52a5b3552486c84173b50e   39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    rendered-worker-09d941014c5651a44a7ddd31564bdd79   39de2f3d075d84c945f02d209c02c17b24d5dd71   3.2.0             35d
    ```

2. installing/installing_vmc/modules/installation-disk-partitioning.adoc