### PR TITLE
_templates/_page_openshift.html.erb changes to fix the sidebar, breadcrumb, and navbar

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -4,11 +4,7 @@ nav#main {
 
 .navbar.navbar-default.navbar-openshift.navbar-origin {
   background:
-    linear-gradient(
-      rgba(0, 61, 110, 0.34),
-      rgba(0, 61, 110, 0.34)
-    ),
-    url("../_images/origin-masthead.jpg") 20% 25% repeat-x;
+    linear-gradient(rgba(0, 61, 110, 0.34), rgba(0, 61, 110, 0.34)), url("../_images/origin-masthead.jpg") 20% 25% repeat-x;
   background-size: 150rem;
   border: 0;
   height: 90px;
@@ -30,7 +26,7 @@ td.gsc-clear-button {
   display: none;
 }
 
-div.gsc-option-menu-container > div.gsc-selected-option-container {
+div.gsc-option-menu-container>div.gsc-selected-option-container {
   width: auto !important
 }
 
@@ -48,15 +44,18 @@ License: https://creativecommons.org/licenses/by/2.0/
   position: relative;
   bottom: -20px;
 }
+
 .attribution .btn {
   color: #808080;
-  color: rgba(175,175,175, .65);
+  color: rgba(175, 175, 175, .65);
   font-size: 11px;
 }
+
 .attribution .btn:hover {
   text-decoration: none;
   color: #aaa;
 }
+
 .popover-content {
   font-size: 12px;
   line-height: 1.3;
@@ -66,13 +65,15 @@ License: https://creativecommons.org/licenses/by/2.0/
 /* Footer Edits 12/11/2015 */
 @media screen and (max-width: 768px) {
   .footer-openshift {
-      height: 190px;
+    height: 190px;
   }
 }
+
 .footer-openshift a {
   top: 0;
   margin-left: 0;
 }
+
 .footer-origin-docs {
   padding: 20px;
   color: #ccc;
@@ -87,10 +88,12 @@ License: https://creativecommons.org/licenses/by/2.0/
 .footer-origin-docs a {
   text-decoration: none;
 }
+
 #footer_social {
   text-align: center;
   margin: 10px 0 20px;
 }
+
 #footer_social a {
   margin: 0 10px;
 }
@@ -98,43 +101,52 @@ License: https://creativecommons.org/licenses/by/2.0/
 #footer_logo {
   margin-left: 0;
 }
+
 #powered_by_openshift img {
   text-align: center;
 }
+
 #built_with_asciibinder img {
   width: 140px;
 }
+
 @media screen and (min-width: 769px) {
- body {
-   margin-bottom: 200px;
- }
+  body {
+    margin-bottom: 200px;
+  }
 }
+
 @media screen and (max-width: 768px) {
   .sidebar {
     border-right: 1px solid #e7e7e7;
     background: #fff;
   }
-  .footer-origin-docs,
-  .footer-openshift {
-    display: none; /* hide absolute positioned footer at mobile */
+
+  .footer-origin-docs, .footer-openshift {
+    display: none;
+    /* hide absolute positioned footer at mobile */
   }
-  .visible-xs-block .footer-origin-docs,
-  .visible-xs-block .footer-openshift {
+
+  .visible-xs-block .footer-origin-docs, .visible-xs-block .footer-openshift {
     /* show alternate footer positioned relative at mobile */
     display: block;
     position: relative;
     margin-top: 50px;
   }
+
   footer {
     text-align: center;
   }
+
   footer img {
     margin: 10px 0;
   }
+
   footer .text-right {
     text-align: center !important;
   }
-  #footer_social > a {
+
+  #footer_social>a {
     top: 24px;
   }
 }
@@ -178,6 +190,7 @@ span.clipboard-button:hover {
     color: #404040;
   }
 }
+
 /* End ClipboardJS edits */
 
 /* Collapsible content */
@@ -185,7 +198,8 @@ details {
   width: 100%;
   margin-bottom: 10px;
 }
- details > summary {
+
+details>summary {
   font-size: 0.92em;
   padding: 4px 6px;
   background-color: #f9f9f9;
@@ -196,19 +210,22 @@ details {
   margin-bottom: 1.5em;
   display: list-item;
 }
- details > div {
+
+details>div {
   border-radius: 0 0 5px 5px;
   background-color: #f9f9f9;
   padding: 4px 6px;
   margin: 0.5em 0.7em 1.5em 0.7em;
   box-shadow: 2px 2px 2px #8a8a8a;
 }
+
 #collapsibleButtonDiv {
   position: relative;
   width: 100%;
   padding: 1em 0em;
   font-size: .92em;
 }
+
 button[name="button-collapse-expand-all"] {
   position: absolute;
   right: 100px;
@@ -216,8 +233,9 @@ button[name="button-collapse-expand-all"] {
   margin-right: 10px;
   z-index: 1;
 }
+
 .span-collapse-expand-all {
-  display:inline-block;
+  display: inline-block;
   width: 100px;
   position: absolute;
   right: 0px;
@@ -225,9 +243,11 @@ button[name="button-collapse-expand-all"] {
   text-align: justify;
   z-index: 1;
 }
+
 .span-collapse-expand-all:hover {
   cursor: pointer;
 }
+
 /* END Collapsible content */
 
 .fa-inverse:hover {
@@ -270,7 +290,7 @@ button[name="button-collapse-expand-all"] {
 
 .main h2, .main .h2 {
   border-top: 0px;
-  padding-top: 10px;
+  padding-top: 3px;
   margin-top: 0;
 }
 
@@ -287,21 +307,21 @@ button[name="button-collapse-expand-all"] {
   padding: 2px 0 0 0;
 }
 
-.ulist p,
-.olist p {
+.ulist p, .olist p {
   margin-bottom: 1em;
 }
 
-.nav > li  > a.hover{
+.nav>li>a.hover {
   background-color: none;
 }
 
 h1, h2, h3, h4, h5, h6, .h1, .h2, .h3, .h4, .h5, .h6 {
   position: relative;
   text-transform: none;
+  overflow-wrap: break-word;
 }
 
-h2 > a.anchor, h3 > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {
+h2>a.anchor, h3>a.anchor, h4>a.anchor, h5>a.anchor, h6>a.anchor {
   display: block;
   font-weight: normal;
   margin-left: -1.5ex;
@@ -310,10 +330,10 @@ h2 > a.anchor, h3 > a.anchor, h4 > a.anchor, h5 > a.anchor, h6 > a.anchor {
   text-decoration: none !important;
   visibility: hidden;
   width: 1.5ex;
-  z-index: 1001;
+  z-index: 2;
 }
 
-h2 > a.anchor:before, h3 > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before {
+h2>a.anchor:before, h3>a.anchor:before, h4>a.anchor:before, h5>a.anchor:before, h6>a.anchor:before {
   content: "\f0c1";
   display: block;
   font-family: FontAwesome;
@@ -323,20 +343,11 @@ h2 > a.anchor:before, h3 > a.anchor:before, h4 > a.anchor:before, h5 > a.anchor:
   padding-top: 0.2em;
 }
 
-h4 > a.anchor:before, h5 > a.anchor:before, h6 > a.anchor:before {
+h4>a.anchor:before, h5>a.anchor:before, h6>a.anchor:before {
   font-size: 1em;
 }
 
-h2:hover > a.anchor,
-h2 > a.anchor:hover,
-h3:hover > a.anchor,
-h3 > a.anchor:hover,
-h4:hover > a.anchor,
-h4 > a.anchor:hover,
-h5:hover > a.anchor,
-h5 > a.anchor:hover,
-h6:hover > a.anchor,
-h6 > a.anchor:hover {
+h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:hover>a.anchor, h4>a.anchor:hover, h5:hover>a.anchor, h5>a.anchor:hover, h6:hover>a.anchor, h6>a.anchor:hover {
   visibility: visible;
 }
 
@@ -346,16 +357,232 @@ h6 > a.anchor:hover {
   padding-left: 25px;
 }
 
+/* keyframe animation */
 
-@media (min-width: 768px) {
+  @keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+  }
+
+  /* Firefox < 16 */
+  @-moz-keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+  }
+
+  /* Safari, Chrome and Opera > 12.1 */
+  @-webkit-keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+  }
+
+  /* Internet Explorer */
+  @-ms-keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+  }
+
+  /* Opera < 12.1 */
+  @-o-keyframes fadein {
+      from { opacity: 0; }
+      to   { opacity: 1; }
+  }
+
+/*fixed sidebar, navbar, and breadcrumb css */
+@media (min-width: 1425px) {
+  html {
+    scroll-padding-top: 155px;
+    /* height of fixed header */
+  }
+
+  body {
+    margin: 0px;
+    margin-bottom: 40px;
+  }
+
   .main {
-    padding-left: 30px;
+    margin-top: 130px;
+    border-left: 0px solid #e7e7e7;
+    margin-left: 315px;
+    width: 800px;
+  }
+
+  .sidebar {
+    font-weight: 300;
+    overflow-wrap: break-word;
+    position: fixed;
+    overflow-y: scroll;
+    z-index: 2;
+    width: 300px;
+    background-color: #fff;
+    margin-left: 5px;
+    display: flex;
+    flex-flow: column;
+    top: 190px;
+    bottom: 10px;
+    display: block;
+    -webkit-animation: fadein 0.35s ease-in; /* Safari, Chrome and Opera > 12.1 */
+       -moz-animation: fadein 0.35s ease-in; /* Firefox < 16 */
+        -ms-animation: fadein 0.35s ease-in; /* Internet Explorer */
+         -o-animation: fadein 0.35s ease-in; /* Opera < 12.1 */
+            animation: fadein 0.35s ease-in;
+  }
+
+  #hc-search {
+    position: fixed;
+    top: 160px;
+    width: 296px;
+  }
+
+  .breadcrumb {
+    margin: 0;
+    padding: 18px 0 10px;
+    font-size: 0.92em;
+    min-height: 65px;
+    position: fixed;
+    z-index: 2;
+    background-color: #fff;
+    width: 1400px;
+    margin-top: 60px;
+    margin-left:  5px;
+  }
+
+  .container {
+    width: 1440px;
+    position: relative;
+  }
+
+  nav#main {
+    height: 90px;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 5;
+    width: 100%;
+  }
+
+.page-header h1 {
+  font-size: 30px;
+  font-weight: 400;
+  letter-spacing: inherit;
+  color: inherit;
+  margin: 10px 0 0 0;
+  padding: 2px 0 15px 0;
+}
+
+  #hc-modal-content {
+    height: 80vh;
+    margin: auto;
+    width: 80%;
+    z-index: 4;
+    background-color: white;
+  }
+
+  footer#rh {
+    background-color: #000;
+    padding: 0px 0;
+    z-index: 5;
+  }
+
+  .close-btn-sm {
+    display: none;
+  }
+
+  /*side toc styling here */
+
+    #toc:before {
+    font-family: "RedHatText",Overpass,"Open Sans",Helvetica,Arial,sans-serif;     
+    content: "TABLE OF CONTENTS";
+    color: #545454;
+    font-size: 0.82em;
+    text-decoration: none;
+    text-align: left;
+    padding-bottom: 0.6em;
+    padding-top: 0.6em;
+    padding-left: 0.8em;
+    text-rendering: optimizeLegibility;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  #toc {
+    float: right;
+    padding-top: 0.1em !important;
+    font-size: 0.8em;
+    overflow-wrap: break-word;
+    width: 300px;
+    position: fixed;
+    display: flex;
+    flex-flow: column;
+    top: 165px;
+    bottom: 1px;
+    margin-left: 780px;
+    height: auto;
+    max-height: 800px;
+    overflow-y: auto;
+    z-index: 2;
+    vertical-align: top;
+    border-left: solid;
+    border-width: 1px;
+    border-color: #E7E7E7;
+    -webkit-animation: fadein 0.35s ease-in;
+       -moz-animation: fadein 0.35s ease-in;
+        -ms-animation: fadein 0.35s ease-in;
+         -o-animation: fadein 0.35s ease-in;
+            animation: fadein 0.35s ease-in;
+  }
+
+  #toc>ul {
+    margin-left: -2em !important;
+    list-style: outside none none !important;
+    height: inherit;
+  }
+
+  #toc ul.sectlevel0>li>a {
+    list-style: outside none none !important;
+  }
+
+  #toc ul.sectlevel2 {
+    margin-left: -20px;
+  }
+
+  #toc ul.sectlevel0 ul.sectlevel1 {
+    margin-top: 0.2em;
+    list-style: outside none none !important;
+  }
+
+  #toc ul {
+    font-family: "Open Sans", "DejaVu Sans", "Sans", sans-serif;
+    list-style-type: none;
+    margin-bottom: 0.2em !important;
+  }
+
+  #toc li {
+    margin-bottom: 0.4em !important;
+  }
+
+  #toc a:link {
+    text-decoration: none;
+    font-size: inherit;
+  }
+
+  #toc a:hover {
+    text-decoration: underline;
+  }
+
+  #toc a:active {
+    font-weight: bold;
+  }
+
+  .toc-active {
+    font-weight: bold;
+  }
+
+  #toctitle {
+    color: #7a2518;
   }
 }
 
-/*
- * Sidebar
- */
+/*Sidebar*/
 
 .nav-header {
   font-size: 18px;
@@ -393,32 +620,186 @@ h6 > a.anchor:hover {
   padding-left: 50px;
 }
 
-.nav-sidebar > li > a {
+.nav-sidebar>li>a {
   padding: 7px 0;
 }
 
-.nav-sidebar > li > a:focus, .nav-sidebar > li > a:hover {
+.nav-sidebar>li>a:focus, .nav-sidebar>li>a:hover {
   background: transparent;
 }
 
 .sidebar {
   font-weight: 300;
-  display: none;
   padding-top: 13px;
   overflow-wrap: break-word;
 }
 
-@media screen and (max-width: 767px) {
+/*tablet browsers*/
+
+@media screen and (max-width: 1424px) {
+  .main {
+    border-left: 0px solid #e7e7e7;
+    width: 100%;
+    padding-top: 0px;  
+  }
+
   .sidebar {
-    padding-left: 30px;
-    padding-right: 0;
+    left: -49%;
+    top: 0px;
+    font-weight: 300;
+    overflow-wrap: break-word;
+    position: fixed;
+    margin-left: 49%;
+    padding-top: 10px;
+    overflow-y: scroll;
+    height: 100%;
+    z-index: 9999;
+    width: 33%;
+    background-color: #fff;
+    filter: drop-shadow(0 0 0.15rem grey);
+    transition: all .3s ease;
+    display: none;
+  }
+
+  .breadcrumb {
+    margin: 0;
+    padding: 3px 0 20px;
+    font-size: 0.92em;
+  }
+
+  .open-btn-sm {
+    margin-top: -53px;
+    font-size: 20px;
+    opacity: 90%;
+    position: fixed;
+    z-index: 9;
+    filter: drop-shadow(0 0 0.1rem grey);
+  }
+
+  .close-btn-sm {
+    border: 1px solid lightgrey;
+    font-size: 14px;
+    height: 25px;
+    width: 26px;
+    margin: 4px 0px;
+    padding: 2px 2px 2px 2px;
+  }
+
+  #hc-search-btn {
+    border: 1px solid lightgrey;
+    font-size: 12px;
+    height: 25px;
+    width: 26px;
+  }
+
+  .btn-close {
+    padding: 2px;
   }
 }
 
-@media screen and (min-width: 768px) {
+@media screen and (max-width: 1199px) {
+  .main {
+    border-left: 0px solid #e7e7e7;
+    width: 100%;
+  }
+
   .sidebar {
+    left: -33%;
+    font-weight: 300;
+    overflow-wrap: break-word;
+    position: fixed;
+    margin-left: 49%;
+    padding-top: 10px;
+    overflow-y: scroll;
+    height: 100%;
+    z-index: 9999;
+    width: 33%;
+    background-color: #fff;
+    filter: drop-shadow(0 0 0.15rem grey);
+    transition: all .3s ease;
+    display: none;
+  }
+
+  .breadcrumb {
+    margin: 0;
+    padding: 3px 0 20px;
+    font-size: 0.92em;
+  }
+
+  .open-btn-sm {
+    margin-top: -53px;
+    font-size: 20px;
+    opacity: 90%;
+    position: fixed;
+    z-index: 9;
+    filter: drop-shadow(0 0 0.1rem grey);
+  }
+
+  .close-btn-sm {
+    border: 1px solid lightgrey;
+    font-size: 14px;
+    height: 25px;
+    width: 26px;
+    margin: 4px 0px;
+    padding: 2px 2px 2px 2px;
+  }
+
+  #hc-search-btn {
+    border: 1px solid lightgrey;
+    font-size: 12px;
+    height: 25px;
+    width: 26px;
+  }
+
+  .btn-close {
+    padding: 2px;
+  }
+}
+
+/*mobile browsers*/
+@media screen and (max-width: 767px) {
+  .sidebar {
+    font-weight: 300;
+    overflow-wrap: break-word;
+    position: fixed;
+    padding-top: 10px;
+    overflow-y: scroll;
+    height: 100%;
     border-right: 1px solid #e7e7e7;
     display: block;
+    z-index: 9999;
+    width: 300px;
+    background-color: #fff;
+    filter: drop-shadow(0 0 0.15rem grey);
+    transition: all .3s ease;
+    display: none;
+  }
+
+  .breadcrumb {
+    margin: 0;
+    padding: 3px 0 20px;
+    font-size: 0.92em;
+  }
+
+  .open-btn-sm {
+    margin-top: -65px;
+    font-size: 20px;
+    opacity: 90%;
+    position: fixed;
+    z-index: 6;
+    filter: drop-shadow(0 0 0.1rem grey);
+  }
+
+  .close-btn-sm {
+    border: 1px solid lightgrey;
+    font-size: 14px;
+    height: 25px;
+    width: 26px;
+    padding: 2px 2px 2px 2px;
+  }
+
+  .btn-close {
+    padding: 2px;
   }
 }
 
@@ -427,7 +808,7 @@ h6 > a.anchor:hover {
  * --------------------------------------------------
  */
 
-body > .container {
+body>.container {
   overflow-x: hidden;
 }
 
@@ -435,12 +816,13 @@ body > .container {
   margin-right: 20px;
 }
 
-@media screen and (max-width: 767px) {
+
+@media screen and (max-width: 1199px) {
   .row-offcanvas {
     position: relative;
     -webkit-transition: all .25s ease-out;
-         -o-transition: all .25s ease-out;
-            transition: all .25s ease-out;
+    -o-transition: all .25s ease-out;
+    transition: all .25s ease-out;
   }
 
   .row-offcanvas-right {
@@ -451,400 +833,232 @@ body > .container {
     left: 0;
   }
 
-  .row-offcanvas-right
-  .sidebar-offcanvas {
-    right: -75%; /* 8 columns */
+  .row-offcanvas-right .sidebar-offcanvas {
+    right: -75%;
+    /* 8 columns */
   }
 
-  .row-offcanvas-left
-  .sidebar-offcanvas {
-    left: -75%; /* 8 columns */
+  .row-offcanvas-left .sidebar-offcanvas {
+    position: fixed;
+    overflow-y: scroll;
+    left: -49%;
+    z-index: 9999;
+    width: 34%;
   }
 
   .row-offcanvas-right.active {
-    right: 75%; /* 8 columns */
+    right: 75%;
+    /* 8 columns */
   }
 
   .row-offcanvas-left.active {
-    left: 75%; /* 8 columns */
+    left: 75%;
+    /* 8 columns */
+  }
+
+  .sidebar-offcanvas {
+    overflow: hidden;
+    position: absolute;
+    left: 75%;
+    top: 0;
+    width: 75%;
+    /* 8 columns */
+  }
+}
+
+@media screen and (max-width: 812px) {
+  .row-offcanvas {
+    position: relative;
+    -webkit-transition: all .25s ease-out;
+    -o-transition: all .25s ease-out;
+    transition: all .25s ease-out;
+  }
+
+  .row-offcanvas-right {
+    right: 0;
+  }
+
+  .row-offcanvas-left {
+    left: 0;
+  }
+
+  .row-offcanvas-right .sidebar-offcanvas {
+    right: -75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left .sidebar-offcanvas {
+    left: -49%;
+    /* 8 columns */
+    width: 55%;
+  }
+
+  .row-offcanvas-right.active {
+    right: 75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left.active {
+    left: 75%;
+    /* 8 columns */
   }
 
   .sidebar-offcanvas {
     overflow: hidden;
     position: absolute;
     top: 0;
-    width: 75%; /* 8 columns */
+    width: 75%;
+    /* 8 columns */
   }
 }
 
- p {
-  margin: 0 0 0.92em;
-  font-size: 0.92em;
- }
+@media screen and (max-width: 767px) {
+  .row-offcanvas {
+    position: relative;
+    -webkit-transition: all .25s ease-out;
+    -o-transition: all .25s ease-out;
+    transition: all .25s ease-out;
+  }
 
- /* for code lines inside tables*/
- table > tbody > tr > td> p > code {
-   white-space: pre-wrap;
-   word-wrap: break-word;
- }
+  .row-offcanvas-right {
+    right: 0;
+  }
 
- /* for codeblocks inside tables*/
-table > tbody > tr > td > div > div > div > pre {
-  white-space: pre-wrap;
+  .row-offcanvas-left {
+    left: 0;
+  }
+
+  .row-offcanvas-right .sidebar-offcanvas {
+    right: -75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left .sidebar-offcanvas {
+    left: -50%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-right.active {
+    right: 75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left.active {
+    left: 75%;
+    /* 8 columns */
+  }
+
+  .sidebar-offcanvas {
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    width: 75%;
+    /* 8 columns */
+  }
 }
 
- /* for column code lines inside tables*/
-table > tbody > tr > td > div > div > p > code {
+@media screen and (max-width: 653px) {
+  .row-offcanvas {
+    position: relative;
+    -webkit-transition: all .25s ease-out;
+    -o-transition: all .25s ease-out;
+    transition: all .25s ease-out;
+  }
+
+  .row-offcanvas-right {
+    right: 0;
+  }
+
+  .row-offcanvas-left {
+    left: 0;
+  }
+
+  .row-offcanvas-right .sidebar-offcanvas {
+    right: -75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left .sidebar-offcanvas {
+    left: -49%;
+    /* 8 columns */
+    width: 75%;
+  }
+
+  .row-offcanvas-right.active {
+    right: 75%;
+    /* 8 columns */
+  }
+
+  .row-offcanvas-left.active {
+    left: 75%;
+    /* 8 columns */
+  }
+
+  .sidebar-offcanvas {
+    overflow: hidden;
+    position: absolute;
+    top: 0;
+    width: 75%;
+    /* 8 columns */
+  }
+}
+
+p {
+  margin: 0 0 0.92em;
+  font-size: 0.92em;
+}
+
+/* for code lines inside tables*/
+table>tbody>tr>td>p>code {
   white-space: pre-wrap;
   word-wrap: break-word;
 }
 
- /* Remnants of Asciidoctor default stylesheet - remove styles as needed */
+/* for codeblocks inside tables*/
+table>tbody>tr>td>div>div>div>pre {
+  white-space: pre-wrap;
+}
+
+/* for column code lines inside tables*/
+table>tbody>tr>td>div>div>p>code {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+
+/* Remnants of Asciidoctor default stylesheet - remove styles as needed */
 
 #map_canvas img, #map_canvas embed, #map_canvas object, .map_canvas img, .map_canvas embed, .map_canvas object {
-     max-width: none !important;
+  max-width: none !important;
 }
- .left {
-     float: left !important;
+
+.left {
+  float: left !important;
 }
- .right {
-     float: right !important;
+
+.right {
+  float: right !important;
 }
- .text-left {
-     text-align: left !important;
+
+.text-left {
+  text-align: left !important;
 }
- .text-right {
-     text-align: right !important;
+
+.text-right {
+  text-align: right !important;
 }
- .text-center {
-     text-align: center !important;
+
+.text-center {
+  text-align: center !important;
 }
- .text-justify {
-     text-align: justify !important;
+
+.text-justify {
+  text-align: justify !important;
 }
- .hide {
-     display: none;
+
+.hide {
+  display: none;
 }
- .subheader, #content #toctitle, .admonitionblock td.content > .title, .audioblock > .title, .exampleblock > .title, .imageblock > .title, .listingblock > .title, .literalblock > .title, .stemblock > .title, .openblock > .title, .paragraph > .title, .quoteblock > .title, table.tableblock > .title, .verseblock > .title, .videoblock > .title, .dlist > .title, .olist > .title, .ulist > .title, .qlist > .title, .hdlist > .title {
-     line-height: 1.4;
-     color: #7a2518;
-     font-weight: 300;
-     margin-top: 0.2em;
-     margin-bottom: 0.5em;
-}
- abbr, acronym {
-     text-transform: uppercase;
-     font-size: 90%;
-     color: #333333;
-     border-bottom: 1px dotted #dddddd;
-     cursor: help;
-}
- abbr {
-     text-transform: none;
-}
- blockquote {
-     margin: 0 0 1.25em;
-     padding: 0.5625em 1.25em 0 1.1875em;
-     border-left: 3px solid #487c58;
-}
- blockquote cite {
-     display: block;
-     font-size: inherit;
-     color: #454545;
-}
- blockquote cite:before {
-     content: "\2014 \0020";
-}
- blockquote cite a, blockquote cite a:visited {
-     color: #454545;
-}
- blockquote, blockquote p {
-     line-height: 1.6;
-     color: #6e6e6e;
-}
- @media only screen and (min-width: 768px) {
-     #toctitle, .sidebarblock > .content > .title {
-         line-height: 1.4;
-    }
-     #toctitle, .sidebarblock > .content > .title {
-         font-size: 1.6875em;
-    }
-}
- table {
-     background: white;
-     margin-bottom: 1.25em;
-     border: solid 1px #dddddd;
-     font-size: 15px;
-}
- table thead, table tfoot {
-     background: whitesmoke;
-     font-weight: bold;
-}
- table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td {
-     padding: 0.5em 0.625em 0.625em;
-     font-size: inherit;
-     color: #333333;
-     text-align: left;
-}
- table tr th, table tr td {
-     padding: 0.5625em 0.625em;
-     font-size: 14px;
-     color: #545454;
-     font-weight: 400;
-}
- table tr.even, table tr.alt, table tr:nth-of-type(even) {
-     background: #f9f9f9;
-}
- table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
-     display: table-cell;
-     line-height: 1.8;
-}
- .clearfix:before, .clearfix:after, .float-group:before, .float-group:after {
-     content: " ";
-     display: table;
-}
- .clearfix:after, .float-group:after {
-     clear: both;
-}
- *:not(pre) > code {
-     white-space: nowrap;
-     background-color: #f9f9f9;
-     border: 0 solid #dddddd;
-     -webkit-border-radius: 0px;
-     border-radius: 0px;
-     text-shadow: none;
-     line-height: 1;
-     font-weight: 400; /* normal */
-     vertical-align: baseline;
-     padding: 2px 4px;
-}
- pre code {
-     text-shadow: none;
-}
- .keyseq {
-     color: #666666;
-}
- kbd:not(.keyseq) {
-     display: inline-block;
-     color: #333333;
-     font-size: 0.75em;
-     line-height: 1.4;
-     background-color: #f7f7f7;
-     border: 1px solid #ccc;
-     -webkit-border-radius: 3px;
-     border-radius: 3px;
-     -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset;
-     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset;
-     margin: -0.15em 0.15em 0 0.15em;
-     padding: 0.2em 0.6em 0.2em 0.5em;
-     vertical-align: middle;
-     white-space: nowrap;
-}
- .keyseq kbd:first-child {
-     margin-left: 0;
-}
- .keyseq kbd:last-child {
-     margin-right: 0;
-}
- .menuseq, .menu {
-     color: #1a1a1a;
-}
- b.button:before, b.button:after {
-     position: relative;
-     top: -1px;
-     font-weight: normal;
-}
- b.button:before {
-     content: "[";
-     padding: 0 3px 0 2px;
-}
- b.button:after {
-     content: "]";
-     padding: 0 2px 0 3px;
-}
- p a > code:hover {
-     color: #561309;
-}
- #header, #content, #footnotes, #footer {
-     width: 100%;
-     margin-left: auto;
-     margin-right: auto;
-     margin-top: 0;
-     margin-bottom: 0;
-     max-width: 62.5em;
-     *zoom: 1;
-     position: relative;
-     padding-left: 0.9375em;
-     padding-right: 0.9375em;
-}
- #header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after {
-     content: " ";
-     display: table;
-}
- #header:after, #content:after, #footnotes:after, #footer:after {
-     clear: both;
-}
- #content:before {
-     content: none;
-}
- #header {
-     margin-bottom: 2.5em;
-}
- #header > h1 {
-     color: black;
-     font-weight: 300;
-     border-bottom: 1px solid #d8d8d8;
-     margin-bottom: -28px;
-     padding-bottom: 32px;
-}
- #header span {
-     color: #6e6e6e;
-}
- #header #revnumber {
-     text-transform: capitalize;
-}
- #header br {
-     display: none;
-}
- #header br + span {
-     padding-left: 3px;
-}
- #header br + span:before {
-     content: "\2013 \0020";
-}
- #header br + span.author {
-     padding-left: 0;
-}
- #header br + span.author:before {
-     content: ", ";
-}
- #toc {
-     border-bottom: 3px double #e5e5e5;
-     padding-top: 1em;
-     margin-bottom: 1.05em;
-}
- #toc > ul {
-     margin-left: 0.25em;
-}
- #toc ul.sectlevel0 > li > a {
-     font-style: italic;
-}
- #toc ul.sectlevel0 ul.sectlevel1 {
-     margin-left: 0;
-     margin-top: 0.5em;
-     margin-bottom: 0.5em;
-}
- #toc ul {
-     font-family: "Open Sans", "DejaVu Sans", "Sans", sans-serif;
-     list-style-type: none;
-}
- #toc a {
-     text-decoration: none;
-     font-size: 0.92em;
-}
- #toc a:active {
-     text-decoration: underline;
-}
- #toctitle {
-     color: #7a2518;
-}
- @media only screen and (min-width: 768px) {
-     body.toc2 {
-         padding-left: 15em;
-         padding-right: 0;
-    }
-     #toc.toc2 {
-         background-color: #fafaf9;
-         position: fixed;
-         width: 15em;
-         left: 0;
-         top: 0;
-         border-right: 1px solid #e5e5e5;
-         border-bottom: 0;
-         z-index: 1000;
-         padding: 1.25em 1em;
-         height: 100%;
-         overflow: auto;
-    }
-     #toc.toc2 #toctitle {
-         margin-top: 0;
-         font-size: 1.2em;
-    }
-     #toc.toc2 > ul {
-         font-size: .90em;
-         margin-bottom: 0;
-    }
-     #toc.toc2 ul ul {
-         margin-left: 0;
-         padding-left: 1em;
-    }
-     #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
-         padding-left: 0;
-         margin-top: 0.5em;
-         margin-bottom: 0.5em;
-    }
-     body.toc2.toc-right {
-         padding-left: 0;
-         padding-right: 15em;
-    }
-     body.toc2.toc-right #toc.toc2 {
-         border-right: 0;
-         border-left: 1px solid #e5e5e5;
-         left: auto;
-         right: 0;
-    }
-}
- @media only screen and (min-width: 1280px) {
-     body.toc2 {
-         padding-left: 20em;
-         padding-right: 0;
-    }
-     #toc.toc2 {
-         width: 20em;
-    }
-     #toc.toc2 #toctitle {
-         font-size: 1.375em;
-    }
-     #toc.toc2 > ul {
-         font-size: 0.95em;
-    }
-     #toc.toc2 ul ul {
-         padding-left: 1.25em;
-    }
-     body.toc2.toc-right {
-         padding-left: 0;
-         padding-right: 20em;
-    }
-}
- #content #toc {
-     border-style: solid;
-     border-width: 1px;
-     border-color: #e3e3dd;
-     margin-bottom: 1.25em;
-     padding: 1.25em;
-     background: #fafaf9;
-     border-width: 0;
-     -webkit-border-radius: 4px;
-     border-radius: 4px;
-}
- #content #toc > :first-child {
-     margin-top: 0;
-}
- #content #toc > :last-child {
-     margin-bottom: 0;
-}
- #content #toctitle {
-     font-size: 1.375em;
-}
- #footer {
-     max-width: 100%;
-     background-color: #333333;
-     padding: 1.25em;
-}
- #footer-text {
-     color: #cccccc;
-     line-height: 1.44;
-}
+
 /* code blocks */
  .audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .verseblock, .videoblock {
      margin-bottom: 1em;
@@ -915,120 +1129,617 @@ table > tbody > tr > td > div > div > p > code {
     color: #404040;
     font-weight: bold;
 }
- .admonitionblock.important td.content:before {
-    content: "IMPORTANT\a";
-    white-space: pre;
-    color: #404040;
-    font-weight: bold;
+
+.subheader, #content #toctitle, .admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title {
+  line-height: 1.4;
+  color: #7a2518;
+  font-weight: 300;
+  margin-top: 0.2em;
+  margin-bottom: 0.5em;
 }
- .admonitionblock.warning td.content:before {
-    content: "WARNING\a";
-    white-space: pre;
-    color: #404040;
-    font-weight: bold;
+
+abbr, acronym {
+  text-transform: uppercase;
+  font-size: 90%;
+  color: #333333;
+  border-bottom: 1px dotted #dddddd;
+  cursor: help;
 }
- .admonitionblock.tip td.content:before {
-    content: "TIP\a";
-    white-space: pre;
-    color: #404040;
-    font-weight: bold;
+
+abbr {
+  text-transform: none;
 }
- .admonitionblock.caution td.content:before {
-    content: "CAUTION\a";
-    white-space: pre;
-    color: #404040;
-    font-weight: bold;
+
+blockquote {
+  margin: 0 0 1.25em;
+  padding: 0.5625em 1.25em 0 1.1875em;
+  border-left: 3px solid #487c58;
 }
- .admonitionblock > table td.content > :last-child > :last-child {
-     margin-bottom: 0;
+
+blockquote cite {
+  display: block;
+  font-size: inherit;
+  color: #454545;
 }
- .exampleblock > .content {
-     border-style: solid;
-     border-width: 1px;
-     border-color: #e6e6e6;
-     margin-bottom: 1.25em;
-     padding: 1.25em;
-     background: white;
-     -webkit-border-radius: 4px;
-     border-radius: 4px;
+
+blockquote cite:before {
+  content: "\2014 \0020";
 }
- .exampleblock > .content > :first-child {
-     margin-top: 0;
+
+blockquote cite a, blockquote cite a:visited {
+  color: #454545;
 }
- .exampleblock > .content > :last-child {
-     margin-bottom: 0;
+
+blockquote, blockquote p {
+  line-height: 1.6;
+  color: #6e6e6e;
 }
- .exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6, .exampleblock > .content p {
-     color: #333333;
+
+@media only screen and (min-width: 768px) {
+
+  #toctitle, .sidebarblock>.content>.title {
+    line-height: 1.4;
+  }
+
+  #toctitle, .sidebarblock>.content>.title {
+    font-size: 1.6875em;
+  }
 }
- .exampleblock > .content h1, .exampleblock > .content h2, .exampleblock > .content h3, .exampleblock > .content #toctitle, .sidebarblock.exampleblock > .content > .title, .exampleblock > .content h4, .exampleblock > .content h5, .exampleblock > .content h6 {
-     line-height: 1;
-     margin-bottom: 0.625em;
+
+table {
+  background: white;
+  margin-bottom: 1.25em;
+  border: solid 1px #dddddd;
+  font-size: 15px;
 }
- .exampleblock > .content h1.subheader, .exampleblock > .content h2.subheader, .exampleblock > .content h3.subheader, .exampleblock > .content .subheader#toctitle, .sidebarblock.exampleblock > .content > .subheader.title, .exampleblock > .content h4.subheader, .exampleblock > .content h5.subheader, .exampleblock > .content h6.subheader {
-     line-height: 1.4;
+
+table thead, table tfoot {
+  background: whitesmoke;
+  font-weight: bold;
 }
- .exampleblock.result > .content {
-     -webkit-box-shadow: 0 1px 8px #e3e3dd;
-     box-shadow: 0 1px 8px #e3e3dd;
+
+table thead tr th, table thead tr td, table tfoot tr th, table tfoot tr td {
+  padding: 0.5em 0.625em 0.625em;
+  font-size: inherit;
+  color: #333333;
+  text-align: left;
 }
- .sidebarblock {
-     border-style: solid;
-     border-width: 1px;
-     border-color: #e3e3dd;
-     margin-top: -1.0em;
-     margin-bottom: 1.6em;
-     padding: .5em;
-     background: #F1F3F5;
-     -webkit-border-radius: 4px;
-     border-radius: 4px;
-     overflow-x: auto;
+
+table tr th, table tr td {
+  padding: 0.5625em 0.625em;
+  font-size: 14px;
+  color: #545454;
+  font-weight: 400;
 }
- .sidebarblock > :first-child {
-     margin-top: 0;
+
+table tr.even, table tr.alt, table tr:nth-of-type(even) {
+  background: #f9f9f9;
 }
- .sidebarblock > :last-child {
-     margin-bottom: 0;
+
+table thead tr th, table tfoot tr th, table tbody tr td, table tr td, table tfoot tr td {
+  display: table-cell;
+  line-height: 1.8;
 }
- .sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p {
-     color: #333333;
+
+.clearfix:before, .clearfix:after, .float-group:before, .float-group:after {
+  content: " ";
+  display: table;
 }
- .sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock > .content > .title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6 {
-     line-height: 1;
-     margin-bottom: 0.625em;
+
+.clearfix:after, .float-group:after {
+  clear: both;
 }
- .sidebarblock h1.subheader, .sidebarblock h2.subheader, .sidebarblock h3.subheader, .sidebarblock .subheader#toctitle, .sidebarblock > .content > .subheader.title, .sidebarblock h4.subheader, .sidebarblock h5.subheader, .sidebarblock h6.subheader {
-     line-height: 1.4;
+
+*:not(pre)>code {
+  background-color: #f9f9f9;
+  border: 0 solid #dddddd;
+  -webkit-border-radius: 0px;
+  border-radius: 0px;
+  text-shadow: none;
+  line-height: 1;
+  font-weight: 400;
+  /* normal */
+  vertical-align: baseline;
+  padding: 2px 4px;
+  word-wrap: break-word;
 }
- .sidebarblock > .content > .title {
-     color: #7a2518;
-     margin-top: 0;
-     line-height: 1.6;
+
+pre code {
+  text-shadow: none;
 }
- .exampleblock > .content > :last-child > :last-child, .exampleblock > .content .olist > ol > li:last-child > :last-child, .exampleblock > .content .ulist > ul > li:last-child > :last-child, .exampleblock > .content .qlist > ol > li:last-child > :last-child, .sidebarblock > .content > :last-child > :last-child, .sidebarblock > .content .olist > ol > li:last-child > :last-child, .sidebarblock > .content .ulist > ul > li:last-child > :last-child, .sidebarblock > .content .qlist > ol > li:last-child > :last-child {
-     margin-bottom: 0;
+
+.keyseq {
+  color: #666666;
 }
+
+kbd:not(.keyseq) {
+  display: inline-block;
+  color: #333333;
+  font-size: 0.75em;
+  line-height: 1.4;
+  background-color: #f7f7f7;
+  border: 1px solid #ccc;
+  -webkit-border-radius: 3px;
+  border-radius: 3px;
+  -webkit-box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset;
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.2), 0 0 0 2px white inset;
+  margin: -0.15em 0.15em 0 0.15em;
+  padding: 0.2em 0.6em 0.2em 0.5em;
+  vertical-align: middle;
+  white-space: nowrap;
+}
+
+.keyseq kbd:first-child {
+  margin-left: 0;
+}
+
+.keyseq kbd:last-child {
+  margin-right: 0;
+}
+
+.menuseq, .menu {
+  color: #1a1a1a;
+}
+
+b.button:before, b.button:after {
+  position: relative;
+  top: -1px;
+  font-weight: normal;
+}
+
+b.button:before {
+  content: "[";
+  padding: 0 3px 0 2px;
+}
+
+b.button:after {
+  content: "]";
+  padding: 0 2px 0 3px;
+}
+
+p a>code:hover {
+  color: #561309;
+}
+
+#header, #content, #footnotes, #footer {
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  margin-top: 0;
+  margin-bottom: 0;
+  max-width: 62.5em;
+  *zoom: 1;
+  position: relative;
+  padding-left: 0.9375em;
+  padding-right: 0.9375em;
+}
+
+#header:before, #header:after, #content:before, #content:after, #footnotes:before, #footnotes:after, #footer:before, #footer:after {
+  content: " ";
+  display: table;
+}
+
+#header:after, #content:after, #footnotes:after, #footer:after {
+  clear: both;
+}
+
+#content:before {
+  content: none;
+}
+
+#header {
+  margin-bottom: 2.5em;
+}
+
+#header>h1 {
+  color: black;
+  font-weight: 300;
+  border-bottom: 1px solid #d8d8d8;
+  margin-bottom: -28px;
+  padding-bottom: 32px;
+}
+
+#header span {
+  color: #6e6e6e;
+}
+
+#header #revnumber {
+  text-transform: capitalize;
+}
+
+#header br {
+  display: none;
+}
+
+#header br+span {
+  padding-left: 3px;
+}
+
+#header br+span:before {
+  content: "\2013 \0020";
+}
+
+#header br+span.author {
+  padding-left: 0;
+}
+
+#header br+span.author:before {
+  content: ", ";
+}
+
+#toc {
+  padding-top: 1em;
+  margin-bottom: 1.05em;
+}
+
+#toc>ul {
+  margin-left: 0.25em;
+}
+
+#toc ul.sectlevel0 ul.sectlevel1 {
+  margin-left: 0;
+  margin-top: 0.5em;
+  margin-bottom: 0.5em;
+}
+
+#toc ul {
+  font-family: "Open Sans", "DejaVu Sans", "Sans", sans-serif;
+  list-style-type: none;
+}
+
+#toc a {
+  text-decoration: none;
+  font-size: 0.92em;
+}
+
+#toc a:active {
+  text-decoration: underline;
+}
+
+#toctitle {
+  color: #7a2518;
+}
+
+@media only screen and (min-width: 768px) {
+  body.toc2 {
+    padding-left: 15em;
+    padding-right: 0;
+  }
+
+  #toc.toc2 {
+    background-color: #fafaf9;
+    position: fixed;
+    width: 15em;
+    left: 0;
+    top: 0;
+    border-right: 1px solid #e5e5e5;
+    border-bottom: 0;
+    z-index: 1000;
+    padding: 1.25em 1em;
+    height: 100%;
+    overflow: auto;
+  }
+
+  #toc.toc2 #toctitle {
+    margin-top: 0;
+    font-size: 1.2em;
+  }
+
+  #toc.toc2>ul {
+    font-size: .90em;
+    margin-bottom: 0;
+  }
+
+  #toc.toc2 ul ul {
+    margin-left: 0;
+    padding-left: 1em;
+  }
+
+  #toc.toc2 ul.sectlevel0 ul.sectlevel1 {
+    padding-left: 0;
+    margin-top: 0.5em;
+    margin-bottom: 0.5em;
+  }
+
+  body.toc2.toc-right {
+    padding-left: 0;
+    padding-right: 15em;
+  }
+
+  body.toc2.toc-right #toc.toc2 {
+    border-right: 0;
+    border-left: 1px solid #e5e5e5;
+    left: auto;
+    right: 0;
+  }
+}
+
+@media only screen and (min-width: 1280px) {
+  body.toc2 {
+    padding-left: 20em;
+    padding-right: 0;
+  }
+
+  #toc.toc2 {
+    width: 20em;
+  }
+
+  #toc.toc2 #toctitle {
+    font-size: 1.375em;
+  }
+
+  #toc.toc2>ul {
+    font-size: 0.95em;
+  }
+
+  #toc.toc2 ul ul {
+    padding-left: 1.25em;
+  }
+
+  body.toc2.toc-right {
+    padding-left: 0;
+    padding-right: 20em;
+  }
+}
+
+#content #toc {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #e3e3dd;
+  margin-bottom: 1.25em;
+  padding: 1.25em;
+  background: #fafaf9;
+  border-width: 0;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+}
+
+#content #toc> :first-child {
+  margin-top: 0;
+}
+
+#content #toc> :last-child {
+  margin-bottom: 0;
+}
+
+#content #toctitle {
+  font-size: 1.375em;
+}
+
+#footer {
+  max-width: 100%;
+  background-color: #333333;
+  padding: 1.25em;
+}
+
+#footer-text {
+  color: #cccccc;
+  line-height: 1.44;
+}
+
+/* code blocks */
+.audioblock, .imageblock, .literalblock, .listingblock, .stemblock, .verseblock, .videoblock {
+  margin-bottom: 1em;
+}
+
+.admonitionblock td.content>.title, .audioblock>.title, .exampleblock>.title, .imageblock>.title, .listingblock>.title, .literalblock>.title, .stemblock>.title, .openblock>.title, .paragraph>.title, .quoteblock>.title, table.tableblock>.title, .verseblock>.title, .videoblock>.title, .dlist>.title, .olist>.title, .ulist>.title, .qlist>.title, .hdlist>.title {
+  text-rendering: optimizeLegibility;
+  text-align: left;
+  font-family: "Noto Serif", "DejaVu Serif", "Serif", serif;
+  font-weight: normal;
+  font-style: italic;
+  font-size: 16px;
+}
+
+table.tableblock>caption.title {
+  white-space: nowrap;
+  overflow: visible;
+  max-width: 0;
+}
+
+table.tableblock #preamble>.sectionbody>.paragraph:first-of-type p {
+  font-size: inherit;
+}
+
+.admonitionblock>table {
+  border: 0;
+  background: none;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.admonitionblock.note {
+  background: #4e9fde15;
+  border-left: solid #4e9fde;
+}
+
+.admonitionblock.important {
+  background: #ee210015;
+  border-left: solid #ee2100;
+}
+
+.admonitionblock.warning {
+  background: #ec7a0915;
+  border-left: solid #ec7a09;
+}
+
+.admonitionblock.caution {
+  background: #ec7a0915;
+  border-left: solid #ec7a09;
+}
+
+.admonitionblock.tip {
+  background: #32859615;
+  border-left: solid #328596;
+}
+
+.admonitionblock>table td.icon {
+  vertical-align: top;
+  text-align: center;
+  width: 80px;
+}
+
+.admonitionblock>table td.icon img {
+  max-width: none;
+}
+
+.admonitionblock>table td.icon .title {
+  font-weight: 300;
+  text-transform: uppercase;
+}
+
+.admonitionblock>table td.content {
+  padding-left: 0;
+  padding-right: 1.25em;
+  color: #6e6e6e;
+  font-size: .85rem;
+}
+
+.admonitionblock.note td.content:before {
+  content: "NOTE\a";
+  white-space: pre;
+  color: #404040;
+  font-weight: bold;
+}
+
+.admonitionblock.important td.content:before {
+  content: "IMPORTANT\a";
+  white-space: pre;
+  color: #404040;
+  font-weight: bold;
+}
+
+.admonitionblock.warning td.content:before {
+  content: "WARNING\a";
+  white-space: pre;
+  color: #404040;
+  font-weight: bold;
+}
+
+.admonitionblock.tip td.content:before {
+  content: "TIP\a";
+  white-space: pre;
+  color: #404040;
+  font-weight: bold;
+}
+
+.admonitionblock.caution td.content:before {
+  content: "CAUTION\a";
+  white-space: pre;
+  color: #404040;
+  font-weight: bold;
+}
+
+.admonitionblock>table td.content> :last-child> :last-child {
+  margin-bottom: 0;
+}
+
+.exampleblock>.content {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #e6e6e6;
+  margin-bottom: 1.25em;
+  padding: 1.25em;
+  background: white;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+}
+
+.exampleblock>.content> :first-child {
+  margin-top: 0;
+}
+
+.exampleblock>.content> :last-child {
+  margin-bottom: 0;
+}
+
+.exampleblock>.content h1, .exampleblock>.content h2, .exampleblock>.content h3, .exampleblock>.content #toctitle, .sidebarblock.exampleblock>.content>.title, .exampleblock>.content h4, .exampleblock>.content h5, .exampleblock>.content h6, .exampleblock>.content p {
+  color: #333333;
+}
+
+.exampleblock>.content h1, .exampleblock>.content h2, .exampleblock>.content h3, .exampleblock>.content #toctitle, .sidebarblock.exampleblock>.content>.title, .exampleblock>.content h4, .exampleblock>.content h5, .exampleblock>.content h6 {
+  line-height: 1;
+  margin-bottom: 0.625em;
+}
+
+.exampleblock>.content h1.subheader, .exampleblock>.content h2.subheader, .exampleblock>.content h3.subheader, .exampleblock>.content .subheader#toctitle, .sidebarblock.exampleblock>.content>.subheader.title, .exampleblock>.content h4.subheader, .exampleblock>.content h5.subheader, .exampleblock>.content h6.subheader {
+  line-height: 1.4;
+}
+
+.exampleblock.result>.content {
+  -webkit-box-shadow: 0 1px 8px #e3e3dd;
+  box-shadow: 0 1px 8px #e3e3dd;
+}
+
+.sidebarblock {
+  border-style: solid;
+  border-width: 1px;
+  border-color: #e3e3dd;
+  margin-top: -1.0em;
+  margin-bottom: 1.6em;
+  padding: .5em;
+  background: #F1F3F5;
+  -webkit-border-radius: 4px;
+  border-radius: 4px;
+  overflow-x: auto;
+}
+
+.sidebarblock> :first-child {
+  margin-top: 0;
+}
+
+.sidebarblock> :last-child {
+  margin-bottom: 0;
+}
+
+.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock>.content>.title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6, .sidebarblock p {
+  color: #333333;
+}
+
+.sidebarblock h1, .sidebarblock h2, .sidebarblock h3, .sidebarblock #toctitle, .sidebarblock>.content>.title, .sidebarblock h4, .sidebarblock h5, .sidebarblock h6 {
+  line-height: 1;
+  margin-bottom: 0.625em;
+}
+
+.sidebarblock h1.subheader, .sidebarblock h2.subheader, .sidebarblock h3.subheader, .sidebarblock .subheader#toctitle, .sidebarblock>.content>.subheader.title, .sidebarblock h4.subheader, .sidebarblock h5.subheader, .sidebarblock h6.subheader {
+  line-height: 1.4;
+}
+
+.sidebarblock>.content>.title {
+  color: #7a2518;
+  margin-top: 0;
+  line-height: 1.6;
+}
+
+.exampleblock>.content> :last-child> :last-child, .exampleblock>.content .olist>ol>li:last-child> :last-child, .exampleblock>.content .ulist>ul>li:last-child> :last-child, .exampleblock>.content .qlist>ol>li:last-child> :last-child, .sidebarblock>.content> :last-child> :last-child, .sidebarblock>.content .olist>ol>li:last-child> :last-child, .sidebarblock>.content .ulist>ul>li:last-child> :last-child, .sidebarblock>.content .qlist>ol>li:last-child> :last-child {
+  margin-bottom: 0;
+}
+
 /* For this only we do not want padding */
 .listingblock pre.rouge, .listingblock pre.rouge code {
   padding: 0;
 }
+
 /* source code appears in pre blocks */
- .literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] {
-     background-color: #f9f9f9;
-     border: 1px #aab7b8 solid;
-     padding: 1.75em 2em;
-     word-wrap: break-word;
-     color: #404040;
-     font-family: "Roboto Mono", monospace;
+.literalblock pre, .literalblock pre[class], .listingblock pre, .listingblock pre[class] {
+  background-color: #f9f9f9;
+  border: 1px #aab7b8 solid;
+  padding: 1.75em 2em;
+  word-wrap: break-word;
+  color: #404040;
+  font-family: "Roboto Mono", monospace;
 }
- .literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap {
-     overflow-x: auto;
-     white-space: pre;
-     word-wrap: normal;
+
+.literalblock pre.nowrap, .literalblock pre[class].nowrap, .listingblock pre.nowrap, .listingblock pre[class].nowrap {
+  overflow-x: auto;
+  white-space: pre;
+  word-wrap: normal;
 }
- .literalblock pre > code, .literalblock pre[class] > code, .listingblock pre > code, .listingblock pre[class] > code {
-     display: block;
+
+.literalblock pre>code, .literalblock pre[class]>code, .listingblock pre>code, .listingblock pre[class]>code {
+  display: block;
 }
+
 /* this adds overflow for code blocks */
 /* negative padding undoes the parent padding for .iteralblock pre */
 .listingblock pre.rouge code {
@@ -1037,708 +1748,904 @@ table > tbody > tr > td > div > div > p > code {
   white-space: pre;
   overflow-x: auto;
 }
- .listingblock > .content {
-     position: relative;
-}
- .listingblock:hover code[class*=" language-"]:before {
-     text-transform: uppercase;
-     font-size: 0.9em;
-     color: #999;
-     position: absolute;
-     top: 0.375em;
-     right: 0.375em;
-}
- .listingblock:hover code.asciidoc:before {
-     content: "asciidoc";
-}
- .listingblock:hover code.clojure:before {
-     content: "clojure";
-}
- .listingblock:hover code.css:before {
-     content: "css";
-}
- .listingblock:hover code.go:before {
-     content: "go";
-}
- .listingblock:hover code.groovy:before {
-     content: "groovy";
-}
- .listingblock:hover code.html:before {
-     content: "html";
-}
- .listingblock:hover code.java:before {
-     content: "java";
-}
- .listingblock:hover code.javascript:before {
-     content: "javascript";
-}
- .listingblock:hover code.python:before {
-     content: "python";
-}
- .listingblock:hover code.ruby:before {
-     content: "ruby";
-}
- .listingblock:hover code.sass:before {
-     content: "sass";
-}
- .listingblock:hover code.scss:before {
-     content: "scss";
-}
- .listingblock:hover code.xml:before {
-     content: "xml";
-}
- .listingblock:hover code.yaml:before {
-     content: "yaml";
-}
- .listingblock.terminal pre .command:before {
-     content: attr(data-prompt);
-     padding-right: 0.5em;
-     color: #999;
-}
- .listingblock.terminal pre .command:not([data-prompt]):before {
-     content: '$';
-}
- table.pyhltable {
-     border: 0;
-     margin-bottom: 0;
-}
- table.pyhltable td {
-     vertical-align: top;
-     padding-top: 0;
-     padding-bottom: 0;
-}
- table.pyhltable td.code {
-     padding-left: .75em;
-     padding-right: 0;
-}
- .highlight.pygments .lineno, table.pyhltable td:not(.code) {
-     color: #999;
-     padding-left: 0;
-     padding-right: .5em;
-     border-right: 1px solid #d8d8d8;
-}
- .highlight.pygments .lineno {
-     display: inline-block;
-     margin-right: .25em;
-}
- table.pyhltable .linenodiv {
-     background-color: transparent !important;
-     padding-right: 0 !important;
-}
- .quoteblock {
-     margin: 0 0 1.25em 0;
-     padding: 0.5625em 1.25em 0 1.1875em;
-     border-left: 3px solid #487c58;
-}
- .quoteblock blockquote {
-     margin: 0 0 1.25em 0;
-     padding: 0 0 0.625em 0;
-     border: 0;
-}
- .quoteblock blockquote > .paragraph:last-child p {
-     margin-bottom: 0;
-}
- .quoteblock .attribution {
-     margin-top: -0.625em;
-     padding-bottom: 0.625em;
-     font-size: inherit;
-     color: #454545;
-     line-height: 1.6;
-}
- .quoteblock .attribution br {
-     display: none;
-}
- .quoteblock .attribution cite {
-     display: block;
-}
- table.tableblock {
-     max-width: 100%;
-}
- table.tableblock td .paragraph:last-child p > p:last-child, table.tableblock th > p:last-child, table.tableblock td > p:last-child {
-     margin-bottom: 0;
-}
- table.tableblock, th.tableblock, td.tableblock {
-     border: 0 solid #dddddd;
-}
- table.grid-all th.tableblock, table.grid-all td.tableblock {
-     border-width: 0 1px 1px 0;
-}
- table.grid-all tfoot > tr > th.tableblock, table.grid-all tfoot > tr > td.tableblock {
-     border-width: 1px 1px 0 0;
-}
- table.grid-cols th.tableblock, table.grid-cols td.tableblock {
-     border-width: 0 1px 0 0;
-}
- table.grid-all * > tr > .tableblock:last-child, table.grid-cols * > tr > .tableblock:last-child {
-     border-right-width: 0;
-}
- table.grid-rows th.tableblock, table.grid-rows td.tableblock {
-     border-width: 0 0 1px 0;
-}
- table.grid-all tbody > tr:last-child > th.tableblock, table.grid-all tbody > tr:last-child > td.tableblock, table.grid-all thead:last-child > tr > th.tableblock, table.grid-rows tbody > tr:last-child > th.tableblock, table.grid-rows tbody > tr:last-child > td.tableblock, table.grid-rows thead:last-child > tr > th.tableblock {
-     border-bottom-width: 0;
-}
- table.grid-rows tfoot > tr > th.tableblock, table.grid-rows tfoot > tr > td.tableblock {
-     border-width: 1px 0 0 0;
-}
- table.frame-all {
-     border-width: 1px;
-}
- table.frame-sides {
-     border-width: 0 1px;
-}
- table.frame-topbot {
-     border-width: 1px 0;
-}
- table.tableblock th.halign-left, table.tableblock td.halign-left {
-     text-align: left;
-}
- table.tableblock th.halign-right, table.tableblock td.halign-right {
-     text-align: right;
-}
- table.tableblock th.halign-center, table.tableblock td.halign-center {
-     text-align: center;
-}
- table.tableblock th.valign-top, table.tableblock td.valign-top {
-     vertical-align: top;
-}
- table.tableblock th.valign-bottom, table.tableblock td.valign-bottom {
-     vertical-align: bottom;
-}
- table.tableblock th.valign-middle, table.tableblock td.valign-middle {
-     vertical-align: middle;
-}
- table thead th, table tfoot th {
-     font-weight: bold;
-}
- tbody tr th {
-     display: table-cell;
-     line-height: 1.6;
-     background: whitesmoke;
-}
- tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
-     color: #333333;
-     font-weight: bold;
-}
- td > div.verse {
-     white-space: pre;
-}
- ul.unstyled, ol.unnumbered, ul.checklist, ul.none {
-     list-style-type: none;
-}
- ul.unstyled, ol.unnumbered, ul.checklist {
-     margin-left: 0.625em;
-}
- ul.checklist li > p:first-child > .fa-check-square-o:first-child, ul.checklist li > p:first-child > input[type="checkbox"]:first-child {
-     margin-right: 0.25em;
-}
- ul.checklist li > p:first-child > input[type="checkbox"]:first-child {
-     position: relative;
-     top: 1px;
-}
- ul.inline {
-     margin: 0 auto 0.625em auto;
-     margin-left: -1.375em;
-     margin-right: 0;
-     padding: 0;
-     list-style: none;
-     overflow: hidden;
-}
- ul.inline > li {
-     list-style: none;
-     float: left;
-     margin-left: 1.375em;
-     display: block;
-}
- ul.inline > li > * {
-     display: block;
-}
- .unstyled dl dt {
-     font-weight: normal;
-     font-style: normal;
-}
- ol.arabic {
-     list-style-type: decimal;
-}
- ol.decimal {
-     list-style-type: decimal-leading-zero;
-}
- ol.loweralpha {
-     list-style-type: lower-alpha;
-}
- ol.upperalpha {
-     list-style-type: upper-alpha;
-}
- ol.lowerroman {
-     list-style-type: lower-roman;
-}
- ol.upperroman {
-     list-style-type: upper-roman;
-}
- ol.lowergreek {
-     list-style-type: lower-greek;
-}
- .hdlist > table, .colist > table {
-     border: 0;
-     background: none;
-     margin-bottom: 0;
-}
- .hdlist > table > tbody > tr, .colist > table > tbody > tr {
-     background: none;
-}
- td.hdlist1 {
-     padding-right: .75em;
-     font-weight: bold;
-}
- td.hdlist1, td.hdlist2 {
-     vertical-align: top;
-}
- .literalblock + .colist, .listingblock + .colist {
-     margin-top: -0.5em;
-}
- .colist > table tr > td:first-of-type {
-     padding: 0 .75em;
-     line-height: 1;
-     vertical-align: top
-}
- .colist > table tr > td:last-of-type {
-     padding: 0 0 0.5em 0;
-}
+
+.listingblock>.content {
+  position: relative;
+}
+
+.listingblock:hover code[class*=" language-"]:before {
+  text-transform: uppercase;
+  font-size: 0.9em;
+  color: #999;
+  position: absolute;
+  top: 0.375em;
+  right: 0.375em;
+}
+
+.listingblock:hover code.asciidoc:before {
+  content: "asciidoc";
+}
+
+.listingblock:hover code.clojure:before {
+  content: "clojure";
+}
+
+.listingblock:hover code.css:before {
+  content: "css";
+}
+
+.listingblock:hover code.go:before {
+  content: "go";
+}
+
+.listingblock:hover code.groovy:before {
+  content: "groovy";
+}
+
+.listingblock:hover code.html:before {
+  content: "html";
+}
+
+.listingblock:hover code.java:before {
+  content: "java";
+}
+
+.listingblock:hover code.javascript:before {
+  content: "javascript";
+}
+
+.listingblock:hover code.python:before {
+  content: "python";
+}
+
+.listingblock:hover code.ruby:before {
+  content: "ruby";
+}
+
+.listingblock:hover code.sass:before {
+  content: "sass";
+}
+
+.listingblock:hover code.scss:before {
+  content: "scss";
+}
+
+.listingblock:hover code.xml:before {
+  content: "xml";
+}
+
+.listingblock:hover code.yaml:before {
+  content: "yaml";
+}
+
+.listingblock.terminal pre .command:before {
+  content: attr(data-prompt);
+  padding-right: 0.5em;
+  color: #999;
+}
+
+.listingblock.terminal pre .command:not([data-prompt]):before {
+  content: '$';
+}
+
+table.pyhltable {
+  border: 0;
+  margin-bottom: 0;
+}
+
+table.pyhltable td {
+  vertical-align: top;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+table.pyhltable td.code {
+  padding-left: .75em;
+  padding-right: 0;
+}
+
+.highlight.pygments .lineno, table.pyhltable td:not(.code) {
+  color: #999;
+  padding-left: 0;
+  padding-right: .5em;
+  border-right: 1px solid #d8d8d8;
+}
+
+.highlight.pygments .lineno {
+  display: inline-block;
+  margin-right: .25em;
+}
+
+table.pyhltable .linenodiv {
+  background-color: transparent !important;
+  padding-right: 0 !important;
+}
+
+.quoteblock {
+  margin: 0 0 1.25em 0;
+  padding: 0.5625em 1.25em 0 1.1875em;
+  border-left: 3px solid #487c58;
+}
+
+.quoteblock blockquote {
+  margin: 0 0 1.25em 0;
+  padding: 0 0 0.625em 0;
+  border: 0;
+}
+
+.quoteblock blockquote>.paragraph:last-child p {
+  margin-bottom: 0;
+}
+
+.quoteblock .attribution {
+  margin-top: -0.625em;
+  padding-bottom: 0.625em;
+  font-size: inherit;
+  color: #454545;
+  line-height: 1.6;
+}
+
+.quoteblock .attribution br {
+  display: none;
+}
+
+.quoteblock .attribution cite {
+  display: block;
+}
+
+table.tableblock {
+  max-width: 100%;
+}
+
+table.tableblock td .paragraph:last-child p>p:last-child, table.tableblock th>p:last-child, table.tableblock td>p:last-child {
+  margin-bottom: 0;
+}
+
+table.tableblock, th.tableblock, td.tableblock {
+  border: 0 solid #dddddd;
+}
+
+table.grid-all th.tableblock, table.grid-all td.tableblock {
+  border-width: 0 1px 1px 0;
+}
+
+table.grid-all tfoot>tr>th.tableblock, table.grid-all tfoot>tr>td.tableblock {
+  border-width: 1px 1px 0 0;
+}
+
+table.grid-cols th.tableblock, table.grid-cols td.tableblock {
+  border-width: 0 1px 0 0;
+}
+
+table.grid-all *>tr>.tableblock:last-child, table.grid-cols *>tr>.tableblock:last-child {
+  border-right-width: 0;
+}
+
+table.grid-rows th.tableblock, table.grid-rows td.tableblock {
+  border-width: 0 0 1px 0;
+}
+
+table.grid-all tbody>tr:last-child>th.tableblock, table.grid-all tbody>tr:last-child>td.tableblock, table.grid-all thead:last-child>tr>th.tableblock, table.grid-rows tbody>tr:last-child>th.tableblock, table.grid-rows tbody>tr:last-child>td.tableblock, table.grid-rows thead:last-child>tr>th.tableblock {
+  border-bottom-width: 0;
+}
+
+table.grid-rows tfoot>tr>th.tableblock, table.grid-rows tfoot>tr>td.tableblock {
+  border-width: 1px 0 0 0;
+}
+
+table.frame-all {
+  border-width: 1px;
+}
+
+table.frame-sides {
+  border-width: 0 1px;
+}
+
+table.frame-topbot {
+  border-width: 1px 0;
+}
+
+table.tableblock th.halign-left, table.tableblock td.halign-left {
+  text-align: left;
+}
+
+table.tableblock th.halign-right, table.tableblock td.halign-right {
+  text-align: right;
+}
+
+table.tableblock th.halign-center, table.tableblock td.halign-center {
+  text-align: center;
+}
+
+table.tableblock th.valign-top, table.tableblock td.valign-top {
+  vertical-align: top;
+}
+
+table.tableblock th.valign-bottom, table.tableblock td.valign-bottom {
+  vertical-align: bottom;
+}
+
+table.tableblock th.valign-middle, table.tableblock td.valign-middle {
+  vertical-align: middle;
+}
+
+table thead th, table tfoot th {
+  font-weight: bold;
+}
+
+tbody tr th {
+  display: table-cell;
+  line-height: 1.6;
+  background: whitesmoke;
+}
+
+tbody tr th, tbody tr th p, tfoot tr th, tfoot tr th p {
+  color: #333333;
+  font-weight: bold;
+}
+
+td>div.verse {
+  white-space: pre;
+}
+
+ul.unstyled, ol.unnumbered, ul.checklist, ul.none {
+  list-style-type: none;
+}
+
+ul.unstyled, ol.unnumbered, ul.checklist {
+  margin-left: 0.625em;
+}
+
+ul.checklist li>p:first-child>.fa-check-square-o:first-child, ul.checklist li>p:first-child>input[type="checkbox"]:first-child {
+  margin-right: 0.25em;
+}
+
+ul.checklist li>p:first-child>input[type="checkbox"]:first-child {
+  position: relative;
+  top: 1px;
+}
+
+ul.inline {
+  margin: 0 auto 0.625em auto;
+  margin-left: -1.375em;
+  margin-right: 0;
+  padding: 0;
+  list-style: none;
+  overflow: hidden;
+}
+
+ul.inline>li {
+  list-style: none;
+  float: left;
+  margin-left: 1.375em;
+  display: block;
+}
+
+ul.inline>li>* {
+  display: block;
+}
+
+.unstyled dl dt {
+  font-weight: normal;
+  font-style: normal;
+}
+
+ol.arabic {
+  list-style-type: decimal;
+}
+
+ol.decimal {
+  list-style-type: decimal-leading-zero;
+}
+
+ol.loweralpha {
+  list-style-type: lower-alpha;
+}
+
+ol.upperalpha {
+  list-style-type: upper-alpha;
+}
+
+ol.lowerroman {
+  list-style-type: lower-roman;
+}
+
+ol.upperroman {
+  list-style-type: upper-roman;
+}
+
+ol.lowergreek {
+  list-style-type: lower-greek;
+}
+
+.hdlist>table, .colist>table {
+  border: 0;
+  background: none;
+  margin-bottom: 0;
+}
+
+.hdlist>table>tbody>tr, .colist>table>tbody>tr {
+  background: none;
+}
+
+td.hdlist1 {
+  padding-right: .75em;
+  font-weight: bold;
+}
+
+td.hdlist1, td.hdlist2 {
+  vertical-align: top;
+}
+
+.literalblock+.colist, .listingblock+.colist {
+  margin-top: -0.5em;
+}
+
+.colist>table tr>td:first-of-type {
+  padding: 0 .75em;
+  line-height: 1;
+  vertical-align: top
+}
+
+.colist>table tr>td:last-of-type {
+  padding: 0 0 0.5em 0;
+}
+
 /* Fix subsequent paras for same bullet */
 .colist .paragraph p {
   font-size: 14px;
   line-height: 1.8;
   margin: 0.5em 0;
 }
+
 .colist .admonitionblock {
   margin-top: 0.5em;
   padding-top: 0.75em;
 }
-.qanda > ol > li > p > em:only-child {
-     color: #1d4b8f;
+
+.qanda>ol>li>p>em:only-child {
+  color: #1d4b8f;
 }
- .thumb, .th {
-     line-height: 0;
-     display: inline-block;
-     border: solid 4px white;
-     -webkit-box-shadow: 0 0 0 1px #dddddd;
-     box-shadow: 0 0 0 1px #dddddd;
+
+.thumb, .th {
+  line-height: 0;
+  display: inline-block;
+  border: solid 4px white;
+  -webkit-box-shadow: 0 0 0 1px #dddddd;
+  box-shadow: 0 0 0 1px #dddddd;
 }
- .imageblock.left, .imageblock[style*="float: left"] {
-     margin: 0.25em 0.625em 1.25em 0;
+
+.imageblock.left, .imageblock[style*="float: left"] {
+  margin: 0.25em 0.625em 1.25em 0;
 }
- .imageblock.right, .imageblock[style*="float: right"] {
-     margin: 0.25em 0 1.25em 0.625em;
+
+.imageblock.right, .imageblock[style*="float: right"] {
+  margin: 0.25em 0 1.25em 0.625em;
 }
- .imageblock > .title {
-     margin-bottom: 0;
+
+.imageblock>.title {
+  margin-bottom: 0;
 }
- .imageblock.thumb, .imageblock.th {
-     border-width: 6px;
+
+.imageblock.thumb, .imageblock.th {
+  border-width: 6px;
 }
- .imageblock.thumb > .title, .imageblock.th > .title {
-     padding: 0 0.125em;
+
+.imageblock.thumb>.title, .imageblock.th>.title {
+  padding: 0 0.125em;
 }
- .image.left, .image.right {
-     margin-top: 0.25em;
-     margin-bottom: 0.25em;
-     display: inline-block;
-     line-height: 0;
+
+.image.left, .image.right {
+  margin-top: 0.25em;
+  margin-bottom: 0.25em;
+  display: inline-block;
+  line-height: 0;
 }
- .image.left {
-     margin-right: 0.625em;
+
+.image.left {
+  margin-right: 0.625em;
 }
- .image.right {
-     margin-left: 0.625em;
+
+.image.right {
+  margin-left: 0.625em;
 }
- a.image {
-     text-decoration: none;
+
+a.image {
+  text-decoration: none;
 }
- span.footnote, span.footnoteref {
-     vertical-align: super;
-     font-size: 0.875em;
+
+span.footnote, span.footnoteref {
+  vertical-align: super;
+  font-size: 0.875em;
 }
- span.footnote a, span.footnoteref a {
-     text-decoration: none;
+
+span.footnote a, span.footnoteref a {
+  text-decoration: none;
 }
- span.footnote a:active, span.footnoteref a:active {
-     text-decoration: underline;
+
+span.footnote a:active, span.footnoteref a:active {
+  text-decoration: underline;
 }
+
 .dlist dt {
   padding-bottom: 0.5em;
 }
+
 /* This overrides the 0 margin from subdomain.css */
 .dlist dd {
   margin-left: 1.5em;
 }
- #footnotes {
-     padding-top: 0.75em;
-     padding-bottom: 0.75em;
-     margin-bottom: 0.625em;
-}
- #footnotes hr {
-     width: 20%;
-     min-width: 6.25em;
-     margin: -.25em 0 .75em 0;
-     border-width: 1px 0 0 0;
-}
- #footnotes .footnote {
-     padding: 0 0.375em;
-     line-height: 1.3;
-     font-size: 0.875em;
-     margin-left: 1.2em;
-     text-indent: -1.2em;
-     margin-bottom: .2em;
-}
- #footnotes .footnote a:first-of-type {
-     font-weight: bold;
-     text-decoration: none;
-}
- #footnotes .footnote:last-of-type {
-     margin-bottom: 0;
-}
- #content #footnotes {
-     margin-top: -0.625em;
-     margin-bottom: 0;
-     padding: 0.75em 0;
-}
- .gist .file-data > table {
-     border: none;
-     background: #fff;
-     width: 100%;
-     margin-bottom: 0;
-}
- .gist .file-data > table td.line-data {
-     width: 99%;
-}
- div.unbreakable {
-     page-break-inside: avoid;
-}
- code {
-     color: #404040;
-     background-color: #e7e7e7;
-     font-weight: bold;
-     font-family: "Roboto Mono", monospace;
-}
- h5 {
-     color: #404040;
-}
- strong {
-     color: #404040;
-     font-weight: bold;
-}
- a strong {
-     color: inherit;
-}
- a code {
-     color: inherit;
-}
- .replaceable {
-     font-style: italic;
-     font-family: inherit;
-}
- .parameter {
-     font-style: italic;
-     font-family: monospace;
-}
- .userinput {
-     font-weight: bold;
-     font-family: monospace;
-}
- .envar {
-     font-weight: bold;
-     font-family: monospace;
-     font-size: 90%;
-}
- .sysitem {
-     font-weight: bold;
-     font-size: 90%;
-}
- .package {
-     font-weight: bold;
-     font-size: 90%;
-}
- .filename {
-     font-weight: bold;
-     font-style: italic;
-     font-size: 90%;
-}
- .big {
-     font-size: larger;
-}
- .small {
-     font-size: smaller;
-}
- .underline {
-     text-decoration: underline;
-}
- .overline {
-     text-decoration: overline;
-}
- .line-through {
-     text-decoration: line-through;
-}
- .aqua {
-     color: #00bfbf;
-}
- .aqua-background {
-     background-color: #00fafa;
-}
- .black {
-     color: black;
-}
- .black-background {
-     background-color: black;
-}
- .blue {
-     color: #0000bf;
-}
- .blue-background {
-     background-color: #0000fa;
-}
- .fuchsia {
-     color: #bf00bf;
-}
- .fuchsia-background {
-     background-color: #fa00fa;
-}
- .gray {
-     color: #606060;
-}
- .gray-background {
-     background-color: #7d7d7d;
-}
- .green {
-     color: #006000;
-}
- .green-background {
-     background-color: #007d00;
-}
- .lime {
-     color: #00bf00;
-}
- .lime-background {
-     background-color: #00fa00;
-}
- .maroon {
-     color: #600000;
-}
- .maroon-background {
-     background-color: #7d0000;
-}
- .navy {
-     color: #000060;
-}
- .navy-background {
-     background-color: #00007d;
-}
- .olive {
-     color: #606000;
-}
- .olive-background {
-     background-color: #7d7d00;
-}
- .purple {
-     color: #600060;
-}
- .purple-background {
-     background-color: #7d007d;
-}
- .red {
-     color: #bf0000;
-}
- .red-background {
-     background-color: #fa0000;
-}
- .silver {
-     color: #909090;
-}
- .silver-background {
-     background-color: #bcbcbc;
-}
- .teal {
-     color: #006060;
-}
- .teal-background {
-     background-color: #007d7d;
-}
- .white {
-     color: #bfbfbf;
-}
- .white-background {
-     background-color: #fafafa;
-}
- .yellow {
-     color: #bfbf00;
-}
- .yellow-background {
-     background-color: #fafa00;
-}
- span.icon > .fa {
-     cursor: default;
-}
- .admonitionblock td.icon [class^="fa icon-"] {
-     font-size: 2.5em;
-     cursor: default;
-     padding-top: .125em;
-}
- .admonitionblock td.icon .icon-note:before {
-     content: "\f05a";
-     color: #4E9FDD;
-}
- .admonitionblock td.icon .icon-tip:before {
-     content: "\f0eb";
-     color: #2C8596;
-}
- .admonitionblock td.icon .icon-warning:before {
-     content: "\f071";
-     color: #ec7a08;
-}
- .admonitionblock td.icon .icon-caution:before {
-     content: "\f06d";
-     color: #ec7a08;
-}
- .admonitionblock td.icon .icon-important:before {
-     content: "\f06a";
-     color: #e00;
-}
- .conum[data-value] {
-     display: inline-block;
-     color: white !important;
-     background-color: #394b54;
-     -webkit-border-radius: 100px;
-     border-radius: 100px;
-     text-align: center;
-     width: 20px;
-     height: 20px;
-     font-size: 12px;
-     line-height: 20px;
-     font-family: "Open Sans", "Sans", sans-serif;
-     font-style: normal;
-     font-weight: bold;
-     text-indent: -1px;
-}
- .conum[data-value] * {
-     color: white !important;
-}
- .conum[data-value] + b {
-     display: none;
-}
- .conum[data-value]:after {
-     content: attr(data-value);
-}
- pre .conum[data-value] {
-     text-shadow: 0 0;
-     position: relative;
-     top: -2px;
-}
- b.conum * {
-     color: inherit !important;
-}
- .conum:not([data-value]):empty {
-     display: none;
-}
- .print-only {
-     display: none !important;
-}
- @media print {
-     @page {
-         margin: 1.25cm 0.75cm;
-    }
-     * {
-         -webkit-box-shadow: none !important;
-         box-shadow: none !important;
-         text-shadow: none !important;
-    }
-     a, a:visited {
-         color: inherit !important;
-         text-decoration: underline !important;
-    }
-     a[href^="http:"]:after, a[href^="https:"]:after {
-         content: " (" attr(href) ")";
-    }
-     a[href^="#"], a[href^="#"]:visited, a[href^="mailto:"], a[href^="mailto:"]:visited {
-         text-decoration: none !important;
-    }
-     abbr[title]:after {
-         content: " (" attr(title) ")";
-    }
-     pre, blockquote {
-         page-break-inside: avoid;
-    }
-     code {
-         color: #191919;
-    }
-     thead {
-         display: table-header-group;
-    }
-     tr, img {
-         page-break-inside: avoid;
-    }
-     img {
-         max-width: 100% !important;
-    }
-     p {
-         orphans: 3;
-         widows: 3;
-    }
-     h2, h3, #toctitle, .sidebarblock > .content > .title, #toctitle, .sidebarblock > .content > .title {
-         page-break-after: avoid;
-    }
-     #toc, .sidebarblock {
-         background: none !important;
-    }
-     #toc {
-         border-bottom: 1px solid #d8d8d8 !important;
-         padding-bottom: 0 !important;
-    }
-     .sect1 {
-         padding-bottom: 0 !important;
-    }
-     .sect1 + .sect1 {
-         border: none !important;
-    }
-     body.book #header {
-         text-align: center;
-    }
-     body.book #header > h1 {
-         border: none !important;
-         margin: 2.5em 0 1em 0;
-         padding: 0;
-    }
-     body.book #header span {
-         line-height: 1.6;
-    }
-     body.book #header br {
-         display: block;
-    }
-     body.book #header br + span {
-         padding-left: 0;
-    }
-     body.book #header br + span:before {
-         content: none !important;
-    }
-     body.book #toc {
-         border: none !important;
-         text-align: left !important;
-         padding: 0 !important;
-    }
-     #footer {
-         background: none !important;
-    }
-     #footer-text {
-         color: #333333 !important;
-    }
-     .hide-on-print {
-         display: none !important;
-    }
-     .print-only {
-         display: block !important;
-    }
-     .hide-for-print {
-         display: none !important;
-    }
-     .show-for-print {
-         display: inherit !important;
-    }
+
+#footnotes {
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
+  margin-bottom: 0.625em;
+}
+
+#footnotes hr {
+  width: 20%;
+  min-width: 6.25em;
+  margin: -.25em 0 .75em 0;
+  border-width: 1px 0 0 0;
+}
+
+#footnotes .footnote {
+  padding: 0 0.375em;
+  line-height: 1.3;
+  font-size: 0.875em;
+  margin-left: 1.2em;
+  text-indent: -1.2em;
+  margin-bottom: .2em;
+}
+
+#footnotes .footnote a:first-of-type {
+  font-weight: bold;
+  text-decoration: none;
+}
+
+#footnotes .footnote:last-of-type {
+  margin-bottom: 0;
+}
+
+#content #footnotes {
+  margin-top: -0.625em;
+  margin-bottom: 0;
+  padding: 0.75em 0;
+}
+
+.gist .file-data>table {
+  border: none;
+  background: #fff;
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.gist .file-data>table td.line-data {
+  width: 99%;
+}
+
+div.unbreakable {
+  page-break-inside: avoid;
+}
+
+code {
+  color: #404040;
+  background-color: #e7e7e7;
+  font-weight: bold;
+  font-family: "Roboto Mono", monospace;
+}
+
+h5 {
+  color: #404040;
+}
+
+strong {
+  color: #404040;
+  font-weight: bold;
+}
+
+a strong {
+  color: inherit;
+}
+
+a code {
+  color: inherit;
+}
+
+.replaceable {
+  font-style: italic;
+  font-family: inherit;
+}
+
+.parameter {
+  font-style: italic;
+  font-family: monospace;
+}
+
+.userinput {
+  font-weight: bold;
+  font-family: monospace;
+}
+
+.envar {
+  font-weight: bold;
+  font-family: monospace;
+  font-size: 90%;
+}
+
+.sysitem {
+  font-weight: bold;
+  font-size: 90%;
+}
+
+.package {
+  font-weight: bold;
+  font-size: 90%;
+}
+
+.filename {
+  font-weight: bold;
+  font-style: italic;
+  font-size: 90%;
+}
+
+.big {
+  font-size: larger;
+}
+
+.small {
+  font-size: smaller;
+}
+
+.underline {
+  text-decoration: underline;
+}
+
+.overline {
+  text-decoration: overline;
+}
+
+.line-through {
+  text-decoration: line-through;
+}
+
+.aqua {
+  color: #00bfbf;
+}
+
+.aqua-background {
+  background-color: #00fafa;
+}
+
+.black {
+  color: black;
+}
+
+.black-background {
+  background-color: black;
+}
+
+.blue {
+  color: #0000bf;
+}
+
+.blue-background {
+  background-color: #0000fa;
+}
+
+.fuchsia {
+  color: #bf00bf;
+}
+
+.fuchsia-background {
+  background-color: #fa00fa;
+}
+
+.gray {
+  color: #606060;
+}
+
+.gray-background {
+  background-color: #7d7d7d;
+}
+
+.green {
+  color: #006000;
+}
+
+.green-background {
+  background-color: #007d00;
+}
+
+.lime {
+  color: #00bf00;
+}
+
+.lime-background {
+  background-color: #00fa00;
+}
+
+.maroon {
+  color: #600000;
+}
+
+.maroon-background {
+  background-color: #7d0000;
+}
+
+.navy {
+  color: #000060;
+}
+
+.navy-background {
+  background-color: #00007d;
+}
+
+.olive {
+  color: #606000;
+}
+
+.olive-background {
+  background-color: #7d7d00;
+}
+
+.purple {
+  color: #600060;
+}
+
+.purple-background {
+  background-color: #7d007d;
+}
+
+.red {
+  color: #bf0000;
+}
+
+.red-background {
+  background-color: #fa0000;
+}
+
+.silver {
+  color: #909090;
+}
+
+.silver-background {
+  background-color: #bcbcbc;
+}
+
+.teal {
+  color: #006060;
+}
+
+.teal-background {
+  background-color: #007d7d;
+}
+
+.white {
+  color: #bfbfbf;
+}
+
+.white-background {
+  background-color: #fafafa;
+}
+
+.yellow {
+  color: #bfbf00;
+}
+
+.yellow-background {
+  background-color: #fafa00;
+}
+
+span.icon>.fa {
+  cursor: default;
+}
+
+.admonitionblock td.icon [class^="fa icon-"] {
+  font-size: 2.5em;
+  cursor: default;
+  padding-top: .125em;
+}
+
+.admonitionblock td.icon .icon-note:before {
+  content: "\f05a";
+  color: #4E9FDD;
+}
+
+.admonitionblock td.icon .icon-tip:before {
+  content: "\f0eb";
+  color: #2C8596;
+}
+
+.admonitionblock td.icon .icon-warning:before {
+  content: "\f071";
+  color: #ec7a08;
+}
+
+.admonitionblock td.icon .icon-caution:before {
+  content: "\f06d";
+  color: #ec7a08;
+}
+
+.admonitionblock td.icon .icon-important:before {
+  content: "\f06a";
+  color: #e00;
+}
+
+.conum[data-value] {
+  display: inline-block;
+  color: white !important;
+  background-color: #394b54;
+  -webkit-border-radius: 100px;
+  border-radius: 100px;
+  text-align: center;
+  width: 20px;
+  height: 20px;
+  font-size: 12px;
+  line-height: 20px;
+  font-family: "Open Sans", "Sans", sans-serif;
+  font-style: normal;
+  font-weight: bold;
+  text-indent: -1px;
+}
+
+.conum[data-value] * {
+  color: white !important;
+}
+
+.conum[data-value]+b {
+  display: none;
+}
+
+.conum[data-value]:after {
+  content: attr(data-value);
+}
+
+pre .conum[data-value] {
+  text-shadow: 0 0;
+  position: relative;
+  top: -2px;
+}
+
+b.conum * {
+  color: inherit !important;
+}
+
+.conum:not([data-value]):empty {
+  display: none;
+}
+
+.print-only {
+  display: none !important;
+}
+
+@media print {
+  @page {
+    margin: 1.25cm 0.75cm;
+  }
+
+  * {
+    -webkit-box-shadow: none !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+  }
+
+  a, a:visited {
+    color: inherit !important;
+    text-decoration: underline !important;
+  }
+
+  a[href^="http:"]:after, a[href^="https:"]:after {
+    content: " ("attr(href) ")";
+  }
+
+  a[href^="#"], a[href^="#"]:visited, a[href^="mailto:"], a[href^="mailto:"]:visited {
+    text-decoration: none !important;
+  }
+
+  abbr[title]:after {
+    content: " ("attr(title) ")";
+  }
+
+  pre, blockquote {
+    page-break-inside: avoid;
+  }
+
+  code {
+    color: #191919;
+  }
+
+  thead {
+    display: table-header-group;
+  }
+
+  tr, img {
+    page-break-inside: avoid;
+  }
+
+  img {
+    max-width: 100% !important;
+  }
+
+  p {
+    orphans: 3;
+    widows: 3;
+  }
+
+  h2, h3, #toctitle, .sidebarblock>.content>.title, #toctitle, .sidebarblock>.content>.title {
+    page-break-after: avoid;
+  }
+
+  #toc, .sidebarblock {
+    background: none !important;
+  }
+
+  #toc {
+    border-bottom: 1px solid #d8d8d8 !important;
+    padding-bottom: 0 !important;
+  }
+
+  .sect1 {
+    padding-bottom: 0 !important;
+  }
+
+  .sect1+.sect1 {
+    border: none !important;
+  }
+
+  body.book #header {
+    text-align: center;
+  }
+
+  body.book #header>h1 {
+    border: none !important;
+    margin: 2.5em 0 1em 0;
+    padding: 0;
+  }
+
+  body.book #header span {
+    line-height: 1.6;
+  }
+
+  body.book #header br {
+    display: block;
+  }
+
+  body.book #header br+span {
+    padding-left: 0;
+  }
+
+  body.book #header br+span:before {
+    content: none !important;
+  }
+
+  body.book #toc {
+    border: none !important;
+    text-align: left !important;
+    padding: 0 !important;
+  }
+
+  #footer {
+    background: none !important;
+  }
+
+  #footer-text {
+    color: #333333 !important;
+  }
+
+  .hide-on-print {
+    display: none !important;
+  }
+
+  .print-only {
+    display: block !important;
+  }
+
+  .hide-for-print {
+    display: none !important;
+  }
+
+  .show-for-print {
+    display: inherit !important;
+  }
 }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -4,6 +4,7 @@
 <!--[if gt IE 9]><!-->
 <html>
 <!--<![endif]-->
+
 <head>
   <meta charset="utf-8">
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
@@ -11,12 +12,12 @@
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css">
-  <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/docs.css" rel="stylesheet" />
   <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/search.css" rel="stylesheet" />
   <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/autumn.css" rel="stylesheet" />
   <link href="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" rel="apple-touch-icon-precomposed" type="image/png">
   <link href="https://assets.openshift.net/content/subdomain/favicon32x32.png" rel="shortcut icon" type="text/css">
   <link href="https://assets.openshift.net/content/osh-nav-footer.css" rel="stylesheet" type="text/css" media="screen, print" />
+  <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/docs.css" rel="stylesheet" />
   <!--[if IE]><link rel="shortcut icon" href="https://assets.openshift.net/content/subdomain/favicon.ico"><![endif]-->
   <!-- or, set /favicon.ico for IE10 win -->
   <meta content="OpenShift" name="application-name">
@@ -24,18 +25,36 @@
   <meta content="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" name="msapplication-TileImage">
   <%= render("_templates/_analytics.html.erb", :distro_key => distro_key) %>
 </head>
+
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>
   <%
     unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"];
   %>
   <div class="container">
-    <p class="toggle-nav visible-xs pull-left">
-      <button class="btn btn-default btn-sm" type="button" data-toggle="offcanvas">Toggle nav</button>
-    </p>
+    <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
     <ol class="breadcrumb">
