### PR TITLE
BZ-1918383 4.7 Known Issue vSphere scaling up a node

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1961,6 +1961,15 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821771[*BZ#1821771*])
 
+* When powering on a virtual machine on vSphere with user-provisioned infrastructure, the process of scaling up a node might not work as expected. A known issue in the hypervisor configuration causes machines to be created within the hypervisor but not powered on. If a node appears to be stuck in the `Provisioning` state after scaling up a machine set, you can investigate the status of the virtual machine in the vSphere instance itself. Use the VMware commands `govc tasks` and `govc events` to determine the status of the virtual machine. Check for a similar error message to the following:
++
+[source,terminal]
+----
+[Invalid memory setting: memory reservation (sched.mem.min) should be equal to memsize(8192). ]
+----
++
+You can attempt to resolve the issue with the steps in this link:https://kb.vmware.com/s/article/2002779[VMware KBase article]. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5785341[[UPI vSphere\] Node scale-up doesn't work as expected]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918383[*BZ#1918383*])
+
 * If you are running a cluster on VMware that uses `x86_64` architecture and has the `platform: none` field set in the `install-config.yaml` file, a fresh installation on {product-title} cluster version 4.7 or an upgrade from cluster version 4.6 to version 4.7 might fail. This failure happens when a cluster uses virtual machines (VMs) that are configured with virtual hardware version 14 or greater. As a workaround, you can configure VMs to use virtual hardware version 13.
 +
 Clusters that are deployed to VMware Cloud (VMC) do not experience these issues with virtual hardware version 14 or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941714[*BZ#1941714*])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1918383

Adds Known Issue to the 4.7 Release Notes - [UPI vSphere] node scale up doesn't work as expected.

Preview: https://deploy-preview-32243--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-known-issues