### PR TITLE
Replaced kube-apiserver with kube-scheduler

### DIFF
--- a/modules/nodes-scheduler-default-creating.adoc
+++ b/modules/nodes-scheduler-default-creating.adoc
@@ -89,7 +89,7 @@ For example:
 $ oc patch Scheduler cluster --type='merge' -p '{"spec":{"policy":{"name":"scheduler-policy"}}}' --type=merge
 ----
 +
-After making the change to the `Scheduler` config resource, wait for the `openshift-kube-apiserver` pods to redeploy. This can take several minutes. Until the pods redeploy, new scheduler does not take effect.
+After making the change to the `Scheduler` config resource, wait for the `openshift-kube-scheduler` pods to redeploy. This can take several minutes. Until the pods redeploy, new scheduler does not take effect.
 
 . Verify the scheduler policy is configured by viewing the log of a scheduler pod in the `openshift-kube-scheduler` namespace. The following command checks for the predicates and priorities that are being registered by the scheduler:
 +


### PR DESCRIPTION
I'm submitting this PR because I think there is a minor issue with the OpenShift documentation.
When a change on default scheduler is applied, only openshift-kube-scheduler pods are restarted.
openshift-kube-apiserver pods are never restarted