### PR TITLE
OSDOCS-1967: Add network policy audit logging

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -870,6 +870,8 @@ Topics:
   Topics:
   - Name: About network policy
     File: about-network-policy
+  - Name: Logging network policy
+    File: logging-network-policy
   - Name: Creating a network policy
     File: creating-network-policy
   - Name: Viewing a network policy

--- a/modules/nw-networkpolicy-audit-concept.adoc
+++ b/modules/nw-networkpolicy-audit-concept.adoc
@@ -1,0 +1,48 @@
+[id="nw-networkpolicy-audit-concept_{context}"]
+= Network policy audit logging
+
+The OVN-Kubernetes cluster network provider uses Open Virtual Network (OVN) ACLs to manage network policy. Audit logging exposes allow and deny ACL events.
+
+You can configure the destination for network policy audit logs, such as a syslog server or a UNIX domain socket.
+Regardless of any additional configuration, an audit log is always saved to `/var/log/ovn/acl-audit-log.log` on each OVN-Kubernetes pod in the cluster.
+
+Network policy audit logging is enabled per namespace by annotating the namespace with the `k8s.ovn.org/acl-logging` key as in the following example:
+
+.Example namespace annotation
+[source,yaml]
+----
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: example1
+  annotations:
+    k8s.ovn.org/acl-logging: |-
+      {
+        "deny": "info",
+        "allow": "info"
+      }
+----
+
+The logging format is compatible with syslog as defined by RFC5424. The syslog facility is configurable and defaults to `local0`. An example log entry might resemble the following:
+
+.Example ACL deny log entry
+[source,text]
+----
+2021-06-13T19:33:11.590Z|00005|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_deny-all", verdict=drop, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:39,dl_dst=0a:58:0a:80:02:37,nw_src=10.128.2.57,nw_dst=10.128.2.55,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+----
+
+The following table describes namespace annotation values:
+
+.Network policy audit logging namespace annotation
+[cols=".^4,.^6a",options="header"]
+|====
+|Annotation|Value
+
+|`k8s.ovn.org/acl-logging`
+|
+You must specify at least one of `allow`, `deny`, or both to enable network policy audit logging for a namespace.
+
+`deny`:: Optional: Specify `alert`, `warning`, `notice`, `info`, or `debug`.
+`allow`:: Optional: Specify `alert`, `warning`, `notice`, `info`, or `debug`.
+
+|====

--- a/modules/nw-networkpolicy-audit-configure.adoc
+++ b/modules/nw-networkpolicy-audit-configure.adoc
@@ -1,0 +1,228 @@
+[id="nw-networkpolicy-audit-configure_{context}"]
+= Configuring network policy auditing for a cluster
+
+As a cluster administrator, you can customize network policy audit logging for your cluster.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+* To customize the network policy audit logging configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc edit network.operator.openshift.io/cluster
+----
++
+[TIP]
+====
+You can alternatively customize and apply the following YAML to configure audit logging:
+
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      policyAuditConfig:
+        destination: "null"
+        maxFileSize: 50
+        rateLimit: 20
+        syslogFacility: local0
+----
+====
+
+.Verification
+
+. To create a namespace with network policies complete the following steps:
+.. Create a namespace for verification:
++
+[source,terminal]
+----
+$ cat <<EOF| oc create -f -
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: verify-audit-logging
+  annotations:
+    k8s.ovn.org/acl-logging: '{ "deny": "alert", "allow": "alert" }'
+EOF
+----
++
+.Example output
+[source,text]
+----
+namespace/verify-audit-logging created
+----
+
+.. Enable audit logging:
++
+[source,terminal]
+----
+$ oc annotate namespace verify-audit-logging k8s.ovn.org/acl-logging='{ "deny": "alert", "allow": "alert" }'
+----
++
+[source,text]
+----
+namespace/verify-audit-logging annotated
+----
+
+.. Create network policies for the namespace:
++
+[source,terminal]
+----
+$ cat <<EOF| oc create -n verify-audit-logging -f -
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: deny-all
+spec:
+  podSelector:
+    matchLabels:
+  policyTypes:
+  - Ingress
+  - Egress
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-same-namespace
+spec:
+  podSelector: {}
+  policyTypes: 
+   - Ingress
+   - Egress
+  ingress:
+    - from:
+        - podSelector: {}
+  egress: 
+    - to: 
+       - namespaceSelector: 
+          matchLabels: 
+            namespace: verify-audit-logging
+EOF
+----
++
+.Example output
+[source,text]
+----
+networkpolicy.networking.k8s.io/deny-all created
+networkpolicy.networking.k8s.io/allow-from-same-namespace created
+----
+
+. Create a pod for source traffic in the `default` namespace:
++
+[source,terminal]
+----
+$ cat <<EOF| oc create -n default -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: client
+spec:
+  containers:
+    - name: client
+      image: registry.access.redhat.com/rhel7/rhel-tools
+      command: ["/bin/sh", "-c"]
+      args:
+        ["sleep inf"]
+EOF
+----
+
+. Create two pods in the `verify-audit-logging` namespace:
++
+[source,terminal]
+----
+$ for name in client server; do
+cat <<EOF| oc create -n verify-audit-logging -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${name}
+spec:
+  containers:
+    - name: ${name}
+      image: registry.access.redhat.com/rhel7/rhel-tools
+      command: ["/bin/sh", "-c"]
+      args:
+        ["sleep inf"]
+EOF
+done
+----
++
+.Example output
+[source,text]
+----
+pod/client created
+pod/server created
+----
+
+. To generate traffic and produce network policy audit log entries, complete the following steps:
+
+.. Obtain the IP address for pod named `server` in the `verify-audit-logging` namespace:
++
+[source,terminal]
+----
+$ POD_IP=$(oc get pods server -n verify-audit-logging -o jsonpath='{.status.podIP}')
+----
+
+.. Ping the IP address from the previous command from the pod named `client` in the `default` namespace and confirm that all packets are dropped:
++
+[source,terminal]
+----
+$ oc exec -it client -n default -- /bin/ping -c 2 $POD_IP
+----
++
+.Example output
+[source,text]
+----
+PING 10.128.2.55 (10.128.2.55) 56(84) bytes of data.
+
+--- 10.128.2.55 ping statistics ---
+2 packets transmitted, 0 received, 100% packet loss, time 2041ms
+----
+
+.. Ping the IP address saved in the `POD_IP` shell environment variable from the pod named `client` in the `verify-audit-logging` namespace and confirm that all packets are allowed:
++
+[source,terminal]
+----
+$ oc exec -it client -n verify-audit-logging -- /bin/ping -c 2 $POD_IP
+----
++
+.Example output
+[source,text]
+----
+PING 10.128.0.86 (10.128.0.86) 56(84) bytes of data.
+64 bytes from 10.128.0.86: icmp_seq=1 ttl=64 time=2.21 ms
+64 bytes from 10.128.0.86: icmp_seq=2 ttl=64 time=0.440 ms
+
+--- 10.128.0.86 ping statistics ---
+2 packets transmitted, 2 received, 0% packet loss, time 1001ms
+rtt min/avg/max/mdev = 0.440/1.329/2.219/0.890 ms
+----
+
+. Display the latest entries in the network policy audit log:
++
+[source,terminal]
+----
+$ for pod in $(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers=true | awk '{ print $1 }') ; do
+    oc exec -it $pod -n openshift-ovn-kubernetes -- tail -4 /var/log/ovn/acl-audit-log.log
+  done
+----
++
+.Example output
+[source,text]
+----
+Defaulting container name to ovn-controller.
+Use 'oc describe pod/ovnkube-node-hdb8v -n openshift-ovn-kubernetes' to see all of the containers in this pod.
+2021-06-13T19:33:11.590Z|00005|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_deny-all", verdict=drop, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:39,dl_dst=0a:58:0a:80:02:37,nw_src=10.128.2.57,nw_dst=10.128.2.55,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+2021-06-13T19:33:12.614Z|00006|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_deny-all", verdict=drop, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:39,dl_dst=0a:58:0a:80:02:37,nw_src=10.128.2.57,nw_dst=10.128.2.55,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+2021-06-13T19:44:10.037Z|00007|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_allow-from-same-namespace_0", verdict=allow, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:3b,dl_dst=0a:58:0a:80:02:3a,nw_src=10.128.2.59,nw_dst=10.128.2.58,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+2021-06-13T19:44:11.037Z|00008|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_allow-from-same-namespace_0", verdict=allow, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:3b,dl_dst=0a:58:0a:80:02:3a,nw_src=10.128.2.59,nw_dst=10.128.2.58,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+----

