### PR TITLE
4.8 Metering release note for deprecation and scheduled removal

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -256,6 +256,9 @@ For more information, see xref:../scalability_and_performance/what-huge-pages-do
 [id="ocp-4-8-monitoring"]
 === Monitoring
 
+[id="ocp-4-8-metering"]
+=== Metering
+The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled to be removed in {product-title} 4.9.
 
 [id="ocp-4-8-scale"]
 === Scale
@@ -345,7 +348,7 @@ In the table, features are marked with the following statuses:
 |Metering Operator
 |DEP
 |DEP
-|
+|DEP
 
 |Scheduler policy
 |GA


### PR DESCRIPTION
Adds 4.8 release note to the Metering section with a reminder that the Metering Operator is deprecated and is scheduled for removal in 4.9.

Preview: https://deploy-preview-33093--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-metering