### PR TITLE
OSDOCS-998: declarative configs for SDN

### DIFF
--- a/modules/nw-disabling-multicast.adoc
+++ b/modules/nw-disabling-multicast.adoc
@@ -33,6 +33,23 @@ $ oc annotate {namespace} <namespace> \ <1>
 ----
 +
 <1> The `namespace` for the project you want to disable multicast for.
+ifeval::["{context}" == "ovn-kubernetes-disabling-multicast"]
++
+[TIP]
+====
+You can alternatively apply the following YAML to delete the annotation:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <namespace>
+  annotations:
+    k8s.ovn.org/multicast-enabled: null
+----
+====
+endif::[]
 
 ifeval::["{context}" == "openshift-sdn-disabling-multicast"]
 :!annotation:

--- a/modules/nw-egress-ips-node.adoc
+++ b/modules/nw-egress-ips-node.adoc
@@ -22,3 +22,18 @@ $ oc label nodes <node_name> k8s.ovn.org/egress-assignable="" <1>
 ----
 +
 <1> The name of the node to label.
++
+[TIP]
+====
+You can alternatively apply the following YAML to add the label to a node:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Node
+metadata:
+  labels:
+    k8s.ovn.org/egress-assignable: ""
+  name: <node_name>
+----
+====

--- a/modules/nw-egress-router-configmap.adoc
+++ b/modules/nw-egress-router-configmap.adoc
@@ -51,6 +51,30 @@ $ oc create configmap egress-routes \
 ----
 +
 In the previous command, the `egress-routes` value is the name of the `ConfigMap` object to create and `my-egress-destination.txt` is the name of the file that the data is read from.
++
+[TIP]
+====
+You can alternatively apply the following YAML to create the config map:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: egress-routes
+data:
+  destination: |
+    # Egress routes for Project "Test", version 3
+
+    80   tcp 203.0.113.25
+
+    8080 tcp 203.0.113.26 80
+    8443 tcp 203.0.113.26 443
+
+    # Fallback
+    203.0.113.27
+----
+====
 
 . Create an egress router pod definition and specify the `configMapKeyRef` stanza for the `EGRESS_DESTINATION` field in the environment stanza:
 +

--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -31,6 +31,23 @@ You can enable multicast between pods for your project.
 $ oc annotate {namespace} <namespace> \
     {annotation}
 ----
+ifeval::["{context}" == "ovn-kubernetes-enabling-multicast"]
++
+[TIP]
+====
+You can alternatively apply the following YAML to add the annotation:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: <namespace>
+  annotations:
+    k8s.ovn.org/multicast-enabled: "true"
+----
+====
+endif::[]
 
 .Verification
 

--- a/modules/nw-nodeport-service-range-edit.adoc
+++ b/modules/nw-nodeport-service-range-edit.adoc
@@ -25,6 +25,21 @@ $ oc patch network.config.openshift.io cluster --type=merge -p \
   }'
 ----
 +
+[TIP]
+====
+You can alternatively apply the following YAML to update the node port range:
+
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  serviceNodePortRange: "30000-<port>"
+----
+====
++
 .Example output
 [source,terminal]
 ----

--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -106,6 +106,22 @@ $ oc patch sriovoperatorconfig default \
   --type=merge -n openshift-sriov-network-operator \
   --patch '{ "spec": { "enableInjector": <value> } }'
 ----
++
+[TIP]
+====
+You can alternatively apply the following YAML to update the Operator:
+
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableInjector: <value>
+----
+====
 
 [id="disable-enable-sr-iov-operator-admission-control-webhook_{context}"]
 == Disabling or enabling the SR-IOV Network Operator admission controller webhook
@@ -128,6 +144,22 @@ $ oc patch sriovoperatorconfig default --type=merge \
   -n openshift-sriov-network-operator \
   --patch '{ "spec": { "enableOperatorWebhook": <value> } }'
 ----
++
+[TIP]
+====
+You can alternatively apply the following YAML to update the Operator:
+
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableOperatorWebhook: <value>
+----
+====
 
 [id="configuring-custom-nodeselector_{context}"]
 == Configuring a custom NodeSelector for the SR-IOV Network Config daemon
@@ -153,9 +185,26 @@ $ oc patch sriovoperatorconfig default --type=json \
   --patch '[{
       "op": "replace",
       "path": "/spec/configDaemonNodeSelector",
-      "value": {<node-label>}
+      "value": {<node_label>}
     }]'
 ----
 +
-Replace `<node-label>` with a label to apply as in the following example:
+Replace `<node_label>` with a label to apply as in the following example:
 `"node-role.kubernetes.io/worker": ""`.
++
+[TIP]
+====
+You can alternatively apply the following YAML to update the Operator:
+
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  configDaemonNodeSelector:
+    <node_label>
+----
+====


### PR DESCRIPTION
Please review the foll:

* [Enabling multicast for a project](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/enabling-multicast.html#nw-enabling-multicast_ovn-kubernetes-enabling-multicast)
* [Disabling multicast for a project](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/disabling-multicast?utm_source=github&utm_campaign=bot_dp)
* [Labeling a node to host egress IP addresses](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-node_configuring-egress-ips-ovn)
* [Configuring an egress router destination mappings with a config map](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-router-configmap.html#configuring-egress-router-configmap_configuring-egress-router-configmap)
* [Expanding the node port range](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-node-port-service-range.html#nw-nodeport-service-range-edit_configuring-node-port-service-range)
* [SR-IOV: Enabling the resource injector](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#disable-enable-network-resource-injector_configuring-sriov-operator)
* [...same page...SR-IOV: Enabling the Operator admission controller webhook](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#disable-enable-sr-iov-operator-admission-control-webhook_configuring-sriov-operator)
* [...same page...SR-IOV: Custom node selector for SR-IOV network config daemon](https://deploy-preview-32817--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#configuring-custom-nodeselector_configuring-sriov-operator)

---

`oc patch` instances are followed by a TIP
that suggests a YAML manifest can be applied
as an alternative.

`oc create cm --from-file` instance shows
the file contents in line under the `data` field.

`oc annotate` has some success with namespaces
and OVN-K, but fails with Netnamespaces and SDN.