### PR TITLE
OSDOCS-2071: Added links to AWS Transit gateway info

### DIFF
--- a/modules/rosa-enable-private-cluster-existing.adoc
+++ b/modules/rosa-enable-private-cluster-existing.adoc
@@ -12,7 +12,7 @@ After a cluster has been created, you can later enable the cluster to be private
 
 .Prerequisites
 
-AWS VPC Peering, VPN, DirectConnect, or TransitGateway has been configured to allow private access.
+AWS VPC Peering, VPN, DirectConnect, or link:https://docs.aws.amazon.com/whitepapers/latest/aws-vpc-connectivity-options/aws-transit-gateway.html[TransitGateway] has been configured to allow private access.
 
 .Procedure
 

--- a/modules/rosa-enable-private-cluster-new.adoc
+++ b/modules/rosa-enable-private-cluster-new.adoc
@@ -12,7 +12,7 @@ You can enable the private cluster setting when creating a new {product-title} c
 
 .Prerequisites
 
-AWS VPC Peering, VPN, DirectConnect, or TransitGateway has been configured to allow private access.
+AWS VPC Peering, VPN, DirectConnect, or link:https://docs.aws.amazon.com/whitepapers/latest/aws-vpc-connectivity-options/aws-transit-gateway.html[TransitGateway] has been configured to allow private access.
 
 .Procedure
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2071

Preview: https://deploy-preview-32477--osdocs.netlify.app/openshift-rosa/latest/cloud_infrastructure_access/rosa-private-cluster.html

No QE needed, this is not a content change. Please merge to branch/dedicated-4