### PR TITLE
BZ1849398 - Change ovirtadmin@internal and admin@internal to ocpadmin…

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -298,14 +298,14 @@ For example:
 ifndef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://rhv-env.virtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://ovirtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
@@ -322,7 +322,7 @@ endif::openshift-origin[]
 +
 [source,terminal]
 ----
-admin@internal
+ocpadmin@internal
 ----
 +
 ... For `oVirt engine password`, enter the {rh-virtualization} admin password.

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -291,9 +291,9 @@ link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 .. Paste the pull secret that you obtained from the
-link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site. 
-* If you do not have a pull secret from the {cloud-redhat-com} site, you can paste the pull secret another private registry. 
-* If you do not need the cluster to pull images from a private registry, you can paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret. 
+link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+* If you do not have a pull secret from the {cloud-redhat-com} site, you can paste the pull secret another private registry.
+* If you do not need the cluster to pull images from a private registry, you can paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret.
 endif::openshift-origin[]
 endif::rhv[]
 ifdef::rhv[]
@@ -320,14 +320,14 @@ For example:
 ifndef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://rhv-env.virtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://ovirtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
@@ -345,7 +345,7 @@ endif::openshift-origin[]
 +
 [source,terminal]
 ----
-admin@internal
+ocpadmin@internal
 ----
 +
 .. For `oVirt engine password`, enter the {rh-virtualization} admin password.
@@ -384,10 +384,10 @@ display in your terminal.
 [source,terminal]
 ----
 ...
-INFO Install complete!                            
-INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig' 
-INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com 
-INFO Login to the console with user: "kubeadmin", and password: "4vYBz-Ee6gm-ymBZj-Wt5AL" 
+INFO Install complete!
+INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig'
+INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
+INFO Login to the console with user: "kubeadmin", and password: "4vYBz-Ee6gm-ymBZj-Wt5AL"
 INFO Time elapsed: 36m22s
 ----
 +

--- a/modules/installation-rhv-creating-install-config-file.adoc
+++ b/modules/installation-rhv-creating-install-config-file.adoc
@@ -35,7 +35,7 @@ $ openshift-install create install-config --dir $ASSETS_DIR
 ? SSH Public Key /home/user/.ssh/id_dsa.pub
 ? Platform <ovirt>
 ? Engine FQDN[:PORT] [? for help] <engine.fqdn>
-? Enter ovirt-engine username <ovirtadmin@internal>
+? Enter ovirt-engine username <ocpadmin@internal>
 ? Enter password <******>
 ? oVirt cluster <cluster>
 ? oVirt storage <storage>

--- a/modules/installing-rhv-insecure-mode.adoc
+++ b/modules/installing-rhv-insecure-mode.adoc
@@ -27,7 +27,7 @@ Installing in *insecure* mode is not recommended, because it enables a potential
 ovirt_url: \https://ovirt.example.com/ovirt-engine/api
 ovirt_fqdn: ovirt.example.com
 ovirt_pem_url: ""
-ovirt_username: admin@internal
+ovirt_username: ocpadmin@internal
 ovirt_password: super-secret-password
 ovirt_insecure: true
 ----

--- a/modules/installing-rhv-verifying-rhv-environment.adoc
+++ b/modules/installing-rhv-verifying-rhv-environment.adoc
@@ -61,14 +61,14 @@ For example:
 ifndef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://rhv-env.virtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 [source,terminal]
 ----
-$ curl -k -u ovirtadmin@internal:pw123 \
+$ curl -k -u ocpadmin@internal:pw123 \
 https://ovirtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]

--- a/modules/virt-importing-vm-cli.adoc
+++ b/modules/virt-importing-vm-cli.adoc
@@ -30,7 +30,7 @@ type: Opaque
 stringData:
   ovirt: |
     apiUrl: <api_endpoint> <2>
-    username: admin@internal
+    username: ocpadmin@internal
     password: <3>
     caCert: |
       -----BEGIN CERTIFICATE-----
@@ -40,7 +40,7 @@ EOF
 ----
 <1> Optional. You can specify a different namespace in all the CRs.
 <2> Specify the API endpoint of the RHV Manager, for example, `\"https://www.example.com:8443/ovirt-engine/api"`
-<3> Specify the password for `admin@internal`.
+<3> Specify the password for `ocpadmin@internal`.
 <4> Specify the RHV Manager CA certificate. You can obtain the CA certificate by running the following command:
 +
 [source,terminal]

--- a/modules/virt-importing-vm-wizard.adoc
+++ b/modules/virt-importing-vm-wizard.adoc
@@ -75,7 +75,7 @@ $ openssl s_client -connect <RHV_Manager_FQDN>:443 -showcerts < /dev/null
 +
 The CA certificate is the second certificate in the output.
 
-** *Username*: RHV Manager user name, for example, `admin@internal`
+** *Username*: RHV Manager user name, for example, `ocpadmin@internal`
 ** *Password*: RHV Manager password
 
 * If you select a saved RHV instance, the wizard connects to the RHV instance using the saved credentials.


### PR DESCRIPTION
This change applies to BZ#1849398 https://bugzilla.redhat.com/show_bug.cgi?id=1849398. 

Change any "ovirtadmin@internal" or "admin@internal" references to "ocpadmin@internal".

This PR applies to OCP 4.6  and later.

https://deploy-preview-32440--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-default.html

@dougsland @Gal-Zaidman 