### PR TITLE
Fix example ingress for v1 API version

### DIFF
--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -29,8 +29,12 @@ spec:
     http:
       paths:
       - backend:
-          serviceName: frontend
-          servicePort: 443
+          service:
+            name: frontend
+            port:
+              number: 443
+        path: /
+        pathType: Prefix
   tls:
   - hosts:
     - www.example.com
@@ -80,9 +84,9 @@ metadata:
     uid: 4e6c59cc-704d-4f44-b390-617d879033b6
 spec:
   host: www.example.com
-  to:
-    kind: Service
-    name: frontend
+  path: /
+  port:
+    targetPort: https
   tls:
     certificate: |
       -----BEGIN CERTIFICATE-----
@@ -94,4 +98,7 @@ spec:
       [...]
       -----END RSA PRIVATE KEY-----
     termination: reencrypt
+  to:
+    kind: Service
+    name: frontend
 ----


### PR DESCRIPTION
Fix the example ingress in the `nw-ingress-creating-a-route-via-an-ingress` module to use the correct format for the ingress v1 API version, and change the example route to reflect more accurately the route that is generated for the ingress.

Follow-up to https://github.com/openshift/openshift-docs/pull/28252/commits/aeff3a1359d8334bf3569ffd8e1050777c1f1e78.

* `modules/nw-ingress-creating-a-route-via-an-ingress.adoc`: Fix the ingress service backend specification and HTTP path specification in the example ingress object to use the ingress v1 fields.  Tweak the example route to more accurately reflect the route that will be generated for the example ingress.