### PR TITLE
BZ1871794: Added a NOTE to the config-yaml file

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -218,9 +218,14 @@ of {product-title} will support defining multiple compute pools during
 installation. Only one control plane pool is used.
 <3> Whether to enable or disable simultaneous multithreading (SMT), or `hyperthreading`. By default, SMT is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable SMT, you must disable it in all cluster machines; this includes both control plane and compute machines.
 +
+[NOTE]
+====
+Simultaneous multithreading (SMT) is enabled by default. If SMT is not enabled in your BIOS settings, the `hyperthreading` parameter has no effect.
+====
++
 [IMPORTANT]
 ====
-If you disable simultaneous multithreading (SMT) using the `install-config.yaml` file or in your BIOS settings, ensure that your capacity planning accounts for the dramatically decreased machine performance. If you disable SMT in the BIOS, the `hyperthreading` parameter in the `install-config.yaml` file will have no effect.
+If you disable `hyperthreading`, whether in the BIOS or in the `install-config.yaml`, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
 <4> You must set the value of the `replicas` parameter to `0`. This parameter
 controls the number of workers that the cluster creates and manages for you,


### PR DESCRIPTION
Applies to 4.5+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1871794
QE Approval Needed: @miabbott, @pamoedom 
Preview Link: 

- [Sample `install-config.yaml` file for bare metal](https://deploy-preview-32959--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metall). See the 3rd call out, the new content is the NOTE. 

The same content also appears at the following locations: https://deploy-preview-32959--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-bare-metal-config-yaml_installing-bare-metal-network-customizations and https://deploy-preview-32959--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html. 