+      <% if (version == "4.10" || distro_key == "openshift-webscale") %>
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>This documentation is work in progress and might not be complete or fully tested.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
+        </div>
+      </span>
+      <% end %>
+
+      <% if ((unsupported_versions.include? version) && (distro_key == "openshift-enterprise")) %>
+      
+      <span>
+        <div class="alert alert-danger" role="alert" id="support-alert">
+          <strong>You are viewing documentation for a release that is no longer supported.</strong> The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html" class="link-primary" style="color: #545454 !important;">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
+        </div>
+      </span>
+      
+      <% end %>
+
       <li class="sitename">
-        <a href="/"><%= site_name %></a>
+        <a href="/">
+          <%= site_name %></a>
       </li>
       <li class="hidden-xs active">
         <% if (distro_key == "openshift-enterprise") %>
@@ -71,7 +90,7 @@
               <option value="3.0">3.0</option>
           </select>
         <% else %>
-          <%= breadcrumb_root %>
+        <%= breadcrumb_root %>
         <% end %>
       </li>
       <li class="hidden-xs active">
@@ -81,18 +100,17 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-
       <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro") %>
       <span text-align="right" style="float: right !important">
-        <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-enterprise") ? "enterprise-#{version}" : "dedicated-4" %>/<%= repo_path %>">
+        <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == " openshift-enterprise") ? "enterprise-#{version}" : "dedicated-4" %>/
+          <%= repo_path %>">
           Page history
         </a>
         <%
           unless (unsupported_versions.include? version)
         %>
         /
