### PR TITLE
Try for smaller definition list callouts

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -23,6 +23,20 @@
   <meta content="#000000" name="msapplication-TileColor">
   <meta content="https://assets.openshift.net/content/subdomain/touch-icon-precomposed.png" name="msapplication-TileImage">
   <%= render("_templates/_analytics.html.erb", :distro_key => distro_key) %>
+  <style>
+  .myblock {
+    margin-top: -1em;
+  }
+  .myblock .paragraph, .myblock dd p {
+    margin-bottom: 0.25em;
+  }
+  .myblock .dlist {
+    font-size: 14px;
+  }
+  .myblock .dlist p:last-child {
+    margin-bottom: 0.25em;
+  }
+  </style>
 </head>
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>


### PR DESCRIPTION
So this experiment makes them smaller:

<img width="530" alt="Screen Shot 2021-06-03 at 5 35 19 PM" src="https://user-images.githubusercontent.com/354496/120715388-888ad000-c492-11eb-8fd6-8dbc506c8dc3.png">

Not quite `font-size: 14px` because elsewhere a `font-size: 0.92em` eats it, but that can be fixed probably.

Requires:

```
----
code <variable_1>
code <variable_2>
----
+
[i-am-a-css-class-for-this]
--
where:

<variable_1>:: Specifies the explanation of the first variable.
<variable_2>:: Specifies the explanation of the first variable.
--
```