### PR TITLE
BZ1957931 - remove extra thumbprint example

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -20,7 +20,7 @@ for instructions. See link:https://youtu.be/2uLKvB8Z5D0[Securing Automated Decry
 for a presentation on Tang.
 
 . Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line. For both DHCP and static networking, you also must provide the `rd.neednet=1` kernel argument.
-
++
 [IMPORTANT]
 ====
 Skipping this step causes the second boot to fail.
@@ -28,7 +28,7 @@ Skipping this step causes the second boot to fail.
 
 [start=4]
 . Install the `clevis` package, if it is not already installed:
-
++
 [source,terminal]
 ----
 $ sudo yum install clevis -y
@@ -61,15 +61,9 @@ PLjNyRdGw03zlRoGjQYMahSZGu9
 ----
 eyJhbmc3SlRyMXpPenc3ajhEQ01tZVJiTi1oM...
 ----
-+
-.Example output
-[source,terminal]
-----
-ewogInVybCI6ICJodHRwczovL3RhbmcuZXhhbXBsZS5jb20iLAogInRocCI6ICJaUk1leTFjR3cwN3psVExHYlhuUWFoUzBHdTAiCn0K
-----
 
 . In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
-
++
 [IMPORTANT]
 ====
 If you are also configuring boot disk mirroring on the affected nodes, record the server thumbprint for later use, and skip this step. You will configure disk encryption when configuring boot disk mirroring.


### PR DESCRIPTION
[BZ1957931](https://bugzilla.redhat.com/show_bug.cgi?id=1957931) - removes extra thumbprint example output in step 5-b. The second example output is a carryover of a base64 encode step that was removed in 4.6 and is not something that is encountered with the procedure in 4.7+. 

Also fixes a couple of formatting issues.

**PREVIEW LINK:** https://deploy-preview-32389--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-encrypt-disk-tang_installing-customizing