### PR TITLE
[enterprise-4.5] BZ-1805062: Added workaround for machineNetwork

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -264,8 +264,12 @@ endif::openshift-origin[]
 |Array of objects
 
 |`networking.machineNetwork.cidr`
-|Required if you use `networking.machineNetwork`. The IP block address pool. The default is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default is `192.168.126.0/24`.
-|IP network. IP networks are represented as strings using Classless Inter-Domain Routing (CIDR) notation with a traditional IP address or network number, followed by the forward slash (/) character, followed by a decimal value between 0 and 32 that describes the number of significant bits. For example, `10.0.0.0/16` represents IP addresses `10.0.0.0` through `10.0.255.255`.
+|Required if you use `networking.machineNetwork`. An IP address block. The default is `10.0.0.0/16` for all platforms other than libvirt. For libvirt, the default is `192.168.126.0/24`.
+|IP network in Classless Inter-Domain Routing (CIDR) notation. For example, `10.0.0.0/16`.
+[NOTE]
+====
+Set the `networking.machineNetwork` to match the CIDR that the preferred NIC resides in.
+====
 
 ifndef::openshift-origin[]
 |`networking.networkType`


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/31923