### PR TITLE
OSDOCS-1861: Add discussion of multi-network policy

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -890,6 +890,8 @@ Topics:
     File: understanding-multiple-networks
   - Name: About virtual routing and forwarding
     File: about-virtual-routing-and-forwarding
+  - Name: Configuring multi-network policy
+    File: configuring-multi-network-policy
   - Name: Attaching a pod to an additional network
     File: attaching-pod
   - Name: Removing a pod from an additional network

--- a/modules/nw-multi-network-policy-differences.adoc
+++ b/modules/nw-multi-network-policy-differences.adoc
@@ -1,0 +1,31 @@
+[id="nw-multi-network-policy-differences_{context}"]
+= Differences between multi-network policy and network policy
+
+Although the `MultiNetworkPolicy` API implements the `NetworkPolicy` API, there are several important differences:
+
+* You must use the `MultiNetworkPolicy` API:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+----
+
+* You must use the `multi-networkpolicy` resource name when using the CLI to interact with multi-network policies. For example, you can view a multi-network policy object with the `oc get multi-networkpolicy <name>` command where `<name>` is the name of a multi-network policy.
+
+* You must specify an annotation with the name of the network attachment definition that defines the macvlan additional network:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: <network_name>
+----
++
+--
+where:
+
+`<network_name>`:: Specifies the name of a network attachment definition.
+--

--- a/modules/nw-multi-network-policy-enable.adoc
+++ b/modules/nw-multi-network-policy-enable.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
+
+[id="nw-multi-network-policy-enable_{context}"]
+= Enabling multi-network policy for the cluster
+
+As a cluster administrator, you can enable multi-network policy support on your cluster.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the `multinetwork-enable-patch.yaml` file with the following YAML:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  useMultiNetworkPolicy: true
+----
+
+. Configure the cluster to enable multi-network policy:
++
+[source,terminal]
+----
+$ oc patch network.operator.openshift.io cluster --type=merge --patch-file=multinetwork-enable-patch.yaml
+----
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----

--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -3,19 +3,28 @@
 // * networking/network_policy/creating-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
+:name: network
+:role: admin
 ifeval::[{product-version} >= 4.6]
 :ovn:
 endif::[]
+ifeval::["{context}" == "configuring-multi-network-policy"]
+:multi:
+:name: multi-network
+:role: cluster-admin
+endif::[]
 
 [id="nw-networkpolicy-create_{context}"]
-= Creating a network policy
+= Creating a {name} policy
 
-To define granular rules describing ingress or egress network traffic allowed for namespaces in your cluster, you can create a network policy.
+To define granular rules describing ingress or egress network traffic allowed for namespaces in your cluster, you can create a {name} policy.
 
