### PR TITLE
BZ1860543 Add warning that redeployment playbooks might fail

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -223,6 +223,11 @@ $ jq '.summary.warning,.summary.expired' $HOME/cert-expiry-report.yyyymmddTHHMMS
 [[redeploy-certificates]]
 == Redeploying Certificates
 
+[WARNING]
+====
+Redeployment playbooks restart control plane services and might cause cluster downtime. An error in one service can cause a playbook to fail and affect cluster health. If a playbook fails, you might need to resolve problems manually and restart the playbook. A playbook must finish all tasks sequentially to succeed.
+====
+
 Use the following playbooks to redeploy master, etcd, node, registry, and router
 certificates on all relevant hosts. You can redeploy all of them at once using
 the current CA, redeploy certificates for specific components only, or redeploy


### PR DESCRIPTION
For 3.11: 
https://bugzilla.redhat.com/show_bug.cgi?id=1860543

Direct link to doc preview: https://deploy-preview-32646--osdocs.netlify.app/openshift-enterprise/latest/install_config/redeploying_certificates.html#redeploy-certificates

