### PR TITLE
Fixed typo found after merge

### DIFF
--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -28,7 +28,7 @@ Some `ccoctl` commands make AWS API calls to create or modify AWS resources. To 
 +
 [source,terminal]
 ----
-$ ccoctl aws create key-pair
+$ ccoctl aws create-key-pair
 ----
 +
 .Example output:
@@ -56,7 +56,7 @@ Where:
 +
 ** `_<name>_` is the name used to tag any cloud resources that are created for tracking.
 ** `_<aws-region>_` is the AWS region in which cloud resources will be created.
-** `_<path_to_ccoctl_output_dir>_` is the path to the public key file that the `ccoctl aws create key-pair` command generated.
+** `_<path_to_ccoctl_output_dir>_` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
 +
 .Example output:
 +


### PR DESCRIPTION
For 4.8+
Preview: https://deploy-preview-32912--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts

Typo reported in Slack by QE.