### PR TITLE
OSSMDOC-332: release notes 2.0.5.1

### DIFF
--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,6 +19,8 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {ProductShortName} fixed issues
 
+* link:https://issues.redhat.com/browse/MAISTRA-2378[MAISTRA-2378] When the cluster is configured to use OpenShiftSDN with `ovs-multitenant` and the mesh contains a large number of namespaces (200+), the {product-title} networking plugin is unable to configure the namespaces quickly. {ProductShortName} times out causing namespaces to be continuously dropped from the service mesh and then reenlisted.
+
 * link:https://issues.redhat.com/browse/MAISTRA-2370[MAISTRA-2370] Handle tombstones in listerInformer. The updated cache codebase was not handling tombstones when translating the events from the namespace caches to the aggregated cache, leading to a panic in the go routine.
 
 * link:https://issues.redhat.com/browse/OSSM-449[OSSM-449] VirtualService and Service causes an error "Only unique values for domains are permitted. Duplicate entry of domain."


### PR DESCRIPTION
- Aligned team: Service mesh
- For branches: 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/OSSMDOC-332
- release notes 2.0.5.1
Link to doc preview:
https://deploy-preview-32717--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-fixed-issues_ossm-release-notes
- sme review: knrc
- QE review: tviera
- peer review: 

This has been reviewed by SME and QE and is ready for peer review and merge.