### PR TITLE
Use predefined {product-version} instead for consistency

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -1,20 +1,19 @@
 [id="ipi-install-configuration-files"]
 = Configuration files
 :context: ipi-install-configuration-files
-:release: 4.7
 
 
 include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+1]
 
-ifeval::[{release} <= 4.3]
+ifeval::[{product-version} <= 4.3]
 include::modules/ipi-install-configuring-the-metal3-config-file.adoc[leveloffset=+1]
 endif::[]
 
-ifeval::[{release} >= 4.4]
+ifeval::[{product-version} >= 4.4]
 include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+1]
 endif::[]
 
-ifeval::[{release} >= 4.6]
+ifeval::[{product-version} >= 4.6]
 include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+1]
 endif::[]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -2,8 +2,6 @@
 = Expanding the cluster
 include::modules/common-attributes.adoc[]
 :context: ipi-install-expanding
-:release: 4.7
-
 
 After deploying an installer-provisioned {product-title} cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
 

--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -2,7 +2,6 @@
 = Prerequisites
 include::modules/common-attributes.adoc[]
 :context: ipi-install-prerequisites
-:release: 4.8
 
 toc::[]
 
@@ -12,13 +11,13 @@ ifdef::openshift-origin[. One provisioner node with {op-system-first} installed.
 ifndef::openshift-origin[. One provisioner node with {op-system-base-full} 8.x installed.]
 . Three control plane nodes.
 . Baseboard Management Controller (BMC) access to each node.
-ifeval::[{release} > 4.5]
+ifeval::[{product-version} > 4.5]
 . At least one network:
 .. One *required* routable network
 .. One *optional* network for provisioning nodes; and,
 .. One *optional* management network.
 endif::[]
-ifeval::[{release} < 4.6]
+ifeval::[{product-version} < 4.6]
 . At least two networks:
 .. One *required* routable network
 .. One *required* network for provisioning nodes; and,
@@ -28,12 +27,12 @@ endif::[]
 Before starting an installer-provisioned installation of {product-title}, ensure the hardware environment meets the following requirements.
 
 include::modules/ipi-install-node-requirements.adoc[leveloffset=+1]
-ifeval::[{release} >= 4.6]
+ifeval::[{product-version} >= 4.6]
 include::modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc[leveloffset=+1]
 endif::[]
 include::modules/ipi-install-network-requirements.adoc[leveloffset=+1]
 ifdef::upstream[]
-ifeval::[{release} >= 4.5]
+ifeval::[{product-version} >= 4.5]
 // Include IPv6 information only in DRAFT documentation
 include::modules/ipi-install-ipv6-network-requirements.adoc[leveloffset=+1]
 endif::[]

--- a/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
@@ -2,7 +2,6 @@
 = Troubleshooting
 include::modules/common-attributes.adoc[]
 :context: ipi-install-troubleshooting
-:release: 4.8
 
 toc::[]
 

--- a/modules/installation-osp-kuryr-octavia-configuration.adoc
+++ b/modules/installation-osp-kuryr-octavia-configuration.adoc
@@ -37,7 +37,7 @@ the registry. For example:
 --namespace=registry.access.redhat.com/rhosp13 \
 --push-destination=<local-ip-from-undercloud.conf>:8787 \
 --prefix=openstack- \
---tag-from-label {version}-{release} \
+--tag-from-label {version}-{product-version} \
 --output-env-file=/home/stack/templates/overcloud_images.yaml \
 --output-images-file /home/stack/local_registry_images.yaml
 ----

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -43,7 +43,7 @@ networking:
 |
 |The public CIDR (Classless Inter-Domain Routing) of the external network. For example, `10.0.0.0/24`
 ifdef::upstream[]
-ifeval::[{release} >= 4.5]
+ifeval::[{product-version} >= 4.5]
 or `2620:52:0:1302::/64`
 endif::[]
 endif::[]
@@ -84,8 +84,8 @@ controlPlane:
 |
 |Replicas sets the number of control plane (master) nodes included as part of the {product-title} cluster.
 
-ifeval::[{release} >= 4.4]
-ifeval::[{release} <= 4.6]
+ifeval::[{product-version} >= 4.4]
+ifeval::[{product-version} <= 4.6]
 a| [[provisioningNetworkInterface]]`provisioningNetworkInterface` |  | The name of the network interface on control plane nodes connected to the
 provisioning network.
 endif::[]
@@ -103,7 +103,7 @@ default name resolves correctly.
 
 | [[ingressvip]]`ingressVIP` | `test.apps.<clustername.clusterdomain>` | The VIP to use for ingress traffic.
 
-ifeval::[{release} < 4.5]
+ifeval::[{product-version} < 4.5]
 Provide this setting or pre-configure it in the DNS so that the default name resolves correctly.
 |[[dnsVIP]]`dnsVIP` | | The VIP to use for internal DNS communication.
 
@@ -121,8 +121,8 @@ endif::[]
 |Description
 
 
-ifeval::[{release} > 4.3]
-ifeval::[{release} < 4.6]
+ifeval::[{product-version} > 4.3]
+ifeval::[{product-version} < 4.6]
 |`provisioningDHCPExternal`
 | false
 |Defines if the installer uses an external DHCP or the provisioner node DHCP.
@@ -144,12 +144,12 @@ a|`provisioningNetworkCIDR`
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
 |The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the `provisioning` subnet. For example, `172.22.0.2`
-ifeval::[{release} >= 4.5]
+ifeval::[{product-version} >= 4.5]
 or `2620:52:0:1307::2`
 endif::[]
 .
 
-ifeval::[{release} == 4.6]
+ifeval::[{product-version} == 4.6]
 Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
 endif::[]
 
@@ -170,7 +170,7 @@ endif::[]
 | A URL to override the default operating system image for the bootstrap node. The URL must contain a SHA-256 hash of the image. For example:
 `https://mirror.openshift.com/rhcos-<version>-qemu.qcow2.gz?sha256=<uncompressed_sha256>`
 ifdef::upstream[]
-ifeval::[{release} >= 4.5]
+ifeval::[{product-version} >= 4.5]
  or  `http://[2620:52:0:1307::1]/rhcos-<version>-qemu.x86_64.qcow2.gz?sha256=<uncompressed_sha256>`
 endif::[]
 endif::[]
@@ -184,19 +184,19 @@ endif::[]
 | `provisioningNetwork`
 |
 | Set this parameter to `Disabled` to disable the requirement for a `provisioning` network. User may only do virtual media based provisioning, or bring up the cluster using assisted installation. If using power management, BMC's must be accessible from the machine networks. User must provide two IP addresses on the external network that are used for the provisioning services.
-ifeval::[{release} >= 4.6]
+ifeval::[{product-version} >= 4.6]
 Set this parameter to `managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
 Set this parameter to `unmanaged` to still enable the provisioning network but take care of manual configuration of DHCP. Virtual Media provisioning is recommended but PXE is still available if required.
 endif::[]
 
-ifeval::[{release} == 4.6]
+ifeval::[{product-version} == 4.6]
 | `provisioningHostIP`
 |
 | Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
 endif::[]
 
-ifeval::[{release} > 4.4]
+ifeval::[{product-version} > 4.4]
 | `httpProxy`
 |
 | Set this parameter to the appropriate HTTP proxy used within your environment.
@@ -238,7 +238,7 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 |
 | The MAC address of the NIC the host will use to boot on the `provisioning`  network.
 
-ifeval::[{release} < 4.6]
+ifeval::[{product-version} < 4.6]
 | [[hardwareProfile]]`hardwareProfile`
 | `default`
 | This parameter exposes the device name that the installer attempts to deploy the {product-title} cluster for the control plane and worker nodes. The value defaults to `default` for control plane nodes and `unknown` for worker nodes. The list of profiles includes: `default`, `libvirt`, `dell`, `dell-raid`, and `openstack`. The `default` parameter attempts to install on `/dev/sda` of the {product-title} cluster nodes.

--- a/modules/ipi-install-bmc-addressing-for-dell.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell.adoc
@@ -42,8 +42,8 @@ See the following sections for additional details.
 
 For Redfish virtual media on Dell servers, use `idrac-virtualmedia://` in the `address` setting. Using `redfish-virtualmedia://` will not work.
 
-ifeval::[{release} >= 4.6]
-ifeval::[{release} < 4.7]
+ifeval::[{product-version} >= 4.6]
+ifeval::[{product-version} < 4.7]
 [NOTE]
 ====
 Redfish virtual media on Dell servers has a known issue in {product-title} 4.6, which will be resolved in a future release.

--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -45,7 +45,7 @@ Configure the control plane and worker nodes as follows:
 | NIC1 PXE-enabled (provisioning network) | 1
 |===
 
-ifeval::[{release} > 4.3]
+ifeval::[{product-version} > 4.3]
 
 .Configuring nodes without the `provisioning` network
 
@@ -60,7 +60,7 @@ NICx is a routable network (`baremetal`) that is used for the installation of th
 
 endif::[]
 
-ifeval::[{release} > 4.6]
+ifeval::[{product-version} > 4.6]
 .Configuring nodes for Secure Boot
 
 Secure Boot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications and the operating system. Red Hat only supports Secure Boot when deploying with RedFish Virtual Media.

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -103,7 +103,7 @@ $ cp install-config.yaml ~/clusterconfigs
 $ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{release} >= 4.6]
