### PR TITLE
OSDOCS-1865: RN: Tracking network flows

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -103,6 +103,21 @@ The Network Resources Injector that is deployed with the Operator is enhanced to
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#nw-sriov-hugepages_about-sriov[Huge pages resource injection for Downward API].
 
+[id="ocp-4-8-tracking-network-flows"]
+==== Tracking network flows
+
+{product-title} {product-version} adds support for sending the metadata about network flows on the pod network to a network flows collector. The following protocols are supported:
+
+* NetFlow
+
+* sFlow
+
+* IPFIX
+
+Packet data is not sent to the network flows collector. Packet-level metadata such as the protocol, source address, destination address, port numbers, number of bytes, and other packet-level information is sent to the network flows collector.
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/tracking-network-flows.adoc#tracking-network-flows[Tracking network flows].
+
 [id="ocp-4-8-storage"]
 === Storage
 
@@ -306,7 +321,7 @@ In the table, features are marked with the following statuses:
 |Use of `dhclient` in {op-system-first}
 |DEP
 |DEP
-|DEP  
+|DEP
 
 |====
 


### PR DESCRIPTION
Release notes PR.

Please review [Tracking network flows](https://deploy-preview-32099--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-tracking-network-flows) in the release notes.

The link (and the build) are broken until #32089 is merged.

----
Applies to branch enterprise-4.8 and milestone Future-Release.