### PR TITLE
Added errata notes for release 4.6.31

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2922,13 +2922,29 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-05-25
 
-{product-title} release 4.6.30 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1565[RHBA-2021:1565] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1566[RHSA-2021:1566] advisory.
+{product-title} release 4.6.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1565[RHBA-2021:1565] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1566[RHSA-2021:1566] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6068671[{product-title} 4.6.30 container image list]
 
 [id="ocp-4-6-30-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-31"]
+=== RHBA-2021:2100 - {product-title} 4.6.31 bug fix update
+
+Issued: 2021-06-01
+
+{product-title} release 4.6.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2100[RHBA-2021:2100] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2101[RHBA-2021:2101] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6078721[{product-title} 4.6.31 container image list]
+
+[id="ocp-4-6-31-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
This PR adds notes for release 4.6.31.

* applies to 4.6 only
* [direct preview link here](https://deploy-preview-32919--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-31)