### PR TITLE
BZ-1918383 4.5 Known Issue vSphere scaling up a node

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1688,6 +1688,15 @@ In the table below, features are marked with the following statuses:
 [id="ocp-4-5-known-issues"]
 == Known issues
 
+* When powering on a virtual machine on vSphere with user-provisioned infrastructure, the process of scaling up a node might not work as expected. A known issue in the hypervisor configuration causes machines to be created within the hypervisor but not powered on. If a node appears to be stuck in the `Provisioning` state after scaling up a machine set, you can investigate the status of the virtual machine in the vSphere instance itself. Use the VMware commands `govc tasks` and `govc events` to determine the status of the virtual machine. Check for a similar error message to the following:
++
+[source,terminal]
+----
+[Invalid memory setting: memory reservation (sched.mem.min) should be equal to memsize(8192). ]
+----
++
+You can attempt to resolve the issue with the steps in this link:https://kb.vmware.com/s/article/2002779[VMware KBase article]. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5785341[[UPI vSphere\] Node scale-up doesn't work as expected]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918383[*BZ#1918383*])
+
 * If your internal Elasticsearch instance uses persistent volume claims (PVCs), the PVCs must contain a `logging-cluster:elasticsearch` label. Without the label, during the upgrade the garbage collection process removes those PVCs and the Elasticsearch Operator creates new PVCs. If you are updating from an {product-title} version prior to version 4.4.30, you must manually add the label to the Elasticsearch PVCs. After {product-title} 4.4.30, the Elasticsearch Operator automatically adds the label to the PVCs.
 
 * When upgrading to a new {product-title} z-stream release, connectivity to the API server might be interrupted as nodes are upgraded, causing API requests to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1845411[*BZ#1845411*])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1918383

Adds Known Issue to the 4.5 Release Notes - [UPI vSphere] node scale up doesn't work as expected.

Preview: https://deploy-preview-32240--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-5-release-notes.html#ocp-4-5-known-issues