### PR TITLE
RHDEVDOCS-2966 tracker for Bug 1956414 - [DOC] Remove mention of mult…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -354,18 +354,13 @@ networking:
 |`Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
 
 |`sshKey`
-| The SSH key or keys to authenticate access your cluster machines.
+| The SSH key to authenticate access to your cluster machines.
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-a|One or more keys. For example:
-```
-sshKey:
-  key1...
-  key2...
-  key3...
-```
+a|For example, `sshKey: ssh-ed25519 AAAA..`.
+
 |====
 
 


### PR DESCRIPTION
…iple ssh-keys from user doc as it is currently not officially supported

- Aligned team: Dev Tools
- For branches: 4.5+
- https://issues.redhat.com/browse/RHDEVDOCS-2966
- Direct link to doc preview: https://deploy-preview-32138--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html and ctrl+f search for `sshKey` or look at the last row in "Table 2. Optional parameters"
 
- SME review: Waiting for review by @staebler
- QE review: Waiting for review by @tsze-redhat 
- Peer review: Waiting for review by team
- <Please merge now>
