### PR TITLE
Telcodocs 85 RN: 4.6 Release Notes description for Intel N3000 and ACC100 cards

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -576,6 +576,28 @@ In addition to the features provided in the previous pre-releases, this version 
 * Improvements to supportability, such as integration gathering and better status reporting.
 * A method for in-field emergency configuration overrides was devised and documented.
 
+[id="ocp-4-6-optimizing-data-plane-performance-with-intel-devices"]
+==== Optimizing data plane performance with Intel devices
+
+{product-title} {product-version} supports the:
+
+* OpenNESS Operator for Intel FPGA PAC N3000
+* OpenNESS SR-IOV Operator for Wireless FEC Accelerators
+
+[NOTE]
+====
+The N3000 Operator requires a prebuilt driver container with the Open Programmable Accelerator Engine (OPAE) out of tree kernel modules. The prebuilt driver container is built and shipped by Intel and is currently supported with {product-title} 4.6.16.
+If a different {product-title} version is requested contact Intel through their premier support portal at link:http://premiersupport.intel.com[Intel® Premier Support Access] or at mailto:openness.n3000.operator@intel.com[openness.n3000.operator@intel.com].
+
+For more details, see link:https://catalog.redhat.com/software/operators/detail/6001a748e4e3f23b0b6ad765[OpenNESS Operator for Wireless FEC Accelerators].
+====
+
+These Operators support the requirements of vRAN deployments for low power, cost, and latency, while also delivering the capacity to manage spikes in performance for a range of use cases. One of the most compute-intensive 4G and 5G workloads is RAN layer 1 (L1) forward error correction (FEC), which resolves data transmission errors over unreliable or noisy communication channels.
+
+Delivering high performance FEC is critical to 5G maintaining high performance as it matures and as more users depend on the network. FEC has been typically implemented on Field Programmable Gate Arrays (FPGA) accelerator cards, like the Intel PAC N300 and more recently on the Intel vRAN Dedicated Accelerator ACC100.
+
+For more information, see xref:../scalability_and_performance/cnf-optimize-data-performance-n3000.adoc#cnf-optimize-data-performance-n3000[Optimizing data plane performance with the Intel FPGA PAC N3000 and Intel vRAN Dedicated Accelerator ACC100].
+
 [id="ocp-4-6-dev-exp"]
 === Developer experience
 
@@ -3035,18 +3057,18 @@ link:https://access.redhat.com/solutions/6128971[{product-title} 4.6.35 containe
 [id="ocp-4-6-35-cluster-operator-gatherer-enhancement"]
 ===== Insights Operator enhancement
 
-With this update, the Insights Operator `Gather` method can now collect logs from pods that are related to unhealthy Operators, and pods that are co-located in the same namespace as the Operator. This allows the Insights Operator to determine the namespace associated with the Operator and include pod logs in the bundle. As a result, the Insights Operator is now collecting logs from unhealthy pods not only related to the Operator, but from every pod that lives in the operator namespace.  
+With this update, the Insights Operator `Gather` method can now collect logs from pods that are related to unhealthy Operators, and pods that are co-located in the same namespace as the Operator. This allows the Insights Operator to determine the namespace associated with the Operator and include pod logs in the bundle. As a result, the Insights Operator is now collecting logs from unhealthy pods not only related to the Operator, but from every pod that lives in the operator namespace.
 
 [id="ocp-4-6-35-bug-fixes"]
 ==== Bug fixes
 
 * Previously, when starting a single-stack IPv6 cluster on nodes with IPv4 address, the kubelet might have used the IPv4 IP instead of the IPv6 IP for the node IP. Consequently, host network pods would have IPv4 IPs rather than IPv6 IPs, which made them unreachable from IPv6-only pods. This update fixes the node-IP-picking code, which results in the kubelet using the IPv6 IPs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942488[*BZ#1942488*])
 
-* The fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1953097[*BZ#1953097*] enabled the CoreDNS `bufsize` plug-in with a size of 1232 bytes. Some primitive DNS resolvers are not capable of receiving DNS response messages over UDP that are greater than 512 bytes. Consequently, some DNS resolvers, such as Go's internal DNS library, are unable to receive verbose DNS responses from the DNS Operator. This update sets the CoreDNS `bufsize` to 512 bytes for all servers. As a result, UDP DNS messages are now properly received. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970140[*BZ#1970140*]) 
+* The fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1953097[*BZ#1953097*] enabled the CoreDNS `bufsize` plug-in with a size of 1232 bytes. Some primitive DNS resolvers are not capable of receiving DNS response messages over UDP that are greater than 512 bytes. Consequently, some DNS resolvers, such as Go's internal DNS library, are unable to receive verbose DNS responses from the DNS Operator. This update sets the CoreDNS `bufsize` to 512 bytes for all servers. As a result, UDP DNS messages are now properly received. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970140[*BZ#1970140*])
 
-* Previously, a lack of proper timeouts when executing HTTP connections left connections opened. As a result, these connections accumulated until reaching the maximum limit, and consequently the Operator would become incapable of processing incoming events. This update adds timeouts to the HTTP client used by the Operator, which ensures that open connections are closed after the timeout is reached. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1959563[*BZ#1959563*]) 
+* Previously, a lack of proper timeouts when executing HTTP connections left connections opened. As a result, these connections accumulated until reaching the maximum limit, and consequently the Operator would become incapable of processing incoming events. This update adds timeouts to the HTTP client used by the Operator, which ensures that open connections are closed after the timeout is reached. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1959563[*BZ#1959563*])
 
-* Previously, removing `selector` from a service exposed via a route resulted in the duplication of `endpointslices` that would be created for the service's pods, which would trigger HAProxy reload errors due to duplicate server entries. This update filters out accidental duplicate server lines when writing out the HAProxy config file, so that deleting the selector from a service no longer causes the router to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965329[*BZ#1965329*]) 
+* Previously, removing `selector` from a service exposed via a route resulted in the duplication of `endpointslices` that would be created for the service's pods, which would trigger HAProxy reload errors due to duplicate server entries. This update filters out accidental duplicate server lines when writing out the HAProxy config file, so that deleting the selector from a service no longer causes the router to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965329[*BZ#1965329*])
 
 [id="ocp-4-6-35-upgrading"]
 ==== Upgrading


### PR DESCRIPTION
Release notes description for https://issues.redhat.com/browse/CNF-1498 and https://issues.redhat.com/browse/CNF-620. 

PR preview link https://deploy-preview-33147--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-optimizing-data-plane-performance-with-intel-devices