### PR TITLE
Erroneous sample output includes 'run-level 0' for a non control plane component

### DIFF
--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -38,26 +38,26 @@ $ oc edit project <name>
 .Example output
 [source,yaml]
 ----
-apiVersion: v1
+apiVersion: project.openshift.io/v1
 kind: Project
 metadata:
   annotations:
     openshift.io/node-selector: "type=user-node,region=east" <1>
-    openshift.io/sa.scc.mcs: s0:c17,c14
-    openshift.io/sa.scc.supplemental-groups: 1000300000/10000
-    openshift.io/sa.scc.uid-range: 1000300000/10000
-  creationTimestamp: 2019-06-10T14:39:45Z
+    openshift.io/description: ""
+    openshift.io/display-name: ""
+    openshift.io/requester: kube:admin
+    openshift.io/sa.scc.mcs: s0:c30,c5
+    openshift.io/sa.scc.supplemental-groups: 1000880000/10000
+    openshift.io/sa.scc.uid-range: 1000880000/10000
+  creationTimestamp: "2021-05-10T12:35:04Z"
   labels:
-    openshift.io/run-level: "0"
+    kubernetes.io/metadata.name: demo
   name: demo
-  resourceVersion: "401885"
-  selfLink: /api/v1/namespaces/openshift-kube-apiserver
-  uid: 96ecc54b-8b8d-11e9-9f54-0a9ae641edd0
+  resourceVersion: "145537"
+  uid: 3f8786e3-1fcb-42e3-a0e3-e2ac54d15001
 spec:
   finalizers:
   - kubernetes
-status:
-  phase: Active
 ----
 <1> Add the `openshift.io/node-selector` with the appropriate `<key>:<value>` pairs.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1953936

https://deploy-preview-32347--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-project_nodes-scheduler-node-selectors