### PR TITLE
BZ:1708232 - Adds Java S2I content

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1010,7 +1010,7 @@ Topics:
     File: index
   - Name: Java
     File: java
-    Distros: openshift-online,openshift-origin
+    Distros: openshift-online,openshift-origin,openshift-enterprise
   - Name: .NET Core
     File: dot_net_core
     Distros: openshift-online,openshift-enterprise,openshift-dedicated,openshift-aro

--- a/using_images/s2i_images/java.adoc
+++ b/using_images/s2i_images/java.adoc
@@ -13,15 +13,10 @@ toc::[]
 [[s2i-images-java-overview]]
 == Overview
 
-{product-title} provides an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I
-builder image] for building Java applications.  This builder image takes your
-application source or binary artifacts, builds the source using Maven (if source
-was provided), and assembles the artifacts with any required dependencies to
-create a new, ready-to-run image containing your Java application. This
-resulting image can be run on {product-title} or run directly with Docker.
+{product-title} provides
+xref:../../architecture/core_concepts/builds_and_image_streams.adoc#source-build[S2I builder images] for building Java applications. These builder images take your application source or binary artifacts, build the source using Maven, if the source was provided, and assemble the artifacts with any required dependencies to create a new, ready-to-run image containing your Java application. This resulting image can be run on {product-title} or run directly with Docker.
 
-The builder image is intended for use with
+The builder images are intended for use with
 link:https://maven.apache.org[Maven]-based Java standalone projects that are run
 via main class.
 
@@ -29,33 +24,51 @@ via main class.
 [[s2i-images-java-versions]]
 == Versions
 
-The current version of the Java S2I builder image supports OpenJDK 1.8, Jolokia
-1.3.5, and Maven 3.3.9-2.8.
+The current version of the Java S2I builder images support OpenJDK 1.8 and 11,
+Jolokia 1.6.2, and Maven 3.6.
 
 
 [[s2i-images-java-images]]
 == Images
 
-The RHEL 7 image is available through the Red Hat Registry:
+The RHEL 7 and RHEL 8 images are available through the Red Hat Registry.
+
+[NOTE]
+====
+link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io] requires authentication. For details on
+how to configure your environment for link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io], see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
+====
+
+*RHEL 7 based images*
 
 ----
 $ docker pull registry.redhat.io/redhat-openjdk-18/openjdk18-openshift
+$ docker pull registry.redhat.io/openjdk/openjdk-11-rhel7
+----
+
+*RHEL 8 based images*
+
+----
+$ docker pull registry.redhat.io/ubi8/openjdk-8
+$ docker pull registry.redhat.io/ubi8/openjdk-11
 ----
 
 ifdef::openshift-online[]
-You can use the image through the `redhat-openjdk18-openshift` image stream.
+You can use these images through the following image streams:
+
+* `redhat-openjdk18-openshift` (RHEL 7, JDK 8)
+* `ubi8-openjdk-11` (RHEL UBI 8, JDK 11)
+* `ubi8-openjdk-8` (RHEL UBI 8, JDK 8)
+* `openjdk-11-rhel7` (RHEL 7, JDK 11)
+* `java` (Catch-all image stream that incorporates all of the other image streams, and unless otherwise specified, via a tag, defaults to RHEL 8/JDK 11.)
 endif::openshift-online[]
 
 ifndef::openshift-online[]
-To use this image on {product-title}, you can either access it directly from
-the Red Hat Registry or push it into your
-xref:../../install_config/registry/index.adoc#install-config-registry-overview[{product-title}
-container image registry].  Additionally, you can create an
-xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image
-stream] that points to the image, either in your container image registry or at the
-external location. Your {product-title} resources can then reference the
-link:https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json[image
-stream definition].
+To use these images on {product-title}, you can either access them directly from
+the Red Hat Registry or push them into your
+xref:../../install_config/registry/index.adoc#install-config-registry-overview[{product-title} container image registry]. Additionally, you can create an
+xref:../../architecture/core_concepts/builds_and_image_streams.adoc#image-streams[image stream] that points to the image, either in your container image registry or at the external location. Your {product-title} resources can then reference the
+link:https://raw.githubusercontent.com/jboss-container-images/openjdk/release/templates/image-streams.json[image stream definition].
 endif::openshift-online[]
 
 [[s2i-images-java-build-process]]
