### PR TITLE
Applied edit per QE feedback in RN tracker

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -89,7 +89,7 @@ The {product-title} installation program for Google Cloud Platform (GCP) now cre
 [id="ocp-4-8-custom-console-routes-use-custom-domains-cluster-api"]
 ==== Custom console routes now use the new CustomDomains cluster API
 
-For `console` and `downloads` routes, custom routes functionally is now implemented to use the new `ingress` config route configuration API. The Console Operator already contained custom route customization, but for the `console` route only. Now, if the `console` custom route is set up in both the `ingress` config and `console-operator` config, then the new `ingress` config custom route configuration takes precedent, because the route configuration via `console-operator` config is being deprecated.
+For `console` and `downloads` routes, custom routes functionality is now implemented to use the new `ingress` config route configuration API `spec.componentRoutes`. The Console Operator config already contained custom route customization, but for the `console` route only. The route configuration via `console-operator` config is being deprecated. Therefore, if the `console` custom route is set up in both the `ingress` config and `console-operator` config, then the new `ingress` config custom route configuration takes precedent.
 
 [id="ocp-4-8-access-code-snippet-from-quick-start"]
 ==== Access a code snippet from a Quick Start


### PR DESCRIPTION
This addresses feedback from QE in  https://github.com/openshift/openshift-docs/issues/29652#issuecomment-854292436

Preview build: https://deploy-preview-33372--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-custom-console-routes-use-custom-domains-cluster-api

FYI @jeana-redhat 