### PR TITLE
BZ 1959667: [DOCS] Instruction to restart OCP instance is not correct when the webconsole-config configmap file changed

### DIFF
--- a/install_config/cluster_metrics.adoc
+++ b/install_config/cluster_metrics.adoc
@@ -597,8 +597,7 @@ clusterInfo:
 ----
 ====
 
-Once you have updated and saved the webconsole-config configmap file, you must
-restart your {product-title} instance.
+After you update and save the *webconsole-config* configmap file, your web console pods restart after the delay set by the liveness probe configuration, which is 30 seconds by default.
 
 When your {product-title} server is back up and running, metrics are displayed on the pod overview pages.
 


### PR DESCRIPTION
* Version: OCPv3.11
* Description: webconsole-config configmap is only used by webconsole pods, so need not to restart OCP instance after changing the configmap
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1959667