### PR TITLE
Bug 1950653: RHDEVDOCS-3033: Add link from build topic to Docker build reference topic

### DIFF
--- a/modules/builds-strategy-docker-build-arguments.adoc
+++ b/modules/builds-strategy-docker-build-arguments.adoc
@@ -6,6 +6,11 @@
 
 You can set link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[docker build arguments] using the `BuildArgs` array. The build arguments are passed to docker when a build is started.
 
+[TIP]
+====
+See link:https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact[Understand how ARG and FROM interact] in the Dockerfile reference documentation.
+====
+
 .Procedure
 
 To set docker build arguments, add entries to the `BuildArgs` array, which is located in the `dockerStrategy` definition of the `BuildConfig` object. For example:
@@ -18,3 +23,8 @@ dockerStrategy:
     - name: "foo"
       value: "bar"
 ----
+
+[NOTE]
+====
+Only the `name` and `value` fields are supported. Any settings on the `valueFrom` field are ignored.
+====

--- a/modules/builds-strategy-docker-build.adoc
+++ b/modules/builds-strategy-docker-build.adoc
@@ -6,4 +6,9 @@
 [id="builds-strategy-docker-build_{context}"]
 = Docker build
 
-The docker build strategy invokes the docker build command, and it expects a repository with a Dockerfile and all required artifacts in it to produce a runnable image.
+{product-title} uses Buildah to build a container image from a Dockerfile. For more information on building container images with Dockerfiles, see link:https://docs.docker.com/engine/reference/builder/[the Dockerfile reference documentation].
+
+[TIP]
+====
+If you work with build arguments, see link:https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact[Understand how ARG and FROM interact] in the Dockerfile reference documentation.
+====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.5, 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3033
- Direct link to doc preview: 
-- https://deploy-preview-32982--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/understanding-image-builds.html#builds-strategy-docker-build_understanding-image-builds
-- https://deploy-preview-32982--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/build-strategies.html#builds-strategy-docker-build-arguments_build-strategies
- SME review:  @adambkaplan 
- QE review: @xiuwang 
- Peer review: Oss Tikhomirova
- All reviews completed and approved. Ready to merge.