### PR TITLE
Update docs with more clarity around Ignition

### DIFF
--- a/modules/ignition-config-viewing.adoc
+++ b/modules/ignition-config-viewing.adoc
@@ -22,20 +22,36 @@ Here’s a snippet from that file:
 [source,terminal]
 ----
 $ cat $HOME/testconfig/bootstrap.ign | jq
-\\{
-  "ignition": \\{
-        "config": \\{},
-  "storage": \\{
-        "files": [
-          \\{
-            "filesystem": "root",
-            "path": "/etc/motd",
-            "user": \\{
-              "name": "root"
-            },
-            "append": true,
-            "contents": \\{
-              "source": "data:text/plain;charset=utf-8;base64,VGhpcyBpcyB0aGUgYm9vdHN0cmFwIG5vZGU7IGl0IHdpbGwgYmUgZGVzdHJveWVkIHdoZW4gdGhlIG1hc3RlciBpcyBmdWxseSB1cC4KClRoZSBwcmltYXJ5IHNlcnZpY2UgaXMgImJvb3RrdWJlLnNlcnZpY2UiLiBUbyB3YXRjaCBpdHMgc3RhdHVzLCBydW4gZS5nLgoKICBqb3VybmFsY3RsIC1iIC1mIC11IGJvb3RrdWJlLnNlcnZpY2UK",
+{
+  "ignition": {
+    "version": "3.2.0"
+  },
+  "passwd": {
+    "users": [
+      {
+        "name": "core",
+        "sshAuthorizedKeys": [
+          "ssh-rsa AAAAB3NzaC1yc...."
+        ]
+      }
+    ]
+  },
+  "storage": {
+    "files": [
+      {
+        "overwrite": false,
+        "path": "/etc/motd",
+        "user": {
+          "name": "root"
+        },
+        "append": [
+          {
+            "source": "data:text/plain;charset=utf-8;base64,VGhpcyBpcyB0aGUgYm9vdHN0cmFwIG5vZGU7IGl0IHdpbGwgYmUgZGVzdHJveWVkIHdoZW4gdGhlIG1hc3RlciBpcyBmdWxseSB1cC4KClRoZSBwcmltYXJ5IHNlcnZpY2VzIGFyZSByZWxlYXNlLWltYWdlLnNlcnZpY2UgZm9sbG93ZWQgYnkgYm9vdGt1YmUuc2VydmljZS4gVG8gd2F0Y2ggdGhlaXIgc3RhdHVzLCBydW4gZS5nLgoKICBqb3VybmFsY3RsIC1iIC1mIC11IHJlbGVhc2UtaW1hZ2Uuc2VydmljZSAtdSBib290a3ViZS5zZXJ2aWNlCg=="
+          }
+        ],
+        "mode": 420
+      },
+...
 ----
 
 To decode the contents of a file listed in the `bootstrap.ign` file, pipe the
@@ -45,17 +61,17 @@ the bootstrap machine from the output shown above:
 
 [source,terminal]
 ----
-$ echo VGhpcyBpcyB0aGUgYm9vdHN0cmFwIG5vZGU7IGl0IHdpbGwgYmUgZGVzdHJveWVkIHdoZW4gdGhlIG1hc3RlciBpcyBmdWxseSB1cC4KClRoZSBwcmltYXJ5IHNlcnZpY2UgaXMgImJvb3RrdWJlLnNlcnZpY2UiLiBUbyB3YXRjaCBpdHMgc3RhdHVzLCBydW4gZS5nLgoKICBqb3VybmFsY3RsIC1iIC1mIC11IGJvb3RrdWJlLnNlcnZpY2UK | base64 --decode
+$ echo VGhpcyBpcyB0aGUgYm9vdHN0cmFwIG5vZGU7IGl0IHdpbGwgYmUgZGVzdHJveWVkIHdoZW4gdGhlIG1hc3RlciBpcyBmdWxseSB1cC4KClRoZSBwcmltYXJ5IHNlcnZpY2VzIGFyZSByZWxlYXNlLWltYWdlLnNlcnZpY2UgZm9sbG93ZWQgYnkgYm9vdGt1YmUuc2VydmljZS4gVG8gd2F0Y2ggdGhlaXIgc3RhdHVzLCBydW4gZS5nLgoKICBqb3VybmFsY3RsIC1iIC1mIC11IHJlbGVhc2UtaW1hZ2Uuc2VydmljZSAtdSBib290a3ViZS5zZXJ2aWNlCg== | base64 --decode
 ----
 
 .Example output
 [source,terminal]
 ----
-This is the bootstrap machine; it will be destroyed when the master is fully up.
+This is the bootstrap node; it will be destroyed when the master is fully up.
 
-The primary service is "bootkube.service". To watch its status, run, e.g.:
+The primary services are release-image.service followed by bootkube.service. To watch their status, run e.g.
 
-journalctl -b -f -u bootkube.service
+  journalctl -b -f -u release-image.service -u bootkube.service
 ----
 
 Repeat those commands on the `master.ign` and `worker.ign` files to see the source
@@ -80,20 +96,20 @@ machines, both master and worker machine Ignition config information is stored i
 * Size: The file is more than 1300 lines long, with path to various types of resources.
 * The content of each file that will be copied to the machine is actually encoded
 into data URLs, which tends to make the content a bit clumsy to read. (Use the
-  jq and base64 commands shown previously to make the content more readable.)
+  `jq` and `base64` commands shown previously to make the content more readable.)
 * Configuration: The different sections of the Ignition config file are generally
  meant to contain files that are just dropped into a machine’s file system, rather
  than commands to modify existing files. For example, instead of having a section
  on NFS that configures that service, you would just add an NFS configuration
  file, which would then be started by the init process when the system comes up.
-* users: A user named core is created, with your ssh key assigned to that user.
+* users: A user named `core` is created, with your SSH key assigned to that user.
 This allows you to log in to the cluster with that user name and your
 credentials.
 * storage: The storage section identifies files that are added to each machine. A
 few notable files include `/root/.docker/config.json` (which provides credentials
   your cluster needs to pull from container image registries) and a bunch of
   manifest files in `/opt/openshift/manifests` that are used to configure your cluster.
-* systemd: The systemd section holds content used to create systemd unit files.
+* systemd: The `systemd` section holds content used to create `systemd` unit files.
 Those files are used to start up services at boot time, as well as manage those
 services on running systems.
 * Primitives: Ignition also exposes low-level primitives that other tools can

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -43,7 +43,12 @@ The kinds of components that MCO can change include:
 * **config**: Create Ignition config objects (see the link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition configuration specification]) to do things like modify files, systemd services, and other features on {product-title} machines, including:
 - **Configuration files**: Create or overwrite files in the `/var` or `/etc` directory.
 - **systemd units**: Create and set the status of a systemd service or add to an existing systemd service by dropping in additional settings.
-- **users and groups**: Change ssh keys in the passwd section post-installation.
+- **users and groups**: Change SSH keys in the passwd section post-installation.
+
+[IMPORTANT]
+====
+Changing SSH keys via machine configs is only supported for the `core` user.
+====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.
 ifndef::openshift-origin[]


### PR DESCRIPTION
Some style updates and a warning about only supporting the `core` user for
SSH key manipulation.

Preview link: https://deploy-preview-32894--osdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-rhcos.html

Preview link: https://deploy-preview-32894--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#machine-config-overview-post-install-machine-configuration-tasks