### PR TITLE
RHDEVDOCS-3009 Add info on Kubernetes matchLabels to "Forwarding application logs from specific pods" topic

### DIFF
--- a/modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc
+++ b/modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc
@@ -5,6 +5,8 @@ As a cluster administrator, you can use Kubernetes pod labels to gather log data
 
 Suppose that you have an application composed of pods running alongside other pods in various namespaces. If those pods have labels that identify the application, you can gather and output their log data to a specific log collector.
 
+To specify the pod labels, you use one or more `matchLabels` key-value pairs. If you specify multiple key-value pairs, the pods must match all of them to be selected.
+
 .Procedure
 
 . Create a `ClusterLogForwarder` custom resource (CR) YAML file.
@@ -23,29 +25,39 @@ spec:
   pipelines:
     - inputRefs: [ myAppLogData ] <3>
       outputRefs: [ default ] <4>
-  inputs:
+  inputs: <5>
     - name: myAppLogData
       application:
         selector:
-          matchLabels:
-            environment: production <5>
-            app: nginx <5>
-        namespaces: <6>
+          matchLabels: <6>
+            environment: production
+            app: nginx
+        namespaces: <7>
         - app1
         - app2
-  outputs: <7>
-    - default <8>
+  outputs: <8>
+    - default
     ...
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
-<3> Specify the input for the pipeline.
-<4> Specify the output for the pipeline.
-<5> Specify the labels of pods whose log data you want to gather.
-<6> Optional: Specify one or more namespaces.
-<7> Specify the output to forward your log data to. The optional `default` output shown here sends log data to the internal Elasticsearch instance.
+<3> Specify one or more comma-separated values from `inputs[].name`.
+<4> Specify one or more comma-separated values from `outputs[]`.
+<5> Define a unique `inputs[].name` for each application that has a unique set of pod labels.
+<6> Specify the key-value pairs of pod labels whose log data you want to gather. You must specify both a key and value, not just a key. To be selected, the pods must match all the key-value pairs.
+<7> Optional: Specify one or more namespaces.
+<8> Specify one or more outputs to forward your log data to. The optional `default` output shown here sends log data to the internal Elasticsearch instance.
 
 . Optional: To restrict the gathering of log data to specific namespaces, use `inputs[].name.application.namespaces`, as shown in the preceding example.
+
+. Optional: You can send log data from additional applications that have different pod labels to the same pipeline.
+.. For each unique combination of pod labels, create an additional `inputs[].name` section similar to the one shown.
+.. Update the `selectors` to match the pod labels of this application.
+.. Add the new `inputs[].name` value to `inputRefs`. For example:
++
+----
+- inputRefs: [ myAppLogData, myOtherAppLogData ]
+----
 
 . Create the CR object:
 +
@@ -53,3 +65,7 @@ spec:
 ----
 $ oc create -f <file-name>.yaml
 ----
+
+.Additional resources
+
+* For more information on `matchLabels` in Kubernetes, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#resources-that-support-set-based-requirements[Resources that support set-based requirements].


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: master, enterprise-4.7, enterprise-4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3009
- Direct link to doc preview: Not available. This topic is temporarily unpublished (not included) in master and enterprise-4.7. It will be re-published at the end of May, when OpenShift Logging 5.1 is GA. For now, please review the file as shown in the "Files changed" tab, above.
- SME review: Reviewed by @sichvoge  
- QE review: Reviewed by @kabirbhartiRH 
- Peer review: Reviewed by @jc-berger and @Preeticp 
- Ready to merge.