### PR TITLE
RHDEVDOCS-2985 Logging: Create RNs for 5.0.3 RHSA-2021:1515 OSE-LOGGING

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -10,19 +10,15 @@ toc::[]
 
 The following advisories are available for {ProductName} 5.0:
 
-* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Errata Advisory for Openshift Logging 5.0.0]
-* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)]
-* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 for OpenShift Logging Bug Fix Release (5.0.2)]
+* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Bug Fix Advisory for OpenShift Logging 5.0.0]
+* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.1)]
+* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.2)]
+* link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)]
 
 [id="openshift-logging-5-0-inclusive-language"]
 == Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
-
-// Release Notes by version
-include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
 
 [id="openshift-logging-5-0-deprecated-removed-features"]
 == Deprecated and removed features
@@ -35,3 +31,9 @@ Deprecated functionality is still included in OpenShift Logging and continues to
 === Elasticsearch Curator
 
 The Elasticsearch Curator is deprecated in OpenShift Logging 5.0 and will be removed in OpenShift Logging 5.1. Elasticsearch Curator helps you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator,  xref:../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[configure the log retention time].
+
+// Release Notes by version
+include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]

--- a/modules/cluster-logging-release-notes-5.0.0.adoc
+++ b/modules/cluster-logging-release-notes-5.0.0.adoc
@@ -1,7 +1,8 @@
 [id="cluster-logging-release-notes-5-0-0"]
 = OpenShift Logging 5.0.0
 
-This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Errata Advisory for Openshift Logging 5.0.0].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Bug Fix Advisory for OpenShift Logging 5.0.0].
+
 
 [id="openshift-logging-5-0-new-features-and-enhancements"]
 == New features and enhancements

--- a/modules/cluster-logging-release-notes-5.0.1.adoc
+++ b/modules/cluster-logging-release-notes-5.0.1.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-1"]
 = OpenShift Logging 5.0.1
 
