### PR TITLE
BZ1878946 (OCP 4.7 RN) remove etcd cluster operator from restrictions

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -319,7 +319,6 @@ Note the following restrictions for {product-title} on IBM Z and LinuxONE:
 ** OpenShift Serverless
 ** Helm command-line interface (CLI) tool
 ** Controlling overcommit and managing container density on nodes
-** etcd cluster Operator
 ** CSI volume cloning
 ** NVMe
 ** 4K FCP block device


### PR DESCRIPTION
- BZ https://bugzilla.redhat.com/show_bug.cgi?id=1878946

- Reviewer: Holger Wolf

- Preview: https://deploy-preview-32841--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-ibm-z

Related PR for 4.6: https://github.com/openshift/openshift-docs/pull/32848

Related PR for 4.5 https://github.com/openshift/openshift-docs/pull/32851