### PR TITLE
Remove non-support of network encryption for 4.7+

### DIFF
--- a/migration/migrating_3_4/planning-migration-3-to-4.adoc
+++ b/migration/migrating_3_4/planning-migration-3-to-4.adoc
@@ -142,15 +142,6 @@ If your {product-title} 3.11 cluster used the `ovs-subnet` or `ovs-multitenant` 
 
 For more information, see xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
 
-[discrete]
-==== Encrypting traffic between hosts
-
-In {product-title} 3.11, you could use IPsec to encrypt traffic between hosts. {product-title} {product-version} does not support IPsec. It is recommended to use Red Hat OpenShift Service Mesh to enable mutual TLS between services.
-
-ifndef::openshift-origin[]
-For more information, see xref:../../service_mesh/v1x/ossm-architecture.adoc#ossm-architecture-v1x[Understanding Red Hat OpenShift Service Mesh].
-endif::[]
-
 [id="migration-preparing-logging"]
 === Logging considerations
 


### PR DESCRIPTION
Resolving https://github.com/openshift/openshift-docs/issues/32015

4.7+ support IPSec.

