### PR TITLE
BZ1886229, BZ1937285 - Multipathing, zfcp

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -98,6 +98,8 @@ include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffs
 
 == Next steps
 
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Enabling multipathing with kernel arguments on {op-system}].
+
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 
 * If necessary, you can

--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -77,22 +77,23 @@ rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 
 +
 [NOTE]
 ====
-If additional LUNs are configured with NPIV, FCP requires `zfcp.allow_lun_scan=0`.
+If additional LUNs are configured with NPIV, FCP requires `zfcp.allow_lun_scan=0`. If you must enable `zfcp.allow_lun_scan=1` because you use a CSI driver, for example, you must configure your NPIV so that each node cannot access the boot partition of another node.
 ====
 ... Leave all other parameters unchanged.
 +
-[NOTE]
+[IMPORTANT]
 ====
-Additional post-installation steps are required to fully enable multipathing. See “Completing installation on user-provisioned infrastructure” for more information.
+Additional post-installation steps are required to fully enable multipathing. For more information, see “Enabling multipathing with kernel arguments on {op-system}" in _Post-installation machine configuration tasks_.
 ====
+// Add xref once it's allowed.
 +
-The following is an example parameter file `bootstrap-0.parm` for the bootstrap machine with multipathing:
+The following is an example parameter file `worker-1.parm` for a worker node with multipathing:
 +
 [source,terminal]
 ----
 rd.neednet=1 dfltcc=off rd.multipath=default console=ttysclp0 coreos.inst.install_dev=/dev/mapper/mpatha
 coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
 rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
 !condev

--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -12,6 +12,12 @@
 Multipathing is only supported when it is activated using the machine config as documented in the following procedure. It must be enabled after {op-system} installation.
 ====
 
+[IMPORTANT]
+====
+On IBM Z and LinuxONE, you can enable multipathing only if you configured your cluster for it during installation. For more information, see "Creating {op-system-first} machines" in _Installing a cluster with z/VM on IBM Z and LinuxONE_.
+====
+// Add xref once it's allowed.
+
 .Prerequisites
 * You have a running {product-title} cluster that uses version 4.7 or later.
 * You are logged in to the cluster as a user with administrative privileges.


### PR DESCRIPTION
Changes made in docs because of [BZ1886229](https://bugzilla.redhat.com/show_bug.cgi?id=1886229) require notes that mention it works differently on IBM Z. 

Update also covers this [BZ1937285](https://bugzilla.redhat.com/show_bug.cgi?id=1937285)
Related PR: https://github.com/openshift/openshift-docs/pull/32468

OCP version for cherry-picking: 4.7, 4.8
Reviewer: Wolfgang Voesch, Holger Wolf
Preview: 

- [Creating Red Hat Enterprise Linux CoreOS (RHCOS) machines](https://deploy-preview-32413--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z)
- [Enabling multipathing with kernel arguments on RHCOS](https://deploy-preview-32413--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#rhcos-enabling-multipath_post-install-machine-configuration-tasks)
