### PR TITLE
OSDOCS-2151: Added OCM procedures for add-on services to the ROSA docs 

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -70,6 +70,15 @@ Topics:
 - Name: Upgrading ROSA
   File: rosa-upgrading
 ---
+Name: Add-on services
+Dir: adding_service_cluster
+Distros: openshift-rosa
+Topics:
+- Name: Adding services to a cluster
+  File: adding-service
+- Name: Available services
+  File: rosa-available-services
+---
 Name: Nodes
 Dir: nodes
 Distros: openshift-rosa

--- a/adding_service_cluster/adding-service.adoc
+++ b/adding_service_cluster/adding-service.adoc
@@ -2,10 +2,10 @@ include::modules/attributes-openshift-dedicated.adoc[]
 [id="adding-service"]
 :context: adding-service
 
-= Adding services to your {product-title} cluster
+= Adding services to a {product-title} cluster
 
 
-You can add on services to your existing {product-title} clusters.
+You can add services to your existing {product-title} cluster.
 
 include::modules/adding-service-existing.adoc[leveloffset=+1]
 include::modules/access-service.adoc[leveloffset=+1]

--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -1,0 +1,17 @@
+include::modules/attributes-openshift-dedicated.adoc[]
+[id="rosa-available-services"]
+= Add-on services available for {product-title}
+:context: rosa-available-services
+
+
+Learn more about available services you can add on to your {product-title} (ROSA) cluster.
+
+include::modules/osd-rhoam.adoc[leveloffset=+1]
+include::modules/codeready-workspaces.adoc[leveloffset=+1]
+
+[NOTE]
+====
+You must first install the ROSA `cluster-logging-operator` using the `rosa` CLI before installing the AWS CloudWatch service through the OpenShift Cluster Manager (OCM) console.
+
+For more information, see xref:../logging/rosa-install-logging.adoc#rosa-install-logging[Install the logging add-on service] for information about the AWS CloudWatch log forwarding service.
+====

--- a/logging/rosa-install-logging.adoc
+++ b/logging/rosa-install-logging.adoc
@@ -24,3 +24,7 @@ The AWS CloudWatch log forwarding service on ROSA has the following approximate 
 |===
 
 include::modules/rosa-install-logging-addon.adoc[leveloffset=+1]
+
+[id="additional-resources_adding-service"]
+== Additional resources
+* xref:../adding_service_cluster/adding-service.adoc#adding-service[Adding services to your cluster]

--- a/modules/access-service.adoc
+++ b/modules/access-service.adoc
@@ -7,7 +7,7 @@
 = Accessing installed services on your cluster
 
 
-Once you have successfully installed a service on your cluster, you can then access it through the {product-title} console.
+After you successfully install a service on your cluster, you can access the service through the OpenShift console.
 
 
 .Prerequisites
@@ -21,14 +21,14 @@ Once you have successfully installed a service on your cluster, you can then acc
 
 . Select the cluster with an installed service you want to access.
 
-. Navigate to the *Add-ons* tab, and locate the installed service you want to access.
+. Navigate to the *Add-ons* tab, and locate the installed service that you want to access.
 
-. Click *View on console* from the service option to open the {product-title} console.
+. Click *View on console* from the service option to open the OpenShift console.
 
-. Enter your credentials to log in to the {product-title} console.
+. Enter your credentials to log in to the OpenShift console.
 
 . Click the *Red Hat Applications* menu by clicking the three-by-three matrix icon in the upper right corner of the main screen.
 
-. Select the service you want to open from the drop-down menu. A new browser tab will open and you will be required to authenticate through Red Hat Single Sign-On.
+. Select the service you want to open from the drop-down menu. A new browser tab opens and you are required to authenticate through Red Hat Single Sign-On.
 
 You have now accessed your service and can begin using it.

--- a/modules/adding-service-existing.adoc
+++ b/modules/adding-service-existing.adoc
@@ -4,20 +4,25 @@
 
 [id="adding-service-existing_{context}"]
 
-= Adding on a service to your cluster
+= Adding a service to a cluster
 
 
-You can add on a service to an existing {product-title} cluster through the OpenShift Cluster Manager (OCM).
+You can add a service to an existing {product-title} cluster through the OpenShift Cluster Manager (OCM).
 
 
 .Prerequisites
 
-- You have created and provisioned an {product-title} cluster.
-- Your cluster meets all prerequisites necessary for the service you want to add on to your cluster.
+* You have created and provisioned a cluster for {product-title}.
+* Your cluster meets all of the prerequisites for the service that you want to add on to your cluster.
+* For paid add-on services, note the following considerations:
+** If the organization has sufficient quota, and if the service is compatible with the cluster, the service appears in OCM.
+** If the organization has never had quota, or if the cluster is not compatible, then the service does not display.
+** If the organization had quota in the past, but the quota is currently `0`, the service is still visible but disabled in OCM until you get more quota.
+
 
 [NOTE]
 ====
