### PR TITLE
TELCODOCS-158: fixing typo in already merged CNF 1483

### DIFF
--- a/modules/cnf-reducing-netqueues-using-pao.adoc
+++ b/modules/cnf-reducing-netqueues-using-pao.adoc
@@ -12,7 +12,7 @@ In real-time or low latency systems all the unnecessary interrupt request lines 
 
 In deployments with applications that require system, {product-title} networking or in mixed deployments with Data Plane Development Kit (DPDK) workloads, multiple queues are needed to achieve good throughput and the number of NIC queues should either be adapted or remain unchanged. For example, to achieve low latency the number of NIC queues for DPDK based workloads should be reduced to just the number of reserved or housekeeping CPUs.
 
-Too many queues are created by default for each CPU and these do not fit into the interrupt tables for house keeping CPUs when tuning for low latency. Reducing the number of queues makes proper tuning possible. Smaller number of queues means smaller number of interrups which then fit in the IRQ table.
+Too many queues are created by default for each CPU and these do not fit into the interrupt tables for housekeeping CPUs when tuning for low latency. Reducing the number of queues makes proper tuning possible. Smaller number of queues means smaller number of interrupts which then fit in the IRQ table.
 
 [id="adjusting-nic-queues-with-the-performance-profile_{context}"]
 == Adjusting the NIC queues with the performance profile


### PR DESCRIPTION
I noticed a small typo in the merged docs and I am fixing it with this PR. 
JIRA is https://issues.redhat.com/browse/CNF-1483
Preview link https://deploy-preview-33063--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes?utm_source=github&utm_campaign=bot_dp#reducing-nic-queues-using-the-performance-addon-operator_cnf-master

Affects 4.8 and master 