### PR TITLE
[enterprise-4.6] GH#33080: [okd] Pipeline information is not quite accurate for 4.7

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -539,7 +539,7 @@ Topics:
   File: kn-cli-tools
 - Name: Pipelines CLI (tkn)
   Dir: tkn_cli
-  Distros: openshift-enterprise,openshift-webscale,openshift-origin
+  Distros: openshift-enterprise,openshift-webscale
   Topics:
   - Name: Installing tkn
     File: installing-tkn
@@ -1199,7 +1199,7 @@ Topics:
 ---
 Name: Pipelines
 Dir: pipelines
-Distros: openshift-enterprise,openshift-webscale,openshift-origin
+Distros: openshift-enterprise,openshift-webscale
 Topics:
 - Name: Understanding OpenShift Pipelines
   File: understanding-openshift-pipelines


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/33117