### PR TITLE
CCO-21 RN content for 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -235,6 +235,17 @@ For more information, see xref:../scalability_and_performance/what-huge-pages-do
 [id="ocp-4-8-dev-exp"]
 === Developer experience
 
+[id="ocp-4-8-auth"]
+=== Authentication and authorization
+
+[id="ocp-4-8-auth-tp-aws-sts"]
+==== Running {product-title} using AWS Security Token Service (STS) for credentials is generally available
+
+You can now use the Cloud Credential Operator (CCO) utility (`ccoctl`) to configure the CCO to use the Amazon Web Services Security Token Service (AWS STS). When the CCO is configured to use STS, it assigns IAM roles that provide short-term, limited-privilege security credentials to components.
+
+This feature was previously introduced as a Technology Preview feature in {product-title} 4.7, and is now generally available in {product-title} 4.8.
+
+For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Using manual mode with STS].
 
 [id="ocp-4-8-notable-technical-changes"]
 == Notable technical changes
@@ -551,6 +562,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 |
+
+|AWS Security Token Service (STS)
+|-
+|TP
+|GA
 
 |====
 


### PR DESCRIPTION
Release notes content for [CCO-21](https://issues.redhat.com/browse/CCO-21) (as part of https://issues.redhat.com/browse/OSDOCS-1953)
Preview: [Feature writeup](https://deploy-preview-32880--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-auth-tp-aws-sts), [tech preview table](https://deploy-preview-32880--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-technology-preview)
Note - link to STS mode docs works but that content is outdated (4.7 version) until #31136 is merged