### PR TITLE
Changes docs to reference v6 Elasticsearch only in 4.7

### DIFF
--- a/modules/cluster-logging-collector-log-forward-about.adoc
+++ b/modules/cluster-logging-collector-log-forward-about.adoc
@@ -16,7 +16,7 @@ An _output_ is the destination for log data and a pipeline defines simple routin
 
 An output can be either:
 
-* `elasticsearch` to forward logs to an external Elasticsearch v5.x cluster, specified by server name or FQDN, and/or the internal {product-title} Elasticsearch logstore. 
+* `elasticsearch` to forward logs to an external Elasticsearch 6 (all releases) cluster, specified by server name or FQDN, and/or the internal {product-title} Elasticsearch logstore. 
 * `forward` to forward logs to an external log aggregation solution. This option uses the Fluentd *forward* protocols.
 
 A _pipeline_ associates the type of data to an output. A type of data you can forward is one of the following:
@@ -99,4 +99,3 @@ spec:
 <10> A name to describe the pipeline.
 <11> The source type, `logs.app`, `logs.infra`, or `logs.audit`.
 <12> The name of one or more outputs configured in the CR.
-

--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-es_{context}"]
 = Forwarding logs to an external Elasticsearch instance
 
-You can optionally forward logs to an external Elasticsearch instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can optionally forward logs to an external Elasticsearch 6 (all releases) instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 To configure log forwarding to an external Elasticsearch instance, create a `ClusterLogForwarder` custom resource (CR) with an output to that instance and a pipeline that uses the output. The external Elasticsearch output can use the HTTP (insecure) or HTTPS (secure HTTP) connection.
 

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -10,7 +10,7 @@ Forwarding cluster logs to external third-party systems requires a combination o
 * An _output_ is the destination for log data that you define, or where you want the logs sent. An output can be one of the following types:
 +
 --
-* `elasticsearch`. An external Elasticsearch instance. The `elasticsearch` output can use a TLS connection.
+* `elasticsearch`. An external Elasticsearch 6 (all releases) instance. The `elasticsearch` output can use a TLS connection.
 
 * `fluentdForward`. An external log aggregation solution that supports Fluentd. This option uses the Fluentd *forward* protocols. The `fluentForward` output can use a TCP or TLS connection and supports shared-key authentication by providing a *shared_key* field in a secret. Shared-key authentication can be used with or without TLS.
 


### PR DESCRIPTION
No BZ. Followup of #32361.

Preview: https://deploy-preview-32537--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forwarding-about_cluster-logging-external

This has been approved and requested by QE, as per the other PR.