### PR TITLE
[WIP] Multiarch-1252: KVM updates for 4.8

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -65,6 +65,8 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+1]
 
+include::modules/installation-three-node-cluster.adoc[leveloffset=+1]
+
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-kvm-user-infra-machines-iso.adoc[leveloffset=+1]
@@ -91,7 +93,7 @@ include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffs
 
 .Additional resources
 
-* See also link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within OpenShift4 nodes without SSH].
+* link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within OpenShift4 nodes without SSH].
 
 == Next steps
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -71,6 +71,8 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+include::modules/installation-three-node-cluster.adoc[leveloffset=+1]
+
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-kvm-user-infra-machines-iso.adoc[leveloffset=+1]


### PR DESCRIPTION
- OCP version: 4.8 and later
- JIRA issue: https://issues.redhat.com/browse/MULTIARCH-1252, https://issues.redhat.com/browse/MULTIARCH-770
- Google review doc:https://docs.google.com/document/d/1Gz4gYWwyGqxRj9mVVLeL-nSHW71cdBk_ajCqQBz9eGo/edit?usp=sharing
- Reviewer: Holger Wolf, Wolfgang Voesch, Phil Chan
- Preview pages:
  - [Installing a cluster with KVM on IBM Z and LinuxONE](https://deploy-preview-33137--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html)
  - [Installing a cluster with KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-33137--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html)