### PR TITLE
Added release notes for 4.7.12, fixed broken link

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2370,7 +2370,7 @@ To upgrade an existing {product-title} 4.7 cluster to this latest release, see x
 
 Issued: 2021-05-19
 
-{product-title} release 4.7.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:1550[RHSA-2021:1550] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1551[RHSA-2021:1551] advisory.
+{product-title} release 4.7.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1550[RHBA-2021:1550] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1551[RHSA-2021:1551] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2440,6 +2440,22 @@ In an upcoming release of {product-title}, OAuth tokens that do not include a SH
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957015[*BZ#1957015*])
 
 [id="ocp-4-7-11-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-12"]
+=== RHSA-2021:1561 - {product-title} 4.7.12 bug fix and security update
+
+Issued: 2021-05-24
+
+{product-title} release 4.7.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:1561[RHSA-2021:1561] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1562[RHSA-2021:1562] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6067301[{product-title} 4.7.12 container image list]
+
+[id="ocp-4-7-12-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
This PR adds notes for today's 4.7.12 release.

It also fixes a broken link. 

* applies to 4.7 only
* [direct link here](https://deploy-preview-32743--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-12)