@@ -69,32 +82,34 @@ By default, the Java S2I builder image uses Maven to build the project with the
 following goals and options:
 
 ----
-mvn -Dmaven.repo.local=/tmp/artifacts/m2 -s /tmp/artifacts/configuration/settings.xml -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true package -Djava.net.preferIPv4Stack=true
+mvn -e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga -Dfabric8.skip=true --batch-mode -Djava.net.preferIPv4Stack=true -s /tmp/artifacts/configuration/settings.xml -Dmaven.repo.local=/tmp/artifacts/m2  package
 ----
 
 Based on these defaults, the builder image compiles the project and copies all
 the transitive dependencies into the output directory without running tests.
-Additionally, if the project has a profile named `*openshift*`, then it is
+Additionally, if the project has a profile named `openshift`, it is
 activated for the build.
 
 You can override these default goals and options by specifying the following environment variables:
 
-.Java Environment Variables
-[options="header"]
 |===
-
 |Variable name |Description
 
-|`*ARTIFACT_DIR*`
-|The relative path to the target where JAR files are created for multi-module builds.
+|`MAVEN_S2I_ARTIFACT_DIRS`
+|Relative paths of source directories to scan for build output, which are copied to `DEPLOY_DIR`. Defaults to `target`.
 
-|`*JAVA_MAIN_CLASS*`
-|The main class to use as the argument to Java. This can also be specified in the *_.s2i/environment_* file as a Maven property inside the project (*docker.env.Main*).
+|`JAVA_MAIN_CLASS`
+|A main class to use as the argument for `java`. When this environment variable is given, all jar files in `JAVA_APP_DIR` are added to the classpath and `JAVA_LIB_DIR`.
 
-|`*MAVEN_ARGS*`
-|The arguments that are passed to the mvn command.
+|`MAVEN_ARGS`
+|The arguments that are passed to the `mvn` command. Defining this variable replaces the defaults, which are `-e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package`.
+
+|`MAVEN_ARGS_APPEND`
+|Additional Maven arguments.
 
 |===
+
+This is a selection of the environment variables available for configuring the behavior of the OpenJDK containers. For a comprehensive list, see <<s2i-images-java-environment-variables>>.
 
 [[s2i-images-java-deploy-applications]]
 == Building and Deploying Java Applications
@@ -103,9 +118,7 @@ ifdef::openshift-enterprise[]
 [IMPORTANT]
 ====
 The
-link:https://github.com/jboss-openshift/application-templates/blob/master/jboss-image-streams.json[OpenJDK
-image stream] must first be installed. If you ran a standard installation, the
-image stream will be present.
+link:https://raw.githubusercontent.com/jboss-container-images/openjdk/release/templates/image-streams.json[OpenJDK image stream] must first be installed. If you ran a standard installation, the image stream will be present.
 ====
 endif::openshift-enterprise[]
 
@@ -115,38 +128,41 @@ or from binary artifacts.
 [[s2i-images-java-deploy-applications-from-source]]
 == Building and Deploying from Source
 
-The Java S2I builder image can be used to build an application from source by running `oc
-new-app` against a source repository:
+The Java S2I builder image can be used to build an application from source by running `oc new-app` against a source repository:
 
 ifdef::openshift-online[]
+[source,terminal]
 ----
 $ oc new-app redhat-openjdk18-openshift~https://github.com/jboss-openshift/openshift-quickstarts --context-dir=undertow-servlet
 ----
 endif::openshift-online[]
 
 ifndef::openshift-online[]
+[source,terminal]
 ----
 $ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~https://github.com/jboss-openshift/openshift-quickstarts --context-dir=undertow-servlet
 ----
 endif::openshift-online[]
 
-By default, tests are not run.  To build an application and run tests as part of
-the build, override the default `MAVEN_ARGS`, as in the following command:
+By default, tests are not run. To build an application and run tests as part of
+the build, override the default `MAVEN_ARGS`, as shown in the following command:
 
 ifdef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
+$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context_dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
 ----
 endif::openshift-online[]
 
 ifndef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
+$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context_dir> --build-env='MAVEN_ARGS=-e -Popenshift -Dcom.redhat.xpaas.repo.redhatga package'
 ----
 endif::openshift-online[]
 
 If a Java project consists of multiple Maven modules, it can be useful to
