### PR TITLE
OSDOCS-2218: Migrating Deploying section from Google Docs to GitHub

### DIFF
--- a/modules/sandboxed-containers-installing-operator-cli.adoc
+++ b/modules/sandboxed-containers-installing-operator-cli.adoc
@@ -3,5 +3,107 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-installing-operator-cli_{context}"]
+= Installing the {sandboxed-containers-operator} using the CLI
 
-= Installing the Sandboxed Containers Operator using the CLI
+You can install the {sandboxed-containers-operator} using the {product-title} CLI.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have subscribed to the {sandboxed-containers-first} catalog.
++
+[NOTE]
+====
+Subscribing to the {sandboxed-containers-first} catalog provides `openshift-sandboxed-containers-operator` namespace access to the {sandboxed-containers-operator}.
+====
+
+.Procedure
+
+. Create a YAML file that contains the following manifest:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-sandboxed-containers-operator
+
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-sandboxed-containers-kataconfig-group
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  targetNamespaces:
+    - openshift-sandboxed-containers
+
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: sandboxed-containers-operatorhub
+  namespace: openshift-sandboxed-containers-operator
+spec:
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  name: sandboxed-containers-kataconfig
+  startingCSV: openshift-sandboxed-containers-kataconfig.v1.0.0
+  channel: "preview-1.0"
+  approval: "Automatic"
+----
++
+[NOTE]
+====
+Using the *preview-1.0* channel ensures that you install the version of {sandboxed-containers-first} that is compatible with your {product-title} version.
+====
+
+. Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects for {sandboxed-containers-first}:
++
+[source,terminal]
+----
+$ oc create -f <file name>.yaml
+----
+
+. Ensure that the Operator is correctly installed:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-sandboxed-containers-operator
+----
++
+.Example output
++
+----
+NAME                             DISPLAY                                  VERSION  REPLACES                    PHASE
+openshift-sandboxed-containers   openshift-sandboxed-containers-operator  1.0.0    <csv-of-previous-version>   Succeeded
+----
+. View the available deployments:
++
+[source,terminal]
+----
+$ oc get deployments -n openshift-sandboxed-containers-operator
+----
++
+.Example output
+----
+NAME                                        READY  UP-TO-DATE   AVAILABLE   AGE
+openshift-sandboxed-containers-operator                         1/111       9m48s
+----
+
+.Verification
+
+* Verify that the Operator is up and running, so you can create the `KataConfig` resource to trigger the installation.
++
+[source,terminal]
+----
+$ oc get deployments -n openshift-sandboxed-containers-operator
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                                READY   UP-TO-DATE   AVAILABLE   AGE
+openshift-sandboxed-containers-controller-manager   1/1     1            1           40d
+----

--- a/modules/sandboxed-containers-installing-operator-web-console.adoc
+++ b/modules/sandboxed-containers-installing-operator-web-console.adoc
@@ -3,5 +3,45 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-installing-operator-web-console_{context}"]
+= Installing the {sandboxed-containers-operator} using the web console
 
-= Installing the Sandboxed Containers Operator using the web console
+You can install the {sandboxed-containers-operator} from the {product-title} web console.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Open a browser window and log in to the {product-title} web console.
+
+. From the *Administrator* perspective, navigate to *Operators* → *OperatorHub*.
+
+. In the *Filter by keyword* field, type `OpenShift sandboxed containers`.
+
+. Select the *{sandboxed-containers-first}* tile.
+
+. Read the information about the Operator and click *Install*.
+
+. On the *Install Operator* page:
+.. Select *preview-1.0* from the list of available *Update Channel* options. This ensures that you install the version of {sandboxed-containers-first} that is compatible with your {product-title} version.
+.. For *Installed Namespace*, ensure that the Operator recommended namespace option is selected. This installs the Operator in the mandatory `openshift-sandboxed-containers-operator` namespace, which is automatically created if it does not exist.
++
+[NOTE]
+====
+Attempting to install the {sandboxed-containers-operator} in a namespace other than `openshift-sandboxed-containers-operator` causes the installation to fail.
+====
+.. For *Approval Strategy*, ensure that *Automatic*, which is the default value, is selected. {sandboxed-containers-first} automatically updates when a new z-stream release is available.
+
+. Click *Install* to make the Operator available to the {sandboxed-containers-first} namespace.
+
+The {sandboxed-containers-operator} is now installed on your cluster. You can trigger the Operator by enabling the runtime on your cluster. You can do this by creating the `KataConfig` custom resource using the OpenShift CLI (`oc`).
+
+[source,yaml]
+----
+apiVersion: kataconfiguration.openshift.io/v1
+kind: KataConfig
+metadata:
+  name: example-kataconfig
+----

