### PR TITLE
BZ1944035: Failed to add a different instance type node to cluster when using separate /var partition

### DIFF
--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -100,6 +100,12 @@ spec:
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 MiB (Mebibytes) is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
++
+[NOTE]
+====
+When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
+====
+
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -116,6 +116,11 @@ spec:
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
++
+[NOTE]
+====
+When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
+====
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -164,7 +164,11 @@ spec:
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
-
++
+[NOTE]
+====
+When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
+====
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and
 `openshift` subdirectories:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1944035

Three files changes. Here is one preview of each topic using the updated file:
Optional: Creating a separate `/var` partition, step 3 note, AWS, Azure, GCP, 
https://deploy-preview-32572--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-disk-partitioning-upi-templates_installing-restricted-networks-aws

Disk partitioning, step 3 note, vSphere and VMC installs
https://deploy-preview-32572--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations.html#installation-disk-partitioning_installing-vsphere-network-customizations

Disk partitioning, step 3 note, bare metal installs
https://deploy-preview-32572--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced_disk_installing-bare-metal