### PR TITLE
[GH#32958] Example is incorrect for OKD

### DIFF
--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -37,6 +37,7 @@ You cannot add a node selector directly to an existing scheduled pod. You must l
 +
 For example, the following `Node` object has the `region: east` label: 
 +
+ifndef::openshift-origin[]
 .Sample `Node` object with a label
 [source,yaml]
 ----
@@ -61,6 +62,33 @@ metadata:
     region: east <1>
 ----
 <1> Label to match the pod node selector.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+.Sample `Node` object with a label
+[source,yaml]
+----
+kind: Node
+apiVersion: v1
+metadata:
+  name: ip-10-0-131-14.ec2.internal
+  selfLink: /api/v1/nodes/ip-10-0-131-14.ec2.internal
+  uid: 7bc2580a-8b8e-11e9-8e01-021ab4174c74
+  resourceVersion: '478704'
+  creationTimestamp: '2019-06-10T14:46:08Z'
+  labels:
+    beta.kubernetes.io/os: linux
+    failure-domain.beta.kubernetes.io/zone: us-east-1a
+    node.openshift.io/os_version: '4.5'
+    node-role.kubernetes.io/worker: ''
+    failure-domain.beta.kubernetes.io/region: us-east-1
+    node.openshift.io/os_id: fedora
+    beta.kubernetes.io/instance-type: m4.large
+    kubernetes.io/hostname: ip-10-0-131-14
+    beta.kubernetes.io/arch: amd64
+    region: east <1>
+----
+<1> Label to match the pod node selector.
+endif::openshift-origin[]
 +
 A pod has the `type: user-node,region: east` node selector:
 +


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/32958

Added ifdefs for OKD for the _Sample Node object with a label_ output in the _Node selectors on specific pods and nodes_ section.
Preview OCP: https://deploy-preview-32970--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors
Preview OKD: http://file.rdu.redhat.com/~mburke/issue-32958/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors