### PR TITLE
SRVCOM-1249: Add the Serverless 1.15.0 release notes

### DIFF
--- a/modules/knative-service-cluster-local.adoc
+++ b/modules/knative-service-cluster-local.adoc
@@ -12,16 +12,21 @@ Publicly accessible URLs are accessible from outside of the cluster.
 However, developers may need to build back-end services that are only be accessible from inside the cluster, known as _private services_.
 // Cluster administrators can configure private services for the cluster so that all services are private by default.
 // Need to add additional details about editing the configmap for admins
-Developers can label individual services in the cluster with the `serving.knative.dev/visibility=cluster-local` label to make them private.
+Developers can label individual services in the cluster with the `networking.knative.dev/visibility=cluster-local` label to make them private.
+
+[IMPORTANT]
+====
+For {ServerlessProductName} 1.15.0 and newer versions, the `serving.knative.dev/visibility` label is no longer available. You must update existing services to use the `networking.knative.dev/visibility` label instead.
+====
 
 .Procedure
 
-* Set the visibility for your service by adding the `serving.knative.dev/visibility=cluster-local` label:
+* Set the visibility for your service by adding the `networking.knative.dev/visibility=cluster-local` label:
 +
 
 [source,terminal]
 ----
-$ oc label ksvc <service_name> serving.knative.dev/visibility=cluster-local
+$ oc label ksvc <service_name> networking.knative.dev/visibility=cluster-local
 ----
 
 .Verification

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * serverless/release-notes.adoc
+
+[id="serverless-rn-1-15-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.15.0
+
+[id="new-features-1.15.0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.21.0.
+* {ServerlessProductName} now uses Knative Eventing 0.21.0.
+* {ServerlessProductName} now uses Kourier 0.21.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.21.0.
+* {ServerlessProductName} now uses Knative Kafka 0.21.1.
+
+[IMPORTANT]
+====
+The `serving.knative.dev/visibility` label, which was previously used to create private services, is now deprecated. You must update existing services to use the `networking.knative.dev/visibility` label instead.
+====

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -9,6 +9,7 @@ toc::[]
 For an overview of {ServerlessProductName} functionality, see xref:../serverless/serverless-getting-started.adoc#serverless-getting-started[Getting started with OpenShift Serverless].
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-15-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-14-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-13-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-12-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Add the release notes for Serverless 1.15.0

For versions 4.6+

https://issues.redhat.com/browse/SRVCOM-1249

Preview: https://deploy-preview-32700--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes?utm_source=github&utm_campaign=bot_dp#serverless-rn-1-15-0_serverless-release-notes
https://deploy-preview-32700--osdocs.netlify.app/openshift-enterprise/latest/serverless/networking/serverless-ossm-custom-domains.html#knative-service-cluster-local_serverless-ossm-custom-domains