### PR TITLE
TELCODOCS-162: New PR to update CNF-792 already merged

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1931,7 +1931,6 @@ Topics:
 - Name: Performance Addon Operator for low latency nodes
   File: cnf-performance-addon-operator-for-low-latency-nodes
   Distros: openshift-origin,openshift-enterprise
-  Distros: openshift-origin,openshift-enterprise
 - Name: Creating a performance profile
   File: cnf-create-performance-profiles
   Distros: openshift-origin,openshift-enterprise

--- a/modules/cnf-about-the-profile-creator-tool.adoc
+++ b/modules/cnf-about-the-profile-creator-tool.adoc
@@ -10,6 +10,6 @@ The tool consumes `must-gather` data from the cluster and several user-supplied 
 
 The tool is run by one of the following methods:
 
-..  Invoking `podman`
+* Invoking `podman`
 
-.. Calling a wrapper script
+* Calling a wrapper script

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -5,13 +5,13 @@
 [id="gathering-data-about-your-cluster-using-must-gather_{context}"]
 = Gathering data about your cluster using `must-gather`
 
-The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run `must-gather` to capture information about your cluster .
+The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run `must-gather` to capture information about your cluster.
 
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
 * Access to the Performance Addon Operator image.
-* The OpenShift Container Platform CLI (`oc`) installed.
+* The OpenShift CLI (`oc`) installed.
 
 .Procedure
 
@@ -22,7 +22,7 @@ The Performance Profile Creator (PPC) tool requires `must-gather` data. As a clu
 [source,terminal]
 
 ----
-$ oc adm must-gather --image=<PAO image> --dest-dir=<dir>
+$ oc adm must-gather --image=<PAO_image> --dest-dir=<dir>
 ----
 +
 [NOTE]

--- a/modules/cnf-how-run-podman-to-create-profile.adoc
+++ b/modules/cnf-how-run-podman-to-create-profile.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+// Epic CNF-792 (4.8)
+// * scalability_and_performance/cnf-create-performance-profiles.adoc
+
+[id="how-to-run-podman-to-create-a-profile_{context}"]
+= How to run `podman` to create a performance profile
+
+The following example illustrates how to run `podman` to create a performance profile with 20 reserved CPUs that are to be split across the NUMA nodes.
+
+Node hardware configuration:
+
+* 80 CPUs
+* Hyperthreading enabled
+* Two NUMA nodes
+* Even numbered CPUs run on NUMA node 0 and odd numbered CPUs run on NUMA node 1
+
+Run `podman` to create the performance profile:
+
+[source,terminal]
+----
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
+----
+
+The created profile is described in the following YAML:
+
+[source,yaml]
+----
+  apiVersion: performance.openshift.io/v2
+  kind: PerformanceProfile
+  metadata:
+    name: performance
+  spec:
+    cpu:
+      isolated: 10-39,50-79
+      reserved: 0-9,40-49
+    nodeSelector:
+      node-role.kubernetes.io/worker-cnf: ""
+    numa:
+      topologyPolicy: restricted
+    realTimeKernel:
+      enabled: true
+----
+
+[NOTE]
+====
+In this case, 10 CPUs are reserved on NUMA node 0 and 10 are reserved on NUMA node 1.
+====

--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -4,10 +4,10 @@
 
 
 [id="performance-profile-creator-arguments_{context}"]
-=  Performance Profile Creator arguments
+= Performance Profile Creator arguments
 
 .Performance Profile Creator arguments
