### PR TITLE
Add x710 hardware to 4.6 and 4.7

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -7,6 +7,7 @@
 
 {product-title} supports the following Network Interface Card (NIC) models:
 
+* Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
 * Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
 * Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
 * Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1958915

Bring the X710 hardware from 4.8 and add it to 4.6 and 4.7.

The careful reader can notice that X710 is a [supported device](https://deploy-preview-32446--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov) for SR-IOV.

-----
Applies to enterprise-4.6 and enterprise-4.7. Please add milestone Next-Release.