### PR TITLE
BZ1958300: Correct a misnamed state from the list of supported reigions.

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -27,6 +27,6 @@ regions:
 * `southamerica-east1` (São Paulo, Brazil)
 * `us-central1` (Council Bluffs, Iowa, USA)
 * `us-east1` (Moncks Corner, South Carolina, USA)
-* `us-east4` (Ashburn, Northern Virginia, USA)
+* `us-east4` (Ashburn, Virginia, USA)
 * `us-west1` (The Dalles, Oregon, USA)
 * `us-west2` (Los Angeles, California, USA)


### PR DESCRIPTION
This ticket corrects the incorrect name of Virginia from the list of the supported regions in GCP.

Version: OCP 4.6+

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1958300

Preview: https://deploy-preview-32649--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account