-["cols="30%,70%",options="header"]
+[cols="30%,70%",options="header"]
 |===
 | Argument | Description
 
@@ -24,7 +24,7 @@ If this argument is set to `true` you should not disable hyperthreading in the B
 ====
 
 | `info`
-a| This captures cluster information and is used in discovery mode only. Discovery mode also requires the `must-gather-dir-path`. If any other arguments are set they are ignored.
+a| This captures cluster information and is used in discovery mode only. Discovery mode also requires the `must-gather-dir-path` argument. If any other arguments are set they are ignored.
 
 Possible values:
 

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -10,7 +10,7 @@ The performance profile wrapper script simplifies the running of the Performance
 .Prerequisites
 
 * Access to the Performance Addon Operator image.
-* Access to `must-gather` tarball.
+* Access to the `must-gather` tarball.
 
 .Procedure
 
@@ -169,12 +169,12 @@ There two types of arguments:
 +
 [NOTE]
 ====
-Discovery mode inspects your cluster using the output from `must-gather`. The output produced includes information on the:
+Discovery mode inspects your cluster using the output from `must-gather`. The output produced includes information on:
 
-* NUMA cell partitioning with the allocated CPU ids
+* The NUMA cell partitioning with the allocated CPU IDs
 * Whether hyperthreading is enabled
 
-Using this information you can set appropriate values for some of the arguments supplied to the performance profile creator tool.
+Using this information you can set appropriate values for some of the arguments supplied to the Performance Profile Creator tool.
 ====
 +
 [source,terminal]

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -5,7 +5,7 @@
 [id="running-the-performance-profile-profile-cluster-using-podman_{context}"]
 = Running the Performance Profile Creator using `podman`
 
-As a cluster administrator, you can run `podman` and Performance Profile Creator to create a performance profile.
+As a cluster administrator, you can run `podman` and the Performance Profile Creator to create a performance profile.
 
 .Prerequisites
 
@@ -63,16 +63,16 @@ Flags:
       --user-level-networking             Run with User level Networking(DPDK) enabled
 ----
 
-. Run the performance profile creator tool in discovery mode:
+. Run the Performance Profile Creator tool in discovery mode:
 +
 [NOTE]
 ====
-Discovery mode inspects your cluster using the output from `must-gather`. The output produced includes information on the:
+Discovery mode inspects your cluster using the output from `must-gather`. The output produced includes information on:
 
-* NUMA cell partitioning with the allocated CPU ids
+* The NUMA cell partitioning with the allocated CPU ids
 * Whether hyperthreading is enabled
 
-Using this information you can set appropriate values for some of the arguments supplied to the performance profile creator tool.
+Using this information you can set appropriate values for some of the arguments supplied to the Performance Profile Creator tool.
 ====
 +
 [source,terminal]
@@ -99,19 +99,16 @@ The `info` option requires a value which specifies the output format. Possible v
 $ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
-The following arguments are required:
+[NOTE]
+====
+The Performance Profile Creator arguments are shown in the Performance Profile Creator arguments table. The following arguments are required:
 
 * `reserved-cpu-count`
 * `mcp-name`
-+
-The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`.
 * `rt-kernel`
-+
-[NOTE]
-====
-For Single Node OpenShift (SNO) use `--mcp-name=master`.
-====
 
+The `mcp-name` argument in this example is set to `worker-cnf` based on the output of the command `oc get mcp`. For Single Node OpenShift (SNO) use `--mcp-name=master`.
+====
 +
 . Review the created YAML file:
 +
@@ -153,45 +150,3 @@ spec:
 ----
 $ oc apply -f my-performance-profile.yaml
 ----
-
-.How to run `podman` to create a Performance profile
-The following example illustrates how to run `podman` to create a performance profile with 20 reserved CPUs that are to be split across the NUMA nodes.
-
-Node hardware configuration:
-
-* 80 CPUs
-* Hyperthreading enabled
-* Two NUMA nodes
-* Even numbered CPUs run on NUMA node 0 and odd numbered CPUs run on NUMA node 1
-
-Run `podman` to create the performance profile:
-
-[source,terminal]
-----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
-----
-
-The created profile is described in the following YAML:
-
-[source,yaml]
-----
-  apiVersion: performance.openshift.io/v2
-  kind: PerformanceProfile
-  metadata:
-    name: performance
-  spec:
-    cpu:
-      isolated: 10-39,50-79
-      reserved: 0-9,40-49
-    nodeSelector:
-      node-role.kubernetes.io/worker-cnf: ""
-    numa:
-      topologyPolicy: restricted
-    realTimeKernel:
-      enabled: true
-----
-
-[NOTE]
-====
-In this case, 10 CPUs are reserved on NUMA node 0 and 10 are reserved on NUMA node 1.
-====

--- a/scalability_and_performance/cnf-create-performance-profiles.adoc
+++ b/scalability_and_performance/cnf-create-performance-profiles.adoc
@@ -1,11 +1,11 @@
 [id="cnf-create-performance-profiles"]
-= Creating a Performance Profile
+= Creating a performance profile
 include::modules/common-attributes.adoc[]
-:context: cnf-performance-profiles
+:context: cnf-create-performance-profiles
 
 toc::[]
 
-Learn about the Performance Profile Creator and how you can use it to create a performance profile.
+Learn about the Performance Profile Creator (PPC) and how you can use it to create a performance profile.
 
 include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+1]
 
@@ -13,10 +13,13 @@ include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[levelof
 
 include::modules/cnf-running-the-performance-creator-profile.adoc[leveloffset=+2]
 
+include::modules/cnf-how-run-podman-to-create-profile.adoc[leveloffset=+3]
+
 include::modules/cnf-running-the-performance-creator-profile-offline.adoc[leveloffset=+2]
 
 include::modules/cnf-performance-profile-creator-arguments.adoc[leveloffset=+2]
 
-.Additional resources
+[id="{context}-additional-resources"]
+== Additional resources
 * For more information about the `must-gather` tool,
 see xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster].


### PR DESCRIPTION
Additional comments came in after https://issues.redhat.com/browse/CNF-792 was merged into main and cherry-picked to 4.8. Addressing these here.
Original dev Epic is [CNF-792](https://issues.redhat.com/browse/CNF-792)
Preview Link: https://deploy-preview-33021--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html

Original PR: https://github.com/openshift/openshift-docs/pull/30639