### PR TITLE
OSDOCS-2115: Release notes for setting Ingress Controller thread count

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -189,6 +189,13 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress[Configuring global access for an Ingress Controller on GCP].
 
+[id="ocp-4-8-setting-ingress-configuring-thread-count"]
+==== Setting Ingress Controller thread count
+
+{product-title} 4.8 adds support for setting the thread count to increase the amount of incoming connections a cluster can handle.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-setting-thread-count_configuring-ingress[Setting Ingress Controller thread count].
+
 [id="ocp-4-8-storage"]
 === Storage
 


### PR DESCRIPTION
4.8 release note for setting Ingress Controller thread count:
https://issues.redhat.com/browse/OSDOCS-2115
https://issues.redhat.com/browse/OSDOCS-2201

Preview: https://deploy-preview-33262--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-networking

@rfredette @lihongan can you please review this release note and let me know if you have any feedback? Thank you! :)