### PR TITLE
OSDOCS-2028: Release notes for new wildcard subject

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -92,6 +92,21 @@ The `Default` audit log policy now logs request bodies for OAuth access token cr
 
 For more information about audit log policies, see xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[Configuring the node audit log policy].
 
+[id="ocp-4-8-security-wildcard-subjects-headless-services"]
+==== Wildcard subject for service serving certificates for headless services
+
+Generating a service serving certificate for headless services now includes a wildcard subject in the format of `*.<service.name>.<service.namespace>.svc`. This allows for TLS-protected connections to individual stateful set pods without having to manually generate certificates for these pods.
+
+[IMPORTANT]
+====
+Because the generated certificates contain wildcard subjects for headless services, do not use the service CA if your client must differentiate between individual pods. In this case:
+
+* Generate individual TLS certificates by using a different CA.
+* Do not accept the service CA as a trusted CA for connections that are directed to individual pods and must not be impersonated by other pods. These connections must be configured to trust the CA that was used to generate the individual TLS certificates.
+====
+
+For more information, see xref:../security/certificates/service-serving-certificate.adoc#add-service-certificate_service-serving-certificate[Add a service certificate].
+
 [id="ocp-4-8-networking"]
 === Networking
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2028

Preview: https://deploy-preview-32969--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-security-wildcard-subjects-headless-services