### PR TITLE
Added Cluster Loader deprecation notice

### DIFF
--- a/scalability_and_performance/using-cluster-loader.adoc
+++ b/scalability_and_performance/using-cluster-loader.adoc
@@ -7,6 +7,11 @@ toc::[]
 
 Cluster Loader is a tool that deploys large numbers of various objects to a cluster, which creates user-defined cluster objects. Build, configure, and run Cluster Loader to measure performance metrics of your {product-title} deployment at various cluster states.
 
+[IMPORTANT]
+====
+Cluster Loader is now deprecated and will be removed in a future release.
+====
+
 include::modules/installing-cluster-loader.adoc[leveloffset=+1]
 
 include::modules/running-cluster-loader.adoc[leveloffset=+1]


### PR DESCRIPTION
Preview build: https://deploy-preview-32703--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-features

https://issues.redhat.com/browse/PERFSCALE-1037
https://issues.redhat.com/browse/OSDOCS-2141

Related to https://github.com/openshift/openshift-docs/pull/32034

This will be released in 4,8 and backported to earlier versions