### PR TITLE
OSDOCS-1584: Update monitoring maintenance and support section

### DIFF
--- a/modules/monitoring-support-considerations.adoc
+++ b/modules/monitoring-support-considerations.adoc
@@ -21,3 +21,8 @@ The Alertmanager configuration is deployed as a secret resource in the `openshif
 * *Installing custom Prometheus instances on {product-title}.*
 * *Enabling symptom based monitoring by using the `Probe` custom resource definition (CRD) in Prometheus Operator.*
 * *Modifying Alertmanager configurations by using the `AlertmanagerConfig` CRD in Prometheus Operator.*
+
+[NOTE]
+====
+Backward compatibility for metrics, recording rules, or alerting rules is not guaranteed.
+====


### PR DESCRIPTION
[OSDOCS-1584](https://issues.redhat.com/browse/OSDOCS-1584) - https://issues.redhat.com/browse/OSDOCS-1584

Adds similar wording that is now used in the Monitoring [Alerting rule changes](https://docs.openshift.com/container-platform/4.7/release_notes/ocp-4-7-release-notes.html#ocp-4-7-monitoring-alerting-rule-changes) section of the release notes. Can modify to be a note instead of a new bullet if necessary.

Preview: https://deploy-preview-33375--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack?utm_source=github&utm_campaign=bot_dp#support-considerations_configuring-the-monitoring-stack