### PR TITLE
CNV-6897 Added note about support for dual-stack services

### DIFF
--- a/modules/virt-creating-a-service-from-a-virtual-machine.adoc
+++ b/modules/virt-creating-a-service-from-a-virtual-machine.adoc
@@ -8,6 +8,26 @@
 
 Create a service from a running virtual machine by first creating a `Service` object to expose the virtual machine.
 
+[NOTE]
+====
+If IPv4 and IPv6 dual-stack networking is enabled for your cluster, you can create a service that uses IPv4, IPv6, or both, by defining the `spec.ipFamilyPolicy` and the `spec.ipFamilies` fields in the `Service` object.
+
+The `spec.ipFamilyPolicy` field can be set to one of the following values:
+
+* `SingleStack`: The control plane assigns a cluster IP address for the service based on the first configured service cluster IP range.
+
+* `PreferDualStack`: The control plane assigns both IPv4 and IPv6 cluster IP addresses for the service on clusters that have dual-stack configured.
+
+* `RequireDualStack`: This option fails for clusters that do not have dual-stack networking enabled. For clusters that have dual-stack configured, the behavior is the same as when the value is set to `PreferDualStack`. The control plane allocates cluster IP addresses from both IPv4 and IPv6 address ranges.
+
+You can define which IP family to use for single-stack or define the order of IP families for dual-stack by setting the `spec.ipFamilies` field to one of the following array values:
+
+* `[IPv4]`
+* `[IPv6]`
+* `[IPv4, IPv6]`
+* `[IPv6, IPv4]`
+====
+
 The `ClusterIP` service type exposes the virtual machine internally, within the cluster. The `NodePort` or `LoadBalancer` service types expose the virtual machine externally, outside of the cluster.
 
 This procedure presents an example of how to create, connect to, and expose a `Service` object of `type: ClusterIP` as a virtual machine-backed service.

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -31,3 +31,5 @@ include::modules/virt-template-windows-vmi.adoc[leveloffset=+2]
 include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset=+1]
 .Additional resources
 * xref:../../../networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc#configuring-externalip[Configuring external IPs]
+
+* xref:../../../rest_api/network_apis/service-core-v1.adoc#service-core-v1[Service API specification]


### PR DESCRIPTION
This PR addresses [CNV-6897](https://issues.redhat.com/browse/CNV-6897)

Added a note to the Creating a Service from a VM module that dual-stack services are supported if the underlying cluster has dual-stack enabled.

Applies to enterprise-4.8

Preview build: https://deploy-preview-32642--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt