### PR TITLE
Bug 1724454: example VLAN configurations

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -30,6 +30,9 @@ Ordering is important when adding kernel arguments: `ip=`, `nameserver=`, and th
 ====
 
 .Routing and bonding options for ISO
+
+The following table provides examples for configuring networking of your {op-system-first} nodes. These are networking options that are passed to the `dracut` tool during system boot. For more information about the networking options supported by `dracut`, see the `dracut.cmdline` manual page.
+
 |===
 |Description |Examples
 
@@ -70,6 +73,22 @@ ip=enp1s0:dhcp
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
+a|Optional: You can configure VLANs on individual interfaces by using the `vlan=` parameter.
+a| 
+To configure a VLAN on a network interface and use a static IP address:
+
+----
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0.100:none
+vlan=enp2s0.100:enp2s0
+----
+
+To configure a VLAN on a network interface and to use DHCP:
+
+----
+ip=enp2s0.100:dhcp
+vlan=enp2s0.100:enp2s0
+----
+
 a|You can provide multiple DNS servers by adding a `nameserver=` entry for each server.
 a|
 ----
@@ -103,6 +122,24 @@ enter the specific IP address you want and related information. For example:
 ----
 bond=bond0:em1,em2:mode=active-backup
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
+----
+
+a|Optional: You can configure VLANs on bonded interfaces by using the `vlan=` parameter.
+a|
+To configure the bonded interface with a VLAN and to use DHCP:
+
+----
+ip=bond0.100:dhcp
+bond=bond0:em1,em2:mode=active-backup
+vlan=bond0.100:bond0
+----
+
+To configure the bonded interface with a VLAN and to use a static IP address:
+
+----
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
+bond=bond0:em1,em2:mode=active-backup
+vlan=bond0.100:bond0
 ----
 
 |===


### PR DESCRIPTION
Provides examples for configuring VLANs on the kernel command line
when installing RHCOS.