### PR TITLE
OSDOCS-2115: fixing post-merge typo

### DIFF
--- a/modules/nw-ingress-setting-thread-count.adoc
+++ b/modules/nw-ingress-setting-thread-count.adoc
@@ -19,5 +19,5 @@ $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge 
 +
 [NOTE]
 ====
-If you have a node that is capable of running large amounts of resrouces, you can configure `spec.nodePlacement.nodeSelector` with labels that match the capacity of the intended node, and configure `spec.tuningOptions.threadCount` to an appropriately high value.
+If you have a node that is capable of running large amounts of resources, you can configure `spec.nodePlacement.nodeSelector` with labels that match the capacity of the intended node, and configure `spec.tuningOptions.threadCount` to an appropriately high value.
 ====


### PR DESCRIPTION
Fixed a typo that was found after merging. For 4.8+

Found here: https://github.com/openshift/openshift-docs/pull/32853

https://issues.redhat.com/browse/OSDOCS-2201

https://issues.redhat.com/browse/OSDOCS-2115
