### PR TITLE
[enterprise-4.6] Fixing GitHub issue #29538 - Resolving merge conflict for enterprise-4.6

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -17,6 +17,8 @@ xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installin
 In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
 ====
 
+* Shared storage is required to enable live migration.
+
 * You must manage your Compute nodes according to the number and size of the virtual machines that you want to host in the cluster.
 
 * To deploy {VirtProductName} in a disconnected environment, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[configure Operator Lifecycle Manager on restricted networks].


### PR DESCRIPTION
Conflicts:
	virt/install/preparing-cluster-for-virt.adoc

Cherry Picked from 64faaacd6a369287aea11dd5f522baed63cd6e6e xref: https://github.com/openshift/openshift-docs/pull/32289

Merge conflict resolved for enterprise-4.6

@sjhala-ccs if you can check and merge, that would be great. Thanks.