### PR TITLE
[enterprise-4.6] Can add quay.io to blockedRegistries that cause operator pod with ImagePullBackOff error

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -12,7 +12,7 @@ When pulling or pushing images, the container runtime searches the registries li
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries including the registry.redhat.io and quay.io registries are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries must also be added.
 ====
 
 .Procedure

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -10,6 +10,11 @@ You can block any registry by editing the `image.config.openshift.io/cluster` cu
 
 When pulling or pushing images, the container runtime searches the registries listed under the `registrySources` parameter in the `image.config.openshift.io/cluster` CR. If you created a list of registries under the `blockedRegistries` parameter, the container runtime does not search those registries. All other registries are allowed.
 
+[WARNING]
+====
+To prevent pod failure, do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list, as they are required by payload images within your environment.
+====
+
 .Procedure
 
 . Edit the `image.config.openshift.io/cluster` CR:

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -58,7 +58,7 @@ status:
 +
 [NOTE]
 ====
-When the `allowedRegistries` parameter is defined, all registries including the registry.redhat.io and quay.io registries are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment.
+When the `allowedRegistries` parameter is defined, all registries, including the registry.redhat.io and quay.io registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list.
 ====
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to registries and reboots the nodes when it detects changes. Changes to the insecure and blocked registries appear in the `/etc/containers/registries.conf` file on each node.

--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -45,7 +45,7 @@ Either `blockedRegistries` or `allowedRegistries` can be set, but not both.
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries including `registry.redhat.io` and `quay.io` are blocked unless explicitly listed. If using the parameter, declare source registries `registry.redhat.io` and `quay.io` as required by payload images within your environment, to prevent pod failure. For disconnected clusters, mirror registries should also be added.
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. When using the parameter,  to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list. For disconnected clusters, mirror registries must also be added.
 ====
 
 The `status` field of the `image.config.openshift.io/cluster` resource holds observed values from the cluster.


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/32762