### PR TITLE
[wip] CNF-620: documenting support for the OpenNESS SR-IOV Operator for Wireless FEC Accelerators in 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -324,6 +324,23 @@ You can now create a performance profile using the Performance Profile Creator (
 
 For more information, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a Performance Profile].
 
+[id="ocp-4-8-optimizing-data-plane-performance-with-intel-devices"]
+==== Optimizing data plane performance with the Intel® vRAN Dedicated Accelerator ACC100
+
+{product-title} {product-version} support the OpenNESS SR-IOV Operator for Wireless FEC Accelerators.
+
+This Operator supports the requirements of vRAN deployments for low power, cost and latency, whilst also delivering the capacity to manage spikes in performance for a range of use cases. One of the most compute-intensive 4G and 5G workloads is RAN layer 1 (L1) forward error correction (FEC), which resolves data transmission errors over unreliable or noisy communication channels.
+
+Delivering high performance FEC is critical to 5G maintaining high performance as it matures and as more users depend on the network. FEC is now supported on the Intel vRAN Dedicated Accelerator ACC100 card with the OpenNESS SR-IOV Operator for Wireless FEC Accelerator.
+
+For more information, see Optimizing data plane performance with the Intel® vRAN Dedicated Accelerator ACC100.
+
+The referenced section describes how to:
+
+* Install the OpenNESS SR-IOV Operator for Wireless FEC Accelerators.
+* Configure the OpenNESS SR-IOV Operator for Wireless FEC Accelerators for the Intel vRAN Dedicated Accelerator ACC100.
+* Verify that all OpenNESS features are working together.
+
 [id="ocp-4-8-nfd-operator"]
 ==== Node Feature Discovery Operator
 


### PR DESCRIPTION
Documenting support in 4.8 Release Notes for OpenNESS SR-IOV Operator for Wireless FEC Accelerators and ACC100 card.

Preview: https://deploy-preview-33328--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-optimizing-data-plane-performance-with-intel-devices