### PR TITLE
User-replaced values: added examples showing mutliple words and a file path

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -21,9 +21,7 @@ In the Atom editor, you can use `Ctrl`+`J` to undo hard wrapping on a paragraph.
 ====
 
 == Assembly file metadata
-
-Every assembly file should contain the following metadata at the top, with no line
-spacing in between, except where noted:
+Every assembly file should contain the following metadata at the top, with no line spacing in between, except where noted:
 
 ----
 [id="<unique-heading-for-assembly>"]                            <1>
@@ -903,9 +901,7 @@ Now using project "my-project" on server "https://openshift.example.com:6443".
 ----
 ....
 
-* To mark up command syntax, use the code block and wrap any replaceable values in
-angle brackets (`<>`) with the required command parameter, using underscores
-(`_`) between words as necessary for legibility. For example:
+* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility. For example:
 +
 ....
 To view a list of objects for the specified object type, enter the following command:
@@ -927,6 +923,33 @@ This renders as:
 --
 +
 NOTE: Avoid using full command syntax inline with sentences.
+
+* When referring to a path to a location that the user has selected or created, treat the part of the path that the user chose as a replaceable value. For example:
++
+....
+Create a secret that contains the certificate and key in the `openshift-config` namespace:
+
+[source,terminal]
+----
+$ oc create secret tls <certificate> --cert=<path_to_certificate>/cert.crt --key=<path_to_key>/cert.key -n openshift-config
+----
+....
++
+This renders as:
++
+--
+> Create a secret that contains the certificate and key in the `openshift-config` namespace:
+>
+> ----
+> $ oc create secret tls <certificate> --cert=<path_to_certificate>/cert.crt --key=<path_to_key>/cert.key -n openshift-config
+> ----
+--
++
+The following example shows a more complex use of user-chosen elements and prescriptive placement:
++
+....
+<resource_group_name>/providers/Microsoft.Compute/diskEncryptionSets/<disk_encryption_set_name>
+....
 
 * If you must provide additional information on what a line of a code block
 represents, use callouts (`<1>`, `<2>`, etc.) to provide that information.
@@ -1661,12 +1684,20 @@ a|
 `<project>`
 
 `<deployment>`
+
+`<install_mode_value>`
 ....
 
 a|
 > Use the following command to roll back a Deployment, specifying the Deployment name:
 >
 > `oc rollback <deployment>`
+>
+> &nbsp;
+>
+> Apply the new configuration file:
+>
+> `oc apply -f <path_to_configuration_file>/<filename>.yaml`
 
 |Use single asterisks for web console / GUI items (menus, buttons, page titles, etc.).
 Use two characters to form the arrow in a series of menu items (`$$->$$`).


### PR DESCRIPTION
Attempt to make more clear that guidance on user-replaced values includes path values (when they are user-supplied and not to a specific location).

**Previews**
- [Code blocks, command syntax, and example output](https://github.com/openshift/openshift-docs/blob/4d9afc86541eefbf98a3221ac09d699e80cd0106/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output), new bullet "When referring to a path..."
- [Quick markup reference](https://github.com/openshift/openshift-docs/blob/d297ee28021913041e2fd793d311ff54023a26a0/contributing_to_docs/doc_guidelines.adoc#quick-markup-reference)