### PR TITLE
CNV-10277: live migration limits update

### DIFF
--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -6,50 +6,37 @@
 [id="virt-configuring-live-migration-limits_{context}"]
 = Configuring live migration limits and timeouts
 
-Configure live migration limits and timeouts for the cluster by adding updated
-key:value fields to the `kubevirt-config` configuration file, which is located in the
+Configure live migration limits and timeouts for the cluster by updating the `HyperConverged` custom resource (CR), which is located in the
 `openshift-cnv` namespace.
 
 .Procedure
 
-* Edit the `kubevirt-config` configuration file and add the necessary
-live migration parameters. The following example shows the default values:
+* Edit the `HyperConverged` CR and add the necessary live migration parameters.
 +
-
 [source,terminal]
 ----
-$ oc edit configmap kubevirt-config -n openshift-cnv
+$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
 ----
 +
 .Example configuration file
 [source,yaml]
 ----
-apiVersion: v1
-data:
-  default-network-interface: masquerade
-  feature-gates: DataVolumes,SRIOV,LiveMigration,CPUManager,CPUNodeDiscovery,Sidecar,Snapshot
-  migrations: |-
-    parallelMigrationsPerCluster: "5"
-    parallelOutboundMigrationsPerNode: "2"
-    bandwidthPerMigration: "64Mi"
-    completionTimeoutPerGiB: "800"
-    progressTimeout: "150"
-  machine-type: pc-q35-rhel8.3.0
-  selinuxLauncherType: virt_launcher.process
-  smbios: |-
-    Family: Red Hat
-    Product: Container-native virtualization
-    Manufacturer: Red Hat
-    Sku: 2.6.0
-    Version: 2.6.0
-kind: ConfigMap
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
 metadata:
-  creationTimestamp: "2021-03-26T18:01:04Z"
-  labels:
-    app: kubevirt-hyperconverged
-  name: kubevirt-config
+  name: kubevirt-hyperconverged
   namespace: openshift-cnv
-  resourceVersion: "15371295"
-  selfLink: /api/v1/namespaces/openshift-cnv/configmaps/kubevirt-config
-  uid: <uuid>
+spec:
+  liveMigrationConfig: <1>
+    bandwidthPerMigration: 64Mi
+    completionTimeoutPerGiB: 800
+    parallelMigrationsPerCluster: 5
+    parallelOutboundMigrationsPerNode: 2
+    progressTimeout: 150
 ----
+<1> In this example, the `spec.liveMigrationConfig` array contains the default values for each field.
++
+[NOTE]
+====
+You can restore the default value for any `spec.liveMigrationConfig` field by deleting that key/value pair and saving the file. For example, delete `progressTimeout: <value>` to restore the default `progressTimeout: 150`.
+====

--- a/virt/live_migration/virt-live-migration-limits.adoc
+++ b/virt/live_migration/virt-live-migration-limits.adoc
@@ -5,9 +5,9 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-Live migration limits and timeouts are applied so that migration processes do
+Apply live migration limits and timeouts so that migration processes do
 not overwhelm the cluster. Configure these settings by editing the
-`kubevirt-config` configuration file.
+`HyperConverged` custom resource (CR).
 
 include::modules/virt-configuring-live-migration-limits.adoc[leveloffset=+1]
 include::modules/virt-live-migration-limits-reftable.adoc[leveloffset=+1]


### PR DESCRIPTION
- [CNV-10277](https://issues.redhat.com/browse/CNV-10277)
- enterprise-4.8 only
- [Preview build](https://deploy-preview-33094--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits?utm_source=github&utm_campaign=bot_dp)
- This PR does not cover the default CPU model part of the Jira subtask (that will be covered in a release note)