### PR TITLE
BZ1960736: Added warning to not create NetNamespace objects

### DIFF
--- a/modules/nw-egress-ips-automatic.adoc
+++ b/modules/nw-egress-ips-automatic.adoc
@@ -10,8 +10,8 @@ for a specific namespace across one or more nodes.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -46,6 +46,11 @@ $ oc patch netnamespace project2 --type=merge -p \
   '{"egressIPs": ["192.168.1.101"]}'
 ----
 +
+[NOTE]
+====
+Because OpenShift SDN manages the `NetNamespace` object, you can make changes only by modifying the existing `NetNamespace` object. Do not create a new `NetNamespace` object.
+====
+
 . Indicate which nodes can host egress IP addresses by setting the `egressCIDRs`
 parameter for each host using the following JSON:
 +

--- a/modules/nw-egress-ips-static.adoc
+++ b/modules/nw-egress-ips-static.adoc
@@ -9,8 +9,8 @@ In {product-title} you can associate one or more egress IP addresses with a name
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 
@@ -43,6 +43,11 @@ $ oc patch netnamespace project1 --type=merge \
 ----
 +
 To provide high availability, set the `egressIPs` value to two or more IP addresses on different nodes. If multiple egress IP addresses are set, then pods use all egress IP addresses roughly equally.
++
+[NOTE]
+====
+Because OpenShift SDN manages the `NetNamespace` object, you can make changes only by modifying the existing `NetNamespace` object. Do not create a new `NetNamespace` object.
+====
 
 . Manually assign the egress IP to the node hosts. Set the `egressIPs` parameter
 on the `HostSubnet` object on the node host. Using the following JSON, include


### PR DESCRIPTION
This PR:
* fixes [BZ#1960736](https://bugzilla.redhat.com/show_bug.cgi?id=1960736)
* cleans up other prerequisite steps in the assembly
* applies to 4.5+

[Direct preview links here](https://deploy-preview-32639--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-automatic_egress-ips) and [here](https://deploy-preview-32639--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html#nw-egress-ips-static_egress-ips)

Reviews requested:
* SME @danwinship 
* FYI @jboxman 