### PR TITLE
CNV-10206: Adding info about DV annotations 

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2770,6 +2770,8 @@ Topics:
       File: virt-reserving-pvc-space-fs-overhead
     - Name: Configuring CDI to work with namespaces that have a compute resource quota
       File: virt-configuring-cdi-for-namespace-resourcequota
+    - Name: Managing data volume annotations
+      File: virt-managing-data-volume-annotations
     - Name: Using preallocation for data volumes
       File: virt-using-preallocation-for-datavolumes
     - Name: Uploading local disk images by using the web console

--- a/modules/virt-dv-annotations.adoc
+++ b/modules/virt-dv-annotations.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-managing-data-volume-annotations.adoc
+
+[id="virt-dv-annotations_{context}"]
+= Example: Data volume annotations
+
+This example shows how you can configure data volume (DV) annotations to control which network the importer pod uses. The `v1.multus-cni.io/default-network: bridge-network` annotation causes the pod to use the multus network named `bridge-network` as its default network.
+If you want the importer pod to use both the default network from the cluster and the secondary multus network, use the `k8s.v1.cni.cncf.io/networks: <network_name>` annotation.
+
+.Multus network annotation example
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: DataVolume
+metadata:
+  name: dv-ann
+  annotations:
+      v1.multus-cni.io/default-network: bridge-network <1>
+spec:
+  source:
+      http:
+         url: "example.exampleurl.com"
+  pvc:
+    accessModes:
+      - ReadWriteOnce
+    resources:
+      requests:
+        storage: 1Gi
+----
+<1> Multus network annotation

--- a/virt/virtual_machines/virtual_disks/virt-managing-data-volume-annotations.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-managing-data-volume-annotations.adoc
@@ -1,0 +1,10 @@
+[id="virt-virt-managing-data-volume-annotations"]
+= Managing data volume annotations
+include::modules/virt-document-attributes.adoc[]
+:context: virt-managing-data-volume-annotations
+
+toc::[]
+
+Data volume (DV) annotations allow you to manage pod behavior. You can add one or more annotations to a data volume, which then propagates to the created importer pods.
+
+include::modules/virt-dv-annotations.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR covers Jira story [CNV-10206](https://issues.redhat.com/browse/CNV-10206) ( https://issues.redhat.com/browse/CNV-10206 ).

The story deals with new support for passing specific DV annotations as part of controlling pod behavior

CP: 4.8

Preview: https://deploy-preview-33116--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-managing-data-volume-annotations?utm_source=github&utm_campaign=bot_dp