### PR TITLE
TELCODOCS-256: stop using CoreDNS-mDNS in 4.8

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -7,6 +7,10 @@
 
 Installer-provisioned installation of {product-title} involves several network requirements by default. First, installer-provisioned installation involves a non-routable `provisioning` network for provisioning the operating system on each bare metal node and a routable `baremetal` network. Since installer-provisioned installation deploys `ironic-dnsmasq`, the networks should have no other DHCP servers running on the same broadcast domain. Network administrators must reserve IP addresses for each node in the {product-title} cluster.
 
+ifeval::[{product-version} > 4.7]
+{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. Once the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
+endif::[]
+
 .Network Time Protocol (NTP)
 
 ifeval::[{product-version} <= 4.7]


### PR DESCRIPTION
Added a note to stop using CoreDNS-mDNS in 4.8 to resolve node names to their IP addresses, thereby eliminating broadcast DNS traffic.

Fixes: [TELCODOCS-256](https://issues.redhat.com/browse/TELCODOCS-256)

See https://issues.redhat.com/browse/TELCODOCS-256 for additional details.

Signed-off-by: John Wilkins <jowilkin@redhat.com>
