### PR TITLE
Multiarch-1252: KVM updates for 4.8

### DIFF
--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -17,18 +17,22 @@ One or more KVM host machines based on {op-system-base} 8.3 or later. Each {op-s
 
 The smallest {product-title} clusters require the following nodes:
 
-* One temporary bootstrap machine
+.Default monitoring stack components
+[options="header"]
+|===
+|Hosts |Description
 
-* Three control plane, or master, machines
-
-* At least two compute machines, which are also known as worker machines
-
-[NOTE]
-====
-The cluster requires the bootstrap machine to deploy the {product-title} cluster
+|One temporary bootstrap machine
+|The cluster requires the bootstrap machine to deploy the {product-title} cluster
 on the three control plane machines. You can remove the bootstrap machine after
 you install the cluster.
-====
+|Three control plane machines
+|The control plane machines run the Kubernetes and {product-title} services that form the control plane.
+
+|At least two compute machines, which are also known as worker machines.
+|The workloads requested by {product-title} users run on the compute machines.
+
+|===
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
- OCP version: 4.8 and later
- JIRA issue: https://issues.redhat.com/browse/MULTIARCH-1252,
 
- Changing the Reqs to a table to be in sync with changes in this PR, which includes adding a 3-node cluster and further enhancements: https://github.com/openshift/openshift-docs/pull/32618/
 
- Google review doc:https://docs.google.com/document/d/1AxZKvN6CeShnJl7atDBB_cSoDeyfp0VmSJaYrluRCds/edit#
- Reviewer: Holger Wolf, Wolfgang Voesch, Phil Chan
- Preview pages:
   - [Installing a cluster with KVM on IBM Z and LinuxONE](https://deploy-preview-33357--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#installation-requirements-user-infra_installing-ibm-z-kvm)
   - [Installing a cluster with KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-33357--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html#installation-requirements-user-infra_installing-restricted-networks-ibm-z-kvm)