### PR TITLE
BZ1959599: Imagepull errors rejected by policy while deploying application through catalog

### DIFF
--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -12,7 +12,7 @@ When pulling or pushing images, the container runtime searches the registries li
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries must also be added.
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries and the default internal image registry, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
 ====
 
 .Procedure
@@ -46,6 +46,7 @@ spec:
     - quay.io
     - registry.redhat.io
     - reg1.io/myrepo/myapp:latest
+    - image-registry.openshift-image-registry.svc:5000
 status:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 ----
@@ -74,38 +75,84 @@ The following policy indicates that only images from the example.com, quay.io, a
 [source,terminal]
 ----
 {
-	"default": [{
-		"type": "reject"
-	}],
-	"transports": {
-		"atomic": {
-			"example.com": [{
-				"type": "insecureAcceptAnything"
-			}],
-			"quay.io": [{
-				"type": "insecureAcceptAnything"
-			}],
-			"registry.redhat.io": [{
-				"type": "insecureAcceptAnything"
-			}]
-		},
-		"docker": {
-			"example.com": [{
-				"type": "insecureAcceptAnything"
-			}],
-			"quay.io": [{
-				"type": "insecureAcceptAnything"
-			}],
-			"registry.redhat.io": [{
-				"type": "insecureAcceptAnything"
-			}]
-		},
-		"docker-daemon": {
-			"": [{
-				"type": "insecureAcceptAnything"
-			}]
-		}
-	}
+   "default":[
+      {
+         "type":"reject"
+      }
+   ],
+   "transports":{
+      "atomic":{
+         "example.com":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "image-registry.openshift-image-registry.svc:5000":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "insecure.com":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "quay.io":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "reg4.io/myrepo/myapp:latest":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "registry.redhat.io":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ]
+      },
+      "docker":{
+         "example.com":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "image-registry.openshift-image-registry.svc:5000":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "insecure.com":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "quay.io":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "reg4.io/myrepo/myapp:latest":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ],
+         "registry.redhat.io":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ]
+      },
+      "docker-daemon":{
+         "":[
+            {
+               "type":"insecureAcceptAnything"
+            }
+         ]
+      }
+   }
 }
 ----
 ====
@@ -127,5 +174,6 @@ spec:
     - quay.io
     - registry.redhat.io
     - insecure.com
+    - image-registry.openshift-image-registry.svc:5000
 ----
 ====

--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -43,6 +43,7 @@ spec:
     - example.com
     - quay.io
     - registry.redhat.io
+    - image-registry.openshift-image-registry.svc:5000
     insecureRegistries:
     - insecure.com
 status:

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -50,16 +50,17 @@ spec:
     - registry.redhat.io
     - insecure.com <3>
     - reg4.io/myrepo/myapp:latest
+    - image-registry.openshift-image-registry.svc:5000
 status:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
 ----
 <1> Contains configurations that determine how the container runtime should treat individual registries when accessing images for builds and pods. It does not contain configuration for the internal cluster registry.
-<2> Specify an insecure registry, or optionally a repository in that regisstry.
+<2> Specify an insecure registry. You can specify a repository in that registry.
 <3> Ensure that any insecure registries are included in the `allowedRegistries` list.
 +
 [NOTE]
 ====
-When the `allowedRegistries` parameter is defined, all registries, including the registry.redhat.io and quay.io registries, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list.
+When the `allowedRegistries` parameter is defined, all registries, including the registry.redhat.io and quay.io registries and the default internal image registry, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, add all registries including the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added. 
 ====
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to the registries, then drains and uncordons the nodes when it detects changes. After the nodes return to the `Ready` state, changes to the insecure and blocked registries appear in the `/etc/containers/registries.conf` file on each node.

--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -27,7 +27,7 @@ Every element of this list contains a location of the registry specified by the 
 The namespace for this config map is `openshift-config`. The format of the config map is to use the registry hostname as the key, and the PEM-encoded certificate as the value, for each additional registry CA to trust.
 
 |`externalRegistryHostnames`
-|Provides the hostnames for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in `publicDockerImageRepository` field in image streams. The value must be in `hostname[:port]` format.
+|Provides the host names for the default external image registry. The external hostname should be set only when the image registry is exposed externally. The first value is used in `publicDockerImageRepository` field in image streams. The value must be in `hostname[:port]` format.
 
 |`registrySources`
 |Contains configuration that determines how the container runtime should treat individual registries when accessing images for builds and
@@ -47,7 +47,7 @@ Either `blockedRegistries` or `allowedRegistries` can be set, but not both.
 
 [WARNING]
 ====
-When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. When using the parameter,  to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list. For disconnected clusters, mirror registries must also be added.
+When the `allowedRegistries` parameter is defined, all registries, including `registry.redhat.io` and `quay.io` registries and the default internal image registry, are blocked unless explicitly listed. When using the parameter, to prevent pod failure, add all registries including the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
 ====
 
 The `status` field of the `image.config.openshift.io/cluster` resource holds observed values from the cluster.
@@ -60,6 +60,6 @@ The `status` field of the `image.config.openshift.io/cluster` resource holds obs
 |Set by the Image Registry Operator, which controls the `internalRegistryHostname`. It sets the hostname for the default internal image registry. The value must be in `hostname[:port]` format. For backward compatibility, you can still use the `OPENSHIFT_DEFAULT_REGISTRY` environment variable, but this setting overrides the environment variable.
 
 |`externalRegistryHostnames`
-|Set by the Image Registry Operator, provides the external hostnames for the image registry when it is exposed externally. The first value is used in `publicDockerImageRepository` field in image streams. The values must be in `hostname[:port]` format.
+|Set by the Image Registry Operator, provides the external host names for the image registry when it is exposed externally. The first value is used in `publicDockerImageRepository` field in image streams. The values must be in `hostname[:port]` format.
 
 |===

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -57,16 +57,17 @@ spec:
     name: myconfigmap
   registrySources:
     containerRuntimeSearchRegistries: <1>
-    - "reg1.io"
-    - "reg2.io"
-    - "reg3.io"
+    - reg1.io
+    - reg2.io
+    - reg3.io
     allowedRegistries: <2>
     - example.com
     - quay.io
     - registry.redhat.io
-    - "reg1.io"
-    - "reg2.io"
-    - "reg3.io"
+    - reg1.io
+    - reg2.io
+    - reg3.io
+    - image-registry.openshift-image-registry.svc:5000
 ...
 status:
   internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
@@ -76,10 +77,10 @@ status:
 +
 [NOTE]
 ====
-When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries, are blocked unless explicitly listed. If you use this parameter, to prevent pod failure, you must add `registry.redhat.io` and `quay.io` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list. 
+When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries and the default internal image registry, are blocked unless explicitly listed. If you use this parameter, to prevent pod failure, add all registries including the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added. 
 ====
 
-. To check that the registries have been added, use the following command on a node:
+. To check that the registries have been added, when a node returns to the `Ready` state, use the following command on the node:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1959599

Previews:
[Image controller config parameters](https://deploy-preview-33046--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-parameters_image-configuration)
[Adding specific registries](https://deploy-preview-33046--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-allowed_image-configuration)
[Allowing insecure registries (under call-out 3)](https://deploy-preview-33046--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-insecure_image-configuration)
[Adding registries that allow short names (under call-out 2)](https://deploy-preview-33046--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-shortname_image-configuration)
