### PR TITLE
Specify the load tested during Perf/scale runs

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -6,21 +6,35 @@
 [id="master-node-sizing_{context}"]
 =  Control plane node sizing
 
-The control plane node resource requirements depend on the number of nodes in the cluster. The following control plane node size recommendations are based on the results of control plane density focused testing.
+The control plane node resource requirements depend on the number of nodes in the cluster. The following control plane node size recommendations are based on the results of control plane density focused testing. The control plane tests create the following objects across the cluster in each of the namespaces depending on the node counts:
 
-[options="header",cols="3*"]
+- 12 image streams
+- 3 build configurations
+- 6 builds
+- 1 deployment with 2 pod replicas mounting two secrets each
+- 2 deployments with 1 pod replica mounting two secrets
+- 3 services pointing to the previous deployments
+- 3 routes pointing to the previous deployments
+- 10 secrets, 2 of which are mounted by the previous deployments
+- 10 config maps, 2 of which are mounted by the previous deployments
+
+
+[options="header",cols="4*"]
 |===
-| Number of worker nodes |CPU cores |Memory (GB)
+| Number of worker nodes |Cluster load (namespaces) | CPU cores |Memory (GB)
 
 | 25
+| 500
 | 4
 | 16
 
 | 100
+| 1000
 | 8
 | 32
 
 | 250
+| 4000
 | 16
 | 96
 


### PR DESCRIPTION
This commit adds information around the load on the cluster during the
control plane testing to help users and customers plan their environment
accordingly.