### PR TITLE
Add Butane Release Note in 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -45,6 +45,10 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-8-rhcos"]
 === {op-system-first}
 
+[id="ocp-4-8-rhcos-butane"]
+==== Butane config transpiler simplifies creation of machine configs
+
+{product-title} now includes the Butane config transpiler to assist with producing and validating machine configs. Documentation now recommends using Butane to create machine configs for LUKS disk encryption, boot disk mirroring, and custom kernel modules.
 
 [id="ocp-4-8-installation-and-upgrade"]
 === Installation and upgrade
@@ -356,7 +360,7 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4-moderate` profile will be completed in a future release.
 
 [id="ocp-4-8-coreDNS-version-update"]
-==== CoreDNS update to version 1.8.1 
+==== CoreDNS update to version 1.8.1
 
 In {product-title} 4.8, CoreDNS uses version 1.8.1, which has several bug fixes, renamed metrics, and dual-stack IPv6 enablement.
 


### PR DESCRIPTION
Adds 4.8 Butane release notes based on 4.8 Issue Tracker comment: https://github.com/openshift/openshift-docs/issues/29652#issuecomment-850731936

**PREVIEW LINK:** https://deploy-preview-33239--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-rhcos-butane