### PR TITLE
PSAP-444: NTO - using built-in TuneD profiles

### DIFF
--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -3,17 +3,17 @@
 // * scalability_and_performance/using-node-tuning-operator.adoc
 
 [id="custom-tuning-example_{context}"]
-= Custom tuning example
+= Custom tuning examples
+
+*Using TuneD profiles from the default CR*
 
 The following CR applies custom node-level tuning for
 {product-title} nodes with label
 `tuned.openshift.io/ingress-node-label` set to any value.
-As an administrator, use the following command to create a custom Tuned CR.
 
-.Custom tuning example
-[source,terminal]
+.Example: custom tuning using the openshift-control-plane TuneD profile
+[source,yaml]
 ----
-$ oc create -f- <<_EOF_
 apiVersion: tuned.openshift.io/v1
 kind: Tuned
 metadata:
@@ -34,7 +34,6 @@ spec:
     - label: tuned.openshift.io/ingress-node-label
     priority: 10
     profile: openshift-ingress
-_EOF_
 ----
 
 [IMPORTANT]
@@ -43,3 +42,45 @@ Custom profile writers are strongly encouraged to include the default TuneD
 daemon profiles shipped within the default Tuned CR. The example above uses the
 default `openshift-control-plane` profile to accomplish this.
 ====
+
+*Using built-in TuneD profiles*
+
+Given the successful rollout of the NTO-managed daemon set, the TuneD operands
+all manage the same version of the TuneD daemon. To list the built-in TuneD
+profiles supported by the daemon, query any TuneD pod in the following way:
+
+[source,terminal]
+----
+$ oc exec $tuned_pod -n openshift-cluster-node-tuning-operator -- find /usr/lib/tuned/ -name tuned.conf -printf '%h\n' | sed 's|^.*/||'
+----
+
+You can use the profile names retrieved by this in your custom tuning specification.
+
+.Example: using built-in hpc-compute TuneD profile
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-node-hpc-compute
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift node profile for HPC compute workloads
+      include=openshift-node,hpc-compute
+    name: openshift-node-hpc-compute
+
+  recommend:
+  - match:
+    - label: tuned.openshift.io/openshift-node-hpc-compute
+    priority: 20
+    profile: openshift-node-hpc-compute
+----
+
+In addition to the built-in `hpc-compute` profile, the example above includes
+the `openshift-node` TuneD daemon profile shipped within the default
+Tuned CR to use OpenShift-specific tuning for compute nodes.
+
+// Note the issues with including profiles sharing the same ancestor: see link:https://bugzilla.redhat.com/show_bug.cgi?id=1825882[BZ#1825882]


### PR DESCRIPTION
Changes:
  - Add documentation wrt using TuneD profiles shipped within the TuneD daemon.
  - Make the custom tuning using the openshift-control-plane TuneD profile look nicer by changing the formatting to yaml.