### PR TITLE
BZ-1953626: Cannot alloc memory SR-IOV

### DIFF
--- a/modules/nw-sriov-troubleshooting.adoc
+++ b/modules/nw-sriov-troubleshooting.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-device.adoc
+
+[id="nw-sriov-troubleshooting_{context}"]
+= Troubleshooting SR-IOV configuration
+
+After following the procedure to configure an SR-IOV network device, the following sections address some error conditions.
+
+To display the state of nodes, run the following command:
+
+[source,terminal]
+----
+$ oc get sriovnetworknodestates -n openshift-sriov-network-operator <node_name>
+----
+
+where: `<node_name>` specifies the name of a node with an SR-IOV network device.
+
+.Error output: Cannot allocate memory
+[source,terminal]
+----
+"lastSyncError": "write /sys/bus/pci/devices/0000:3b:00.1/sriov_numvfs: cannot allocate memory"
+----
+
+When a node indicates that it cannot allocate memory, check the following items:
+
+* Confirm that global SR-IOV settings are enabled in the BIOS for the node.
+
+* Confirm that VT-d is enabled in the BIOS for the node.

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -8,11 +8,17 @@ toc::[]
 You can configure a Single Root I/O Virtualization (SR-IOV) device in your cluster.
 
 include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
+
 // A direct companion to nw-sriov-networknodepolicy-object
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
+
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
+
+include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
+
 :FeatureName: CNI VRF plug-in
 include::modules/technology-preview.adoc[leveloffset=+1]
+
 include::modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc[leveloffset=+1]
 
 [id="configuring-sriov-device-next-steps"]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1953626

The primary goal is to address the specific situation from the BZ--
the BIOS for one node was not configured to enable SR-IOV--
but a secondary goal is to establish a topic that can address
additional issues by adding level-two headings.

Topic "Troubleshooting SR-IOV configuration" is a new topic on the [Configuring an SR-IOV network device](https://deploy-preview-32619--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html) page.

-----
Applies to enterprise-4.6, 4.7, and 4.8 and milestone Next-Release.