### PR TITLE
OSDOCS-1880: Cloud/Cluster Infra 4.8 Release Notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -279,6 +279,10 @@ For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.a
 [id="ocp-4-8-machine-api"]
 === Machine API
 
+[id="ocp-4-8-vsphere-machine-autoscaler-to-from-zero"]
+==== Scaling machines running in vSphere to and from zero with the cluster autoscaler
+
+When running machines in vSphere, you can now set the `minReplicas` value to `0` in the `MachineAutoscaler` resource definition. When this value is set to `0`, the cluster autoscaler scales the machine set to and from zero depending on if the machines are in use. For more information, see the xref:../machine_management/applying-autoscaling.html#machine-autoscaler-cr_applying-autoscaling[MachineAutoscaler resource definition].
 
 [id="ocp-4-8-nodes"]
 === Nodes


### PR DESCRIPTION
4.8 Cloud/Cluster Infra release notes epic: https://issues.redhat.com/browse/OSDOCS-1880

Preview: https://deploy-preview-33148--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-machine-api