### PR TITLE
Removing OKD distro from topic_map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1708,7 +1708,7 @@ Topics:
 ---
 Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
-Distros: openshift-origin,openshift-enterprise
+Distros: openshift-enterprise
 Topics:
 - Name: Understanding OpenShift sandboxed containers
   File: understanding-sandboxed-containers


### PR DESCRIPTION
Applies to 4.8+ 
No QE ack needed, just a topic map update to remove OKD distro. 