### PR TITLE
bz1956738-bsl-error-velero-log (MTC 1.5.0)

### DIFF
--- a/modules/migration-error-messages.adoc
+++ b/modules/migration-error-messages.adoc
@@ -12,42 +12,53 @@ This section describes common error messages you might encounter with the {mtc-f
 [id="ca-certificate-error-in-console_{context}"]
 == CA certificate error in the {mtc-short} console
 
-If a `CA certificate error` message is displayed the first time you try to access the {mtc-short} console, the likely cause is the use of self-signed CA certificates in one of the clusters.
+If the {mtc-short} console displays a `CA certificate error` message the first time you try to access it, the likely cause is that a cluster uses self-signed CA certificates.
 
-To resolve this issue, navigate to the `oauth-authorization-server` URL displayed in the error message and accept the certificate. To resolve this issue permanently, add the certificate to the trust store of your web browser.
+Navigate to the `oauth-authorization-server` URL in the error message and accept the certificate. To resolve this issue permanently, install the certificate authority so that it is trusted.
 
-If an `Unauthorized` message is displayed after you have accepted the certificate, navigate to the {mtc-short} console and refresh the web page.
+If the browser displays an `Unauthorized` message after you have accepted the CA certificate, navigate to the {mtc-short} console and then refresh the web page.
 
 [id="oauth-timeout-error-in-console_{context}"]
 == OAuth timeout error in the {mtc-short} console
 
-If a `connection has timed out` message is displayed in the {mtc-short} console after you have accepted a self-signed certificate, the causes are likely to be the following:
+If the {mtc-short} console displays a `connection has timed out` message after you have accepted a self-signed certificate, the cause is likely to be one of the following:
 
 * Interrupted network access to the OAuth server
 * Interrupted network access to the {product-title} console
-* Proxy configuration that blocks access to the `oauth-authorization-server` URL. See link:https://access.redhat.com/solutions/5514491[MTC console inaccessible because of OAuth timeout error] for details.
+* Proxy configuration blocking access to the OAuth server. See link:https://access.redhat.com/solutions/5514491[MTC console inaccessible because of OAuth timeout error] for details.
 
-You can determine the cause of the timeout.
+To determine the cause:
 
-.Procedure
+* Inspect the {mtc-short} console web page with a browser web inspector.
+* Check the `Migration UI` pod log for errors.
 
-. Navigate to the {mtc-short} console and inspect the elements with the browser web inspector.
-. Check the `MigrationUI` pod log:
-+
+[id="backup-storage-location-errors-in-velero-pod-log_{context}"]
+== Backup storage location errors in the Velero pod log
+
+If a `Velero` `Backup` custom resource contains a reference to a backup storage location (BSL) that does not exist, the `Velero` pod log might display the following error messages:
+
+.BSL error messages
 [source,terminal]
 ----
-$ oc logs <MigrationUI_Pod> -n openshift-migration
+Error checking repository for stale locks
+
+Error getting backup storage location: backupstoragelocation.velero.io \"my-bsl\" not found
 ----
 
-[id="podvolumebackups-timeout-error-in-velero-log_{context}"]
-== PodVolumeBackups timeout error in Velero pod log
+You can ignore these error messages. A missing BSL cannot cause a migration to fail.
 
-If a migration fails because Restic times out, the following error is displayed in the `Velero` pod log.
+[id="podvolumebackups-timeout-error-in-velero-log_{context}""]
+== Pod volume backup timeout error in the Velero pod log
 
-.Example output
+If a migration fails because `Restic` times out, the `Velero` pod log displays the following error:
+
+.Pod volume backup timeout error
 [source,terminal]
 ----
-level=error msg="Error backing up item" backup=velero/monitoring error="timed out waiting for all PodVolumeBackups to complete" error.file="/go/src/github.com/heptio/velero/pkg/restic/backupper.go:165" error.function="github.com/heptio/velero/pkg/restic.(*backupper).BackupPodVolumes" group=v1
+level=error msg="Error backing up item" backup=velero/monitoring error="timed out
+waiting for all PodVolumeBackups to complete" error.file="/go/src/github.com/
+heptio/velero/pkg/restic/backupper.go:165" error.function="github.com/heptio/
+velero/pkg/restic.(*backupper).BackupPodVolumes" group=v1
 ----
 
 The default value of `restic_timeout` is one hour. You can increase this parameter for large migrations, keeping in mind that a higher value may delay the return of error messages.
@@ -68,12 +79,12 @@ spec:
 
 . Click *Save*.
 
-[id="resticverifyerrors-in-the-migmigration-custom-resource_{context}"]
-== ResticVerifyErrors in the MigMigration custom resource
+[id="resticverifyerrors-in-the-migmigration-custom-resource_{context}""]
+== Restic verification errors in the MigMigration custom resource
 
-If data verification fails when migrating a persistent volume with the file system data copy method, the following error is displayed in the `MigMigration` CR.
+If data verification fails when migrating a persistent volume with the file system data copy method, the `MigMigration` CR displays the following error:
 
-.Example output
+.MigMigration CR status
 [source,yaml]
 ----
 status:
@@ -94,7 +105,7 @@ status:
 A data verification error does not cause the migration process to fail.
 ====
 
-You can check the `Restore` CR to identify the source of the data verification error.
+You can check the `Restore` CR to troubleshoot the data verification error.
 
 .Procedure
 
@@ -108,7 +119,7 @@ $ oc describe <registry-example-migration-rvwcm> -n openshift-migration
 +
 The output identifies the persistent volume with `PodVolumeRestore` errors.
 +
-.Example output
+.Restore CR with pod volume restore error
 [source,yaml]
 ----
 status:
@@ -132,7 +143,7 @@ $ oc describe <migration-example-rvwcm-98t49>
 +
 The output identifies the `Restic` pod that logged the errors.
 +
-.Example output
+.PodVolumeRestore CR with Restic pod error
 [source,yaml]
 ----
   completionTimestamp: 2020-05-01T20:49:12Z
@@ -149,23 +160,27 @@ The output identifies the `Restic` pod that logged the errors.
 $ oc logs -f <restic-nr2v5>
 ----
 
-ifeval::["{mtc-version}" < "1.3"]
 [id="restic-permission-denied-error-for-nfs-storage_{context}"]
-== `restic: permission denied` error for NFS storage
+== Restic permission error when migrating from NFS storage with root_squash enabled
 
-If you are migrating data from NFS storage and `root_squash` is enabled, `Restic` maps to `nfsnobody` and does not have permission to perform the migration. The following error is displayed in the `Restic` pod log.
+If you are migrating data from NFS storage and `root_squash` is enabled, `Restic` maps to `nfsnobody` and does not have permission to perform the migration. The `Restic` pod log displays the following error:
 
-.Example output
+.Restic permission error
 [source,terminal]
 ----
-backup=openshift-migration/<backup_id> controller=pod-volume-backup error="fork/exec /usr/bin/restic: permission denied" error.file="/go/src/github.com/vmware-tanzu/velero/pkg/controller/pod_volume_backup_controller.go:280" error.function="github.com/vmware-tanzu/velero/pkg/controller.(*podVolumeBackupController).processBackup" logSource="pkg/controller/pod_volume_backup_controller.go:280" name=<backup_id> namespace=openshift-migration
+backup=openshift-migration/<backup_id> controller=pod-volume-backup error="fork/exec
+/usr/bin/restic: permission denied" error.file="/go/src/github.com/vmware-tanzu/
+velero/pkg/controller/pod_volume_backup_controller.go:280" error.function=
+"github.com/vmware-tanzu/velero/pkg/controller.(*podVolumeBackupController).processBackup"
+logSource="pkg/controller/pod_volume_backup_controller.go:280" name=<backup_id>
+namespace=openshift-migration
 ----
 
-You can resolve this issue by creating a supplemental group for Restic and adding the group ID to the `MigrationController` CR manifest.
+You can resolve this issue by creating a supplemental group for `Restic` and adding the group ID to the `MigrationController` CR manifest.
 
 .Procedure
 
-. Create a supplemental group for Restic on the NFS storage.
+. Create a supplemental group for `Restic` on the NFS storage.
 . Set the `setgid` bit on the NFS directories so that group ownership is inherited.
 . Add the `restic_supplemental_groups` parameter to the `MigrationController` CR manifest on the source and target clusters:
 +
@@ -177,4 +192,3 @@ spec:
 <1> Specify the supplemental group ID.
 
 . Wait for the `Restic` pods to restart so that the changes are applied.
-endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1956738

BSL error messages in Velero log
Also, some minor improvements in other sections of the module

4.5+

Preview: https://deploy-preview-32517--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#backup-storage-location-errors-in-velero-pod-log_troubleshooting-3-4

QE approved