### PR TITLE
CNV-11783: bumping HCO variable for 2.6.3

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.2
+:HCOVersion: 2.6.3
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
* [CNV-11783](https://issues.redhat.com/browse/CNV-11783)
* CP to 4.7 and 4.8
attn @tiraboschi 