### PR TITLE
MGMT-1152: Generate ImageContentSourcePolicy scoped to a registry

### DIFF
--- a/modules/generating-icsp-object-scoped-to-a-registry.adoc
+++ b/modules/generating-icsp-object-scoped-to-a-registry.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster.adoc
+
+[id="generating-icsp-object-scoped-to-a-registry_{context}"]
+= Widening the scope of the mirror image catalog to reduce the frequency of cluster node reboots
+
+You can scope the mirrored image catalog at the repository level or the wider registry level. A widely scoped `ImageContentSourcePolicy` resource reduces the number of times the nodes need to reboot in response to changes to the resource.
+
+To widen the scope of the mirror image catalog in the `ImageContentSourcePolicy` resource, perform the following procedure.
+
+.Prerequisites
+
+* Install the {product-title} CLI `oc`.
+* Log in as a user with `cluster-admin` privileges.
+* Configure a mirrored image catalog for use in your disconnected cluster.
+
+.Procedure
+
+. Run the following command, specifying values for `<local_registry>`, `<pull_spec>`, and `<pull_secret_file>`:
++
+[source,terminal]
+----
+$ oc adm catalog mirror <local_registry>/<pull_spec> <local_registry> -a <pull_secret_file> --icsp-scope=registry
+----
++
+where:
++
+--
+<local_registry>:: is the local registry you have configured for your disconnected cluster, for example, `local.registry:5000`.
+<pull_spec>:: is the pull specification as configured in your disconnected registry, for example, `redhat/redhat-operator-index:v{product-version}`
+<pull_secret_file>:: is the `registry.redhat.io` pull secret in `.json` file format downloaded from the link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site.
+--
++
+The `oc adm catalog mirror` command creates a `/redhat-operator-index-manifests` directory and generates `imageContentSourcePolicy.yaml`, `catalogSource.yaml`, and `mapping.txt` files.
+
+. Apply the new `ImageContentSourcePolicy` resource to the cluster:
++
+[source,terminal]
+----
+$ oc apply -f imageContentSourcePolicy.yaml
+----
+
+.Verification
+
+* Verify that `oc apply` successfully applied the change to `ImageContentSourcePolicy`:
++
+[source,terminal]
+----
+$ oc get ImageContentSourcePolicy -o yaml
+----
++
+.Example output
+
+[source,yaml]
+----
+apiVersion: v1
+items:
+- apiVersion: operator.openshift.io/v1alpha1
+  kind: ImageContentSourcePolicy
+  metadata:
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"operator.openshift.io/v1alpha1","kind":"ImageContentSourcePolicy","metadata":{"annotations":{},"name":"redhat-operator-index"},"spec":{"repositoryDigestMirrors":[{"mirrors":["local.registry:5000"],"source":"registry.redhat.io"}]}}
+...
+----
+
+After you update the `ImageContentSourcePolicy` resource, {product-title} deploys the new settings to each node and the cluster starts using the mirrored repository for requests to the source repository.

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -55,8 +55,13 @@ include::modules/update-restricted.adoc[leveloffset=+1]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]
 
+include::modules/generating-icsp-object-scoped-to-a-registry.adoc[leveloffset=+1]
+
 [id="additional-resources_security-container-signature"]
 == Additional resources
+
+* xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+
 * xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine Config Overview]
 
 * xref:../updating/installing-update-service.adoc#installing-update-service[Installing and configuring the OpenShift Update Service]


### PR DESCRIPTION
Document updates for: [TELCODOCS-65](https://issues.redhat.com/browse/TELCODOCS-65)

See https://issues.redhat.com/browse/MGMT-1152 for additional details.

This work is for main, enterprise-4.6, enterprise-4.7, enterprise-4.8, enterprise-4.9. 

Preview link: https://deploy-preview-33001--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster?utm_source=github&utm_campaign=bot_dp#generating-icsp-object-scoped-to-a-registry_updating-restricted-network-cluster
