### PR TITLE
FIPS is only supported on x86_64

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Starting with version 4.3, you can install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries.
+You can install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture.
 
 For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines. These configuration methods ensure that your cluster meet the requirements of a FIPS compliance audit: only FIPS Validated / Modules in Process cryptography packages are enabled before the initial system boot.
 
@@ -36,6 +36,9 @@ Because FIPS must be enabled before the operating system that your cluster uses 
 
 |Use of FIPS compatible golang compiler.
 |TLS FIPS support is not complete but is planned for future {product-title} releases.
+
+|FIPS support across multiple architectures.
+|FIPS is currently only supported on {product-title} deployments using the `x86_64` architecture.
 
 |===
 

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -68,6 +68,12 @@ If you need to deploy your cluster to an xref:../installing/installing_aws/insta
 
 ifndef::openshift-origin[]
 You can also configure the cluster machines to use xref:../installing/installing-fips.adoc#installing-fips[FIPS Validated / Modules in Process cryptographic libraries] during installation.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+
 endif::[]
 
 [id="installing-preparing-cluster-for-users"]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -242,6 +242,11 @@ host must trust the certificate.
 <10> The ID of your existing Route 53 private hosted zone. Providing an existing hosted zone requires that you supply your own VPC and the hosted zone is already associated with the VPC prior to installing your cluster. If undefined, the installation program creates a new hosted zone.
 ifndef::openshift-origin[]
 <11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <12> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.
 endif::openshift-origin[]
@@ -258,6 +263,11 @@ an unknown AWS region. The endpoint URL must use the `https` protocol and the
 host must trust the certificate.
 ifndef::openshift-origin[]
 <9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <10> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -101,10 +101,10 @@ endif::private,gov[]
 ifdef::private,gov[]
     outboundType: UserDefinedRouting <13>
 endif::private,gov[]
-ifndef::gov[] 
+ifndef::gov[]
     cloudName: AzurePublicCloud
 endif::gov[]
-ifdef::gov[]    
+ifdef::gov[]
     cloudName: AzureUSGovernmentCloud <14>
 endif::gov[]
 pullSecret: '{"auths": ...}' <1>
@@ -200,6 +200,11 @@ endif::gov[]
 ifdef::vnet[]
 ifndef::openshift-origin[]
 <13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -209,6 +214,11 @@ endif::vnet[]
 ifdef::private[]
 ifndef::openshift-origin[]
 <14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <15> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -218,6 +228,11 @@ endif::private[]
 ifdef::gov[]
 ifndef::openshift-origin[]
 <15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <16> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -227,6 +242,11 @@ endif::gov[]
 ifndef::vnet,private,gov[]
 ifndef::openshift-origin[]
 <9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -238,6 +238,11 @@ ifdef::ibm-power[IBM Power Systems infrastructure.]
 ifdef::rhv[RHV infrastructure.]
 ifndef::openshift-origin[]
 <11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 endif::openshift-origin[]
 ifndef::restricted[]
 <12> The pull secret that you obtained from the

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -272,6 +272,10 @@ Not all CCO modes are supported for all cloud providers. For more information on
 ifndef::openshift-origin[]
 |`fips`
 |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 [NOTE]
 ====
 If you are using Azure File storage, you cannot enable FIPS mode.

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -196,6 +196,11 @@ endif::restricted[]
 ifdef::vpc[]
 ifndef::openshift-origin[]
 <9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -205,6 +210,11 @@ endif::vpc[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
 <10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -214,6 +224,11 @@ endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
 <6> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -76,10 +76,15 @@ endif::openshift-origin[]
 ====
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
-<5> Specify the main project where the VM instances reside. 
+<5> Specify the main project where the VM instances reside.
 <6> Specify the region that your VPC network is in.
 ifndef::openshift-origin[]
 <7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 <8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -141,6 +141,11 @@ in vSphere.
 <12> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster, omit this parameter.
 ifndef::openshift-origin[]
 <13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -43,6 +43,11 @@ The kinds of components that MCO can change include:
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.
 ifndef::openshift-origin[]
 * **fips**: Enable link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#using-the-system-wide-cryptographic-policies_security-hardening[FIPS] mode. FIPS should be set at installation-time setting and not a post-installation procedure.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 endif::openshift-origin[]
 * **extensions**: Extend {op-system} features by adding selected pre-packaged software. For this feature, available extensions include link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#protecting-systems-against-intrusive-usb-devices_security-hardening[usbguard] and kernel modules.
 * **Custom resources (for `ContainerRuntime` and `Kubelet`)**: Outside of machine configs, MCO manages two special custom resources for modifying CRI-O container runtime settings (`ContainerRuntime` CR) and the Kubelet service (`Kubelet` CR).

--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -31,6 +31,11 @@ The following table lists Operator metadata annotations that can be manually def
 - `cni`: Operator provides a Container Network Interface (CNI) Kubernetes plug-in.
 - `csi`: Operator provides a Container Storage Interface (CSI) Kubernetes plug-in.
 - `fips`: Operator accepts the FIPS mode of the underlying platform and works on nodes that are booted into FIPS mode.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 - `proxy-aware`: Operator supports running on a cluster behind a proxy. Operator accepts the standard proxy environment variables  `HTTP_PROXY` and `HTTPS_PROXY`, which Operator Lifecycle Manager (OLM) provides to the Operator automatically when the cluster is configured to use a proxy. Required environment variables are passed down to Operands for managed workloads.
 
 |`operators.openshift.io/valid-subscription`

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -30,6 +30,11 @@ In addition, you must not upgrade your compute machines to {op-system-base} 8 be
 For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
 ====
 ** If you deployed {product-title} in FIPS mode, you must enable FIPS on the {op-system-base} machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/chap-federal_standards_and_regulations#sec-Enabling-FIPS-Mode[Enabling FIPS Mode] in the {op-system-base} 7 documentation.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
 endif::[]
 ** NetworkManager 1.0 or later.
 ** 1 vCPU.

--- a/modules/security-compliance-nist.adoc
+++ b/modules/security-compliance-nist.adoc
@@ -5,11 +5,16 @@
 [id="security-compliance-nist_{context}"]
 = Understanding compliance and risk management
 
-ifndef::openshift-origin[] 
+ifndef::openshift-origin[]
 FIPS compliance is one of the most critical components required in
 highly secure environments, to ensure that only supported cryptographic
-technologies are allowed on nodes. 
-endif::openshift-origin[] 
+technologies are allowed on nodes.
+
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+endif::openshift-origin[]
 
 To understand Red Hat's view of {product-title} compliance frameworks, refer
 to the Risk Management and Regulatory Readiness chapter of the


### PR DESCRIPTION
When discussing BZ#1955621 with the OCP Multi Arch team, it was
pointed out that using FIPS is only supported on `x86_64`
deployments of OCP.

We lacked this restriction in our docs, so this attempts to add it in
the right places for the docs.

See:  https://bugzilla.redhat.com/show_bug.cgi?id=1955621
See:  https://issues.redhat.com/browse/MULTIARCH-690