### PR TITLE
Bug 1959776: Clarify that accessTokenMaxAgeSeconds must be positive

### DIFF
--- a/modules/oauth-configuring-internal-oauth.adoc
+++ b/modules/oauth-configuring-internal-oauth.adoc
@@ -34,7 +34,7 @@ spec:
 ----
 <1> Set `accessTokenMaxAgeSeconds` to control the lifetime of access tokens.
 The default lifetime is 24 hours, or 86400 seconds. This attribute cannot
-be negative.
+be negative. If set to zero, the default lifetime is used.
 
 . Apply the new configuration file:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1959776

This Pull Request clarifies that the `accessTokenMaxAgeSeconds` must be a positive number. In case of 0 or a negative, it will become a default:
- In case of 0 - it will use the Operator default: https://github.com/openshift/cluster-authentication-operator/blob/907a3befa0e7a6e485535d19a65840ee0f784b83/pkg/controllers/configobservation/oauth/observe_tokenconfig.go#L57-L59
- In case of a negative value, it will use emit an error: https://github.com/openshift/oauth-apiserver/blob/f5f2b49495ee68f60f160b0a9d1be18e1813a146/pkg/oauth/apis/oauth/validation/validation.go#L196-L200