### PR TITLE
GH#32400 - Fix indentation for Pod object

### DIFF
--- a/modules/compliance-results.adoc
+++ b/modules/compliance-results.adoc
@@ -58,10 +58,10 @@ spec:
       volumeMounts:
       - mountPath: "/workers-scan-results"
         name: workers-scan-vol
-    volumes:
-     - name: workers-scan-vol
-       persistentVolumeClaim:
-         claimName: rhcos4-moderate-worker
+  volumes:
+    - name: workers-scan-vol
+      persistentVolumeClaim:
+        claimName: rhcos4-moderate-worker
 ----
 
 . After the pod is running, download the results:


### PR DESCRIPTION
This fixes the YAML indentation for `volumes`.

- https://github.com/openshift/openshift-docs/issues/32400