### PR TITLE
OSDOCS-2197 STS: delete OIDC keys post-installation

### DIFF
--- a/installing/installing_aws/uninstalling-cluster-aws.adoc
+++ b/installing/installing_aws/uninstalling-cluster-aws.adoc
@@ -8,3 +8,5 @@ toc::[]
 You can remove a cluster that you deployed to Amazon Web Services (AWS).
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]
+
+include::modules/cco-ccoctl-deleting-sts-resources.adoc[leveloffset=+1]

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -41,7 +41,7 @@ $ ccoctl aws create-key-pair
 2021/04/13 11:01:03 Copying signing key for use by installer
 ----
 +
-Where `serviceaccount-signer.private` and `serviceaccount-signer.public` are the generated key files.
+where `serviceaccount-signer.private` and `serviceaccount-signer.public` are the generated key files.
 +
 This command also creates a private key that the cluster requires during installation in `/_<path_to_ccoctl_output_dir>_/tls/bound-service-account-signing-key.key`.
 
@@ -52,7 +52,7 @@ This command also creates a private key that the cluster requires during install
 $ ccoctl aws create-identity-provider --name=__<name>__ --region=__<aws_region>__ --public-key-file=__<path_to_ccoctl_output_dir>__/serviceaccount-signer.public
 ----
 +
-Where:
+where:
 +
 ** `_<name>_` is the name used to tag any cloud resources that are created for tracking.
 ** `_<aws-region>_` is the AWS region in which cloud resources will be created.
@@ -69,7 +69,7 @@ Where:
 2021/04/13 11:16:18 Identity Provider created with ARN: arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com
 ----
 +
-Where `02-openid-configuration` is a discovery document and `03-keys.json` is a JSON web key set file.
+where `02-openid-configuration` is a discovery document and `03-keys.json` is a JSON web key set file.
 +
 This command also creates a YAML configuration file in `/_<path_to_ccoctl_output_dir>_/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
 

--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/uninstalling-cluster-aws.adoc
+
+[id="cco-ccoctl-deleting-sts-resources_{context}"]
+= Deleting AWS resources with the Cloud Credential Operator utility
+
+To clean up resources after uninstalling an {product-title} cluster with the Cloud Credential Operator (CCO) in manual mode with STS, you can use the CCO utility (`ccoctl`) to remove the AWS resources that `ccoctl` created during installation.
+
+.Prerequisites
+
+* Extract and prepare the `ccoctl` binary.
+* Install an {product-title} cluster with the CCO in manual mode with STS.
+
+.Procedure
+
+* Delete the AWS resources that `ccoctl` created:
++
+[source,terminal,subs="+quotes"]
+----
+$ ccoctl aws delete --name=__<name>__ --region=__<aws_region>__
+----
++
+where:
++
+** `_<name>_` matches the name used to originally create and tag the cloud resources.
+** `_<aws-region>_` is the AWS region in which cloud resources will be deleted.
++
+.Example output:
++
+[source,terminal,subs="+quotes"]
+----
+2021/04/08 17:50:41 Identity Provider object .well-known/openid-configuration deleted from the bucket __<name>__-oidc
+2021/04/08 17:50:42 Identity Provider object keys.json deleted from the bucket __<name>__-oidc
+2021/04/08 17:50:43 Identity Provider bucket __<name>__-oidc deleted
+2021/04/08 17:51:05 Policy __<name>__-openshift-cloud-credential-operator-cloud-credential-o associated with IAM Role __<name>__-openshift-cloud-credential-operator-cloud-credential-o deleted
+2021/04/08 17:51:05 IAM Role __<name>__-openshift-cloud-credential-operator-cloud-credential-o deleted
+2021/04/08 17:51:07 Policy __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials associated with IAM Role __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
+2021/04/08 17:51:07 IAM Role __<name>__-openshift-cluster-csi-drivers-ebs-cloud-credentials deleted
+2021/04/08 17:51:08 Policy __<name>__-openshift-image-registry-installer-cloud-credentials associated with IAM Role __<name>__-openshift-image-registry-installer-cloud-credentials deleted
+2021/04/08 17:51:08 IAM Role __<name>__-openshift-image-registry-installer-cloud-credentials deleted
+2021/04/08 17:51:09 Policy __<name>__-openshift-ingress-operator-cloud-credentials associated with IAM Role __<name>__-openshift-ingress-operator-cloud-credentials deleted
+2021/04/08 17:51:10 IAM Role __<name>__-openshift-ingress-operator-cloud-credentials deleted
+2021/04/08 17:51:11 Policy __<name>__-openshift-machine-api-aws-cloud-credentials associated with IAM Role __<name>__-openshift-machine-api-aws-cloud-credentials deleted
+2021/04/08 17:51:11 IAM Role __<name>__-openshift-machine-api-aws-cloud-credentials deleted
+2021/04/08 17:51:39 Identity Provider with ARN arn:aws:iam::__<aws_account_id>__:oidc-provider/__<name>__-oidc.s3.__<aws_region>__.amazonaws.com deleted
+----
+
+.Verification
+
+You can verify that the resources are deleted by querying AWS. For more information, refer to AWS documentation.

--- a/modules/sts-mode-installing-manual-config.adoc
+++ b/modules/sts-mode-installing-manual-config.adoc
@@ -62,7 +62,7 @@ OPENID_BUCKET_URL="https://<oidc_bucket_name>.s3.<aws_region>.amazonaws.com"
 }
 ----
 +
-Where:
+where:
 
 *** `<public_signing_key_id>` is generated from the public key with:
 +

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -589,6 +589,7 @@ include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
 
 [id="post-install-rotate-remove-cloud-creds"]
 == Rotating or removing cloud provider credentials
+
 After installing {product-title}, some organizations require the rotation or removal of the cloud provider credentials that were used during the initial installation.
 
 To allow the cluster to use the new credentials, you must update the secrets that the xref:../operators/operator-reference.adoc#cloud-credential-operator_red-hat-operators[Cloud Credential Operator (CCO)] uses to manage cloud provider credentials.


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2197 (as part of https://issues.redhat.com/browse/OSDOCS-1953) - due to coverage in RNs and other areas, this has basically been reduced to OIDC deletion.

**Preview:** [Deleting AWS resources with the Cloud Credential Operator utility](https://deploy-preview-32722--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/uninstalling-cluster-aws.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-aws)