### PR TITLE
Added spec.defaultNetwork.type for the example

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -86,6 +86,7 @@ metadata:
   name: cluster
 spec:
   defaultNetwork:
+  type: OpenShiftSDN
     openshiftSDNConfig:
       vxlanPort: 4800
 ----

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -86,7 +86,7 @@ metadata:
   name: cluster
 spec:
   defaultNetwork:
-  type: OpenShiftSDN
+    type: OpenShiftSDN
     openshiftSDNConfig:
       vxlanPort: 4800
 ----


### PR DESCRIPTION
In the example in "Specify a different VXLAN port for the OpenShift SDN network provider" , `type: OpenShiftSDN` is missing which will make the installation to fail with:

~~~
localhost bootkube.sh[13465]: [#1] failed to create some manifests:
localhost bootkube.sh[13465]: "cluster-network-03-config.yml": failed to create networks.v1.operator.openshift.io/cluster -n : Network.operator.openshift.io "cluster" is invalid: spec.defaultNetwork.type: Required value
~~~

This is also applicable to 4.7 branch