-explicitly specify the artifact output directory.  Specifying the directory
+explicitly specify the artifact output directory. Specifying the directory
 where the Maven project outputs the artifacts enables the S2I build to pick
 them up.
 
@@ -154,50 +170,436 @@ To specify the modules to build and the artifact output directory, use the
 following command:
 
 ifdef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+$ oc new-app redhat-openjdk18-openshift~<git_repo_URL> --context-dir=<context_dir> --build-env='MAVEN_S2I_ARTIFACT_DIRS=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
 ----
 endif::openshift-online[]
 
 ifndef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context-dir> --build-env='ARTIFACT_DIR=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
+$ oc new-app registry.redhat.io/redhat-openjdk-18/openjdk18-openshift~<git_repo_URL> --context-dir=<context_dir> --build-env='MAVEN_S2I_ARTIFACT_DIRS=relative/path/to/artifacts/dir' --build-env='MAVEN_ARGS=install -pl <groupId>:<artifactId> -am'
 ----
 endif::openshift-online[]
 
 [[s2i-images-java-deploy-applications-from-binary]]
 == Building and Deploying from Binary Artifacts
 
-The Java S2I builder image can be used to build an application using binary
-artifacts that you provide.  To do so, first create a new binary build using the
-`oc new-build` command:
+You can use the Java S2I builder image to build an application using binary
+artifacts that you provide.
 
+. Create a new binary build:
++
 ifdef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-build --name=<application-name> redhat-openjdk18-openshift --binary=true
+$ oc new-build --name=<application_name> redhat-openjdk18-openshift --binary=true
 ----
 endif::openshift-online[]
 
++
 ifndef::openshift-online[]
+[source,terminal]
 ----
-$ oc new-build --name=<application-name> registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --binary=true
+$ oc new-build --name=<application_name> registry.redhat.io/redhat-openjdk-18/openjdk18-openshift --binary=true
 ----
 endif::openshift-online[]
 
-Next, start a build using the `oc start-build` command, specifying the path to
-the binary artifacts on your local machine:
+. Start a build and specify the path to the binary artifacts on your local machine:
++
+[source,terminal]
+----
+$ oc start-build <application_name> --from-dir=/path/to/artifacts --follow
+----
 
+. Create an application:
++
+[source,terminal]
 ----
-$ oc start-build <application-name> --from-dir=/path/to/artifacts --follow
+$ oc new-app <application_name>
 ----
 
-Finally, use the `oc new-app` command to create an application:
+[[s2i-images-java-environment-variables]]
+== Java Environment Variables
 
