### PR TITLE
release-notes: dhclient is deprecated

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -206,6 +206,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |
 
+|Use of `dhclient` in {op-system-first}
+|DEP
+|DEP
+|DEP  
+
 |====
 
 [id="ocp-4-8-deprecated-features"]
@@ -215,6 +220,11 @@ In the table, features are marked with the following statuses:
 ==== Descheduler operator.openshift.io/v1beta1 API group is deprecated
 
 The `operator.openshift.io/v1beta1` API group for the descheduler is deprecated and might be removed in a future release. Use the `operator.openshift.io/v1` API group instead.
+
+[id="ocp-4-8-dhclient-deprecated"]
+==== Use of dhclient in {op-system-first} is deprecated
+
+Starting with {product-title} 4.6, {op-system-first} switched to using `NetworkManager` in the `initramfs` to configure networking during early boot. As part of this change, the use of the `dhclient` binary for DHCP was deprecated. Use the `NetworkManager` internal DHCP client for networking configuration instead. The `dhclient` binary will be removed from {op-system-first} in a future release. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1908462[BZ#1908462] for more information.
 
 [id="ocp-4-8-removed-features"]
 === Removed features


### PR DESCRIPTION
The use of `dhclient` is deprecated in RHCOS; it is planned to be
removed as part of OCP 4.9