### PR TITLE
Fix telemetry typo in the odo release notes

### DIFF
--- a/cli_reference/developer_cli_odo/odo-release-notes.adoc
+++ b/cli_reference/developer_cli_odo/odo-release-notes.adoc
@@ -25,7 +25,7 @@ Note that this feature introduces many breaking changes, see xref:../../cli_refe
 
 * When creating a component from a devfile, `odo create` now uses a default component name if the name is not specified.
 
-* `odo` now has Telemetry. See xref:../../cli_reference/developer_cli_odo/understanding-odo.adoc#telemetry-in-odo[Telemtry section] to learn how to modify your Telemetry consent preferences.
+* `odo` now has Telemetry. See xref:../../cli_reference/developer_cli_odo/understanding-odo.adoc#telemetry-in-odo[Telemetry section] to learn how to modify your Telemetry consent preferences.
 
 *  With `odo service`, you can now add or remove custom resource definitions and `ServiceInstance` information in your devfile.   
  


### PR DESCRIPTION
@vikram-redhat There is one typo issue in the odo release notes, minimum version that the change applies to should be 4.7 in my opinion, could you arrange someone to review them? Thanks.