### PR TITLE
BZ-1843158: Added link to removing credentials for admin-level

### DIFF
--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -78,3 +78,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -66,3 +66,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials]. 

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -78,3 +78,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -100,3 +100,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -76,3 +76,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -186,3 +186,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -72,3 +72,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -175,3 +175,4 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -5,7 +5,7 @@
 [id="manually-removing-cloud-creds_{context}"]
 = Removing cloud provider credentials
 
-After installing an {product-title} cluster with the Cloud Credential Operator (CCO) in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is not required unless something that requires an administrator-level credential needs to be changed, for instance during an upgrade.
+After installing an {product-title} cluster with the Cloud Credential Operator (CCO) in mint mode, you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is required only during changes that require its elevated permissions, such as upgrades.
 
 [NOTE]
 ====


### PR DESCRIPTION
Applies to 4.7+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1843158
Pending QE Approval: 
Preview Links: 

- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-iam-user_installing-aws-account [Second bullet under Additional Resources]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-vpc.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region.html#next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installing-aws-user-infra-next-steps [4th bullet]
- https://deploy-preview-32144--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installing-restricted-networks-aws-next-steps [5th bullet]