### PR TITLE
Adjusted guidance around cluster maximums

### DIFF
--- a/modules/openshift-cluster-maximums.adoc
+++ b/modules/openshift-cluster-maximums.adoc
@@ -5,23 +5,21 @@
 [id="cluster-maximums_{context}"]
 = {product-title} tested cluster maximums
 
-[options="header",cols="7*"]
+The values in the following table were tested independently of each other and represent the maximum for that particular resource type. It might not be valid to consider these maximums in combinations. Appropriate capacity planning and testing should be performed for large environments. Other objects are created during the test runs, but are not close to the tested maximums. For example, when testing namespaces per cluster, deployments per namespace, or number of nodes, thousands of pods, services, deployments, secrets, config maps, and builds are created, but are not close to the cluster maximums.
+
+[options="header",cols="5*"]
 |===
-| Maximum type |4.1 and 4.2 tested maximum |4.3 tested maximum |4.4 tested maximum |4.5 tested maximum |4.6 tested maximum |4.7 tested maximum
+| Maximum type |4.1 and 4.2 tested maximum |4.3 tested maximum |4.4 tested maximum |4.5, 4.6, 4.7, and 4.8 tested maximum
 
 | Number of nodes
 | 2,000
 | 2,000
 | 250
 | 500
-| 500
-| 500
 
 | Number of pods ^[1]^
 | 150,000
 | 150,000
-| 62,500
-| 62,500
 | 62,500
 | 62,500
 
@@ -30,12 +28,8 @@
 | 500
 | 500
 | 500
-| 500
-| 500
 
 | Number of pods per core
-| There is no default value.
-| There is no default value.
 | There is no default value.
 | There is no default value.
 | There is no default value.
@@ -46,20 +40,14 @@
 | 10,000
 | 10,000
 | 10,000
-| 10,000
-| 10,000
 
 | Number of builds
 | 10,000 (Default pod RAM 512 Mi) - Pipeline Strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
-| 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
-| 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
 | Number of pods per namespace ^[3]^
-| 25,000
-| 25,000
 | 25,000
 | 25,000
 | 25,000
@@ -70,12 +58,8 @@
 | 10,000
 | 10,000
 | 10,000
-| 10,000
-| 10,000
 
 | Number of services per namespace
-| 5,000
-| 5,000
 | 5,000
 | 5,000
 | 5,000
@@ -86,12 +70,8 @@
 | 5,000
 | 5,000
 | 5,000
-| 5,000
-| 5,000
 
 | Number of deployments per namespace ^[3]^
-| 2,000
-| 2,000
 | 2,000
 | 2,000
 | 2,000

--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -7,13 +7,9 @@ toc::[]
 
 Consider the following tested object maximums when you plan your {product-title} cluster.
 
-These guidelines are based on the largest possible cluster. For smaller
-clusters, the maximums are lower. There are many factors that
-influence the stated thresholds, including the etcd version or storage data
-format.
+These guidelines are based on the largest possible cluster. For smaller clusters, the maximums are lower. There are many factors that influence the stated thresholds, including the etcd version or storage data format.
 
-In most cases, exceeding these numbers results in lower overall performance. It
-does not necessarily mean that the cluster will fail.
+In most cases, exceeding these numbers results in lower overall performance. It does not necessarily mean that the cluster will fail.
 
 include::modules/openshift-cluster-maximums-major-releases.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/PERFSCALE-868

Preview build: https://deploy-preview-32936--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums?utm_source=github&utm_campaign=bot_dp