### PR TITLE
SRVCOM-1296: Update serverless docs IDs

### DIFF
--- a/modules/serverless-deleting-crds.adoc
+++ b/modules/serverless-deleting-crds.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+//  * serverless/admin_guide/removing-openshift-serverless.adoc
+
+[id="serverless-deleting-crds_{context}"]
+= Deleting {ServerlessProductName} custom resource definitions
+
+After uninstalling the {ServerlessProductName}, the Operator and API custom resource definitions (CRDs) remain on the cluster.
+You can use the following procedure to remove the remaining CRDs.
+
+[IMPORTANT]
+====
+Removing the Operator and API CRDs also removes all resources that were defined using them, including Knative services.
+====
+
+.Prerequisites
+
+* You uninstalled Knative Serving and removed the {ServerlessOperatorName}.
+
+.Procedure
+
+* To delete the remaining {ServerlessProductName} CRDs, enter the following command:
++
+[source,terminal]
+----
+$ oc get crd -oname | grep 'knative.dev' | xargs oc delete
+----

--- a/modules/serverless-gpu-resources-kn.adoc
+++ b/modules/serverless-gpu-resources-kn.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+//  * serverless/integrations/gpu-resources.adoc
+
+[id="serverless-gpu-resources-kn_{context}"]
+= Specifying GPU requirements for a service
+
+After GPU resources are enabled for your {product-title} cluster, you can specify GPU requirements for a Knative service using the `kn` CLI.
+
+[NOTE]
+====
+Using NVIDIA GPU resources is not supported for IBM Z and IBM Power Systems.
+====
+
+.Procedure
+
+. Create a Knative service and set the GPU resource requirement limit to `1` by using the `--limit nvidia.com/gpu=1` flag:
++
+[source,terminal]
+----
+$ kn service create hello --image <service-image> --limit nvidia.com/gpu=1
+----
++
+A GPU resource requirement limit of `1` means that the service has 1 GPU resource dedicated. Services do not share GPU resources. Any other services that require GPU resources must wait until the GPU resource is no longer in use.
++
+A limit of 1 GPU also means that applications exceeding usage of 1 GPU resource are restricted. If a service requests more than 1 GPU resource, it is deployed on a node where the GPU resource requirements can be met.
+
+. Optional. For an existing service, you can change the GPU resource requirement limit to `3` by using the `--limit nvidia.com/gpu=3` flag:
++
+[source,terminal]
+----
+$ kn service update hello --limit nvidia.com/gpu=3
+----

--- a/serverless/admin_guide/installing-knative-eventing.adoc
+++ b/serverless/admin_guide/installing-knative-eventing.adoc
@@ -13,15 +13,16 @@ This guide provides information about installing Knative Eventing using the defa
 
 // For more information about configuration options for the KnativeEventing custom resource definition, see xref:../../serverless/admin_guide/serverless-install-config-options.adoc#serverless-install-config-options[Advanced installation configuration options].
 
-[id="installing-knative-eventing-prerequisites"]
+[id="prerequisites_installing-knative-eventing"]
 == Prerequisites
+
 * You have access to an {product-title} account with cluster administrator access.
 * You have installed {ServerlessOperatorName}.
 
 include::modules/serverless-install-eventing-web-console.adoc[leveloffset=+1]
 include::modules/serverless-install-eventing-yaml.adoc[leveloffset=+1]
 
-[id="installing-knative-eventing-next-steps"]
+[id="next-steps_installing-knative-eventing"]
 == Next steps
 
 * Install the Knative CLI to use `kn` commands with Knative Eventing. For example, `kn source` commands. See xref:../../serverless/installing-kn.adoc#installing-kn[Installing the Knative CLI].

