### PR TITLE
New content for configuring cert rotation params

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2708,6 +2708,8 @@ Topics:
       File: virt-configuring-ip-for-vms
     - Name: Configuring an SR-IOV network device for virtual machines
       File: virt-configuring-sriov-device-for-vms
+    - Name: Configuring certificate rotation
+      File: virt-configuring-certificate-rotation
     - Name: Defining an SR-IOV network
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network

--- a/modules/virt-configuring-certificate-rotation.adoc
+++ b/modules/virt-configuring-certificate-rotation.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc
+
+[id="virt-configuring-certificate-rotation_{context}"]
+= Configuring certificate rotation
+
+You can do this during {VirtProductName} installation in the web console or after installation in the `HyperConverged` custom resource (CR).
+
+.Procedure
+
+. Open the `HyperConverged` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+----
+
+. Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format].
+
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+ name: kubevirt-hyperconverged
+ namespace: openshift-cnv
+spec:
+  certConfig:
+    ca:
+      duration: 48h0m0s
+      renewBefore: 24h0m0s <1>
+    server:
+      duration: 24h0m0s  <2>
+      renewBefore: 12h0m0s  <3>
+----
+<1> The value of `ca.renewBefore` must be less than or equal to the value of `ca.duration`.
+<2> The value of `server.duration` must be less than or equal to the value of `ca.duration`.
+<3> The value of `server.renewBefore` must be less than or equal to the value of `server.duration`.
+
+. Apply the YAML file to your cluster.

--- a/modules/virt-troubleshooting-cert-rotation-parameters.adoc
+++ b/modules/virt-troubleshooting-cert-rotation-parameters.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc
+
+[id="virt-troubleshooting-cert-rotation-parameters_{context}"]
+= Troubleshooting certificate rotation parameters
+
+Deleting one or more `certConfig` values causes them to revert to the default values, unless the default values conflict with one of the following conditions:
+
+* The value of `ca.renewBefore` must be less than or equal to the value of `ca.duration`.
+
+* The value of `server.duration` must be less than or equal to the value of `ca.duration`.
+
+* The value of `server.renewBefore` must be less than or equal to the value of `server.duration`.
+
+
+If the default values conflict with these conditions, you will receive an error.
+
+If you remove the `server.duration` value in the following example, the default value of `24h0m0s` is greater than the value of `ca.duration`, conflicting with the specified conditions.
+
+.Example
+[source,yaml]
+----
+certConfig:
+   ca:
+     duration: 4h0m0s
+     renewBefore: 1h0m0s
+   server:
+     duration: 4h0m0s
+     renewBefore: 4h0m0s
+----
+
+This results in the following error message:
+
+[source,terminal]
+----
+error: hyperconvergeds.hco.kubevirt.io "kubevirt-hyperconverged" could not be patched: admission webhook "validate-hco.kubevirt.io" denied the request: spec.certConfig: ca.duration is smaller than server.duration
+----
+
+The error message only mentions the first conflict. Review all certConfig values before you proceed.

--- a/virt/install/installing-virt-cli.adoc
+++ b/virt/install/installing-virt-cli.adoc
@@ -22,6 +22,11 @@ To specify the nodes where you want {VirtProductName} to install its components,
 
 include::modules/virt-subscribing-cli.adoc[leveloffset=+1]
 
+[NOTE]
+====
+You can xref:../../virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc#virt-configuring-certificate-rotation[configure certificate rotation] parameters in the YAML file.
+====
+
 include::modules/virt-deploying-operator-cli.adoc[leveloffset=+1]
 
 == Next steps
@@ -29,4 +34,3 @@ include::modules/virt-deploying-operator-cli.adoc[leveloffset=+1]
 You might want to additionally configure the following components:
 
 * The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
-

--- a/virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc
+++ b/virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc
@@ -1,0 +1,11 @@
+[id="virt-configuring-certificate-rotation"]
+= Configuring certificate rotation
+include::modules/virt-document-attributes.adoc[]
+:context: virt-configuring-certificate-rotation
+
+Configure certificate rotation parameters to replace existing certificates.
+
+toc::[]
+
+include::modules/virt-configuring-certificate-rotation.adoc[leveloffset=+1]
+include::modules/virt-troubleshooting-cert-rotation-parameters.adoc[leveloffset=+1]


### PR DESCRIPTION
4.8 and later

Re: [CNV-6894](https://issues.redhat.com/browse/CNV-6894)

New content: https://deploy-preview-32485--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.html

Note and link added in Subscribing... section: https://deploy-preview-32485--osdocs.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html