### PR TITLE
[enterprise-4.5] BZ-1877344: Added pod phases and statuses

### DIFF
--- a/modules/odc-interacting-with-applications-and-components.adoc
+++ b/modules/odc-interacting-with-applications-and-components.adoc
@@ -28,3 +28,13 @@ This feature is available only when you create applications using the *From Git*
 ** *Helm Releases*: Clear to condense the components deployed as Helm Release into cards with an overview of a given release.
 ** *Knative Services*: Clear to condense the Knative Service components into cards with an overview of a given component.
 ** *Operator Groupings* Clear to condense the components deployed with an Operator into cards with an overview of the given group.
+
+* The status or phase of the pod is indicated by different colors and tooltips as:
+** *Running* (image:odc_pod_running.png[title="Pod Running"]): The pod is bound to a node and all of the containers are created. At least one container is still running or is in the process of starting or restarting.
+** *Not Ready* (image:odc_pod_not_ready.png[title="Pod Not Ready"]): The pods which are running multiple containers, not all containers are ready.
+** *Warning*(image:odc_pod_warning.png[title="Pod Warning"]): Containers in pods are being terminated, however termination did not succeed. Some containers may be other states.
+** *Failed*(image:odc_pod_failed.png[title="Pod Failed"]): All containers in the pod terminated but least one container has terminated in failure. That is, the container either exited with non-zero status or was terminated by the system.
+** *Pending*(image:odc_pod_pending.png[title="Pod Pending"]): The pod is accepted by the Kubernetes cluster, but one or more of the containers has not been set up and made ready to run. This includes time a pod spends waiting to be scheduled as well as the time spent downloading container images over the network.
+** *Succeeded*(image:odc_pod_succeeded.png[title="Pod Succeeded"]): All containers in the pod terminated successfully and will not be restarted.
+** *Terminating*(image:odc_pod_terminating.png[title="Pod Terminating"]): When a pod is being deleted, it is shown as *Terminating* by some kubectl commands. *Terminating* status is not one of the pod phases. A pod is granted a graceful termination period, which defaults to 30 seconds.
+** *Unknown*(image:odc_pod_unknown.png[title="Pod Unknown"]): The state of the pod could not be obtained. This phase typically occurs due to an error in communicating with the node where the pod should be running.


### PR DESCRIPTION
Cherry Picked from 0d66288edc662538d95c117d2880b60ea9a8e8be xref: https://github.com/openshift/openshift-docs/pull/31920