### PR TITLE
OSDOCS-1846, WRKLDS-241/242: Consolidated assembly for TLS profiles

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1697,6 +1697,9 @@ Topics:
     File: nodes-nodes-resources-configuring
   - Name: Allocating specific CPUs for nodes in a cluster
     File: nodes-nodes-resources-cpus
+  - Name: Enabling TLS profiles for the kubelet
+    File: nodes-nodes-tls
+    Distros: openshift-enterprise,openshift-origin
 #  - Name: Monitoring for problems in your nodes
 #    File: nodes-nodes-problem-detector
   - Name: Machine Config Daemon metrics

--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assemblies:
+//
+// * security/tls-profiles.adoc
+
+[id="tls-profiles-ingress-configuring_{context}"]
+= Configuring the TLS security profile for the Ingress Controller
+
+To configure a TLS security profile for the Ingress Controllers, edit the `IngressController` custom resource (CR) to specify a predefined or custom TLS profile. If a TLS profile is not configured, the default value is based on the TLS profile set for the API server.
+
+.Sample `IngressController` CR that configures the `Old` TLS security profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  tlsSecurityProfile:
+    old: {}
+    type: Old
+ ...
+----
+
+The TLS security profile defines the minimum TLS version and the TLS ciphers for TLS connections for Ingress Controllers.
+
+You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `IngressController` custom resource (CR) under `Status.Tls Profile` and the configured TLS security profile under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed under both parameters.
+
+[IMPORTANT]
+====
+The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3` it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+
+The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the `IngressController` CR in the `openshift-ingress-operator` project to configure the TLS security profile:
++
+[source,terminal]
+----
+$ oc edit IngressController default -n openshift-ingress-operator
+----
+
+. Add the `spec.tlsSecurityProfile` field:
++
+.Sample `IngressController` CR for a `Custom` profile
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  tlsSecurityProfile:
+    type: Custom <1>
+    custom: <2>
+      ciphers: <3>
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS11
+ ...
+----
+<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+<2> Specify:
+* `old: {}`
+* `intermediate: {}`
+* `custom:`
+<2> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+
+. Save the file to apply the changes.
+
+.Verification
+
+* Verify that the profile is set in the `IngressController` CR:
++
+[source,terminal]
+----
+$ oc describe IngressController default -n openshift-ingress-operator
+----
++
+.Example output
+[source,terminal]
+----
+Name:         default
+Namespace:    openshift-ingress-operator
+Labels:       <none>
+Annotations:  <none>
+API Version:  operator.openshift.io/v1
+Kind:         IngressController
+ ...
+Spec:
+ ...
+  Tls Security Profile:
+    Custom:
+      Ciphers:
+        ECDHE-ECDSA-CHACHA20-POLY1305
+        ECDHE-RSA-CHACHA20-POLY1305
+        ECDHE-RSA-AES128-GCM-SHA256
+        ECDHE-ECDSA-AES128-GCM-SHA256
+      Min TLS Version:  VersionTLS11
+    Type:               Custom
+ ...
+----

--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -1,0 +1,133 @@
+// Module included in the following assemblies:
+//
+// * security/tls-profiles.adoc
+
+ifeval::["{context}" == "tls-security-profiles"]
+:tls:
+endif::[]
+
+[id="tls-profiles-kubelet-configuring_{context}"]
+= Configuring the TLS security profile for the kubelet
+
+To configure a TLS security profile for the kubelet when it is acting as an HTTP server, create a `KubeletConfig` custom resource (CR) to specify a predefined or custom TLS profile for specific nodes. If a TLS profile is not configured, the default TLS profile is `Intermediate`. 
+
+ifdef::tls[]
+The kubelet uses its HTTP/GRPC server to communicate with the Kubernetes API server, which sends commands to pods, gathers logs, and run exec commands on pods through the kubelet.
+endif::[]
+
+.Sample `KubeletConfig` CR that configures the `Old` TLS security profile on worker nodes
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: KubeletConfig
+ ...
+spec:
+  tlsSecurityProfile:
+    old: {}
+    type: Old
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: ""
+----
+
+You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `kubelet.conf` file on a configured node.
+
+[IMPORTANT]
+====
+The kubelet does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3` it is not supported. The kubelet converts the `Modern` profile to `Intermediate`.
+
+The kubelet also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create a `KubeletConfig` CR to configure the TLS security profile:
++
+.Sample `KubeletConfig` CR for a `Custom` profile
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: set-kubelet-tls-security-profile
+spec:
+  tlsSecurityProfile:
+    type: Custom <1>
+    custom: <2>
+      ciphers: <3>
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS11
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: "" <4>
+----
++
+<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+<2> Specify:
+* `old: {}`
+* `intermediate: {}`
+* `custom:`
+<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+<4> Optional: Specify the machine config pool label for the nodes you want to apply the TLS security profile. 
+
+. Create the `KubeletConfig` object:
++
+[source,terminal]
+----
+$ oc create -f <filename>
+----
++
+Depending on the number of worker nodes in the cluster, wait for the configured nodes to be rebooted one by one.
+
+.Verification
+
+To verify that the profile is set,  perform the following steps after the nodes are in the `Ready` state:
+
+. Start a debug session for a configured node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Set `/host` as the root directory within the debug shell:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+. View the `kubelet.conf` file:
++
+[source,terminal]
+----
+sh-4.4# cat /etc/kubernetes/kubelet.conf
+----
++
+.Example output
+[source,terminal]
+----
+kind: KubeletConfiguration
+apiVersion: kubelet.config.k8s.io/v1beta1
+ ...
+  "tlsCipherSuites": [
+    "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+    "TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384",
+    "TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256",
+    "TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"
+  ],
+  "tlsMinVersion": "VersionTLS12",
+----
+
+ifeval::["{context}" == "tls-security-profiles"]
+:!tls:
+endif::[]

