### PR TITLE
BZ1860508: Fixed incorrect commands

### DIFF
--- a/modules/infrastructure-moving-registry.adoc
+++ b/modules/infrastructure-moving-registry.adoc
@@ -17,7 +17,7 @@ You configure the registry Operator to deploy its pods to different nodes.
 +
 [source,terminal]
 ----
-$ oc get configs.imageregistry.operator.openshift.io cluster -o yaml
+$ oc get configs.imageregistry.operator.openshift.io/cluster -o yaml
 ----
 +
 .Example output
@@ -55,7 +55,7 @@ status:
 +
 [source,terminal]
 ----
-$ oc edit configs.imageregistry.operator.openshift.io cluster
+$ oc edit configs.imageregistry.operator.openshift.io/cluster
 ----
 
 . Add the following lines of text the `spec` section of the object:


### PR DESCRIPTION
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1860508
Applies to 4.5+
QE approval need: @wzheng1 
Preview Link: [Moving the default registry](https://deploy-preview-32997--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-moving-registry_creating-infrastructure-machinesets) - See procedure steps 1 and 2.