### PR TITLE
Bug 1942837: sysctl tutorial: drop net.ipv4.route.min_pmtu

### DIFF
--- a/modules/nodes-containers-sysctls-setting.adoc
+++ b/modules/nodes-containers-sysctls-setting.adoc
@@ -14,7 +14,7 @@ that node. As with node-level sysctls, use the taints and toleration feature
 or labels on nodes to schedule those pods onto the right nodes.
 
 The following example uses the pod `securityContext` to set a safe sysctl
-`kernel.shm_rmid_forced` and two unsafe sysctls, `net.ipv4.route.min_pmtu` and
+`kernel.shm_rmid_forced` and two unsafe sysctls, `net.core.somaxconn` and
 `kernel.msgmax`. There is no distinction between _safe_ and _unsafe_ sysctls in
 the specification.
 
@@ -42,8 +42,8 @@ spec:
     sysctls:
     - name: kernel.shm_rmid_forced
       value: "0"
-    - name: net.ipv4.route.min_pmtu
-      value: "552"
+    - name: net.core.somaxconn
+      value: "1024"
     - name: kernel.msgmax
       value: "65536"
   ...

--- a/modules/nodes-containers-sysctls-unsafe.adoc
+++ b/modules/nodes-containers-sysctls-unsafe.adoc
@@ -60,7 +60,7 @@ spec:
   kubeletConfig:
     allowedUnsafeSysctls: <2>
       - "kernel.msg*"
-      - "net.ipv4.route.min_pmtu"
+      - "net.core.somaxconn"
 ----
 <1> Specify the label from the machine config pool.
 <2> List the unsafe sysctls you want to allow.


### PR DESCRIPTION
The tutorial is busted, and likely always has been busted. the net.* sysctls are applied to containers when they're in a private network namespace.
However, net.ipv4.route.min_pmtu is not one of the sysctls that are added to a new network namespace.

This commit replaces uses with "net.core.somaxconn", an unsafe sysctl that is able to be applied to a namespace

Signed-off-by: Peter Hunt <pehunt@redhat.com>