--- a/modules/sandboxed-containers-preparing-openshift-cluster.adoc
+++ b/modules/sandboxed-containers-preparing-openshift-cluster.adoc
@@ -3,5 +3,109 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-preparing-openshift-cluster_{context}"]
+= Preparing your cluster for {sandboxed-containers-first}
 
-= Preparing your cluster for OpenShift sandboxed containers
+Before you install {sandboxed-containers-first}, ensure that your {product-title} cluster meets the following requirements:
+
+* Your cluster must be installed on bare metal infrastructure with {op-system-first} workers. Your cluster must use installer-provisioned infrastructure.
+// To Do: Add link to bare metal instructions: ../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal]
+// To Do: Add link to installer provisioned infrastructure: ../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installer provisioned infrastructure]
++
+[IMPORTANT]
+====
+* {sandboxed-containers-first} only supports {op-system} worker nodes. RHEL 7 or RHEL  8 nodes are not supported.
+* Nested virtualization is not supported.
+====
+
+[id="sandboxed-containers-additional-resource-requirements_{context}"]
+== Additional resource requirements for {sandboxed-containers-first}
+
+{sandboxed-containers-first} is a product that brings the ability to run workloads inside a sandboxed runtime, such as Kata Containers, to your {product-title} clusters. Each pod is represented by a virtual machine (VM). Each VM runs in a `qemu` process and hosts a `kata-agent` process that acts as a supervisor for managing container workloads and processes that are running in those containers. There are two additional processes that add more overhead:
+
+* `containerd-shim-kata-v2` is used to communicate with the pod.
+* `virtiofsd` handles host file system access on behalf of the guest.
+
+Each VM is configured with a default amount of memory. Additional memory is hot-plugged into the VM for containers that explicitly request memory.
+
+* If a container runs without a given memory resource, it is able to consume free memory. It will do so until the total memory used by the VM reaches the default allocation. The guest and its I/O buffers also consume memory.
+* If a container is given a specific amount of memory, then that memory is hot-plugged into the VM before the container starts.
+* If a memory limit is specified, then the workload is terminated if it consumes more memory than the limit. If no memory limit is specified, the kernel  that is running on the virtual machine might run out of memory. If the kernel runs out of memory it might terminate other processes on the virtual machine.
+
+.Default memory sizes
+
+The following table lists some the default values for resource allocation.
+
+[cols="2,2"]
+|===
+|Resource |Value
+
+|Memory allocated by default to a virtual machine | 2Gi
+|Guest Linux kernel memory usage at boot | ~110Mi
+|Memory used by the QEMU process (excluding VM memory) | ~30Mi
+|Memory used by the `virtiofsd` process (excluding VM I/O buffers) | ~10Mi
+|Memory used by the `containerd-shim-kata-v2` process | ~20Mi
+|File buffer cache data after running `dnf install` on Fedora | ~300Mi* ^[1]^
+|===
+[.small]
+--
+
+1. File buffers appear and are accounted for in multiple locations:
+* In the guest where it appears as file buffer cache.
+* In the `virtiofsd` daemon that maps allowed user-space file I/O operations.
+* In the QEMU process as guest memory.
+
+[NOTE]
+====
+Total memory usage is properly accounted for by the memory utilization metrics, which only count that memory once.
+====
+--
+
+link:https://kubernetes.io/docs/concepts/scheduling-eviction/pod-overhead/[Pod overhead] describes the amount of system resources that a pod on a node uses. You can get the current pod overhead for the `kata` runtime class by using `oc describe runtimeclass kata` as shown below.
+
+.Example
+[source,terminal]
+----
+$ oc describe runtimeclass kata
+----
+
+.Example output
+[source,terminal]
+----
+Name:         kata
+[...]
+Metadata:
+[...]
+Overhead:
+  Pod Fixed:
+    Cpu:     250m
+    Memory:  350Mi
+[...]
+----
+
+You can change the pod overhead by changing the `spec.overhead` field for a `RuntimeClass`. For instance, if the configuration that you run for your containers consumes more than 350Mi of memory for the QEMU process and guest kernel data, you can alter the `RuntimeClass` overhead to suit your needs.
+
+[NOTE]
+====
+The specified default overhead values are supported by Red Hat. Changing default overhead values is not supported and can result in technical issues.
+====
+
+.Example
+[source,yaml]
+----
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1
+metadata:
+  name: kata
+overhead:
+  podFixed:
+    memory: "500Mi"
+    cpu: "500m"
+----
+
+* The default allocation for virtual machines is 2Gi.
+* The Linux kernel uses approximately 100Mi of memory at boot time.
+* The QEMU process uses approximately 30Mi of memory.
+* The `virtiofsd` process uses approximately 10Mi of memory.
+* The `shim-v2` process uses approximately 20Mi of memory.
+
+When performing any kind of file system I/O in the guest, file buffers are allocated in the guest kernel. The file buffers are also mapped in the QEMU process on the host, as well as on the `virtiofsd` process. For example, if you use 300Mi of file buffer cache in the guest, both QEMU and `virtiofsd` appear to use 300Mi additional memory. However, the same memory is being used in all three cases. In other words, the total memory usage is only 300Mi, mapped in three different places. This is correctly accounted for when reporting the memory utilization metrics.

