### PR TITLE
[enterprise-4.5] BZ-1843158: Backport Removing cloud provider credent…

### DIFF
--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -63,3 +63,4 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -52,3 +52,4 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -78,3 +78,4 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -66,3 +66,4 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -142,3 +142,4 @@ include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -62,3 +62,4 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * xref:../../installing/install_config/customizations.adoc#customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -158,3 +158,4 @@ include::modules/installation-aws-user-infra-installation.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* If necessary, you can xref:../../post_installation_configuration/cluster-tasks.adoc#manually-removing-cloud-creds_post-install-cluster-tasks[remove cloud provider credentials].

--- a/modules/manually-removing-cloud-creds.adoc
+++ b/modules/manually-removing-cloud-creds.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-account.adoc
+
+[id="manually-removing-cloud-creds_{context}"]
+= Removing cloud provider credentials
+
+After installing an {product-title} cluster on Amazon Web Services (AWS), you can remove the administrator-level credential secret from the `kube-system` namespace in the cluster. The administrator-level credential is required only during changes that require its elevated permissions, such as upgrades.
+[NOTE]
+====
+Prior to a non z-stream upgrade, you must reinstate the credential secret with the administrator-level credential. If the credential is not present, the upgrade might be blocked.
+====
+
+.Prerequisites
+
+* Your cluster is installed on a platform that supports removing cloud credentials from the CCO.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Workloads* -> *Secrets*.
+
+. In the table on the *Secrets* page, find the `aws-creds` root secret for AWS.
++
+[cols=2,options=header]
+|===
+|Platform
+|Secret name
+
+|AWS
+|`aws-creds`
+
+|===
+
+. Click the *Options* menu {kebab} in the same row as the secret and select *Delete Secret*.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -89,3 +89,5 @@ Understand and configure pod disruption budgets.
 
 include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+2]
 include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
+
+include::modules/manually-removing-cloud-creds.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to 4.5 only
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1843158
Pending QE Approval:
Preview Links:

- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#manually-removing-cloud-creds_post-install-cluster-tasks
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-vpc.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#next-steps [3rd bullet]
- https://deploy-preview-32152--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#next-steps [4th bullet]

** This module was backported from 4.7 to 4.5 and 4.6** 