### PR TITLE
GH#33227: [okd] Discussion of Machine Config Daemon should not mention RHCOS and RHEL

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -27,10 +27,19 @@ While some entries contain commands for getting specific logs, the most comprehe
 |Description
 |Notes
 
+ifndef::openshift-origin[]
 |mcd_host_os_and_version
 |[]string{"os", "version"}
 |Shows the OS that MCD is running on, such as RHCOS or RHEL. In case of RHCOS, the version is provided.
 |
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+|mcd_host_os_and_version
+|[]string{"os", "version"}
+|Shows the OS that MCD is running on, such as Fedora.
+|
+endif::openshift-origin[]
 
 |ssh_accessed
 |counter


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/33227

- In table 1 MCO Metrics, mcd_host_os_and_version description mentions RHCOS as example twice, RHEL once -- I changed the RHEL and RHCOS references to Fedora. Removed reference to OS version, as it doesn't appear in Prometheus in OKD.

Internal-only preview: http://file.rdu.redhat.com/~mburke/okd-issue-33227/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.html