### PR TITLE
BZ1969981 - Fix typo in arch overview

### DIFF
--- a/modules/architecture-platform-benefits.adoc
+++ b/modules/architecture-platform-benefits.adoc
@@ -15,7 +15,7 @@ of technology areas.
 {product-title} provides enterprise-ready enhancements to Kubernetes, including the following enhancements:
 
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
-* Hybrid cloud deployments. You can deploy {product-title} clusters to variety of public cloud platforms or in your data center.
+* Hybrid cloud deployments. You can deploy {product-title} clusters to a variety of public cloud platforms or in your data center.
 endif::[]
 ifdef::openshift-dedicated[]
 * {product-title} clusters are deployed on AWS environments and can be used as part of a hybrid approach for application management.

--- a/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Container Storage Interface (CSI) inline ephemeral volumes allow you to define a `Pod` spec that creates inline ephemeral volumes when a pod is deployed and delete them when a pod is destroyed.
+Container Storage Interface (CSI) inline ephemeral volumes allow you to define a `Pod` specification that creates inline ephemeral volumes when a pod is deployed and delete them when a pod is destroyed.
 
 This feature is only available with supported Container Storage Interface (CSI) drivers.
 

--- a/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Container Storage Interface (CSI) inline ephemeral volumes allow you to define a `Pod` specification that creates inline ephemeral volumes when a pod is deployed and delete them when a pod is destroyed.
+Container Storage Interface (CSI) inline ephemeral volumes allow you to define a `Pod` spec that creates inline ephemeral volumes when a pod is deployed and delete them when a pod is destroyed.
 
 This feature is only available with supported Container Storage Interface (CSI) drivers.
 


### PR DESCRIPTION
[BZ1969981](https://bugzilla.redhat.com/show_bug.cgi?id=1969981) - fix typo in Architecture Overview section.