### PR TITLE
Correct the verb install to noun follow up

### DIFF
--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -259,7 +259,7 @@ The number of primary shards for the index templates is equal to the number of E
 
 .. Click *Create*. This creates the OpenShift Logging components, the `Elasticsearch` custom resource and components, and the Kibana interface.
 
-. Verify the install:
+. Verify the installation:
 
 .. Switch to the *Workloads* -> *Pods* page.
 


### PR DESCRIPTION
One additional change suggested by https://github.com/openshift/openshift-docs/pull/32727