+ifndef::multi[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
 ====
+endif::multi[]
 
 .Prerequisites
 
@@ -28,8 +37,11 @@ the OVN-Kubernetes network provider or the OpenShift SDN network provider with `
 endif::ovn[]
 This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `admin` privileges.
-* You are working in the namespace that the network policy applies to.
+* You are logged in to the cluster with a user with `{role}` privileges.
+* You are working in the namespace that the {name} policy applies to.
+ifndef::multi[]
+* Your cluster is using a cluster network provider that supports `NetworkPolicy` objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+endif::multi[]
 
 .Procedure
 
@@ -44,39 +56,74 @@ $ touch <policy_name>.yaml
 --
 where:
 
-`<policy_name>`:: Specifies the network policy file name.
+`<policy_name>`:: Specifies the {name} policy file name.
 --
 
-.. Define a network policy in the file that you just created, such as in the following examples:
+.. Define a {name} policy in the file that you just created, such as in the following examples:
 +
 .Deny ingress from all pods in all namespaces
 [source,yaml]
 ----
+ifndef::multi[]
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
+endif::multi[]
+ifdef::multi[]
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+endif::multi[]
 metadata:
   name: deny-by-default
+ifdef::multi[]
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: <network_name>
+endif::multi[]
 spec:
   podSelector:
   ingress: []
 ----
+ifdef::multi[]
++
+--
+where
+
+`<network_name>`:: Specifies the name of a network attachment definition.
+--
+endif::multi[]
 +
 .Allow ingress from all pods in the same namespace
 [source,yaml]
 ----
+ifndef::multi[]
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
+endif::multi[]
+ifdef::multi[]
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+endif::multi[]
 metadata:
   name: allow-same-namespace
+ifdef::multi[]
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: <network_name>
+endif::multi[]
 spec:
   podSelector:
   ingress:
   - from:
     - podSelector: {}
 ----
+ifdef::multi[]
++
+--
+where
 
+`<network_name>`:: Specifies the name of a network attachment definition.
+--
+endif::multi[]
 
-. To create the network policy object, enter the following command:
+. To create the {name} policy object, enter the following command:
 +
 [source,terminal]
 ----
@@ -86,16 +133,26 @@ $ oc apply -f <policy_name>.yaml -n <namespace>
 --
 where:
 
-`<policy_name>`:: Specifies the network policy file name.
+`<policy_name>`:: Specifies the {name} policy file name.
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 +
 .Example output
 [source,terminal]
 ----
-networkpolicy "default-deny" created
+ifndef::multi[]
+networkpolicy.networking.k8s.io/default-deny created
+endif::multi[]
+ifdef::multi[]
+multinetworkpolicy.k8s.cni.cncf.io/default-deny created
+endif::multi[]
 ----
 
 ifdef::ovn[]
 :!ovn:
 endif::ovn[]
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-delete.adoc
+++ b/modules/nw-networkpolicy-delete.adoc
@@ -3,19 +3,28 @@
 // * networking/network_policy/deleting-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
+:name: network
+:role: admin
 ifeval::[{product-version} >= 4.6]
 :ovn:
 endif::[]
+ifeval::["{context}" == "configuring-multi-network-policy"]
+:multi:
+:name: multi-network
+:role: cluster-admin
+endif::[]
 
 [id="nw-networkpolicy-delete_{context}"]
-= Deleting a network policy
+= Deleting a {name} policy
 
-You can delete a network policy in a namespace.
+You can delete a {name} policy in a namespace.
 
+ifndef::multi[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can delete any network policy in the cluster.
 ====
+endif::multi[]
 
 .Prerequisites
 
@@ -28,31 +37,41 @@ the OVN-Kubernetes network provider or the OpenShift SDN network provider with `
 endif::ovn[]
 This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `admin` privileges.
-* You are working in the namespace where the network policy exists.
+* You are logged in to the cluster with a user with `{role}` privileges.
+* You are working in the namespace where the {name} policy exists.
 
 .Procedure
 
-* To delete a `NetworkPolicy` object, enter the following command:
+* To delete a {name} policy object, enter the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete networkpolicy <policy_name> -n <namespace>
+$ oc delete {name}policy <policy_name> -n <namespace>
 ----
 +
 --
 where:
 
-`<policy_name>`:: Specifies the name of the network policy.
+`<policy_name>`:: Specifies the name of the {name} policy.
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 +
 .Example output
 [source,text]
 ----
-networkpolicy.networking.k8s.io/allow-same-namespace deleted
+ifndef::multi[]
+networkpolicy.networking.k8s.io/default-deny deleted
+endif::multi[]
+ifdef::multi[]
+multinetworkpolicy.k8s.cni.cncf.io/default-deny deleted
+endif::multi[]
 ----
 
 ifdef::ovn[]
 :!ovn:
 endif::ovn[]
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -2,19 +2,28 @@
 //
 // * networking/network_policy/editing-network-policy.adoc
 
+:name: network
+:role: admin
 ifeval::[{product-version} >= 4.6]
 :ovn:
 endif::[]
+ifeval::["{context}" == "configuring-multi-network-policy"]
+:multi:
+:name: multi-network
+:role: cluster-admin
+endif::[]
 
 [id="nw-networkpolicy-edit_{context}"]
-= Editing a network policy
+= Editing a {name} policy
 
-You can edit a network policy in a namespace.
+You can edit a {name} policy in a namespace.
 
+ifndef::multi[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can edit a network policy in any namespace in the cluster.
 ====
+endif::multi[]
 
 .Prerequisites
 
@@ -27,16 +36,16 @@ the OVN-Kubernetes network provider or the OpenShift SDN network provider with `
 endif::ovn[]
 This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `admin` privileges.
-* You are working in the namespace where the network policy exists.
+* You are logged in to the cluster with a user with `{role}` privileges.
+* You are working in the namespace where the {name} policy exists.
 
 .Procedure
 
-. Optional: To list the network policy objects in a namespace, enter the following command:
+. Optional: To list the {name} policy objects in a namespace, enter the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get networkpolicy -n <namespace>
+$ oc get {name}policy
 ----
 +
 --
@@ -45,9 +54,9 @@ where:
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 
-. Edit the `NetworkPolicy` object.
+. Edit the {name} policy object.
 
-** If you saved the network policy definition in a file, edit the file and make any necessary changes, and then enter the following command.
+** If you saved the {name} policy definition in a file, edit the file and make any necessary changes, and then enter the following command.
 +
 [source,terminal]
 ----
@@ -61,11 +70,11 @@ where:
 `<policy_file>`:: Specifies the name of the file containing the network policy.
 --
 
-** If you need to update the `NetworkPolicy` object directly, enter the following command:
+** If you need to update the {name} policy object directly, enter the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit networkpolicy <policy_name> -n <namespace>
+$ oc edit {name}policy <policy_name> -n <namespace>
 ----
 +
 --
@@ -75,20 +84,25 @@ where:
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 
-. Confirm that the `NetworkPolicy` object is updated.
+. Confirm that the {name} policy object is updated.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc describe networkpolicy <policy_name> -n <namespace>
+$ oc describe {name}policy <policy_name> -n <namespace>
 ----
 +
 --
 where:
 
-`<policy_name>`:: Specifies the name of the network policy.
+`<policy_name>`:: Specifies the name of the {name} policy.
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 
 ifdef::ovn[]
 :!ovn:
 endif::ovn[]
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-view.adoc
+++ b/modules/nw-networkpolicy-view.adoc
@@ -3,47 +3,58 @@
 // * networking/network_policy/viewing-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
+:name: network
+:role: admin
+ifeval::["{context}" == "configuring-multi-network-policy"]
+:multi:
+:name: multi-network
+:role: cluster-admin
+endif::[]
+
 [id="nw-networkpolicy-view_{context}"]
-= Viewing network policies
+= Viewing {name} policies
 
-You can examine the network policies in a namespace.
+You can examine the {name} policies in a namespace.
 
+ifndef::multi[]
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can view any network policy in the cluster.
 ====
+endif::multi[]
 
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `admin` privileges.
-* You are working in the namespace where the network policy exists.
+* You are logged in to the cluster with a user with `{role}` privileges.
+* You are working in the namespace where the {name} policy exists.
 
 .Procedure
 
-* List network policies in a namespace:
+* List {name} policies in a namespace:
 
-** To view `NetworkPolicy` objects defined in a namespace, enter the following
+** To view {name} policy objects defined in a namespace, enter the following
 command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get networkpolicy
+$ oc get {name}policy
 ----
 
-** Optional: To examine a specific network policy, enter the following command:
+** Optional: To examine a specific {name} policy, enter the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc describe networkpolicy <policy_name> -n <namespace>
+$ oc describe {name}policy <policy_name> -n <namespace>
 ----
 +
 --
 where:
 
-  `<policy_name>`:: Specifies the name of the network policy to inspect.
+  `<policy_name>`:: Specifies the name of the {name} policy to inspect.
   `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
+ifndef::multi[]
 +
 For example:
 +
@@ -69,3 +80,10 @@ Spec:
   Not affecting egress traffic
   Policy Types: Ingress
 ----
+endif::multi[]
+
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/networking/multiple_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/configuring-multi-network-policy.adoc
@@ -1,0 +1,39 @@
+[id="configuring-multi-network-policy"]
+= Configuring multi-network policy
+include::modules/common-attributes.adoc[]
+:context: configuring-multi-network-policy
+
+toc::[]
+
+As a cluster administrator, you can configure network policy for additional networks.
+
+[NOTE]
+====
+You can specify multi-network policy for only macvlan additional networks.
+Other types of additional networks, such as ipvlan, are not supported.
+====
+
+include::modules/nw-multi-network-policy-differences.adoc[leveloffset=+1]
+include::modules/nw-multi-network-policy-enable.adoc[leveloffset=+1]
+
+[id="{context}-working-with-multi-network-policy"]
+== Working with multi-network policy
+
+As a cluster administrator, you can create, edit, view, and delete multi-network policies.
+
+[id="{context}-prerequisites"]
+=== Prerequisites
+
+* You have enabled multi-network policy support for your cluster.
+
+include::modules/nw-networkpolicy-create.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-edit.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-view.adoc[leveloffset=+2]
+include::modules/nw-networkpolicy-delete.adoc[leveloffset=+2]
+
+[id="{context}-additional-resources"]
+== Additional resources
+
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* xref:../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[Understanding multiple networks]
+* xref:../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Configuring a macvlan network]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1861

~So this rebased off of https://github.com/openshift/openshift-docs/pull/32708 and all those changes appear here as well. Ideally, 32708 is merged first.~ The following content is specific to this PR:

Previews
- [Configuring multi-network policy](https://deploy-preview-32252--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-multi-network-policy.html)

(So mostly `modules/nw-multi-network-policy-*.adoc` files.)