### PR TITLE
KATA-681: Upgrading section - moving doc from Google Docs to GitHub

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1706,16 +1706,18 @@ Topics:
 - Name: Disabling Windows container workloads
   File: disabling-windows-container-workloads
 ---
-Name: Sandboxed Container Support for OpenShift
+Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Understanding OpenShift sandboxed containers
   File: understanding-sandboxed-containers
-- Name: Deploying sandboxed containers workloads
+- Name: Deploying OpenShift sandboxed containers workloads
   File: deploying-sandboxed-container-workloads
-- Name: Disabling sandboxed container workloads
+- Name: Disabling OpenShift sandboxed container workloads
   File: disabling-sandboxed-container-workloads
+- Name: Upgrade OpenShift sandboxed containers
+  File: upgrade-sandboxed-containers
 ---
 Name: Logging
 Dir: logging

--- a/sandboxed_containers/upgrade-sandboxed-containers.adoc
+++ b/sandboxed_containers/upgrade-sandboxed-containers.adoc
@@ -1,0 +1,25 @@
+[id="upgrade-sandboxed-containers"]
+= Upgrade {sandboxed-containers-first}
+include::modules/common-attributes.adoc[]
+:context: upgrade-sandboxed-containers
+
+toc::[]
+
+You can upgrade the components of {sandboxed-containers-first} by upgrading {sandboxed-containers-operator} and {sandboxed-containers-first} artifacts.
+
+[id="sandboxed-containers-upgrade-operator"]
+== Upgrade {sandboxed-containers-operator}
+
+You can use Operator Lifecycle Manager (OLM) to manually or automatically upgrade the {sandboxed-containers-operator}. You can select manual or automatic upgrade during the initial deployment. In the context of manual upgrades, the web console shows the available updates that can be installed by the cluster administrator.
+
+.Additional resources
+* xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators]
+
+[id="sandboxed-containers-upgrade-artifacts"]
+== Upgrade the {sandboxed-containers-first} artifacts
+
+The {sandboxed-containers-first} artifacts are deployed onto the cluster using {op-system-first} extensions.
+
+//Update the Red Hat CoreOS extension with the updated link once PR is approved for the Understanding section.
+
+The {op-system} extension `sandboxed containers` contains the required components to run Kata Containers such as the Kata containers runtime, the hypervisor QEMU, and other dependencies. The extension is upgraded when upgrading the cluster to a new release of {product-title}.


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/KATA-681
Applies to 4.8+
Preview Link: https://deploy-preview-32441--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/upgrade-sandboxed-containers.html

**Preliminary doc is in Google Doc and we are in the process of moving it from Google to GitHub. This is a part of the 2nd draft.**