### PR TITLE
Fix callouts and ellipsis typo in samples of logging

### DIFF
--- a/modules/cluster-logging-updating-logging.adoc
+++ b/modules/cluster-logging-updating-logging.adoc
@@ -101,7 +101,7 @@ $ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b
   "cluster_name" : "elasticsearch",
   "status" : "green",
 }
-....
+...
 
 ----
 

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -28,7 +28,7 @@ $ oc edit ClusterLogging instance
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
 
-....
+...
 
 spec:
   collection:
@@ -39,7 +39,7 @@ spec:
   curation:
     curator:
       nodeSelector: <1>
-          node-role.kubernetes.io/infra: ''
+        node-role.kubernetes.io/infra: ''
       resources: null
       schedule: 30 3 * * *
     type: curator
@@ -47,7 +47,7 @@ spec:
     elasticsearch:
       nodeCount: 3
       nodeSelector: <1>
-          node-role.kubernetes.io/infra: ''
+        node-role.kubernetes.io/infra: ''
       redundancyPolicy: SingleRedundancy
       resources:
         limits:
@@ -62,14 +62,14 @@ spec:
   visualization:
     kibana:
       nodeSelector: <1>
-          node-role.kubernetes.io/infra: '' <1>
+        node-role.kubernetes.io/infra: ''
       proxy:
         resources: null
       replicas: 1
       resources: null
     type: kibana
 
-....
+...
 
 ----
 <1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.
@@ -134,7 +134,7 @@ metadata:
   creationTimestamp: '2020-04-13T19:07:55Z'
   labels:
     node-role.kubernetes.io/infra: ''
-....
+...
 ----
 
 * To move the Kibana pod, edit the `ClusterLogging` CR to add a node selector:
@@ -144,16 +144,16 @@ metadata:
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
 
-....
+...
 
 spec:
 
-....
+...
 
   visualization:
     kibana:
       nodeSelector: <1>
-        node-role.kubernetes.io/infra: '' <1>
+        node-role.kubernetes.io/infra: ''
       proxy:
         resources: null
       replicas: 1


### PR DESCRIPTION
@vikram-redhat There are two issues on the samples of logging docs, minimum version that the change applies to should be 4.5 in my opinion, could you arrange someone to review them? Thanks.

1. modules/cluster-logging-updating-logging.adoc
   ellipsis used `....`, I modified it to `...` following the doc guideline.

2. modules/infrastructure-moving-logging.adoc
    ellipsis used `....`, I modified it to `...` following the doc guideline.
    some callouts <1> no need, remove it in my commit.
    indent was updated to the same format in my commit.
    