### PR TITLE
[ShiftStack: OSDOCS-2025] Full availability zone Cinder volumes

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1109,6 +1109,8 @@ Topics:
 #    File: configuring-registry-storage-openstack-user-infrastructure
   - Name: Configuring the registry for Azure user-provisioned infrastructure
     File: configuring-registry-storage-azure-user-infrastructure
+  - Name: Configuring the registry for OpenStack
+    File: configuring-registry-storage-osp
   - Name: Configuring the registry for bare metal
     File: configuring-registry-storage-baremetal
   - Name: Configuring the registry for vSphere

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -520,6 +520,10 @@ This property is deprecated. To use a flavor as the default for all machine pool
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
+|`compute.platform.openstack.rootVolume.zones`
+|For compute machines, the availability zone to install root volumes on. If you do not set this value, the installer selects the default availability zone.
+|A list of strings, for example `["zone-1", "zone-2"]`.
+
 |`controlPlane.platform.openstack.additionalNetworkIDs`
 |Additional networks that are associated with control plane machines. Allowed address pairs are not created for additional networks.
 |A list of one or more UUIDs as strings. For example, `fa806b2f-ac49-4bce-b9db-124bc64209bf`.
@@ -533,6 +537,10 @@ On clusters that use Kuryr, {rh-openstack} Octavia does not support availability
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
+
+|`controlPlane.platform.openstack.rootVolume.zones`
+|For control plane machines,  the availability zone to install root volumes on. If you do not set this value, the installer selects the default availability zone.
+|A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`platform.openstack.clusterOSImage`
 |The location from which the installer downloads the {op-system} image.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -521,7 +521,7 @@ On clusters that use Kuryr, {rh-openstack} Octavia does not support availability
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
 |`compute.platform.openstack.rootVolume.zones`