--- a/modules/sandboxed-containers-scheduling-workloads.adoc
+++ b/modules/sandboxed-containers-scheduling-workloads.adoc
@@ -3,5 +3,60 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-scheduling-workloads_{context}"]
+= Scheduling {sandboxed-containers-first} workloads
 
-= Scheduling sandboxed containers workloads
+You can schedule your workloads to run on {sandboxed-containers-first}.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Add `runtimeClassName: kata` to any pod-templated resources:
+* `Pod` objects
+* `ReplicaSet` objects
+* `ReplicationController` objects
+* `StatefulSet` objects
+* `Deployment` objects
+* `DeploymentConfig` objects
+
+.Example for Pod objects
+[source,yaml]
+----
+  apiVersion: v1
+  kind: Pod
+  metadata:
+   name: mypod
+  spec:
+    runtimeClassName: kata
+----
+
+.Example for Deployment objects
+[source,yaml]
+----
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: mypod
+    labels:
+      app: mypod
+  spec:
+    replicas: 3
+    selector:
+      matchLabels:
+        app: mypod
+    template:
+      metadata:
+        labels:
+          app: mypod
+      spec:
+        runtimeClassName: kata
+        containers:
+        - name: mypod
+          image: myImage
+----
+
+After the pod-templated resource is created with `runtimeClassName: kata`, {product-title} begins scheduling the workload on {sandboxed-containers-first} enabled nodes. If no selector is used, the default is set to all worker nodes.  Your workload runs on {sandboxed-containers-first}.

--- a/modules/sandboxed-containers-selecting-nodes.adoc
+++ b/modules/sandboxed-containers-selecting-nodes.adoc
@@ -3,5 +3,67 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-selecting-nodes_{context}"]
+= Selecting nodes for {sandboxed-containers-first}
 
-= Selecting nodes for OpenShift sandboxed containers
+You can selectively install the Kata runtime on specific workers.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have installed the OpenShift CLI (oc).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Identify the labels that you want to use for selecting your nodes. For this example, use labels to selects to be chosen as candidates to run on your {sandboxed-containers-first} workloads. If the nodes exist, they are selected.
+.. To apply a label to a node, run the following command:
++
+[source,terminal]
+----
+$ oc label node <worker_node_name> <label>=<value>
+----
++
+This labels your worker node with the `<label>` label that has a value of `<value>`.
+
+. To add a label selector, edit the `KataConfig` custom resource (CR):
++
+[source,terminal]
+----
+$ oc edit kataconfig
+----
+.Example
++
+[source,yaml]
+----
+  apiVersion: kataconfiguration.openshift.io/v1
+  kind: KataConfig
+  metadata:
+    name: cluster-kataconfig
+  spec:
+    kataConfigPoolSelector:
+      matchLabels:
+         custom-kata-machine-pool: true
+----
+
+.Verification
+
+* You can check to see if the nodes in the `machine-config-pool` object are going through a config update.
+** If you are using the default nodes, you can monitor the `machine-config-pool` resource by running:
++
+[source,terminal]
+----
+$ watch oc get mcp worker
+----
+** If you are using selected nodes, you can monitor the `machine-config-pool` resource by running:
++
+[source,terminal]
+----
+$ watch oc get mcp kata-oc
+----
+
+* You can run `watch oc describe kataconfig cluster-kataconfig` to display information about `sandboxed-containers` extension failure on a node. The information is gathered from the status of the `machine-config-pool` object. You can view the information by running:
++
+[source,terminal]
+----
+$ oc describe mcp <machine-config-pool>
+----

