### PR TITLE
MIG-520: Command to get exposed image registry route for DIM (MTC 1.5.0)

### DIFF
--- a/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
@@ -2,6 +2,7 @@
 = Migrating your applications
 include::modules/common-attributes.adoc[]
 :context: migrating-applications-3-4
+:migrating-applications-3-4:
 
 toc::[]
 
@@ -74,3 +75,5 @@ You can increase the number of objects to be migrated or exclude resources from 
 
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
 include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+
+:migrating-applications-3-4!:

--- a/modules/migration-adding-cluster-to-cam.adoc
+++ b/modules/migration-adding-cluster-to-cam.adoc
@@ -15,6 +15,7 @@ You can add a cluster to the {mtc-full} ({mtc-short}) web console.
 ** You must specify the Azure resource group name for the cluster.
 ** The clusters must be in the same Azure resource group.
 ** The clusters must be in the same geographic location.
+* If you are using direct image migration, you must expose a route to
 
 .Procedure
 
@@ -40,9 +41,22 @@ eyJhbGciOiJSUzI1NiIsImtpZCI6IiJ9.eyJpc3MiOiJrdWJlcm5ldGVzL3NlcnZpY2VhY2NvdW50Iiw
 * *Cluster name*: The cluster name can contain lower-case letters (`a-z`) and numbers (`0-9`). It must not contain spaces or international characters.
 * *URL*: Specify the API server URL, for example, `\https://<www.example.com>:8443`.
 * *Service account token*: Paste the `migration-controller` service account token.
-* *Exposed route host to image registry*: If you are using direct image migration, specify the exposed route to the image registry of the source cluster, for example, `www.example.apps.cluster.com`.
+* *Exposed route host to image registry*: If you are using direct image migration, specify the exposed route to the image registry of the source cluster.
 +
-You can specify a port. The default port is `5000`.
+To create the route, run the following command:
++
+** For {product-title} 3:
++
+[source,terminal]
+----
+$ oc create route passthrough --service=docker-registry --port=5000 -n default
+----
+** For {product-title} 4:
++
+[source,terminal]
+----
+$ oc create route passthrough --service=image-registry --port=5000 -n openshift-image-registry
+----
 
 * *Azure cluster*: You must select this option if you use Azure snapshots to copy your data.
 * *Azure resource group*: This field is displayed if *Azure cluster* is selected. Specify the Azure resource group.

--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -15,7 +15,7 @@ You can create a migration plan in the {mtc-full} ({mtc-short}) web console.
 * You must ensure that the same {mtc-short} version is installed on all clusters.
 * You must add the clusters and the replication repository to the {mtc-short} web console.
 * If you want to use the _move_ data copy method to migrate a persistent volume (PV), the source and target clusters must have uninterrupted network access to the remote volume.
-* If you want to use direct image migration, you must specify the exposed route to the image registry of the source cluster by using the {mtc-short} web console or by updating the `MigCluster` custom resource manifest.
+* If you want to use direct image migration, you must specify the exposed route to the image registry of the source cluster. This can be done by using the {mtc-short} web console or by updating the `MigCluster` custom resource manifest.
 
 .Procedure
 

--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -15,7 +15,7 @@ You can create a migration plan in the {mtc-full} ({mtc-short}) web console.
 * You must ensure that the same {mtc-short} version is installed on all clusters.
 * You must add the clusters and the replication repository to the {mtc-short} web console.
 * If you want to use the _move_ data copy method to migrate a persistent volume (PV), the source and target clusters must have uninterrupted network access to the remote volume.
-* If you want to use direct image migration, the `MigCluster` custom resource manifest of the source cluster must specify the exposed route of the internal image registry.
+* If you want to use direct image migration, you must specify the exposed route to the image registry of the source cluster by using the {mtc-short} web console or by updating the `MigCluster` custom resource manifest.
 
 .Procedure
 

--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -44,6 +44,22 @@ You can create multiple `MigMigration` CRs for a single `MigPlan` CR for the fol
 * The _version_ of the installed {mtc-full} Operator must be the same on all clusters.
 * You must configure an object storage as a replication repository.
 * If you are using direct image migration, you must expose a secure registry route on all remote clusters.
++
+To create the route, run the following command on a remote cluster:
+
+** For {product-title} 3:
++
+[source,terminal]
+----
+$ oc create route passthrough --service=docker-registry --port=5000 -n default
+----
+** For {product-title} 4:
++
+[source,terminal]
+----
+$ oc create route passthrough --service=image-registry --port=5000 -n openshift-image-registry
+----
+
 * If you are using direct volume migration, the source cluster must not have an HTTP proxy configured.
 
 .Procedure

--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -41,7 +41,7 @@ You can create multiple `MigMigration` CRs for a single `MigPlan` CR for the fol
 * You must have `cluster-admin` privileges for all clusters.
 * You must install the {product-title} CLI (`oc`).
 * You must install the {mtc-full} Operator on all clusters.
-* The _version_ of the installed {mtc-full} Operator must be the same on all clusters.
+* You must use the same version of the installed {mtc-full} Operator on all clusters.
 * You must configure an object storage as a replication repository.
 * If you are using direct image migration, you must expose a secure registry route on all remote clusters.
 +

--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -36,4 +36,6 @@ endif::[]
 *** The volumes must have the same storage class.
 
 * If you perform a direct volume migration in a proxy environment, you must configure an Stunnel TCP proxy.
-* If you perform a direct image migration, you must expose the internal registry of the source cluster to external traffic.
+ifndef::migrating-applications-3-4[]
+* If you perform a direct image migration, you must expose the secure registry of the source cluster to external traffic.
+endif::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-520

4.5+

QE approved. Ready for peer review.

Previews:
https://deploy-preview-32731--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html#migration-adding-cluster-to-cam_migrating-applications-3-4 (step 5)

https://deploy-preview-32731--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html#migration-migrating-applications-api_migrating-applications-3-4 (Prerequisites)

https://deploy-preview-32731--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.html#migration-adding-cluster-to-cam_migrating-4-1-4 (step 5)

https://deploy-preview-32731--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_4_1_4/migrating-applications-with-cam-4-1-4.html#migration-migrating-applications-api_migrating-4-1-4 (Prerequisites)