### PR TITLE
OSDOCS-1811: Remove workarounds for multitenant network policy

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -32,11 +32,6 @@ This mode is the default for OpenShift SDN.
 . Create the following `NetworkPolicy` objects:
 .. A policy named `allow-from-openshift-ingress`.
 +
-[IMPORTANT]
-====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
-====
-+
 [source,terminal]
 ----
 $ cat << EOF| oc create -f -
@@ -94,56 +89,44 @@ spec:
 EOF
 ----
 
-. If the `default` Ingress Controller configuration has the `spec.endpointPublishingStrategy: HostNetwork` value set, you must apply a label to the `default` {product-title} namespace to allow network traffic between the Ingress Controller and the project:
-
-.. Determine if your `default` Ingress Controller uses the `HostNetwork` endpoint publishing strategy:
+. Optional: To confirm that the network policies exist in your current project, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get --namespace openshift-ingress-operator ingresscontrollers/default \
-  --output jsonpath='{.status.endpointPublishingStrategy.type}'
-----
-
-.. If the previous command reports the endpoint publishing strategy as `HostNetwork`, set a label on the `default` namespace:
-+
-[source,terminal]
-----
-$ oc label namespace default 'network.openshift.io/policy-group=ingress'
-----
-
-. Confirm that the `NetworkPolicy` object exists in your current project
-by running the following command:
-+
-[source,terminal]
-----
-$ oc get networkpolicy <policy-name> -o yaml
-----
-+
-In the following example, the `allow-from-openshift-ingress` `NetworkPolicy`
-object is displayed:
-+
-[source,terminal]
-----
-$ oc get -n project1 networkpolicy allow-from-openshift-ingress -o yaml
+$ oc describe networkpolicy
 ----
 +
 .Example output
-[source,terminal]
+[source,text]
 ----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-from-openshift-ingress
-  namespace: project1
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: ingress
-  podSelector: {}
-  policyTypes:
-  - Ingress
+Name:         allow-from-openshift-ingress
+Namespace:    example1
+Created on:   2020-06-09 00:28:17 -0400 EDT
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
+  Allowing ingress traffic:
+    To Port: <any> (traffic allowed to all ports)
+    From:
+      NamespaceSelector: network.openshift.io/policy-group: ingress
+  Not affecting egress traffic
+  Policy Types: Ingress
+
+
+Name:         allow-from-openshift-monitoring
+Namespace:    example1
+Created on:   2020-06-09 00:29:57 -0400 EDT
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
+  Allowing ingress traffic:
+    To Port: <any> (traffic allowed to all ports)
+    From:
+      NamespaceSelector: network.openshift.io/policy-group: monitoring
+  Not affecting egress traffic
+  Policy Types: Ingress
 ----
 
 ifdef::ovn[]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1811

Preview: [Configuring multitenant isolation with network policy](https://deploy-preview-33195--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html)

TODO: Update policy label names in release note for this: https://github.com/openshift/openshift-docs/pull/32956 & https://github.com/openshift/openshift-docs/pull/33350.