### PR TITLE
Can add quay.io to blockedRegistries that cause operator pod with ImagePullBackOff error

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -12,7 +12,7 @@ When pulling or pushing images, the container runtime searches the registries li
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries including the `registry.redhat.io` and `quay.io` registries are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries must also be added.
 ====
 
 .Procedure

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -10,6 +10,11 @@ You can block any registry, and optionally an individual repository within a reg
 
 When pulling or pushing images, the container runtime searches the registries listed under the `registrySources` parameter in the `image.config.openshift.io/cluster` CR. If you created a list of registries under the `blockedRegistries` parameter, the container runtime does not search those registries. All other registries are allowed.
 
+[WARNING]
+====
+To prevent pod failure, do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list, as they are required by payload images within your environment.
+====
+
 .Procedure
 
 . Edit the `image.config.openshift.io/cluster` CR:

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -59,7 +59,7 @@ status:
 +
 [NOTE]
 ====
-When the `allowedRegistries` parameter is defined, all registries including the registry.redhat.io and quay.io registries are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment.
+When the `allowedRegistries` parameter is defined, all registries, including the registry.redhat.io and quay.io registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list.
 ====
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to the registries, then drains and uncordons the nodes when it detects changes. After the nodes return to the `Ready` state, changes to the insecure and blocked registries appear in the `/etc/containers/registries.conf` file on each node.

--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -47,7 +47,7 @@ Either `blockedRegistries` or `allowedRegistries` can be set, but not both.
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries including `registry.redhat.io` and `quay.io` are blocked unless explicitly listed. When using the parameter,  to prevent pod failure, declare the `registry.redhat.io` and `quay.io` registries, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. When using the parameter,  to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list. For disconnected clusters, mirror registries must also be added.
 ====
 
 The `status` field of the `image.config.openshift.io/cluster` resource holds observed values from the cluster.

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -76,7 +76,7 @@ status:
 +
 [NOTE]
 ====
-When the `allowedRegistries` parameter is defined, all registries including the `registry.redhat.io` and `quay.io` registries are blocked unless explicitly listed. If you use this parameter, to prevent pod failure, add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. 
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. If you use this parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list. 
 ====
 
 . To check that the registries have been added, use the following command on a node:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1960553

Preview of new note: https://deploy-preview-32762--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-blocked_image-configuration

Example of edited text, the note under Step 1: https://deploy-preview-32762--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-shortname_image-configuration