### PR TITLE
BZ1962279: Updated 2nd callout to add 's' to sample value for httpsproxy field.

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -81,7 +81,7 @@ apiVersion: v1
 baseDomain: my.domain.com
 proxy:
   httpProxy: http://<username>:<pswd>@<ip>:<port> <1>
-  httpsProxy: http://<username>:<pswd>@<ip>:<port> <2>
+  httpsProxy: https://<username>:<pswd>@<ip>:<port> <2>
   noProxy: example.com <3>
 additionalTrustBundle: | <4>
     -----BEGIN CERTIFICATE-----


### PR DESCRIPTION
CP to 4.6, 4.7, and 4.8

https://bugzilla.redhat.com/show_bug.cgi?id=1962279

Under Configuring the cluster-wide proxy during installation, updated the first step in the procedure has sample code. Updated the 2nd callout to add 's' to sample value for httpsproxy field.

Worth noting that this module appears in ~40 assemblies, but here are the 3 assemblies that the BZ referenced.

ZVM installation: https://deploy-preview-33288--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-configure-proxy_installing-ibm-z

ZVM disconnected install: https://deploy-preview-33288--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html#installation-configure-proxy_installing-restricted-networks-ibm-z

KVM installation: https://deploy-preview-33288--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#installation-configure-proxy_installing-ibm-z-kvm

No QE required.