### PR TITLE
BZ1822903: Updated the Network Security Groups requirements table 

### DIFF
--- a/modules/installation-about-custom-azure-vnet.adoc
+++ b/modules/installation-about-custom-azure-vnet.adoc
@@ -79,26 +79,29 @@ The network security group rules must be in place before you install the cluster
 
 |`80`
 |Allows HTTP traffic
-|x
 |
+|x
 
 |`443`
 |Allows HTTPS traffic
-|x
 |
+|x
 
 |`6443`
 |Allows communication to the control plane machines
 |x
-|x
+|
 
 |`22623`
 |Allows communication to the machine config server
 |x
-|x
-
+|
 |===
 
+[NOTE]
+====
+Since cluster components do not modify the user-provided network security groups, which the Kubernetes controllers update, a pseudo-network security group is created for the Kubernetes controller to modify without impacting the rest of the environment.
+====
 
 [id="installation-about-custom-azure-permissions_{context}"]
 == Division of permissions


### PR DESCRIPTION
Updated the NSG requirements table to show the correct control plane vs compute ports.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1822903

Preview: https://deploy-preview-32322--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html#installation-about-custom-azure-vnet-nsg-requirements_installing-azure-vnet

Applies to 4.5+