### PR TITLE
GH#33366: Added a link to the origin of cluster-backup.sh for clarity

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -45,7 +45,7 @@ sh-4.2# chroot /host
 +
 [TIP]
 ====
-`cluster-backup.sh` is maintained as a component of [`cluster-etcd-operator`](https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/etcd/cluster-backup.sh) and is a wrapper around the `etcdctl snapshot save` command.
+`cluster-backup.sh` is maintained as a component of `[cluster-etcd-operator](https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/etcd/cluster-backup.sh)` and is a wrapper around the `etcdctl snapshot save` command.
 ====
 +
 [source,terminal]

--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -43,6 +43,11 @@ sh-4.2# chroot /host
 
 . Run the `cluster-backup.sh` script and pass in the location to save the backup to.
 +
+[TIP]
+====
+`cluster-backup.sh` is maintained as a component of [`cluster-etcd-operator`](https://github.com/openshift/cluster-etcd-operator/blob/master/bindata/etcd/cluster-backup.sh) and is a wrapper around the `etcdctl snapshot save` command.
+====
++
 [source,terminal]
 ----
 sh-4.4# /usr/local/bin/cluster-backup.sh /home/core/assets/backup


### PR DESCRIPTION
#33366 Clarifies language and adds a link to the origin of the file.