### PR TITLE
For 4.8 CSI/in-tree topics, add migration notice

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-cinder.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-cinder.adoc
@@ -21,6 +21,16 @@ For {product-title}, automatic migration from OpenStack Cinder in-tree to the CS
 With migration enabled, volumes provisioned using the existing in-tree plug-in are automatically migrated to use the OpenStack Cinder CSI driver. For more information, see xref:persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration feature].
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision Cinder storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
+
 include::modules/persistent-storage-csi-cinder-storage-class.adoc[leveloffset=+1]
 
 .Additional resources

--- a/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
@@ -29,8 +29,11 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-{product-title} defaults to using an in-tree, or non-CSI, driver to provision AWS EBS storage. Automatic migration from AWS EBS in-tree to the CSI driver is available as a Technology Preview feature.
-With automatic migration enabled, volumes provisioned using the existing in-tree driver are automatically migrated to use the AWS EBS CSI driver. For more information, see xref:persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision AWS EBS storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
 ====
 
 For information about dynamically provisioning AWS EBS persistent volumes in {product-title}, see xref:../../storage/persistent_storage/persistent-storage-aws.adoc#persistent-storage-aws[Persistent storage using AWS Elastic Block Store].

--- a/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-gcp-pd.adoc
@@ -21,7 +21,11 @@ To create CSI-provisioned persistent volumes (PVs) that mount to GCP PD storage 
 
 [IMPORTANT]
 ====
-{product-title} defaults to using an in-tree, or non-CSI, driver to provision GCP PD storage. This in-tree driver will be removed in a subsequent update of {product-title}. Volumes provisioned using the existing in-tree driver are planned for migration to the CSI driver at that time.
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision GCP PD storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
 ====
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]

--- a/storage/persistent_storage/persistent-storage-aws.adoc
+++ b/storage/persistent_storage/persistent-storage-aws.adoc
@@ -20,6 +20,15 @@ requested by users.
 
 [IMPORTANT]
 ====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision AWS EBS storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
+
+[IMPORTANT]
+====
 High-availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====

--- a/storage/persistent_storage/persistent-storage-azure.adoc
+++ b/storage/persistent_storage/persistent-storage-azure.adoc
@@ -19,6 +19,15 @@ requested by users.
 
 [IMPORTANT]
 ====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision Azure Disk storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
+
+[IMPORTANT]
+====
 High availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====

--- a/storage/persistent_storage/persistent-storage-cinder.adoc
+++ b/storage/persistent_storage/persistent-storage-cinder.adoc
@@ -13,8 +13,14 @@ shared across the {product-title} cluster.
 Persistent volume claims are specific to a project or namespace and can be
 requested by users.
 
-For {product-title}, automatic migration from OpenStack Cinder in-tree to the Container Storage Interface (CSI) driver is available as a Technology Preview (TP) feature.
-With migration enabled, volumes provisioned using the existing in-tree plug-in are automatically migrated to use the OpenStack Cinder CSI driver. For more information, see xref:../container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration feature].
+[IMPORTANT]
+====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision Cinder storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
 
 .Additional resources
 * For more information about how OpenStack Block Storage provides persistent block storage management for virtual hard drives, see link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/8/html-single/architecture_guide/index#comp-cinder[OpenStack Cinder].

--- a/storage/persistent_storage/persistent-storage-gce.adoc
+++ b/storage/persistent_storage/persistent-storage-gce.adoc
@@ -24,6 +24,15 @@ requested by users.
 
 [IMPORTANT]
 ====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision gcePD storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
+
+[IMPORTANT]
+====
 High availability of storage in the infrastructure is left to the underlying
 storage provider.
 ====

--- a/storage/persistent_storage/persistent-storage-vsphere.adoc
+++ b/storage/persistent_storage/persistent-storage-vsphere.adoc
@@ -18,6 +18,15 @@ shared across the {product-title} cluster.
 Persistent volume claims are specific to a project or namespace and can be
 requested by users.
 
+[IMPORTANT]
+====
+{product-title} defaults to using an in-tree (non-CSI) plug-in to provision vSphere storage.
+
+In future {product-title} versions, volumes provisioned using existing in-tree plug-ins are planned for migration to their equivalent CSI driver. CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
+
+After full migration, in-tree plug-ins will eventually be removed in future versions of {product-title}.
+====
+
 .Additional resources
 
 * link:https://www.vmware.com/au/products/vsphere.html[VMware vSphere]


### PR DESCRIPTION
Here's the notice text I'm proposing for 4.8 for CSI driver topics that have in-tree plugins, as well as in-tree plugin topics that have CSI drivers. The build fails for this PR due to the xref to the auto migration topic, which is on a separate PR https://github.com/openshift/openshift-docs/pull/31774.

Preview: https://deploy-preview-33190--osdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html
The notice text has been add to the following topics (CSIs and in-tree):
- AWS EBS
- GCE
- Cinder
- Azure Disk (CSI topic change is in this PR https://github.com/openshift/openshift-docs/pull/31491)
- vSphere (CSI topic change is in this PR https://github.com/openshift/openshift-docs/pull/31498)

PTAL @jsafrane, @gnufied, @huffmanca, @bertinatto, @tsmetana, @jhou1 @duanwei33