--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -1,0 +1,110 @@
+// Module included in the following assemblies:
+//
+// * security/tls-profiles.adoc
+
+[id="tls-profiles-kubernetes-configuring_{context}"]
+= Configuring the TLS security profile for the control plane
+
+To configure a TLS security profile for the control plane (the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, and OpenShift OAuth server), edit the `APIServer` custom resource (CR) to specify a predefined or custom TLS profile. Setting the TLS security profile in the `APIServer` CR propagates the setting to the listed control plane components. If a TLS profile is not configured, the default TLS profile is `Intermediate`.
+
+[NOTE]
+====
+The default TLS security profile for the Ingress Controller is based on the TLS profile set for the API server.
+====
+
+.Sample `APIServer` CR that configures the `Old` TLS security profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: APIServer
+ ...
+spec:
+  tlsSecurityProfile:
+    old: {}
+    type: Old
+ ...
+----
+
+The TLS security profile defines the minimum TLS version and the TLS ciphers required to communicate with the control plane components.
+
+You can see the configured TLS security profile in the `APIServer` custom resource (CR) under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed.
+
+[NOTE]
+====
+The control plane does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3` it is not supported.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the default `APIServer` CR to configure the TLS security profile:
++
+[source,terminal]
+----
+$ oc edit APIServer cluster
+----
+
+. Add the `spec.tlsSecurityProfile` field:
++
+.Sample `APIServer` CR for a `Custom` profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  tlsSecurityProfile:
+    type: Custom <1>
+    custom: <2>
+      ciphers: <3>
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS11
+----
+<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+<2> Specify:
+* `old: {}`
+* `intermediate: {}`
+* `custom:`
+<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+
+. Save the file to apply the changes. 
+
+.Verification
+
+* Verify that the TLS security profile is set in the `APIServer` CR:
++
+[source,terminal]
+----
+$ oc describe apiserver cluster
+----
++
+.Example output
+[source,terminal]
+----
+Name:         cluster
+Namespace:
+ ...
+API Version:  config.openshift.io/v1
+Kind:         APIServer
+ ...
+Spec:
+  Audit:
+    Profile:  Default
+  Tls Security Profile:
+    Custom:
+      Ciphers:
+        ECDHE-ECDSA-CHACHA20-POLY1305
+        ECDHE-RSA-CHACHA20-POLY1305
+        ECDHE-RSA-AES128-GCM-SHA256
+        ECDHE-ECDSA-AES128-GCM-SHA256
+      Min TLS Version:  VersionTLS11
+    Type:               Custom
+ ...
+----

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -58,7 +58,7 @@ When using one of the predefined profile types, the effective profile configurat
 // TODO: Make sure all this is captured somewhere as necessary
 // [IMPORTANT]
 // ====
-// The HAProxy Ingress controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+// The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
 //
 // The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
 // ====

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -17,7 +17,16 @@ include::modules/nw-installation-ingress-config-asset.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-controller-configuration-parameters.adoc[leveloffset=+1]
 
-include::modules/nw-ingress-controller-tls-profiles.adoc[leveloffset=+2]
+[id="configuring-ingress-controller-tls"]
+=== Ingress Controller TLS security profiles
+
+TLS security profiles provide a way for servers to regulate which ciphers a connecting client can use when connecting to the server.
+
+// Understanding TLS security profiles
+include::modules/tls-profiles-understanding.adoc[leveloffset=+4]
+
+// Configuring the TLS profile for the Ingress Controller
+include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+4]
 
 include::modules/nw-ingress-controller-endpoint-publishing-strategies.adoc[leveloffset=+2]
 

--- a/nodes/nodes/nodes-nodes-tls.adoc
+++ b/nodes/nodes/nodes-nodes-tls.adoc
@@ -1,0 +1,21 @@
+:context: nodes-nodes-tls
+[id="nodes-nodes-tls"]
+= Enabling TLS security profiles for the kubelet
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+You can use a TLS (Transport Layer Security) security profile to define which TLS ciphers are required by the kubelet when it is acting as an HTTP server. The kubelet uses its HTTP/GRPC server to communicate with the Kubernetes API server, which sends commands to pods, gathers logs, and run exec commands on pods through the kubelet.
+
+A TLS security profile defines the TLS ciphers that the Kubernetes API server must use when connecting with the kubelet to protect communication between the kubelet and the Kubernetes API server.
+
+[NOTE]
+====
+By default, when the kubelet acts as a client with the Kubernetes API server, it automatically negotiates the TLS parameters with the API server.
+====
+
+include::modules/tls-profiles-understanding.adoc[leveloffset=+1]
+
+include::modules/tls-profiles-kubelet-configuring.adoc[leveloffset=+1]
+
+

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-TLS security profiles provide a way for servers to regulate which ciphers a connecting client can use when connecting to the server. This ensures that {product-title} components use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
+TLS security profiles provide a way for servers to regulate which ciphers a client can use when connecting to the server. This ensures that {product-title} components use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
 
 Cluster administrators can choose which TLS security profile to use for each of the following components:
 
@@ -17,7 +17,6 @@ This includes the Kubernetes API server, Kubernetes controller manager, Kubernet
 // NOTE: etcd and OpenShift controller manager are not included
 
 * the kubelet, when it acts as an HTTP server for the Kubernetes API server
-// TODO: add links once the procedures have been added?
 
 // Understanding TLS security profiles
 include::modules/tls-profiles-understanding.adoc[leveloffset=+1]
@@ -25,15 +24,11 @@ include::modules/tls-profiles-understanding.adoc[leveloffset=+1]
 // Viewing TLS security profile details
 include::modules/tls-profiles-view-details.adoc[leveloffset=+1]
 
-////
+// Configuring for ingress
+include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+1]
 
-// TODO: Configuring for ingress
-// include::modules/todo.adoc[leveloffset=+1]
+// Configuring for the control plane
+include::modules/tls-profiles-kubernetes-configuring.adoc[leveloffset=+1]
 
-// TODO: Configuring for the control plane
-// include::modules/todo.adoc[leveloffset=+1]
-
-// TODO: Configuring for kubelet
-// include::modules/todo.adoc[leveloffset=+1]
-
-////
+// Configuring for kubelet
+include::modules/tls-profiles-kubelet-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/WRKLDS-242
https://issues.redhat.com/browse/WRKLDS-241
https://issues.redhat.com/browse/OSDOCS-1846
Plus new configuring TLS for Ingress Controller topic.

Previews: [
_Configuring TLS security profiles_ in Security and Compliance](https://deploy-preview-32826--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html)
[_Understanding TLS Profiles_ in Ingress Operator](https://deploy-preview-32826--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#tls-profiles-ingress-configuring_configuring-ingress) (modules/tls-profiles-understanding.adoc forthcoming)
[_Enabling TLS profiles for the kubelet_ in Nodes](https://deploy-preview-32826--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls.html)