### PR TITLE
Rel Notes doc text for 4.6.32 release

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2957,3 +2957,30 @@ link:https://access.redhat.com/solutions/6078721[{product-title} 4.6.31 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-32"]
+=== RHBA-2021:2157 - {product-title} 4.6.32 bug fix update
+
+Issued: 2021-06-08
+
+{product-title} release 4.6.32 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2157[RHBA-2021:2157] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2158[RHBA-2021:2158] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6100131[{product-title} 4.6.32 container image list]
+
+[id="ocp-4-6-32-bug-fixes"]
+==== Bug fixes
+
+* Previously, when creating a new binding from the *Role Bindings* tab of the *Role* page, the web console prefilled the incorrect role name and namespace in the form. With this release, the new binding has the default `cluster-admin` role. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1950490[*BZ#1950490*])
+
+* Previously, namespaces were missing from the Machine Config Operator `relatedObjects` resource, and logs for some on-premises services were not collected in `must-gather` as a result. With this release, the required namespaces are added to the Machine Config Operator `relatedObjects` resource and logs for on-premises services are collected in `must-gather`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955715[*BZ#1955715*])
+
+* Previously, both the Cloud Credential Operator (CCO) and the Cluster Version Operator (CVO) reported if the CCO deployment was unhealthy. This resulted in double reporting if there was an issue. With this release, the CCO no longer reports if its deployment is unhealthy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1958959[*BZ#1958959*])
+
+* Previously, for traffic originating in a member of a service and redirected by the load balancer to the same member, Open Virtual Network (OVN) changed the source IP address of the packets to the IP address of the load balancer. If a network policy was applied, this type of traffic was sometimes blocked unnecessarily. With this release, Kuryr opens traffic to the IP addresses of all services in the namespace of a network policy, and the traffic is not blocked. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1963846[*BZ#1963846*])
+
+[id="ocp-4-6-32-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
For release 8 June 2021

Preview: https://deploy-preview-33111--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-32