### PR TITLE
WMCO-451 - Added Notice of Custom Port Limitations

### DIFF
--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -73,8 +73,13 @@ spec:
         hybridOverlayVXLANPort: 9898 <2>
 ----
 <1> Specify the CIDR configuration used for nodes on the additional overlay network. The `hybridClusterNetwork` CIDR cannot overlap with the `clusterNetwork` CIDR.
-<2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken]. 
+<2> Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
 --
++
+[NOTE]
+====
+Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 is not supported on clusters with a custom `hybridOverlayVXLANPort` value because this Windows server version does not support selecting a custom VXLAN port.
+====
 
 . Save the `cluster-network-03-config.yml` file and quit the text editor.
 . Optional: Back up the `manifests/cluster-network-03-config.yml` file. The


### PR DESCRIPTION
This change address an issue brought up in WMCO-451 - https://github.com/openshift/windows-machine-config-operator/issues/451. For this fix, a note was added to specify that custom VXLAN ports are not supported in the latest version of the Windows Server.

Applies to: WMCO 2.0+/OCP 4.7+

Preview: https://deploy-preview-32620--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations