### PR TITLE
[WIP] xrefs in modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ install:
  - pip3 install aura.tar.gz
 
 script:
- - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.7 --no-upstream-fetch && python3 makeBuild.py
+ - python3 build_for_portal.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.7 --no-upstream-fetch && python3 makeBuild.py
 
 after_success:
 - bash ./automerge.sh

--- a/applications/application-health.adoc
+++ b/applications/application-health.adoc
@@ -2,6 +2,7 @@
 [id="application-health"]
 = Monitoring application health by using health checks
 include::modules/common-attributes.adoc[]
+:docs_root: ..
 
 toc::[]
 
@@ -13,6 +14,7 @@ In software systems, components can become unhealthy due to transient issues suc
 // modules required to cover the user story. You can also include other
 // assemblies.
 
+include::modules/deployments-replicationcontrollers.adoc[leveloffset=+2]
 
 include::modules/application-health-about.adoc[leveloffset=+1]
 

--- a/applications/application_life_cycle_management/creating-applications-using-cli.adoc
+++ b/applications/application_life_cycle_management/creating-applications-using-cli.adoc
@@ -3,6 +3,7 @@
 include::modules/common-attributes.adoc[]
 :context: creating-applications-using-cli
 
+
 toc::[]
 
 You can create an {product-title} application from components that include

--- a/applications/deployments/what-deployments-are.adoc
+++ b/applications/deployments/what-deployments-are.adoc
@@ -2,6 +2,7 @@
 = Understanding Deployment and DeploymentConfig objects
 include::modules/common-attributes.adoc[]
 :context: what-deployments-are
+:docs_root: ../..
 
 toc::[]
 

--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -75,7 +75,7 @@ To install a cluster in FIPS mode, follow the instructions to install a customiz
 
 [NOTE]
 ====
-If you are using Azure File storage, you cannot enable FIPS mode. 
+If you are using Azure File storage, you cannot enable FIPS mode.
 ====
 
 To apply `AES CBC` encryption to your etcd data store, follow the xref:../security/encrypting-etcd.adoc#encrypting-etcd[Encrypting etcd data] process after you install your cluster.

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -2,6 +2,7 @@
 = Selecting a cluster installation method and preparing it for users
 include::modules/common-attributes.adoc[]
 :context: installing-preparing
+:docs_root: ..
 
 toc::[]
 
@@ -30,6 +31,9 @@ If you want to install and manage {product-title} yourself, you can install it o
 You can deploy an {product-title} 4 cluster to both on-premise hardware and to cloud hosting services, but all of the machines in a cluster must be in the same datacenter or cloud hosting service.
 
 If you want to use {product-title} but do not want to manage the cluster yourself, you have several managed service options. If you want a cluster that is fully managed by Red Hat, you can use link:https://www.openshift.com/products/dedicated/[OpenShift Dedicated] or link:https://www.openshift.com/products/online/[OpenShift Online]. You can also use OpenShift as a managed service on Azure, AWS, IBM Cloud, or Google Cloud. For more information about managed services, see the link:https://www.openshift.com/products[OpenShift Products] page.
+
+include::modules/deployments-replicationcontrollers.adoc[leveloffset=+2]
+
 
 [id="installing-preparing-migrate"]
 === Have you used {product-title} 3 and want to use {product-title} 4?

--- a/installing/installing_rhv/installing-rhv-restricted-network.adoc
+++ b/installing/installing_rhv/installing-rhv-restricted-network.adoc
@@ -2,6 +2,7 @@
 = Installing a cluster on {rh-virtualization} in a restricted network
 include::modules/common-attributes.adoc[]
 :context: installing-rhv-restricted-network
+:docs_root: ../..
 
 toc::[]
 
@@ -32,6 +33,9 @@ Be sure to also review this site list if you are configuring a proxy.
 ====
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
+
+include::modules/deployments-replicationcontrollers.adoc[leveloffset=+2]
+
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/modules/deployments-replicationcontrollers.adoc
+++ b/modules/deployments-replicationcontrollers.adoc
@@ -15,6 +15,21 @@ A replication controller configuration consists of:
 
 A selector is a set of labels assigned to the pods that are managed by the replication controller. These labels are included in the `Pod` definition that the replication controller instantiates. The replication controller uses the selector to determine how many instances of the pod are already running in order to adjust as needed.
 
+FIND IT HERE
+
+// xref from a module to an anchor in an assembly in the same book
+xref:{docs_root}/applications/deployments/what-deployments-are.adoc#what-deployments-are-build-blocks[What deployments are: Module to assembly in same book]
+
+// xref from a module to an anchor in a module in an assembly in the same book - you need the context. YOU can't link from a module to another module as modules are not published independently.
+xref:{docs_root}/applications/deployments/what-deployments-are.adoc#deployments-kube-deployments_what-deployments-are[Deployments Kube: Module to module (in assembly) in same book]
+
+// xref from a module to an anchor in an assembly in another book
+xref:{docs_root}/installing/installing-preparing.adoc#installing-preparing-existing-components[installing preparing - Module to assembly in another book]
+
+// xref from a module to an anchor in a module in an assembly in another book - you need the context.
+xref:{docs_root}/installing/installing_rhv/installing-rhv-restricted-network.adoc#cluster-entitlements_installing-rhv-restricted-network[Installing RHV Entitlements - Module to module (in assembly) in another book]
+
+
 The replication controller does not perform auto-scaling based on load or traffic, as it does not track either. Rather, this requires its replica
 count to be adjusted by an external auto-scaler.
 

--- a/virt/virtual_machines/advanced_vm_management/virt-automating-management-tasks.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-automating-management-tasks.adoc
@@ -2,6 +2,7 @@
 = Automating management tasks
 include::modules/virt-document-attributes.adoc[]
 :context: virt-automating-management-tasks
+:docs_root: ../../..
 
 toc::[]
 
@@ -18,3 +19,4 @@ xref:../../../virt/virtual_machines/virt-accessing-vm-consoles.adoc#virt-accessi
 
 include::modules/virt-example-ansible-playbook-creating-vms.adoc[leveloffset=+1]
 
+include::modules/deployments-replicationcontrollers.adoc[leveloffset=+1]


### PR DESCRIPTION
This is a live example of creating modules using the docs_root attribute (the manual method (option 1) as specified in the accompanying Google doc).

I have used actual assemblies at various levels and in various books (in places where the content doesn't make sense, so please be aware of that).

Please ignore the build.py and build_for_portal.py files, as they are WIP for porting this content to the portal.

Examples of the use of xref in various locations and depths. You would want to verify that the links from the included module (**deployments-replicationcontrollers.adoc**) work at all these levels and areas.

* Module included at top level in one book: https://deploy-preview-32075--osdocs.netlify.app/openshift-enterprise/latest/applications/application-health.html#deployments-replicationcontrollers_application-health
* Module included at level 2 depth: https://deploy-preview-32075--osdocs.netlify.app/openshift-enterprise/latest/applications/deployments/what-deployments-are.html#deployments-replicationcontrollers_what-deployments-are
* Module included at level 3 depth: https://deploy-preview-32075--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-automating-management-tasks.html#deployments-replicationcontrollers_virt-automating-management-tasks
* Module included in another book at the top level: https://deploy-preview-32075--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#deployments-replicationcontrollers_installing-preparing
