### PR TITLE
BZ1949303: Adding documentation for restricted network upgrade 

### DIFF
--- a/modules/obtaining-ocp-packages-restricted-network-cluster.adoc
+++ b/modules/obtaining-ocp-packages-restricted-network-cluster.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster.adoc
+
+[id="obtaining-ocp-packages-restricted-network-cluster_{context}"]
+= Obtaining {product-title} packages
+
+Before you can update your {op-system-base-full} compute machines on a restricted network cluster, you must obtain the required images and components and store them in your repository.
+
+[IMPORTANT]
+====
+You must obtain the required images and software components on a system with the same architecture as the cluster that is in your disconnected environment.
+====
+
+.Prerequisites
+
+* Obtain a {op-system-base-full} 7 server that you have root access to, with access to the internet and at least 110 GB of disk space. Download the required software repositories and container images to your computer.
+
+* Plan to maintain a web server within your disconnected environment to serve the mirrored repositories. Copy the repositories from the internet-connected host to this web server, either over the network or by using physical media in disconnected deployments.
+
+* Provide a source control repository. After installation, your nodes must access source code in a source code repository, such as Git.
++
+When building applications in {product-title}, your build might contain external dependencies, such as a Maven Repository or Gemfiles for Ruby applications.
+
+* Provide a registry within the disconnected environment.
+
+.Procedure
+
+On the RHEL 7 server with an internet connection, sync the repositories:
+
+. To ensure that the packages are not deleted after you sync the repository, import the GPG key:
++
+[source,terminal]
+----
+$ rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release
+----
+
+. Register the server with the Red Hat Customer Portal. You must use the credentials that are associated with the account that has access to {product-title} subscriptions:
++
+[source,terminal]
+----
+$ subscription-manager register
+----
+
+. Pull the latest subscription data from Red Hat Subscription Manager:
++
+[source,terminal]
+----
+$ subscription-manager refresh
+----
+
+. Attach a subscription that provides {product-title} channels.
+.. Find an available subscription pool that provides {product-title} channels:
++
+[source,terminal]
+----
+$ subscription-manager list --available --matches '*OpenShift*'
+----
+
+.. Attach a pool ID for a subscription that provides {product-title}:
++
+[source,terminal]
+----
+$ subscription-manager attach --pool=<pool_id>
+----
++
+[source,terminal]
+----
+$ subscription-manager repos --disable="*"
+----
+
+. Enable only the repositories required by {product-title} {product-version}.
++
+[source,terminal]
+----
+# subscription-manager repos \
+    --enable="rhel-7-server-rpms" \
+    --enable="rhel-7-fast-datapath-rpms" \
+    --enable="rhel-7-server-extras-rpms" \
+    --enable="rhel-7-server-optional-rpms" \
+    --enable="rhel-7-server-ose-4.7-rpms" \
+    --enable="rhel-7-server-ansible-2.9-rpms"
+----
+
+. Make a directory to store the software in the server's storage or to a USB drive or other external device:
++
+[source,terminal]
+----
+$ mkdir -p </path/to/repos>
+----
++
+[IMPORTANT]
+====
+If you can re-connect this server to the disconnected LAN and use it as the repository server, store the files locally. If you cannot, use USB-connected storage so you can transport the software to a repository server in your disconnected LAN.
+====
+
+. Sync the packages and create the repository for each of them.
++
+[source,terminal]
+----
+$ for repo in \
+  rhel-7-server-rpms \
+  rhel-7-fast-datapath-rpms\
+  rhel-7-server-extras-rpms \
+  rhel-7-server-optional-rpms\
+  rhel-7-server-ansible-2.9-rpms \
+  rhel-7-server-ose-4.7-rpms
+do
+  reposync --gpgcheck -lm --repoid=${repo} --download_path=</path/to/repos> <1>
+  createrepo -v </path/to/repos/>${repo} -o </path/to/repos/>${repo} <1>
+done
+----
+<1> Provide the path to the directory you created.

--- a/modules/populate-registry-restricted-network-cluster.adoc
+++ b/modules/populate-registry-restricted-network-cluster.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster.adoc
+
+[id="populate-registry-restricted-network-cluster_{context}"]
+= Populate the registry
+
+From within your disconnected environment, tag and push the images to your internal registry:
+
+[IMPORTANT]
+====
+The following steps are a generic guide to loading the images into a registry.
+You might need to take more or different actions to load the images.
+====
+
+. Before you push the images into the registry, re-tag each image.
+** For images in the `openshift4` repository, tag the image as both the major and minor version number. For example, to tag the {product-title} node image:
++
+[source,terminal]
+----
+$ docker tag registry.redhat.io/openshift4/ose-node:<tag> registry.example.com/openshift3/ose-node:<tag>
+$ docker tag registry.redhat.io/openshift4/ose-node:<tag> registry.example.com/openshift3/ose-node:{major-tag}
+----
+** For other images, tag the image with the exact version number. For example, to tag the etcd image:
++
+[source,terminal]
+----
+$ docker tag registry.redhat.io/rhel7/etcd:3.2.28 registry.example.com/rhel7/etcd:3.2.28
+----
+
+. Push each image into the registry. For example, to push the {product-title} node images:
++
+[source,terminal]
+----
+$ docker push registry.example.com/openshift4/ose-node:<tag>
+$ docker push registry.example.com/openshift4/ose-node:{major-tag}
+----

--- a/modules/prepare-populate-repo-server-restricted-network-cluster.adoc
+++ b/modules/prepare-populate-repo-server-restricted-network-cluster.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster.adoc
+
+[id="prepare-populate-repo-server-restricted-network-cluster_{context}"]
+= Prepare and populate the repository server
+
+During the installation, and any future updates, you need a webserver to host the software. RHEL 7 can provide the Apache webserver.
+
+. Prepare the webserver:
+.. If you need to install a new webserver in your disconnected environment, install a new RHEL 7 system with at least 110 GB of space on your LAN. During RHEL installation, select the *Basic Web Server* option.
+.. If you are re-using the server where you downloaded the {product-title} software and required images, install Apache on the server:
++
+[source,terminal]
+----
+$ sudo yum install httpd
+----
+
+. Place the repository files into Apache’s root folder.
+** If you are re-using the server:
++
+[source,terminal]
+----
+$ mv /path/to/repos /var/www/html/
+$ chmod -R +r /var/www/html/repos
+$ restorecon -vR /var/www/html
+----
+
+** If you installed a new server, attach external storage and then copy the files:
++
+[source,terminal]
+----
+$ cp -a /path/to/repos /var/www/html/
+$ chmod -R +r /var/www/html/repos
+$ restorecon -vR /var/www/html
+----
+
+. Add the firewall rules:
++
+[source,terminal]
+----
+$ sudo firewall-cmd --permanent --add-service=http
+$ sudo firewall-cmd --reload
+----
+
+. Enable and start Apache for the changes to take effect:
++
+[source,terminal]
+----
+$ systemctl enable httpd
+$ systemctl start httpd
+----

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating-restricted-network-cluster.adoc
 
 :_content-type: PROCEDURE
 [id="rhel-compute-updating-minor_{context}"]

--- a/updating/updating-restricted-network-cluster.adoc
+++ b/updating/updating-restricted-network-cluster.adoc
@@ -65,6 +65,19 @@ include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
 include::modules/generating-icsp-object-scoped-to-a-registry.adoc[leveloffset=+2]
 
+[id="upgrading-rhel-nodes-restricted-network"]
+== Upgrading RHEL nodes on a restricted network
+
+The following procedures update {op-system-base-full} worker nodes on a restricted network.
+
+include::modules/obtaining-ocp-packages-restricted-network-cluster.adoc[leveloffset=+2]
+
+include::modules/prepare-populate-repo-server-restricted-network-cluster.adoc[leveloffset=+2]
+
+include::modules/populate-registry-restricted-network-cluster.adoc[leveloffset=+3]
+
+include::modules/rhel-compute-updating.adoc[leveloffset=+2]
+
 [id="additional-resources_security-container-signature"]
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1949303
Applies to 4.5+
Preview Link: [Upgrading RHEL nodes on a restricted network
](https://deploy-preview-33007--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster?utm_source=github&utm_campaign=bot_dp#upgrading-rhel-nodes-restricted-network)
QE approval pending.