### PR TITLE
BZ1962418: adding note about ssh key algorithms for FIPS

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -172,6 +172,11 @@ $ ssh-keygen -t ed25519 -N '' \
 +
 Running this command generates an SSH key that does not require a password in
 the location that you specified.
++
+[NOTE]
+====
+If you plan to install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture, do not create a key that uses the `ed25519` algorithm. Instead, create a key that uses the `rsa` or `ecdsa` algorithm.
+====
 
 . Start the `ssh-agent` process as a background task:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1962418

Preview: https://deploy-preview-33336--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#ssh-agent-using_installing-aws-customizations

Confirming versions, but likely 4.5+