### PR TITLE
Remove duplicate key

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1900,7 +1900,6 @@ Topics:
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
   Distros: openshift-origin,openshift-enterprise
-  Distros: openshift-origin,openshift-enterprise
 - Name: Provisioning and deploying a distributed unit (DU)
   File: cnf-provisioning-and-deploying-a-distributed-unit
   Distros: openshift-webscale


### PR DESCRIPTION
While the YAML is invalid, ascii_binder does not consider this an error.

@vikram-redhat FYI

```
/Users/jasonb/Self/work/get-code-blocks/node_modules/js-yaml/lib/loader.js:187
  throw generateError(state, message);
  ^
YAMLException: duplicated mapping key (47:3)

 44 | - Name: Performance Addon Operato ...
 45 |   File: cnf-performance-addon-ope ...
 46 |   Distros: openshift-origin,opens ...
 47 |   Distros: openshift-origin,opens ...
--------^
 48 | - Name: Provisioning and deployin ...
 49 |   File: cnf-provisioning-and-depl ...
```