### PR TITLE
OSDOCS-2230: Added OpenShift sandboxed containers 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -837,6 +837,18 @@ This feature was previously introduced as a Technology Preview feature in {produ
 
 For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Using manual mode with STS].
 
+[id="ocp-4.8-sandboxed-containers"]
+=== {sandboxed-containers-first}
+
+[id="ocp-4.8-sandboxed-containers-tp"]
+==== {sandboxed-containers-first} support on {product-title} (Technology Preview)
+
+{sandboxed-containers-first} 1.0.0 Technology Preview release introduces built-in support for running Kata Containers as an additional runtime. {sandboxed-containers-first} enables users to choose Kata Containers as an additional runtime to provide additional isolation for their workloads. The {sandboxed-containers-operator} automates the tasks of installing, removing, and updating Kata Containers. It allows for tracking the state of those tasks by describing the `KataConfig` custom resource.
+
+{sandboxed-containers-first} are only supported on bare metal. {op-system-first} is the only supported operating system for {sandboxed-containers-first} 1.0.0. Disconnected environments are not supported in {product-title} {product-version}.
+
+For more information, see xref:../sandboxed_containers/understanding-sandboxed-containers.adoc#understanding-sandboxed-containers[Understanding OpenShift sandboxed containers]
+
 [id="ocp-4-8-notable-technical-changes"]
 == Notable technical changes
 
@@ -1185,6 +1197,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |
 
+|OpenShift sandboxed containers
+|-
+|-
+|TP
+
 |Vertical Pod Autoscaler
 |TP
 |TP
@@ -1287,6 +1304,61 @@ You can attempt to resolve the issue with the steps in this link:https://kb.vmwa
 * An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace, at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*])
 
 * The Console Operator does not properly update the `Ingress` resource with the `componentRoutes` conditions for either of the console's routes (`console` or `downloads`). (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954148[*BZ#1954148*])
+
+* If you are using {sandboxed-containers-first}, you cannot use the `hostPath` volume in a {product-title} cluster to mount a file or directory from the host node’s file system into your pod.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
+
+* If you are running Fedora on {sandboxed-containers-first}, you need a workaround to install some packages. Some packages, like `iputils`, require file access permission changes that {product-title} does not grant to containers by default. To run containers that require such special permissions, it is necessary to add an annotation to the YAML file describing the workload, which tells `virtiofsd` to accept such file permissions for that workload. The required annotations are:
++
+[source,yaml]
+----
+io.katacontainers.config.hypervisor.virtio_fs_extra_args: [ "-o", "modcaps=+sys_admin", "-o", "xattr" ]
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1915377[*BZ#1915377*])
+
+* In the 4.8 release, adding a value to `kataConfgPoolSelector` by using the {product-title} web console causes `scheduling.nodeSelector` to be populated with an empty value. Pods that use `RuntimeClass` with the value of `kata` might be scheduled to nodes that do not have the Kata Containers runtime installed.
++
+To work around this issue, specify the `nodeSelector` value manually in the `RuntimeClass` `kata` by running the following command:
++
+[source,terminal]
+----
+$ oc edit runtimeclass kata
+----
++
+The following is an example of a `RuntimeClass` with the correct `nodeSelector` statement.
++
+[source,yaml]
+----
+apiVersion: node.k8s.io/v1
+handler: kata
+kind: RuntimeClass
+metadata:
+  creationTimestamp: "2021-06-14T12:54:19Z"
+  name: kata
+overhead:
+  podFixed:
+    cpu: 250m
+    memory: 350Mi
+scheduling:
+  nodeSelector:
+    custom-kata-pool: "true"
+----
++
+(link:https://issues.redhat.com/browse/KATA-764[*KATA-764*])
+
+* The {sandboxed-containers-operator} details page on Operator Hub contains a few missing fields. The missing fields do not prevent you from installing the {sandboxed-containers-operator} in 4.8.
++
+(link:https://issues.redhat.com/browse/KATA-826[*KATA-826*])
+
+* Creating multiple `KataConfig` custom resources results in a silent failure. The {product-title} web console does not provide a prompt to notify the user that creating more than one custom resource has failed.
++
+(link:https://issues.redhat.com/browse/KATA-725[*KATA-725*])
+
+* Sometimes the Operator Hub in the {product-title} web console does not display icons for an Operator.
++
+(link:https://issues.redhat.com/browse/KATA-804[*KATA-804*])
 
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Preview Links:  

- [OpenShift sandboxed containers](https://deploy-preview-33105--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4.8-sandboxed-containers). 
- [Technology Preview](https://deploy-preview-33105--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-technology-preview). See the table. I inserted a row with OpenShift sandboxed containers. 
- [Known Issues](https://deploy-preview-33105--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-known-issues). I added 2 bullets about Known Issues about OpenShift sandboxed containers.

Applies to 4.8 RN. 
https://issues.redhat.com/browse/OSDOCS-2230
QE and SME ack required. 