--- a/modules/nw-networkpolicy-audit-disable.adoc
+++ b/modules/nw-networkpolicy-audit-disable.adoc
@@ -1,0 +1,45 @@
+[id="nw-networkpolicy-audit-disable_{context}"]
+= Disabling network policy audit logging for a namespace
+
+As a cluster administrator, you can disable network policy audit logging for a namespace.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+* To disable network policy audit logging for a namespace, enter the following command:
++
+[source,terminal]
+----
+$ annotate --overwrite namespace <namespace> k8s.ovn.org/acl-logging={}
+----
++
+--
+where:
+
+`<namespace>`:: Specifies the name of the namespace.
+--
++
+[TIP]
+====
+You can alternatively apply the following YAML to disable audit logging:
+
+[source,yaml]
+----
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: <namespace>
+  annotations:
+    k8s.ovn.org/acl-logging: null
+----
+====
++
+.Example output
+[source,terminal]
+----
+namespace/verify-audit-logging annotated
+----

--- a/modules/nw-networkpolicy-audit-enable.adoc
+++ b/modules/nw-networkpolicy-audit-enable.adoc
@@ -1,0 +1,67 @@
+[id="nw-networkpolicy-audit-enable_{context}"]
+= Enabling network policy audit logging for a namespace
+
+As a cluster administrator, you can enable network policy audit logging for a namespace.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+* To enable network policy audit logging for a namespace, enter the following command:
++
+[source,terminal]
+----
+$ oc annotate namespace <namespace> \
+  k8s.ovn.org/acl-logging='{ "deny": "alert", "allow": "notice" }'
+----
++
+--
+where:
+
+`<namespace>`:: Specifies the name of the namespace.
+--
++
+[TIP]
+====
+You can alternatively apply the following YAML to enable audit logging:
+
+[source,yaml]
+----
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: <namespace>
+  annotations:
+    k8s.ovn.org/acl-logging: |-
+      {
+        "deny": "alert",
+        "allow": "notice"
+      }
+----
+====
++
+.Example output
+[source,terminal]
+----
+namespace/verify-audit-logging annotated
+----
+
+.Verification
+
+* Display the latest entries in the network policy audit log:
++
+[source,terminal]
+----
+$ for pod in $(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-node --no-headers=true | awk '{ print $1 }') ; do
+    oc exec -it $pod -n openshift-ovn-kubernetes -- tail -4 /var/log/ovn/acl-audit-log.log
+  done
+----
++
+.Example output
+[source,text]
+----
+2021-06-13T19:33:11.590Z|00005|acl_log(ovn_pinctrl0)|INFO|name="verify-audit-logging_deny-all", verdict=drop, severity=alert: icmp,vlan_tci=0x0000,dl_src=0a:58:0a:80:02:39,dl_dst=0a:58:0a:80:02:37,nw_src=10.128.2.57,nw_dst=10.128.2.55,nw_tos=0,nw_ecn=0,nw_ttl=64,icmp_type=8,icmp_code=0
+----

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -259,7 +259,42 @@ ifdef::operator[]
 If the field is present, IPsec is enabled for the cluster.
 endif::operator[]
 
