### PR TITLE
RHDEVDOCS-3034: Create release notes section for Openshift Logging 5.0.4

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -14,6 +14,7 @@ The following advisories are available for {ProductName} 5.0:
 * link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.1)]
 * link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.2)]
 * link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)]
+* link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 Moderate: Openshift Logging security and bugs update (5.0.4)]
 
 [id="openshift-logging-5-0-inclusive-language"]
 == Making open source more inclusive
@@ -37,3 +38,4 @@ include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.4.adoc[leveloffset=+1]

--- a/modules/cluster-logging-release-notes-5.0.3.adoc
+++ b/modules/cluster-logging-release-notes-5.0.3.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-3"]
 = OpenShift Logging 5.0.3
 
-This release includes link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)]
+This release includes link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)].
 
 
 [id="openshift-logging-5-0-3-security-fixes"]

--- a/modules/cluster-logging-release-notes-5.0.4.adoc
+++ b/modules/cluster-logging-release-notes-5.0.4.adoc
@@ -1,0 +1,23 @@
+[id="cluster-logging-release-notes-5-0-4"]
+= OpenShift Logging 5.0.4
+
+This release includes link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 Moderate: Openshift Logging security and bugs update (5.0.4)].
+
+
+[id="openshift-logging-5-0-4-security-fixes"]
+== Security fixes
+
+* gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index
+validation. (link:https://access.redhat.com/security/cve/CVE-2021-3121[*CVE-2021-3121*])
+
+
+The following Jira issues contain the above CVEs:
+
+* LOG-1364 CVE-2021-3121 cluster-logging-operator-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5]. (link:https://issues.redhat.com/browse/LOG-1364[*LOG-1364*])
+
+[id="openshift-logging-5-0-4-bug-fixes"]
+== Bug fixes
+
+This release also includes the following bug fixes:
+
+* LOG-1328 Port fix to 5.0.z for BZ-1945168. (link:https://issues.redhat.com/browse/LOG-1364[*LOG-1364*])


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.7, 4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3034
- Direct link to doc preview: https://deploy-preview-33000--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-0-4
- SME review: @vimalk78
- QE review: @kabirbhartiRH 
- Peer review: @jc-berger 
- All reviews complete. Ready to merge.