### PR TITLE
WINC-551: Updated the autoscaling documentation

### DIFF
--- a/machine_management/applying-autoscaling.adoc
+++ b/machine_management/applying-autoscaling.adoc
@@ -32,9 +32,43 @@ include::modules/cluster-autoscaler-cr.adoc[leveloffset=+2]
 :FeatureResourceName: ClusterAutoscaler
 include::modules/deploying-resource.adoc[leveloffset=+2]
 
-== Next steps
+//
+// Addresses WINC-551 - https://github.com/openshift/openshift-docs/pull/32773 - Delete before merge
+//
 
-* After you configure the cluster autoscaler, you must configure at least one machine autoscaler.
+[id="cluster-autoscaler-machineset"]
+== Configuring the machine set
+
+The machine set which creates the Windows Machines requires configuring a file template. On creation, a `windows-user-data` secret is created. On subsequent use, the `windows-user-data` may be used by the machine sets. The associated machine sets may have the following labels:
+
+* `machine.openshift.io/os-id: Windows`
+* `machine.openshift.io/cluster-api-machine-role: worker`
+* `machine.openshift.io/cluster-api-machine-type: worker`
+
+The following label has to be added to the machine spec within the machine set spec:
+
+* `node-role.kubernetes.io/worker:``
+
+[IMPORTANT]
+====
+If these labels are not added, the the Windows node will not be marked as a `worker` node.
+====
+
+.Procedure
+
+* Configure the machine set template with values from your environment, using the required guides:
+
+** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS machine set]
+** xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure machine set]
+** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP machine set]
+** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[OSP machine set]
+** xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#creating-machineset-rhv[RHV machine set]
+** xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[vSphere machine set]
+
+After you configure the cluster autoscaler and defined the machine set, you must configure at least one machine autoscaler.
+//
+// Delete before Merge
+//
 
 [id="configuring-machineautoscaler"]
 == Configuring the machine autoscalers


### PR DESCRIPTION
This ticket addresses the changes in [WINC-551](https://issues.redhat.com/browse/WINC-551) - https://github.com/openshift/windows-machine-config-operator/pull/279

With these changes, I created a new model that specifies how the machineset needs to be configured for autoscaling.

Versions: 4.7+

Preview: https://deploy-preview-32773--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-machinesetapplying-autoscaling