### PR TITLE
 Update 4.8+ doc that OCP supports only RHEL 7.9 worker nodes

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -155,7 +155,7 @@ ifndef::ibm-power[|4]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.8 - 7.9]
+ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.9]
 |2
 |8 GB
 |120 GB

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -8,22 +8,22 @@
 [id="rhel-compute-requirements_{context}"]
 = System requirements for RHEL compute nodes
 
-The Red Hat Enterprise Linux (RHEL) compute machine hosts, which are also known as worker machine hosts, in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements.
+The Red Hat Enterprise Linux (RHEL) compute, or worker, machine hosts in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements:
 
 * You must have an active {product-title} subscription on your Red Hat account. If you do not, contact your sales representative for more information.
 
-* Production environments must provide compute machines to support your expected workloads. As a cluster administrator, you must calculate the expected workload and add about 10 percent for overhead. For production environments, allocate enough resources so that a node host failure does not affect your maximum capacity.
+* Production environments must provide compute machines to support your expected workloads. As a cluster administrator, you must calculate the expected workload and add about 10% for overhead. For production environments, allocate enough resources so that a node host failure does not affect your maximum capacity.
 * Each system must meet the following hardware requirements:
 ** Physical or virtual system, or an instance running on a public or private IaaS.
 ifdef::openshift-origin[]
 ** Base OS: CentOS 7.4.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale[]
-** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL 7.8 - 7.9] with "Minimal" installation option.
+** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL 7.9] with "Minimal" installation option.
 +
 [IMPORTANT]
 ====
-Only RHEL 7.8 - 7.9 is supported in {product-title} {product-version}. You must not upgrade your compute machines to RHEL 8.
+Only RHEL 7.9 is supported in {product-title} {product-version}. You must not upgrade your compute machines to RHEL 8.
 ====
 ** If you deployed {product-title} in FIPS mode, you must enable FIPS on the RHEL machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the RHEL 7 documentation.
 endif::[]
@@ -32,12 +32,12 @@ endif::[]
 ** Minimum 8 GB RAM.
 ** Minimum 15 GB hard disk space for the file system containing `/var/`.
 ** Minimum 1 GB hard disk space for the file system containing `/usr/local/bin/`.
-** Minimum 1 GB hard disk space for the file system containing the system's temporary directory. The system’s temporary directory is determined according to the rules defined in the tempfile module in Python’s standard library.
+** Minimum 1 GB hard disk space for the file system containing its temporary directory. The temporary system directory is determined according to the rules defined in the tempfile module in the Python standard library.
 * Each system must meet any additional requirements for your system provider. For example, if you installed your cluster on VMware vSphere, your disks must be configured according to its link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[storage guidelines] and the `disk.enableUUID=true` attribute must be set.
 
-* Each system must be able to access the cluster's API endpoints by using DNS-resolvable host names. Any network security access control that is in place must allow the system access to the cluster's API service endpoints.
+* Each system must be able to access the cluster's API endpoints by using DNS-resolvable host names. Any network security access control that is in place must allow system access to the cluster's API service endpoints.
 
 [id="csr-management-rhel_{context}"]
 == Certificate signing requests management
 
-Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
+Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet that is serving and approving certificate requests.


### PR DESCRIPTION
[OSDOCS-2140](https://issues.redhat.com/browse/OSDOCS-2140)
(Relates to 4.7 refs to RHEL 7.9 support: https://github.com/openshift/openshift-docs/pull/31722)

**Goals:**

- ~~Communicate that OCP 4.8 GA is on RHEL 8.4 content~~ (this should be addressed in a separate PR)
- ~~Determine where to update language that RHEL 7 workers are deprecated
	- Use `modules/deprecated-feature.adoc` or similar language~~ deprecation note tracked in https://github.com/openshift/openshift-docs/pull/32074
	- Create separate PR for ~~4.8 Release Notes~~ deprecation wording
- Minor edits for style guide consistency (**<- these do not need SME or QE review**)

**Preview links:** 
* **System requirements for RHEL compute nodes**
	https://deploy-preview-32070--osdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-rhel-compute.html#rhel-compute-requirements_adding-rhel-compute

* **Minimum resource requirements**
	https://deploy-preview-32070--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal