### PR TITLE
OSDOCS-2088: Added release note on Accessing  a code snippet from a Quick Start

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -82,6 +82,11 @@ The {product-title} installation program for Google Cloud Platform (GCP) now cre
 
 For `console` and `downloads` routes, custom routes functionally is now implemented to use the new `ingress` config route configuration API. The Console Operator already contained custom route customization, but for the `console` route only. Now, if the `console` custom route is set up in both the `ingress` config and `console-operator` config, then the new `ingress` config custom route configuration takes precedent, because the route configuration via `console-operator` config is being deprecated.
 
+[id="ocp-4-8-access-code-snippet-from-quick-start"]
+==== Access a code snippet from a Quick Start
+
+You can now execute a CLI snippet when it is included in a Quick Start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
+
 [id="ocp-4-8-security"]
 === Security and compliance
 


### PR DESCRIPTION
Relates to https://issues.redhat.com/browse/OSDOCS-2088
Preview build: https://deploy-preview-33015--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-access-code-snippet-from-quick-start