### PR TITLE
OSDOCS-2109: Release notes for CoreOS version updates

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -328,6 +328,11 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 
 In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4-moderate` profile will be completed in a future release.
 
+[id="ocp-4-8-coreDNS-version-update"]
+==== CoreDNS update to version 1.8.1 
+
+In {product-title} 4.8, CoreDNS uses version 1.8.1, which has several bug fixes, renamed metrics, and dual-stack IPv6 enablement.
+
 [id="ocp-4-8-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
4.8 release note for CoreDNS version update:
https://issues.redhat.com/browse/OSDOCS-2109
https://issues.redhat.com/browse/OSDOCS-2148

Preview: https://deploy-preview-33269--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-coreDNS-version-update

@jechen0648 can you please review this release note and let me know if you have any feedback? Thanks! :)