### PR TITLE
Add catalog build rm feature to 4.8 relnote

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -419,7 +419,7 @@ In the table, features are marked with the following statuses:
 |`oc adm catalog build`
 |DEP
 |DEP
-|DEP
+|REM
 
 |`--filter-by-os` flag for `oc adm catalog mirror`
 |GA
@@ -491,14 +491,6 @@ Starting with {product-title} 4.6, {op-system-first} switched to using `NetworkM
 
 Cluster Loader is now deprecated and will be removed in a future release.
 
-[id="ocp-4-8-pkgman-cmds"]
-==== Operator SDK package manifest format commands
-
-As part of the continued deprecation of the Operator package manifest format, the following commands have been removed from the Operator SDK CLI:
-
-* `generate packagemanifest`
-* `run packagemanifest`
-
 [id="ocp-4-8-removed-features"]
 === Removed features
 
@@ -520,6 +512,15 @@ registry.redhat.io/rhpam-7/rhpam-businesscentral-monitoring-rhel8:7.9.0
 registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.9.0
 registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.9.0
 ----
+
+[id="ocp-4-8-pkgman-cmds"]
+==== Operator package manifest format commands
+
+As part of the continued deprecation of the Operator package manifest format, the following commands have been removed:
+
+* `operator-sdk generate packagemanifest`
+* `operator-sdk run packagemanifest`
+* `oc adm catalog build`
 
 [id="ocp-4-8-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
xref: https://github.com/openshift/openshift-docs/issues/29652#issuecomment-840355799

* Denote `oc adm catalog build` command as removed in tracker table
* Move `operator-sdk` pkgman commands section from the "Deprecated features" (incorrect initial placement) to "Removed features"
* Add `oc adm catalog build` to list of removed pkgman commands

Preview: [Operator package manifest format commands](https://deploy-preview-33379--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-pkgman-cmds)