### PR TITLE
Add pkgman-related relnotes for 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -196,22 +196,22 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 [id="ocp-4-8-olm"]
 === Operator lifecycle
 
-[id="ocp-4-7-admin-error-reporting"]
+[id="ocp-4-8-admin-error-reporting"]
 ==== Enhanced error reporting for administrators
 
 A cluster administrator using Operator Lifecycle Manager (OLM) to install an Operator can encounter error conditions that are related either to the current API or low-level APIs. Previously, there was little insight into why OLM could not fulfill a request to install or update an Operator. These errors could range from trivial issues like typos in object properties or missing RBAC, to more complex issues where items could not be loaded from the catalog due to metadata parsing.
 
 Because administrators should not require understanding of the interaction process between the various low-level APIs or access to the OLM pod logs to successfully debug such issues, {product-title} 4.8 introduces the following enhancements in OLM to provide administrators with more comprehensible error reporting and messages:
 
-[id="ocp-4-7-installplan-errors"]
+[id="ocp-4-8-installplan-errors"]
 Retrying install plans::
 Install plans, defined by an `InstallPlan` object, can encounter transient errors, for example, due to API server availability or conflicts with other writers. Previously, these errors would result in the termination of partially-applied install plans that required manual cleanup. With this enhancement, the Catalog Operator now retries errors during install plan execution for up to one minute. The new `.status.message` field provides a human-readable indication when retries are occurring.
 
-[id="ocp-4-7-operatorgroup-errors"]
+[id="ocp-4-8-operatorgroup-errors"]
 Indicating invalid Operator groups::
 Creating a subscription in a namespace with no Operator groups or multiple Operator groups would previously result in a stalled Operator installation with an install plan that stays in `phase=Installing` forever. With this enhancement, the install plan immediately transitions to `phase=Failed` so that the administrator can correct the invalid Operator group, and then delete and re-create the subscription again.
 
-[id="ocp-4-7-candidate-operator-errors"]
+[id="ocp-4-8-candidate-operator-errors"]
 Specific reporting when no candidate Operators found::
 `ResolutionFailed` events, which are created when dependency resolution in a namespace fails, now provide more specific text when the namespace contains a subscription that references a package or channel that does not exist in the referenced catalog source. Previously, this message was generic:
 +
@@ -247,8 +247,14 @@ no operators found with name <name>.<version> in channel <name> of package <name
 ----
 
 [id="ocp-4-8-osdk"]
-
 === Operator development
+
+[id="ocp-4-8-pkgman-to-bundle"]
+==== Migration of Operator projects from package manifest format to bundle format
+
+The bundle format is the preferred Operator packaging format for Operator Lifecycle Manager (OLM) starting in {product-title} 4.6. If you have an Operator project that was initially created in the package manifest format, which has been deprecated, you can now use the Operator SDK `pkgman-to-bundle` command to migrate the project to the bundle format.
+
+For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format].
 
 [id="ocp-4-8-images"]
 === Images
@@ -356,7 +362,7 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4-moderate` profile will be completed in a future release.
 
 [id="ocp-4-8-coreDNS-version-update"]
-==== CoreDNS update to version 1.8.1 
+==== CoreDNS update to version 1.8.1
 
 In {product-title} 4.8, CoreDNS uses version 1.8.1, which has several bug fixes, renamed metrics, and dual-stack IPv6 enablement.
 
@@ -383,22 +389,22 @@ In the table, features are marked with the following statuses:
 |`OperatorSource` objects
 |REM
 |REM
-|
+|REM
 
-|Package Manifest Format (Operator Framework)
+|Package manifest format (Operator Framework)
 |DEP
 |DEP
-|
+|DEP
 
 |`oc adm catalog build`
 |DEP
 |DEP
-|
+|DEP
 
 |`--filter-by-os` flag for `oc adm catalog mirror`
 |GA
 |DEP
-|
+|DEP
 
 |v1beta1 CRDs
 |DEP
@@ -464,6 +470,14 @@ Starting with {product-title} 4.6, {op-system-first} switched to using `NetworkM
 ==== Cluster Loader is deprecated
 
 Cluster Loader is now deprecated and will be removed in a future release.
+
+[id="ocp-4-8-pkgman-cmds"]
+==== Operator SDK package manifest format commands
+
+As part of the continued deprecation of the Operator package manifest format, the following commands have been removed from the Operator SDK CLI:
+
+* `generate packagemanifest`
+* `run packagemanifest`
 
 [id="ocp-4-8-removed-features"]
 === Removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1930 (release note follow-up for https://github.com/openshift/openshift-docs/pull/32942)

* Add feature note for new `pkgman-to-bundle` migration command
* Add deprecation notice for `generate|run packagemanifest`
* Update removed features table for OLM/OSDK-related items
* Cleanup some errant "4-7" heading IDs

Preview:

* [New migration feature](https://deploy-preview-33332--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-osdk)
* [Deprecation updates](https://deploy-preview-33332--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-removed-features)