### PR TITLE
Fix missing label on OpenShift Logging with multitenant isolation mode

### DIFF
--- a/modules/cluster-logging-deploy-multitenant.adoc
+++ b/modules/cluster-logging-deploy-multitenant.adoc
@@ -22,9 +22,14 @@ For example:
 $ oc adm pod-network join-projects --to=openshift-operators-redhat openshift-logging
 ----
 
-* If you configured multitenant isolation mode with the OpenShift SDN CNI plug-in set to the *NetworkPolicy* mode, create a network policy object in the `openshift-logging` namespace that allows ingress from the `openshift-operators-redhat` project to the `openshift-logging` project.
+* If you configured multitenant isolation mode with the OpenShift SDN CNI plug-in set to the *NetworkPolicy* mode, set a label on the `openshift-operators-redhat` namespace and create a network policy object in the `openshift-logging` namespace that allows ingress from the `openshift-operators-redhat` project to the `openshift-logging` project.
 +
 For example:
++
+[source,terminal]
+----
+$ oc label namespace openshift-operators-redhat project=openshift-operators-redhat
+----
 +
 [source,yaml]
 ----


### PR DESCRIPTION
When OpenShift Logging with multitenant isolation using NetworkPolicy mode was deployed,
network traffic from the `openshift-operators-redhat` namespace to the `openshift-logging` namespace was not allowed
because a label was used in the network policy object but was not set on the `openshift-operators-redhat` namespace.