### PR TITLE
Fix typo in file cli_reference/openshift_cli/getting-started-cli.adoc

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -75,7 +75,7 @@ endif::[]
 ifndef::openshift-origin[]
 . Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
 . Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command-line interface* section, select *Linux* from the drop-down menu and click *Download command-line tools*.
+. In the *Command line interface* section, select *Linux* from the drop-down menu and click *Download command-line tools*.
 endif::[]
 . Unpack the archive:
 +
@@ -113,7 +113,7 @@ endif::[]
 ifndef::openshift-origin[]
 . Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
 . Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command-line interface* section, select *Windows* from the drop-down menu and click *Download command-line tools*.
+. In the *Command line interface* section, select *Windows* from the drop-down menu and click *Download command-line tools*.
 endif::[]
 . Unzip the archive with a ZIP program.
 . Move the `oc` binary to a directory that is on your `PATH`.
@@ -146,7 +146,7 @@ endif::[]
 ifndef::openshift-origin[]
 . Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
 . Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command-line interface* section, select *MacOS* from the drop-down menu and click *Download command-line tools*.
+. In the *Command line interface* section, select *MacOS* from the drop-down menu and click *Download command-line tools*.
 endif::[]
 . Unpack and unzip the archive.
 . Move the `oc` binary to a directory on your PATH.


### PR DESCRIPTION
@vikram-redhat There is one minor issue on the section naming(no `-` between words), minimum version that the change applies to should be 4.5 in my opinion, could you arrange someone to review it? Thanks.

Attached the correct one on the screenshot just captured, fyi.
<img width="680" alt="oc-cli" src="https://user-images.githubusercontent.com/46341043/120915903-06401d00-c6d9-11eb-8056-ec3a305b821a.png">
