### PR TITLE
Rm Operator Metering from OF list

### DIFF
--- a/modules/olm-operator-framework.adoc
+++ b/modules/olm-operator-framework.adoc
@@ -19,7 +19,4 @@ The Operator Registry stores cluster service versions (CSVs) and custom resource
 OperatorHub::
 OperatorHub is a web console for cluster administrators to discover and select Operators to install on their cluster. It is deployed by default in {product-title}.
 
-Operator Metering::
-Operator Metering collects operational metrics about Operators on the cluster for Day 2 management and aggregating usage metrics.
-
 These tools are designed to be composable, so you can use any that are useful to you.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1484

Deprecated since [4.6](https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-metering-operator-deprecated) but was still listed here.

Preview: https://deploy-preview-32506--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-what-operators-are.html#olm-operator-framework_olm-what-operators-are