### PR TITLE
[virt] Bumping HCO version for 2.6.2

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.0
+:HCOVersion: 2.6.2
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- https://issues.redhat.com/browse/CNV-11374
- Because this affects the current version, CP to enterprise-4.7 and 4.8 (usually these go straight into the version branch)
- FYI @tiraboschi I merged this because the release is already out; please let me know if there is anything unique about the upgrade path that needs a separate PR. Thanks!