### PR TITLE
BZ1872580: Fixed a broken link for 4.7

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -28,9 +28,9 @@ include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
 
 .Additional resources
-* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
+* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions-iam-roles_installing-aws-account[Required AWS permissions for IAM roles].
 
-include::modules/rhel-worker-tag.adoc[leveloffset=+2]
+include::modules/rhel-worker-tag.adoc[leveloffset=+1]
 
 include::modules/rhel-adding-node.adoc[leveloffset=+1]
 

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -26,9 +26,9 @@ include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
 
 .Additional resources
-* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
+* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions-iam-roles_installing-aws-account[Required AWS permissions for IAM roles].
 
-include::modules/rhel-worker-tag.adoc[leveloffset=+2]
+include::modules/rhel-worker-tag.adoc[leveloffset=+1]
 
 include::modules/rhel-adding-more-nodes.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This is a continuation of the BZ1872580 bug which needed updated documentation for RHEL Worker nodes.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1872580

Version: 4.7+

Previews: 
1, Adding a RHEL node: https://deploy-preview-33273--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-attaching-instance-aws_adding-rhel-compute

2. Adding more RHEL nodes: https://deploy-preview-33273--osdocs.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html#rhel-attaching-instance-aws_more-rhel-compute