### PR TITLE
OSDOCS2143: Added topic about configuring GCP Internal Ingress Load Balancer Global Access Option

### DIFF
--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -104,3 +104,4 @@ include::modules/installation-gcp-user-infra-completing.adoc[leveloffset=+1]
 
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+* xref:../../networking/ingress-operator.adoc#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress[Configure Global Access for an Ingress Controller on GCP].

--- a/modules/nw-ingress-controller-configuration-gcp-global-access.adoc
+++ b/modules/nw-ingress-controller-configuration-gcp-global-access.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * ingress/configure-ingress-operator.adoc
+
+[id="nw-ingress-controller-configuration-gcp-global-access_{context}"]
+= Configuring global access for an Ingress Controller on GCP
+
+An Ingress Controller created on GCP with an internal load balancer generates an internal IP address for the service. A cluster administrator can specify the global access option, which enables clients in any region within the same VPC network and compute region as the load balancer, to reach the workloads running on your cluster.
+
+For more information, see the GCP documentation for link:https://cloud.google.com/kubernetes-engine/docs/how-to/internal-load-balancing#global_access[global access].
+
+.Prerequisites
+
+* You deployed an {product-title} cluster on GCP infrastructure.
+* You configured an Ingress Controller to use an internal load balancer.
+* You installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Configure the Ingress Controller resource to allow global access.
++
+[NOTE]
+====
+You can also create an Ingress Controller and specify the global access option.
+====
++
+.. Configure the Ingress Controller resource:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator edit ingresscontroller/default
+----
++
+.. Edit the YAML file:
++
+.Sample `clientAccess` configuration to `Global`
+[source,yaml]
+----
+  spec:
+    endpointPublishingStrategy:
+      loadBalancer:
+        providerParameters:
+          gcp:
+            clientAccess: Global <1>
+          type: GCP
+        scope: Internal
+      type: LoadBalancerService
+----
+<1> Set `gcp.clientAccess` to `Global`.
+
+.. Save the file to apply the changes.
++
+. Run the following command to verify that the service allows global access:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress operator edit svc/router-default -o yaml
+----
++
+The output shows that global access is enabled for GCP with the annotation, `networking.gke.io/internal-load-balancer-allow-global-access`.

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -42,7 +42,7 @@ If not set, the default value is based on `infrastructure.config.openshift.io/cl
 * Bare metal: `NodePortService`
 * Other: `HostNetwork`
 
-The `endpointPublishingStrategy` value cannot be updated.
+For most platforms, the `endpointPublishingStrategy` value cannot be updated. However, on GCP, you can configure the `loadbalancer.providerParameters.gcp.clientAccess` subfield.
 
 |`defaultCertificate`
 |The `defaultCertificate` value is a reference to a secret that contains the default certificate that is served by the Ingress controller. When Routes do not specify their own certificate, `defaultCertificate` is used.

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -48,6 +48,8 @@ include::modules/nw-ingress-sharding-namespace-labels.adoc[leveloffset=+3]
 
 include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+2]
 
+include::modules/nw-ingress-controller-configuration-gcp-global-access.adoc[leveloffset=+2]
+
 include::modules/nw-ingress-default-internal.adoc[leveloffset=+2]
 
 include::modules/nw-route-admission-policy.adoc[leveloffset=+2]

--- a/nodes/clusters/nodes-cluster-overcommit.adoc
+++ b/nodes/clusters/nodes-cluster-overcommit.adoc
@@ -74,4 +74,4 @@ include::modules/nodes-cluster-overcommit-project-disable.adoc[leveloffset=+2]
 == Additional resources
 
 For information setting per-project resource limits, see
-xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-setting-resources_deployment-operations[Setting deployment resources].
+xref:../../applications/deployments/managing-deployment-processes.adoc#deployments-triggers_deployment-operations[Setting deployment resources].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1834

Preview Link: https://deploy-preview-32226--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress