### PR TITLE
Added errata notes for release 4.7.13

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2369,7 +2369,7 @@ To upgrade an existing {product-title} 4.7 cluster to this latest release, see x
 
 Issued: 2021-05-19
 
-{product-title} release 4.7.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1550[RHBA-2021:1550] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1551[RHSA-2021:1551] advisory.
+{product-title} release 4.7.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1550[RHBA-2021:1550] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1551[RHSA-2021:1551] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2448,13 +2448,29 @@ To upgrade an existing {product-title} 4.7 cluster to this latest release, see x
 
 Issued: 2021-05-24
 
-{product-title} release 4.7.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:1561[RHSA-2021:1561] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1562[RHSA-2021:1562] advisory.
+{product-title} release 4.7.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:1561[RHSA-2021:1561] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1562[RHSA-2021:1562] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6067301[{product-title} 4.7.12 container image list]
 
 [id="ocp-4-7-12-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-13"]
+=== RHSA-2021:2121 - {product-title} 4.7.13 bug fix and security update
+
+Issued: 2021-05-31
+
+{product-title} release 4.7.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:2121[RHSA-2021:2121] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2122[RHSA-2021:2122] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6078781[{product-title} 4.7.13 container image list]
+
+[id="ocp-4-7-13-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
This PR adds notes for release 4.7.13. I've also added some security-related language to previous versions where it was missing.

* version 4.7 only
* [direct preview here](https://deploy-preview-32918--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-13)