### PR TITLE
bz1961335 - Fix output in sc command

### DIFF
--- a/modules/persistent-storage-csi-gcp-pd-encrypted-pv.adoc
+++ b/modules/persistent-storage-csi-gcp-pd-encrypted-pv.adoc
@@ -55,7 +55,7 @@ IsDefaultClass:        No
 Annotations:           None
 Provisioner:           pd.csi.storage.gke.io
 Parameters:            disk-encryption-kms-key=projects/key-project-id/locations/location/keyRings/ring-name/cryptoKeys/key-name,type=pd-standard
-AllowVolumeExpansion:  unset
+AllowVolumeExpansion:  true
 MountOptions:          none
 ReclaimPolicy:         Delete
 VolumeBindingMode:     WaitForFirstConsumer


### PR DESCRIPTION
bz1961335 - Fix output in sc command
https://bugzilla.redhat.com/show_bug.cgi?id=1961335
https://deploy-preview-32578--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-gcp-pd.html
Under section "Creating a custom-encrypted persistent volume" output of 2nd step, change AllowVolumeExpansion from "unset" to "true".