### PR TITLE
Replace SELinux disabling example with setting permissive mode

### DIFF
--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -18,9 +18,11 @@ Improper use of kernel arguments can result in your systems becoming unbootable.
 
 Examples of kernel arguments you could set include:
 
-* **selinux=0**: Disables Security Enhanced Linux (SELinux).
-While not recommended for production, disabling SELinux can
-improve performance by 2% - 3%.
+* **enforcing=0**: Configures Security Enhanced Linux (SELinux) to run in permissive mode.
+In permissive mode, the system acts as if SELinux is enforcing the loaded security policy, 
+including labeling objects and emitting access denial entries in the logs, 
+but it does not actually deny any operations. While not recommended for production systems, 
+permissive mode can be helpful for debugging.  
 
 * **nosmt**: Disables symmetric multithreading (SMT) in the kernel.
 Multithreading allows multiple logical threads for each CPU.
@@ -68,7 +70,7 @@ rendered-master-23e785de7587df95a4b517e0647e5ab7   52dd3ba6a9a527fc3ab42afac8d12
 rendered-worker-5d596d9293ca3ea80c896a1191735bb1   52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 ----
 
-. Create a `MachineConfig` object file that identifies the kernel argument (for example, `05-worker-kernelarg-selinuxoff.yaml`)
+. Create a `MachineConfig` object file that identifies the kernel argument (for example, `05-worker-kernelarg-selinuxpermissive.yaml`)
 +
 [source,yaml]
 ----
@@ -77,25 +79,25 @@ kind: MachineConfig
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker<1>
-  name: 05-worker-kernelarg-selinuxoff<2>
+  name: 05-worker-kernelarg-selinuxpermissive<2>
 spec:
   config:
     ignition:
       version: 3.1.0
   kernelArguments:
-    - selinux=0<3>
+    - enforcing=0<3>
 ----
 +
 <1> Applies the new kernel argument only to worker nodes.
 <2> Named to identify where it fits among the machine configs (05) and what it does (adds
-a kernel argument to turn off SELinux).
-<3> Identifies the exact kernel argument as `selinux=0`.
+a kernel argument to configure SELinux permissive mode).
+<3> Identifies the exact kernel argument as `enforcing=0`.
 
 . Create the new machine config:
 +
 [source,terminal]
 ----
-$ oc create -f 05-worker-kernelarg-selinuxoff.yaml
+$ oc create -f 05-worker-kernelarg-selinuxpermissive.yaml
 ----
 
 . Check the machine configs to see that the new one was added:
@@ -116,7 +118,7 @@ NAME                                               GENERATEDBYCONTROLLER        
 01-worker-container-runtime                        52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 01-worker-kubelet                                  52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 
-05-worker-kernelarg-selinuxoff                                                                3.1.0             105s
+05-worker-kernelarg-selinuxpermissive                                                         3.1.0             105s
 
 99-master-generated-registries                     52dd3ba6a9a527fc3ab42afac8d12b693534c8c9   3.2.0             33m
 99-master-ssh                                                                                 3.1.0             40m
@@ -164,9 +166,9 @@ To use host binaries, run `chroot /host`
 sh-4.2# cat /host/proc/cmdline
 BOOT_IMAGE=/ostree/rhcos-... console=tty0 console=ttyS0,115200n8
 rootflags=defaults,prjquota rw root=UUID=fd0... ostree=/ostree/boot.0/rhcos/16...
-coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 selinux=0
+coreos.oem.id=qemu coreos.oem.id=ec2 ignition.platform.id=ec2 enforcing=0
 
 sh-4.2# exit
 ----
 +
-You should see the `selinux=0` argument added to the other kernel arguments.
+You should see the `enforcing=0` argument added to the other kernel arguments.


### PR DESCRIPTION
It is not a good idea to have an example on how to disable SELinux on RHCOS via MCO.

The main reason is that disabling SELinux in RHCOS is **potentially DANGEROUS** in case somebody wants to re-enable it again, because just running an autorelabel in a RHCOS system as one would do in RHEL8 is a horrible idea. More details on why it is a bad idea and the complex procedure that must be run instead are documented here: https://access.redhat.com/solutions/5176171

Apart from that, disabling SELinux is unsafe, as it is one of the key security technologies that allows proper isolation between containers.

Instead, showing how to set permissive mode via kernel arguments is interesting as long as it can be helpful with debugging, while at the same time still serves for the purpose of showing how to set a kernel parameter via MCO.