### PR TITLE
nodes/kernel-arguments: tweak example to avoid disabling SELinux

### DIFF
--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -18,9 +18,8 @@ Improper use of kernel arguments can result in your systems becoming unbootable.
 
 Examples of kernel arguments you could set include:
 
-* **selinux=0**: Disables Security Enhanced Linux (SELinux).
-While not recommended for production, disabling SELinux can
-improve performance by 2% - 3%.
+* **panic=<seconds>**: Changes kernel behaviour on panic, automatically
+rebooting after the given delay (in seconds).
 
 * **nosmt**: Disables symmetric multithreading (SMT) in the kernel.
 Multithreading allows multiple logical threads for each CPU.
@@ -68,7 +67,7 @@ rendered-master-23e785de7587df95a4b517e0647e5ab7   52dd3ba6a9a527fc3ab42afac8d12
 rendered-worker-5d596d9293ca3ea80c896a1191735bb1   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 ----
 
-. Create a `MachineConfig` object file that identifies the kernel argument (for example, `05-worker-kernelarg-selinuxoff.yaml`)
+. Create a `MachineConfig` object file that identifies the kernel argument (for example, `05-worker-kernelarg-panicreboot.yaml`)
 +
 [source,yaml]
 ----
@@ -77,25 +76,25 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker<1>
-  name: 05-worker-kernelarg-selinuxoff<2>
+  name: 05-worker-kernelarg-panicreboot<2>
 spec:
   config:
     ignition:
       version: 3.1.0
   kernelArguments:
-    - selinux=0<3>
+    - panic=30<3>
 ----
 +
 <1> Applies the new kernel argument only to worker nodes.
 <2> Named to identify where it fits among the machine configs (05) and what it does (adds
-a kernel argument to turn off SELinux).
-<3> Identifies the exact kernel argument as `selinux=0`.
+a kernel argument to automatically reboot on panics, after 30 seconds).
+<3> Identifies the exact kernel argument as `panic=30`.
 
 . Create the new machine config:
 +
 [source,terminal]
 ----
-$ oc create -f 05-worker-kernelarg-selinuxoff.yaml
+$ oc create -f 05-worker-kernelarg-panicreboot.yaml
 ----
 
 . Check the machine configs to see that the new one was added:
@@ -116,7 +115,7 @@ NAME                                               GENERATEDBYCONTROLLER        
 01-worker-container-runtime                        52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 
-05-worker-kernelarg-selinuxoff                                                                3.1.0             105s
+05-worker-kernelarg-panicreboot                                                               3.1.0             105s
 
 99-master-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 99-master-ssh                                                                                 3.1.0             40m
@@ -164,9 +163,9 @@ To use host binaries, run `chroot /host`
 sh-4.2# cat /host/proc/cmdline
 BOOT_IMAGE=/ostree/rhcos-... console=tty0 console=ttyS0,115200n8
 rootflags=defaults,prjquota rw root=UUID=fd0... ostree=/ostree/boot.0/rhcos/16...
-coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 selinux=0
+coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 panic=30
 
 sh-4.2# exit
 ----
 +
-You should see the `selinux=0` argument added to the other kernel arguments.
+You should see the `panic=30` argument added to the other kernel arguments.


### PR DESCRIPTION
This updates the kargs MachineConfig example to show the usage of
'panic=30' instead of 'selinux=0'.
It attempts to avoid steering users into disabling SELinux, which
has adverse conseguences on file labels and is mildly complex to
revert once done.
The new example instead does not have persisent side-effects past
the current boot, and can be easily reverted afterwards.