### PR TITLE
RHDEVDOCS-3019 Doc issue from bz#1776636: Couldn't display the pod logs

### DIFF
--- a/modules/cluster-logging-visualizer-indices.adoc
+++ b/modules/cluster-logging-visualizer-indices.adoc
@@ -31,6 +31,8 @@ The audit logs are not stored in the internal {product-title} Elasticsearch inst
 
 * Elasticsearch documents must be indexed before you can create index patterns. This is done automatically, but it might take a few minutes in a new or updated cluster.
 
+* Check that the index is set to *.all*. If the index is not set to *.all*, only the OpenShift system logs will be listed.
+
 .Procedure
 
 To define index patterns and create visualizations in Kibana:


### PR DESCRIPTION
Doc issue from bz#1776636: Couldn't display the pod logs if the log 
isn't in the default kibana pattern

- Aligned team: Dev Tools
- For branches: 4.5-4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3019
- Direct link to doc preview: https://deploy-preview-32672--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-visualizer.html#cluster-logging-visualizer-indices_cluster-logging-visualizer
- SME review: Requested review by @lukas-vlcek
- QE review:  Approved by @anpingli 
- Peer review: Will request
- <Please merge now>