### PR TITLE
[CANCELLED] Changed the attribute pipelines-ver to pipelines-1.2

### DIFF
--- a/modules/pipelines-document-attributes.adoc
+++ b/modules/pipelines-document-attributes.adoc
@@ -9,4 +9,4 @@
 //
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: Pipelines
-:pipelines-ver: pipelines-1.4
+:pipelines-ver: pipelines-1.2


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.6`
- **JIRA issues**: [Add appropriate value of the {pipelines-ver} attribute in 4.6 docs](https://issues.redhat.com/browse/RHDEVDOCS-2863)
- **Preview pages**: Wherever the `pipelines-ver` attribute has been used in the branch `enterprise-4.6`.
- **Reviewer**: Preeti Chandrasekhar

**Note** for @Preeticp : I have manually checked the Pipelines pages in the `enterprise-4.6` branch that are most likely to be affected by this change. All of them contains `{pipelines-ver}`, and none of them contains hard-coded pipelines version (1.2), so I think we are good with the tiny change in the attribute file. 