--- a/serverless/admin_guide/installing-knative-serving.adoc
+++ b/serverless/admin_guide/installing-knative-serving.adoc
@@ -10,15 +10,16 @@ After you install the {ServerlessOperatorName}, you can install Knative Serving.
 This guide provides information about installing Knative Serving using the default settings. However, you can configure more advanced settings in the `KnativeServing` custom resource definition (CRD).
 For more information about configuration options for the `KnativeServing` CRD, see xref:../../serverless/admin_guide/serverless-install-config-options.adoc#serverless-install-config-options[Advanced installation configuration options].
 
-[id="installing-knative-serving-prerequisites"]
+[id="prerequisites_installing-knative-serving"]
 == Prerequisites
+
 * You have access to an {product-title} account with cluster administrator access.
 * You have installed the {ServerlessOperatorName}.
 
 include::modules/serverless-install-serving-web-console.adoc[leveloffset=+1]
 include::modules/serverless-install-serving-yaml.adoc[leveloffset=+1]
 
-[id="installing-knative-serving-next-steps"]
+[id="next-steps_installing-knative-serving"]
 == Next steps
 
 * For cloud events functionality on {ServerlessProductName}, you can install the Knative Eventing component. See the documentation on xref:../../serverless/admin_guide/installing-knative-eventing.adoc#installing-knative-eventing[Installing Knative Eventing].

--- a/serverless/admin_guide/installing-openshift-serverless.adoc
+++ b/serverless/admin_guide/installing-openshift-serverless.adoc
@@ -37,7 +37,7 @@ See xref:../../machine_management/manually-scaling-machineset.adoc#manually-scal
 
 include::modules/serverless-install-web-console.adoc[leveloffset=+1]
 
-[id="installing-openshift-serverless-next-steps"]
+[id="next-steps_installing-openshift-serverless"]
 == Next steps
 
 * After the {ServerlessOperatorName} is installed, you can install the Knative Serving component. See the documentation on xref:../../serverless/admin_guide/installing-knative-serving.adoc#installing-knative-serving[Installing Knative Serving].

--- a/serverless/admin_guide/removing-openshift-serverless.adoc
+++ b/serverless/admin_guide/removing-openshift-serverless.adoc
@@ -18,29 +18,10 @@ include::modules/serverless-uninstalling-knative-serving.adoc[leveloffset=+1]
 // Uninstalling Knative Eventing
 include::modules/serverless-uninstalling-knative-eventing.adoc[leveloffset=+1]
 
-[id="removing-the-operator"]
+[id="removing-openshift-serverless-removing-the-operator"]
 == Removing the {ServerlessOperatorName}
 
 You can remove the {ServerlessOperatorName} from the host cluster by following the documentation on xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster].
 
-[id="deleting-serverless-CRDs"]
-== Deleting {ServerlessProductName} custom resource definitions
-
-After uninstalling the {ServerlessProductName}, the Operator and API custom resource definitions (CRDs) remain on the cluster.
-You can use the following procedure to remove the remaining CRDs.
-
-[IMPORTANT]
-====
-Removing the Operator and API CRDs also removes all resources that were defined using them, including Knative services.
-====
-
-== Prerequisites
-*  You uninstalled Knative Serving and removed the {ServerlessOperatorName}.
-
-.Procedure
-* To delete the remaining {ServerlessProductName} CRDs, enter the following command:
-+
-[source,terminal]
-----
-$ oc get crd -oname | grep 'knative.dev' | xargs oc delete
-----
+// deleting serverless CRDs
+include::modules/serverless-deleting-crds.adoc[leveloffset=+1]

--- a/serverless/admin_guide/serverless-install-config-options.adoc
+++ b/serverless/admin_guide/serverless-install-config-options.adoc
@@ -14,6 +14,7 @@ include::modules/knative-serving-advanced-config.adoc[leveloffset=+1]
 // image::eventing-form-view.png[Create Knative Eventing form]
 // TODO: Add when there's more information for eventing.
 
-[id="serverless-install-config-options-additional-resources"]
+[id="additional-resources_serverless-install-config-options"]
 == Additional resources
