### PR TITLE
Fix bad ifdef in 4.6 install-config

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -117,9 +117,7 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <11>
 endif::openshift-origin[]
-endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...' <13>
-ifdef::restricted[]
 ifndef::openshift-origin[]
 additionalTrustBundle: | <14>
   -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
Fixing an `ifdef` error that results in duplicate `sshKey: 'ssh-ed25519 AAAA...'` in 4.6 install-config.yaml example.

Preview: https://deploy-preview-32367--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-bare-metal-config-yaml_installing-bare-metal-network-customizations