### PR TITLE
Bug 1963198: Add a note on configuring multiple IdPs

### DIFF
--- a/modules/identity-provider-about-request-header.adoc
+++ b/modules/identity-provider-about-request-header.adoc
@@ -7,7 +7,9 @@
 
 A request header identity provider identifies users from request
 header values, such as `X-Remote-User`. It is typically used in combination with
-an authenticating proxy, which sets the request header value.
+an authenticating proxy, which sets the request header value. The
+request header identity provider cannot be combined with other identity providers
+that use direct password logins, such as HTPasswd, Keystone, LDAP or Basic authentication.
 
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1963198

This Pull Request clarifies an error message mentioned in [BZ1963198](https://bugzilla.redhat.com/show_bug.cgi?id=1963198). The root cause of if is that Request Header and HTPasswd IdPs require different interaction (redirect vs password challenge).