### PR TITLE
OSDOCS-2024 - Add disk encryption for UPI docs

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -131,6 +131,8 @@ include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
@@ -162,6 +164,7 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* If necessary, you can
-xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc#configuring-registry-storage-baremetal[Set up your registry and configure registry storage].

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -150,6 +150,8 @@ include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -152,6 +152,8 @@ include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+3]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -73,6 +73,9 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -60,6 +60,8 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -62,6 +62,8 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -80,6 +80,8 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -69,6 +69,8 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -67,6 +67,8 @@ include::modules/machine-vsphere-machines.adoc[leveloffset=+1]
 
 include::modules/installation-disk-partitioning.adoc[leveloffset=+1]
 
+include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
+
 include::modules/architecture-rhcos-updating-bootloader.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-2024](https://issues.redhat.com/browse/OSDOCS-2024)
This applies to 4.7+. Need to determine if a separate PR for the includes only should apply to 4.5 and 4.6.

**Preview links to where I've added the module :**
- [Installing a cluster on bare metal with network customizations](https://deploy-preview-32554--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-special-config-encrypt-disk-tang_installing-bare-metal-network-customizations)
- more links to add