-To add a service to an {product-title} cluster, you must be the cluster owner.
+To add a service to a cluster, you must be the cluster owner.
 ====
 
 .Procedure
@@ -28,7 +33,8 @@ To add a service to an {product-title} cluster, you must be the cluster owner.
 
 . Click the *Add-ons* tab.
 
-. Navigate to the service option you want to add, click *Install*. An installing icon will appear to indicate that the service has begun installing.
+. Click the service option you want to add, click *Install*. An installing icon appears, indicating that the service has begun installing.
++
+A green check mark appears in the service option when the installation is complete. You might have to refresh your browser to see the installation status.
 
-
-A green check mark will appear in the service option when the installation is complete. When the service is *Installed*, click *View in console* to access the service.
+. When the service is *Installed*, click *View in console* to access the service.

--- a/modules/codeready-workspaces.adoc
+++ b/modules/codeready-workspaces.adoc
@@ -1,0 +1,9 @@
+
+[id="codeready-workspaces_{context}"]
+= Red Hat CodeReady Workspaces
+
+The Red Hat CodeReady Workspaces service is available as an add-on to your {product-title} cluster. CodeReady Workspaces is a developer tool that makes cloud-native development practical for teams, using Kubernetes and containers to provide any member of the development or IT team with a consistent, preconfigured development environment. Developers can create code, build, and test in containers running on Red Hat OpenShift.
+
+.Additional resources
+
+* For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/1.1/[Red Hat CodeReady Workspaces] documentation.

--- a/modules/deleting-service.adoc
+++ b/modules/deleting-service.adoc
@@ -4,28 +4,28 @@
 // * assemblies/adding-service.adoc
 
 [id="deleting-service_{context}"]
+= Deleting a service from a cluster
 
-= Deleting a service from your {product-title} cluster
 
-
-You can delete add-on services from your {product-title} cluster through the OpenShift Cluster Manager (OCM) or the OCM CLI.
+You can delete the add-on services from your {product-title} cluster through the OpenShift Cluster Manager (OCM) console or the OCM CLI.
 
 .Procedure
 
 . Navigate to the *Clusters* page in link:https://cloud.redhat.com/openshift/[OCM].
 
-. Select the cluster with the installed service you want to delete.
+. Click the cluster with the installed service that you want to delete.
 
-. Navigate to the *Add-ons* tab, and locate the installed service you want to delete.
+. Navigate to the *Add-ons* tab, and locate the installed service that you want to delete.
 
-. From the installed service option, click the menu and select *Uninstall add-on* from the drop down menu.
+. From the installed service option, click the menu and select *Uninstall add-on* from the drop-down menu.
 
-. You must type the name of the service you want to delete in the confirmation message that appears.
+. You must type the name of the service that you want to delete in the confirmation message that appears.
 
-. Click *Uninstall*. You are returned to the *Add-ons* tab and an uninstalling state icon will be present on the service option you deleted.
+. Click *Uninstall*. You are returned to the *Add-ons* tab and an uninstalling state icon is present on the service option you deleted.
 
 . To delete the add-on service from your cluster through the OCM CLI, enter the following command:
 +
+[source,terminal]
 ----
-ocm delete api/clusters_mgmt/v1/clusters/{cluster_id}/addons/{addon_id}
+$ ocm delete api/clusters_mgmt/v1/clusters/<cluster_id>/addons/<addon_id>
 ----

--- a/modules/rosa-install-logging-addon.adoc
+++ b/modules/rosa-install-logging-addon.adoc
@@ -21,6 +21,11 @@ For `<cluster_name>`, enter the name of your cluster.
 
 . When prompted, accept the default `yes` to install the `cluster-logging-operator`.
 . When prompted, accept the default `yes` to install the optional Amazon CloudWatch log forwarding add-on or enter `no` to decline the installation of this add-on.
++
+[NOTE]
+====
+It is not necessary to install the AWS CloudWatch service when you install the `cluster-logging-operator`. You can install the AWS CloudWatch service at any time through the OpenShift Cluster Manager (OCM) console from the cluster's *Add-ons* tab.
+====
 . For the collection of applications, infrastructure, and audit logs, accept the default values or change them as needed:
 +
 * *Applications logs*: Lets the Operator collect application logs, which includes everything that is _not_ deployed in the openshift-*, kube-*, and default namespaces. Default: `yes`


### PR DESCRIPTION
Added OCM procedures for add-on services to the ROSA docs and updated the Cloudwatch logging add-on procedures.

JIRA: https://issues.redhat.com/browse/OSDOCS-2151

Previews:

**Adding Service:** https://deploy-preview-32548--osdocs.netlify.app/openshift-rosa/latest/adding_service_cluster/adding-service.html

**Available Services:** https://deploy-preview-32548--osdocs.netlify.app/openshift-rosa/latest/adding_service_cluster/rosa-available-services.html

**Install Logging Addon:** https://deploy-preview-32548--osdocs.netlify.app/openshift-rosa/latest/logging/rosa-install-logging.html

Peer reviewer: Please merge to branch/dedicated