### PR TITLE
BZ1872580: Adds unlisted permissions for RHEL workers

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -27,10 +27,7 @@ include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 
 include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
 
-.Additional resources
-* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
-
-include::modules/rhel-worker-tag.adoc[leveloffset=+2]
+include::modules/rhel-worker-tag.adoc[leveloffset=+1]
 
 include::modules/rhel-adding-node.adoc[leveloffset=+1]
 

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -25,10 +25,7 @@ include::modules/rhel-preparing-node.adoc[leveloffset=+1]
 
 include::modules/rhel-attaching-instance-aws.adoc[leveloffset=+1]
 
-.Additional resources
-* See xref:../installing/installing_aws/installing-aws-account.adoc#installation-aws-permissions_installing-aws-account[Required AWS permissions for IAM roles]
-
-include::modules/rhel-worker-tag.adoc[leveloffset=+2]
+include::modules/rhel-worker-tag.adoc[leveloffset=+1]
 
 include::modules/rhel-adding-more-nodes.adoc[leveloffset=+1]
 

--- a/modules/rhel-attaching-instance-aws.adoc
+++ b/modules/rhel-attaching-instance-aws.adoc
@@ -11,4 +11,8 @@ Using the Amazon IAM console in your browser, you may select the needed roles an
 
 .Procedure
 . From the AWS IAM console, create your link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#create-iam-role[desired IAM role].
-. link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#attach-iam-role[Attach the IAM role] to the desired worker node.
+. link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#attach-iam-role[Attach the IAM role] to the desired worker node. The following permissions are required:
+
+* `sts:AssumeRole`
+* `ec2:DescribeInstances`
+* `ec2:DescribeRegions`


### PR DESCRIPTION
This PR adds the permissions needed for the RHEL worker node when attaching an IAM role. This is related to #33273.

Version: 4.5 and 4.6

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1872580

Previews:
1. Adding a RHEL Worker Node: https://deploy-preview-33285--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-attaching-instance-aws_adding-rhel-compute
2. Adding more RHEL Worker Nodes: https://deploy-preview-33285--osdocs.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html#rhel-attaching-instance-aws_more-rhel-compute