--- a/modules/sandboxed-containers-triggering-installation-kata-runtime.adoc
+++ b/modules/sandboxed-containers-triggering-installation-kata-runtime.adoc
@@ -3,5 +3,74 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-triggering-installation-kata-runtime_{context}"]
-
 = Triggering the installation of the Kata runtime
+
+You must create one `KataConfig` custom resource (CR) to trigger the {sandboxed-containers-operator} to do the following:
+
+* Install the needed {op-system} extensions, such as QEMU and `kata-containers`, on your {op-system} node.
+* Ensure that the runtime, link:https://github.com/cri-o/cri-o[CRI-O], is configured with the correct Kata runtime handlers.
+* Create a `RuntimeClass` custom resource with necessary configurations for additional overhead caused by virtualization and the required additional processes.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create the `KataConfig` resource:
++
+[source,terminal]
+----
+$ oc create -f <file name>.yaml
+----
++
+.Example
++
+[source,yaml]
+----
+apiVersion: kataconfiguration.openshift.io/v1
+kind: KataConfig
+metadata:
+  name: cluster-kataconfig
+----
+
+. Monitor the installation progress.
+** You can describe the `KataConfig` installation:
++
+[source,terminal]
+----
+$ oc describe kataconfig
+----
++
+*** Verify the *Completed nodes* field in the status.
+*** If the value of *Completed nodes* matches the number of worker nodes, then the installation is completed. The status also contains a list of nodes where the installation is completed.
+** You can check the progress of the installation by watching the `KataConfig` resource:
++
+[source, terminal]
+----
+$ watch -n 10 oc describe kataconfig
+----
++
+Alternatively, you can check the status of the `KataConfig` resource. This can be done by running `oc get KataConfig <name> -oyaml` and inspecting the `status` field in the output.
+
+The Kata runtime is now installed on the cluster and ready for use as a secondary runtime.  Verify that you see a newly created `RuntimeClass` for Kata on your cluster.
+
+[IMPORTANT]
+====
+{sandboxed-containers-first} installs Kata only as a secondary optional runtime on the cluster and not as the primary runtime.
+====
+
+.Verification
+
+* You can monitor the values of the `KataConfig` custom resource by running:
++
+[source, terminal]
+----
+$ watch oc describe KataConfig cluster-kataconfig
+----
+
+
+// If your Kata runtime installation is not successful, see Troubleshooting {sandboxed-containers-first}.
+//TODO: add xref to the Troubleshooting Section

--- a/modules/sandboxed-containers-viewing-workloads-from-cli.adoc
+++ b/modules/sandboxed-containers-viewing-workloads-from-cli.adoc
@@ -4,4 +4,30 @@
 
 [id="sandboxed-containers-viewing-workloads-from-cli_{context}"]
 
-= Viewing sandboxed containers workloads from the CLI
+= Viewing {sandboxed-containers-first} workloads from the CLI
+
+You can view the `runtimeClass` that the pods for your workloads use from the CLI.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Inspect the `runtimeClassName` field on the pod to see a pod running on {sandboxed-containers-first} versus a normal container.
++
+** On the node, each pod has a corresponding `qemu` process.
+
+.Verification
+
+* You can check the logs of the `openshift-sandboxed-containers-operator` controller pod to see detailed messages about the steps it is running.
+** You can retrieve the name of the controller pod by running:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-sandboxed-containers-operator | grep openshift-sandboxed-containers-operator-controller-manager
+----
++
+This enables you to monitor the logs of the container manager of that pod. 

