### PR TITLE
OSDOCS-2113: Release notes for Configuring PROXY protocol for an Ingress Controller

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -187,6 +187,7 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/tra
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-converting-http-header-case_configuring-ingress[Converting HTTP header case].
 
+
 [id="ocp-4-8-ingress-configuring-global-access-gcp"]
 ==== Configuring global access for an Ingress Controller on GCP
 
@@ -200,6 +201,13 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 {product-title} 4.8 adds support for setting the thread count to increase the amount of incoming connections a cluster can handle.
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-setting-thread-count_configuring-ingress[Setting Ingress Controller thread count].
+
+[id="ocp-4-8-ingress-configuring-proxy-protocol"]
+==== Configuring the PROXY protocol for an Ingress Controller
+
+{product-title} 4.8 adds support for configuring the PROXY protocol for the Ingress Controller on non-cloud platforms, specifically for `HostNetwork` or `NodePortService` endpoint publishing strategy types.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress[Configuring PROXY protocol for an Ingress Controller].
 
 [id="ocp-4-8-storage"]
 === Storage


### PR DESCRIPTION
4.8 release notes for Configuring PROXY protocol for an Ingress Controller: https://issues.redhat.com/browse/OSDOCS-2113

Preview: https://deploy-preview-33241--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-networking

@Miciah @quarterpin please take a look at this RN and let me know if you have feedback. Note-this topic is still not merged, so the See link does not work. Merge is pending QA.
