### PR TITLE
BZ1901766 ListAttachedRolePolicies to IAM perms for AWS install

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -127,6 +127,7 @@ If you use an existing VPC, your account does not require these permissions for 
 * `iam:GetRole`
 * `iam:GetRolePolicy`
 * `iam:GetUser`
+* `iam:ListAttachedRolePolicies`
 * `iam:ListInstanceProfilesForRole`
 * `iam:ListRoles`
 * `iam:ListUsers`


### PR DESCRIPTION
For versions 4.5+:
https://bugzilla.redhat.com/show_bug.cgi?id=1901766

Please find preview at:
https://deploy-preview-32244--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account

added iam:ListAttachedRolePolicies
to table Required IAM permissions for installation

Already tested by QA. Please review, @yunjiang29 