### PR TITLE
GH#33080: [okd] Pipeline information is not quite accurate for 4.7

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -583,7 +583,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Pipelines CLI (tkn)
   Dir: tkn_cli
-  Distros: openshift-enterprise,openshift-origin
+  Distros: openshift-enterprise
   Topics:
   - Name: Installing tkn
     File: installing-tkn
@@ -1338,7 +1338,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin,openshift-dedicated
 - Name: Pipelines
   Dir: pipelines
-  Distros: openshift-enterprise,openshift-origin
+  Distros: openshift-enterprise
   Topics:
   - Name: OpenShift Pipelines release notes
     File: op-release-notes


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/33080

OpenShift Pipelines not available in OKD.

Previews 
No Pipelines link in _CI/CD_ book:  http://file.rdu.redhat.com/~mburke/issue-33080/cicd/builds/understanding-image-builds.html
No Pipelines CLI in _CLI tools_ book: http://file.rdu.redhat.com/~mburke/issue-33080/cli_reference/openshift_cli/getting-started-cli.html