### PR TITLE
OSSMDOC-322 RN for OSSM 1.1.4/2.0.4

### DIFF
--- a/modules/ossm-document-attributes-1x.adoc
+++ b/modules/ossm-document-attributes-1x.adoc
@@ -12,7 +12,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 1.1.13
+:ProductVersion: 1.1.14
 :MaistraVersion: 1.1
 :product-build:
 :DownloadURL: registry.redhat.io

--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -12,7 +12,7 @@
 :ProductName: Red Hat OpenShift Service Mesh
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 2.0.3
+:ProductVersion: 2.0.4
 :MaistraVersion: 2.0
 :product-build:
 :DownloadURL: registry.redhat.io

--- a/modules/ossm-rn-new-features-1x.adoc
+++ b/modules/ossm-rn-new-features-1x.adoc
@@ -27,14 +27,18 @@ Result – If changed, describe the current user experience
 |1.4.8
 
 |Jaeger
-|1.17.9
+|1.17.8
 
 |Kiali
-|1.12.14
+|1.12.16
 
 |3scale Istio Adapter
 |1.0.0
 |===
+
+== New features {ProductName} 1.1.14
+
+This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
 == New features {ProductName} 1.1.13
 
@@ -290,65 +294,9 @@ spec:
   ...
 ----
 
-The version field specifies the version of ServiceMesh to install and defaults to the latest available version.
-
-
-== New features {ProductName} 1.0.11
-
-This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+The version field specifies the version of {ProductShortName} to install and defaults to the latest available version.
 
 [NOTE]
 ====
-There are manual steps that must be completed to address CVE-2020-8663.  See instructions above.
+Note that support for {ProductName} v1.0 ended in October, 2020.  You must upgrade to either v1.1 or v2.0.
 ====
-
-== New features {ProductName} 1.0.10
-
-This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs).
-
-== New features {ProductName} 1.0.9
-
-This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs).
-
-== New features {ProductName} 1.0.8
-
-This release of {ProductName} addresses compatibility issues with {product-title} 4.4. You must upgrade {ProductName} to 1.0.8 before you upgrade from {product-title} 4.3 to {product-title} 4.4.
-
-== New features {ProductName} 1.0.7
-
-This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs).
-
-== New features {ProductName} 1.0.6
-
-This release contains internal improvements.
-
-== New features {ProductName} 1.0.5
-
-This release contains internal improvements.
-
-== New features {ProductName} 1.0.4
-
-This release of {ProductName} adds support for Kiali 1.0.9, and addresses Common Vulnerabilities and Exposures (CVEs).
-
-== New features {ProductName} 1.0.3
-
-This release of {ProductName} adds support for Kiali 1.0.8, and addresses Common Vulnerabilities and Exposures (link:https://access.redhat.com/errata/RHSA-2019:4222[CVEs]).
-
-== New features {ProductName} 1.0.2
-
-This release of {ProductName} adds support for Istio 1.1.17, Jaeger 1.13.1, Kiali 1.0.7, and the 3scale Istio Adapter 1.0 and {product-title} 4.2.
-
-== New features {ProductName} 1.0.1
-
-This release of {ProductName} adds support for Istio 1.1.11, Jaeger 1.13.1, Kiali 1.0.6, and the 3scale Istio Adapter 1.0 and {product-title} 4.1.
-
-== New features {ProductName} 1.0
-
-This release of {ProductName} adds support for Istio 1.1.11, Jaeger 1.13.1, Kiali 1.0.5, and the 3scale Istio Adapter 1.0 and {product-title} 4.1.
-
-Other notable changes in this release include the following:
-
-* The Kubernetes Container Network Interface (CNI) plug-in is always on.
-* The control plane is configured for multitenancy by default. Single tenant, cluster-wide control plane configurations are deprecated.
-* The OpenShift Elasticsearch, Jaeger, Kiali, and {ProductShortName} Operators are installed from OperatorHub.
-* You can create and specify control plane templates.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -30,12 +30,15 @@ Result – If changed, describe the current user experience
 |1.20.3
 
 |Kiali
-|1.24.6
+|1.24.8
 
 |3scale Istio Adapter
 |2.0.0
 |===
 
+== New features {ProductName} 2.0.4
+
+This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
 == New features {ProductName} 2.0.3
 


### PR DESCRIPTION
Updating the release notes for the CVE release.

Note that the Jaeger version was bumped with the last release, but then there was a blocker and 1.17.9 was put on hold. Rolling back the Jaeger version to the correct version.