### PR TITLE
[enterprise-4.6] Liveness probe does not respect the next periodSeconds if timeoutSeconds over periodSeconds

### DIFF
--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/application-health.adoc
+// * applications/application-health.adoc
 
 [id="application-health-about_{context}"]
 = Understanding health checks
@@ -51,9 +51,9 @@ initialization is complete.
 You can configure several fields to control the behavior of a probe:
 
 * `initialDelaySeconds`: The time, in seconds, after the container starts before the probe can be scheduled. The default is 0.
-* `periodSeconds`: The delay, in seconds, between performing probes. The default is `10`.
-* `timeoutSeconds`: The number of seconds of inactivity after which the probe times out and the container is assumed to have failed. The default is `1`.
-* `successThreshold`: The number of times that the probe must report success after a failure in order to reset the container status to successful. The value must be `1` for a liveness probe. The default is `1`.
+* `periodSeconds`: The delay, in seconds, between performing probes. The default is `10`. This value must be greater than `timeoutSeconds`. 
+* `timeoutSeconds`: The number of seconds of inactivity after which the probe times out and the container is assumed to have failed. The default is `1`. This value must be lower than `periodSeconds`.
+* `successThreshold`: The number of times that the probe must report success after a failure to reset the container status to successful. The value must be `1` for a liveness probe. The default is `1`.
 * `failureThreshold`: The number of times that the probe is allowed to fail. The default is 3. After the specified attempts:
 ** for a liveness probe, the container is restarted
 ** for a readiness probe, the pod is marked `Unready`

--- a/modules/application-health-configuring.adoc
+++ b/modules/application-health-configuring.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * nodes/application-health.adoc
+// * applications/application-health.adoc
 
 [id="application-health-configuring_{context}"]
 = Configuring health checks using the CLI
@@ -35,20 +35,22 @@ spec:
       tcpSocket:  <4>
         port: 8080 <5>
       initialDelaySeconds: 15 <6>
-      timeoutSeconds: 1 <7>
-    readinessProbe: <8>
-      httpGet: <9>
-        host: my-host <10>
-        scheme: HTTPS <11>
+      periodSeconds: 20 <7>
+      timeoutSeconds: 10 <8>
+    readinessProbe: <9>
+      httpGet: <10>
+        host: my-host <11>
+        scheme: HTTPS <12>
         path: /healthz
-        port: 8080 <12>
-    startupProbe: <13>
-      exec: <14>
-        command: <15>
+        port: 8080 <13>
+    startupProbe: <14>
+      exec: <15>
+        command: <16>
         - cat
         - /tmp/healthy
-      failureThreshold: 30 <16>
-      periodSeconds: 10 <17>
+      failureThreshold: 30 <17>
+      periodSeconds: 20 <18>
+      timeoutSeconds: 10 <19>
 ----
 <1> Specify the container name.
 <2> Specify the container image to deploy.
@@ -56,21 +58,25 @@ spec:
 <4> Specify a test to perform, here a TCP Socket test.
 <5> Specify the port on which the container is listening.
 <6> Specify the time, in seconds, after the container starts before the probe can be scheduled.
-<7> Specify the number of seconds between probes.
-<8> Optional: Create a Readiness probe.
-<9> Specify the type of test to perform, here an HTTP test.
-<10> Specify a host IP address. When `host` is not defined, the `PodIP` is used.
-<11> Specify `HTTP` or `HTTPS`. When `scheme` is not defined, the `HTTP` scheme is used.
-<12> Specify the port on which the container is listening.
-<13> Optional: Create a Startup probe.
-<14> Specify the type of test to perform, here an Container Execution probe.
-<15> Specify the commands to execute on the container.
-<16> Specify the number of times to try the probe after a failure.
-<17> Specify the number of seconds to perform the probe.
+<7> Specify the number of seconds to perform the probe. The default is `10`. This value must be greater than `timeoutSeconds`.
+<8> Specify the number of seconds of inactivity after which the probe is assumed to have failed. The default is `1`. This value must be lower than `periodSeconds`.
+<9> Optional: Create a Readiness probe.
+<10> Specify the type of test to perform, here an HTTP test.
+<11> Specify a host IP address. When `host` is not defined, the `PodIP` is used.
+<12> Specify `HTTP` or `HTTPS`. When `scheme` is not defined, the `HTTP` scheme is used.
+<13> Specify the port on which the container is listening.
+<14> Optional: Create a Startup probe.
+<15> Specify the type of test to perform, here an Container Execution probe.
+<16> Specify the commands to execute on the container.
+<17> Specify the number of times to try the probe after a failure.
+<18> Specify the number of seconds to perform the probe. The default is `10`. This value must be greater than `timeoutSeconds`.
+<19> Specify the number of seconds of inactivity after which the probe is assumed to have failed. The default is `1`. This value must be lower than `periodSeconds`.
 +
 [NOTE]
 ====
 If the `initialDelaySeconds` value is lower than the `periodSeconds` value, the first Readiness probe occurs at some point between the two periods due to an issue with timers.
+
+The `timeoutSeconds` value must be lower than the `periodSeconds` value. 
 ====
 
 . Create the `Pod` object:

--- a/modules/odc-adding-health-checks.adoc
+++ b/modules/odc-adding-health-checks.adoc
@@ -20,7 +20,14 @@ You can use the *Topology* view to add health checks to your deployed applicatio
 .. Click *Add Readiness Probe*, to see a form containing the parameters for the probe.
 .. Click the *Type* drop-down list to select the request type you want to add. For example, in this case, select *Container Command* to select the command that will be executed inside the container.
 .. In the *Command* field, add an argument `cat`, similarly, you can add multiple arguments for the check, for example, add another argument `/tmp/healthy`.
-.. Retain or modify the default values for the other parameters as required, and click the check mark at the bottom of the form. The *Readiness Probe Added* message is displayed.
+.. Retain or modify the default values for the other parameters as required.
++
+[NOTE]
+====
+The `Timeout` value must be lower than the `Period` value. The `Timeout` default value is `1`. The `Period` default value is `10`.
+====
+.. Click the check mark at the bottom of the form. The *Readiness Probe Added* message is displayed.
+
 . Click *Add* to add the health check. You are redirected to the *Topology* view and the container is restarted.
 . In the side panel, verify that the probes have been added by clicking on the deployed Pod under the *Pods* section.
 . In the *Pod Details* page, click the listed container in the *Containers* section.

--- a/modules/odc-editing-health-checks.adoc
+++ b/modules/odc-editing-health-checks.adoc
@@ -25,7 +25,14 @@ You can use the *Topology* view to edit health checks added to your application,
 * To add a new health probe, in addition to existing health checks, click the add probe links. For example, to add a Liveness probe that checks if your container is running:
 +
 .. Click *Add Liveness Probe*, to see a form containing the parameters for the probe.
-.. Edit the probe parameters as required, and click the check mark at the bottom of the form. The *Liveness Probe Added* message is displayed.
+.. Edit the probe parameters as required.
++
+[NOTE]
+====
+The `Timeout` value must be lower than the `Period` value. The `Timeout` default value is `1`. The `Period` default value is `10`.
+==== 
+.. Click the check mark at the bottom of the form. The *Liveness Probe Added* message is displayed.
+
 . Click *Save* to save your modifications and add the additional probes to your container. You are redirected to the *Topology* view.
 . In the side panel, verify that the probes have been added by clicking on the deployed pod under the *Pods* section.
 . In the *Pod Details* page, click the listed container in the *Containers* section.

--- a/modules/olm-enabling-operator-restricted-network.adoc
+++ b/modules/olm-enabling-operator-restricted-network.adoc
@@ -96,9 +96,17 @@ spec:
               serviceAccountName: etcd-operator
     strategy: deployment
 ----
++
+--
 <1> Inject the images referenced by the Operator by using environment variables.
 <2> Specify each image by a digest (SHA), not by an image tag.
 <3> Also reference the Operator container image by a digest (SHA), not by an image tag.
+--
++
+[NOTE]
+====
+When configuring probes, the `timeoutSeconds` value must be lower than the `periodSeconds` value. The `timeoutSeconds` default value is `1`. The `periodSeconds` default value is `10`.
+====
 
 . Add the `disconnected` annotation, which indicates that the Operator works in a disconnected environment:
 +

--- a/modules/virt-define-http-liveness-probe.adoc
+++ b/modules/virt-define-http-liveness-probe.adoc
@@ -13,9 +13,17 @@ liveness probes.
 
 . Customize a YAML configuration file to create an HTTP liveness probe, using
 the following code block as an example. In this example:
++
+--
 * You configure a probe using `spec.livenessProbe.httpGet`, which queries port `1500` of the virtual machine instance, after an initial delay of `120` seconds.
 * The virtual machine instance installs and runs a minimal HTTP server
 on port `1500` using `cloud-init`.
+--
++
+[NOTE]
+====
+The `timeoutSeconds` value must be lower than the `periodSeconds` value. The `timeoutSeconds` default value is `1`. The `periodSeconds` default value is `10`.
+====
 +
 [source,yaml]
 ----

--- a/modules/virt-define-readiness-probe.adoc
+++ b/modules/virt-define-readiness-probe.adoc
@@ -14,12 +14,20 @@ readiness probes.
 . Customize a YAML configuration file to create a readiness probe. Readiness
 probes are configured in a similar manner to liveness probes. However, note the
 following differences in this example:
++
+--
 * Readiness probes are saved using a different spec name. For example, you
 create a readiness probe as `spec.readinessProbe` instead of as
 `spec.livenessProbe.<type-of-probe>`.
 * When creating a readiness probe, you optionally set a `failureThreshold` and a
 `successThreshold` to switch between `ready` and `non-ready` states, should the probe
 succeed or fail multiple times.
+--
++
+[NOTE]
+====
+The `timeoutSeconds` value must be lower than the `periodSeconds` value. The `timeoutSeconds` default value is `1`. The `periodSeconds` default value is `10`.
+====
 +
 [source,yaml]
 ----

--- a/modules/virt-define-tcp-liveness-probe.adoc
+++ b/modules/virt-define-tcp-liveness-probe.adoc
@@ -13,9 +13,17 @@ TCP liveness probes.
 
 . Customize a YAML configuration file to create an TCP liveness probe, using
 this code block as an example. In this example:
++
+--
 * You configure a probe using `spec.livenessProbe.tcpSocket`, which queries port `1500` of the virtual machine instance, after an initial delay of `120` seconds.
 * The virtual machine instance installs and runs a minimal HTTP server
 on port `1500` using `cloud-init`.
+--
++
+[NOTE]
+====
+The `timeoutSeconds` value must be lower than the `periodSeconds` value. The `timeoutSeconds` default value is `1`. The `periodSeconds` default value is `10`.
+====
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Manual cherrypick of #32219