### PR TITLE
CNV-11417: Deprecate RHV and VMware VM import

### DIFF
--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -11,6 +11,8 @@ You can import a single Red Hat Virtualization (RHV) virtual machine into {VirtP
 :FeatureName: Importing a RHV VM
 include::modules/deprecated-feature.adoc[leveloffset=+1]
 
+This feature will be replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
+
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
 include::modules/virt-importing-vm-prerequisites.adoc[leveloffset=+1]
 include::modules/virt-importing-vm-wizard.adoc[leveloffset=+1]

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -6,12 +6,12 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-You can import a VMware vSphere 6.5, 6.7, or 7.0 VM or VM template into {VirtProductName} by using the VM Import wizard.
+You can import a VMware vSphere 6.5, 6.7, or 7.0 VM or VM template into {VirtProductName} by using the VM Import wizard. If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
 
 :FeatureName: Importing a VMware VM
 include::modules/deprecated-feature.adoc[leveloffset=+1]
 
-If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
+This feature will be replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
 
 include::modules/virt-features-for-storage-matrix.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/CNV-11417

Added deprecation notice and link to MTV to sections on importing VMs from RHV and VMware into CNV.

Does not require QE.

Previews: 

https://deploy-preview-33252--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html

https://deploy-preview-33252--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html