### PR TITLE
Pipelines 1.14 RN - Remove jib maven restriction for IBM P/Z

### DIFF
--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -126,8 +126,6 @@ fsGroup:
 
 * When you run Maven and Jib Maven cluster tasks on an IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters, set the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
 
-* On IBM Power Systems, IBM Z, and LinuxONE, a Jib Maven cluster task fails.
-
 * Triggers throw error resulting from bad handling of the JSON format, if you have the following configuration in the trigger binding:
 +
 [source, YAML]


### PR DESCRIPTION
OCP version for cherry-picking: 4.7, 4.8
JIRA issues: https://issues.redhat.com/browse/SRVKP-1464
Reviewer: Nourhane Bziouech, Snehlata Mohite
Preview pages: [Release Notes Known Issues
](https://deploy-preview-32119--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#known-issues-1-4_op-release-notes)

cc @sounix000 