### PR TITLE
RHDEVDOCS-2384: Document usage of privileged builds and the new default SCC `pipelines-scc` for SA `pipelines`.  

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1328,10 +1328,12 @@ Topics:
     File: uninstalling-pipelines
   - Name: Creating CI/CD solutions for applications using OpenShift Pipelines
     File: creating-applications-with-cicd-pipelines
-  - Name: Reducing resource consumption of OpenShift Pipelines
-    File: reducing-pipelines-resource-consumption
   - Name: Working with OpenShift Pipelines using the Developer perspective
     File: working-with-pipelines-using-the-developer-perspective
+  - Name: Reducing resource consumption of OpenShift Pipelines
+    File: reducing-pipelines-resource-consumption
+  - Name: Using pods in a privileged security context
+    File: using-pods-in-a-privileged-security-context
 - Name: GitOps
   Dir: gitops
   Distros: openshift-enterprise

--- a/cicd/pipelines/using-pods-in-a-privileged-security-context.adoc
+++ b/cicd/pipelines/using-pods-in-a-privileged-security-context.adoc
@@ -1,0 +1,30 @@
+[id='using-pods-in-a-privileged-security-context']
+= Using pods in a privileged security context
+include::modules/common-attributes.adoc[]
+include::modules/pipelines-document-attributes.adoc[]
+:context: using-pods-in-a-privileged-security-context
+
+toc::[]
+
+The default configuration of OpenShift Pipelines 1.3.x and later versions does not allow you to run pods with privileged security context, if the pods result from pipeline run or task run.
+For such pods, the default service account is `pipeline`, and the security context constraint (SCC) associated with the `pipelines` service account is `pipelines-scc`. The `pipelines-scc` SCC is similar to the `anyuid` SCC, but with a minor difference as defined in the YAML file for the SCC of pipelines:
+
+.Example `SecurityContextConstraints` object
+[source,yaml,subs="attributes+"]
+----
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+...
+fsGroup:
+  type: MustRunAs
+...
+----
+
+In addition, the `Buildah` cluster task, shipped as part of the OpenShift Pipelines, uses `vfs` as the default storage driver.
+
+include::modules/op-running-pipeline-and-task-run-pods-with-privileged-security-context.adoc[leveloffset=+1]
+
+
+== Additional resources
+
+* For information on managing SCCs, refer to xref:../../authentication/managing-security-context-constraints.adoc[Managing security context constraints].

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -89,7 +89,7 @@ Support for `when` expressions and `finally` tasks are unavailable in the {produ
 
 * The `pipelines-scc` Security Context Constraint (SCC) is used with the default `pipeline` service account for pipelines. This new service account is similar to `anyuid`, but with a minor difference as defined in the YAML for SCC of {product-title} 4.7:
 +
-[source, YAML]
+[source,yaml,subs="attributes+"]
 ----
 fsGroup:
   type: MustRunAs
@@ -106,7 +106,12 @@ fsGroup:
 
 * The `creds-init` helper image for building and deploying is removed.
 
-* In the triggers spec and binding, the deprecated field `template.Name` is removed in favor of `template.Ref`.
+* In the triggers spec and binding, the deprecated field `template.name` is removed in favor of `template.ref`. You should update all `eventListener` definitions to use the `ref` field.
++
+[NOTE]
+====
+Upgrade from {pipelines-shortname} 1.3.x and earlier versions to {pipelines-shortname} 1.4.0 breaks event listeners because of the unavailability of the `template.name` field. For such cases, use {pipelines-shortname} 1.4.1 to avail the restored `template.name` field.
+====
 
 * For `EventListener` custom resources/objects, the fields `PodTemplate` and `ServiceType` are deprecated in favor of `Resource`.
 
@@ -128,7 +133,7 @@ fsGroup:
 
 * Triggers throw error resulting from bad handling of the JSON format, if you have the following configuration in the trigger binding:
 +
-[source, YAML]
+[source,yaml,subs="attributes+"]
 ----
 params:
   - name: github_json
@@ -138,11 +143,13 @@ To resolve the issue:
 ** If you are using triggers v0.11.0 and above, use the `marshalJSON` CEL function, which takes a JSON object or array and returns the JSON encoding of that object or array as a string.
 ** If you are using older triggers version, add the following annotation in the trigger template:
 +
-[source, YAML]
+[source,yaml,subs="attributes+"]
 ----
 annotations:
   triggers.tekton.dev/old-escape-quotes: "true"
 ----
+
+* When upgrading from {pipelines-shortname} 1.3.x to 1.4.x, you must recreate the routes.
 
 [id="fixed-issues-1-4_{context}"]
 == Fixed issues
@@ -186,3 +193,7 @@ annotations:
 * Previously, a pipeline result that contained an invalid variable would be added to the pipeline run with the literal expression of the variable intact. Therefore, it was difficult to assess whether the results were populated correctly. This issue is fixed by filtering out the pipeline run results that reference failed task runs. Now, a pipeline result that contains an invalid variable will not be emitted by the pipeline run at all.
 
 * The `tkn eventlistener describe` command is fixed to avoid crashing without a template. It also displays the details about trigger references.
+
+* Upgrades from {pipelines-shortname} 1.3.x and earlier versions to {pipelines-shortname} 1.4.0 breaks event listeners because of the unavailability of `template.name`. In {pipelines-shortname} 1.4.1, the `template.name` has been restored to avoid breaking event listeners in triggers.
+
+* In {pipelines-shortname} 1.4.1, the `ConsoleQuickStart` custom resource has been updated to align with {product-title} 4.7 capabilities and behavior.

--- a/modules/op-running-pipeline-and-task-run-pods-with-privileged-security-context.adoc
+++ b/modules/op-running-pipeline-and-task-run-pods-with-privileged-security-context.adoc
@@ -1,0 +1,69 @@
+[id='op-running-pipeline-and-task-run-pods-with-privileged-security-context']
+= Running pipeline run and task run pods with privileged security context
+:context: op-running-pipeline-and-task-run-pods-with-privileged-security-context
+
+toc::[]
+
+.Procedure
+
+To run a pod (resulting from pipeline run or task run) with the `privileged` security context, do the following modifications:
+
+* Configure the associated user account or service account to have an explicit SCC. You can perform the configuration using any of the following methods:
+** Execute the following OpenShift command:
++
+[source, terminal]
+----
+$ oc adm policy add-scc-to-user <scc-name> -z <service-account-name>
+----
+** Alternatively, modify the YAML files for `RoleBinding`, and `Role` or `ClusterRole`:
+
++
+.Example `RoleBinding` object
+[source,yaml,subs="attributes+"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: service-account-name <1>
+  namespace: default
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: pipelines-scc-clusterrole <2>
+subjects:
+- kind: ServiceAccount
+  name: pipeline
+  namespace: default
+
+----
+<1> Substitute with an appropriate service account name.
+<2> Substitute with an appropriate cluster role based on the role binding you use.
+
++
+.Example `ClusterRole` object
+[source,yaml,subs="attributes+"]
+----
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: pipelines-scc-clusterrole <1>
+rules:
+- apiGroups:
+  - security.openshift.io
+  resourceNames:
+  - nonroot
+  resources:
+  - securitycontextconstraints
+  verbs:
+  - use
+----
+<1> Substitute with an appropriate cluster role based on the role binding you use.
+
++
+[NOTE]
+====
+As a best practice, create a copy of the default YAML files and make changes in the duplicate file.
+====
++
+
+* If you do not use the `vfs` storage driver, configure the service account associated with the task run or the pipeline run to have a privileged SCC, and set the security context as `privileged: true`.

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -31,7 +31,7 @@ If you have `cluster-admin` privileges, you can adjust the default SCC policies 
 be more permissive.
 ////
 
-The cluster contains eight default SCCs:
+The cluster contains nine default SCCs:
 
 * `anyuid`
 * `hostaccess`
@@ -48,6 +48,7 @@ effectively root on the cluster and must be trusted accordingly.
 * `nonroot`
 * `privileged`
 * `restricted`
+* `pipelines-scc`
 
 
 [IMPORTANT]


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `4.7`, `4.8`
- **JIRA issues**: [RHDEVDOCS-2384](https://issues.redhat.com/browse/RHDEVDOCS-2384)
- **Preview pages**: 
  - [Using pods in a privileged security context](https://deploy-preview-32088--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pods-in-a-privileged-security-context.html) - A new assembly containing a shiny new procedural module.
  - [Managing security context constraints](https://deploy-preview-32088--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html)
    - List of default SCCs in the section [About security context constraints](https://deploy-preview-32088--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-about_configuring-internal-oauth)
    - Note at the end of the section [SCC prioritization](https://deploy-preview-32088--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#scc-prioritization_configuring-internal-oauth)
   - [Pipelines 1.4 Release Notes](https://deploy-preview-32088--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-4_op-release-notes) - changes made for Pipelines 1.4.1 patch release.
- **Reviewer**: Vincent Demeester, Pavol Pitonak, Preeti Chandrasekhar