### PR TITLE
BZ1971068: correcting AWS instances

### DIFF
--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -153,14 +153,13 @@ the CloudFormation template for the security group and roles.
 * `m4.xlarge`
 * `m4.2xlarge`
 * `m4.4xlarge`
-* `m4.8xlarge`
 * `m4.10xlarge`
 * `m4.16xlarge`
 * `m5.xlarge`
 * `m5.2xlarge`
 * `m5.4xlarge`
 * `m5.8xlarge`
-* `m5.10xlarge`
+* `m5.12xlarge`
 * `m5.16xlarge`
 * `m5a.xlarge`
 * `m5a.2xlarge`

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -109,7 +109,6 @@ the CloudFormation template for the security group and roles.
 * `m4.xlarge`
 * `m4.2xlarge`
 * `m4.4xlarge`
-* `m4.8xlarge`
 * `m4.10xlarge`
 * `m4.16xlarge`
 * `m5.large`
@@ -117,7 +116,7 @@ the CloudFormation template for the security group and roles.
 * `m5.2xlarge`
 * `m5.4xlarge`
 * `m5.8xlarge`
-* `m5.10xlarge`
+* `m5.12xlarge`
 * `m5.16xlarge`
 * `m5a.large`
 * `m5a.xlarge`

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -49,11 +49,6 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
-|`m4.8xlarge`
-|
-|x
-|x
-
 |`m4.10xlarge`
 |
 |x
@@ -89,7 +84,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
-|`m5.10xlarge`
+|`m5.12xlarge`
 |
 |x
 |x


### PR DESCRIPTION
In the followup discussions about [BZ1878374](https://bugzilla.redhat.com/show_bug.cgi?id=1878374) , it was pointed out that two of the AWS instances types listed don't exist according to [AWS](https://aws.amazon.com/ec2/instance-types/).

This PR corrects those instances and should be merged along with a companion bug in the installer repo. The PR for /installer is https://bugzilla.redhat.com/show_bug.cgi?id=1971068, so I'm linking this PR to that bug.

@cuppett, will you please +1 this change?

See also https://github.com/openshift/installer/pull/4990

Preview is here: https://deploy-preview-33358--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-supported-aws-machine-types_installing-aws-user-infra

4.7+
