### PR TITLE
Refresh network policy procedures

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -846,7 +846,7 @@ Topics:
     File: editing-network-policy
   - Name: Deleting a network policy
     File: deleting-network-policy
-  - Name: Defining a default network policy
+  - Name: Defining a default network policy for projects
     File: default-network-policy
   - Name: Configuring multitenant network policy
     File: multitenant-network-policy

--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -1,59 +1,101 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/creating-network-policy.adoc
-// * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
-[id="nw-networkpolicy-create_{context}"]
+ifeval::[{product-version} >= 4.6]
+:ovn:
+endif::[]
 
+[id="nw-networkpolicy-create_{context}"]
 = Creating a network policy
 
-To define granular rules describing ingress network traffic allowed for projects
-in your cluster, you can create a network policy.
+To define granular rules describing ingress or egress network traffic allowed for namespaces in your cluster, you can create a network policy.
+
+[NOTE]
+====
+If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
+====
 
 .Prerequisites
 
-* Your cluster is using a default CNI network provider that supports `NetworkPolicy` objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+* Your cluster is using a cluster network provider that supports `NetworkPolicy` objects, such as
+ifndef::ovn[]
+the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+ifdef::ovn[]
+the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with `admin` privileges.
+* You are working in the namespace that the network policy applies to.
 
 .Procedure
 
 . Create a policy rule:
-.. Create a `<policy-name>.yaml` file where `<policy-name>` describes the policy
-rule.
-.. In the file you just created define a policy object, such as in the following
-example:
+.. Create a `<policy_name>.yaml` file:
 +
+[source,terminal]
+----
+$ touch <policy_name>.yaml
+----
++
+--
+where:
+
+`<policy_name>`:: Specifies the network policy file name.
+--
+
+.. Define a network policy in the file that you just created, such as in the following examples:
++
+.Deny ingress from all pods in all namespaces
 [source,yaml]
 ----
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: <policy-name> <1>
+  name: deny-by-default
 spec:
   podSelector:
   ingress: []
 ----
-<1> Specify a name for the policy object.
++
+.Allow ingress from all pods in the same namespace
+[source,yaml]
+----
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-same-namespace
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
+----
 
-. Run the following command to create the policy object:
+
+. To create the network policy object, enter the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <policy-name>.yaml -n <project>
+$ oc apply -f <policy_name>.yaml -n <namespace>
 ----
 +
-In the following example, a new `NetworkPolicy` object is created in a project
-named `project1`:
-+
-[source,terminal]
-----
-$ oc create -f default-deny.yaml -n project1
-----
+--
+where:
+
+`<policy_name>`:: Specifies the network policy file name.
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
 +
 .Example output
 [source,terminal]
 ----
 networkpolicy "default-deny" created
 ----
+
+ifdef::ovn[]
+:!ovn:
+endif::ovn[]

--- a/modules/nw-networkpolicy-delete.adoc
+++ b/modules/nw-networkpolicy-delete.adoc
@@ -1,25 +1,58 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/deleting-network-policy.adoc
-// * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
-[id="nw-networkpolicy-delete_{context}"]
+ifeval::[{product-version} >= 4.6]
+:ovn:
+endif::[]
 
+[id="nw-networkpolicy-delete_{context}"]
 = Deleting a network policy
 
-You can delete a network policy.
+You can delete a network policy in a namespace.
+
+[NOTE]
+====
+If you log in with a user with the `cluster-admin` role, then you can delete any network policy in the cluster.
+====
 
 .Prerequisites
 
+* Your cluster is using a cluster network provider that supports `NetworkPolicy` objects, such as
+ifndef::ovn[]
+the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+ifdef::ovn[]
+the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with `admin` privileges.
+* You are working in the namespace where the network policy exists.
 
 .Procedure
 
-* To delete a `NetworkPolicy` object, enter the following command. Replace `<policy-name>` with the name of the object.
+* To delete a `NetworkPolicy` object, enter the following command:
 +
 [source,terminal]
 ----
-$ oc delete networkpolicy <policy-name>
+$ oc delete networkpolicy <policy_name> -n <namespace>
 ----
