### PR TITLE
New note that CDI mirrors cluster-wide proxy config

### DIFF
--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.adoc
@@ -37,8 +37,12 @@ include::modules/virt-importing-vm-to-block-pv.adoc[leveloffset=+1]
 
 include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
 
+[NOTE]
+====
+CDI now uses the {product-title} xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy configuration].
+====
+
 [id="{context}_additional-resources"]
 == Additional resources
 
 * xref:../../../virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Configure preallocation mode] to improve write performance for data volume operations.
-

--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
@@ -22,7 +22,7 @@ The resizing procedure varies based on the operating system installed on the vir
 xref:../../../virt/virtual_machines/importing_vms/virt-tls-certificates-for-dv-imports.adoc#virt-adding-tls-certificates-for-authenticating-dv-imports_virt-tls-certificates-for-dv-imports[included in a config map]
 in the same namespace as the data volume and referenced in the data volume configuration.
 
-* To import a container disk: 
+* To import a container disk:
 ** You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-preparing-container-disk-for-vms_virt-using-container-disks-with-vms[prepare a container disk from a virtual machine image] and store it in your container registry before importing it.
 ** If the container registry does not have TLS, you must xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms[add the registry to the `cdi-insecure-registries` config map] before you can import a container disk from it.
 
@@ -30,6 +30,11 @@ in the same namespace as the data volume and referenced in the data volume confi
 for this operation to complete successfully.
 
 include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
+[NOTE]
+====
+CDI now uses the {product-title} xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy configuration].
+====
 
 include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
 


### PR DESCRIPTION
For release 4.8 and later. 

Addresses https://issues.redhat.com/browse/CNV-8907

Note added below the CDI supported operations matrix section.
Preview 1: https://deploy-preview-32574--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.html
Preview 2: https://deploy-preview-32574--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.html