### PR TITLE
OSDOCS-1895: Monitoring 4.8 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -635,6 +635,29 @@ For more information, see xref:../openshift_images/image-configuration.adoc#imag
 [id="ocp-4-8-monitoring"]
 === Monitoring
 
+[id="ocp-4-8-monitoring-alerting-rule-changes"]
+==== Alerting rule changes
+
+{product-title} 4.8 includes the following alerting rule changes:
+
+.Alerting rule changes
+[%collapsible]
+====
+* The `ThanosSidecarPrometheusDown` alert severity is updated from _critical_ to _warning_.
+* The `ThanosSidecarUnhealthy` alert severity is updated from _critical_ to _warning_.
+* The `ThanosQueryHttpRequestQueryErrorRateHigh` alert severity is updated from _critical_ to _warning_.
+* The `ThanosQueryHttpRequestQueryRangeErrorRateHigh` alert severity is updated from _critical_ to _warning_.
+* The `ThanosQueryInstantLatencyHigh` critical alert is removed. This alert fired if Thanos Querier had a high latency for instant queries.
+* The `ThanosQueryRangeLatencyHigh` critical alert is removed. This alert fired if Thanos Querier had a high latency for range queries.
+* For all Thanos Querier alerts, the `for` duration is increased to 1 hour.
+* For all Thanos sidecar alerts, the `for` duration is increased to 1 hour.
+
+[NOTE]
+=====
+Red Hat does not guarantee backward compatibility for metrics, recording rules, or alerting rules.
+=====
+====
+
 [id="ocp-4-8-monitoring-removed-API-alerts"]
 ==== Alerts and information on APIs in use that will be removed in the next release
 
@@ -644,6 +667,52 @@ For more information, see xref:../openshift_images/image-configuration.adoc#imag
 * `APIRemovedInNextEUSReleaseInUse` - for APIs that will be removed in the next {product-title} link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support] (EUS) release.
 
 You can use the new `APIRequestCount` API to track what is using the deprecated APIs. This allows you to plan whether any actions are required in order to upgrade to the next release.
+
+[id="ocp-4-8-monitoring-stack-dependency-version-updates"]
+==== Version updates to monitoring stack components and dependencies
+
+{product-title} 4.8 includes version updates to the following monitoring stack components and dependencies:
+
+* The Prometheus Operator is now on version 0.48.1.
+* Prometheus is now on version 2.26.1.
+* The `node-exporter` agent is now on version 1.1.2.
+* Thanos is now on version 0.20.2.
+* Grafana is now on version 7.5.5.
+
+[id="ocp-4-8-monitoring-kube-state-metrics-v2.0.0-upgrade"]
+==== kube-state-metrics upgraded to version 2.0.0
+
+`kube-state-metrics` is upgraded to version 2.0.0. The following metrics were deprecated in `kube-state-metrics` version 1.9 and are effectively removed in version 2.0.0:
+
+* Non-generic resource metrics for pods:
+** kube_pod_container_resource_requests_cpu_cores
+** kube_pod_container_resource_limits_cpu_cores
+** kube_pod_container_resource_requests_memory_bytes
+** kube_pod_container_resource_limits_memory_bytes
+* Non-generic resource metrics for nodes:
+** kube_node_status_capacity_pods
+** kube_node_status_capacity_cpu_cores
+** kube_node_status_capacity_memory_bytes
+** kube_node_status_allocatable_pods
+** kube_node_status_allocatable_cpu_cores
+** kube_node_status_allocatable_memory_bytes
+
+[id="ocp-4-8-monitoring-removed-grafana-alertmanager-ui-links"]
+==== Removed Grafana and Alertmanager UI links
+
+The link to the third-party Alertmanager UI is removed from the *Monitoring* -> *Alerting* page in the {product-title} web console. Additionally, the link to the third-party Grafana UI is removed from the *Monitoring* -> *Dashboards* page. You can still access the routes to the Grafana and Alertmanager UIs in the web console in the *Administrator* perspective by navigating to the *Networking* -> *Routes* page in the `openshift-monitoring` project.
+
+[id="ocp-4-8-monitoring-dashboards-updates-web-console"]
+==== Monitoring dashboard enhancements in the web console
+
+New enhancements are available on the *Monitoring* -> *Dashboards* page in the {product-title} web console:
+
+* When you zoom in on a single graph by selecting an area with the mouse, all other graphs now update to reflect the same time range.
+* Dashboard panels are now organized into groups, which you can expand and collapse.
+* Single-value panels now support changing color depending on their value.
+* Dashboard labels now display in the *Dashboard* drop-down list.
+* You can now specify a custom time range for a dashboard by selecting *Custom time range* in the *Time Range* drop-down list.
+* When applicable, you can now select the *All* option in a dashboard filter drop-down menu to display data for all of the options in that filter.
 
 [id="ocp-4-8-metering"]
 === Metering


### PR DESCRIPTION
4.8 Monitoring release notes epic: https://issues.redhat.com/browse/OSDOCS-1895

Based on 4.8 Monitoring [cluster-monitoring-operator] CHANGELOG: https://github.com/openshift/cluster-monitoring-operator/blob/master/CHANGELOG.md#48

Preview: https://deploy-preview-33188--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-monitoring