### PR TITLE
Added release notes for 4.6.28 / typo fix

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -904,7 +904,7 @@ Status:
         Status:                True
         Type:                  Established
       Kind:                    CustomResourceDefinition <1>
-      Name:                    etcdclusters.etcd.database.coreos.com <1>
+      Name:                    etcdclusters.etcd.database.coreos.com <2>
 ...
 ----
 <1> Resource type.
@@ -2873,6 +2873,31 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6014371[{product-title} 4.6.27 container image list]
 
 [id="ocp-4-6-27-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-28"]
+=== RHBA-2021:1487 - {product-title} 4.6.28 bug fix update
+
+Issued: 2021-05-12
+
+{product-title} release 4.6.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1487[RHBA-2021:1487] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1488[RHBA-2021:1488] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6018861[{product-title} 4.6.28 container image list]
+
+[id="ocp-4-6-28-bug-fixes"]
+==== Bug fixes
+
+* Previously, during installation, the SDN pods were repeatedly crashing and restarting until other parts of the installation were complete, resulting in long installation times. With this update, the SDN pods can read the partially-installed cluster state and wait until the right time to proceed. As a result, the SDN pods do not crash, and installations are not delayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1950407[*BZ#1950407*])
+
+* Previously, the Cluster Samples Operator could make changes to the controller cache for objects it was watching, which caused errors when Kubernetes managed the controller cache. This update adds fixes to how the Cluster Samples Operator uses information in the controller cache. As a result, the Cluster Samples Operator does not cause errors by modifying controller caches. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1950809[*BZ#1950809*])
+
+* Previously, creating a sample application from the web console could fail because the application's resources were being created out of order. This update specifies the order in which those resources are created, resulting in a more stable process for creating sample applications. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1933666[*BZ#1933666*])
+
+[id="ocp-4-6-28-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
For release on 12 May 2021.

Includes small typo fix in [Operator API sample output](https://deploy-preview-32412--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-operator-api)


[Direct preview for RN](https://deploy-preview-32412--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-28)