### PR TITLE
Add OLM to Terms Glossary

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -457,6 +457,17 @@ more on Operator naming.
 Usage: OperatorHub
 
 ''''
+=== Operator Lifecycle Manager (OLM)
+Usage: Operator Lifecycle Manager, OLM
+
+Refer to this component without a preceding article ("the").
+
+.Examples of correct usage
+====
+You can use OpenShift Lifecycle Manager (OLM) to manually or automatically upgrade an Operator.
+====
+
+''''
 === Options menu
 
 Usage: Options menu; use sparingly; not to be confused with Actions menu, which


### PR DESCRIPTION
Usage of the term Operator Lifecycle Manager (OLM) should not be preceded by an article. For example, it should not be "You can use the OLM...." 