### PR TITLE
Documentation refers to RHCOS AMI instead of FCOS

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -15,6 +15,7 @@ You can also install to regions that do not have a {op-system} AMI published by
 importing your own AMI.
 ====
 
+ifndef::openshift-origin[]
 .{op-system} AMIs
 
 [cols="2a,2a",options="header"]
@@ -84,3 +85,4 @@ importing your own AMI.
 |`ami-010de485a2ee23e5e`
 
 |===
+endif::openshift-origin[]


### PR DESCRIPTION
https://github.com/openshift/okd/issues/532

Hid the [AMI table in OKD per Vadim](https://github.com/openshift/okd/issues/532#issuecomment-833275360).

Internal-only preview: http://file.rdu.redhat.com/~mburke/okd-issue-532/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws