### PR TITLE
BZ1936731: Adds information on setting the mount options for container storage

### DIFF
--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -35,6 +35,51 @@ Because `/var` must be in place before a fresh installation of {op-system-first}
 If you follow the steps to create a separate `/var` partition in this procedure, it is not necessary to create the Kubernetes manifest and Ignition config files again as described later in this section.
 ====
 
+.Prerequisites
+
+* If container storage is on the root partition, ensure that this root partition is mounted with the `pquota` option by including `rootflags=pquota` in the GRUB command line.
+
+* If the container storage is on a partition that is mounted by `/etc/fstab`, ensure that the following mount option is included in the `/etc/fstab` file:
++
+[source,terminal]
+----
+/dev/sdb1      /var           xfs defaults,pquota 0 0
+----
+
+* If the container storage is on a partition that is mounted by `systemd`, ensure that the `MachineConfig` object includes the following mount option as in this example:
++
+[source,yaml]
+----
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      disks:
+        - device: /dev/sdb
+          partitions:
+            - label: var
+              sizeMiB: 240000
+              startMiB: 0
+            filesystems:
+        - device: /dev/disk/by-partlabel/var
+          format: xfs
+          path: /var
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Before=local-fs.target
+            [Mount]
+            Where=/var
+            What=/dev/disk/by-partlabel/var
+            Options=defaults,pquota
+            [Install]
+            WantedBy=local-fs.target
+          enabled: true
+          name: var.mount
+----
+
 .Procedure
 
 . Create a directory to hold the {product-title} installation files:
@@ -100,12 +145,6 @@ spec:
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 MiB (Mebibytes) is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
-+
-[NOTE]
-====
-When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
-====
-
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -48,6 +48,51 @@ Because `/var` must be in place before a fresh installation of
 by creating a machine config that is inserted during the `openshift-install`
 preparation phases of an {product-title} installation.
 
+.Prerequisites
+
+* If container storage is on the root partition, ensure that this root partition is mounted with the `pquota` option by including `rootflags=pquota` in the GRUB command line.
+
+* If the container storage is on a partition that is mounted by `/etc/fstab`, ensure that the following mount option is included in the `/etc/fstab` file:
++
+[source,terminal]
+----
+/dev/sdb1      /var           xfs defaults,pquota 0 0
+----
+
+* If the container storage is on a partition that is mounted by `systemd`, ensure that the `MachineConfig` object includes the following mount option as in this example:
++
+[source,yaml]
+----
+spec:
+  config:
+    ignition:
+      version: 3.1.0
+    storage:
+      disks:
+        - device: /dev/sdb
+          partitions:
+            - label: var
+              sizeMiB: 240000
+              startMiB: 0
+            filesystems:
+        - device: /dev/disk/by-partlabel/var
+          format: xfs
+          path: /var
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Before=local-fs.target
+            [Mount]
+            Where=/var
+            What=/dev/disk/by-partlabel/var
+            Options=defaults,pquota
+            [Install]
+            WantedBy=local-fs.target
+          enabled: true
+          name: var.mount
+----
+
 .Procedure
 
 . Create a directory to hold the {product-title} installation files:
@@ -116,11 +161,6 @@ spec:
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
-+
-[NOTE]
-====
-When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
-====
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +


### PR DESCRIPTION
This ticket adds prerequisite information when setting the "/var" partition so that users can property flag the partition.


Version: 4.7, maybe 4.5+

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1936731

Preview 1: https://deploy-preview-32960--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-disk-partitioning-upi-templates_installing-restricted-networks-aws
Preview 2: https://deploy-preview-32960--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#installation-disk-partitioning_installing-vmc-user-infra