### PR TITLE
KATA-681: Upgrading section - moving doc from Google Docs to GitHub

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1696,16 +1696,18 @@ Topics:
 - Name: Disabling Windows container workloads
   File: disabling-windows-container-workloads
 ---
-Name: Sandboxed Container Support for OpenShift
+Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Understanding OpenShift sandboxed containers
   File: understanding-sandboxed-containers
-- Name: Deploying sandboxed containers workloads
+- Name: Deploying OpenShift sandboxed containers workloads
   File: deploying-sandboxed-container-workloads
-- Name: Disabling sandboxed container workloads
+- Name: Uninstalling OpenShift sandboxed container workloads
   File: disabling-sandboxed-container-workloads
+- Name: Upgrading OpenShift sandboxed containers
+  File: upgrading-sandboxed-containers
 ---
 Name: Logging
 Dir: logging

--- a/modules/sandboxed-containers-upgrading-artifacts.adoc
+++ b/modules/sandboxed-containers-upgrading-artifacts.adoc
@@ -1,0 +1,13 @@
+//Module included in the following assemblies:
+//
+// * sandboxed_containers/deploying_sandboxed_containers.adoc
+
+[id="sandboxed-containers-selecting-nodes_{context}"]
+
+= Selecting nodes for OpenShift sandboxed containers
+
+The OpenShift sandboxed containers artifacts are deployed onto the cluster using Red Hat CoreOS extensions.
+
+//Update the Red Hat CoreOS extension with the updated link once PR is approved for the Understanding section.
+
+The RHCOS extension `sandboxed containers` contains the required components to run Kata containers such as the Kata containers runtime, the hypervisor QEMU-kiwi and its dependencies. The extension is upgraded when upgrading the cluster to a new release of {product-title}.

--- a/modules/sandboxed-containers-upgrading-operator.adoc
+++ b/modules/sandboxed-containers-upgrading-operator.adoc
@@ -1,0 +1,11 @@
+//Module included in the following assemblies:
+//
+// * sandboxed_containers/upgrading-sandboxed-containers.adoc
+
+[id="sandboxed-containers-upgrading-operator_{context}"]
+
+= Upgrading the OpenShift sandboxed containers operator
+
+The operator itself can be upgraded via the OpenShift Lifecycle Manager (OLM) either manually or automatically. You can select manual or automatic during the initial deployment. In case of manual upgrades the web console shows available updates which can be installed by the cluster administrator.
+
+// Add link to this doc: For more information, see link:https://docs.openshift.com/container-platform/4.7/operators/admin/olm-upgrading-operators.html

--- a/sandboxed_containers/upgrading-sandboxed-containers.adoc
+++ b/sandboxed_containers/upgrading-sandboxed-containers.adoc
@@ -1,0 +1,9 @@
+[id="upgrading-sandboxed-containers"]
+= Upgrading OpenShift sandboxed containers
+include::modules/common-attributes.adoc[]
+:context: upgrading-sandboxed-containers
+
+toc::[]
+
+include::modules/sandboxed-containers-upgrading-operator.adoc[leveloffset=+1]
+include::modules/sandboxed-containers-upgrading-artifacts.adoc[leveloffset=+1]


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/KATA-681
Applies to 4.8+
Preview Link: https://deploy-preview-32328--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/upgrading-sandboxed-containers.html

**Preliminary doc is in Google Doc and we are in the process of moving it from Google to GitHub. This is a part of the 2nd draft.** 