### PR TITLE
OSSMDOC-331 Additional RN content.

### DIFF
--- a/modules/ossm-rn-new-features-1x.adoc
+++ b/modules/ossm-rn-new-features-1x.adoc
@@ -44,6 +44,121 @@ This release of {ProductName} addresses Common Vulnerabilities and Exposures (CV
 
 This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
+[IMPORTANT]
+====
+There are manual steps that must be completed to address CVE-2021-29492 and CVE-2021-31920.
+====
+
+[id="manual-updates-cve-2021-29492_{context}"]
+=== Manual updates required by CVE-2021-29492 and CVE-2021-31920
+
+Istio contains a remotely exploitable vulnerability where an HTTP request path with multiple slashes or escaped slash characters (``%2F` or ``%5C`) could potentially bypass an Istio authorization policy when path-based authorization rules are used.
+
+For example, assume an Istio cluster administrator defines an authorization DENY policy to reject the request at path `/admin`. A request sent to the URL path `//admin` will NOT be rejected by the authorization policy.
+
+According to https://tools.ietf.org/html/rfc3986#section-6[RFC 3986], the path `//admin` with multiple slashes should technically be treated as a different path from the `/admin`. However, some backend services choose to normalize the URL paths by merging multiple slashes into a single slash. This can result in a bypass of the authorization policy (`//admin` does not match `/admin`), and a user can access the resource at path `/admin` in the backend; this would represent a security incident.
+
+Your cluster is impacted by this vulnerability if you have authorization policies using `ALLOW action + notPaths` field or `DENY action + paths field` patterns. These patterns are vulnerable to unexpected policy bypasses.
+
+Your cluster is NOT impacted by this vulnerability if:
+
+* You don’t have authorization policies.
+* Your authorization policies don’t define `paths` or `notPaths` fields.
+* Your authorization policies use `ALLOW action + paths` field or `DENY action + notPaths` field patterns. These patterns could only cause unexpected rejection instead of policy bypasses. The upgrade is optional for these cases.
+
+[NOTE]
+====
+The {ProductName} configuration location for path normalization is different from the Istio configuration.
+====
+
+=== Updating the path normalization configuration
+
+Istio authorization policies can be based on the URL paths in the HTTP request.
+https://en.wikipedia.org/wiki/URI_normalization[Path normalization], also known as URI normalization, modifies and standardizes the incoming requests' paths so that the normalized paths can be processed in a standard way.
+Syntactically different paths may be equivalent after path normalization.
+
+Istio supports the following normalization schemes on the request paths before evaluating against the authorization policies and routing the requests:
+
+.Normalization schemes
+[options="header"]
+[cols="a, a, a, a"]
+|====
+| Option | Description | Example |Notes
+|`NONE`
+|No normalization is done. Anything received by Envoy will be forwarded exactly as-is to any backend service.
+|`../%2Fa../b` is evaluated by the authorization policies and sent to your service.
+|This setting is vulnerable to CVE-2021-31920.
+
+|`BASE`
+|This is currently the option used in the *default* installation of Istio. This applies the https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path[`normalize_path`] option on Envoy proxies, which follows https://tools.ietf.org/html/rfc3986[RFC 3986] with extra normalization to convert backslashes to forward slashes.
+|`/a/../b` is normalized to `/b`. `\da` is normalized to `/da`.
+|This setting is vulnerable to CVE-2021-31920.
+
+| `MERGE_SLASHES`
+| Slashes are merged after the _BASE_ normalization.
+| `/a//b` is normalized to `/a/b`.
+|Update to this setting to mitigate CVE-2021-31920.
+
+|`DECODE_AND_MERGE_SLASHES`
+|The strictest setting when you allow all traffic by default. This setting is recommended, with the caveat that you must thoroughly test your authorization policies routes. https://tools.ietf.org/html/rfc3986#section-2.1[Percent-encoded] slash and backslash characters (`%2F`, `%2f`, `%5C` and `%5c`) are decoded to `/` or `\`, before the `MERGE_SLASHES` normalization.
+|`/a%2fb` is normalized to `/a/b`.
+|Update to this setting to mitigate CVE-2021-31920.  This setting is more secure, but also has the potential to break applications.  Test your applications before deploying to production.
+|====
+
+The normalization algorithms are conducted in the following order:
+
+. Percent-decode `%2F`, `%2f`, `%5C` and `%5c`.
+. The https://tools.ietf.org/html/rfc3986[RFC 3986] and other normalization implemented by the https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path[`normalize_path`] option in Envoy.
+. Merge slashes.
+
+[WARNING]
+====
+While these normalization options represent recommendations from HTTP standards and common industry practices, applications may interpret a URL in any way it chooses to. When using denial policies, ensure that you understand how your application behaves.
+====
+
+=== Path normalization configuration examples
+
+Ensuring Envoy normalizes request paths to match your backend services' expectations is critical to the security of your system.
+The following examples can be used as a reference for you to configure your system.
+The normalized URL paths, or the original URL paths if `NONE` is selected, will be:
+
+. Used to check against the authorization policies.
+. Forwarded to the backend application.
+
+.Configuration examples
+[options="header"]
+[cols="a, a"]
+|====
+|If your application... |Choose...
+|Relies on the proxy to do normalization
+|`BASE`, `MERGE_SLASHES` or `DECODE_AND_MERGE_SLASHES`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986] and does not merge slashes.
+|`BASE`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986] and merges slashes, but does not decode https://tools.ietf.org/html/rfc3986#section-2.1[percent-encoded] slashes.
+|`MERGE_SLASHES`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986], decodes https://tools.ietf.org/html/rfc3986#section-2.1[percent-encoded] slashes, and merges slashes.
+|`DECODE_AND_MERGE_SLASHES`
+
+|Processes request paths in a way that is incompatible with https://tools.ietf.org/html/rfc3986[RFC 3986].
+|`NONE`
+|====
+
+=== Configuring your SMCP for path normalization
+
+To configure path normalization for {ProductName}, specify the following in your `ServiceMeshControlPlane`.  Use the configuration examples to help determine the settings for your system.
+
+.SMCP v1 pathNormalization
+[source,yaml]
+----
+spec:
+  global:
+    pathNormalization: <option>
+----
+
+
 == New features {ProductName} 1.1.13
 
 This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -44,6 +44,168 @@ This release of {ProductName} addresses Common Vulnerabilities and Exposures (CV
 
 This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
+[IMPORTANT]
+====
+There are manual steps that must be completed to address CVE-2021-29492 and CVE-2021-31920.
+====
+
+[id="manual-updates-cve-2021-29492_{context}"]
+=== Manual updates required by CVE-2021-29492 and CVE-2021-31920
+
+Istio contains a remotely exploitable vulnerability where an HTTP request path with multiple slashes or escaped slash characters (``%2F` or ``%5C`) could potentially bypass an Istio authorization policy when path-based authorization rules are used.
+
+For example, assume an Istio cluster administrator defines an authorization DENY policy to reject the request at path `/admin`. A request sent to the URL path `//admin` will NOT be rejected by the authorization policy.
+
+According to https://tools.ietf.org/html/rfc3986#section-6[RFC 3986], the path `//admin` with multiple slashes should technically be treated as a different path from the `/admin`. However, some backend services choose to normalize the URL paths by merging multiple slashes into a single slash. This can result in a bypass of the authorization policy (`//admin` does not match `/admin`), and a user can access the resource at path `/admin` in the backend; this would represent a security incident.
+
+Your cluster is impacted by this vulnerability if you have authorization policies using `ALLOW action + notPaths` field or `DENY action + paths field` patterns. These patterns are vulnerable to unexpected policy bypasses.
+
+Your cluster is NOT impacted by this vulnerability if:
+
+* You don’t have authorization policies.
+* Your authorization policies don’t define `paths` or `notPaths` fields.
+* Your authorization policies use `ALLOW action + paths` field or `DENY action + notPaths` field patterns. These patterns could only cause unexpected rejection instead of policy bypasses. The upgrade is optional for these cases.
+
+[NOTE]
+====
+The {ProductName} configuration location for path normalization is different from the Istio configuration.
+====
+
+=== Updating the path normalization configuration
+
+Istio authorization policies can be based on the URL paths in the HTTP request.
+https://en.wikipedia.org/wiki/URI_normalization[Path normalization], also known as URI normalization, modifies and standardizes the incoming requests' paths so that the normalized paths can be processed in a standard way.
+Syntactically different paths may be equivalent after path normalization.
+
+Istio supports the following normalization schemes on the request paths before evaluating against the authorization policies and routing the requests:
+
+.Normalization schemes
+[options="header"]
+[cols="a, a, a, a"]
+|====
+| Option | Description | Example |Notes
+|`NONE`
+|No normalization is done. Anything received by Envoy will be forwarded exactly as-is to any backend service.
+|`../%2Fa../b` is evaluated by the authorization policies and sent to your service.
+|This setting is vulnerable to CVE-2021-31920.
+
+|`BASE`
+|This is currently the option used in the *default* installation of Istio. This applies the https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path[`normalize_path`] option on Envoy proxies, which follows https://tools.ietf.org/html/rfc3986[RFC 3986] with extra normalization to convert backslashes to forward slashes.
+|`/a/../b` is normalized to `/b`. `\da` is normalized to `/da`.
+|This setting is vulnerable to CVE-2021-31920.
+
+| `MERGE_SLASHES`
+| Slashes are merged after the _BASE_ normalization.
+| `/a//b` is normalized to `/a/b`.
+|Update to this setting to mitigate CVE-2021-31920.
+
+|`DECODE_AND_MERGE_SLASHES`
+|The strictest setting when you allow all traffic by default. This setting is recommended, with the caveat that you must thoroughly test your authorization policies routes. https://tools.ietf.org/html/rfc3986#section-2.1[Percent-encoded] slash and backslash characters (`%2F`, `%2f`, `%5C` and `%5c`) are decoded to `/` or `\`, before the `MERGE_SLASHES` normalization.
+|`/a%2fb` is normalized to `/a/b`.
+|Update to this setting to mitigate CVE-2021-31920.  This setting is more secure, but also has the potential to break applications.  Test your applications before deploying to production.
+|====
+
+The normalization algorithms are conducted in the following order:
+
+. Percent-decode `%2F`, `%2f`, `%5C` and `%5c`.
+. The https://tools.ietf.org/html/rfc3986[RFC 3986] and other normalization implemented by the https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/network/http_connection_manager/v3/http_connection_manager.proto#envoy-v3-api-field-extensions-filters-network-http-connection-manager-v3-httpconnectionmanager-normalize-path[`normalize_path`] option in Envoy.
+. Merge slashes.
+
+[WARNING]
+====
+While these normalization options represent recommendations from HTTP standards and common industry practices, applications may interpret a URL in any way it chooses to. When using denial policies, ensure that you understand how your application behaves.
+====
+
+=== Path normalization configuration examples
+
+Ensuring Envoy normalizes request paths to match your backend services' expectations is critical to the security of your system.
+The following examples can be used as a reference for you to configure your system.
+The normalized URL paths, or the original URL paths if `NONE` is selected, will be:
+
+. Used to check against the authorization policies.
+. Forwarded to the backend application.
+
+.Configuration examples
+[options="header"]
+[cols="a, a"]
+|====
+|If your application... |Choose...
+|Relies on the proxy to do normalization
+|`BASE`, `MERGE_SLASHES` or `DECODE_AND_MERGE_SLASHES`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986] and does not merge slashes.
+|`BASE`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986] and merges slashes, but does not decode https://tools.ietf.org/html/rfc3986#section-2.1[percent-encoded] slashes.
+|`MERGE_SLASHES`
+
+|Normalizes request paths based on https://tools.ietf.org/html/rfc3986[RFC 3986], decodes https://tools.ietf.org/html/rfc3986#section-2.1[percent-encoded] slashes, and merges slashes.
+|`DECODE_AND_MERGE_SLASHES`
+
+|Processes request paths in a way that is incompatible with https://tools.ietf.org/html/rfc3986[RFC 3986].
+|`NONE`
+|====
+
+=== Configuring your SMCP for path normalization
+
+To configure path normalization for {ProductName}, specify the following in your `ServiceMeshControlPlane`.  Use the configuration examples to help determine the settings for your system.
+
+.SMCP v2 pathNormalization
+[source,yaml]
+----
+spec:
+  techPreview:
+    global:
+      pathNormalization: <option>
+----
+
+=== Configuring for case normalization
+
+In some environments, it may be useful to have paths in authorization policies compared in a case insensitive manner.
+For example, treating `https://myurl/get` and `https://myurl/GeT` as equivalent.
+In those cases, you can use the `EnvoyFilter` shown below.
+This filter will change both the path used for comparison and the path presented to the application.
+
+Save the `EnvoyFilter` to a file and execute the following command:
+
+[source,terminal]
+----
+$ oc create -f <myEnvoyFilterFile>
+----
+
+[source,yaml]
+----
+apiVersion: networking.istio.io/v1alpha3
+kind: EnvoyFilter
+metadata:
+  name: ingress-case-insensitive
+  namespace: istio-system
+spec:
+  configPatches:
+  - applyTo: HTTP_FILTER
+    match:
+      context: GATEWAY
+      listener:
+        filterChain:
+          filter:
+            name: "envoy.filters.network.http_connection_manager"
+            subFilter:
+              name: "envoy.filters.http.router"
+    patch:
+      operation: INSERT_BEFORE
+      value:
+        name: envoy.lua
+        typed_config:
+            "@type": "type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua"
+            inlineCode: |
+              function envoy_on_request(request_handle)
+                local path = request_handle:headers():get(":path")
+                request_handle:headers():replace(":path", string.lower(path))
+              end
+
+----
+
+
 == New features {ProductName} 2.0.3
 
 This release of {ProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.


### PR DESCRIPTION
Additional release note content with  information for how to mitigate CVE-2021-29492 and CVE-2021-31920.

I added an additional "notes" column to the table with normalization schemes to add information about recommended settings.  Let me know if there's a better way I could have phrased things, or if something doesn't make sense.

New content appears here ->
https://deploy-preview-32580--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-4 

https://deploy-preview-32580--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v1x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-1-1-14 

Eng review - brian-avery
QE review -gbaufake
Peer review - rolfedh