### PR TITLE
BZ1964305: Restic supplemental groups workaround

### DIFF
--- a/modules/migration-known-issues.adoc
+++ b/modules/migration-known-issues.adoc
@@ -23,12 +23,19 @@ These annotations preserve the UID range, ensuring that the containers retain th
 
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 
-* If a large migration fails because Restic times out, you can increase the `restic_timeout` parameter value (default: `1h`) in the `MigrationController` CR.
+* If a large migration fails because Restic times out, you can increase the `restic_timeout` parameter value (default: `1h`) in the `MigrationController` custom resource (CR) manifest.
 
 * If you select the data verification option for PVs that are migrated with the file system copy method, performance is significantly slower.
 
-ifeval::["{mtc-version}" < "1.4"]
-* If you are migrating data from NFS storage and `root_squash` is enabled, `Restic` maps to `nfsnobody`. The migration fails and a permission error is displayed in the `Restic` pod log. You can resolve this issue by creating a supplemental group for Restic. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1873641[*BZ#1873641*])
-
-* If Velero has an invalid `BackupStorageLocation` during start-up, it will crash-loop until the invalid `BackupStorageLocation` is removed. This scenario is triggered by incorrect credentials, a non-existent S3 bucket, and other configuration errors. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1881707[*BZ#1881707*])
-endif::[]
+* If you are migrating data from NFS storage and `root_squash` is enabled, `Restic` maps to `nfsnobody`. The migration fails and a permission error is displayed in the `Restic` pod log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1873641[*BZ#1873641*])
++
+You can resolve this issue by adding supplemental groups for `Restic` to the `MigrationController` CR manifest:
++
+[source,yaml]
+----
+spec:
+...
+  restic_supplemental_groups:
+  - 5555
+  - 6666
+----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1964305

Added workaround for Restic supplemental groups bug to Known Issues.

4.5+

Preview of change: https://deploy-preview-32783--osdocs.netlify.app/openshift-enterprise/latest/migration/migrating_3_4/troubleshooting-3-4.html#migration-known-issues_migrating-3-4

Verified by QE. Ready for peer review.