### PR TITLE
CNV-10282: disable TLS with the HCO

### DIFF
--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -5,7 +5,7 @@
 [id="virt-disabling-tls-for-registry_{context}"]
 = Disabling TLS for a container registry to use as insecure registry
 
-You can disable TLS (transport layer security) for a container registry by adding the registry to the `cdi-insecure-registries` config map.
+You can disable TLS (transport layer security) for one or more container registries by editing the `insecureRegistries` field of the `HyperConverged` custom resource.
 
 .Prerequisites
 
@@ -13,11 +13,19 @@ You can disable TLS (transport layer security) for a container registry by addin
 
 .Procedure
 
-* Add the registry to the `cdi-insecure-registries` config map in the `cdi` namespace.
+* Edit the `HyperConverged` custom resource and add a list of insecure registries to the `spec.storageImport.insecureRegistries` field.
 +
-[source,terminal]
+[source,yaml]
 ----
-$ oc patch configmap cdi-insecure-registries -n cdi \
-  --type merge -p '{"data":{"mykey": "<insecure-registry-host>:5000"}}' <1>
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+  storageImport:
+    insecureRegistries: <1>
+      - "private-registry-example-1:5000"
+      - "private-registry-example-2:5000"
 ----
-<1> Replace `<insecure-registry-host>` with the registry hostname.
+<1> Replace the examples in this list with valid registry host names.

--- a/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
@@ -24,7 +24,7 @@ in the same namespace as the data volume and referenced in the data volume confi
 
 * To import a container disk:
 ** You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-preparing-container-disk-for-vms_virt-using-container-disks-with-vms[prepare a container disk from a virtual machine image] and store it in your container registry before importing it.
-** If the container registry does not have TLS, you must xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms[add the registry to the `cdi-insecure-registries` config map] before you can import a container disk from it.
+** If the container registry does not have TLS, you must xref:../../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms[add the registry to the `insecureRegistries` field of the `HyperConverged` custom resource] before you can import a container disk from it.
 
 * You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass-in-cdi_virt-preparing-cdi-scratch-space[define a storage class or prepare CDI scratch space]
 for this operation to complete successfully.


### PR DESCRIPTION
- [CNV-10282](https://issues.redhat.com/browse/CNV-10282)
- enterprise-4.8 only
- [Preview build](https://deploy-preview-33118--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.html#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms)