### PR TITLE
Updated 4.8 RNs regarding Cluster Loader deprecation

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -323,6 +323,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
+|Cluster Loader
+|GA
+|GA
+|DEP
+
 |====
 
 [id="ocp-4-8-deprecated-features"]
@@ -337,6 +342,11 @@ The `operator.openshift.io/v1beta1` API group for the descheduler is deprecated 
 ==== Use of dhclient in {op-system-first} is deprecated
 
 Starting with {product-title} 4.6, {op-system-first} switched to using `NetworkManager` in the `initramfs` to configure networking during early boot. As part of this change, the use of the `dhclient` binary for DHCP was deprecated. Use the `NetworkManager` internal DHCP client for networking configuration instead. The `dhclient` binary will be removed from {op-system-first} in a future release. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1908462[BZ#1908462] for more information.
+
+[id="ocp-4-8-cluster-loader-deprecated"]
+==== Cluster Loader is deprecated
+
+Cluster Loader is now deprecated and will be removed in a future release.
 
 [id="ocp-4-8-removed-features"]
 === Removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/PERFSCALE-1037
https://issues.redhat.com/browse/OSDOCS-2141

Related to https://github.com/openshift/openshift-docs/pull/32702

Preview build: https://deploy-preview-32703--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-removed-features