### PR TITLE
[WIP] Updating guidelines for allowing xrefs in modules

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -223,7 +223,7 @@ link:https://redhat-documentation.github.io/modular-docs/#creating-procedure-mod
 
 [NOTE]
 ====
-When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syntax to suppress TOC formatting within a module. Do not use `==` headings or xrefs in modules.
+When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syntax to suppress TOC formatting within a module. Do not use `==` headings for these sections in modules.
 ====
 
 [id="product-name-and-version"]
@@ -371,12 +371,11 @@ There might be advanced networking examples that require specific IP addresses, 
 ====
 
 == Links, hyperlinks, and cross references
-Links can be used to cross-reference internal assemblies or send readers to external information resources for further reading.
+Links can be used to cross-reference internal assemblies or modules, or to send readers to external information resources for further reading.
 
 In OpenShift docs:
 
 * All links to internal content is created using `xref` and **must have an anchor ID**.
-* Only use `xref` in assemblies, not modules.
 * All links to external websites are created using `link`.
 
 [IMPORTANT]
@@ -391,9 +390,18 @@ To provide an example URL path that you do not want to render as a hyperlink, us
 `\https://www.example.com`
 ....
 
-=== Internal cross-references
-Whenever possible the link to another assembly should be part of the actual sentence.
+=== Internal cross-references (xrefs) in assemblies
+
+Follow these guidelines when using an xref in an assembly.
+
+*General guidelines*
+
+Whenever possible, the link to another assembly should be part of the actual sentence.
 Avoid creating links as a separate sentence that begins with "See [this assembly] for more information on x".
+
+*Syntax*
+
+You must use the `.adoc` extension in order for the link to work correctly. You must also specify an anchor ID.
 
 [NOTE]
 ====
@@ -401,8 +409,8 @@ Use the relative file path (from the file you are editing, to the file you are l
 even if you are linking to the same directory that you are writing in. This makes search and replace
 operations to fix broken links much easier.
 
-For example, if you are writing in *_architecture/core_concepts/deployments.adoc_* and you want to
-link to *_architecture/core_concepts/routes.adoc_* then you must include the path back to the first
+For example, if you are writing in `architecture/core_concepts/deployments.adoc` and you want to
+link to `architecture/core_concepts/routes.adoc` then you must include the path back to the first
 level of the assembly directory:
 
 ----
@@ -423,6 +431,22 @@ Before you can create a domain, you must first xref:../dev_guide/application_lif
 >
 > Before you can create a domain, you must first xref:../dev_guide/application_lifecycle/new_app.adoc#dev-guide-new-app[create an application].
 
+=== Internal cross-references (xrefs) in modules
+
+Follow these guidelines when using an xref in a module.
+
+*General guidelines*
+
+* Use xrefs in modules sparingly; do not overlink.
+* You can use xrefs in the additional resources section.
+* You can use xrefs in the prerequisites section. However, if the process is integral to the current workflow, include the module in the assembly instead of using an xref.
+* You can use xrefs to link to reference modules. These reference modules should typically be included in the same assembly.
+* Try to avoid xrefs to conceptual information in a module body. The relevant conceptual information should be included in the assembly.
+
+*Syntax*
+
+TODO - Add implementation/syntax details for using xrefs in modules once we know the details.
+
 === Links to external websites
 
 If you want to link to a different website, use:
@@ -436,55 +460,6 @@ IMPORTANT: You must use `link:` before the start of the URL.
 IMPORTANT: You cannot link to a repository that is hosted on www.github.com.
 
 TIP: If you want to build a link from a URL _without_ changing the text from the actual URL, just print the URL without adding a `[friendly text]` block at the end; it will automatically be rendered as a link.
-
-=== Links to internal content
-There are two scenarios for linking to other assemblies:
-
-1. Link to another file that exists in the same directory.
-2. Link to another file that exists in a separate directory.
-
-The following examples use the example directory structure shown here:
-....
-/
-/foo
-/foo/bar.adoc
-/baz
-/baz/zig.adoc
-/baz/zag.adoc
-....
-
-*Link to assembly in same directory*
-
-----
-xref:<filename>#anchor-id[friendly title]
-----
-
-You must use the `.adoc` file extension. The document processor will correctly link this to the resulting HTML file.
-
-For example, using the above syntax, if you are working on `zig.adoc` and want to link to `zag.adoc`, do it this way:
-
-----
-xref:../zag.adoc#baz-zag[comment]
-----
-
-where `baz-zag` is the anchor ID at the top of the file `zag.adoc`.
-
-*Link to assembly in different directory*
-
-----
-xref:../dir/<filename>.adoc#anchor-id[friendly title]
-----
-
-For example, if you are working on `bar.adoc` and you want to link to `zig.adoc`, do it this way:
-
-----
-xref:../baz/zig.adoc#baz-zig[see the ZIG manual for more]
-----
-
-[NOTE]
-====
-You must use the .adoc extension in order for the link to work correctly and you must specify an anchor ID.
-====
 
 == Embedding an external file
 


### PR DESCRIPTION
Drafting an update to the guidelines to allow using xrefs in modules.

Per mod docs guidelines, xrefs are now allowed in modules: https://github.com/redhat-documentation/modular-docs/pull/162.

Still waiting on some implementation details.

**Do not start using xrefs in modules yet. We are still waiting for the approval from @vikram-redhat before we can do so.**