### PR TITLE
[srvls][SRVKE-788] Add additional Kafka SASL docs

### DIFF
--- a/modules/serverless-kafka-sasl-public-certs.adoc
+++ b/modules/serverless-kafka-sasl-public-certs.adoc
@@ -1,0 +1,21 @@
+// Module is included in the following assemblies:
+//
+// serverless/event_workflows/serverless-kafka.adoc
+
+[id="serverless-kafka-sasl-public-certs_{context}"]
+= Configuring SASL authentication using public CA certificates
+
+If you want to use SASL with public CA certificates, you must use the `tls.enabled=true` flag, rather than the `ca.crt` argument, when creating the secret. For example:
+
+[source,terminal]
+----
+$ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-literal=tls.enabled=true \
+  --from-literal=password="SecretPassword" \
+  --from-literal=saslType="SCRAM-SHA-512" \
+  --from-literal=user="my-sasl-user"
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kafka-sasl.adoc
+++ b/modules/serverless-kafka-sasl.adoc
@@ -2,7 +2,7 @@
 //
 // serverless/event_workflows/serverless-kafka.adoc
 
-[id="serverless-configuring-sasl-authentication-against-an-apache-kafka_{context}"]
+[id="serverless-kafka-sasl_{context}"]
 = Configuring SASL authentication
 
 .Prerequisites
@@ -22,7 +22,7 @@ Red Hat recommends to enable TLS in addition to SASL.
 +
 [source,terminal]
 ----
-$ kubectl create secret --namespace <namespace> generic <kafka_auth_secret> \
+$ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
   --from-file=ca.crt=caroot.pem \
   --from-literal=password="SecretPassword" \
   --from-literal=saslType="SCRAM-SHA-512" \
@@ -43,7 +43,7 @@ $ oc edit knativekafka
 
 . Reference your secret and the namespace of the secret:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
 kind: KnativeKafka
@@ -67,7 +67,7 @@ Make sure to specify the matching port in the bootstrap server.
 +
 For example:
 +
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operator.serverless.openshift.io/v1alpha1
 kind: KnativeKafka

--- a/serverless/event_workflows/serverless-kafka.adoc
+++ b/serverless/event_workflows/serverless-kafka.adoc
@@ -61,3 +61,4 @@ If you choose to enable SASL, Red Hat recommends to also enable TLS.
 
 include::modules/serverless-kafka-tls.adoc[leveloffset=+2]
 include::modules/serverless-kafka-sasl.adoc[leveloffset=+2]
+include::modules/serverless-kafka-sasl-public-certs.adoc[leveloffset=+2]


### PR DESCRIPTION
Applies for 4.6+

New content preview link: https://deploy-preview-32689--osdocs.netlify.app/openshift-enterprise/latest/serverless/event_workflows/serverless-kafka.html#serverless-kafka-sasl-public-certs_serverless-kafka