### PR TITLE
OSDOCS-2088: Added a Quick Start highlighting markdown reference

### DIFF
--- a/modules/quick-starts-highlighting-reference.adoc
+++ b/modules/quick-starts-highlighting-reference.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * web_console/creating-quick-start-tutorials.adoc
+
+[id="quick-start-highlighting-reference_{context}"]
+= Quick start highlighting markdown reference
+
+The highlighting, or hint, feature enables Quick Starts to contain a link that can highlight and animate a component of the web console.
+
+The markdown syntax contains:
+
+* Bracketed link text
+* The `highlight` keyword, followed by the ID of the element that you want to animate
+
+[id="quick-start-highlighting-perspective-switcher_{context}"]
+== Perspective switcher
+
+[source,yaml]
+----
+[Perspective switcher]{{highlight qs-perspective-switcher}}
+----
+
+[id="quick-start-highlighting-admin-perspective_{context}"]
+== Administrator perspective navigation links
+
+[source,yaml]
+----
+[Home]{{highlight qs-nav-home}}
+[Operators]{{highlight qs-nav-operators}}
+[Workloads]{{highlight qs-nav-workloads}}
+[Serverless]{{highlight qs-nav-serverless}}
+[Networking]{{highlight qs-nav-networking}}
+[Storage]{{highlight qs-nav-storage}}
+[Service catalog]{{highlight qs-nav-servicecatalog}}
+[Compute]{{highlight qs-nav-compute}}
+[User management]{{highlight qs-nav-usermanagement}}
+[Administration]{{highlight qs-nav-administration}}
+----
+
+[id="quick-start-highlighting-dev-perspective_{context}"]
+== Developer perspective navigation links
+
+[source,yaml]
+----
+[Add]{{highlight qs-nav-add}}
+[Topology]{{highlight qs-nav-topology}}
+[Search]{{highlight qs-nav-search}}
+[Project]{{highlight qs-nav-project}}
+[Helm]{{highlight qs-nav-helm}}
+----
+
+[id="quick-start-highlighting-common-nav_{context}"]
+== Common navigation links
+
+[source,yaml]
+----
+[Builds]{{highlight qs-nav-builds}}
+[Pipelines]{{highlight qs-nav-pipelines}}
+[Monitoring]{{highlight qs-nav-monitoring}}
+----
+
+[id="quick-start-highlighting-masthead-links_{context}"]
+== Masthead links
+
+[source,yaml]
+----
+[CloudShell]{{highlight qs-masthead-cloudshell}}
+[Utility Menu]{{highlight qs-masthead-utilitymenu}}
+[User Menu]{{highlight qs-masthead-usermenu}}
+[Applications]{{highlight qs-masthead-applications}}
+[Import]{{highlight qs-masthead-import}}
+[Help]{{highlight qs-masthead-help}}
+[Notifications]{{highlight qs-masthead-notifications}}
+----

--- a/web_console/creating-quick-start-tutorials.adoc
+++ b/web_console/creating-quick-start-tutorials.adoc
@@ -25,6 +25,8 @@ include::modules/quick-starts-linking-to-others.adoc[leveloffset=+2]
 
 include::modules/quick-starts-supported-tags.adoc[leveloffset=+2]
 
+include::modules/quick-starts-highlighting-reference.adoc[leveloffset=+2]
+
 include::modules/quick-start-content-guidelines.adoc[leveloffset=+1]
 
 [id="quick-start-tutorials-additional-resources"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2088
Preview build: https://deploy-preview-33014--osdocs.netlify.app/openshift-enterprise/latest/web_console/creating-quick-start-tutorials?utm_source=github&utm_campaign=bot_dp#quick-start-highlighting-reference_creating-quick-start-tutorials