### PR TITLE
RHDEVDOCS-3007 temporarily unpublish cluster-logging-collector-log-fo…

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -35,6 +35,6 @@ include::modules/cluster-logging-collector-log-forward-fluentd.adoc[leveloffset=
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-kafka.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-project.adoc[leveloffset=+1]
-include::modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc[leveloffset=+1]
+//include::modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-legacy-fluentd.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-legacy-syslog.adoc[leveloffset=+1]


### PR DESCRIPTION
…rward-logs-from-application-pods.adoc
I will revert this commit in two weeks when OpenShift Logging 5.1 is GA.

- Aligned team: Dev Tools
- For branches: enterprise-4.7 and master. 
- https://issues.redhat.com/browse/RHDEVDOCS-3007
- Direct link to doc preview: https://deploy-preview-<pr number>--osdocs.netlify.app/openshift-enterprise/latest/<path to topic>
- SME review: Approved by @sichvoge 
- Please merge now.