### PR TITLE
BZ-1872580--Adding the IAM role information to the RHEL worker documentation

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -25,6 +25,11 @@ include::modules/rhel-preparing-playbook-machine.adoc[leveloffset=+1]
 
 include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 
+include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
+
+.Additional resources
+* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
+
 include::modules/rhel-worker-tag.adoc[leveloffset=+2]
 
 include::modules/rhel-adding-node.adoc[leveloffset=+1]

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -23,6 +23,11 @@ include::modules/rhel-images-aws.adoc[leveloffset=+2]
 
 include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 
+include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
+
+.Additional resources
+* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
+
 include::modules/rhel-worker-tag.adoc[leveloffset=+2]
 
 include::modules/rhel-adding-more-nodes.adoc[leveloffset=+1]

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -14,9 +14,9 @@
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
-// * machine_management/user_provisioned/more-rhel-compute.adoc
-// * machine_management/user_provisioned/adding-aws-compute-user-infra.adoc 
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
+// * machine_management/user_provisioned/adding-aws-compute-user-infra.adoc
 // * machine_management/user_provisioned/adding-bare-metal-compute-user-infra.adoc
 // * machine_management/user_provisioned/adding-vsphere-compute-user-infra.adoc
 // * post_installation_configuration/node-tasks.adoc

--- a/modules/rhel-adding-more-nodes.adoc
+++ b/modules/rhel-adding-more-nodes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/more-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
 
 [id="rhel-adding-more-nodes_{context}"]
 = Adding more RHEL compute machines to your cluster

--- a/modules/rhel-adding-node.adoc
+++ b/modules/rhel-adding-node.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-adding-node_{context}"]

--- a/modules/rhel-ansible-parameters.adoc
+++ b/modules/rhel-ansible-parameters.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
-// * machine_management/user_provisioned/more-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-ansible-parameters_{context}"]

--- a/modules/rhel-attaching-instance-aws.adoc
+++ b/modules/rhel-attaching-instance-aws.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
+
+
+[id="rhel-attaching-instance-aws_{context}"]
+= Attaching the role permissions to {op-system-base} instance in AWS
+
+Using the Amazon IAM console in your browser, you may select the needed roles and assign them to a worker node.
+
+.Procedure
+. From the AWS IAM console, create your link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#create-iam-role[desired IAM role].
+. link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#attach-iam-role[Attach the IAM role] to the desired worker node.

--- a/modules/rhel-compute-overview.adoc
+++ b/modules/rhel-compute-overview.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
-// * machine_management/user_provisioned/more-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-compute-overview_{context}"]

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
-// * machine_management/user_provisioned/more-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 

--- a/modules/rhel-images-aws.adoc
+++ b/modules/rhel-images-aws.adoc
@@ -16,6 +16,7 @@ AMI IDs correspond to native boot images for AWS. Because an AMI must exist befo
 
 * Use this command to list {op-system-base} 7.9 Amazon Machine Images (AMI):
 +
+--
 [source,terminal]
 ----
 $ aws ec2 describe-images --owners 309956199498 \ <1>
@@ -24,24 +25,23 @@ $ aws ec2 describe-images --owners 309956199498 \ <1>
 --region us-east-1 \ <4>
 --output table <5>
 ----
-+
 <1> The `--owners` command option shows Red Hat images based on the account ID `309956199498`.
 +
 [IMPORTANT]
 ====
 This account ID is required to display AMI IDs for images that are provided by Red Hat.
 ====
-+
 <2> The `--query` command option sets how the images are sorted with the parameters `'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]'`. In this case, the images are sorted by the creation date, and the table is structured to show the creation date, the name of the image, and the AMI IDs.
 <3> The `--filter` command option sets which version of {op-system-base} is shown. In this example, since the filter is set by `"Name=name,Values=RHEL-7.9*"`, then {op-system-base} 7.9 AMIs are shown.
 <4> The `--region` command option sets where the region where an AMI is stored.
 <5> The `--output` command option sets how the results are displayed.
+--
 
 [NOTE]
 ====
 When creating a {op-system-base} compute machine for AWS, ensure that the AMI is {op-system-base} 7.9.
 ====
-+
+
 .Example output
 [source,terminal]
 ----

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
-// * machine_management/user_provisioned/more-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
+// * machine_management/more-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-preparing-node_{context}"]

--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-preparing-playbook-machine_{context}"]

--- a/modules/rhel-removing-rhcos.adoc
+++ b/modules/rhel-removing-rhcos.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * machine_management/user_provisioned/adding-rhel-compute.adoc
+// * machine_management/adding-rhel-compute.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [id="rhel-removing-rhcos_{context}"]


### PR DESCRIPTION
This ticket tracks all the changes to the RHEL worker node documentation. For this extension, information on associating IAM roles with the node are documented.

Version: OCP 4.5+

fixes BZ#1872580

https://bugzilla.redhat.com/show_bug.cgi?id=1872580

Preview Build:

Adding a new RHEL Worker Node: https://deploy-preview-32751--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-attaching-instance-aws_adding-rhel-compute
Adding more RHEL Worker Nodes: https://deploy-preview-32751--osdocs.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html#rhel-attaching-instance-aws_more-rhel-compute