### PR TITLE
Add 'Indicating deprecated features' section to the docs guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -532,6 +532,11 @@ See
 link:https://github.com/openshift/openshift-docs/pull/13878/files#diff-615ba1bf3b09d11a9c2604b775aa32f2[an
 example] of how this is applied.
 
+== Indicating deprecated features
+
+To indicate that a feature is deprecated, include the `modules/deprecated-feature.adoc` file in the feature's assembly, or to each relevant assembly such as for a deprecated Operator, to keep the supportability wording consistent across deprecated features. Provide a value for the :FeatureName: variable before you include this module.
+
+See link:https://github.com/openshift/openshift-docs/pull/31776/files[an example] of how this is applied.
 
 == Verification of your content
 All documentation changes must be verified by a QE team associate before merging. This includes executing all "Procedure" changes and confirming expected results. There are exceptions for typo-level changes, formatting-only changes, and other negotiated documentation sets and distributions.


### PR DESCRIPTION
Adds the "Indicating deprecated features" section to the OCP docs guidelines.

@openshift/team-documentation PTAL