### PR TITLE
Removing extra full stop from optimizing storage assembly

### DIFF
--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -87,7 +87,7 @@ In a scaled/HA {product-title} registry cluster deployment:
 * The storage technology must support RWX access mode and must ensure read-after-write consistency.
 * The preferred storage technology is object storage.
 * Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft Azure Blob Storage, and OpenStack Swift are supported.
-* Object storage should be S3 or Swift compliant..
+* Object storage should be S3 or Swift compliant.
 * For non-cloud platforms, such as vSphere and bare metal installations, the only configurable technology is file storage.
 * Block storage is not configurable.
 


### PR DESCRIPTION
This applies to master, enterprise-4.6, enterprise 4.7 and enterprise-4.8.

The preview content is [here](https://deploy-preview-32257--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimizing-storage.html#recommended-configurable-storage-technology_persistent-storage).