### PR TITLE
RHDEVDOCS-3052: Fix how `buildArgs` is capitalized

### DIFF
--- a/modules/builds-strategy-docker-build-arguments.adoc
+++ b/modules/builds-strategy-docker-build-arguments.adoc
@@ -4,7 +4,7 @@
 [id="builds-strategy-docker-build-arguments_{context}"]
 = Adding docker build arguments
 
-You can set link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[docker build arguments] using the `BuildArgs` array. The build arguments are passed to docker when a build is started.
+You can set link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[docker build arguments] using the `buildArgs` array. The build arguments are passed to docker when a build is started.
 
 [TIP]
 ====
@@ -13,7 +13,7 @@ See link:https://docs.docker.com/engine/reference/builder/#understand-how-arg-an
 
 .Procedure
 
-To set docker build arguments, add entries to the `BuildArgs` array, which is located in the `dockerStrategy` definition of the `BuildConfig` object. For example:
+To set docker build arguments, add entries to the `buildArgs` array, which is located in the `dockerStrategy` definition of the `BuildConfig` object. For example:
 
 [source,yaml]
 ----

--- a/modules/builds-strategy-docker-build.adoc
+++ b/modules/builds-strategy-docker-build.adoc
@@ -10,5 +10,5 @@
 
 [TIP]
 ====
-If you work with build arguments, see link:https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact[Understand how ARG and FROM interact] in the Dockerfile reference documentation.
+If you set Docker build arguments by using the `buildArgs` array, see link:https://docs.docker.com/engine/reference/builder/#understand-how-arg-and-from-interact[Understand how ARG and FROM interact] in the Dockerfile reference documentation.
 ====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.5, 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3052
- Direct link to doc preview: 
-- https://deploy-preview-33192--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/understanding-image-builds.html#builds-strategy-docker-build_understanding-image-builds
- https://deploy-preview-33192--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/build-strategies.html#builds-strategy-docker-build-arguments_build-strategies
- SME review:  @gabemontero 
- QE review: @kabirbhartiRH 
- Peer review: TBD
<- All reviews completed and approved. Ready to merge.>