### PR TITLE
KATA-681: Understanding section: moving doc from Google Docs to GitHub

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -27,7 +27,7 @@ endif::[]
 :rh-storage-first: Red Hat OpenShift Container Storage
 :rh-storage: OpenShift Container Storage
 :sandboxed-containers-first: OpenShift sandboxed containers
-:sandboxed-containers: Sandboxed Containers Operator
+:sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
 ifdef::openshift-origin[]

--- a/modules/sandboxed-containers-about-sandboxing.adoc
+++ b/modules/sandboxed-containers-about-sandboxing.adoc
@@ -1,7 +1,0 @@
-//Module included in the following assemblies:
-//
-// * sandboxed_containers/understanding_sandboxed_containers.adoc
-
-[id="about-sandboxing_{context}"]
-
-= About sandboxing

--- a/modules/sandboxed-containers-building-blocks.adoc
+++ b/modules/sandboxed-containers-building-blocks.adoc
@@ -4,4 +4,8 @@
 
 [id="sandboxed-containers-building-blocks_{context}"]
 
-= Sandboxed containers building blocks
+= {sandboxed-containers-first} building blocks
+
+The {sandboxed-containers-operator} encapsulates all of the components from Kata containers. It manages installation, lifecycle, and configuration tasks.
+
+The {sandboxed-containers-operator} is packaged in the xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-working-bundle-images[Operator bundle format] as two container images. The bundle image contains metadata and is required to make the operator OLM-ready. The second container image contains the actual controller that monitors and manages the `KataConfig` resource.

--- a/modules/sandboxed-containers-common-terms.adoc
+++ b/modules/sandboxed-containers-common-terms.adoc
@@ -1,0 +1,27 @@
+//Module included in the following assemblies:
+//
+// * sandboxed_containers/understanding_sandboxed_containers.adoc
+[id="sandboxed-containers-common-terms_{context}"]
+= {sandboxed-containers-first} common terms
+
+The following terms are used throughout the documentation.
+
+Sandbox:: A sandbox is an isolated environment where programs can run. In a sandbox, you can run untested or untrusted programs without risking harm to the host machine or the operating system.
++
+In the context of {sandboxed-containers-first}, sandboxing is achieved by running workloads in a different kernel using virtualization, providing enhanced control over the interactions between multiple workloads that run on the same host.
+
+Pod:: A pod is a construct that is inherited from Kubernetes and {product-title}. It represents resources where containers can be deployed. Containers run inside of pods, and pods are used to specify resources that can be shared between multiple containers.
++
+In the context of {sandboxed-containers-first}, a pod is implemented as a virtual machine. Several containers can run in the same pod on the same virtual machine.
+
+{sandboxed-containers-operator}:: An Operator is a software component that automates operations, which are actions that a human operator could do on the system.
++
+The {sandboxed-containers-operator} is tasked with managing the lifecycle of sandboxed containers on a cluster. It deals with operations, such as the installation and removal of sandboxed containers software and status monitoring.
+
+Kata Containers:: Kata Containers is a core upstream project that is used to build {sandboxed-containers-first}. {sandboxed-containers-first} integrate Kata Containers with {product-title}.
+
+KataConfig:: `KataConfig` objects represent configurations of sandboxed containers. They store information about the state of the cluster, such as the nodes on which the software is deployed.
+
+{op-system} extensions:: {op-system-first} extensions are a mechanism to install optional {product-title} software. The {sandboxed-containers-operator} uses this mechanism to deploy sandboxed containers on a cluster.
+
+Runtime class:: A `RuntimeClass` object describes which runtime can be used to run a given workload. A runtime class that is named `kata` is installed and deployed by the {sandboxed-containers-operator}. The runtime class contains information about the runtime that describes resources that the runtime needs to operate, such as the link:https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/[pod overhead].

