### PR TITLE
OSDOCS-2098: Add release note for IPsec encryption - 4.10

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -61,6 +61,12 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-8-networking"]
 === Networking
 
+[id="ocp-4-8-ovn-kubernetes-ipsec-enable"]
+==== OVN-Kubernetes network provider: Enable IPsec after installation
+
+// Fix xref after OSDOCS-2098 merges
+If you are using the OVN-Kubernetes cluster network provider, you can now enable IPsec encryption after cluster installation. For more information on how to enable IPsec, see xref::../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption].
+
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2098

Preview: [OVN-Kubernetes network provider: Enable IPsec after installation](https://deploy-preview-32195--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-ovn-kubernetes-ipsec-enable)