### PR TITLE
Consolidated support and component matrix

### DIFF
--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -23,31 +23,6 @@ For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understandin
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
 
-[id="getting-support"]
-== Pipelines support
-
-The following compatibility matrix shows the support status and compatible versions for the various {pipelines-title} components:
-
-|===
-|{pipelines-title} | Support status | Pipelines | Triggers | CLI | Catalog | {product-title}
-
-| 1.4
-|General Availability (GA)
-
-|0.22
-
-|0.12 Technology Preview (TP)
-
-|0.17
-
-|0.22
-
-|4.7
-
-|===
-
-For questions and feedback, you can send an email to the product team at pipelines-interest@redhat.com.
-
 // Modules included, most to least recent
 include::modules/op-release-notes-1-4.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-1.adoc
+++ b/modules/gitops-release-notes-1-1.adoc
@@ -5,20 +5,12 @@
 [id="gitops-release-notes-1-1_{context}"]
 = Release notes for {gitops-title} 1.1
 
-[id="new-features-1-1_{context}"]
-== New features
-{gitops-title} 1.1 is now available on {product-title} 4.7. These are the new features in {gitops-title} 1.1:
+{gitops-title} 1.1 is now available on {product-title} 4.7.
 
-* The `ApplicationSet` feature is now added (Technology Preview). The `ApplicationSet` feature enables both automation and greater flexibility when managing Argo CD applications across a large number of clusters and within monorepos. It also makes self-service usage possible on multitenant Kubernetes clusters.
-* Argo CD is now integrated with cluster logging stack and with the {product-title} Monitoring and Alerting features.
-* Argo CD auth is now integrated with {product-title}.
-* Argo CD applications controller now supports horizontal scaling.
-* Argo CD Redis servers now support high availability (HA).
+[id="support-matrix-1-1_{context}"]
+== Support matrix
 
-[id="technology-preview-features-1-1_{context}"]
-== Technology Preview features
-
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
@@ -28,10 +20,12 @@ In the table below, features are marked with the following statuses:
 
 - *GA*: _General Availability_
 
-.Technology Preview tracker
+Note the following scope of support on the Red Hat Customer Portal for these features:
+
+.Support matrix
 [cols="1,1",options="header"]
 |===
-| Feature | OCP 4.7
+| Feature | {gitops-title} 1.1
 | Argo CD
 | GA
 | Argo CD ApplicationSet
@@ -42,6 +36,15 @@ In the table below, features are marked with the following statuses:
 | TP
 |===
 
+[id="new-features-1-1_{context}"]
+== New features
+In addition to the fixes and stability improvements, the following sections highlight what is new in {gitops-title} 1.1:
+
+* The `ApplicationSet` feature is now added (Technology Preview). The `ApplicationSet` feature enables both automation and greater flexibility when managing Argo CD applications across a large number of clusters and within monorepos. It also makes self-service usage possible on multitenant Kubernetes clusters.
+* Argo CD is now integrated with cluster logging stack and with the {product-title} Monitoring and Alerting features.
+* Argo CD auth is now integrated with {product-title}.
+* Argo CD applications controller now supports horizontal scaling.
+* Argo CD Redis servers now support high availability (HA).
 
 [id="fixed-issues-1-1_{context}"]
 == Fixed issues

--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -40,8 +40,8 @@ The supported profiles are:
 
 .. Select an *Update Channel*.
 
-*** The *Stable* channel enables installation of the latest stable release of the {pipelines-title} Operator.
-*** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the *Stable* channel.
+*** The *Stable* channel enables installation of the latest stable and supported release of the {pipelines-title} Operator.
+*** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the *Stable* channel and is not supported.
 
 . Click *Install*. You will see the Operator listed on the *Installed Operators* page.
 +

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -9,7 +9,7 @@
 
 [NOTE]
 ====
