### PR TITLE
Bug 1975846: [DOCS] Fix wrong JSON bool value in a imagestream trigger example annotation

### DIFF
--- a/modules/images-triggering-updates-imagestream-changes-kubernetes-about.adoc
+++ b/modules/images-triggering-updates-imagestream-changes-kubernetes-about.adoc
@@ -22,7 +22,7 @@ Value:
      "namespace": "myapp" <3>
    },
    "fieldPath": "spec.template.spec.containers[?(@.name==\"web\")].image", <4>
-   "paused": "false" <5>
+   "paused": false <5>
  },
  ...
 ]


### PR DESCRIPTION
* Description: JSON boolean type can be true/false, not "true"/"false", replace "false" with false. This wrong example causes an error to convert JSON data type in "openshift-controller" pod of "openshift-controller-manager" project, it also ignores image trigger events.
* You can verify the following error logs from "openshift-controller" pod of "openshift-controller-manager" project, if you specify "false" to "paused:" instead of false.
~~~
unable to extract cache data from *v1.Deployment: json: cannot unmarshal string into Go struct field ObjectFieldTrigger.paused of type bool
~~~
* Reference: https://bugzilla.redhat.com/show_bug.cgi?id=1975846