### PR TITLE
[enterprise-4.7] modules/understanding-upgrade-channels: 

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -106,17 +106,13 @@ endif::openshift-origin[]
 The service recommends only upgrades that have been tested and have no serious issues. It will not suggest updating to a version of {product-title} that contains known vulnerabilities. For example, if your cluster is on {product-version}.1 and {product-title} suggests {product-version}.4, then it is safe for you to update from {product-version}.1 to {product-version}.4. Do not rely on consecutive patch numbers. In this example, {product-version}.2 is not and never was available in the channel.
 
 ifndef::openshift-origin[]
-Update stability depends on your channel. The presence of an update recommendation in the `candidate-{product-version}` channel does not imply that the update is supported. It means that no serious issues have been found with the update yet, but there might not be significant traffic through the update to suggest stability. The presence of an update recommendation in the `fast-{product-version}` or `stable-{product-version}` channels is a declaration that the update is fully supported while it is in the channel. While releases will never be removed from a channel, update recommendations that exhibit serious issues will be removed from all channels. Updates initiated after the update recommendation has been removed might not be supported.
+Update stability depends on your channel. The presence of an update recommendation in the `candidate-{product-version}` channel does not imply that the update is supported. It means that no serious issues have been found with the update yet, but there might not be significant traffic through the update to suggest stability. The presence of an update recommendation in the `fast-{product-version}` or `stable-{product-version}` channels at any point is a declaration that the update is supported. While releases will never be removed from a channel, update recommendations that exhibit serious issues will be removed from all channels. Updates initiated after the update recommendation has been removed are still supported.
 
 Red Hat will eventually provide supported update paths from any supported release in the `fast-{product-version}` or `stable-{product-version}` channels to the latest release in {product-version}.z, although there can be delays while safe paths away from troubled releases are constructed and verified.
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-The presence of an update recommendation in the `stable-4`
-channel is a declaration that the update is fully supported while it is in the
-channel. While releases will never be removed from the channel, update recommendations
-that exhibit serious issues will be removed from the channel. Updates initiated
-after the update recommendation has been removed might not be supported.
+The presence of an update recommendation in the `stable-4` channel at any point is a declaration that the update is supported. While releases will never be removed from the channel, update recommendations that exhibit serious issues will be removed from the channel. Updates initiated after the update recommendation has been removed are still supported.
 endif::openshift-origin[]
 
 ifndef::openshift-origin[]
@@ -138,4 +134,3 @@ ifndef::openshift-origin[]
 
 Your cluster is still supported if you change from the `stable-{product-version}` channel to the `fast-{product-version}` channel. Although you can switch to the `candidate-{product-version}` channel at any time, some releases in that channel might be unsupported release candidates. You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release. You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel, although if the current release was recently promoted to `fast-{product-version}` there can be a delay of up to a day for the release to be promoted to `stable-{product-version}`. If you change to a channel that does not include your current release, an alert displays and no updates can be recommended, but you can safely change back to your original channel at any point.
 endif::openshift-origin[]
-


### PR DESCRIPTION
Blocked update edges are still supported

If we supported them at some point, we will continue to support the
edges even if they are no longer recommended.

Cherrypicked from 26e69380bf41edd80f61cefd9997400835d4cea5 xref:https://github.com/openshift/openshift-docs/pull/32091/
Manual CP required due to wrapped lines in part of 4.7 version