--- a/modules/sandboxed-containers-limitations.adoc
+++ b/modules/sandboxed-containers-limitations.adoc
@@ -1,7 +1,0 @@
-//Module included in the following assemblies:
-//
-// * sandboxed_containers/understanding_sandboxed_containers.adoc
-
-[id="sandboxed-containers-limitations_{context}"]
-
-= Limitations

--- a/modules/sandboxed-containers-os-extensions.adoc
+++ b/modules/sandboxed-containers-os-extensions.adoc
@@ -1,7 +1,0 @@
-//Module included in the following assemblies:
-//
-// * sandboxed_containers/understanding_sandboxed_containers.adoc
-
-[id="sandboxed-containers-os-extensions_{context}"]
-
-= OS extensions

--- a/modules/sandboxed-containers-rhcos-extensions.adoc
+++ b/modules/sandboxed-containers-rhcos-extensions.adoc
@@ -1,0 +1,9 @@
+//Module included in the following assemblies:
+//
+// * sandboxed_containers/understanding_sandboxed_containers.adoc
+
+[id="sandboxed-containers-rhcos-extensions_{context}"]
+
+= {op-system} extensions
+
+The {sandboxed-containers-operator} is based on the {op-system-first} extensions concept. The sandboxed containers {op-system} extension contains RPMs for Kata, QEMU, and its dependencies. You can enable them by using the `MachineConfig` resources that the Machine Config Operator provides.

--- a/modules/sandboxed-containers-uninstalling-kata-runtime.adoc
+++ b/modules/sandboxed-containers-uninstalling-kata-runtime.adoc
@@ -17,4 +17,4 @@ This section describes how to remove and uninstall the `kata` runtime and all it
 oc delete kataconfig <KataConfig_CR_Name>
 ----
 
-The {sandboxed-containers} removes all resources that were initially created to enable the runtime on your cluster. After you run the command above, your cluster is restored to the state prior to the installation process.
+The {sandboxed-containers-operator} removes all resources that were initially created to enable the runtime on your cluster. After you run the command above, your cluster is restored to the state prior to the installation process.

--- a/sandboxed_containers/understanding-sandboxed-containers.adoc
+++ b/sandboxed_containers/understanding-sandboxed-containers.adoc
@@ -1,5 +1,5 @@
 [id="understanding-sandboxed-containers"]
-= Understanding OpenShift sandboxed containers
+= Understanding {sandboxed-containers-first}
 include::modules/common-attributes.adoc[]
 
 :context: understanding-sandboxed-containers
@@ -16,13 +16,18 @@ toc::[]
 - Ensure proper isolation and sandboxing for testing software.
 - Ensure default resource containment through VM boundaries.
 
-Furthermore, {sandboxed-containers-first} provide an additional option for users to choose from the type of workload they want to run to cover a wide variety of use cases.
+{sandboxed-containers-first} also provides users the ability to choose from the type of workload that they want to run to cover a wide variety of use cases.
+
+You can use the {sandboxed-containers-operator} to perform tasks such as installation and removal, updates, and status monitoring.
 
 Sandboxed containers are only supported on bare metal.
 
-{op-system-first} is the only supported operating system for {product-title} 4.8.
+{op-system-first} is the only supported operating system for {sandboxed-containers-first} 1.0.0.
 
-include::modules/sandboxed-containers-about-sandboxing.adoc[leveloffset=+1]
+include::modules/sandboxed-containers-common-terms.adoc[leveloffset=+1]
 include::modules/sandboxed-containers-building-blocks.adoc[leveloffset=+1]
-include::modules/sandboxed-containers-os-extensions.adoc[leveloffset=+1]
-include::modules/sandboxed-containers-limitations.adoc[leveloffset=+1]
+include::modules/sandboxed-containers-rhcos-extensions.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-add-extensions_post-install-machine-configuration-tasks[Adding extensions to RHCOS]


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/KATA-681
Applies to 4.8+
Preview Link: https://deploy-preview-32307--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/understanding-sandboxed-containers.html 

**Preliminary doc is in Google Doc and we are in the process of moving it from Google to GitHub. This is a part of the 2nd draft.**