-        <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= (distro_key == "openshift-enterprise") ? "[enterprise-#{version}] Issue in file #{repo_path}" :
-          ((distro_key == "openshift-dedicated") ? "[dedicated] Issue in file #{repo_path}" : "[online] Issue in file #{repo_path}") %>">
+        <a href="https://github.com/openshift/openshift-docs/issues/new?title=<%= (distro_key == " openshift-enterprise") ? "[enterprise-#{version}] Issue in file #{repo_path}" : ((distro_key=="openshift-dedicated" ) ? "[dedicated] Issue in file #{repo_path}" : "[online] Issue in file #{repo_path}" ) %>">
           Open an issue
         </a>
         <% if (version == "4.5") %>
@@ -110,71 +128,55 @@
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
         <div class="row-fluid">
-          <div id="hc-search">
-            <input id="hc-search-input" type="text">
-            <button id="hc-search-btn">Search</button>
+          <div id="btn-close">
+            <button id="hc-close-btn" onclick="closeNav()" class="close-btn-sm" aria-label="close"><span class="fa fa-times" /></button>
           </div>
-
-          <div id="hc-search-modal">
-            <div id="hc-modal-content">
-              <span id="hc-modal-close">&times;</span>
-              <div id="hc-search-results-wrapper">
-                <div id="hc-search-results"></div>
-                <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
-                <div class="text-center">
-                  <button id="hc-search-more-btn">Show more results</button>
-                </div>
-              </div>
-            </div>
+          <div id="hc-search">
+            <input id="hc-search-input" type="text" aria-label="search">
+            <button id="hc-search-btn" aria-label="search"><span class="fa fa-search" /></button>
           </div>
         </div>
         <%= render("_templates/_nav_openshift.html.erb", :distro_key => distro_key, :navigation => navigation, :group_id => group_id, :topic_id => topic_id, :subgroup_id => subgroup_id, :subtopic_shim => subtopic_shim, :subsubgroup_id => subsubgroup_id) %>
       </div>
+      <div id="hc-search-modal">
+        <div id="hc-modal-content">
+          <span id="hc-modal-close">&times;</span>
+          <div id="hc-search-results-wrapper">
+            <div id="hc-search-results"></div>
+            <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+            <div class="text-center">
+              <button id="hc-search-more-btn">Show more results</button>
+            </div>
+          </div>
+        </div>
+      </div>
       <div class="col-xs-12 col-sm-9 col-md-9 main">
         <div class="page-header">
-          <h1><%= article_title %></h1>
+          <h1>
+            <%= article_title %>
+          </h1>
         </div>
-        <% if (version == "4.10" || distro_key == "openshift-webscale") %>
-          <font size="+1" color="red">This documentation is work in progress and might not be complete or fully tested.</font>
-          <div id="annoying-box"
-            style="position: fixed; top: 100px; left: 10px; width: 100px; height: 100px; color: red">
-              This documentation is work in progress and might not be complete or fully tested.
-          </div>
-        <% end %>
-        <%
-           if ((unsupported_versions.include? version) && (distro_key == "openshift-enterprise"))
-        %>
-          <font size="+1" color="red">You are viewing documentation for a release that is no longer supported. The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html">[4]</a></font>
-          <div id="annoying-box"
-            style="position: fixed; top: 100px; left: 10px; width: 100px; height: 100px; color: red">
-              You are viewing documentation for a release that is no longer supported. The latest supported version of version 3 is <a href="https://docs.openshift.com/container-platform/3.11/welcome/index.html">[3.11]</a>. For the most recent version 4, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html">[4]</a>
-          </div>
-        <% end %>
         <% if (distro_key == "openshift-aro" && version == "3") %>
-          <font size="+1" color="red">
-            <hr>
-            <b>Important</b>
-            </font>
-
-            <p>Azure Red Hat OpenShift 3.11 <b>will be retired 30 June 2022</b>. Support for creation of new Azure Red Hat OpenShift 3.11 clusters continues through 30 November 2020. Following retirement, remaining Azure Red Hat OpenShift 3.11 clusters will be shut down to prevent security vulnerabilities.</p>
-
-            <p>Follow this guide to <a href="https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster">create an Azure Red Hat OpenShift 4 cluster</a>. If you have specific questions, please <a href="mailto:arofeedback@microsoft.com">contact us</a></p>
-            <hr>
+        <font size="+1" color="red">
+          <hr>
+          <b>Important</b>
+        </font>
+        <p>Azure Red Hat OpenShift 3.11 <b>will be retired 30 June 2022</b>. Support for creation of new Azure Red Hat OpenShift 3.11 clusters continues through 30 November 2020. Following retirement, remaining Azure Red Hat OpenShift 3.11 clusters will be shut down to prevent security vulnerabilities.</p>
+        <p>Follow this guide to <a href="https://docs.microsoft.com/en-us/azure/openshift/tutorial-create-cluster">create an Azure Red Hat OpenShift 4 cluster</a>. If you have specific questions, please <a href="mailto:arofeedback@microsoft.com">contact us</a></p>
+        <hr>
         <% end %>
         <% if (distro_key == "openshift-aro" && version == "4") %>
-          <font size="+1" color="red">
-            <hr>
-            <b>Important</b>
-            </font>
-            <p>Azure Red Hat OpenShift is supported by Red Hat and Microsoft. As of February 2021, the documentation will be hosted by Microsoft and Red Hat as outlined below.</p>
-            <hr>
+        <font size="+1" color="red">
+          <hr>
+          <b>Important</b>
+        </font>
+        <p>Azure Red Hat OpenShift is supported by Red Hat and Microsoft. As of February 2021, the documentation will be hosted by Microsoft and Red Hat as outlined below.</p>
+        <hr>
         <% end %>
-
         <%= content %>
       </div>
     </div>
   </div>
-
   <script src="https://assets.openshift.net/content/modernizr.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/subdomain.js" type="text/javascript"></script>
   <script src="https://assets.openshift.net/content/nav-tertiary.js" type="text/javascript"></script>
@@ -185,7 +187,6 @@
   <script src="https://cdnjs.cloudflare.com/ajax/libs/clipboard.js/2.0.6/clipboard.min.js" type="text/javascript"></script>
   <script src="https://docs.openshift.com/container-platform/4.1/_javascripts/clipboard.js" type="text/javascript"></script>
   <script src="https://docs.openshift.com/container-platform/4.1/_javascripts/collapsible.js" type="text/javascript"></script>
-
   <script>
   var dk = '<%= distro_key %>';
   var version = '<%= version %>';
@@ -203,46 +204,212 @@
 
   // only OSD v3 docs have the version variable specified
   if (dk == "openshift-dedicated" && version == "3") {
-      distros['openshift-dedicated'] = ['docs_dedicated_v3']
-    }
+    distros['openshift-dedicated'] = ['docs_dedicated_v3']
+  }
 
   distros[dk] ? hcSearchCategory.apply(null, distros[dk]) : hcSearchCategory("docs");
   </script>
