### PR TITLE
BZ1962494 fix: Migration preparation from BPG added to MTC

### DIFF
--- a/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
@@ -7,17 +7,26 @@ toc::[]
 
 Before you migrate your application workloads with the {mtc-full} ({mtc-short}), review the following checklists.
 
-[id="source-cluster-checklist_{context}"]
-== Source cluster checklist
+[id="resources_{context}"]
+== Resources
+
+* [ ] If your application uses an internal service network or an external route for communicating with services, the relevant route exists.
+* [ ] If your application uses cluster-level resources, you have re-created them on the target cluster.
+* [ ] You have xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-excluding-resources_advanced-migration-options-3-4[excluded] persistent volumes (PVs), image streams, and other resources that you do not want to migrate.
+* [ ] PV data has been backed up in case an application displays unexpected behavior after migration and corrupts the data.
+
+[id="source-cluster_{context}"]
+== Source cluster
 
 * [ ] The cluster meets the link:https://docs.openshift.com/container-platform/3.11/install/prerequisites.html#hardware[minimum hardware requirements].
 * [ ] You have installed the correct legacy {mtc-full} Operator version:
 ** `operator-3.7.yml` on {product-title} version 3.7.
 ** `operator.yml` on {product-title} versions 3.9 to 4.5.
+* [ ] The {mtc-short} version is the same on all clusters.
 * [ ] All nodes have an active {product-title} subscription.
-* [ ] All the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-default-storage-class[run-once tasks] have been performed.
-* [ ] All the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/environment_health_checks.html[environment health checks] have been performed.
-* [ ] You have checked for persistent volumes (PVs) with abnormal configurations  stuck in a *Terminating* state by running the following command:
+* [ ] You have performed all the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/run_once_tasks.html#day-two-guide-default-storage-class[run-once tasks].
+* [ ] You have performed all the link:https://docs.openshift.com/container-platform/3.11/day_two_guide/environment_health_checks.html[environment health checks].
+* [ ] You have checked for PVs with abnormal configurations  stuck in a *Terminating* state by running the following command:
 +
 [source,terminal]
 ----
@@ -42,13 +51,7 @@ $ oc get pods --all-namespaces --field-selector=status.phase=Running \
 +
 Even if the pods are in a *Running* state, a high restart count might indicate underlying problems.
 
-* [ ] You have deleted old images by running the following command:
-+
-[source,terminal]
-----
-$ oc adm prune images
-----
-
+* [ ] You have removed old builds, deployments, and images from each namespace to be migrated by xref:../applications/pruning-objects.adoc#pruning-objects[pruning].
 * [ ] The internal registry uses a link:https://docs.openshift.com/container-platform/3.11/scaling_performance/optimizing_storage.html#registry[supported storage type].
 * [ ] Direct image migration only: The internal registry is link:https://docs.openshift.com/container-platform/3.11/install_config/registry/securing_and_exposing_registry.html#exposing-the-registry[exposed] to external traffic.
 * [ ] You can read and write images to the registry.
@@ -64,8 +67,8 @@ $ oc get csr -A | grep pending -i
 
 * [ ] The link:https://docs.openshift.com/container-platform/3.11/install_config/configuring_authentication.html#overview[identity provider] is working.
 
-[id="target-cluster-checklist_{context}"]
-== Target cluster checklist
+[id="target-cluster_{context}"]
+== Target cluster
 
 * [ ] You have installed {mtc-full} Operator version 1.5.1.
 * [ ] All xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#migration-prerequisites_migrating-applications-3-4[{mtc-short} prerequisites] are met.
@@ -84,10 +87,20 @@ NFS does not require a defined storage class.
 If an application uses an internal image in the `openshift` namespace that is not supported by {product-title} {product-version}, you can manually update the xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-updating-deprecated-internal-images_troubleshooting-3-4[{product-title} 3 image stream tag] with `podman`.
 * [ ] The target cluster and the replication repository have sufficient storage space.
 * [ ] The xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[identity provider] is working.
+* [ ] DNS records for your application exist on the target cluster.
 * [ ] Set the value of the `annotation.openshift.io/host.generated` parameter to `true` for each {product-title} route to update its host name for the target cluster. Otherwise, the migrated routes retain the source cluster host name.
+* [ ] Certificates that your application uses exist on the target cluster.
+* [ ] You have configured appropriate firewall rules on the target cluster.
+* [ ] You have correctly configured load balancing on the target cluster.
+* [ ] If you migrate objects to an existing namespace on the target cluster that has the same name as the namespace being migrated from the source, the target namespace contains no objects of the same name and type as the objects being migrated.
++
+[NOTE]
+====
+Do not create namespaces for your application on the target cluster before migration because this might cause quotas to change.
+====
 
-[id="performance-checklist_{context}"]
-== Performance checklist
+[id="performance_{context}"]
+== Performance
 
 * [ ] The migration network has a minimum throughput of 10 Gbps.
 * [ ] The clusters have sufficient resources for migration.


### PR DESCRIPTION
For versions 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1997024

Migration preparation steps from BPG added to premigration-checklists-3-4.adoc

Direct link to doc preview: hhttps://deploy-preview-33129--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/premigration-checklists-3-4