### PR TITLE
OSDOCS-2221: Add procedure for controlling DNS pod placement

### DIFF
--- a/modules/nw-controlling-dns-pod-placement.adoc
+++ b/modules/nw-controlling-dns-pod-placement.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * networking/dns-operator.adoc
+
+[id="nw-controlling-dns-pod-placement_{context}"]
+= Controlling DNS pod placement
+
+The DNS Operator has two daemon sets: one for CoreDNS and one for managing the `/etc/hosts` file. The daemon set for `/etc/hosts` must run on every node host to add an entry for the cluster image registry to support pulling images. Security policies can prohibit communication between pairs of nodes, which prevents the daemon set for CoreDNS from running on every node.
+
+As a cluster administrator, you can use a custom node selector to configure the daemon set for CoreDNS to run or not run on certain nodes.
+
+
+.Prerequisites
+
+* You installed the `oc` CLI.
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+* To prevent communication between certain nodes, configure the `spec.nodePlacement.nodeSelector` API field:
+
+. Modify the DNS Operator object named `default`:
++
+[source, terminal]
+----
+$ oc edit dns.operator/default
+----
++
+. Specify a node selector that includes only control plane nodes in the `spec.nodePlacement.nodeSelector` API field:
++
+[source,yaml]
+----
+ spec:
+   nodePlacement:
+     nodeSelector:
+       node-role.kubernetes.io/worker: ""
+----
+
+* To allow the daemon set for CoreDNS to run on nodes, configure a taint and toleration:
++
+. Modify the DNS Operator object named `default`:
++
+[source,terminal]
+----
+$ oc edit dns.operator/default
+----
++
+. Specify a taint key and a toleration for the taint:
++
+[source,yaml]
+----
+ spec:
+   nodePlacement:
+     tolerations:
+     - effect: NoExecute
+       key: "dns-only"
+       operators: Equal
+       value: abc
+       tolerationSeconds: 3600 <1>
+----
+<1> If the taint is `dns-only`, it can be tolerated indefinitely. You can omit `tolerationSeconds`.

--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -11,6 +11,8 @@ OpenShift.
 
 include::modules/nw-dns-operator.adoc[leveloffset=+1]
 
+include::modules/nw-controlling-dns-pod-placement.adoc[leveloffset=+1]
+
 include::modules/nw-dns-view.adoc[leveloffset=+1]
 
 include::modules/nw-dns-forward.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2221

Preview: https://deploy-preview-33237--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator.html#nw-controlling-dns-pod-placement_dns-operator