### PR TITLE
Content for TELCODOCS-115

### DIFF
--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -1,11 +1,21 @@
 // This is included in the following assemblies:
 //
-// ipi-install-post-installation-configuration.adoc
-[id='configuring-ntp-for-disconnected-clusters_{context}']
+// installing/installing_bare_metal_ipi/ipi-install-configuration-files
+// installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+[id="configuring-ntp-for-disconnected-clusters_{context}"]
 
-= Configuring NTP for disconnected clusters
+= Configuring NTP for disconnected clusters (optional)
 
-{product-title} installs the `chrony` Network Time Protocol (NTP) service on the cluster nodes. After successfully deploying an installer-provisioned disconnected cluster, configure NTP servers on the control plane nodes, and configure worker nodes as NTP clients of the control plane nodes.
+//This procedure can be executed as a day 1 or day 2 operation with minor differences.
+//The conditional text picks up the context and displays the appropriate alternate steps.
+
+{product-title} installs the `chrony` Network Time Protocol (NTP) service on the cluster nodes.
+ifeval::["{context}" == "ipi-install-configuration-files"]
+Use the following procedure to configure NTP servers on the control plane nodes and configure worker nodes as NTP clients of the control plane nodes before deployment.
+endif::[]
+ifeval::["{context}" == "ipi-install-post-installation-configuration"]
+Use the following procedure to configure NTP servers on the control plane nodes and configure worker nodes as NTP clients of the control plane nodes after a successful deployment.
+endif::[]
 
 image::152_OpenShift_Config_NTP_0421.svg[Configuring NTP for disconnected clusters]
 
@@ -15,13 +25,13 @@ image::152_OpenShift_Config_NTP_0421.svg[Configuring NTP for disconnected cluste
 
 . Create a `~/control-plane-chrony.conf` configuration file for the control plane nodes.
 +
-[source,bash]
+[source,terminal]
 .Configuration file example
 ----
 # Use public servers from the pool.ntp.org project.
 # Please consider joining the pool (https://www.pool.ntp.org/join.html).
 
-# This file is managed by the machine config operator
+# The Machine Config Operator manages this file
 server openshift-master-0.<cluster-name>.<domain> iburst <1>
 server openshift-master-1.<cluster-name>.<domain> iburst
 server openshift-master-2.<cluster-name>.<domain> iburst
@@ -49,16 +59,14 @@ allow all
 local stratum 3 orphan
 ----
 +
-Where:
-+
 <1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
 
 . Create a `~/worker-chrony.conf` configuration file for the worker nodes such that worker nodes reference the NTP servers on the control plane nodes.
 +
-[source,bash]
+[source,terminal]
 .Configuration file example
 ----
-# This file is managed by the machine config operator
+# The Machine Config Operator manages this file.
 server openshift-master-0.<cluster-name>.<domain> iburst <1>
 server openshift-master-1.<cluster-name>.<domain> iburst
 server openshift-master-2.<cluster-name>.<domain> iburst
@@ -77,13 +85,11 @@ logchange 0.5
 logdir /var/log/chrony
 ----
 +
-Where:
-+
 <1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
 
 . Create a `~/ntp-server.yaml` configuration file for telling the Machine Configuration Operator to apply the `~/control-plane-chrony.conf` settings to the NTP servers on the control plane nodes.
 +
-[source,bash]
+[source,terminal]
 .Configuration file example
 ----
 # This example MachineConfig replaces ~/control-plane-chrony.conf
@@ -106,18 +112,16 @@ spec:
           path: /etc/control-plane-chrony.conf
 ----
 +
-Where:
-+
 <1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64-encoded string of the `~/control-plane-chrony.conf` file in the subsequent step.
 
 . Generate a base64 string of the `~/control-plane-chrony.conf` file.
 +
-[source,bash]
+[source,terminal]
 ----
 $ base64 ~/control-plane-chrony.conf
 ----
 +
-[source,bash]
+[source,terminal]
 .Example output
 ----
 IyBVc2UgcHVibGljIHNlcnZlcnMgZnJvbSB0aGUgcG9vbC5udHAub3JnIHByb2plY3QuCiMgUGxl
@@ -140,22 +144,9 @@ IG9ycGhhbgo=
 +
 Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-server.yaml` with the base64-encoded string.
 
-. Apply the `ntp-server.yaml` policy to the control plane nodes.
-+
-[source,bash]
-----
-$ oc apply -f ~/ntp-server.yaml
-----
-+
-[source,bash]
-.Example output
-----
-machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-server created
-----
-
 . Create a `~/ntp-client.yaml` configuration file for telling the Machine Configuration Operator to apply the `~/worker-chrony.conf` settings to the NTP clients on the worker nodes.
 +
-[source,bash]
+[source,terminal]
 .Configuration file example
 ----
 # This example MachineConfig replaces ~/worker-chrony.conf
@@ -178,19 +169,17 @@ spec:
           path: /etc/worker-chrony.conf
 ----
 +
-Where:
-+
 <1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64-encoded string of the `~/worker-chrony.conf` file in the subsequent step.
 
 
 . Generate a base64-encoded string of the `~/worker-chrony.conf` file.
 +
-[source,bash]
+[source,terminal]
 ----
 $ base64 ~/worker-chrony.conf
 ----
 +
-[source,bash]
+[source,terminal]
 .Example output
 ----
 IyBUaGlzIGZpbGUgaXMgbWFuYWdlZCBieSB0aGUgbWFjaGluZSBjb25maWcgb3BlcmF0b3IKc2Vy
@@ -205,15 +194,42 @@ Y2xpZW50bG9nCmxvZ2NoYW5nZSAwLjUKbG9nZGlyIC92YXIvbG9nL2Nocm9ueQo=
 +
 Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-client.yaml` file with the base64-encoded string.
 
+ifeval::["{context}" == "ipi-install-configuration-files"]
+. Copy the `~/ntp-server.yaml` file to the `~/clusterconfigs/manifests` directory.
++
+----
+$ cp ~/ntp-server.yaml ~/clusterconfigs/manifests
+----
+
+. Copy the `~/ntp-client.yaml` file to the `~/clusterconfigs/manifests` directory.
++
+----
+$ cp ~/ntp-client.yaml ~/clusterconfigs/manifests
+----
+endif::[]
+
+ifeval::["{context}" == "ipi-install-post-installation-configuration"]
+. Apply the `ntp-server.yaml` policy to the control plane nodes.
++
+[source,terminal]
+----
+$ oc apply -f ~/ntp-server.yaml
+----
++
+[source,terminal]
+.Example output
+----
+machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-server created
+----
 
 . Apply the `~/ntp-client.yaml` policy to the worker nodes.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc apply -f ~/worker-chrony.conf
 ----
 +
-[source,bash]
+[source,terminal]
 .Example output
 ----
 machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-worker created
@@ -221,7 +237,8 @@ machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-overri
 
 . Check the status of the applied NTP settings.
 +
-[source,bash]
+[source,terminal]
 ----
 $ oc describe machineconfigpool
 ----
+endif::[]


### PR DESCRIPTION
This change creates a day 1 operation and updates the module so that it can support both day 1 and day 2 operations.

Fixes: [TELCODOCS-115](https://issues.redhat.com/browse/TELCODOCS-115)

See https://issues.redhat.com/browse/TELCODOCS-115 for additional details.
@abhatt-rh @ahardin-rh 

Signed-off-by: John Wilkins <jowilkin@redhat.com>

Preview build: https://deploy-preview-32687--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.html#configuring-ntp-for-disconnected-clusters_ipi-install-post-installation-configuration