### PR TITLE
CNV-11006 PCI passthrough

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2676,6 +2676,8 @@ Topics:
       File: virt-dedicated-resources-vm
     - Name: Scheduling virtual machines
       File: virt-schedule-vms
+    - Name: Configuring PCI passthrough
+      File: virt-configuring-pci-passthrough      
 # Importing virtual machines
   - Name: Importing virtual machines
     Dir: importing_vms

--- a/modules/virt-about-pci-passthrough.adoc
+++ b/modules/virt-about-pci-passthrough.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+
+[id="virt-about_pci-passthrough_{context}"]
+= About preparing nodes and the cluster for PCI passthrough
+
+The Peripheral Component Interconnect (PCI) passthrough feature enables you to access and manage hardware devices from a virtual machine. When PCI passthrough is configured, the PCI devices function as if they were physically attached to the virtual machine.
+
+To configure a hardware device as a host device for PCI passthrough, create a `MachineConfig` object file and add kernel arguments to enable Input-Output Memory Management Unit (IOMMU). Bind the PCI device to the Virtual Function I/O (VFIO) driver by creating a `MachineConfig` object file. Then, add the PCI device to the HyperConverged Operator.

--- a/modules/virt-adding-kernel-arguments-enable-iommu.adoc
+++ b/modules/virt-adding-kernel-arguments-enable-iommu.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/configuring-pci-passthrough.adoc
+
+[id="virt-adding-kernel-arguments-enable-IOMMU_{context}"]
+= Adding kernel arguments to enable the IOMMU driver
+
+To enable the IOMMU (Input-Output Memory Management Unit)  driver in the kernel, create the `MachineConfig` object and add the kernel arguments.
+
+.Prerequisites
+* Administrative privilege to a working {product-title} cluster.
+* Intel or AMD CPU hardware.
+* Intel Virtualization Technology for Directed I/O extensions or AMD IOMMU in the BIOS (Basic Input/Output System) is enabled.
+
+.Procedure
+. Create a `MachineConfig` object that identifies the kernel argument. The following example shows a kernel argument for an Intel CPU.
+
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <1>
+  name: 100-worker-iommu <2>
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+  kernelArguments:
+      - intel_iommu=on <3>
+...
+----
+<1> Applies the new kernel argument only to worker nodes.
+<2> The `name` indicates the ranking of this kernel argument (100) among the machine configs and its purpose. If you have an AMD CPU, specify the kernel argument as `amd_iommu=on`.
+<3> Identifies the kernel argument as `intel_iommu` for an Intel CPU.
+
+. Create the new `MachineConfig` object:
++
+[source,terminal]
+----
+$ oc create -f 100-worker-kernel-arg-iommu.yaml
+----
+
+.Verification
+
+* Verify that the new `MachineConfig` object was added.
++
+[source,terminal]
+----
+$ oc get MachineConfig
+----

--- a/modules/virt-adding-pci-device-hyperconverged-operator.adoc
+++ b/modules/virt-adding-pci-device-hyperconverged-operator.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+
+[id="virt-adding-pci-device-hyperconverged-operator_{context}"]
+= Adding PCI devices to the HyperConverged Operator
+To enable the availability of PCI devices in the cluster, add details about the PCI devices to the HyperConverged object. The PCI devices are exposed and permitted to be used in the cluster.
+
+.Procedure
+* Run the following command to add the PCI device information to the YAML file.
++
+[source,terminal]
+----
+$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv -o yaml
+----
++
+.Example
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  permittedHostDevices: <1>
+    pciHostDevices: <2>
+      - pciVendorSelector: 10de:1eb8 <3>
+        resourceName: "nvidia.com/TU104GL_Tesla_T4" <4>
+----
+<1> The host devices that are to be used in the cluster.
+<2> PCI devices available on the node.
+<3> The `vendor-ID` and the `device-ID` for the PCI device.
+<4> The name of the hardware device.
+
+.Verification
+* Use the following command to verify that the PCI device was added to the node.
++
+[source,terminal]
+----
+$ oc describe node cnv-lab.eng.raleigh.redhat.com
+----
++
+.Example
+----
+Capacity:
+  cpu:                            64
+  devices.kubevirt.io/kvm:        110
+  devices.kubevirt.io/tun:        110
+  devices.kubevirt.io/vhost-net:  110
+  ephemeral-storage:              915128Mi
+  hugepages-1Gi:                  0
+  hugepages-2Mi:                  0
+  memory:                         131395264Ki
+  nvidia.com/TU104GL_Tesla_T4:    1
+  pods:                           250
+Allocatable:
+  cpu:                            63500m
+  devices.kubevirt.io/kvm:        110
+  devices.kubevirt.io/tun:        110
+  devices.kubevirt.io/vhost-net:  110
+  ephemeral-storage:              863623130526
+  hugepages-1Gi:                  0
+  hugepages-2Mi:                  0
+  memory:                         130244288Ki
+  nvidia.com/TU104GL_Tesla_T4:    1
+  pods:                           250
+----