+
 * For more information about configuring high availability, see xref:../../serverless/serverless-HA.adoc#serverless-HA[High availability on {ServerlessProductName}].

--- a/serverless/admin_guide/serverless-metering.adoc
+++ b/serverless/admin_guide/serverless-metering.adoc
@@ -15,8 +15,9 @@ For more information about metering on {product-title}, see xref:../../metering/
 Metering is not currently supported for IBM Z and IBM Power Systems.
 ====
 
-[id="installing-metering-serverless_{context}"]
+[id="installing-metering-serverless"]
 == Installing metering
+
 For information about installing metering on {product-title}, see xref:../../metering/metering-installing-metering.adoc#installing-metering[Installing Metering].
 
 include::modules/serverless-metering-datasources.adoc[leveloffset=+1]

--- a/serverless/event_sources/serverless-apiserversource.adoc
+++ b/serverless/event_sources/serverless-apiserversource.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 The API server source is an event source that can be used to connect an event sink, such as a Knative service, to the Kubernetes API server. The API server source watches for Kubernetes events and forwards them to the Knative Eventing broker.
 
-[id="serverless-apiserversource-prerequisites"]
+[id="prerequisites_serverless-apiserversource"]
 == Prerequisites
 
 * You must have a current installation of xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#serverless-install-web-console_installing-openshift-serverless[{ServerlessProductName}], including Knative Serving and Eventing, in your {product-title} cluster. This can be installed by a cluster administrator.

--- a/serverless/event_workflows/serverless-event-delivery.adoc
+++ b/serverless/event_workflows/serverless-event-delivery.adoc
@@ -26,7 +26,7 @@ Back off policy:: The `backoffPolicy` delivery parameter can be used to specify 
 
 include::modules/serverless-subscription-event-delivery-config.adoc[leveloffset=+1]
 
-[id="serverless-event-delivery-additional-resources"]
+[id="additional-resources_serverless-event-delivery"]
 == Additional resources
 
 * See xref:../../serverless/channels/serverless-channels.adoc#serverless-channels[Knative Eventing workflows using channels] for more information about subscriptions.

--- a/serverless/event_workflows/serverless-triggers.adoc
+++ b/serverless/event_workflows/serverless-triggers.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 Using triggers enables you to filter events from the broker for delivery to event sinks.
 
-[id="serverless-triggers-prereqs"]
+[id="prerequisites_serverless-triggers"]
 == Prerequisites
 
 * You have installed Knative Eventing and the `kn` CLI.

--- a/serverless/functions/serverless-developing-go-functions.adoc
+++ b/serverless/functions/serverless-developing-go-functions.adoc
@@ -18,7 +18,7 @@ After you have xref:../../serverless/functions/serverless-functions-getting-star
 
 include::modules/serverless-go-template.adoc[leveloffset=+1]
 
-[id="serverless-developing-go-functions-about-invoking_{context}"]
+[id="serverless-developing-go-functions-about-invoking"]
 == About invoking Golang functions
 
 Golang functions are invoked by using different methods, depending on whether they are triggered by a HTTP request or a CloudEvent.

--- a/serverless/functions/serverless-developing-nodejs-functions.adoc
+++ b/serverless/functions/serverless-developing-nodejs-functions.adoc
@@ -18,7 +18,7 @@ After you have xref:../../serverless/functions/serverless-functions-getting-star
 
 include::modules/serverless-nodejs-template.adoc[leveloffset=+1]
 
-[id="serverless-developing-nodejs-functions-about-invoking_{context}"]
+[id="serverless-developing-nodejs-functions-about-invoking"]
 == About invoking Node.js functions
 
 When using the `kn` CLI to create a function project, you can generate a project that responds to CloudEvents, or one that responds to simple HTTP requests. CloudEvents in Knative are transported over HTTP as a POST request, so both function types listen for and respond to incoming HTTP events.

