### PR TITLE
BZ1970130: Clarify RHCOS image template creation for vSphere

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -62,30 +62,29 @@ endif::openshift-origin[]
 .. Click the *VMs and Templates* view.
 .. Right-click the name of your datacenter.
 .. Click *New Folder* -> *New VM and Template Folder*.
-.. In the window that is displayed, enter the folder name. If you did not specify an existing folder in the `install-config.yaml` file, then create a folder with the same name as the infrastructure ID.
+.. In the window that is displayed, enter the folder name. If you did not specify an existing folder in the `install-config.yaml` file, create a folder with the same name as the infrastructure ID.
 
-. In the vSphere Client, create a template for the OVA image.
+. In the vSphere Client, create a template for the OVA image and then clone the template as needed.
 +
 [NOTE]
 ====
-In the following steps, you use the same template for all of your cluster machines and provide the location for the Ignition config file for that machine type when you provision the VMs.
+In the following steps, you create a template and then clone the template for all of your cluster machines. You then provide the location for the Ignition config file for that cloned machine type when you provision the VMs.
 ====
 .. From the *Hosts and Clusters* tab, right-click your cluster name and select *Deploy OVF Template*.
 .. On the *Select an OVF* tab, specify the name of the {op-system} OVA file that you downloaded.
-.. On the *Select a name and folder* tab, set a *Virtual machine name*, such as {op-system}. Click the name of your vSphere cluster and select the folder you created in the previous step.
+.. On the *Select a name and folder* tab, set a *Virtual machine name* for your template, such as `Template-{op-system}`. Click the name of your vSphere cluster and select the folder you created in the previous step.
 .. On the *Select a compute resource* tab, click the name of your vSphere cluster.
 .. On the *Select storage* tab, configure the storage options for your VM.
 *** Select *Thin Provision* or *Thick Provision*, based on your storage preferences.
 *** Select the datastore that you specified in your `install-config.yaml` file.
 .. On the *Select network* tab, specify the network that you configured for the cluster, if available.
-.. If you plan to use the same template for all cluster machine types, do not specify values on the *Customize template* tab.
+.. When creating the OVF template, do not specify values on the *Customize template* tab or configure the template any further.
 +
 [IMPORTANT]
 ====
-If you plan to add more compute machines to your cluster after you finish
-installation, do not delete this template.
+Do not start the original VM template. The VM template must remain off and must be cloned for new {op-system} machines. Starting the VM template configures the VM template as a VM on the platform, which prevents it from being used as a template that machine sets can apply configurations to.
+//This admonition note also appears in `modules/installation-vsphere-machines.adoc` and `modules/windows-machineset-vsphere.adoc`.
 ====
-
 . After the template deploys, deploy a VM for a machine in the cluster.
 .. Right-click the template name and click *Clone* -> *Clone to Virtual Machine*.
 .. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `control-plane-0` or `compute-1`.

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -75,7 +75,14 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the infrastructure ID and node label.
 <3> Specify the node label to add.
 <4> Specify the vSphere VM network to deploy the machine set to.
-<5> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
+<5> Specify the vSphere VM clone of the template to use, such as `user-5ddjd-rhcos`.
++
+[IMPORTANT]
+====
+Do not specify the original VM template. The VM template must remain off and must be cloned for new {op-system} machines. Starting the VM template configures the VM template as a VM on the platform, which prevents it from being used as a template that machine sets can apply configurations to.
+//This admonition note also appears in `modules/installation-vsphere-machines.adoc` and `modules/windows-machineset-vsphere.adoc`.
+====
++
 <6> Specify the vCenter Datacenter to deploy the machine set on.
 <7> Specify the vCenter Datastore to deploy the machine set on.
 <8> Specify the path to the vSphere VM folder in vCenter, such as `/dc1/vm/user-inst-5ddjd`.

--- a/modules/windows-machineset-vsphere.adoc
+++ b/modules/windows-machineset-vsphere.adoc
@@ -69,6 +69,13 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <4> Configure the Windows node as a compute machine.
 <5> Specify the vSphere VM network to deploy the machine set to.
 <6> Specify the full path of the Windows vSphere VM template to use, such as `/Datacenter/vm/ocp4-llplx/windows-golden-image`. The name must be unique.
++
+[IMPORTANT]
+====
+Do not specify the original VM template. The VM template must remain off and must be cloned for new {op-system} machines. Starting the VM template configures the VM template as a VM on the platform, which prevents it from being used as a template that machine sets can apply configurations to.
+//This admonition note also appears in `modules/installation-vsphere-machines.adoc`.
+====
++
 <7> The `windows-user-data` is created by the WMCO when the first Windows machine is configured. After that, the `windows-user-data` is available for all subsequent machine sets to consume.
 <8> Specify the vCenter Datacenter to deploy the machine set on.
 <9> Specify the vCenter Datastore to deploy the machine set on.


### PR DESCRIPTION
[BZ1970130](https://bugzilla.redhat.com/show_bug.cgi?id=1970130) - I have tried to identify all refs to the OVF template usage in vCenter that would benefit from this distinction. Actually testing the workflow in vCenter is not possible for me, so I relied on an [OVF template demo video](https://www.youtube.com/watch?v=y7o2-KkII2Y) to verify certain vCenter UI elements. This will be applied to OCP 4.5+ docs.

**PREVIEW LINKS:**
- **Creating RHCOS machines in vSphere (Step 4):** https://deploy-preview-33371--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere
- **Sample YAML for a machine set custom resource on vSphere (callout #5):** https://deploy-preview-33371--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#machineset-yaml-vsphere_post-install-cluster-tasks
- **Sample YAML for a Windows MachineSet object on vSphere (callout #6):** https://deploy-preview-33371--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#windows-machineset-vsphere_creating-windows-machineset-vsphere