### PR TITLE
OSDOCS-1967: Add release note for network policy audit logging

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -333,6 +333,12 @@ For more information, refer to xref:../networking/network_policy/about-network-p
 
 When using either the OVN-Kubernetes cluster network provider or the OpenShift SDN cluster network provider, you can use the `policy-group.network.openshift.io/host-network: ""` namespace selector to select host network traffic in a network policy rule.
 
+[id="ocp-4-8-network-policy-audit-logs"]
+==== Network policy audit logs
+
+If you use the OVN-Kubernetes cluster network provider, you can enable audit logging for network policies in a namespace. The logs are in a syslog compatible format and can be saved locally, sent over a UDP connection, or directed to a UNIX domain socket. You can specify whether to log allowed, dropped, or both allowed and dropped connections.
+For more information, see xref:../networking/network_policy/logging-network-policy.adoc#logging-network-policy[Logging network policy events].
+
 [id="ocp-4-8-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1967

Preview: https://deploy-preview-33078--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-network-policy-audit-logs