--- a/modules/virt-assigning-pci-device-virtual-machine.adoc
+++ b/modules/virt-assigning-pci-device-virtual-machine.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+
+[id="virt-assigning-pci-device-virtual-machine_{context}"]
+= Assigning a PCI device to a virtual machine
+
+When a PCI device is available in a cluster, you can assign it to a virtual machine and enable PCI passthrough.
+
+.Procedure
+* Assign the PCI device to a virtual machine as a host device.
++
+.Example
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+spec:
+  domain:
+    devices:
+      hostDevices:
+      - deviceName: nvidia.com/TU104GL_Tesla_T4 <1>
+        name: hostdevices1
+----
+<1> The name of the PCI device that is permitted on the cluster as a host device. The virtual machine can access this host device.
+
+.Verification
+* Use the following command to verify that the host device is available from the virtual machine.
++
+[source,terminal]
+$ lspci -nnk | grep NVIDIA
++
+.Example output
+[source,terminal]
+----
+$ 02:01.0 3D controller [0302]: NVIDIA Corporation GV100GL [Tesla V100 PCIe 32GB] [10de:1eb8] (rev a1)
+----

--- a/modules/virt-binding-devices-vfio-driver.adoc
+++ b/modules/virt-binding-devices-vfio-driver.adoc
@@ -1,0 +1,138 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+
+[id="virt-binding-devices-vfio-driver_{context}"]
+= Binding PCI devices to the VFIO driver
+To bind PCI devices to the VFIO (Virtual Function I/O) driver, obtain the values for `vendor-ID` and `device-ID` from each device and create a list with the values. Add this list to the `MachineConfig` object. The `MachineConfig` Operator generates the `/etc/modprobe.d/vfio.conf` on the nodes with the PCI devices, and binds the PCI devices to the VFIO driver.
+
+.Prerequisites
+* You added kernel arguments to enable IOMMU for the CPU.
+
+.Procedure
+. Create the `MachineConfig` object to enable the binding of PCI devices to the VFIO driver.
++
+.Example
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig <1>
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <2>
+  name: 100-worker-vfiopci-configuration <3>
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,b3B0aW9ucyB2ZmlvLXBjaSBpZHM9MTBkZToxZWI4Cg== <4>
+        mode: 420 <5>
+        overwrite: true
+        path: /etc/modprobe.d/vfio.conf <6>
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,dmZpby1wY2kK <7>
+        mode: 420
+        overwrite: true
+        path: /etc/modules-load.d/vfio-pci.conf <8>
+----
+<1> The type of object being configured is `MachineConfig`.
+<2> Applies the new kernel argument only to worker nodes.
+<3> Named to identify where this `MachineConfig` object fits among the other `MachineConfig` objects.
+<4> The `echo "options vfio-pci ids=10de:1eb8" | base64` command creates the encoded text. The `vendor-ID` value (10de) and the `device-ID` value (1eb8) applies to a single device that binds to the VFIO driver. You can add a list of multiple devices for `source` with their vendor and device information.
+<5> The values specified for `mode` determine the permissions for the file.
+<6> The `/etc/modprobe.d/vfio.conf` was created by the `echo "options vfio-pci ids=10de:1eb8 > /etc/modprobe.d/vfio/conf"` command.
+<7> The `echo "dmZpby1wY2kK" | base64 -d` command and the `vfio-pci` commands create the encoded text for `source` as `dmZpby1wY2kK`. The encoded text translates to `vfio-pci`.
+<8> The file that loads the vfio-pci kernel module on the worker nodes.
+
+. Create a `MachineConfig` object that identifies the kernel argument for the IOMMU configuration:
++
+[source,terminal]
+----
+$ oc create -f 100-worker-kernel-arg-iommu.yaml
+----
+
+. Verify that the `MachineConfig` object was added.
++
+[source,terminal]
+----
+$ oc get MachineConfig
+----
++
+.Example output
+[source, terminal]
+----
+NAME                             GENERATEDBYCONTROLLER                      IGNITIONVERSION  AGE
+00-master                        d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+00-worker                        d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+01-master-container-runtime      d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+01-master-kubelet                d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+01-worker-container-runtime      d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+01-worker-kubelet                d3da910bfa9f4b599af4ed7f5ac270d55950a3a1   3.2.0            25h
+100-worker-iommu                                                            3.2.0            30s
+100-worker-vfiopci-configuration                                            3.2.0            30s
+----
+
+. Run the `lspci` command to obtain the `vendor-ID` and the `device-ID` for the PCI device.
++
+[source, terminal]
+----
+$ lspci -nnv | grep -i nvidia
+----
++
+.Example output
+[source, terminal]
+----
+02:01.0 3D controller [0302]: NVIDIA Corporation GV100GL [Tesla V100 PCIe 32GB] [10de:1eb8] (rev a1)
+----
+
+. Specify the values for `vendor-ID` and `device-ID` and convert the `/etc/modprobe.d/vfio.conf` file to base64 format:
++
+[source,terminal]
+----
+$ echo "options vfio-pci ids=10de:1eb8" | base64
+----
+These values are converted into the `base64 format` and the output is encoded.
++
+.Example output
+[source,terminal]
+----
+b3B0aW9ucyB2ZmlvLXBjaSBpZHM9MTBkZToxZWI4Cg==
+----
+
+. Add the encoded text to `source` in the `MachineConfig` object.
+
+. Convert `vfio-pci` into base64 format and encode the text:
++
+[source,terminal]
+----
+$ echo vfio-pci | base64
+----
+These values are converted into the `base64 format` and the output is encoded.
++
+.Example output
+[source,terminal]
+----
+dmZpby1wY2kK
+----
+
+. Add the encoded text to `source` in the `MachineConfig` object.
+
+.Verification
+* Verify that the VFIO driver is loaded.
++
+[source,terminal]
+----
+$ lspci -nnk -d 10de:
+----
+The output confirms that the VFIO driver is being used.
++
+.Example output
+----
+04:00.0 3D controller [0302]: NVIDIA Corporation GP102GL [Tesla P40] [10de:1eb8] (rev a1)
+        Subsystem: NVIDIA Corporation Device [10de:1eb8]
+        Kernel driver in use: vfio-pci
+        Kernel modules: nouveau
+----

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough.adoc
@@ -1,0 +1,32 @@
+[id="virt-configuring-pci-passthrough"]
+= Configuring PCI passthrough
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-configuring-pci-passthrough
+
+toc::[]
+
+//This assembly contains the content for
+//configuring PCI passthrough by using the CLI. There are
+//plans to enable PCI passthrough configuration
+//by using the web console (next release).
+//When this feature is available in the web console, please
+//add the new content to this assembly.
+
+include::modules/virt-about-pci-passthrough.adoc[leveloffset=+1]
+include::modules/virt-adding-kernel-arguments-enable-iommu.adoc[leveloffset=+2]
+include::modules/virt-binding-devices-vfio-driver.adoc[leveloffset=+2]
+include::modules/virt-adding-pci-device-hyperconverged-operator.adoc[leveloffset=+2]
+
+[id="virt-configuring-vms-for-pci-passthrough"]
+== Configuring virtual machines for PCI passthrough
+
+After the PCI devices have been added to the cluster, you can assign them to virtual machines. The PCI devices are now available as if they are physically connected to the virtual machines.
+
+include::modules/virt-assigning-pci-device-virtual-machine.adoc[leveloffset=+2]
+
+[id="additional-resources_configuring-pci-passthrough"]
+== Additional resources
+* For information about enabling virtualization hardware extensions, refer to link: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/virtualization_deployment_and_administration_guide/sect-troubleshooting-enabling_intel_vt_x_and_amd_v_virtualization_hardware_extensions_in_bios[Enabling Intel VT-X and AMD-V Virtualization Hardware Extensions in BIOS].
+* For information about file permissions, refer to link: https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_basic_system_settings/assembly_managing-file-permissions_configuring-basic-system-settings[Managing file permissions].
+* For information about the Machine Config Operator, refer to xref:../../../post_installation_configuration/machine-configuration-tasks.adoc#post-install-machine-configuration-tasks[Post-installation machine configuration tasks].


### PR DESCRIPTION
This PR is associated with [CNV-11006](https://issues.redhat.com/browse/CNV-11006) Document how to use PCI passthrough.
This PR is for the 4.8 release.