### PR TITLE
TELCODOCS-256: Release notes for Stop using CoreDNS-mDNS to resolve node names to their IP addresses

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -151,6 +151,11 @@ Packet data is not sent to the network flows collector. Packet-level metadata su
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/tracking-network-flows.adoc#tracking-network-flows[Tracking network flows].
 
+[id="ocp-4-8-coredns-mdns"]
+==== CoreDNS-mDNS no longer used to resolve node names to IP addresses
+
+{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. Once the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
+
 [id="ocp-4-8-preparation-HAProxy-2.2"]
 ==== Converting HTTP header names to support upgrading to {product-title} 4.8
 


### PR DESCRIPTION
Preview Link: https://deploy-preview-33112--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-coredns-mdns

Fixes: [TELCODOCS-256](https://issues.redhat.com/browse/TELCODOCS-256)

See https://issues.redhat.com/browse/TELCODOCS-256 for additional details.

Signed-off-by: John Wilkins <jowilkin@redhat.com>