### PR TITLE
Updating example so that it does not use "Understanding..."

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -133,8 +133,8 @@ All titles and section headings must have an anchor ID. The anchor ID must be si
 The following is an example anchor ID in an assembly file:
 
 ----
-[id="understanding-the-monitoring-stack"]
-= Understanding the monitoring stack
+[id="configuring-alert-notifications"]
+= Configuring alert notifications
 ----
 
 [NOTE]
@@ -149,8 +149,8 @@ You must add the `{context}` variable to the end of anchor IDs in module files. 
 The following is an example of an anchor ID in a module file:
 
 ----
-[id="default-monitoring-components_{context}"]
-= Default monitoring components
+[id="sending-notifications-to-external-systems_{context}"]
+= Sending notifications to external systems
 ----
 
 [NOTE]
@@ -167,26 +167,26 @@ Use unique IDs for "Prerequisites", "Additional resources", and "Next steps" tit
 The `prerequisites_`, `additional-resources_`, and `next-steps_` prefixes must end with an underscore (`_`) when declared in an anchor ID in an assembly.
 ====
 
-The following examples include IDs that are unique to the "Understanding the monitoring stack" assembly.
+The following examples include IDs that are unique to the "Configuring alert notifications" assembly:
 
 *Example unique ID for a "Prerequisites" title*
 
 ----
-[id="prerequisites_understanding-the-monitoring-stack"]
+[id="prerequisites_configuring-alert-notifications"]
 == Prerequisites
 ----
 
 *Example unique ID for an "Additional resources" title*
 
 ----
-[id="additional-resources_understanding-the-monitoring-stack"]
+[id="additional-resources_configuring-alert-notifications"]
 == Additional resources
 ----
 
 *Example unique ID for a "Next steps" title*
 
 ----
-[id="next-steps_understanding-the-monitoring-stack"]
+[id="next-steps_configuring-alert-notifications"]
 == Next steps
 ----
 


### PR DESCRIPTION
Because titles that start with "Understanding..." are not allowed for modules*, I find it confusing to use such a title as an example for assemblies. Even if it's okay to start assembly titles this way, this is an exception, and someone skimming the contribution guide might not absorb this nuance.

This PR swaps out the existing assembly title/anchor ID examples.

*according to ISG page 74 + this contribution guide