### PR TITLE
Add `net.ipv4.ping_group_range` to sysctl whitelist

### DIFF
--- a/modules/nodes-containers-sysctls-about.adoc
+++ b/modules/nodes-containers-sysctls-about.adoc
@@ -71,6 +71,7 @@ in the safe set:
 - *_kernel.shm_rmid_forced_*
 - *_net.ipv4.ip_local_port_range_*
 - *_net.ipv4.tcp_syncookies_*
+- *_net.ipv4.ping_group_range_*
 
 All safe sysctls are enabled by default. You can use a sysctl in a pod by modifying
 the `Pod` spec.


### PR DESCRIPTION
According to [1], we should add `net.ipv4.ping_group_range` to sysctl whitelist.

[1] https://github.com/openshift/origin/blob/release-4.7/vendor/k8s.io/kubernetes/pkg/security/podsecuritypolicy/sysctl/mustmatchpatterns.go#L37