### PR TITLE
OSDOCS-2088: Added quick start code snippet syntax reference

### DIFF
--- a/modules/quick-starts-accessing-and-executing-code-snippets.adoc
+++ b/modules/quick-starts-accessing-and-executing-code-snippets.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * web_console/creating-quick-start-tutorials.adoc
+
+[id="quick-starts-accessing-and-executing-code-snippets_{context}"]
+= Code snippet markdown reference
+
+You can execute a CLI code snippet when it is included in a quick start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
+
+[id="quick-starts-syntax-for-inline-code-snippets_{context}"]
+== Syntax for inline code snippets
+
+----
+`code block`{{copy}}
+`code block`{{execute}}
+----
+
+[NOTE]
+====
+If the `execute` syntax is used, the *Copy to clipboard* action is present whether you have the Web Terminal Operator installed or not.
+====
+
+[id="quick-starts-syntax-for-multi-line-code-snippets_{context}"]
+== Syntax for multi-line code snippets
+
+----
+```
+multi line code block
+```{{copy}}
+
+```
+multi line code block
+```{{execute}}
+----

--- a/web_console/creating-quick-start-tutorials.adoc
+++ b/web_console/creating-quick-start-tutorials.adoc
@@ -27,6 +27,8 @@ include::modules/quick-starts-supported-tags.adoc[leveloffset=+2]
 
 include::modules/quick-starts-highlighting-reference.adoc[leveloffset=+2]
 
+include::modules/quick-starts-accessing-and-executing-code-snippets.adoc[leveloffset=+2]
+
 include::modules/quick-start-content-guidelines.adoc[leveloffset=+1]
 
 [id="quick-start-tutorials-additional-resources"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2088
https://issues.redhat.com/browse/ODC-5653

Preview build: https://deploy-preview-33115--osdocs.netlify.app/openshift-enterprise/latest/web_console/creating-quick-start-tutorials?utm_source=github&utm_campaign=bot_dp#quick-starts-accessing-and-executing-code-snippets_creating-quick-start-tutorials

This targets 4.8