### PR TITLE
BZ#1956439 Verify nodes are upgraded

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -176,3 +176,22 @@ $ oc get clusterversion
 NAME      VERSION     AVAILABLE   PROGRESSING   SINCE     STATUS
 version   4.7.0       True        False         2m        Cluster version is 4.7.0
 ----
+
+. If you are upgrading your cluster to the next minor version, like version 4.y to 4.(y+1), it is recommended to confirm your nodes are upgraded before deploying workloads that rely on a new feature:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME                           STATUS   ROLES    AGE   VERSION
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.21.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.21.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.21.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.21.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.21.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.21.0
+----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1956439

~~Confirmed with SME that verifying nodes is no longer necessary in 4.8 because MCO does this check automatically. Will manually backport to 4.5-4.6 to reflect appropriate Kube version in output once verified.~~

Preview: https://deploy-preview-32232--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#update-upgrading-cli_updating-cluster-cli