### PR TITLE
Change name of planning assembly

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1967,7 +1967,7 @@ Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: About migrating from OpenShift Container Platform 3 to 4
   File: about-migrating-from-3-to-4
-- Name: Planning your migration
+- Name: Differences between OpenShift Container Platform 3 and 4
   File: planning-migration-3-4
 - Name: About the Migration Toolkit for Containers
   File: about-mtc-3-4

--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -1,25 +1,18 @@
 [id="planning-migration-3-4"]
-= Planning your migration
+= Differences between {product-title} 3 and 4
 include::modules/common-attributes.adoc[]
 :context: planning-migration-3-4
 
 toc::[]
 
-Before performing your migration to {product-title} {product-version}, it is important to take the time to properly plan for the transition. {product-title} 4 introduces architectural changes and enhancements, so the procedures that you used to manage your {product-title} 3 cluster might not apply for {product-title} 4.
-
-[NOTE]
-====
-This planning document assumes that you are transitioning from {product-title} 3.11 to {product-title} {product-version}.
-====
+{product-title} {product-version} introduces architectural changes and enhancements/ The procedures that you used to manage your {product-title} 3 cluster might not apply to {product-title} 4.
 
 ifndef::openshift-origin[]
-This document provides high-level information on the most important xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#migration-comparing-ocp-3-4[differences between {product-title} 3 and {product-title} 4] and the most noteworthy xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#migration-considerations[migration considerations]. For detailed information on configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For detailed information on new features and other notable technical changes, review the xref:../release_notes/ocp-4-8-release-notes.adoc#ocp-4-8-release-notes[OpenShift Container Platform 4.8 release notes].
+For information on configuring your {product-title} 4 cluster, review the appropriate sections of the {product-title} documentation. For information on new features and other notable technical changes, review the xref:../release_notes/ocp-4-8-release-notes.adoc#ocp-4-8-release-notes[OpenShift Container Platform 4.8 release notes].
 endif::[]
 
 It is not possible to upgrade your existing {product-title} 3 cluster to {product-title} 4. You must start with a new {product-title} 4 installation. Tools are available to assist in migrating your control plane settings and application workloads.
 
-[id="migration-comparing-ocp-3-4"]
-== Comparing {product-title} 3 and {product-title} 4
 With {product-title} 3, administrators individually deployed {op-system-base-full} hosts, and then installed {product-title} on top of these hosts to form a cluster. Administrators were responsible for properly configuring these hosts and performing updates.
 
 {product-title} 4 represents a significant change in the way that {product-title} clusters are deployed and managed. {product-title} 4 includes new technologies and functionality, such as Operators, machine sets, and {op-system-first}, which are core to the operation of the cluster. This technology shift enables clusters to self-manage some functions previously performed by administrators. This also ensures platform stability and consistency, and simplifies installation and scaling.
@@ -27,10 +20,10 @@ With {product-title} 3, administrators individually deployed {op-system-base-ful
 For more information, see xref:../architecture/architecture.adoc#architecture[OpenShift Container Platform architecture].
 
 [id="migration-differences-architecture"]
-=== Architecture differences
+== Architecture differences
 
 [discrete]
-==== Immutable infrastructure
+=== Immutable infrastructure
 
 {product-title} 4 uses {op-system-first}, which is designed to run containerized applications, and provides efficient installation, Operator-based management, and simplified upgrades. {op-system} is an immutable container host, rather than a customizable operating system like {op-system-base}. {op-system} enables {product-title} 4 to manage and automate the deployment of the underlying container host. {op-system} is a part of {product-title}, which means that everything runs inside a container and is deployed using {product-title}.
 
@@ -39,17 +32,17 @@ In {product-title} 4, control plane nodes must run {op-system}, ensuring that fu
 For more information, see xref:../architecture/architecture-rhcos.adoc#architecture-rhcos[{op-system-first}].
 
 [discrete]
-==== Operators
+=== Operators
 
 Operators are a method of packaging, deploying, and managing a Kubernetes application. Operators ease the operational complexity of running another piece of software. They watch over your environment and use the current state to make decisions in real time. Advanced Operators are designed to upgrade and react to failures automatically.
 
 For more information, see xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Understanding Operators].
 
 [id="migration-differences-install"]
