### PR TITLE
Replace 33242 - Add chrony.conf change RHCOS to 4.8 Release Notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -50,6 +50,11 @@ This release adds improvements related to the following components and concepts.
 
 {product-title} now includes the Butane config transpiler to assist with producing and validating machine configs. Documentation now recommends using Butane to create machine configs for LUKS disk encryption, boot disk mirroring, and custom kernel modules.
 
+[id="ocp-4-8-rhcos-chrony-default"]
+==== Change to custom `chrony.conf` default on cloud platforms
+
+If a cloud administrator has already set a custom `/etc/chrony.conf` configuration, {op-system} no longer sets the `PEERNTP=no` option by default on cloud platforms. Otherwise, the `PEERNTP=no` option is still set by default. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1924869[BZ#1924869] for more information.
+
 [id="ocp-4-8-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
Followup to https://github.com/openshift/openshift-docs/pull/33242 - In the previous PR, I had to resolve a rebase conflict in the PR, which added a second commit. Squashing that second commit (13f96989e5c76306638f0469bc1e5995a7564797) was unsuccessful, possibly because there were no changes in it. Rather than merging that PR with 2 commits, I created this PR to merge the chrony.conf RHCOS release note with a single commit per our doc guidelines.