### PR TITLE
BZ-1879627 Update GCP install required permissions

### DIFF
--- a/modules/installation-creating-gcp-iam-shared-vpc.adoc
+++ b/modules/installation-creating-gcp-iam-shared-vpc.adoc
@@ -125,7 +125,8 @@ Manager, so you must create them manually:
 +
 [source,terminal]
 ----
-$ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.instanceAdmin"
+$ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.instanceAdmin.v1"
+$ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.loadBalancerAdmin"
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.networkAdmin"
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/compute.securityAdmin"
 $ gcloud projects add-iam-policy-binding ${PROJECT_NAME} --member "serviceAccount:${MASTER_SERVICE_ACCOUNT}" --role "roles/iam.serviceAccountUser"

--- a/modules/installation-gcp-permissions.adoc
+++ b/modules/installation-gcp-permissions.adoc
@@ -54,10 +54,11 @@ machines use:
 |Account
 |Roles
 
-.5+|Control Plane
-|`roles/compute.instanceAdmin`
+.6+|Control Plane
+|`roles/compute.instanceAdmin.v1`
 |`roles/compute.networkAdmin`
 |`roles/compute.securityAdmin`
+|`roles/compute.loadBalancerAdmin`
 |`roles/storage.admin`
 |`roles/iam.serviceAccountUser`
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1879627

Adds the `roles/compute.loadBalancerAdmin` Control Plane permission and updates `roles/compute.instanceAdmin` to `roles/compute.instanceAdmin.v1`.

Also updates the _Creating IAM roles in GCP_ section for _Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates_.

Previews:

- https://deploy-preview-32090--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-permissions_installing-gcp-account
- https://deploy-preview-32090--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-iam-shared-vpc_installing-gcp-user-infra (Step 7)