-In addition to the stable and preview Operator channels, the {pipelines-title} Operator 1.4.0 comes with the ocp-4.6 and ocp-4.5 deprecated channels. These deprecated channels and support for them will be removed in the following release of {pipelines-title}.
+In addition to the stable and preview Operator channels, the {pipelines-title} Operator 1.4.0 comes with the ocp-4.6, ocp-4.5, and ocp-4.4 deprecated channels. These deprecated channels and support for them will be removed in the following release of {pipelines-title}.
 ====
 
 [id="compatibility-support-matrix-1-4_{context}"]

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -5,29 +5,44 @@
 [id="op-release-notes-1-4_{context}"]
 = Release notes for {pipelines-title} General Availability 1.4
 
-
-[id="new-features-1-4_{context}"]
-== New features
 {pipelines-title} General Availability (GA) 1.4 is now available on {product-title} 4.7.
-
-[IMPORTANT]
-====
-The `Triggers` and `PipelineResources` features are currently Technology Preview features.
-
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
-Technology Preview features support scope] for more information.
-====
 
 [NOTE]
 ====
-In addition to the stable/preview Operator channel for OCP 4.7, the general availability of Pipelines 1.4 comes with the deprecated channels such as `ocp-4.6` and `ocp-4.5`. However, these deprecated channels and support for them will be removed in the following release of {pipelines-title}.
+In addition to the stable and preview Operator channels, the {pipelines-title} Operator 1.4.0 comes with the ocp-4.6 and ocp-4.5 deprecated channels. These deprecated channels and support for them will be removed in the following release of {pipelines-title}.
 ====
+
+[id="compatibility-support-matrix-1-4_{context}"]
+== Compatibility and support matrix
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+In the table below, features are marked with the following statuses:
+
+- *TP*: _Technology Preview_
+
+- *GA*: _General Availability_
+
+Note the following scope of support on the Red Hat Customer Portal for these features:
+
+.Compatibility and support matrix
+[cols="1,1,1",options="header"]
+|===
+| Feature | Version | Support Status
+| Pipelines | 0.22 | GA
+| CLI | 0.17 | GA
+| Catalog | 0.22 | GA
+| Triggers | 0.12 | TP
+| Pipeline resources | - | TP
+|===
+
+
+For questions and feedback, you can send an email to the product team at pipelines-interest@redhat.com.
+
+[id="new-features-1-4_{context}"]
+== New features
 
 In addition to the fixes and stability improvements, the following sections highlight what is new in {pipelines-title} 1.4.
 
@@ -79,31 +94,6 @@ Support for `when` expressions and `finally` tasks are unavailable in the {produ
 fsGroup:
   type: MustRunAs
 ----
-
-[id="technology-preview-features-1-4_{context}"]
-== Technology Preview features
-
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
-
-In the table below, features are marked with the following statuses:
-
-- *TP*: _Technology Preview_
-
-- *GA*: _General Availability_
-
-.Technology Preview tracker
-[cols="1,1,1,1",options="header"]
-|===
-| Feature | OCP 4.5 |OCP 4.6 | OCP 4.7
-| Pipelines | TP | TP | GA
-| CLI | TP | TP | GA
-| Catalog | TP | TP | GA
-| Triggers | TP | TP | TP
-| Pipeline resources | TP | TP | TP
-|===
-
 
 [id="deprecated-features-1-4_{context}"]
 == Deprecated features


### PR DESCRIPTION
This is what we currently have in the docs: https://docs.openshift.com/container-platform/4.7/cicd/pipelines/op-release-notes.html This PR:
- Removes the Pipelines support section and the compatibility matrix table. Consolidates the  compatibility matrix and the TP support table into one table. 
- Removes the TP note for Triggers and PipelineResources. 
- Modifies the deprecated channels note in the RN.

Direct preview link: https://deploy-preview-32056--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html
SME/QE review: Siamak, Pavol
Peer review: Souvik
Applies to 4.7 and 4.8
Aligned team: Dev Tools