### PR TITLE
BZ1967707: Adding note on need to update OVF template on minor release upgrade

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -85,6 +85,16 @@ In the following steps, you use the same template for all of your cluster machin
 If you plan to add more compute machines to your cluster after you finish
 installation, do not delete this template.
 ====
++
+[IMPORTANT]
+====
+After successfully upgrading to the next minor release of OpenShift Container 
+Platform it is recommended that the RHCOS OVA image be upgraded as well. 
+Otherwise, newly created or scaled nodes may fail to install due to 
+incompatibilities between the RHCOS OVA image and the installed version of 
+OpenShift.  To upgrade the OVA image, create a new OVF Template based on the
+updated OVA image. 
+====
 
 . After the template deploys, deploy a VM for a machine in the cluster.
 .. Right-click the template name and click *Clone* -> *Clone to Virtual Machine*.


### PR DESCRIPTION
Issue Overview:
When upgrading from one y stream to the next, the template used to create new RHCOS machines should be upgraded as well.  Otherwise, new RHCOS machines may fail to ignite.   

Proposed Changes:
Currently published article describing remediation: https://access.redhat.com/articles/6090681 

Current proposed changes in this PR augment the UPI vSphere install instructions to add a warning regarding the need to upgrade the OVF template.  Presently, maintainers of OpenShift clusters are not explicitly informed of the need to upgrade the OVF template after a minor upgrade.