-
   <script type="text/javascript">
-    /*<![CDATA[*/
-    $(document).ready(function() {
-      $("[id^='topicGroup']").on('show.bs.collapse', function (event) {
-        if (!($(event.target).attr('id').match(/^topicSubGroup/))) {
-          $(this).parent().find("[id^='tgSpan']").toggleClass("fa-angle-right fa-angle-down");
-        }
-      });
-      $("[id^='topicGroup']").on('hide.bs.collapse', function (event) {
-        if (!($(event.target).attr('id').match(/^topicSubGroup/))) {
-          $(this).parent().find("[id^='tgSpan']").toggleClass("fa-angle-right fa-angle-down");
-        }
-      });
-      $("[id^='topicSubGroup']").on('show.bs.collapse', function () {
-        $(this).parent().find("[id^='sgSpan']").toggleClass("fa-caret-right fa-caret-down");
-      });
-      $("[id^='topicSubGroup']").on('hide.bs.collapse', function () {
-        $(this).parent().find("[id^='sgSpan']").toggleClass("fa-caret-right fa-caret-down");
-      });
-      $("[id^='topicSubSubGroup']").on('show.bs.collapse', function () {
-        $(this).parent().find("[id^='ssgSpan']").toggleClass("fa-caret-right fa-caret-down");
-      });
-      $("[id^='topicSubSubGroup']").on('hide.bs.collapse', function () {
-        $(this).parent().find("[id^='ssgSpan']").toggleClass("fa-caret-right fa-caret-down");
-      });
-
-      const collapsibleContent = document.getElementsByTagName("details");
-        for (var i=0; i < collapsibleContent.length; i++) {
-          collapsibleContent[i].setAttribute("open", "");
-        }
-
+  /*<![CDATA[*/
+  $(document).ready(function() {
+    $("[id^='topicGroup']").on('show.bs.collapse', function(event) {
+      if (!($(event.target).attr('id').match(/^topicSubGroup/))) {
+        $(this).parent().find("[id^='tgSpan']").toggleClass("fa-angle-right fa-angle-down");
+      }
     });
-    /*]]>*/
+    $("[id^='topicGroup']").on('hide.bs.collapse', function(event) {
+      if (!($(event.target).attr('id').match(/^topicSubGroup/))) {
+        $(this).parent().find("[id^='tgSpan']").toggleClass("fa-angle-right fa-angle-down");
+      }
+    });
+    $("[id^='topicSubGroup']").on('show.bs.collapse', function() {
+      $(this).parent().find("[id^='sgSpan']").toggleClass("fa-caret-right fa-caret-down");
+    });
+    $("[id^='topicSubGroup']").on('hide.bs.collapse', function() {
+      $(this).parent().find("[id^='sgSpan']").toggleClass("fa-caret-right fa-caret-down");
+    });
+    $("[id^='topicSubSubGroup']").on('show.bs.collapse', function() {
+      $(this).parent().find("[id^='ssgSpan']").toggleClass("fa-caret-right fa-caret-down");
+    });
+    $("[id^='topicSubSubGroup']").on('hide.bs.collapse', function() {
+      $(this).parent().find("[id^='ssgSpan']").toggleClass("fa-caret-right fa-caret-down");
+    });
+
+    const collapsibleContent = document.getElementsByTagName("details");
+    for (var i = 0; i < collapsibleContent.length; i++) {
+      collapsibleContent[i].setAttribute("open", "");
+    }
+
+  });
+  /*]]>*/
   </script>
+
   <%= render("_templates/_footer.html.erb", :distro_key => distro_key, :images_path => images_path) %>
+
+  <!-- adjust page css based on breadcrumb and/or resize -->
+  <script type="text/javascript">
+    window.addEventListener('DOMContentLoaded', () => {
+      if (window.innerWidth >= 1425) {
+        adjustSide();
+        adjustToc();
+        adjustMain();
+      }
+    });
+
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 1425) {
+        sidebar.style.display = 'block';
+        adjustSide();
+        adjustToc();
+        adjustMain();
+      } else if (window.innerWidth < 1425) {
+        sidebar.style.display = 'none';
+        document.querySelector('.main').style.paddingTop = '0px';        
+      }
+    });
+
+    function adjustSide() {
+      document.querySelector('.sidebar').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 125), 10) + "px";
+      document.querySelector('#hc-search').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 95), 10) + "px";    
+    }
+
+    function adjustToc() {
+      if (document.querySelector('#toc') !== null) {
+        document.querySelector('#toc').style.top = parseInt((document.querySelector('.breadcrumb').offsetHeight + 90), 10) + "px";     
+      } 
+    }
+
+    function adjustMain() {
+      document.querySelector('html').style.scrollPaddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight + 90), 10) + "px";
+      document.querySelector('.main').style.paddingTop = parseInt((document.querySelector('.breadcrumb').offsetHeight - 70), 10) + "px";      
+    }
+
+  </script>
+
+  <!-- remove toc active class when page is loaded -->
+  <script type="text/javascript">
+    window.addEventListener('DOMContentLoaded', () => {
+      var tocItems = $("#toc a");
+
+      for (let i = 0; i < tocItems.length; i++) {
+        tocItems[i].classList.remove("toc-active");
+      }
+    })
+  </script>
+
+  <!-- maintain sidebar scroll position between page loads -->
+  <script type="text/javascript">
+    let sidebar = document.querySelector(".sidebar");
+    let scrolltop = localStorage.getItem("sidebar-scroll");
+
+    if (scrolltop == null) {
+      sidebar.scrollTop = parseInt(top, 10);
+    }
+
+    window.addEventListener("beforeunload", () => {
+      localStorage.setItem("sidebar-scroll", sidebar.scrollTop);
+    });
+
+    window.addEventListener('load', () => {
+      sidebar.scrollTo(0, scrolltop)
+    })
+  </script>
+
+  <!-- open/close the nav -->
+  <script type="text/javascript">
+    function closeNav() {
+      let sidebar = document.querySelector(".sidebar");
+      sidebar.style.display = "none";
+    }
+
+    function openNav() {
+      let sidebar = document.querySelector(".sidebar");
+      sidebar.style.display = "block";
+      sidebar.style.top = "0px";
+    }
+  </script>
+
+  <!-- clear and add toc-active to clicked toc link -->
+  <script type="text/javascript">
+  $("#toc a").click(function() {
+    var tocItems = $("#toc a");
+    for (let i = 0; i < tocItems.length; i++) {
+      tocItems[i].classList.remove("toc-active");
+    }
+    this.classList.add("toc-active");
+  });
+  </script>
+
+  <!-- update active toc class when mouse scrolls -->
+  <script type="text/javascript">
+    window.addEventListener("wheel", () => {
+
+      const ioConfiguration = {
+        "rootMargin": "-120px 0px -400px 0px",
+        "threshold": 0
+      };
+
+      const observer = new IntersectionObserver(setCurrent, ioConfiguration, entries => {
+        entries.forEach(entry => {
+          var id = entry.target.getAttribute('id');
+          //fight with js
+          document.querySelector(`#toc li a[href="#${id}"]`).classList.remove('toc-active');
+        });
+      });
+
+      //track all h1-4 headings that have an id
+      document.querySelectorAll('.main h2[id], .main h3[id]').forEach((h) => {
+        observer.observe(h);
+      });
+
+      //runs when the IntersectionObserver fires
+      function setCurrent(e) {
+        var allTocLinks = document.querySelectorAll("#toc li a");
+        e.map(i => {
+          if (i.isIntersecting && i.intersectionRatio >= 1) {
+            allTocLinks.forEach(link => link.classList.remove("toc-active"));
+            document.querySelector(`#toc li a[href="#${i.target.id}"]`).classList.add('toc-active');
+          }
+        });
+      };
+
+      //make clicked toc item active and stop IntersectionObserver
+      $("#toc a").click(function() {
+        //stop tracking all h1-4 headings that have an id
+        document.querySelectorAll('.main h2[id], .main h3[id]').forEach((h) => {
+          observer.unobserve(h);
+        });
+        var tocItems = $("#toc a");
+        for (let i = 0; i < tocItems.length; i++) {
+          tocItems[i].classList.remove("toc-active");
+        }
+        this.classList.add("toc-active");
+      })
+    })
+  </script>
+
+  <!--handle page scroll top and bottom, add toc-active -->
+  <script type="text/javascript">
+    document.addEventListener('scroll', () => {
+      //scroll to bottom
+      if(document.documentElement.scrollHeight === window.pageYOffset + window.innerHeight) {
+        var tocItems = $("#toc a");
+        for (let i = 0; i < tocItems.length; i++) {
+          tocItems[i].classList.remove("toc-active")
+          };
+          tocItems[tocItems.length - 1].classList.add("toc-active");
+        };
+      //scroll to top
+      if(window.scrollY==0) {
+        var tocItems = $("#toc a");
+        for (let i = 0; i < tocItems.length; i++) {
+          tocItems[i].classList.remove("toc-active")
+          }
+        };
+        tocItems[0].classList.add("toc-active");
+      })
+  </script>
+
 </body>
+
 </html>


### PR DESCRIPTION
Changes to _templates/_page_openshift.html.erb fix the sidebar, navbar, and breadcrumb to improve user experience of long page scrolling. 

Created a new PR against enterprise-4.1 for the css: https://github.com/openshift/openshift-docs/pull/37963

not working in netlify build for now, see here for a random page (requires VPN): http://file.emea.redhat.com/aireilly/files/fixed-sidebar-nav-update/installing/installing_azure_stack_hub/installing-azure-stack-hub-account.html

TODO:

* Highlight/bold the TOC section you are in as you scroll **DONE**
* Make TOC box == NAV box. Maybe it will look more similar to what we currently have if we only keep the right border for the left TOC and left border for the right TOC **DONE**
* Can we extend the left TOC to the available page height? **DONE**
* Maybe remove the search box from the TOC so that it is always visible **DONE**
* Make the TOC more legible **DONE**
* fix top nav alignment  **DONE**
* Fix "annoying box" **DONE**