### PR TITLE
OSDOCS-1811: Add release note for network policy host network selector

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -315,6 +315,24 @@ An OpenShift SDN cluster network provider migration to the OVN-Kubernetes cluste
 The egress IP feature of OpenShift SDN now balances network traffic roughly equally across nodes for a given namespace, if that namespace is assigned multiple egress IP addresses. Each IP address must reside on a different node.
 For more information, refer to xref:../networking/openshift_sdn/assigning-egress-ips.adoc#assigning-egress-ips[Configuring egress IPs for a project] for OpenShift SDN.
 
+[id="ocp-4-8-network-policy-host-network-ingress-controllers"]
+==== Network policy supports selecting host network Ingress Controllers
+
+When using the OpenShift SDN or OVN-Kubernetes cluster network providers, you can select traffic from Ingress Controllers in a network policy rule regardless of whether an Ingress Controller runs on the cluster network or the host network.
+In a network policy rule, the `network.openshift.io/policy-group: ingress` namespace selector matches traffic from an Ingress Controller.
+
+In earlier releases of {product-title} the following limitations existed:
+
+- A cluster using the OpenShift SDN cluster network provider could select traffic from an Ingress Controller on the host network only by applying the `network.openshift.io/policy-group: ingress` label to the `default` namespace.
+- A cluster using the OVN-Kubernetes cluster network provider could not select traffic from an Ingress Controller on the host network.
+
+For more information, refer to xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
+
+[id="ocp-4-8-network-policy-host-network-policy-group"]
+==== Network policy supports selecting host network traffic
+
+When using either the OVN-Kubernetes cluster network provider or the OpenShift SDN cluster network provider, you can use the `policy-group.network.openshift.io/host-network: ""` namespace selector to select host network traffic in a network policy rule.
+
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1811

Preview: [Network policy supports selecting host network Ingress Controllers](https://deploy-preview-32956--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-network-policy-host-network-ingress-controllers)