### PR TITLE
OSDOCS:998 declarative configs for NE

### DIFF
--- a/modules/nw-http2-haproxy.adoc
+++ b/modules/nw-http2-haproxy.adoc
@@ -39,3 +39,16 @@ Enable HTTP/2 on the entire cluster.
 ----
 $ oc annotate ingresses.config/cluster ingress.operator.openshift.io/default-enable-http2=true
 ----
++
+[TIP]
+====
+You can alternatively apply the following YAML to add the annotation:
+[source,yaml]
+----
+apiVersion: v1
+kind: IngressController
+metadata:
+  annotations:
+    ingress.operator.openshift.io/default-enable-http2: "true"
+----
+====

--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -82,6 +82,22 @@ $ oc get --namespace openshift-ingress-operator ingresscontrollers/default \
 map[name:custom-certs-default]
 ----
 +
+[TIP]
+====
+You can alternatively apply the following YAML to set a custom default certificate:
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  defaultCertificate:
+    name: custom-certs-default
+----
+====
++
 The certificate secret name should match the value used to update the CR.
 
 Once the IngressController CR has been modified, the Ingress Operator

--- a/modules/nw-route-admission-policy.adoc
+++ b/modules/nw-route-admission-policy.adoc
@@ -34,3 +34,19 @@ spec:
     namespaceOwnership: InterNamespaceAllowed
 ...
 ----
++
+[TIP]
+====
+You can alternatively apply the following YAML to configure the route admission policy:
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  routeAdmission:
+    namespaceOwnership: InterNamespaceAllowed
+----
+====

--- a/modules/nw-scaling-ingress-controller.adoc
+++ b/modules/nw-scaling-ingress-controller.adoc
@@ -10,6 +10,11 @@ availability requirements such as the requirement to increase throughput. `oc`
 commands are used to scale the `IngressController` resource. The following
 procedure provides an example for scaling up the default `IngressController`.
 
+[NOTE]
+====
+Scaling is not an immediate action, as it takes time to create the desired number of replicas.
+====
+
 .Procedure
 . View the current number of available replicas for the default `IngressController`:
 +
@@ -52,8 +57,19 @@ $ oc get -n openshift-ingress-operator ingresscontrollers/default -o jsonpath='{
 ----
 3
 ----
-
-[NOTE]
++
+[TIP]
 ====
-Scaling is not an immediate action, as it takes time to create the desired number of replicas.
+You can alternatively apply the following YAML to scale an Ingress Controller to three replicas:
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 3               <1>
+----
 ====
+<1> If you need a different amount of replicas, change the `replicas` value.


### PR DESCRIPTION
Please review the following:
-[Scaling an Ingress Controller](https://deploy-preview-32924--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration_configuring-ingress)

-[Setting a custom default certificate](https://deploy-preview-32924--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-setting-a-custom-default-certificate_configuring-ingress)

-[Configuring the route admission policy](https://deploy-preview-32924--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-route-admission-policy_configuring-ingress)

-[Enabling HTTP/2 Ingress connectivity](https://deploy-preview-32924--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-http2-haproxy_configuring-ingress)

Jira story for doc work: https://issues.redhat.com/browse/OSDOCS-2240

`oc patch` and `oc annotate` instances are followed by a TIP that suggests a YAML manifest can be applied as an alternative.