### PR TITLE
OSDOCS-2073 vSphere autoscaling from or to zero feature

### DIFF
--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -24,8 +24,15 @@ spec:
     kind: MachineSet <5>
     name: worker-us-east-1a <6>
 ----
-<1> Specify the machine autoscaler name. To make it easier to identify which machine set this machine autoscaler scales, specify or include the name of the machine set to scale. The machine set name takes the following form: `<clusterid>-<machineset>-<aws-region-az>`
-<2> Specify the minimum number machines of the specified type that must remain in the specified zone after the cluster autoscaler initiates cluster scaling. If running in AWS, GCP, Azure, or {rh-openstack}, this value can be set to `0`. For other providers, do not set this value to `0`.
+<1> Specify the machine autoscaler name. To make it easier to identify which machine set this machine autoscaler scales, specify or include the name of the machine set to scale. The machine set name takes the following form: `<clusterid>-<machineset>-<aws-region-az>`.
+<2> Specify the minimum number machines of the specified type that must remain in the specified zone after the cluster autoscaler initiates cluster scaling. If running in AWS, GCP, Azure, {rh-openstack}, or vSphere, this value can be set to `0`. For other providers, do not set this value to `0`.
++
+You can save on costs by setting this value to `0` for use cases such as running expensive or limited-usage hardware that is used for specialized workloads, or by scaling a machine set with extra large machines. The machine autoscaler scales the machine set down to zero if the machines are not in use.
++
+[IMPORTANT]
+====
+Do not set the `spec.minReplicas` value to `0` for the three compute plane machine sets that are created during the {product-title} installation process for an installer provisioned infrastructure.
+====
 <3> Specify the maximum number machines of the specified type that the cluster autoscaler can deploy in the specified AWS zone after it initiates cluster scaling. Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition is large enough to allow the machine autoscaler to deploy this number of machines.
 <4> In this section, provide values that describe the existing machine set to scale.
 <5> The `kind` parameter value is always `MachineSet`.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2073

Adds vSphere to additional information for `spec.minReplicas` in the MachineAutoscaler resource definition. Also adds a new paragraph with more information/use cases for scaling to and from zero with the machine autoscaler.

Preview: https://deploy-preview-32290--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#machine-autoscaler-cr_applying-autoscaling