### PR TITLE
MTC migration plan steps repeated

### DIFF
--- a/modules/migration-creating-migration-plan-cam.adoc
+++ b/modules/migration-creating-migration-plan-cam.adoc
@@ -20,14 +20,10 @@ You can create a migration plan in the {mtc-full} ({mtc-short}) web console.
 
 . In the {mtc-short} web console, click *Migration plans*.
 . Click *Add migration plan*.
-. Enter the *Plan name* and click *Next*.
+. Enter the *Plan name*.
 +
 The migration plan name must not exceed 253 lower-case alphanumeric characters (`a-z, 0-9`) and must not contain spaces or underscores (`_`).
 
-. Select a *Source cluster*.
-. Select a *Target cluster*.
-. Select a *Replication repository*.
-. Select the projects to be migrated and click *Next*.
 . Select a *Source cluster*, a *Target cluster*, and a *Repository*, and click *Next*.
 . On the *Namespaces* page, select the projects to be migrated and click *Next*.
 . On the *Persistent volumes* page, click a *Migration type* for each PV:


### PR DESCRIPTION
Removes error (repeated steps) in MTC migration plan procedure. No Jira or BZ.

4.5+

No QE required.

Preview: https://deploy-preview-33318--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html#migration-creating-migration-plan-cam_migrating-applications-3-4