### PR TITLE
Correct the verb install to noun

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -435,7 +435,7 @@ $ oc create -f clo-instance.yaml
 +
 This creates the OpenShift Logging components, the `Elasticsearch` custom resource and components, and the Kibana interface.
 
-. Verify the install by listing the pods in the *openshift-logging* project.
+. Verify the installation by listing the pods in the *openshift-logging* project.
 +
 You should see several pods for OpenShift Logging, Elasticsearch, Fluentd, and Kibana similar to the following list:
 +

--- a/modules/nodes-pods-vertical-autoscaler-install.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-install.adoc
@@ -27,7 +27,7 @@ is automatically created if it does not exist.
 
 . Click *Install*.
 
-. Verify the install by listing the VPA Operator components:
+. Verify the installation by listing the VPA Operator components:
 
 .. Navigate to *Workloads* -> *Pods*.
 
@@ -35,7 +35,7 @@ is automatically created if it does not exist.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that there are four deployments running.
 
-. Optional. Verify the install in the {product-title} CLI using the following command: 
+. Optional. Verify the installation in the {product-title} CLI using the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
@vikram-redhat There is one minor issue(the verb `install` should be the noun `installation`) on two files, minimum version that the change applies to should be 4.5 in my opinion, could you arrange someone to review them? Thanks.