### PR TITLE
Small fix for Functions docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -3049,5 +3049,5 @@ Topics:
     File: kn-flags-reference
   - Name: kn service
     File: kn-services-ref
-#  - Name: kn func
-#    File: kn-func-ref
+  - Name: kn func
+    File: kn-func-ref

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -13,6 +13,7 @@
 * {ServerlessProductName} now uses Kourier 0.21.0.
 * {ServerlessProductName} now uses Knative `kn` CLI 0.21.0.
 * {ServerlessProductName} now uses Knative Kafka 0.21.1.
+* {FunctionsProductName} is now available as a Technology Preview.
 
 [IMPORTANT]
 ====

--- a/serverless/functions/serverless-functions-about.adoc
+++ b/serverless/functions/serverless-functions-about.adoc
@@ -22,8 +22,7 @@ The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI. {FunctionsP
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
 * xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
 * xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Golang]
-* Quarkus
-//* SpringBoot - TBC
+* xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
 
 [id="next-steps_serverless-functions-about"]
 == Next steps


### PR DESCRIPTION
NOTE: There is no Jira issue to track this small fix, the docs were just released today and this fix was subsequently requested from our PM.

Direct preview links:
- https://deploy-preview-33232--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-15-0_serverless-release-notes
- https://deploy-preview-33232--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-about.html
- https://deploy-preview-33232--osdocs.netlify.app/openshift-enterprise/latest/serverless/cli_reference/kn-func-ref.html