### PR TITLE
BZ-1944001: specifying node-ip through MCO

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -452,6 +452,9 @@ Topics:
   - Name: Troubleshooting operating system issues
     File: troubleshooting-operating-system-issues
     Distros: openshift-enterprise,openshift-origin
+  - Name: Troubleshooting network issues
+    File: troubleshooting-network-issues
+    Distros: openshift-enterprise,openshift-origin
   - Name: Troubleshooting Operator issues
     File: troubleshooting-operator-issues
   - Name: Investigating pod issues

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -24,7 +24,7 @@ a machine config that is injected directly into the {product-title} installer pr
 
 * Manual changes to nodes are strongly discouraged. If you need to decommission a node and start a new one, those direct changes would be lost.
 
-* MCO is only supported for writing to files in `/etc` and `/var` directories, although there are symbolic links to some directories that can be writeable by being symbolically linked to one of those areas. The `/opt` directory is an example.
+* MCO is only supported for writing to files in `/etc` and `/var` directories, although there are symbolic links to some directories that can be writeable by being symbolically linked to one of those areas. The `/opt` and `/usr/local` directories are examples.
 
 * Ignition is the configuration format used in MachineConfigs. See the link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition Configuration Specification v3.2.0] for details.
 

--- a/modules/nw-how-nw-iface-selected.adoc
+++ b/modules/nw-how-nw-iface-selected.adoc
@@ -1,0 +1,78 @@
+// Applies to 4.6 and newer.
+
+:ign-config-version: 3.1.0
+ifeval::[{product-version} > 4.6]
+:ign-config-version: 3.2.0
+endif::[]
+
+[id="nw-how-nw-iface-selected_{context}"]
+= How the network interface is selected
+
+For installations on bare metal or with virtual machines that have more than one network interface controller (NIC), the NIC that {product-title} uses for communication with the Kubernetes API server is determined by the `nodeip-configuration.service` service unit that is run by systemd when the node boots.
+The service iterates through the network interfaces on the node and the first network interface that is configured with a subnet than can host the IP address for the API server is selected for {product-title} communication.
+
+After the `nodeip-configuration.service` service determines the correct NIC, the service creates the `/etc/systemd/system/kubelet.service.d/20-nodenet.conf` file.
+The `20-nodenet.conf` file sets the `KUBELET_NODE_IP` environment variable to the IP address that the service selected.
+
+When the kubelet service starts, it reads the value of the environment variable from the `20-nodenet.conf` file and sets the IP address as the value to the `--node-ip` kubelet command-line argument.
+As a result, the kubelet service uses the selected IP address as the node IP address.
+
+If hardware or networking is reconfigured after installation, it is possible that the `nodeip-configuration.service` service can select a different NIC after a reboot.
+In some cases, you might be able to detect that a different NIC is selected by reviewing the `INTERNAL-IP` column in the output from the `oc get nodes -o wide` command.
+
+If network communication is disrupted or misconfigured because a different NIC is selected, one strategy for overriding the selection process is to set the correct IP address explicitly.
+The following list identifies the high-level steps and considerations:
+
+* Create a shell script that determines the IP address to use for {product-title} communication. Have the script create a custom unit file such as `/etc/systemd/system/kubelet.service.d/98-nodenet-override.conf`. Use the custom unit file, `98-nodenet-override.conf`, to set the `KUBELET_NODE_IP` environment variable to the IP address.
+
+* Do not overwrite the `/etc/systemd/system/kubelet.service.d/20-nodenet.conf` file. Specify a file name with a numerically higher value such as `98-nodenet-override.conf` in the same directory path. The goal is to have the custom unit file run after `20-nodenet.conf` and override the value of the environment variable.
+
+* Create a machine config object with the shell script as a base64-encoded string and use the Machine Config Operator to deploy the script to the nodes at a file system path such as `/usr/local/bin/override-node-ip.sh`.
+
+* Ensure that `systemctl daemon-reload` runs after the shell script runs. The simplest method is to specify `ExecStart=systemctl daemon-reload` in the machine config, as shown in the following sample.
+
+.Sample machine config to override the network interface for kubelet
+[source,yaml,subs="attributes+"]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+     machineconfiguration.openshift.io/role: worker
+  name: 98-nodenet-override
+spec:
+  config:
+    ignition:
+      version: {ign-config-version}
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<encoded_script>
+        mode: 0755
+        overwrite: true
+        path: /usr/local/bin/override-node-ip.sh
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Override node IP detection
+          Wants=network-online.target
+          Before=kubelet.service
+          After=network-online.target
+          [Service]
+          Type=oneshot
+          ExecStart=/usr/local/bin/override-node-ip.sh
+          ExecStart=systemctl daemon-reload
+          [Install]
+          WantedBy=multi-user.target
+        enabled: true
+        name: nodenet-override.service
+
+----
+
+// Link to info for creating a machine config.
+
+// Clear temporary attributes
+ifdef::ign-config-version[]
+:!ign-config-version:
+endif::[]

--- a/support/troubleshooting/troubleshooting-network-issues.adoc
+++ b/support/troubleshooting/troubleshooting-network-issues.adoc
@@ -1,0 +1,9 @@
+[id="troubleshooting-network-issues"]
+= Troubleshooting network issues
+include::modules/common-attributes.adoc[]
+:context: troubleshooting-network-issues
+
+toc::[]
+
+// How the network interface is selected
+include::modules/nw-how-nw-iface-selected.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1944001

The draft location for this content might change after review by colleagues.  For the draft, it is in the Support > Troubleshooting > [Troubleshooting network issues](https://deploy-preview-32693--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-network-issues.html) section that is newly created for this BZ.

/hold

----
Applies to branches enterprise-4.6, 4.7, and 4.8 and milestone Next-Release.