### PR TITLE
CCXDEV-4884: Insights Operator Enterprise 4.8 Release Notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -659,6 +659,36 @@ The xref:../scalability_and_performance/psap-node-feature-discovery-operator.ado
 [id="ocp-4-8-dev-exp"]
 === Developer experience
 
+[id="ocp-4-8-insights-operator"]
+=== Insights Operator
+
+[id="ocp-4-8-insights-operator-restricted-network"]
+==== Insights Advisor recommendations for restricted networks
+
+In {product-title} 4.8, users operating in restricted networks can gather and upload Insights Operator archives to Insights Advisor to diagnose potential issues. Additionally, users can obfuscate sensitive data contained in the Insights Operator archive before upload.
+
+For more information, see xref:../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc[Using remote health reporting in a restricted network].
+
+[id="ocp-4-8-insights-advisor-improvements"]
+==== Insights Advisor improvements
+
+Insights Advisor in the {product-title} web console now correctly reports 0 issues found. Previously, Insights Advisor gave no information.
+
+[id="ocp-4-8-insights-operator-data-collection-enhancements"]
+==== Insights Operator data collection enhancements
+
+In {product-title} 4.8, the Insights Operator collects the following additional information:
+
+* Non-identifiable cluster workload information to find known security and version issues.
+* The `MachineHealthCheck` and `MachineAutoscaler` definitions.
+* The `virt_platform` and `vsphere_node_hw_version_total` metrics.
+* Information about unhealthy SAP pods to assist in the installation of SAP Smart Data Integration. 
+* The `datahubs.installers.datahub.sap.com` resources to identfy SAP clusters. 
+* A summary of failed `PodNetworkConnectivityChecks` to enhance networking. 
+* Information about the `cluster-version` pods and events from the `openshift-cluster-operator` namespace to debug issues with the `cluster-version` Operator.
+
+With this additional information, Red Hat can provide improved remediation steps in Insights Advisor.
+
 [id="ocp-4-8-auth"]
 === Authentication and authorization
 


### PR DESCRIPTION
This applies to Enterprise 4.8

Jira:
https://issues.redhat.com/browse/CCXDEV-4884

Restricted network gather/upload/obfuscation: https://issues.redhat.com/browse/CCXDEV-4070
Workload Fingerprinting: https://issues.redhat.com/browse/CCXDEV-4255 
Bugzillas:
1. Gather MachineHealthCheck definitions: https://bugzilla.redhat.com/show_bug.cgi?id=1961091
2. Add virt_platform metric to the collected metrics: https://bugzilla.redhat.com/show_bug.cgi?id=1960546
3. Add vsphere_node_hw_version_total metric to the collected metrics: https://bugzilla.redhat.com/show_bug.cgi?id=1955102
4. Improve log gathering logic: https://bugzilla.redhat.com/show_bug.cgi?id=1961067
5. Gather SDI-related MachineConfigs https://bugzilla.redhat.com/show_bug.cgi?id=1959650
6. Gather summary of PodNetworkConnectivityChecks https://bugzilla.redhat.com/show_bug.cgi?id=1949907
7. Gather info about unhealthy SAP pods https://bugzilla.redhat.com/show_bug.cgi?id=1930393
8. Gather datahubs.installers.datahub.sap.com resources from SAP clusters https://bugzilla.redhat.com/show_bug.cgi?id=1940432
9. Insights operator doesn't gather pod information from openshift-cluster-version https://bugzilla.redhat.com/show_bug.cgi?id=1942271
10. Insights status card shows nothing when 0 issues found https://bugzilla.redhat.com/show_bug.cgi?id=1949338 
11. Gather MachineAutoScaler definitions https://bugzilla.redhat.com/show_bug.cgi?id=1966523




Preview:
https://deploy-preview-33064--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-insights-operator