-|For compute machines, the availability zone to install root volumes on. If you do not set this value, the installer selects the default availability zone.
+|For compute machines, the availability zone to install root volumes on. If you do not set a value for this parameter, the installer selects the default availability zone.
 |A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.additionalNetworkIDs`

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -36,6 +36,7 @@ parameters:
 $ oc apply -f <storage_class_file_name>
 ----
 +
+.Example output
 [source,terminal]
 ----
 storageclass.storage.k8s.io/custom-csi-storageclass created
@@ -72,6 +73,7 @@ spec:
 $ oc apply -f <pvc_file_name>
 ----
 +
+.Example output
 [source,terminal]
 ----
 persistentvolumeclaim/csi-pvc-imageregistry created
@@ -84,6 +86,7 @@ persistentvolumeclaim/csi-pvc-imageregistry created
 $ oc patch configs.imageregistry.operator.openshift.io/cluster --type 'json' -p='[{"op": "replace", "path": "/spec/storage/pvc/claim", "value": "csi-pvc-imageregistry"}]'
 ----
 +
+.Example output
 [source,terminal]
 ----
 config.imageregistry.operator.openshift.io/cluster patched
@@ -94,6 +97,7 @@ Over the next several minutes, the configuration is updated.
 .Verification
 
 To confirm that the registry is using the resources that you defined:
+
 . Verify that the PVC claim value is identical to the name that you provided in your PVC definition:
 +
 [source,terminal]
@@ -101,6 +105,7 @@ To confirm that the registry is using the resources that you defined:
 $ oc get configs.imageregistry.operator.openshift.io/cluster -o yaml
 ----
 +
+.Example output
 [source,terminal]
 ----
 ...
@@ -119,6 +124,7 @@ status:
 $ oc get pvc -n openshift-image-registry csi-pvc-imageregistry
 ----
 +
+.Example output
 [source,terminal]
 ----
 NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -3,13 +3,13 @@
 // * registry/configuring_registry_storage/configuring-registry-storage.adoc
 
 [id="installation-registry-osp-creating-custom-pvc_{context}"]
-= Configuring an image registry with a custom back end on clusters that run on {rh-openstack}
+= Configuring an image registry with custom storage on clusters that run on {rh-openstack}
 
 After you install a cluster on {rh-openstack-first}, you can use a Cinder volume that is in a specific availability zone for registry storage.
 
 .Procedure
 
-. Create a YAML file that specifies a storage class that includes the availability zone that you want to use. For example:
+. Create a YAML file that specifies the storage class and availability zone to use. For example:
 +
 [source,yaml]
 ----
@@ -31,13 +31,11 @@ parameters:
 
 . From a command line, apply the configuration:
 +
-.Example input
 [source,terminal]
 ----
 $ oc apply -f <storage_class_file_name>
 ----
 +
-.Example output
 [source,terminal]
 ----
 storageclass.storage.k8s.io/custom-csi-storageclass created
@@ -69,13 +67,11 @@ spec:
 
 . From a command line, apply the configuration:
 +
-.Example input
 [source,terminal]
 ----
 $ oc apply -f <pvc_file_name>
 ----
 +
-.Example output
 [source,terminal]
 ----
 persistentvolumeclaim/csi-pvc-imageregistry created
@@ -83,13 +79,11 @@ persistentvolumeclaim/csi-pvc-imageregistry created
 
 . Replace the original persistent volume claim in the image registry configuration with the new claim:
 +
-.Example input
 [source,terminal]
 ----
 $ oc patch configs.imageregistry.operator.openshift.io/cluster --type 'json' -p='[{"op": "replace", "path": "/spec/storage/pvc/claim", "value": "csi-pvc-imageregistry"}]'
 ----
 +
-.Example output
 [source,terminal]
 ----
 config.imageregistry.operator.openshift.io/cluster patched
@@ -97,16 +91,16 @@ config.imageregistry.operator.openshift.io/cluster patched
 +
 Over the next several minutes, the configuration is updated.
 
-. Verify that the registry is using the resources that you defined:
-.. Verify that the PVC claim value is identical to the name that you provided in your PVC definition:
+.Verification
+
+To confirm that the registry is using the resources that you defined:
+. Verify that the PVC claim value is identical to the name that you provided in your PVC definition:
 +
-.Example input
 [source,terminal]
 ----
 $ oc get configs.imageregistry.operator.openshift.io/cluster -o yaml
 ----
 +
-.Example output
 [source,terminal]
 ----
 ...
@@ -118,15 +112,13 @@ status:
 ...
 ----
 
-.. Verify that the status of the PVC is `Bound`:
+. Verify that the status of the PVC is `Bound`:
 +
-.Example input
 [source,terminal]
 ----
 $ oc get pvc -n openshift-image-registry csi-pvc-imageregistry
 ----
 +
-.Example output
 [source,terminal]
 ----
 NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE

--- a/modules/installation-registry-osp-creating-custom-pvc.adoc
+++ b/modules/installation-registry-osp-creating-custom-pvc.adoc
@@ -1,0 +1,134 @@
+// Module included in the following assemblies:
+//
+// * registry/configuring_registry_storage/configuring-registry-storage.adoc
+
+[id="installation-registry-osp-creating-custom-pvc_{context}"]
+= Configuring an image registry with a custom back end on clusters that run on {rh-openstack}
+
+After you install a cluster on {rh-openstack-first}, you can use a Cinder volume that is in a specific availability zone for registry storage.
+
+.Procedure
+
+. Create a YAML file that specifies a storage class that includes the availability zone that you want to use. For example:
++
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: custom-csi-storageclass
+provisioner: cinder.csi.openstack.org
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+parameters:
+  availability: <availability_zone_name>
+----
++
+[NOTE]
+====
+{product-title} does not verify the existence of the availability zone you choose. Verify the name of the availability zone before you apply the configuration.
+====
+
+. From a command line, apply the configuration:
++
+.Example input
+[source,terminal]
+----
+$ oc apply -f <storage_class_file_name>
+----
++
+.Example output
+[source,terminal]
+----
+storageclass.storage.k8s.io/custom-csi-storageclass created
+----
+
+. Create a YAML file that specifies a persistent volume claim (PVC) that uses your storage class and the `openshift-image-registry` namespace. For example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: csi-pvc-imageregistry
+  namespace: openshift-image-registry <1>
+  annotations:
+    imageregistry.openshift.io: "true"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  volumeMode: Block
+  resources:
+    requests:
+      storage: 100Gi <2>
+  storageClassName: <your_custom_storage_class> <3>
+----
+<1> Enter the namespace `openshift-image-registry`. This namespace allows the Cluster Image Registry Operator to consume the PVC.
+<2> Optional: Adjust the volume size.
+<3> Enter the name of the storage class that you created. 
+
+. From a command line, apply the configuration:
++
+.Example input
+[source,terminal]
+----
+$ oc apply -f <pvc_file_name>
+----
++
+.Example output
+[source,terminal]
+----
+persistentvolumeclaim/csi-pvc-imageregistry created
+----
+
+. Replace the original persistent volume claim in the image registry configuration with the new claim:
++
+.Example input
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io/cluster --type 'json' -p='[{"op": "replace", "path": "/spec/storage/pvc/claim", "value": "csi-pvc-imageregistry"}]'
+----
++
+.Example output
+[source,terminal]
+----
+config.imageregistry.operator.openshift.io/cluster patched
+----
++
+Over the next several minutes, the configuration is updated.
+
+. Verify that the registry is using the resources that you defined:
+.. Verify that the PVC claim value is identical to the name that you provided in your PVC definition:
++
+.Example input
+[source,terminal]
+----
+$ oc get configs.imageregistry.operator.openshift.io/cluster -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+...
+status:
+    ...
+    managementState: Managed
+    pvc:
+      claim: csi-pvc-imageregistry
+...
+----
+
+.. Verify that the status of the PVC is `Bound`:
++
+.Example input
+[source,terminal]
+----
+$ oc get pvc -n openshift-image-registry csi-pvc-imageregistry
+----
++
+.Example output
+[source,terminal]
+----
+NAME                   STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS             AGE
+csi-pvc-imageregistry  Bound    pvc-72a8f9c9-f462-11e8-b6b6-fa163e18b7b5   100Gi      RWO            custom-csi-storageclass  11m
+----

--- a/registry/configuring_registry_storage/configuring-registry-storage-osp.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-osp.adoc
@@ -1,0 +1,8 @@
+[id="configuring-registry-storage-openstack"]
+= Configuring the registry for {rh-openstack}
+include::modules/common-attributes.adoc[]
+:context: configuring-registry-storage-openstack
+
+toc::[]
+
+include::modules/installation-registry-osp-creating-custom-pvc.adoc[leveloffset=+1]


### PR DESCRIPTION
Context: [OSDOCS-2025](https://issues.redhat.com/browse/OSDOCS-2025)

- [x] New install-config.yaml params for feature: https://deploy-preview-32120--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-user.html#installation-configuration-parameters_installing-openstack-user
- [x] ~~Draft Cinder CSI docs for feature - is this already covered by [existing docs](https://docs.openshift.com/container-platform/4.5/post_installation_configuration/storage-configuration.html#openstack-cinder-storage-class_post-install-storage-configuration)?~~
- [x]  New image registry docs: https://deploy-preview-32120--osdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-osp.html

FYI @Fedosin @EmilienM 