### PR TITLE
OSDOCS-2029: Mention that OAuth access token requests are logged for …

### DIFF
--- a/modules/nodes-nodes-audit-config-about.adoc
+++ b/modules/nodes-nodes-audit-config-about.adoc
@@ -15,7 +15,7 @@ Audit log profiles define how to log requests that come to the OpenShift API ser
 |Description
 
 |`Default`
-|Logs only metadata for read and write requests; does not log request bodies. This is the default policy.
+|Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. This is the default policy.
 
 |`WriteRequestBodies`
 |In addition to logging metadata for all requests, logs request bodies for every write request to the API servers (`create`, `update`, `patch`). This profile has more resource overhead than the `Default` profile. ^[1]^


### PR DESCRIPTION
…Default

https://issues.redhat.com/browse/OSDOCS-2029

Preview: https://deploy-preview-32048--osdocs.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#about-audit-log-profiles_audit-log-policy-config