### PR TITLE
[SRVCOM 1299] Serverless Installing CLI add direct links to kn cli

### DIFF
--- a/modules/serverless-installing-cli-linux-ibm-power-rpm.adoc
+++ b/modules/serverless-installing-cli-linux-ibm-power-rpm.adoc
@@ -5,7 +5,7 @@
 [id="installing-cli-linux-ibm-power-rpm_{context}"]
 = Installing the Knative CLI for Linux on IBM Power Systems using an RPM
 
-For {op-system-base-full}, you can install the `kn` CLI as an RPM if you have an active {product-title} subscription on your Red Hat account.
+For {op-system-base-full}, you can install the Knative CLI (`kn`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
 
 .Procedure
 

--- a/modules/serverless-installing-cli-linux-ibm-power-tarball.adoc
+++ b/modules/serverless-installing-cli-linux-ibm-power-tarball.adoc
@@ -5,11 +5,11 @@
 [id="installing-cli-linux-ibm-power-tarball_{context}"]
 = Installing the Knative CLI for Linux on IBM Power Systems
 
-For Linux distributions, you can download the `kn` CLI directly as a `tar.gz` archive.
+For Linux distributions, you can download the Knative CLI (`kn`) directly as a `tar.gz` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest[`kn` CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-ppc64le.tar.gz[`kn` CLI].
 
 . Unpack the archive:
 +
@@ -18,9 +18,9 @@ For Linux distributions, you can download the `kn` CLI directly as a `tar.gz` ar
 $ tar -xf <file>
 ----
 
-. Move the `kn` binary to a directory on your path.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your path, run:
+. To check your `PATH`, run:
 +
 [source,terminal]
 ----

--- a/modules/serverless-installing-cli-linux-ibm-z-rpm.adoc
+++ b/modules/serverless-installing-cli-linux-ibm-z-rpm.adoc
@@ -5,7 +5,7 @@
 [id="installing-cli-linux-ibm-z-rpm_{context}"]
 = Installing the Knative CLI for Linux on IBM Z and LinuxONE using an RPM
 
-For {op-system-base-full}, you can install the `kn` CLI as an RPM if you have an active {product-title} subscription on your Red Hat account.
+For {op-system-base-full}, you can install the Knative CLI (`kn`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
 
 .Procedure
 

--- a/modules/serverless-installing-cli-linux-ibm-z-tarball.adoc
+++ b/modules/serverless-installing-cli-linux-ibm-z-tarball.adoc
@@ -5,11 +5,11 @@
 [id="installing-cli-linux-ibm-z-tarball_{context}"]
 = Installing the Knative CLI for Linux on IBM Z and LinuxONE
 
-For Linux distributions, you can download the `kn` CLI  directly as a `tar.gz` archive.
+For Linux distributions, you can download the Knative CLI (`kn`)  directly as a `tar.gz` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest[`kn` CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-s390x.tar.gz[`kn` CLI].
 
 . Unpack the archive:
 +
@@ -18,9 +18,9 @@ For Linux distributions, you can download the `kn` CLI  directly as a `tar.gz` a
 $ tar -xf <file>
 ----
 
-. Move the `kn` binary to a directory on your path.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your path, run:
+. To check your `PATH`, run:
 +
 [source,terminal]
 ----

--- a/modules/serverless-installing-cli-linux-rpm.adoc
+++ b/modules/serverless-installing-cli-linux-rpm.adoc
@@ -3,9 +3,9 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-linux-rpm_{context}"]
-= Installing the kn CLI for Linux using an RPM
+= Installing the Knative CLI for Linux using an RPM
 
-For Red Hat Enterprise Linux (RHEL), you can install `kn` as an RPM if you have an active {product-title} subscription on your Red Hat account.
+For {op-system-base-full}, you can install the Knative CLI (`kn`) as an RPM if you have an active {product-title} subscription on your Red Hat account.
 
 
 .Procedure

--- a/modules/serverless-installing-cli-linux.adoc
+++ b/modules/serverless-installing-cli-linux.adoc
@@ -3,14 +3,14 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-linux_{context}"]
-= Installing the kn CLI for Linux
+= Installing the Knative CLI for Linux
 
-For Linux distributions, you can download the CLI directly as a `tar.gz` archive.
+For Linux distributions, you can download the Knative CLI (`kn`) directly as a `tar.gz` archive.
 
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz[`kn` CLI].
 
 . Unpack the archive:
 +
@@ -20,9 +20,9 @@ For Linux distributions, you can download the CLI directly as a `tar.gz` archive
 $ tar -xf <file>
 ----
 
-. Move the `kn` binary to a directory on your PATH.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your path, run:
+. To check your `PATH`, run:
 +
 
 [source,terminal]

--- a/modules/serverless-installing-cli-macos.adoc
+++ b/modules/serverless-installing-cli-macos.adoc
@@ -3,19 +3,19 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-macosx_{context}"]
-= Installing the kn CLI for macOS
+= Installing the Knative CLI for macOS
 
-`kn` for macOS is provided as a `tar.gz` archive.
+The Knative CLI (`kn`) for macOS is provided as a `tar.gz` archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-macos-amd64.tar.gz[`kn` CLI].
 
 . Unpack and unzip the archive.
 
-. Move the `kn` binary to a directory on your PATH.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your PATH, open a terminal window and run:
+. To check your `PATH`, open a terminal window and run:
 +
 
 [source,terminal]

--- a/modules/serverless-installing-cli-web-console.adoc
+++ b/modules/serverless-installing-cli-web-console.adoc
@@ -3,9 +3,9 @@
 // serverless/knative-client.adoc
 
 [id="installing-cli-web-console_{context}"]
-= Installing the kn CLI using the {product-title} web console
+= Installing the Knative CLI using the {product-title} web console
 
-Once the {ServerlessOperatorName} is installed, you will see a link to download the `kn` CLI for Linux, macOS and Windows from the *Command Line Tools* page in the {product-title} web console.
+Once the {ServerlessOperatorName} is installed, you will see a link to download the Knative CLI (`kn`) for Linux (x86_64, amd64, s390x, ppc64le), macOS, or Windows from the *Command Line Tools* page in the {product-title} web console.
 
 You can access the *Command Line Tools* page by clicking the image:../images/question-circle.png[title="Help"] icon in the top right corner of the web console and selecting *Command Line Tools* in the drop down menu.
 
@@ -20,9 +20,9 @@ You can access the *Command Line Tools* page by clicking the image:../images/que
 $ tar -xf <file>
 ----
 
-. Move the `kn` binary to a directory on your PATH.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your path, run:
+. To check your `PATH`, run:
 +
 
 [source,terminal]

--- a/modules/serverless-installing-cli-windows.adoc
+++ b/modules/serverless-installing-cli-windows.adoc
@@ -1,21 +1,21 @@
 // Module is included in the following assemblies:
 //
-// serverless/installing-knative-client.adoc
+// serverless/installing-kn.adoc
 
 [id="installing-cli-windows_{context}"]
-= Installing the kn CLI for Windows
+= Installing the Knative CLI for Windows
 
-The CLI for Windows is provided as a zip archive.
+The Knative CLI (`kn`) for Windows is provided as a zip archive.
 
 .Procedure
 
-. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest[CLI].
+. Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-windows-amd64.zip[`kn` CLI].
 
-. Unzip the archive with a ZIP program.
+. Extract the archive with a ZIP program.
 
-. Move the `kn` binary to a directory on your PATH.
+. Move the `kn` binary to a directory on your `PATH`.
 
-. To check your PATH, open the Command Prompt and run the command:
+. To check your `PATH`, open the command prompt and run the command:
 +
 
 [source,terminal]

--- a/serverless/installing-kn.adoc
+++ b/serverless/installing-kn.adoc
@@ -1,6 +1,6 @@
 include::modules/serverless-document-attributes.adoc[]
 [id="installing-kn"]
-= Installing the kn CLI
+= Installing the Knative CLI
 :context: installing-kn
 include::modules/common-attributes.adoc[]
 
@@ -8,7 +8,7 @@ toc::[]
 
 [NOTE]
 ====
-The Knative `kn` CLI does not have its own login mechanism. To log in to the cluster, you must install the `oc` CLI and use the `oc login` command.
+The Knative CLI (`kn`) does not have its own login mechanism. To log in to the cluster, you must install the `oc` CLI and use the `oc login` command.
 
 Installation options for the `oc` CLI will vary depending on your operating system.
 


### PR DESCRIPTION
OCP version for cherry-picking: 4.6, 4.7, 4.8
JIRA issue: https://issues.redhat.com/browse/SRVCOM-1299
Reviewer: Tony Gargya for IBM P/Z
Preview pages: https://deploy-preview-32169--osdocs.netlify.app/openshift-enterprise/latest/serverless/installing-kn.html