### PR TITLE
BZ1886229 Add Multipathing Note for IBM Z 

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -96,7 +96,14 @@ Previously, {op-system} DHCP kernel parameters were not working as expected beca
 ====
 Only enable multipathing with kernel arguments within a machine config as documented. Do not enable multipathing during installation.
 
-For more information, see "Enabling multipath with kernel arguments" in xref:../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Post-installation machine configuration tasks].
+For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Enabling multipathing with kernel arguments on {op-system}].
+====
+
+[IMPORTANT]
+====
+To enable multipathing on IBM Z and LinuxONE, additional steps are required during installation.
+
+For more information, see xref:../installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z[Creating {op-system-first} machines].
 ====
 
 [id="ocp-4-7-rhcos-fetching-aws-from-imdsv2"]


### PR DESCRIPTION
Changes made in docs because of [BZ1886229](https://bugzilla.redhat.com/show_bug.cgi?id=1886229) require notes that mention it works differently on IBM Z.

Related PR: https://github.com/openshift/openshift-docs/pull/32413
OCP version:   4.7, 
Reviewer: Wolfgang Voesch, Holger Wolf
Preview: https://deploy-preview-32468--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-rhcos-supports-multipath