### PR TITLE
OSDOCS-2161: Updating oc logins to pass in username

### DIFF
--- a/modules/cli-developer-basic.adoc
+++ b/modules/cli-developer-basic.adoc
@@ -23,12 +23,6 @@ use.
 .Example: Interactive login
 [source,terminal]
 ----
-$ oc login
-----
-
-.Example: Log in specifying a user name
-[source,terminal]
-----
 $ oc login -u user1
 ----
 

--- a/modules/identity-provider-configuring-apache-request-header.adoc
+++ b/modules/identity-provider-configuring-apache-request-header.adoc
@@ -215,10 +215,10 @@ ticket:
 +
 [source,terminal]
 ----
-# oc login
+# oc login -u <username>
 ----
 +
-Enter your Kerberos user name and password at the prompt.
+Enter your Kerberos password at the prompt.
 ... Log out of the `oc` tool:
 +
 [source,terminal]

--- a/modules/installation-ibm-z-troubleshooting-and-debugging.adoc
+++ b/modules/installation-ibm-z-troubleshooting-and-debugging.adoc
@@ -17,7 +17,7 @@ debug certain issues with an {product-title} installation on IBM Z.
 . Log in to the cluster:
 +
 ----
-$ oc login
+$ oc login -u <username>
 ----
 
 . On the node you want to gather hardware information about, start a debugging

--- a/modules/ldap-failover-configure-openshift.adoc
+++ b/modules/ldap-failover-configure-openshift.adoc
@@ -42,7 +42,7 @@ listed in the Ansible host inventory file.
 . Test a login by using the `oc` CLI:
 +
 ----
-$ oc login https://openshift.example.com:8443
+$ oc login https://openshift.example.com:8443 -u user1
 ----
 +
 You can log in only with valid LDAP credentials.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2161

Previews:
* https://deploy-preview-32271--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/developer-cli-commands.html#login
* https://deploy-preview-32271--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-request-header-identity-provider.html#identity-provider-configuring-apache-request-header_configuring-request-header-identity-provider
* https://deploy-preview-32271--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-ibm-z-troubleshooting-and-debugging_installing-ibm-z
* (No preview for the LDAP failover update - the file is currently not included)