### PR TITLE
Updates related to ArgoCD in OCP GitOps Documentation

### DIFF
--- a/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
+++ b/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
@@ -6,7 +6,12 @@ include::modules/gitops-document-attributes.adoc[]
 
 toc::[]
 
-Once the Red Hat OpenShift GitOps Operator is installed, Argo CD automatically creates a user with `admin` permissions. To manage multiple users, Argo CD allows cluster administrators to configure SSO. You can use Keycloak or a bundled Dex OIDC provider.
+After the {gitops-title} Operator is installed, Argo CD automatically creates a user with `admin` permissions. To manage multiple users, Argo CD allows cluster administrators to configure SSO.
+
+[NOTE]
+====
+Bundled Dex OIDC provider is not supported.
+====
 
 .Prerequisites
 * Red Hat SSO is installed on the cluster.

--- a/modules/installing-gitops-operator-in-web-console.adoc
+++ b/modules/installing-gitops-operator-in-web-console.adoc
@@ -7,14 +7,22 @@
 
 .Prerequisites
 
+* Access to the {product-title} web console.
+* An account with the `cluster-admin` role.
 * You are logged in to the OpenShift cluster as an administrator.
+
+[WARNING]
+====
+If you have already installed the Community version of the Argo CD Operator, remove the Argo CD Community Operator before you install the {gitops-title} Operator.
+====
 
 .Procedure
 
 . Open the *Administrator* perspective of the web console and navigate to *Operators* → *OperatorHub* in the menu on the left.
 
-. Search for `OpenShift GitOps`, click the *Red Hat OpenShift GitOps* tile and then click the *Install* button.
+. Search for `OpenShift GitOps`, click the *{gitops-title}* tile, and then click the *Install* button.
 +
-Red Hat OpenShift GitOps will be installed in all namespaces of the cluster.
+{gitops-title} will be installed in all namespaces of the cluster.
 
-Once the Red Hat OpenShift GitOps Operator is installed, it automatically sets up a ready-to-use Argo CD instance that is available in the `openshift-gitops` namespace, and an Argo CD icon is displayed in the console toolbar.
+After the {gitops-title} Operator is installed, it automatically sets up a ready-to-use Argo CD instance that is available in the `openshift-gitops` namespace, and an Argo CD icon is displayed in the console toolbar.
+You can create subsequent Argo CD instances for your applications under your projects.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.7` and enterprise-`4.8`
- **JIRA issues**: [RHDEVDOCS-2982](https://issues.redhat.com/browse/RHDEVDOCS-2982),  [RHDEVDOCS-2959](https://issues.redhat.com/browse/RHDEVDOCS-2959)
- **Preview pages**: [Configuring SSO for Argo CD on OpenShift](https://deploy-preview-32787--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.html), [Installing GitOps Operator in web console](https://deploy-preview-32787--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/installing-openshift-gitops.html#installing-gitops-operator-in-web-console_getting-started-with-openshift-gitops)
- **Reviewers**: Ruchir Garg, Dewan Ahmed, Preeti Chandrashekar