-This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 for OpenShift Logging Bug Fix Release (5.0.1)].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.1)].
 
 [id="openshift-logging-5-0-1-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.0.2.adoc
+++ b/modules/cluster-logging-release-notes-5.0.2.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-2"]
 = OpenShift Logging 5.0.2
 
-This release includes Red Hat Bug Advisory, link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 for OpenShift Logging Bug Fix Release (5.0.2)].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.2)].
 
 [id="openshift-logging-5-0-2-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.0.3.adoc
+++ b/modules/cluster-logging-release-notes-5.0.3.adoc
@@ -1,0 +1,50 @@
+[id="cluster-logging-release-notes-5-0-3"]
+= OpenShift Logging 5.0.3
+
+This release includes link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)]
+
+
+[id="openshift-logging-5-0-3-security-fixes"]
+== Security fixes
+
+* jackson-databind: arbitrary code execution in slf4j-ext class (link:https://www.redhat.com/security/data/cve/CVE-2018-14718.html[*CVE-2018-14718*])
+* jackson-databind: arbitrary code execution in blaze-ds-opt and blaze-ds-core classes (link:https://www.redhat.com/security/data/cve/CVE-2018-14719.html[*CVE-2018-14719*])
+* jackson-databind: exfiltration/XXE in some JDK classes (link:https://www.redhat.com/security/data/cve/CVE-2018-14720.html[*CVE-2018-14720*])
+* jackson-databind: server-side request forgery (SSRF) in axis2-jaxws class (link:https://www.redhat.com/security/data/cve/CVE-2018-14721.html[*CVE-2018-14721*])
+* jackson-databind: improper polymorphic deserialization in axis2-transport-jms class (link:https://www.redhat.com/security/data/cve/CVE-2018-19360.html[*CVE-2018-19360*])
+* jackson-databind: improper polymorphic deserialization in openjpa class (link:https://www.redhat.com/security/data/cve/CVE-2018-19361.html[*CVE-2018-19361*])
+* jackson-databind: improper polymorphic deserialization in jboss-common-core class (link:https://www.redhat.com/security/data/cve/CVE-2018-19362.html[*CVE-2018-19362*])
+* jackson-databind: default typing mishandling leading to remote code execution (link:https://www.redhat.com/security/data/cve/CVE-2019-14379.htmld[*CVE-2019-14379*])
+* jackson-databind: serialization gadgets in com.pastdev.httpcomponents.configuration.JndiConfiguration (link:https://www.redhat.com/security/data/cve/CVE-2020-24750.html[*CVE-2020-24750*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.PerUserPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-35490.html[*CVE-2020-35490*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.datasources.SharedPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-35491.html[*CVE-2020-35491*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to com.oracle.wls.shaded.org.apache.xalan.lib.sql.JNDIConnectionPool (link:https://www.redhat.com/security/data/cve/CVE-2020-35728.html[*CVE-2020-35728*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to oadd.org.apache.commons.dbcp.cpdsadapter.DriverAdapterCPDS (link:https://www.redhat.com/security/data/cve/CVE-2020-36179.html[*CVE-2020-36179*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.commons.dbcp2.cpdsadapter.DriverAdapterCPDS (link:https://www.redhat.com/security/data/cve/CVE-2020-36180.html[*CVE-2020-36180*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.cpdsadapter.DriverAdapterCPDS (link:https://www.redhat.com/security/data/cve/CVE-2020-36181.html[*CVE-2020-36181*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.cpdsadapter.DriverAdapterCPDS (link:https://www.redhat.com/security/data/cve/CVE-2020-36182.html[*CVE-2020-36182*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.docx4j.org.apache.xalan.lib.sql.JNDIConnectionPool (link:https://www.redhat.com/security/data/cve/CVE-2020-36183.html[*CVE-2020-36183*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.PerUserPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36184.html[*CVE-2020-36184*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp2.datasources.SharedPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36185.html[*CVE-2020-36185*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.PerUserPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36186.html[*CVE-2020-36186*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to org.apache.tomcat.dbcp.dbcp.datasources.SharedPoolDataSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36187.html[*CVE-2020-36187*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.JNDIConnectionSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36188.html[*CVE-2020-36188*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to com.newrelic.agent.deps.ch.qos.logback.core.db.DriverManagerConnectionSource (link:https://www.redhat.com/security/data/cve/CVE-2020-36189.html[*CVE-2020-36189*])
+* jackson-databind: mishandles the interaction between serialization gadgets and typing, related to javax.swing (link:https://www.redhat.com/security/data/cve/CVE-2021-20190.html[*CVE-2021-20190*])
+* golang: data race in certain net/http servers including ReverseProxy can lead to DoS (link:https://www.redhat.com/security/data/cve/CVE-2020-15586.html[*CVE-2020-15586*])
+* golang: ReadUvarint and ReadVarint can read an unlimited number of bytes from invalid inputs (link:https://www.redhat.com/security/data/cve/CVE-2020-16845.html[*CVE-2020-16845*])
+* OpenJDK: Incomplete enforcement of JAR signing disabled algorithms (Libraries, 8249906) (link:https://www.redhat.com/security/data/cve/CVE-2021-2163.html[*CVE-2021-2163*])
+
+The following Jira issues contain the above CVEs:
+
+* LOG-1234 CVE-2020-15586 CVE-2020-16845 openshift-eventrouter: various flaws [openshift-4]. (link:https://issues.redhat.com/browse/LOG-1234[*LOG-1234*])
+* LOG-1243 CVE-2018-14718 CVE-2018-14719 CVE-2018-14720 CVE-2018-14721 CVE-2018-19360 CVE-2018-19361 CVE-2018-19362 CVE-2019-14379 CVE-2020-35490 CVE-2020-35491 CVE-2020-35728... logging-elasticsearch6-container: various flaws [openshift-logging-5.0]. (link:https://issues.redhat.com/browse/LOG-1243[*LOG-1243*])
+
+[id="openshift-logging-5-0-3-bug-fixes"]
+== Bug fixes
+
+This release also includes the following bug fixes:
+
+* LOG-1224 Release 5.0 - ClusterLogForwarder namespace-specific log forwarding does not work as expected. (link:https://issues.redhat.com/browse/LOG-1224[*LOG-1224*])
+* LOG-1232 5.0 - Bug 1859004 - Sometimes the eventrouter couldn't gather event logs. (link:https://issues.redhat.com/browse/LOG-1232[*LOG-1232*])
+* LOG-1299 Release 5.0 - Forwarding logs to Kafka using Chained certificates fails with error "state=error: certificate verify failed (unable to get local issuer certificate)". (link:https://issues.redhat.com/browse/LOG-1299[*LOG-1299*])


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-4.7, enterprise-4.8
- https://issues.redhat.com/browse/RHDEVDOCS-2985
- Direct link to doc preview: https://deploy-preview-32292--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-0-3
- SME review: Requested from @vimalk78 
- QE review: Requested from @anpingli 
- Peer review: Requested from team
- <Please merge now>