### PR TITLE
[enterprise-4.7] Bumping HCO version for 2.6.2

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.1
+:HCOVersion: 2.6.2
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
Cherry Picked from a6443f4ea9b53fd7941bac49d1f7c9e6cced2905 xref: https://github.com/openshift/openshift-docs/pull/32228