### PR TITLE
OSDOCS-1675: Clarify use of third-party UI links in the dev perspective

### DIFF
--- a/modules/monitoring-accessing-third-party-uis-using-the-web-console.adoc
+++ b/modules/monitoring-accessing-third-party-uis-using-the-web-console.adoc
@@ -17,7 +17,7 @@ You can access the Alertmanager, Grafana, Prometheus, and Thanos Querier web UIs
 +
 [NOTE]
 ====
-Access to the third-party Alertmanager, Grafana, Prometheus, and Thanos Querier UIs is not available from the Developer perspective.
+Access to the third-party Alertmanager, Grafana, Prometheus, and Thanos Querier UIs is not available from the Developer perspective. Instead, use the Metrics UI link in the Developer perspective, which includes some predefined CPU, memory, bandwidth, and network packet queries for the selected project.
 ====
 
 . Select the `openshift-monitoring` project in the *Project:* list.

--- a/modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
+++ b/modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
@@ -12,7 +12,7 @@ In the *Developer* perspective, the Metrics UI includes some predefined CPU, mem
 
 [NOTE]
 ====
-Developers can only use the *Developer* perspective and not the *Administrator* perspective. As a developer you can only query metrics for one project at a time. Developers cannot access the third-party UIs provided with {product-title} monitoring.
+Developers can only use the *Developer* perspective and not the *Administrator* perspective. As a developer, you can only query metrics for one project at a time. Developers cannot access the third-party UIs provided with {product-title} monitoring that are for core platform components. Instead, use the Metrics UI for your user-defined project.
 ====
 
 .Prerequisites


### PR DESCRIPTION
[OSDOCS-1675](https://issues.redhat.com/browse/OSDOCS-1675) - https://issues.redhat.com/browse/OSDOCS-1675

Previews:

- Accessing third-party monitoring UIs by using the web console - https://deploy-preview-33381--osdocs.netlify.app/openshift-enterprise/latest/monitoring/accessing-third-party-uis.html#accessing-third-party-uis-using-the-web-console_accessing-third-party-uis
- Querying metrics for user-defined projects as a developer - https://deploy-preview-33381--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics