### PR TITLE
Docs reference Fedora 8 in baremetal IPI prereqs

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
@@ -8,7 +8,8 @@ toc::[]
 
 Installer-provisioned installation of {product-title} requires:
 
-. One provisioner node with {op-system-base-full} 8.x installed.
+ifdef::openshift-origin[. One provisioner node with {op-system-first} installed.]
+ifndef::openshift-origin[. One provisioner node with {op-system-base-full} 8.x installed.]
 . Three control plane nodes.
 . Baseboard Management Controller (BMC) access to each node.
 ifeval::[{release} > 4.5]

--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -24,8 +24,8 @@ While the cluster nodes can contain more than two NICs, the installation process
 
 NIC1 is a non-routable network (`provisioning`) that is only used for the installation of the {product-title} cluster.
 
-The {op-system-base-full} 8.x installation process on the provisioner node might vary. To install {op-system-base-full} 8.x using a local Satellite server or a PXE server, PXE-enable NIC2.
-
+ifndef::openshift-origin[The {op-system-base-full} 8.x installation process on the provisioner node might vary. To install {op-system-base-full} 8.x using a local Satellite server or a PXE server, PXE-enable NIC2.]
+ifdef::openshift-origin[The {op-system-first} installation process on the provisioner node might vary. To install {op-system} using a local Satellite server or a PXE server, PXE-enable NIC2.]
 
 |===
 |PXE |Boot order

--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -20,7 +20,12 @@ ifeval::[{release} > 4.4]
 - **Baseboard Management Controller:** The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, RedFish, or a proprietary protocol.
 endif::[]
 
+ifndef::openshift-origin[]
 - **Latest generation:** Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
+endif::[]
+ifdef::openshift-origin[]
+- **Latest generation:** Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-first} ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system} for the `provisioner` node and {op-system} for the control plane and worker nodes.
+endif::[]
 
 - **Registry node:** Optional: If setting up a disconnected mirrored registry, it is recommended the registry reside in its own node.
 


### PR DESCRIPTION
https://github.com/openshift/okd/issues/542

Changed the Fedora 8.x and Fedora 8 references to Fedora CoreOS (FCOS) or FCOS as appropriate.

Internal-only preview: http://file.rdu.redhat.com/~mburke/okd-issue-542/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html