### PR TITLE
OSDOCS-2073: Update wording from machine autoscaler to cluster autoscaler

### DIFF
--- a/modules/machine-autoscaler-cr.adoc
+++ b/modules/machine-autoscaler-cr.adoc
@@ -27,7 +27,7 @@ spec:
 <1> Specify the machine autoscaler name. To make it easier to identify which machine set this machine autoscaler scales, specify or include the name of the machine set to scale. The machine set name takes the following form: `<clusterid>-<machineset>-<aws-region-az>`.
 <2> Specify the minimum number machines of the specified type that must remain in the specified zone after the cluster autoscaler initiates cluster scaling. If running in AWS, GCP, Azure, {rh-openstack}, or vSphere, this value can be set to `0`. For other providers, do not set this value to `0`.
 +
-You can save on costs by setting this value to `0` for use cases such as running expensive or limited-usage hardware that is used for specialized workloads, or by scaling a machine set with extra large machines. The machine autoscaler scales the machine set down to zero if the machines are not in use.
+You can save on costs by setting this value to `0` for use cases such as running expensive or limited-usage hardware that is used for specialized workloads, or by scaling a machine set with extra large machines. The cluster autoscaler scales the machine set down to zero if the machines are not in use.
 +
 [IMPORTANT]
 ====


### PR DESCRIPTION
New content for [OSDOCS-2073](https://issues.redhat.com/browse/OSDOCS-2073) was already merged in https://github.com/openshift/openshift-docs/pull/32290. This PR makes a small wording update to correct "machine autoscaler" to "cluster autoscaler."

Preview: https://deploy-preview-33277--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#machine-autoscaler-cr_applying-autoscaling