--- a/serverless/integrations/gpu-resources.adoc
+++ b/serverless/integrations/gpu-resources.adoc
@@ -9,41 +9,9 @@ toc::[]
 NVIDIA supports experimental use of GPU resources on {product-title}.
 See link:https://docs.nvidia.com/datacenter/kubernetes/openshift-on-gpu-install-guide/index.html[{product-title} on NVIDIA GPU accelerated clusters] for more information about setting up GPU resources on {product-title}.
 
-After GPU resources are enabled for your {product-title} cluster, you can specify GPU requirements for a Knative service using the `kn` CLI.
+include::modules/serverless-gpu-resources-kn.adoc[leveloffset=+1]
 
-[NOTE]
-====
-Using NVIDIA GPU resources is not supported for IBM Z and IBM Power Systems.
-====
-
-.Procedure
-
-You can specify a GPU resource requirement when you create a Knative service using `kn`.
-
-. Create a service.
-. Set the GPU resource requirement limit to `1` by using `nvidia.com/gpu=1`:
-+
-
-[source,terminal]
-----
-$ kn service create hello --image docker.io/knativesamples/hellocuda-go --limit nvidia.com/gpu=1
-----
-
-+
-A GPU resource requirement limit of `1` means that the service has 1 GPU resource dedicated.
-Services do not share GPU resources. Any other services that require GPU resources must wait until the GPU resource is no longer in use.
-+
-A limit of 1 GPU also means that applications exceeding usage of 1 GPU resource are restricted.
-If a service requests more than 1 GPU resource, it is deployed on a node where the GPU resource requirements can be met.
-
-.Updating GPU requirements for a Knative service using `kn`
-
-* Update the service. Change the GPU resource requirement limit to `3` by using `nvidia.com/gpu=3`:
-
-[source,terminal]
-----
-$ kn service update hello --limit nvidia.com/gpu=3
-----
-
+[id="additional-requirements_gpu-resources"]
 == Additional resources
+
 * For more information about limits, see xref:../../applications/quotas/quotas-setting-per-project.adoc[Setting resource quotas for extended resources].

--- a/serverless/knative_serving/configuring-knative-serving-autoscaling.adoc
+++ b/serverless/knative_serving/configuring-knative-serving-autoscaling.adoc
@@ -10,7 +10,9 @@ toc::[]
 To enable autoscaling for Knative Serving, you must configure concurrency and scale bounds in the revision template.
 
 [NOTE]
+====
 Any limits or targets set in the revision template are measured against a single instance of your application. For example, setting the `target` annotation to `50` will configure the autoscaler to scale the application so that each revision will handle 50 requests at a time.
+====
 
 // Autoscaling
 include::modules/serverless-workflow-autoscaling-kn.adoc[leveloffset=+1]

--- a/serverless/monitoring/serverless-monitoring.adoc
+++ b/serverless/monitoring/serverless-monitoring.adoc
@@ -1,6 +1,3 @@
-// This assembly is included in the following assemblies:
-//
-// <List assemblies here, each on a new line>
 include::modules/serverless-document-attributes.adoc[]
 [id="serverless-monitoring"]
 = Monitoring serverless components

--- a/serverless/networking/serverless-ossm-custom-domains.adoc
+++ b/serverless/networking/serverless-ossm-custom-domains.adoc
@@ -21,7 +21,9 @@ You can customize the domain for your Knative service by configuring the service
 {ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
 ====
 
-.Prerequisites
+[id="prerequisites_serverless-ossm-custom-domains"]
+== Prerequisites
+
 * Install the xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] and xref:../../serverless/admin_guide/installing-knative-serving.adoc#installing-knative-serving[Knative Serving].
 * Install xref:../../service_mesh/v1x/preparing-ossm-installation.adoc#preparing-ossm-installation-v1x[{ProductName}].
 * Complete the configuration steps in xref:../../serverless/networking/serverless-ossm.adoc#serverless-ossm[Using {ProductShortName} with {ServerlessProductName}].
