### PR TITLE
bz1962185 - remove not shipping driver statement

### DIFF
--- a/modules/storage-expanding-csi-volumes.adoc
+++ b/modules/storage-expanding-csi-volumes.adoc
@@ -9,8 +9,5 @@ You can use the Container Storage Interface (CSI) to expand storage volumes afte
 
 {product-title} supports CSI volume expansion by default. However, a specific CSI driver is required.
 
-{product-title} does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by
-link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
-
 {product-title} {product-version} supports version 1.1.0 of the
 link:https://github.com/container-storage-interface/spec[CSI specification].


### PR DESCRIPTION
4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1962185

This PR removes the following statement:
“OpenShift Container Platform does not ship with any CSI drivers. It is recommended to use the CSI drivers provided by community or storage vendors.” 

Because OCP began shipping some CSI drivers in OCP 4.5, this statement is no longer relevant. Note that the support status of current CSI drivers has not changed.

https://deploy-preview-32640--osdocs.netlify.app/openshift-enterprise/latest/storage/expanding-persistent-volumes.html#expanding-csi-volumes_expanding-persistent-volumes

Please ack: @jsafrane, @jhou1 @sferich888 @xltian @vikram-redhat 