++
+--
+where:
+
+`<policy_name>`:: Specifies the name of the network policy.
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
++
+.Example output
+[source,text]
+----
+networkpolicy.networking.k8s.io/allow-same-namespace deleted
+----
+
+ifdef::ovn[]
+:!ovn:
+endif::ovn[]

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -2,54 +2,93 @@
 //
 // * networking/network_policy/editing-network-policy.adoc
 
-[id="nw-networkpolicy-edit_{context}"]
+ifeval::[{product-version} >= 4.6]
+:ovn:
+endif::[]
 
+[id="nw-networkpolicy-edit_{context}"]
 = Editing a network policy
 
 You can edit a network policy in a namespace.
 
+[NOTE]
+====
+If you log in with a user with the `cluster-admin` role, then you can edit a network policy in any namespace in the cluster.
+====
+
 .Prerequisites
 
-* Your cluster is using a default CNI network provider that supports `NetworkPolicy` objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+* Your cluster is using a cluster network provider that supports `NetworkPolicy` objects, such as
+ifndef::ovn[]
+the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+ifdef::ovn[]
+the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
+endif::ovn[]
+This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with `admin` privileges.
+* You are working in the namespace where the network policy exists.
 
 .Procedure
 
-. Optional: List the current `NetworkPolicy` objects.
-.. If you want to list the policy objects in a specific namespace, enter the following command. Replace `<namespace>` with the namespace for a project.
+. Optional: To list the network policy objects in a namespace, enter the following command:
 +
 [source,terminal]
 ----
 $ oc get networkpolicy -n <namespace>
 ----
-
-.. If you want to list the policy objects for the entire cluster, enter the following command:
 +
-[source,terminal]
-----
-$ oc get networkpolicy --all-namespaces
-----
+--
+where:
+
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
 
 . Edit the `NetworkPolicy` object.
 
-.. If you saved the network policy definition in a file, edit the file and make any necessary changes, and then enter the following command. Replace `<policy-file>` with the name of the file containing the object definition.
+** If you saved the network policy definition in a file, edit the file and make any necessary changes, and then enter the following command.
 +
 [source,terminal]
 ----
-$ oc apply -f <policy-file>.yaml
+$ oc apply -n <namespace> -f <policy_file>.yaml
 ----
++
+--
+where:
 
-.. If you need to update the `NetworkPolicy` object directly, you can enter the following command. Replace `<policy-name>` with the name of the `NetworkPolicy` object and `<namespace>` with the name of the project where the object exists.
-+
-[source,terminal]
-----
-$ oc edit <policy-name> -n <namespace>
-----
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+`<policy_file>`:: Specifies the name of the file containing the network policy.
+--
 
-. Confirm that the `NetworkPolicy` object is updated. Replace `<namespace>` with the name of the project where the object exists.
+** If you need to update the `NetworkPolicy` object directly, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get networkpolicy -n <namespace> -o yaml
+$ oc edit networkpolicy <policy_name> -n <namespace>
 ----
++
+--
+where:
+
+`<policy_name>`:: Specifies the name of the network policy.
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
+
+. Confirm that the `NetworkPolicy` object is updated.
++
+[source,terminal]
+----
+$ oc describe networkpolicy <policy_name> -n <namespace>
+----
++
+--
+where:
+
+`<policy_name>`:: Specifies the name of the network policy.
+`<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
+
+ifdef::ovn[]
+:!ovn:
+endif::ovn[]

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/multitenant-network-policy.adoc
-// * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
 ifeval::[{product-version} >= 4.6]
@@ -25,7 +24,7 @@ the OVN-Kubernetes network provider or the OpenShift SDN network provider with `
 endif::ovn[]
 This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with `admin` privileges.
 
 .Procedure
 

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -3,7 +3,6 @@
 // * networking/network_policy/creating-network-policy.adoc
 // * networking/network_policy/viewing-network-policy.adoc
 // * networking/network_policy/editing-network-policy.adoc
-// * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
 [id="nw-networkpolicy-object_{context}"]

--- a/modules/nw-networkpolicy-view.adoc
+++ b/modules/nw-networkpolicy-view.adoc
@@ -1,25 +1,71 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/viewing-network-policy.adoc
-// * networking/configuring-networkpolicy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
 [id="nw-networkpolicy-view_{context}"]
 = Viewing network policies
 
