### PR TITLE
Content for TELCODOCS-113

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc
@@ -10,3 +10,5 @@ After successfully deploying an installer-provisioned cluster, consider the foll
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
 
 include::modules/nw-enabling-a-provisioning-network-after-installation.adoc[leveloffset=+1]
+
+include::modules/nw-osp-configuring-external-load-balancer.adoc[leveloffset=+1]

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -2,14 +2,21 @@
 // TODO
 // * networking/TBD
 // * networking/load-balancing-openstack.adoc
+// * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc jowilkin
 // For thinking and reviewing, adding to networking/load-balancing-openstack.adoc
 
 [id="nw-osp-configuring-external-load-balancer_{context}"]
 = Configuring an external load balancer
 
-You can configure a {product-title} cluster on {rh-openstack-first} to use an external load balancer in place of the default load balancer.
+You can configure an {product-title} cluster
+ifeval::["{context}" == "load-balancing-openstack"]
+on {rh-openstack-first}
+endif::[]
+to use an external load balancer in place of the default load balancer.
 
 // Maybe an About mod in support
+
+
 
 .Prerequisites
 
@@ -24,6 +31,11 @@ You can configure a {product-title} cluster on {rh-openstack-first} to use an ex
 * Your load balancer must be able to access every machine in your cluster. Methods to allow this access include:
 ** Attaching the load balancer to the cluster's machine subnet.
 ** Attaching floating IP addresses to machines that use the load balancer.
+
+[IMPORTANT]
+====
+External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
+====
 
 .Procedure
 
@@ -66,7 +78,7 @@ listenmy-cluster-apps-80
 <load_balancer_ip_address> apps.<cluster_name>.<base_domain>
 ----
 
-. From a command line, use `curl` to verify that the external load balancer and DNS configuration are operational. 
+. From a command line, use `curl` to verify that the external load balancer and DNS configuration are operational.
 
 .. Verify that the cluster API is accessible:
 +


### PR DESCRIPTION
This PR reuses a module. The only material change is that it omits the reference to OpenStack when used in the context of bare metal installation. That is the only thing that requires review.

Fixes: [TELCODOCS-113](https://issues.redhat.com/browse/TELCODOCS-113)

See https://issues.redhat.com/browse/TELCODOCS-113 for additional details.

For release 4.8.

Signed-off-by: John Wilkins <jowilkin@redhat.com>