+ifeval::[{product-version} >= 4.6]
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.
 +
 [source,terminal]
@@ -120,7 +120,7 @@ done
 ----
 
 endif::[]
-ifeval::[{release} < 4.6]
+ifeval::[{product-version} < 4.6]
 . Remove old bootstrap resources if any are left over from a previous deployment attempt.
 +
 [source,terminal]

--- a/modules/ipi-install-creating-the-openshift-manifests.adoc
+++ b/modules/ipi-install-creating-the-openshift-manifests.adoc
@@ -19,7 +19,7 @@ WARNING Making control-plane schedulable by setting MastersSchedulable to true f
 WARNING Discarding the Openshift Manifest that was provided in the target directory because its dependencies are dirty and it needs to be regenerated
 ----
 
-ifeval::[{release} <= 4.3]
+ifeval::[{product-version} <= 4.3]
 . Copy the `metal3-config.yaml` file to the `clusterconfigs/openshift` directory.
 +
 [source,terminal]

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -8,7 +8,7 @@
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 
-ifeval::[{release} == 4.6]
+ifeval::[{product-version} == 4.6]
 [source,yaml]
 ----
 platform:
@@ -26,7 +26,7 @@ Requires providing two IP addresses from the `baremetal` network for the `provis
 ====
 endif::[]
 
-ifeval::[{release} >= 4.7]
+ifeval::[{product-version} >= 4.7]
 [source,yaml]
 ----
 platform:

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -9,7 +9,7 @@ Installer-provisioned installation of {product-title} involves several network r
 
 .Network Time Protocol (NTP)
 
-ifeval::[{release} <= 4.7]
+ifeval::[{product-version} <= 4.7]
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
 
 [IMPORTANT]
@@ -18,7 +18,7 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 ====
 endif::[]
 
-ifeval::[{release} > 4.7]
+ifeval::[{product-version} > 4.7]
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
 
 [IMPORTANT]
@@ -71,16 +71,16 @@ endif::[]
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
 
-ifeval::[{release} > 4.5]
+ifeval::[{product-version} > 4.5]
 . Two virtual IP addresses.
 endif::[]
-ifeval::[{release} <= 4.5]
+ifeval::[{product-version} <= 4.5]
 . Three virtual IP addresses
 endif::[]
 +
 - One IP address for the API endpoint
 - One IP address for the wildcard ingress endpoint
-ifeval::[{release} <= 4.5]
+ifeval::[{product-version} <= 4.5]
 - One IP address for the name server
 endif::[]
 
@@ -88,7 +88,7 @@ endif::[]
 . One IP address for each control plane (master) node.
 . One IP address for each worker node, if applicable.
 
-ifeval::[{release} > 4.6]
+ifeval::[{product-version} > 4.6]
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
@@ -96,7 +96,7 @@ Some administrators prefer to use static IP addresses so that each node's IP add
 ====
 endif::[]
 
-ifeval::[{release} > 4.7]
+ifeval::[{product-version} > 4.7]
 [IMPORTANT]
 .Networking between external load balancers and control plane nodes
 ====
@@ -111,7 +111,7 @@ The following table provides an exemplary embodiment of fully qualified domain n
 | Usage | Host Name | IP
 | API | api.<cluster-name>.<domain> | <ip>
 | Ingress LB (apps) |  *.apps.<cluster-name>.<domain>  | <ip>
-ifeval::[{release} <= 4.5]
+ifeval::[{product-version} <= 4.5]
 | Nameserver | ns1.<cluster-name>.<domain> | <ip>
 endif::[]
 | Provisioner node | provisioner.<cluster-name>.<domain> | <ip>
@@ -130,7 +130,7 @@ For assistance in configuring the DHCP server, check xref:ipi-install-upstream-a
 - xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
 endif::[]
 
-ifeval::[{release} == 4.6]
+ifeval::[{product-version} == 4.6]
 .Additional requirements with no provisioning network
 
 All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
@@ -147,7 +147,7 @@ Configuring additional IP addresses for `bootstrapProvisioningIP` and `provision
 ====
 endif::[]
 
