### PR TITLE
OSDOCS-1858 Subnet CIDR updates based on new way installer creates subnets

### DIFF
--- a/modules/installation-creating-gcp-vpc.adoc
+++ b/modules/installation-creating-gcp-vpc.adoc
@@ -43,14 +43,14 @@ ifdef::shared-vpc[]
 +
 [source,terminal]
 ----
-$ export MASTER_SUBNET_CIDR='10.0.0.0/19'
+$ export MASTER_SUBNET_CIDR='10.0.0.0/17'
 ----
 
 .. Export the compute CIDR:
 +
 [source,terminal]
 ----
-$ export WORKER_SUBNET_CIDR='10.0.32.0/19'
+$ export WORKER_SUBNET_CIDR='10.0.128.0/17'
 ----
 
 .. Export the region to deploy the VPC network and cluster to:

--- a/modules/installation-user-infra-exporting-common-variables.adoc
+++ b/modules/installation-user-infra-exporting-common-variables.adoc
@@ -58,8 +58,8 @@ ifndef::shared-vpc[]
 $ export BASE_DOMAIN='<base_domain>'
 $ export BASE_DOMAIN_ZONE_NAME='<base_domain_zone_name>'
 $ export NETWORK_CIDR='10.0.0.0/16'
-$ export MASTER_SUBNET_CIDR='10.0.0.0/19'
-$ export WORKER_SUBNET_CIDR='10.0.32.0/19'
+$ export MASTER_SUBNET_CIDR='10.0.0.0/17'
+$ export WORKER_SUBNET_CIDR='10.0.128.0/17'
 
 $ export KUBECONFIG=<installation_directory>/auth/kubeconfig <1>
 $ export CLUSTER_NAME=`jq -r .clusterName <installation_directory>/metadata.json`


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1858

Release notes for this included in #32054

Previews:
* [GCP UPI update](https://deploy-preview-32061--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-user-infra-exporting-common-variables_installing-gcp-user-infra)
* [GCP UPI shared VPC update](https://deploy-preview-32061--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-vpc_installing-gcp-user-infra-vpc)