### PR TITLE
BZ1869398: added a missing callout for code

### DIFF
--- a/modules/installation-creating-gcp-bootstrap.adoc
+++ b/modules/installation-creating-gcp-bootstrap.adoc
@@ -93,7 +93,8 @@ EOF
 <5> `control_subnet` is the `selfLink` URL to the control subnet.
 <6> `image` is the `selfLink` URL to the {op-system} image.
 <7> `machine_type` is the machine type of the instance, for example `n1-standard-4`.
-<8> `bootstrap_ign` is the URL output when creating a signed URL above.
+<8> `root_volume_size` is the boot disk size for the bootstrap machine.
+<9> `bootstrap_ign` is the URL output when creating a signed URL.
 
 . Create the deployment by using the `gcloud` CLI:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1869398

for 4.5+

Preview: 
https://deploy-preview-32684--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-bootstrap_installing-gcp-user-infra
