### PR TITLE
CNV BZ1921600 Adding new rows to table to indicate support for RHEL6.10

### DIFF
--- a/modules/virt-creating-configmap.adoc
+++ b/modules/virt-creating-configmap.adoc
@@ -13,10 +13,11 @@ The default `vm-import-controller` config map contains the following RHV operati
 .Operating system and template mapping
 |===
 |RHV VM operating system |{VirtProductName} template
+|`rhel_6_10_plus_ppc64` |`rhel6.10`
+|`rhel_6_ppc64` |`rhel6.10`
+|`rhel_6` |`rhel6.10`
+|`rhel_6x64` |`rhel6.10`
 |`rhel_6_9_plus_ppc64` |`rhel6.9`
-|`rhel_6_ppc64` |`rhel6.9`
-|`rhel_6` |`rhel6.9`
-|`rhel_6x64` |`rhel6.9`
 |`rhel_7_ppc64` |`rhel7.7`
 |`rhel_7_s390x` |`rhel7.7`
 |`rhel_7x64` |`rhel7.7`


### PR DESCRIPTION
This PR covers BZ1921600 ( https://bugzilla.redhat.com/show_bug.cgi?id=1921600 ). 

The bug deals with adding information to a table here ( https://docs.openshift.com/container-platform/4.6/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-creating-configmap_virt-importing-rhv-vm ) that lists supported RHV VM OSes and their related OpenShift Virtualization templates used when creating a config map during the import of a VM. The goal of the new information is to show that there is now support for RHEL6.10 

CP: 4.8

Preview: https://deploy-preview-32227--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html#virt-creating-configmap_virt-importing-rhv-vm