### PR TITLE
BZ1957307 doc correction from Martin Sivak

### DIFF
--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -35,7 +35,7 @@ spec:
 [id="disabling_interrupt_processing_for_individual_pods_{context}"]
 == Disabling interrupt processing for individual pods
 
-To disable interrupt processing for individual pods, ensure that `globallyDisableIrqLoadBalancing` is set to `false` in the performance profile. Then, in the pod specification, set the `irq-load-balancing.crio.io` and `cpu-quota.crio.io` pod annotations to `disable`. An example pod specification snippet that illustrates this is below:
+To disable interrupt processing for individual pods, ensure that `globallyDisableIrqLoadBalancing` is set to `false` in the performance profile. Then, in the pod specification, set the `irq-load-balancing.crio.io` and `cpu-load-balancing.crio.io` pod annotations to `disable`. An example pod specification snippet that illustrates this is below:
 
 [source,yaml]
 ----
@@ -44,12 +44,8 @@ kind: Pod
 metadata:
   annotations:
       irq-load-balancing.crio.io: "disable"
-      cpu-quota.crio.io: "disable"
+      cpu-load-balancing.crio.io: "disable"
 spec:
     runtimeClassName: performance-<profile_name>
 ...
 ----
-
-
-
-


### PR DESCRIPTION
Correction made to section https://docs.openshift.com/container-platform/4.7/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#disabling_interrupt_processing_for_individual_pods_cnf-master as per https://bugzilla.redhat.com/show_bug.cgi?id=1957307

