### PR TITLE
Fixes release date in 3.11.420

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -4411,7 +4411,7 @@ To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest relea
 [[ocp-3-11-420]]
 === RHBA-2021:1147 - {product-title} 3.11.420 bug fix update
 
-Issued: 2021-03-21
+Issued: 2021-04-21
 
 {product-title} release 3.11.420 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHBA-2021:1147[RHBA-2021:1147] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1146[RHBA-2021:1146] advisory.
 


### PR DESCRIPTION
No BZ. Small typo on the release date of 3.11.420. 

Preview: https://deploy-preview-32305--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes.html#ocp-3-11-420

For 3.11. 