### PR TITLE
Add BYO RHEL7 workers to RN DEP table

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1003,6 +1003,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|Bring your own RHEL 7 compute machines
+|GA
+|DEP
+|DEP
+
 |====
 
 [id="ocp-4-7-deprecated-features"]
@@ -2336,4 +2341,4 @@ link:https://access.redhat.com/solutions/6001181[{product-title} 4.7.9 container
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 
-the operator could modify 
+the operator could modify


### PR DESCRIPTION
As part of [OSDOCS-2144](https://issues.redhat.com/browse/OSDOCS-2144), the 4.7 RNs "Deprecated and removed features tracker" table needs to be updated to indicate that BYO RHEL 7 compute machines was deprecated in OCP 4.6. It was announced in [4.6 Release Notes](https://github.com/openshift/openshift-docs/blob/enterprise-4.6/release_notes/ocp-4-6-release-notes.adoc#bring-your-own-op-system-base-7-compute-machines) but never added to the 4.7 table.

**PREVIEW LINK for 4.6 Release Notes - DEP table:**
https://deploy-preview-32101--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-deprecated-removed-features