### PR TITLE
[enterprise-4.6] OSDOCS-2144-Update 4.6+ sys reqs that BYO RHEL7 is deprecated

### DIFF
--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -6,9 +6,9 @@
 
 
 [id="rhel-compute-requirements_{context}"]
-= System requirements for RHEL compute nodes
+= System requirements for {op-system-base} compute nodes
 
-The Red Hat Enterprise Linux (RHEL) compute machine hosts, which are also known as worker machine hosts, in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements.
+The {op-system-base-full} compute, or worker, machine hosts in your {product-title} environment must meet the following minimum hardware specifications and system-level requirements:
 
 * You must have an active {product-title} subscription on your Red Hat account. If you do not, contact your sales representative for more information.
 
@@ -19,13 +19,17 @@ ifdef::openshift-origin[]
 ** Base OS: CentOS 7.4.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale[]
-** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[RHEL 7.8 - 7.9] with "Minimal" installation option.
+** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[{op-system-base} 7.9] with "Minimal" installation option.
 +
 [IMPORTANT]
 ====
-Only RHEL 7.8 - 7.9 is supported in {product-title} {product-version}. You must not upgrade your compute machines to RHEL 8.
+Adding {op-system-base} 7 compute machines to an {product-title} cluster is deprecated. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+In addition, you must not upgrade your compute machines to {op-system-base} 8 because support is not available in this release.
+
+For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
 ====
-** If you deployed {product-title} in FIPS mode, you must enable FIPS on the RHEL machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the RHEL 7 documentation.
+** If you deployed {product-title} in FIPS mode, you must enable FIPS on the {op-system-base} machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the {op-system-base} 7 documentation.
 endif::[]
 ** NetworkManager 1.0 or later.
 ** 1 vCPU.


### PR DESCRIPTION
Cherry-picked from 2d69cf0249d99064a8376a968725ad2756f00ca5 xref: https://github.com/openshift/openshift-docs/pull/32074