-=== Installation and update differences
+== Installation and update differences
 
 [discrete]
-==== Installation process
+=== Installation process
 
 To install {product-title} 3.11, you prepared your {op-system-base-full} hosts, set all of the configuration values your cluster needed, and then ran an Ansible playbook to install and set up your cluster.
 
@@ -62,52 +55,52 @@ If you want to add {op-system-base-full} ({op-system-base}) worker machines to y
 endif::[]
 
 [discrete]
-==== Infrastructure options
+=== Infrastructure options
 
 In {product-title} 3.11, you installed your cluster on infrastructure that you prepared and maintained. In addition to providing your own infrastructure, {product-title} 4 offers an option to deploy a cluster on infrastructure that the {product-title} installation program provisions and the cluster maintains.
 
 For more information, see xref:../architecture/architecture-installation.adoc#installation-overview_architecture-installation[OpenShift Container Platform installation overview].
 
 [discrete]
-==== Upgrading your cluster
+=== Upgrading your cluster
 
 In {product-title} 3.11, you upgraded your cluster by running Ansible playbooks. In {product-title} {product-version}, the cluster manages its own updates, including updates to {op-system-first} on cluster nodes. You can easily upgrade your cluster by using the web console or by using the `oc adm upgrade` command from the OpenShift CLI and the Operators will automatically upgrade themselves. If your {product-title} {product-version} cluster has {op-system-base} worker machines, then you will still need to run an Ansible playbook to upgrade those worker machines.
 
 For more information, see xref:../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[Updating clusters].
 
 [id="migration-considerations"]
-== Migration considerations
+= Migration considerations
 
 Review the changes and other considerations that might affect your transition from {product-title} 3.11 to {product-title} 4.
 
 [id="migration-preparing-storage"]
-=== Storage considerations
+== Storage considerations
 
 Review the following storage changes to consider when transitioning from {product-title} 3.11 to {product-title} {product-version}.
 
 [discrete]
-==== Local volume persistent storage
+=== Local volume persistent storage
 
 Local storage is only supported by using the Local Storage Operator in {product-title} {product-version}. It is not supported to use the local provisioner method from {product-title} 3.11.
 
 For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
 
 [discrete]
-==== FlexVolume persistent storage
+=== FlexVolume persistent storage
 
 The FlexVolume plug-in location changed from {product-title} 3.11. The new location in {product-title} {product-version} is `/etc/kubernetes/kubelet-plugins/volume/exec`. Attachable FlexVolume plug-ins are no longer supported.
 
 For more information, see xref:../storage/persistent_storage/persistent-storage-flexvolume.adoc#persistent-storage-using-flexvolume[Persistent storage using FlexVolume].
 
 [discrete]
-==== Container Storage Interface (CSI) persistent storage
+=== Container Storage Interface (CSI) persistent storage
 
 Persistent storage using the Container Storage Interface (CSI) was link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] in {product-title} 3.11. CSI version 1.1.0 is fully supported in {product-title} {product-version}, but does not ship with any CSI drivers. You must install your own driver.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-using-csi[Persistent storage using the Container Storage Interface (CSI)].
 
 [discrete]
-==== Red Hat OpenShift Container Storage
+=== Red Hat OpenShift Container Storage
 
 Red Hat OpenShift Container Storage 3, which is available for use with {product-title} 3.11, uses Red Hat Gluster Storage as the backing storage.
 
