### PR TITLE
coreos-installer table: fix flag hyphen

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -187,7 +187,7 @@ a|Specify the image URL manually.
 a|`-i,` `--ignition-file <path>`
 a|Embed an Ignition config from a file.
 
-a|`I`, `--ignition-url <URL>`
+a|`-I`, `--ignition-url <URL>`
 a|Embed an Ignition config from a URL.
 
 a|`--ignition-hash <digest>`


### PR DESCRIPTION
Missing hyphen on the 'I', '--ignition-url' flag in table. 
Confirmed in `coreos-installer install --help`
No bz/issue

Present from 4.6