### PR TITLE
CNV Jira Story CNV-6967 Adding notes indicating support for cloning between different persistent volume types with certain limits

### DIFF
--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
@@ -11,9 +11,9 @@ file.
 
 [WARNING]
 ====
-Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+Cloning operations between different volume modes are supported, such as cloning from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`.
 
-For example, if you attempt to clone from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+However, you can only clone between different volume modes if they are of the `contentType: kubevirt`.
 ====
 
 == Prerequisites
@@ -32,4 +32,3 @@ include::modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffse
 include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
 
 :blockstorage!:
-

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
@@ -11,9 +11,9 @@ file.
 
 [WARNING]
 ====
-Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+Cloning operations between different volume modes are supported, such as cloning from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`.
 
-For example, if you attempt to clone from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+However, you can only clone between different volume modes if they are of the `contentType: kubevirt`.
 ====
 
 == Prerequisites
@@ -27,4 +27,3 @@ include::modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffse
 include::modules/virt-template-datavolume-clone.adoc[leveloffset=+1]
 
 include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
-

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
@@ -11,9 +11,9 @@ configuration file, you create a new data volume from the original PVC.
 
 [WARNING]
 ====
-Cloning operations between different volume modes are not supported. The `volumeMode` values must match in both the source and target specifications.
+Cloning operations between different volume modes are supported, such as cloning from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`.
 
-For example, if you attempt to clone from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`, the operation fails with an error message.
+However, you can only clone between different volume modes if they are of the `contentType: kubevirt`.
 ====
 
 == Prerequisites


### PR DESCRIPTION
This PR covers Jira story [CNV-6967](https://issues.redhat.com/browse/CNV-6967) ( https://issues.redhat.com/browse/CNV-6967 ).

The story deals with the new support for cloning VMs from a Filesystem volume to a Block volume and vice-versa. Changes made indicate the new support, while cautioning that such cloning can only be done if the volumes are of the kubevirt content-type. The changes have been made to Warnings at the start of 3 sections pertaining to cloning virtual machines.

CP: 4.8

Preview: 

https://deploy-preview-32471--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.html

https://deploy-preview-32471--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.html

https://deploy-preview-32471--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.html