### PR TITLE
OSDOCS-2183: Added note about how to support a whitelist for multiple IPs or subnets

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -7,6 +7,10 @@
 
 The Ingress Controller can set the default options for all the routes it exposes. An individual route can override some of these defaults by providing specific configurations in its annotations.
 
+[IMPORTANT]
+====
+To create a whitelist with multiple source IPs or subnets, use a space-delimited list. Any other delimiter type causes the list to be ignored without a warning or error message.
+====
 
 //For all the variables outlined in this section, you can set annotations on the
 //*route definition* for the route to alter its configuration.


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2183

Preview: https://deploy-preview-32609--osdocs.netlify.app/openshift-dedicated/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration

Please CP to enterprise-4.3 - 4.8