@@ -116,7 +109,7 @@ Red Hat OpenShift Container Storage 4, which is available for use with {product-
 For more information, see xref:../storage/persistent_storage/persistent-storage-ocs.adoc#red-hat-openshift-container-storage[Persistent storage using Red Hat OpenShift Container Storage] and the link:https://access.redhat.com/articles/4731161[interoperability matrix] article.
 
 [discrete]
-==== Unsupported persistent storage options
+=== Unsupported persistent storage options
 
 Support for the following persistent storage options from {product-title} 3.11 has changed in {product-title} {product-version}:
 
@@ -129,12 +122,12 @@ If you used one of these in {product-title} 3.11, you must choose a different pe
 For more information, see xref:../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
 
 [id="migration-preparing-networking"]
-=== Networking considerations
+== Networking considerations
 
 Review the following networking changes to consider when transitioning from {product-title} 3.11 to {product-title} {product-version}.
 
 [discrete]
-==== Network isolation mode
+=== Network isolation mode
 
 The default network isolation mode for {product-title} 3.11 was `ovs-subnet`, though users frequently switched to use `ovn-multitenant`. The default network isolation mode for {product-title} {product-version} is controlled by a network policy.
 
@@ -143,45 +136,45 @@ If your {product-title} 3.11 cluster used the `ovs-subnet` or `ovs-multitenant` 
 For more information, see xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
 
 [id="migration-preparing-logging"]
-=== Logging considerations
+== Logging considerations
 
 Review the following logging changes to consider when transitioning from {product-title} 3.11 to {product-title} {product-version}.
 
 [discrete]
-==== Deploying OpenShift Logging
+=== Deploying OpenShift Logging
 
 {product-title} 4 provides a simple deployment mechanism for OpenShift Logging, by using a Cluster Logging custom resource.
 
 For more information, see xref:../logging/cluster-logging-deploying.adoc#cluster-logging-deploying_cluster-logging-deploying[Installing OpenShift Logging].
 
 [discrete]
-==== Aggregated logging data
+=== Aggregated logging data
 
 You cannot transition your aggregate logging data from {product-title} 3.11 into your new {product-title} 4 cluster.
 
 For more information, see xref:../logging/cluster-logging.adoc#cluster-logging-about_cluster-logging[About OpenShift Logging].
 
 [discrete]
-==== Unsupported logging configurations
+=== Unsupported logging configurations
 
 Some logging configurations that were available in {product-title} 3.11 are no longer supported in {product-title} {product-version}.
 
 For more information on the explicitly unsupported logging cases, see xref:../logging/config/cluster-logging-maintenance-support.adoc#cluster-logging-maintenance-and-support[Maintenance and support].
 
 [id="migration-preparing-security"]
-=== Security considerations
+== Security considerations
 
 Review the following security changes to consider when transitioning from {product-title} 3.11 to {product-title} {product-version}.
 
 [discrete]
-==== Unauthenticated access to discovery endpoints
+=== Unauthenticated access to discovery endpoints
 
 In {product-title} 3.11, an unauthenticated user could access the discovery endpoints (for example, [x-]`/api/*` and [x-]`/apis/*`). For security reasons, unauthenticated access to the discovery endpoints is no longer allowed in {product-title} {product-version}. If you do need to allow unauthenticated access, you can configure the RBAC settings as necessary; however, be sure to consider the security implications as this can expose internal cluster components to the external network.
 
 // TODO: Anything to xref to, or additional details?
 
 [discrete]
-==== Identity providers
+=== Identity providers
 
 Configuration for identity providers has changed for {product-title} 4, including the following notable changes:
 
@@ -191,17 +184,17 @@ Configuration for identity providers has changed for {product-title} 4, includin
 For more information, see xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[Understanding identity provider configuration].
 
 [discrete]
-==== OAuth token storage format
+=== OAuth token storage format
 
 Newly created OAuth HTTP bearer tokens no longer match the names of their OAuth access token objects. The object names are now a hash of the bearer token and are no longer sensitive. This reduces the risk of leaking sensitive information.
 
 [id="migration-preparing-monitoring"]
-=== Monitoring considerations
+== Monitoring considerations
 
 Review the following monitoring changes to consider when transitioning from {product-title} 3.11 to {product-title} {product-version}.
 
 [discrete]
-==== Alert for monitoring infrastructure availability
+=== Alert for monitoring infrastructure availability
 
 The default alert that triggers to ensure the availability of the monitoring structure was called `DeadMansSwitch` in {product-title} 3.11. This was renamed to `Watchdog` in {product-title} 4. If you had PagerDuty integration set up with this alert in {product-title} 3.11, you must set up the PagerDuty integration for the `Watchdog` alert in {product-title} 4.
 


### PR DESCRIPTION
Change name of current planning assembly to "Differences between OCP 3 and 4". Will be adding a new planning assembly with modules.

4.5+

Preview: https://deploy-preview-33138--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/planning-migration-3-4.html

Does not require QE. Does not require CP because the change has been added to existing PRs.

Ready for peer review.