### PR TITLE
OSSMDOC-326 Note about Jaeger daemonset support.

### DIFF
--- a/modules/jaeger-deployment-best-practices.adoc
+++ b/modules/jaeger-deployment-best-practices.adoc
@@ -12,4 +12,6 @@ This module included in the following assemblies:
 
 * If you have a multitenant implementation and tenants are separated by namespaces, deploy a Jaeger instance to each tenant namespace.
 
+** Jaeger agent as a sidecar is the only supported configuration. Jaeger as a daemonset is not supported for multitenant installations or OpenShift Dedicated.
+
 * If you are installing Jaeger as part of Red Hat OpenShift Service Mesh, Jaeger resources must be installed in the same namespace as the `ServiceMeshControlPlane` resource.

--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -33,6 +33,11 @@ For additional information about {ProductName} lifecycle and supported configura
 
 * The Kiali observability console is only supported on the two most recent releases of the Chrome, Edge, Firefox, or Safari browsers.
 
+[id="ossm-supported-configurations-jaeger_{context}"]
+== Supported configurations for Distributed Tracing
+
+* Jaeger agent as a sidecar is the only supported configuration for Jaeger. Jaeger as a daemonset is not supported for multitenant installations or OpenShift Dedicated.
+
 [id="ossm-supported-configurations-adapters_{context}"]
 == Supported Mixer adapters
 


### PR DESCRIPTION
Adding note about lack of Jaeger support for daemonset on OpenShift Dedicated.  Added to both OSSM and Jaeger docs.

Preview 
https://deploy-preview-33182--osdocs.netlify.app/openshift-enterprise/latest/jaeger/jaeger_install/rhbjaeger-deploying.html#jager-deployment-best-practices_jaeger-deploying 

https://deploy-preview-33182--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-supported-configurations_ossm-release-notes

Eng review - jpkroehling
QE review - jkandasa
Peer review - 