### PR TITLE
BZ1888710 Update CA certificate rotation

### DIFF
--- a/modules/customize-certificates-manually-rotate-service-ca.adoc
+++ b/modules/customize-certificates-manually-rotate-service-ca.adoc
@@ -5,7 +5,7 @@
 [id="manually-rotate-service-ca_{context}"]
 = Manually rotate the service CA certificate
 
-The service CA is valid for 26 months and is automatically refreshed when there is less than six months validity left.
+The service CA is valid for 26 months and is automatically refreshed when there is less than 13 months validity left.
 
 If necessary, you can manually refresh the service CA by using the following procedure.
 

--- a/modules/customize-certificates-understanding-service-serving.adoc
+++ b/modules/customize-certificates-understanding-service-serving.adoc
@@ -17,7 +17,7 @@ and `tls.key` respectively, within a created secret. The
 certificate and key are automatically replaced when they get close to
 expiration.
 
-The service CA certificate, which issues the service certificates, is valid for 26 months and is automatically rotated when there is less than six months validity left. After rotation, the previous service CA configuration is still trusted until its expiration. This allows a grace period for all affected services to refresh their key material before the expiration. If you do not upgrade your cluster during this grace period, which restarts services and refreshes their key material, you might need to manually restart services to avoid failures after the previous service CA expires.
+The service CA certificate, which issues the service certificates, is valid for 26 months and is automatically rotated when there is less than 13 months validity left. After rotation, the previous service CA configuration is still trusted until its expiration. This allows a grace period for all affected services to refresh their key material before the expiration. If you do not upgrade your cluster during this grace period, which restarts services and refreshes their key material, you might need to manually restart services to avoid failures after the previous service CA expires.
 
 [NOTE]
 ====


### PR DESCRIPTION
Update six months to 13 months.

For versions 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1888710

Direct link to doc preview 1: https://deploy-preview-32392--osdocs.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html#understanding-service-serving_service-serving-certificate

Direct link to doc preview 2: https://deploy-preview-32392--osdocs.netlify.app/openshift-enterprise/latest/security/certificates/service-serving-certificate.html#manually-rotate-service-ca_service-serving-certificate