+|`policyAuditConfig`
+|`object`
+|Specify a configuration object for customizing network policy audit logging. If unset, the defaults audit log settings are used.
+
 |====
+
+tag::policy-audit[]
+.`policyAuditConfig` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`rateLimit`
+|integer
+|The maximum number of messages to generate every second per node. The default value is `20` messages per second.
+
+|`maxFileSize`
+|integer
+|The maximum size for the audit log in bytes. The default value is `50000000` or 50MB.
+
+|`destination`
+|string
+|
+One of the following additional audit log targets:
+
+`libc`:: The libc `syslog()` function of the journald process on the host.
+`udp:<host>:<port>`:: A syslog server. Replace `<host>:<port>` with the host and port of the syslog server.
+`unix:<file>`:: A Unix Domain Socket file specified by `<file>`.
+`null`:: Do not send the audit logs to any additional target.
+
+|`syslogFacility`
+|string
+|The syslog facility, such as `kern`, as defined by RFC5424. The default value is `local0`.
+
+|====
+end::policy-audit[]
 
 ifdef::operator[]
 NOTE: You can only change the configuration for your cluster network provider during cluster installation.

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -25,6 +25,8 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |Kubernetes network policy|Supported|Partially supported ^[2]^
 
+|Kubernetes network policy logs|Supported|Not supported
+
 |Multicast|Supported|Supported
 endif::[]
 ifeval::["{context}" == "about-openshift-sdn"]
@@ -41,6 +43,8 @@ ifeval::["{context}" == "about-openshift-sdn"]
 |IPv6|Not supported|Supported ^[4]^
 
 |Kubernetes network policy|Partially supported ^[2]^|Supported
+
+|Kubernetes network policy logs|Not supported|Supported
 
 |Multicast|Supported|Supported
 endif::[]

--- a/networking/network_policy/logging-network-policy.adoc
+++ b/networking/network_policy/logging-network-policy.adoc
@@ -1,0 +1,49 @@
+[id="logging-network-policy"]
+= Logging network policy events
+include::modules/common-attributes.adoc[]
+:context: logging-network-policy
+
+toc::[]
+
+As a cluster administrator, you can configure network policy audit logging for your cluster and enable logging for one or more namespaces.
+
+[NOTE]
+====
+Audit logging of network policies is available for only the xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes cluster network provider].
+====
+
+include::modules/nw-networkpolicy-audit-concept.adoc[leveloffset=+1]
+
+== Network policy audit configuration
+
+The configuration for audit logging is specified as part of the OVN-Kubernetes cluster network provider configuration. The following YAML illustrates default values for network policy audit logging feature.
+
+.Audit logging configuration
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      policyAuditConfig:
+        destination: "null"
+        maxFileSize: 50
+        rateLimit: 20
+        syslogFacility: local0
+----
+
+The following table describes the configuration fields for network policy audit logging.
+
+include::modules/nw-operator-cr.adoc[tag=policy-audit]
+
+include::modules/nw-networkpolicy-audit-configure.adoc[leveloffset=+1]
+include::modules/nw-networkpolicy-audit-enable.adoc[leveloffset=+1]
+include::modules/nw-networkpolicy-audit-disable.adoc[leveloffset=+1]
+
+[id="{context}-additional-resources"]
+== Additional resources
+
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -21,6 +21,7 @@ include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]
 
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
+* xref:../../networking/network_policy/logging-network-policy.adoc#logging-network-policy[Logging network policy events]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
 * xref:../../networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc#about-ipsec-ovn[IPsec encryption configuration]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1967

This PR adds a discussion of network policy audit logging.

Previews:
- [Logging network policy events](https://deploy-preview-33386--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/logging-network-policy.html)