### PR TITLE
Jira:OSDOCS-2159 Update Cluster audit logging

### DIFF
--- a/modules/rosa-sdpolicy-logging.adoc
+++ b/modules/rosa-sdpolicy-logging.adoc
@@ -7,11 +7,11 @@
 = Logging
 
 
-{product-title} provides optional integrated log forwarding to AWS CloudWatch.
+{product-title} provides optional integrated log forwarding to Amazon (AWS) CloudWatch.
 
 [id="rosa-sdpolicy-cluster-audit-logging_{context}"]
 == Cluster audit logging
-Cluster audit logs are always enabled. Audit logs are streamed to a log aggregation system outside the cluster VPC for automated security analysis and secure retention for 1 year. Red Hat controls the log aggregation system. Customers do not have access. Customers can receive a copy of their cluster's audit logs upon request through a support ticket. Audit log requests must specify a date and time range not to exceed 21 days. When requesting audit logs, customers should be aware that audit logs are many GB per day in size.
+Cluster audit logs are available through AWS CloudWatch, if the integration is enabled. If the integration is not enabled, you can request the audit logs by opening a support case.
 
 [id="rosa-sdpolicy-application-logging_{context}"]
 == Application logging


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/OSDOCS-2159

Direct link to Cluster audit logging section:
https://deploy-preview-32634--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-cluster-audit-logging_rosa-service-definition

Minor update to Logging section:
https://deploy-preview-32634--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-logging_rosa-service-definition