-You can list the network policies in your cluster.
+You can examine the network policies in a namespace.
+
+[NOTE]
+====
+If you log in with a user with the `cluster-admin` role, then you can view any network policy in the cluster.
+====
 
 .Prerequisites
 
 * You installed the OpenShift CLI (`oc`).
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with `admin` privileges.
+* You are working in the namespace where the network policy exists.
 
 .Procedure
 
-* To view `NetworkPolicy` objects defined in your cluster, run the following
+* List network policies in a namespace:
+
+** To view `NetworkPolicy` objects defined in a namespace, enter the following
 command:
 +
 [source,terminal]
 ----
 $ oc get networkpolicy
+----
+
+** Optional: To examine a specific network policy, enter the following command:
++
+[source,terminal]
+----
+$ oc describe networkpolicy <policy_name> -n <namespace>
+----
++
+--
+where:
+
+  `<policy_name>`:: Specifies the name of the network policy to inspect.
+  `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
+--
++
+For example:
++
+[source,terminal]
+----
+$ oc describe networkpolicy allow-same-namespace
+----
++
+.Output for `oc describe` command
+[source,text]
+----
+Name:         allow-same-namespace
+Namespace:    ns1
+Created on:   2021-05-24 22:28:56 -0400 EDT
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
+  Allowing ingress traffic:
+    To Port: <any> (traffic allowed to all ports)
+    From:
+      PodSelector: <none>
+  Not affecting egress traffic
+  Policy Types: Ingress
 ----

--- a/networking/network_policy/about-network-policy.adoc
+++ b/networking/network_policy/about-network-policy.adoc
@@ -20,5 +20,6 @@ include::modules/nw-networkpolicy-optimize.adoc[leveloffset=+1]
 [id="about-network-policy-additional-resources"]
 == Additional resources
 
+* xref:../../authentication/using-rbac.adoc#rbac-projects-namespaces_using-rbac[Projects and namespaces]
 * xref:../../networking/network_policy/multitenant-network-policy.adoc#multitenant-network-policy[Configuring multitenant network policy]
 * xref:../../rest_api/network_apis/networkpolicy-networking-k8s-io-v1.adoc#networkpolicy-networking-k8s-io-v1[NetworkPolicy API]

--- a/networking/network_policy/creating-network-policy.adoc
+++ b/networking/network_policy/creating-network-policy.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can create a network policy for a namespace.
+As a user with the `admin` role, you can create a network policy for a namespace.
 
 include::modules/nw-networkpolicy-create.adoc[leveloffset=+1]
 

--- a/networking/network_policy/default-network-policy.adoc
+++ b/networking/network_policy/default-network-policy.adoc
@@ -1,5 +1,5 @@
 [id="default-network-policy"]
-= Creating default network policies for a new project
+= Defining a default network policy for projects
 include::modules/common-attributes.adoc[]
 :context: default-network-policy
 

--- a/networking/network_policy/deleting-network-policy.adoc
+++ b/networking/network_policy/deleting-network-policy.adoc
@@ -5,6 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can delete a network policy from a namespace.
+As a user with the `admin` role, you can delete a network policy from a namespace.
 
 include::modules/nw-networkpolicy-delete.adoc[leveloffset=+1]

--- a/networking/network_policy/editing-network-policy.adoc
+++ b/networking/network_policy/editing-network-policy.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can edit an existing network policy for a namespace.
+As a user with the `admin` role, you can edit an existing network policy for a namespace.
 
 include::modules/nw-networkpolicy-edit.adoc[leveloffset=+1]
 

--- a/networking/network_policy/viewing-network-policy.adoc
+++ b/networking/network_policy/viewing-network-policy.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can view a network policy for a namespace.
+As a user with the `admin` role, you can view a network policy for a namespace.
 
 include::modules/nw-networkpolicy-view.adoc[leveloffset=+1]
 


### PR DESCRIPTION
~The goal of this PR is to bring this content in line with what's known today.~

So this mostly just swaps `cluster-admin` for `admin` and changes the procedure structure/style. Some of these modules will be included with the multi-network policy content.

Foundational improvements with new content are forthcoming in a different PR.

Previews:
- [Creating a network policy](https://deploy-preview-32708--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html)
- [Viewing a network policy](https://deploy-preview-32708--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/viewing-network-policy.html)
- [Editing a network policy](https://deploy-preview-32708--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/editing-network-policy.html)
- [Deleting a network policy](https://deploy-preview-32708--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/deleting-network-policy.html)