### PR TITLE
GH#33230: [OKD] Deprecated features | What's new? | OKD 4

### DIFF
--- a/whats_new/deprecated-features.adoc
+++ b/whats_new/deprecated-features.adoc
@@ -27,14 +27,13 @@ now deprecated.
 |Replaced by Prometheus adapter.
 
 |Atomic Host
-|Replaced by Red Hat Enterprise Linux CoreOS.
+|Replaced by {op-system-first}.
 
 |System containers
-|Replaced by Red Hat Enterprise Linux CoreOS.
+|Replaced by {op-system-first}.
 
 |`projectatomic/docker-1.13` additional search registries
-|CRI-O is the default container runtime for OpenShift v4 on RHCOS and Red
-Hat Enterprise Linux.
+|CRI-O is the default container runtime for {product-title} v4 on Fedora.
 
 |`oc adm diagnostics`
 |Operator-based diagnostics.
@@ -51,7 +50,7 @@ removed, but the functionality changed significantly in OpenShift v4.
 |Improved OpenShift v4 web console.
 
 |Stand-alone registry installations
-|Quay is Red Hat's enterprise container image registry.
+|Quay is Red Hat's container image registry.
 
 |DNSmasq
 |CoreDNS is the default.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/33230

* Red Hat’s enterprise -- Changed to _Quay is Red Hat’s container image registry_.
* Red Hat Enterprise Linux -- Removed
* rhcos -- Changed to _Replaced by Fedora CoreOS_. 

Internal-only preview: http://file.rdu.redhat.com/~mburke/okd-issue-33230/whats_new/deprecated-features.html