### PR TITLE
BZ-1918383 4.8 Known Issue vSphere scaling up a node

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -620,6 +620,15 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821771[*BZ#1821771*])
 
+* When powering on a virtual machine on vSphere with user-provisioned infrastructure, the process of scaling up a node might not work as expected. A known issue in the hypervisor configuration causes machines to be created within the hypervisor but not powered on. If a node appears to be stuck in the `Provisioning` state after scaling up a machine set, you can investigate the status of the virtual machine in the vSphere instance itself. Use the VMware commands `govc tasks` and `govc events` to determine the status of the virtual machine. Check for a similar error message to the following:
++
+[source,terminal]
+----
+[Invalid memory setting: memory reservation (sched.mem.min) should be equal to memsize(8192). ]
+----
++
+You can attempt to resolve the issue with the steps in this link:https://kb.vmware.com/s/article/2002779[VMware KBase article]. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5785341[[UPI vSphere\] Node scale-up doesn't work as expected]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918383[*BZ#1918383*])
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1918383

Adds Known Issue to the 4.8 Release Notes - [UPI vSphere] node scale up doesn't work as expected.

Preview: https://deploy-preview-32245--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-known-issues