### PR TITLE
[enterprise-4.5]Recommendation around master node sizing to handle upgrades

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -26,9 +26,21 @@ The control plane node resource requirements depend on the number of nodes in th
 
 |===
 
+On a cluster with three masters or control plane nodes, the CPU and memory usage will spike up when one of the nodes is stopped, rebooted or fails because the remaining two nodes must handle the load in order to be highly available. This is also expected during upgrades because the masters are cordoned, drained, and rebooted serially to apply the operating system updates, as well as the the control plane Operators update. To avoid cascading failures on large and dense clusters, keep the overall resource usage on the master nodes to at least half of all available capacity to handle the resource usage spikes. Increase the CPU and memory on the master nodes accordingly.
+
+[IMPORTANT]
+====
+The node sizing varies depending on the number of nodes and object counts in the cluster. It also depends on whether the objects are actively being created on the cluster. During object creation, the control plane is more active in terms of resource usage compared to when the objects are in the `running` phase.
+====
+
 [IMPORTANT]
 ====
 Because you cannot modify the control plane node size in a running {product-title} {product-version} cluster, you must estimate your total node count and use the suggested control plane node size during installation.
+====
+
+[IMPORTANT]
+====
+The recommendations are based on the data points captured on {product-title} clusters with OpenShiftSDN as the network plug-in.
 ====
 
 [NOTE]


### PR DESCRIPTION
This commit:
- Adds a recommendation around master node sizing to handle upgrades and
  failures on large and dense clusters as the resource usage is expected
  to increase in such situations.
- Adds a note that the data points are only valid for OpenShift clusters
  using OpenShiftSDN as the network plugin.

Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/32230