### PR TITLE
[srvls][SRVKS-726] Add service mesh support note

### DIFF
--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -24,7 +24,7 @@ spec:
 +
 [IMPORTANT]
 ====
-Adding sidecar injection to Pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
+Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
 . Create a network policy that permits traffic flow from Knative system Pods to Knative services:
 .. Add the `serving.knative.openshift.io/system-namespace=true` label to the `knative-serving` namespace:

--- a/serverless/networking/serverless-ossm-custom-domains.adoc
+++ b/serverless/networking/serverless-ossm-custom-domains.adoc
@@ -16,6 +16,11 @@ By default, Knative services have a fixed domain format:
 
 You can customize the domain for your Knative service by configuring the service as a private service and creating the required {ProductShortName} resources.
 
+[IMPORTANT]
+====
+{ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
+====
+
 .Prerequisites
 * Install the xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] and xref:../../serverless/admin_guide/installing-knative-serving.adoc#installing-knative-serving[Knative Serving].
 * Install xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[{ProductName}].

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 You can enable JSON Web Token (JWT) authentication for Knative services.
 
+[IMPORTANT]
+====
+{ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
+====
+
 [id="serverless-ossm-jwt-prerequisites"]
 == Prerequisites
 

--- a/serverless/networking/serverless-ossm-tls.adoc
+++ b/serverless/networking/serverless-ossm-tls.adoc
@@ -14,6 +14,11 @@ You can create a Transport Layer Security (TLS) key and certificates for a custo
 {ServerlessProductName} is compatible only with full implementations of either {ProductName} 1.x or 2.x. {ServerlessProductName} does not support custom usage of some 1.x resources and some 2.x resources in the same deployment. For example, upgrading to 2.x while still using the control plane `maistra.io/v1` spec is not supported.
 ====
 
+[IMPORTANT]
+====
+{ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
+====
+
 [id="serverless-ossm-tls-prereqs"]
 == Prerequisites
 

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -7,8 +7,18 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+{ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
+====
+
 Using {ProductShortName} with {ServerlessProductName} enables developers to configure additional networking and routing options that are not supported when using {ServerlessProductName} with the default Kourier implementation.
 These options include setting custom domains, using TLS certificates, and using JSON Web Token authentication.
+
+[IMPORTANT]
+====
+Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
+====
 
 [id="serverless-ossm-prerequisites"]
 == Prerequisites


### PR DESCRIPTION
Preview link for main section: https://deploy-preview-32805--osdocs.netlify.app/openshift-enterprise/latest/serverless/networking/serverless-ossm.html
(this note is added in multiple places)

Applies for 4.6+