### PR TITLE
Mv RH catalog table to new topic

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1166,6 +1166,9 @@ Topics:
   - Name: OperatorHub
     Distros: openshift-enterprise,openshift-origin
     File: olm-understanding-operatorhub
+  - Name: Red Hat-provided Operator catalogs
+    Distros: openshift-enterprise
+    File: olm-rh-catalogs
   - Name: CRDs
     Dir: crds
     Topics:

--- a/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -67,6 +67,6 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-understanding-operator-catalog-images_olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -57,6 +57,6 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validate an installation].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-understanding-operator-catalog-images_olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -51,5 +51,5 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-understanding-operator-catalog-images_olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
+* Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If you did not configure {rh-openstack} to accept application traffic over floating IP addresses, xref:../../post_installation_configuration/network-configuration.adoc#installation-osp-configuring-api-floating-ip_post-install-network-configuration[configure {rh-openstack} access with floating IP addresses].

--- a/modules/olm-about-catalogs.adoc
+++ b/modules/olm-about-catalogs.adoc
@@ -1,12 +1,9 @@
 // Module included in the following assemblies:
 //
-// * operators/admin/olm-managing-custom-catalogs.adoc
-// * operators/admin/olm-restricted-networks.adoc
+// * operators/understanding/olm-rh-catalogs.adoc
 
-:tag: v{product-version}
-
-[id="olm-understanding-operator-catalog-images_{context}"]
-= Understanding Operator catalogs
+[id="olm-about-catalogs_{context}"]
+= About Operator catalogs
 
 An Operator catalog is a repository of metadata that Operator Lifecycle Manager (OLM) can query to discover and install Operators and their dependencies on a cluster. OLM always installs Operators from the latest version of a catalog. As of {product-title} 4.6, Red Hat-provided catalogs are distributed using _index images_.
 
@@ -17,34 +14,6 @@ An index image, based on the Operator Bundle Format, is a containerized snapshot
 Starting in {product-title} 4.6, index images provided by Red Hat replace the App Registry catalog images, based on the deprecated Package Manifest Format, that are distributed for previous versions of {product-title} 4. While App Registry catalog images are not distributed by Red Hat for {product-title} 4.6 and later, custom catalog images based on the Package Manifest Format are still supported.
 ====
 
-ifndef::openshift-origin[]
-The following catalogs are distributed by Red Hat:
-
-.Red Hat-provided Operator catalogs
-[cols="20%,55%,25%",options="header"]
-|===
-|Catalog
-|Index image
-|Description
-
-|`redhat-operators`
-|`registry.redhat.io/redhat/redhat-operator-index:{tag}`
-|Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
-
-|`certified-operators`
-|`registry.redhat.io/redhat/certified-operator-index:{tag}`
-|Products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
-
-|`redhat-marketplace`
-|`registry.redhat.io/redhat/redhat-marketplace-index:{tag}`
-|Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
-
-|`community-operators`
-|`registry.redhat.io/redhat/community-operator-index:{tag}`
-|Software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
-|===
-endif::[]
-
 As catalogs are updated, the latest versions of Operators change, and older versions may be removed or altered. In addition, when OLM runs on an {product-title} cluster in a restricted network environment, it is unable to access the catalogs directly from the Internet to pull the latest content.
 
 As a cluster administrator, you can create your own custom index image, either based on a Red Hat-provided catalog or from scratch, which can be used to source the catalog content on the cluster. Creating and updating your own index image provides a method for customizing the set of Operators available on the cluster, while also avoiding the aforementioned restricted network environment issues.
@@ -53,5 +22,3 @@ As a cluster administrator, you can create your own custom index image, either b
 ====
 When creating custom catalog images, previous versions of {product-title} 4 required using the `oc adm catalog build` command, which has been deprecated for several releases. With the availability of Red Hat-provided index images starting in {product-title} 4.6, catalog builders should start switching to using the `opm index` command to manage index images before the `oc adm catalog build` command is removed in a future release.
 ====
-
-:!tag:

--- a/modules/olm-rh-catalogs.adoc
+++ b/modules/olm-rh-catalogs.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * operators/understanding/olm-rh-catalogs.adoc
+
+:tag: v{product-version}
+
+[id="olm-rh-catalogs_{context}"]
+= About Red Hat-provided Operator catalogs
+
+The following Operator catalogs are distributed by Red Hat:
+
+[cols="20%,55%,25%",options="header"]
+|===
+|Catalog
+|Index image
+|Description
+
+|`redhat-operators`
+|`registry.redhat.io/redhat/redhat-operator-index:{tag}`
+|Red Hat products packaged and shipped by Red Hat. Supported by Red Hat.
+
+|`certified-operators`
+|`registry.redhat.io/redhat/certified-operator-index:{tag}`
+|Products from leading independent software vendors (ISVs). Red Hat partners with ISVs to package and ship. Supported by the ISV.
+
+|`redhat-marketplace`
+|`registry.redhat.io/redhat/redhat-marketplace-index:{tag}`
+|Certified software that can be purchased from link:https://marketplace.redhat.com/[Red Hat Marketplace].
+
+|`community-operators`
+|`registry.redhat.io/redhat/community-operator-index:{tag}`
+|Software maintained by relevant representatives in the link:https://github.com/operator-framework/community-operators[operator-framework/community-operators] GitHub repository. No official support.
+|===
+
+:!tag:

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -7,7 +7,9 @@ toc::[]
 
 This guide describes how to work with custom catalogs for Operators packaged using either the xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Bundle Format] or the legacy xref:../../operators/understanding/olm-packaging-format.adoc#olm-package-manifest-format_olm-packaging-format[Package Manifest Format] on Operator Lifecycle Manager (OLM) in {product-title}.
 
-include::modules/olm-understanding-operator-catalog-images.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
 [id="olm-managing-custom-catalogs-bundle-format"]
 == Custom catalogs using the Bundle Format

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -33,9 +33,8 @@ link:https://access.redhat.com/articles/4740011[]
 
 .Additional resources
 
+* xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments]
-
-include::modules/olm-understanding-operator-catalog-images.adoc[leveloffset=+1]
 
 [id="olm-restricted-network-prereqs"]
 == Prerequisites

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -1,0 +1,14 @@
+[id="olm-rh-catalogs"]
+= Red Hat-provided Operator catalogs
+include::modules/common-attributes.adoc[]
+:context: olm-rh-catalogs
+
+toc::[]
+
+include::modules/olm-about-catalogs.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs]
+* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+
+include::modules/olm-rh-catalogs.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2226

Preview: [Red Hat-provided Operator catalogs](https://deploy-preview-32827--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-rh-catalogs.html)

To make the RH-provided Operator catalog information easier to discover, this pulls the re-used content out of the previous 2 locations ([here](https://docs.openshift.com/container-platform/4.7/operators/admin/olm-managing-custom-catalogs.html#olm-understanding-operator-catalog-images_olm-managing-custom-catalogs) and [here](https://docs.openshift.com/container-platform/4.7/operators/admin/olm-restricted-networks.html#olm-understanding-operator-catalog-images_olm-restricted-networks) in current 4.7 docs) and creates a new left-nav assembly right after the OperatorHub topic (vs stuffing yet another level deep under the OLM subdir).

For the previous locations where the content was removed, there are now "Additional resources" links to the new spot.

Reminder: any `vBranch Build` tags seen in the preview will show up as the correct OCP version numbers when merged to the respective version branches.