@@ -31,5 +33,7 @@ include::modules/knative-service-cluster-local.adoc[leveloffset=+1]
 include::modules/serverless-service-mesh-resources.adoc[leveloffset=+1]
 include::modules/serverless-access-custom-domain.adoc[leveloffset=+1]
 
+[id="additional-resources_serverless-ossm-custom-domains"]
 == Additional resources
+
 * For more information about {ProductName}, see xref:../../service_mesh/v1x/ossm-architecture.adoc#ossm-architecture-v1x[Understanding {ProductName}].

--- a/serverless/networking/serverless-ossm-jwt.adoc
+++ b/serverless/networking/serverless-ossm-jwt.adoc
@@ -14,7 +14,7 @@ You can enable JSON Web Token (JWT) authentication for Knative services.
 {ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
 ====
 
-[id="serverless-ossm-jwt-prerequisites"]
+[id="prerequisites_serverless-ossm-jwt"]
 == Prerequisites
 
 * Install xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessProductName}].

--- a/serverless/networking/serverless-ossm-tls.adoc
+++ b/serverless/networking/serverless-ossm-tls.adoc
@@ -19,7 +19,7 @@ You can create a Transport Layer Security (TLS) key and certificates for a custo
 {ServerlessProductName} only supports the use of {ProductName} functionality that is explicitly documented in this guide, and does not support other undocumented features, such as mTLS or custom Istio ingress gateways.
 ====
 
-[id="serverless-ossm-tls-prereqs"]
+[id="prerequisites_serverless-ossm-tls"]
 == Prerequisites
 
 * Install xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessProductName}].

--- a/serverless/networking/serverless-ossm.adoc
+++ b/serverless/networking/serverless-ossm.adoc
@@ -20,7 +20,7 @@ These options include setting custom domains, using TLS certificates, and using 
 Adding sidecar injection to pods in system namespaces such as `knative-serving` and `knative-serving-ingress` is not supported.
 ====
 
-[id="serverless-ossm-prerequisites"]
+[id="prerequisites_serverless-ossm"]
 == Prerequisites
 
 * Install the xref:../../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] and xref:../../serverless/admin_guide/installing-knative-serving.adoc#installing-knative-serving[Knative Serving].

--- a/serverless/serverless-getting-started.adoc
+++ b/serverless/serverless-getting-started.adoc
@@ -22,7 +22,7 @@ Developers on {ServerlessProductName} can use the provided Kubernetes native API
 
 The set of supported features, configurations, and integrations for {ServerlessProductName}, current and past versions, are available at the link:https://access.redhat.com/articles/4912821[Supported Configurations page].
 
-[id="serverless-getting-started-next-steps"]
+[id="next-steps_serverless-getting-started"]
 == Next steps
 
 * Install the xref:../serverless/admin_guide/installing-openshift-serverless.adoc#installing-openshift-serverless[{ServerlessOperatorName}] on your {product-title} cluster to get started.

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -15,7 +15,7 @@ include::modules/serverless-rn-1-12-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-11-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-10-0.adoc[leveloffset=+1]
 
-[id="additional-resources"]
+[id="additional-resources_serverless-release-notes"]
 == Additional resources
 
 {ServerlessProductName} is based on the open source Knative project.

--- a/serverless/serverless-support.adoc
+++ b/serverless/serverless-support.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 include::modules/serverless-getting-support.adoc[leveloffset=+1]
 
-[id="serverless-support-gather-info_{context}"]
+[id="serverless-support-gather-info"]
 == Gathering diagnostic information for support
 
 When opening a support case, it is helpful to provide debugging


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVCOM-1296

Direct link to doc preview: mostly N/A since this PR just updates IDs (no content changes)
- https://deploy-preview-33047--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/removing-openshift-serverless.html#serverless-deleting-crds is also now a module inc.
- https://deploy-preview-33047--osdocs.netlify.app/openshift-enterprise/latest/serverless/integrations/gpu-resources.html is now improved, content split into a module inc.

QE signed off by: @alanfx 