### PR TITLE
CCXDEV-4071 Air-gapped changes to enterprise 4.7 

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -413,6 +413,8 @@ Topics:
     File: opting-out-of-remote-health-reporting
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
+  - Name: Using remote health reporting in a restricted network
+    File: remote-health-reporting-from-restricted-network
 - Name: Gathering data about your cluster
   File: gathering-cluster-data
   Distros: openshift-enterprise,openshift-origin

--- a/modules/insights-operator-copying-archive.adoc
+++ b/modules/insights-operator-copying-archive.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+
+[id="insights-operator-copying-archive_{context}"]
+= Copying an Insights Operator archive
+
+You must create a copy of your Insights Operator data archive for upload to link:https://cloud.redhat.com[cloud.redhat.com].
+
+.Prerequisites
+
+* You are logged in to {product-title} as `cluster-admin`.
+
+.Procedure
+
+. Find the name of the Insights Operator pod that is currently running:
++
+[source,terminal]
+----
+$ INSIGHTS_OPERATOR_POD=$(oc get pods --namespace=openshift-insights -o custom-columns=:metadata.name --no-headers  --field-selector=status.phase=Running)
+----
+
+. Copy the recent data archives from the Insights Operator container:
++
+[source,terminal]
+----
+$ oc cp openshift-insights/$INSIGHTS_OPERATOR_POD:/var/lib/insights-operator ./insights-data
+----
+
+The recent Insights Operator archives are now available in the `insights-data` directory.

--- a/modules/insights-operator-manual-upload.adoc
+++ b/modules/insights-operator-manual-upload.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+
+
+
+[id="insights-operator-manual-upload_{context}"]
+= Uploading an Insights Operator archive
+
+You can manually upload an Insights Operator archive to link:https://cloud.redhat.com[cloud.redhat.com] to diagnose potential issues.
+
+.Prerequisites
+
+* You are logged in to {product-title} as `cluster-admin`.
+* You have a workstation with unrestricted internet access.
+* You have created a copy of the Insights Operator archive.
+
+.Procedure
+
+. Download the `dockerconfig.json` file:
++
+[source,terminal]
+----
+$ oc extract secret/pull-secret -n openshift-config --to=.
+----
+. Copy your `"cloud.openshift.com"` `"auth"` token from the `dockerconfig.json` file:
++
+[source,json,subs="+quotes"]
+----
+{    
+  "auths": {        
+    "cloud.openshift.com": {            
+      "auth": "_<your_token>_",
+      "email": "asd@redhat.com"
+    }
+}
+----
+
+
+. Upload the archive to link:https://cloud.redhat.com[cloud.redhat.com]:
++
+[source,terminal,subs="+quotes"]
+----
+$ curl -v -H "User-Agent: insights-operator/one10time200gather184a34f6a168926d93c330 cluster/_<cluster_id>_" -H "Authorization: Bearer _<your_token>_" -F "upload=@_<path_to_archive>_; type=application/vnd.redhat.openshift.periodic+tar" https://cloud.redhat.com/api/ingress/v1/upload
+----
+where `_<cluster_id>_` is your cluster ID, `_<your_token>_` is the token from your pull secret, and `_<path_to_archive>_` is the path to the Insights Operator archive. 
++
+If the operation is successful, the command returns a `"request_id"` and `"account_number"`:
++
+.Example output
++
+[source,terminal]
+----
+* Connection #0 to host cloud.redhat.com left intact
+{"request_id":"393a7cf1093e434ea8dd4ab3eb28884c","upload":{"account_number":"6274079"}}%
+----
+
+.Verification steps
+
+. Log in to link:https://cloud.redhat.com/openshift[].
+
+. Click the *Clusters* menu in the left pane.
+
+. To display the details of the cluster, click the cluster name.
+
+. Open the *Insights Advisor* tab of the cluster.
++
+If the upload was successful, the tab displays one of the following:
++
+* *Your cluster passed all recommendations*, if Insights Advisor did not identify any issues.
+
+* A list of issues that Insights Advisor has detected, prioritized by risk (low, moderate, important, and critical).

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -1,0 +1,21 @@
+[id="remote-health-reporting-from-restricted-network"]
+= Using remote health reporting in a restricted network
+include::modules/common-attributes.adoc[]
+:context: remote-health-reporting-from-restricted-network
+
+toc::[]
+
+You can manually gather and upload Insights Operator archives to diagnose issues from a restricted network. 
+
+To use the Insights Operator in a restricted network, you must:
+
+* Create a copy of your Insights Operator archive.
+* Upload the Insights Operator archive to link:https://cloud.redhat.com[cloud.redhat.com].
+
+
+include::modules/insights-operator-copying-archive.adoc[leveloffset=+1]
+
+include::modules/insights-operator-manual-upload.adoc[leveloffset=+1]
+
+
+


### PR DESCRIPTION
https://issues.redhat.com/browse/CCXDEV-4071

This PR applies to Enterprise 4.7 

Backport version from the merged 4.8+ chapter: https://github.com/openshift/openshift-docs/pull/32558
This version removes the obfuscation and gather modules and adds one module for copying the archive in 4.7 and 4.6. 

Preview:
https://deploy-preview-32903--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.html

@quarckster this is ready for QA