-ifeval::[{release} > 4.6]
+ifeval::[{product-version} > 4.6]
 .State-driven network configuration requirements (Technology Preview)
 
 {product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.

--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -12,11 +12,11 @@ Installer-provisioned installation involves a number of hardware node requiremen
 
 - **Similar nodes:** Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory and storage configuration.
 
-ifeval::[{release} < 4.5]
+ifeval::[{product-version} < 4.5]
 - **Intelligent Platform Management Interface (IPMI):** Installer-provisioned installation requires IPMI enabled on each node.
 endif::[]
 
-ifeval::[{release} > 4.4]
+ifeval::[{product-version} > 4.4]
 - **Baseboard Management Controller:** The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, RedFish, or a proprietary protocol.
 endif::[]
 
@@ -37,10 +37,10 @@ endif::[]
 
 - **Network interfaces:** Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network *when using the `provisioning` network* for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
 
-ifeval::[{release} > 4.3]
+ifeval::[{product-version} > 4.3]
 - **Unified Extensible Firmware Interface (UEFI):** Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but *omitting the `provisioning` network removes this requirement.*
 endif::[]
 
-ifeval::[{release} > 4.6]
+ifeval::[{product-version} > 4.6]
 - **Secure Boot:** Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications and the operating system. To deploy a {product-title} cluster with Secure Boot, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot **only** when installer-provisioned installation uses Red Fish Virtual Media. Red Hat **does not** support Secure Boot with self-generated keys.
 endif::[]

--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -8,7 +8,7 @@
 
 Expanding the cluster requires a DHCP server. Each node must have a DHCP reservation.
 
-ifeval::[{release}>4.6]
+ifeval::[{product-version}>4.6]
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====

--- a/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
+++ b/modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc
@@ -16,7 +16,7 @@ In the event of a previous failed deployment, remove the artifacts from the fail
 $ ipmitool -I lanplus -U <user> -P <password> -H <management-server-ip> power off
 ----
 
-ifeval::[{release} >= 4.6]
+ifeval::[{product-version} >= 4.6]
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
 +
 [source,bash]
@@ -33,7 +33,7 @@ done
 ----
 
 endif::[]
-ifeval::[{release} < 4.6]
+ifeval::[{product-version} < 4.6]
 . Remove all old bootstrap resources if any are left over from a previous deployment attempt:
 +
 [source,bash]


### PR DESCRIPTION
@johnwilkins, do you think it's possible for us to use `{product-version}` here instead? It's our standard practice for OCP docs.