-----
-$ oc new-app <application-name>
-----
+The following tables provide a comprehensive list of Java environment variables used for configuring the behavior of the OpenJDK containers.
+
+.Configuration environment variables
+[options="header"]
+
+|===
+|Variable name |Description |Example value
+
+|`AB_JOLOKIA_CONFIG`
+|If set, uses this file, including path, as Jolokia JVM agent properties, as described in the Jolokia link:https://www.jolokia.org/reference/html/agents.html#agents-jvm[reference manual]. If not set, the `/opt/jolokia/etc/jolokia.properties` is created using the settings as defined in the manual. Otherwise, the rest of the settings in this document are ignored.
+|`/opt/jolokia/custom.properties`
+
+|`AB_JOLOKIA_DISCOVERY_ENABLED`
+|Enable Jolokia discovery. Defaults to `false`.
+|`true`
+
+|`AB_JOLOKIA_HOST`
+|Host address to bind to. Defaults to `0.0.0.0`.
+|`127.0.0.1`
+
+|`AB_JOLOKIA_ID`
+|Agent ID to use. Defaults to `$HOSTNAME`, which is the container ID.
+|`openjdk-app-1-xqlsj`
+
+|`AB_JOLOKIA_OFF`
+|If set, disables activation of Jolokia, for example, echos an empty value. By default, Jolokia is enabled.
+|`true`
+
+|`AB_JOLOKIA_OPTS`
+|Additional options to be appended to the agent configuration. They should be given in the format `key=value,key=value,...`.
+|`backlog=20`
+
+|`AB_JOLOKIA_PASSWORD`
+|Password for basic authentication. By default, authentication is switched off.
+|`mypassword`
+
+|`AB_JOLOKIA_PORT`
+|Port to listen to. Defaults to `8778`.
+|`5432`
+
+|`AB_JOLOKIA_USER`
+|User for basic authentication. Defaults to `jolokia`.
+|`myusername`
+
+|`AB_PROMETHEUS_ENABLE`
+|Enable the use of the Prometheus agent.
+|`true`
+
+|`AB_PROMETHEUS_JMX_EXPORTER_PORT`
+|Port to use for the Prometheus JMX Exporter.
+|`9799`
+
+|`CONTAINER_CORE_LIMIT`
+|A calculated core limit as described in link:https://www.kernel.org/doc/Documentation/scheduler/sched-bwc.txt[CFS Bandwidth Control].
+|`2`
+
+|`CONTAINER_MAX_MEMORY`
+|Memory limit given to the container.
+|`1024`
+
+|`GC_ADAPTIVE_SIZE_POLICY_WEIGHT`
+|The weighting given to the current GC time versus previous GC times.
+|`90`
+
+|`GC_CONTAINER_OPTIONS`
+|Specify the Java GC to use. The value of this variable should contain the necessary JRE command-line interface options to specify the required GC, which overrides the default of `-XX:+UseParallelOldGC`.
+|`-XX:+UseG1GC`
+
+|`GC_MAX_HEAP_FREE_RATIO`
+|Maximum percentage of heap free after GC to avoid shrinking.
+|`40`
+
+|`GC_MAX_METASPACE_SIZE`
+|The maximum metaspace size.
+|`100`
+
+|`GC_METASPACE_SIZE`
+|The initial metaspace size.
+|`20`
+
+|`GC_MIN_HEAP_FREE_RATIO`
+|Minimum percentage of heap free after GC to avoid expansion.
+|`20`
+
+|`GC_TIME_RATIO`
+|Specifies the ratio of the time spent outside the garbage collection, for example, the time spent for application execution, to the time spent in the garbage collection.
+|`4`
+
+|`HTTPS_PROXY`
+|The location of the https proxy. This takes precedence over `http_proxy` and `HTTP_PROXY`, and is used for both Maven builds and Java runtime.
+|`myuser@127.0.0.1:8080`
+
+|`HTTP_PROXY`
+|The location of the http proxy. This is used for both Maven builds and Java runtime.
+|`127.0.0.1:8080`
+
+|`JAVA_APP_DIR`
+|The directory where the application resides. All paths in your application are relative to this directory.
+|`myapplication/``
+
+|`JAVA_ARGS`
+|Arguments passed to the `java` application.
+|-
+
+|`JAVA_CLASSPATH`
+|The classpath to use. If not given, the startup script checks for a file `JAVA_APP_DIR/classpath` and uses its content literally as classpath. If this file does not exist, all jars in the app dir are added. (`classes:JAVA_APP_DIR/*`).
+|-
+
+|`JAVA_DEBUG`
+|If set, remote debugging is switched on. Disabled by default.
+|`true`
+
+|`JAVA_DEBUG_PORT`
+|Port used for remote debugging. Defaults to `5005`.
+|`8787`
+
+|`JAVA_DIAGNOSTICS`
+|Set this variable to get some diagnostics information to standard output when things are happening. Disabled by default.
+|`true`
+
+|`JAVA_INITIAL_MEM_RATIO`
+|Used when no `-Xms` option is given in `JAVA_OPTS`. This is used to calculate a default initial heap memory based on the maximum heap memory. If used in a container without any memory constraints for the container, this option has no effect. If there is a memory constraint, `-Xms` is set to a ratio of the `-Xmx` memory as set here. The default is `25` which means 25% of the `-Xmx` is used as the initial heap size. You can skip this mechanism by setting this value to `0`, in which case no `-Xms` option is added.
+|`25`
+
+|`JAVA_LIB_DIR`
+|Directory holding the Java jar files and an optional `classpath` file which holds the classpath as either a single line classpath (colon separated) or with jar files listed line-by-line. If not set, `JAVA_LIB_DIR` is the same as `JAVA_APP_DIR`.
+|-
+
+|`JAVA_MAIN_CLASS`
+|A main class to use as the argument for `java`. When this environment variable is given, all jar files in `JAVA_APP_DIR` are added to the classpath and  `JAVA_LIB_DIR`.
+|`com.example.MainClass`
+
+|`JAVA_MAX_INITIAL_MEM`
+|Used when no `-Xms` option is given in `JAVA_OPTS`. This is used to calculate the maximum value of the initial heap memory. If used in a container without any memory constraints for the container, this option has no effect. If there is a memory constraint, `-Xms` is limited to the value set here. The default is `4096` MB, which means the calculated value of `-Xms` is never greater than 4096 MB. The value of this variable is expressed in MB.
+|`4096`
+
+|`JAVA_MAX_MEM_RATIO`
+|Used when no `-Xmx` option is given in `JAVA_OPTS`. This is used to calculate a default maximal heap memory based on a containers restriction. If used in a container without any memory constraints for the container, this option has no effect. If there is a memory constraint, `-Xmx` is set to a ratio of the container available memory as set here. The default is `50`, which means 50% of the available memory is used as an upper boundary. You can skip this mechanism by setting this value to `0`, in which case no `-Xmx` option is added.
+|-
+
+|`JAVA_OPTS`
+|JVM options passed to the `java` command.
+|`-verbose:class`
+
+|`JAVA_OPTS_APPEND`
+|User specified Java options to be appended to generated options in `JAVA_OPTS`.
+|`-Dsome.property=foo`
+
+|`LOGGING_SCRIPT_DEBUG`
+|Set to `true` to enable script debugging. Deprecates `SCRIPT_DEBUG`.
+|`true`
+
+|`MAVEN_ARGS`
+|Arguments to use when calling Maven, replacing the default `package hawt-app:build -DskipTests -e`. Be sure to run the `hawt-app:build` goal when not already bound to the `package` execution phase, otherwise the startup scripts do not work.
+|`-e -Popenshift -DskipTests -Dcom.redhat.xpaas.repo.redhatga package`
+
+|`MAVEN_ARGS_APPEND`
+|Additional Maven arguments.
+|`-X -am -pl`
+
+|`MAVEN_CLEAR_REPO`
+|If set, the Maven repository is removed after the artifact is built. This is useful for keeping the created application image small, but prevents incremental builds. This variable is overridden by `S2I_ENABLE_INCREMENTAL_BUILDS`. Defaults to `false`.
+|-
+
+|`MAVEN_LOCAL_REPO`
+|Directory to use as the local Maven repository.
+|`/home/jboss/.m2/repository`
+
+|`MAVEN_MIRRORS`
+|If set, multi-mirror support is enabled, and other `MAVEN_MIRROR_*` variables are prefixed. For example, `DEV_ONE_MAVEN_MIRROR_URL` and `QE_TWO_MAVEN_MIRROR_URL`.
+|`dev-one,qe-two`
+
+|`MAVEN_MIRROR_URL`
+|The base URL of a mirror used for retrieving artifacts.
+|`\http://10.0.0.1:8080/repository/internal/`
+
+|`MAVEN_REPOS`
+|If set, multi-repo support is enabled, and other `MAVEN_REPO_*` variables are prefixed. For example, `DEV_ONE_MAVEN_REPO_URL` and `QE_TWO_MAVEN_REPO_URL`.
+|`dev-one,qe-two`
+
+|`MAVEN_S2I_ARTIFACT_DIRS`
+|Relative paths of source directories to scan for build output, which are copied to `DEPLOY_DIR`. Defaults to `target`.
+|`target`
+
+|`MAVEN_S2I_GOALS`
+|Space separated list of goals to be run with the maven build. For example, `mvn $MAVEN_S2I_GOALS`. Defaults to `package`.
+|`package install`
+
+|`MAVEN_SETTINGS_XML`
+|Location of custom Maven settings.xml file to use.
+|`/home/jboss/.m2/settings.xml`
+
+|`NO_PROXY`
+|A comma separated list of hosts, IP addresses or domains that can be accessed directly. This is used for both Maven builds and Java runtime.
+|`foo.example.com,bar.example.com`
+
+|`S2I_ARTIFACTS_DIR`
+|Location mount for artifacts persisted with `save-artifacts` script, which are used with incremental builds. This must not be overridden by end users.
+|`${S2I_DESTINATION_DIR}/artifacts}`
+
+|`S2I_DESTINATION_DIR`
+|Root directory for S2I mount, as specified by the `io.openshift.s2i.destination` label. This must not be overridden by end users.
+|`/tmp`
+
+|`S2I_ENABLE_INCREMENTAL_BUILDS`
+|Do not remove source and intermediate build files so they can be saved for use with future builds. Defaults to `true`.
+|`true`
+
+|`S2I_IMAGE_SOURCE_MOUNTS`
+|Comma separated list of relative paths in the source directory which should be included in the image. The list can include wildcards, which are expanded using find. By default, the contents of mounted directories are processed similarly to source folders, where the contents of `S2I_SOURCE_CONFIGURATION_DIR`, `S2I_SOURCE_DATA_DIR`, and `S2I_SOURCE_DEPLOYMENTS_DIR` are copied to their respective target directories. Alternatively, if an `install.sh` file is located in the root of the mount point, it is executed instead. Deprecates `CUSTOM_INSTALL_DIRECTORIES`.
+|`extras/*`
+
+|`S2I_SOURCE_CONFIGURATION_DIR`
+|Relative path to directory containing application configuration files to be copied over to the product configuration directory, see `S2I_TARGET_CONFIGURATION_DIR`. Defaults to `configuration`.
+|`configuration`
+
+|`S2I_SOURCE_DATA_DIR`
+|Relative path to directory containing application data files to be copied over to the product data directory, see `S2I_TARGET_DATA_DIR`. Defaults to `data`.
+|`data`
+
+|`S2I_SOURCE_DEPLOYMENTS_DIR`
+|Relative path to directory containing binary files to be copied over to the product deployment directory, see `S2I_TARGET_DEPLOYMENTS_DIR`. Defaults to `deployments`.
+|`deployments`
+
+|`S2I_SOURCE_DIR`
+|Location of mount for source code to be built. This must not be overridden by end users.
+|`${S2I_DESTINATION_DIR}/src}`
+
+|`S2I_TARGET_CONFIGURATION_DIR`
+|Absolute path to which files located in `S2I_SOURCE_DIR`/`S2I_SOURCE_CONFIGURATION_DIR` are copied.
+|`/opt/eap/standalone/configuration`
+
+|`S2I_TARGET_DATA_DIR`
+|Absolute path to which files located in `S2I_SOURCE_DIR`/`S2I_SOURCE_DATA_DIR` are copied.
+|`/opt/eap/standalone/data`
+
+|`S2I_TARGET_DEPLOYMENTS_DIR`
+|Absolute path to which files located in `S2I_SOURCE_DIR`/`S2I_SOURCE_DEPLOYMENTS_DIR` are copied. Additionally, this is the directory to which build output is copied.
+|`/deployments`
+
+|`http_proxy`
+|The location of the http proxy. This takes precedence over `HTTP_PROXY` and is used for both Maven builds and Java runtime.
+|`\http://127.0.0.1:8080`
+
+|`https_proxy`
+|The location of the https proxy. This takes precedence over `HTTPS_PROXY`, `http_proxy`, and `HTTP_PROXY`, and is used for both Maven builds and Java runtime.
+|`myuser:mypass@127.0.0.1:8080`
+
+|`no_proxy`
+|A comma separated list of hosts, IP addresses or domains that can be accessed directly. This takes precedence over `NO_PROXY` and is used for both Maven builds and Java runtime.
+|`*.example.com`
+
+|`prefix_MAVEN_MIRROR_ID`
+|ID to be used for the specified mirror. If omitted, a unique ID is generated.
+|`internal-mirror`
+
+|`prefix_MAVEN_MIRROR_OF`
+|Repository IDs mirrored by this entry. Defaults to `external:`.
+|-
+
+|`prefix_MAVEN_MIRROR_URL`
+|The URL of the mirror.
+|`\http://10.0.0.1:8080/repository/internal`
+
+|`prefix_MAVEN_REPO_DIRECTORY_PERMISSIONS`
+|Maven repository directory permissions.
+|`775`
+
+|`prefix_MAVEN_REPO_FILE_PERMISSIONS`
+|Maven repository file permissions.
+|`664`
+
+|`prefix_MAVEN_REPO_HOST`
+|Maven repository host, if not using fully defined URL, falls back to service.
+|`repo.example.com`
+
+|`prefix_MAVEN_REPO_ID`
+|Maven repository ID.
+|`my-repo-id`
+
+|`prefix_MAVEN_REPO_LAYOUT`
+|Maven repository layout.
+|`default`
+
+|`prefix_MAVEN_REPO_NAME`
+|Maven repository name.
+|`my-repo-name`
+
+|`prefix_MAVEN_REPO_PASSPHRASE`
+|Maven repository passphrase.
+|`maven1!`
+
+|`prefix_MAVEN_REPO_PASSWORD`
+|Maven repository password.
+|`maven1!`
+
+|`prefix_MAVEN_REPO_PATH`
+|Maven repository path, if not using fully defined URL, falls back to service.
+|`/maven2/`
+
+|`prefix_MAVEN_REPO_PORT`
+|Maven repository port, if not using fully defined URL, falls back to service.
+|`8080`
+
+|`prefix_MAVEN_REPO_PRIVATE_KEY`
+|Maven repository private key.
+|`${user.home}/.ssh/id_dsa`
+
+|`prefix_MAVEN_REPO_PROTOCOL`
+|Maven repository protocol, if not using fully defined URL, falls back to service.
+|`http`
+
+|`prefix_MAVEN_REPO_RELEASES_CHECKSUM_POLICY`
+|Maven repository releases checksum policy.
+|`warn`
+
+|`prefix_MAVEN_REPO_RELEASES_ENABLED`
+|Maven repository releases enabled.
+|`true`
+
+|`prefix_MAVEN_REPO_RELEASES_UPDATE_POLICY`
+|Maven repository releases update policy.
+|`always`
+
+|`prefix_MAVEN_REPO_SERVICE`
+|Maven repository service to lookup if `prefix_MAVEN_REPO_URL` is not specified.
+|`buscentr-myapp`
+
+|`prefix_MAVEN_REPO_SNAPSHOTS_CHECKSUM_POLICY`
+|Maven repository snapshots checksum policy.
+|`warn`
+
+|`prefix_MAVEN_REPO_SNAPSHOTS_ENABLED`
+|Maven repository snapshots enabled.
+|`true`
+
+|`prefix_MAVEN_REPO_SNAPSHOTS_UPDATE_POLICY`
+|Maven repository snapshots update policy.
+|`always`
+
+|`prefix_MAVEN_REPO_URL`
+|Maven repository fully defined URL.
+|`\http://repo.example.com:8080/maven2/`
+
+|`prefix_MAVEN_REPO_USERNAME`
+|Maven repository username.
+|`mavenUser`
+|===
+
+.Configuration environment variables with default values
+[options="header"]
+
+|===
+|Variable name |Description |Value
+
+|`AB_JOLOKIA_AUTH_OPENSHIFT`
+|Switch on client authentication for OpenShift TLS communication. The value of this parameter can be a relative distinguished name which must be contained in a presented client's certificate. Enabling this parameter automatically switches Jolokia into https communication mode. The default CA cert is set to `/var/run/secrets/kubernetes.io/serviceaccount/ca.crt`.
+|`true`
+
+|`AB_JOLOKIA_HTTPS`
+|Switch on secure communication with https. By default, self-signed server certificates are generated if no `serverCert` configuration is given in `AB_JOLOKIA_OPTS`.
+|`true`
+
+|`AB_JOLOKIA_PASSWORD_RANDOM`
+|Determines whether a random `AB_JOLOKIA_PASSWORD` is generated. Set to `true` to generate a random password. The generated value is written to `/opt/jolokia/etc/jolokia.pw`.
+|`true`
+
+|`AB_PROMETHEUS_JMX_EXPORTER_CONFIG`
+|Path to configuration to use for the Prometheus JMX Exporter.
+|`/opt/jboss/container/prometheus/etc/jmx-exporter-config.yaml`
+
+|`S2I_SOURCE_DEPLOYMENTS_FILTER`
+|A space separated list of filters to be applied when copying deployments. Defaults to `*`.
+|`*`
+|===
 
 [[moreinfo]]
-== Additional Information and Examples
+== Additional resources
 
 - Find additional information and examples in the link:https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_java_s2i_for_openshift/[Red Hat JBoss Middleware] documentation.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1708232

Preview: https://deploy-preview-32543--osdocs.netlify.app/openshift-enterprise/latest/using_images/s2i_images/java.html

For 3.11 - Adds Java S2I content.
For OpenShift Online - Updates Java S2I content.

@jmtd This PR adds the initial Java S2I content from the OpenShift Online docs to the 3.11 docs. Ready for your review.

Ready for QE review: @wzheng1 
