### PR TITLE
[enterprise-4.5] Only global pull secrets can be configured in clusters where ImageContentSourcePolicy is set

### DIFF
--- a/modules/builds-image-source.adoc
+++ b/modules/builds-image-source.adoc
@@ -39,6 +39,11 @@ source:
 <4> The directory relative to the build root where the build process can access the file.
 <5> The location of the file to be copied out of the referenced image.
 <6> An optional secret provided if credentials are needed to access the input image.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 
 Optionally, if an input image requires a pull secret, you can link the pull secret to the service account used by the build. By default, builds use the `builder` service account. The pull secret is automatically added to the build if the secret contains a credential that matches the repository hosting the input image. To link a pull secret to the service account used by the build, run:
 

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -30,10 +30,16 @@ By pulling container images needed by {product-title} and then bringing those im
 Even if you don't configure mirroring during {product-title} installation, you can do so later using the `ImageContentSourcePolicy` object.
 
 The following procedure provides a post-installation mirror configuration, where you create an `ImageContentSourcePolicy` object that identifies:
-
+--
 * The source of the container image repository you want to mirror.
 * A separate entry for each mirror repository you want to offer the content
 requested from the source repository.
+--
+
+[NOTE]
+====
+You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project. 
+====
 
 .Prerequisites
 * Access to the cluster as a user with the `cluster-admin` role.

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -59,6 +59,11 @@ $ LOCAL_SECRET_JSON='<path_to_pull_secret>'
 ----
 +
 For `<path_to_pull_secret>`, specify the absolute path to and file name of the pull secret for your mirror registry that you created.
++
+[NOTE]
+====
+If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
+====
 
 .. Export the release mirror:
 +

--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -25,3 +25,8 @@ $ oc adm upgrade --allow-explicit-upgrade --to-image ${LOCAL_REGISTRY}/${LOCAL_R
 <1> The `<sha256_sum_value>` value is the sha256 sum value for the release from the image signature ConfigMap, for example, `@sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
 +
 If you use an `ImageContentSourcePolicy` for the mirror registry, you can use the canonical registry name instead of `LOCAL_REGISTRY`.
++
+[NOTE]
+====
+You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project. 
+====

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -20,3 +20,7 @@ include::modules/images-configuration-insecure.adoc[leveloffset=+2]
 include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
+
+.Additional resources
+
+For more information about global pull secrets, see xref:../openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/31968