### PR TITLE
GRPA-3100: Convert kmod instructions from filetranspiler to Butane

### DIFF
--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -292,21 +292,7 @@ By packaging kernel module software with a `MachineConfig` object, you can
 deliver that software to worker or master nodes at installation time
 or via the Machine Config Operator.
 
-First create a base Ignition config that you would like to use.
-At installation time, the Ignition config will
-contain the ssh public key to add to the `authorized_keys` file for
-the `core` user on the cluster.
-To add the `MachineConfig` object later via the MCO instead, the SSH public key is not required.
-For both type, the example simple-kmod service creates a systemd unit file,
-which requires a `kmods-via-containers@simple-kmod.service`.
-
-[NOTE]
-====
-The systemd unit is a workaround for an
-link:https://github.com/coreos/ignition/issues/586[upstream bug]
-and makes sure that the `kmods-via-containers@simple-kmod.service` gets started
-on boot:
-====
+.Procedure
 
 . Register a RHEL 8 system:
 +
@@ -329,73 +315,12 @@ on boot:
 # yum install podman make git -y
 ----
 
-. Create an Ignition config file that creates a systemd unit file:
-.. Create a directory to host the Ignition config file:
+. Create a directory to host the kernel module and tooling:
 +
 [source,terminal]
 ----
 $ mkdir kmods; cd kmods
 ----
-
-.. Create the Ignition config file that creates a systemd unit file:
-+
-[source,terminal]
-----
-$ cat <<EOF > ./baseconfig.ign
-{
-  "ignition": { "version": "3.2.0" },
-  "passwd": {
-    "users": [
-      {
-        "name": "core",
-        "groups": ["sudo"],
-        "sshAuthorizedKeys": [
-          "ssh-rsa AAAA"
-        ]
-      }
-    ]
-  },
-  "systemd": {
-    "units": [{
-      "name": "require-kvc-simple-kmod.service",
-      "enabled": true,
-      "contents": "[Unit]\nRequires=kmods-via-containers@simple-kmod.service\n[Service]\nType=oneshot\nExecStart=/usr/bin/true\n\n[Install]\nWantedBy=multi-user.target"
-    }]
-  }
-}
-EOF
-----
-+
-[NOTE]
-====
-You must add your public SSH key to the `baseconfig.ign` file
-to use the file during `openshift-install`.
-The public SSH key is not needed if you create the `MachineConfig` object using the MCO.
-====
-
-. Create a base MCO YAML snippet that uses the following configuration:
-+
-[source,terminal]
-----
-$ cat <<EOF > mc-base.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: worker
-  name: 10-kvc-simple-kmod
-spec:
-  config:
-EOF
-----
-+
-[NOTE]
-====
-The `mc-base.yaml` is set to deploy the kernel module on `worker` nodes.
-To deploy on master nodes, change the role from `worker` to `master`.
-To do both, you could repeat the whole procedure using different file names
-for the two types of deployments.
-====
 
 . Get the `kmods-via-containers` software:
 
@@ -413,7 +338,7 @@ $ git clone https://github.com/kmods-via-containers/kmods-via-containers
 $ git clone https://github.com/kmods-via-containers/kvc-simple-kmod
 ----
 
-. Get your module software. In this example, `kvc-simple-kmod` is used:
+. Get your module software. In this example, `kvc-simple-kmod` is used.
 
 . Create a fakeroot directory and populate it with files that you want to
 deliver via Ignition, using the repositories cloned earlier:
@@ -453,23 +378,39 @@ $ cd ../kvc-simple-kmod
 $ make install DESTDIR=${FAKEROOT}/usr/local CONFDIR=${FAKEROOT}/etc/
 ----
 
-. Get a tool called `filetranspiler` and dependent software:
+. Clone the fakeroot directory, replacing any symbolic links with copies of their targets, by running the following command:
 +
 [source,terminal]
 ----
-$ cd .. ; sudo yum install -y python3
-git clone https://github.com/ashcrow/filetranspiler.git
+$ cd .. && rm -rf kmod-tree && cp -Lpr ${FAKEROOT} kmod-tree
 ----
 
-. Generate a final machine config YAML (`mc.yaml`)
-and have it include the base Ignition config, base machine config, and the fakeroot directory
-with files you would like to deliver:
+. Create a Butane config file, `99-simple-kmod.bu`, that embeds the kernel module tree and enables the systemd service:
++
+[source,yaml]
+----
+variant: openshift
+version: 4.8.0
+metadata:
+  name: 99-simple-kmod
+  labels:
+    machineconfiguration.openshift.io/role: worker <1>
+storage:
+  trees:
+    - local: kmod-tree
+systemd:
+  units:
+    - name: kmods-via-containers@simple-kmod.service
+      enabled: true
+----
++
+<1> To deploy on master nodes, change `worker` to `master`.  To deploy on both master and worker nodes, perform the remainder of these instructions once for each node type.
+
+. Use Butane to generate a machine config YAML file, `99-simple-kmod.yaml`, containing the files and configuration to be delivered:
 +
 [source,terminal]
 ----
-$ ./filetranspiler/filetranspile -i ./baseconfig.ign \
-     -f ${FAKEROOT} --format=yaml --dereference-symlinks \
-     | sed 's/^/     /' | (cat mc-base.yaml -) > 99-simple-kmod.yaml
+$ butane 99-simple-kmod.bu --files-dir . -o 99-simple-kmod.yaml
 ----
 
 . If the cluster is not up yet, generate manifest files and add this file to the


### PR DESCRIPTION
The current RHCOS systemd can now enable instantiated services via Ignition.

The embedded SSH key was apparently inherited from the instructions [here](https://github.com/kmods-via-containers/kmods-via-containers#testing-it-out-on-an-ostree-based-host-provisioned-via-ignition) and shouldn't be needed on OCP.  Drop it.