--- a/modules/sandboxed-containers-viewing-workloads-from-web-console.adoc
+++ b/modules/sandboxed-containers-viewing-workloads-from-web-console.adoc
@@ -3,5 +3,23 @@
 // * sandboxed_containers/deploying_sandboxed_containers.adoc
 
 [id="sandboxed-containers-viewing-workloads-from-web-console_{context}"]
+= Viewing {sandboxed-containers-first} workloads from the web console
 
-= Viewing sandboxed containers workloads from the web console
+{sandboxed-containers-first} based workloads look and feel the same as normal workloads when viewed in the web console. The only difference between the two is the `runtimeClassName`. `runtimeClassName` is what decides the runtime used for workloads. In this context, the runtime enabled by {sandboxed-containers-first}-based is `kata`. You can view the `runtimeClass` that the pods for your workloads use.
+
+.Prerequisites
+
+* You have {product-title} {product-version} installed on your cluster.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Navigate to *Administration* -> *Workloads*.
+
+. Identify the type of workload you want to view details for. For example, `Pod`, `Deployment`, `DeploymentConfigs` objects and so on.
+
+. Choose the corresponding workload from the list.
+
+. On the *Details* page, navigate to `runtimeClass`.
+
+. Hover over `runtimeClass` to view more information. If `kata` was used as the runtime, the value of the `runtimeClass` is `kata`.

--- a/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
+++ b/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
@@ -1,16 +1,39 @@
 [id="deploying-sandboxed-containers-workloads"]
-= Deploying OpenShift sandboxed containers workloads
+= Deploying {sandboxed-containers-first} workloads
 include::modules/common-attributes.adoc[]
 :context: deploying-sandboxed-containers
 
 toc::[]
 
-include::modules/sandboxed-containers-installing-operator.adoc[leveloffset=+1]
-include::modules/sandboxed-containers-preparing-openshift-cluster.adoc[leveloffset=+2]
+You can install the {sandboxed-containers-operator} using either the web console or OpenShift CLI (`oc`). Before installing the {sandboxed-containers-operator}, you must prepare your {product-title} cluster.
+
+include::modules/sandboxed-containers-preparing-openshift-cluster.adoc[leveloffset=+1]
+
+.Additional Resources
+* xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Deploying installer-provisioned clusters on bare metal]
+
+== Deploying {sandboxed-containers-operator} using the web console
+
+You can install the Operator and view your workloads from the web console.
+
 include::modules/sandboxed-containers-installing-operator-web-console.adoc[leveloffset=+2]
+
+include::modules/sandboxed-containers-viewing-workloads-from-web-console.adoc[leveloffset=+2]
+
+== Deploying {sandboxed-containers-operator} using the CLI
+
+You can install and deploy the Operator and view workloads from the CLI.
+
 include::modules/sandboxed-containers-installing-operator-cli.adoc[leveloffset=+2]
-include::modules/sandboxed-containers-triggering-installation-kata-runtime.adoc[leveloffset=+2]
-include::modules/sandboxed-containers-selecting-nodes.adoc[leveloffset=+2]
-include::modules/sandboxed-containers-scheduling-workloads.adoc[leveloffset=+1]
-include::modules/sandboxed-containers-viewing-workloads-from-web-console.adoc[leveloffset=+1]
-include::modules/sandboxed-containers-viewing-workloads-from-cli.adoc[leveloffset=+1]
+
+.Additional Resources
+xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster[Installing from OperatorHub using the CLI]
+
+include::modules/sandboxed-containers-triggering-installation-kata-runtime.adoc[leveloffset=+3]
+
+.Additional Resources
+* xref:../rest_api/node_apis/runtimeclass-node-k8s-io-v1.adoc#runtimeclass-node-k8s-io-v1[RuntimeClass]
+
+include::modules/sandboxed-containers-selecting-nodes.adoc[leveloffset=+3]
+include::modules/sandboxed-containers-scheduling-workloads.adoc[leveloffset=+3]
+include::modules/sandboxed-containers-viewing-workloads-from-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
Applies to 4.8+
JIRA Links: https://issues.redhat.com/browse/OSDOCS-2218, https://issues.redhat.com/browse/KATA-685, https://issues.redhat.com/browse/KATA-774
QE and SME ack required.
Preview Link: https://deploy-preview-32825--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads?utm_source=github&utm_campaign=bot_dp