### PR TITLE
modules/update-service-overview: "both OpenShift and RHCOS" -> "OpenShift, including RHCOS"

### DIFF
--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -11,7 +11,7 @@
 [id="update-service-overview_{context}"]
 = About the OpenShift Update Service
 
-The OpenShift Update Service (OSUS) provides over-the-air updates to both {product-title} and {op-system-first}. It provides a graph, or diagram, that contains the _vertices_ of component Operators and the _edges_ that connect them. The edges in the graph show which versions you can safely update to. The vertices are update payloads that specify the intended state of the managed cluster components.
+The OpenShift Update Service (OSUS) provides over-the-air updates to {product-title}, including {op-system-first}. It provides a graph, or diagram, that contains the _vertices_ of component Operators and the _edges_ that connect them. The edges in the graph show which versions you can safely update to. The vertices are update payloads that specify the intended state of the managed cluster components.
 
 The Cluster Version Operator (CVO) in your cluster checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph. When you request an update, the CVO uses the release image for that update to upgrade your cluster. The release artifacts are hosted in Quay as container images.
 ////


### PR DESCRIPTION
The RHCOS mention is from way back in 1ac3751e97 (#12880).  But:

```console
$ git --no-pager grep -h supported modules/rhcos-about.adoc
{op-system} is supported only as a component of {product-title} {product-version} for all {product-title} machines....
```

This commit rephrases the update docs to put RHCOS under OpenShift, so folks don't get ideas and think it is a stand-alone product.