### PR TITLE
Release notes for OSDOCS-1834

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -178,6 +178,13 @@ For more information, see xref:../networking/ovn_kubernetes_network_provider/tra
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-converting-http-header-case_configuring-ingress[Converting HTTP header case].
 
+[id="ocp-4-8-ingress-configuring-global-access-gcp"]
+==== Configuring global access for an Ingress Controller on GCP
+
+{product-title} {product-version} adds support for the global access option for Ingress Controllers created on GCP with an internal load balancer. When the global access option is enabled, clients in any region within the same VPC network and compute region as the load balancer can reach the workloads running on your cluster.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress[Configuring global access for an Ingress Controller on GCP].
+
 [id="ocp-4-8-storage"]
 === Storage
 


### PR DESCRIPTION
4.8 release notes for Configuring global access for an Ingress Controller on GCP: https://issues.redhat.com/browse/OSDOCS-1834
https://issues.redhat.com/browse/OSDOCS-2143

Preview: https://deploy-preview-33244--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-networking

@sgreene570 @lihongan please take a look at this release note and let me know if you have any feedback. Thank you! :)