### PR TITLE
BZ1950240: Added known issue to 4.7 RN

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2108,7 +2108,8 @@ It is recommended that SR-IOV customers should not upgrade to {product-title} 4.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930469[*BZ#1930469*])
 
 * In {product-title} 4.7, `ConfigInformers` objects added to the Operator infrastructure code unsuccessfully start. As a result, the `ConfigObserver` object fails to sync the cache. When this happens, the oVirt CSI Driver Operator shuts down after a couple of minutes, which leads to continual restarts. As a workaround, you can perform the following procedure:
-
++
+--
 . Switch the project to a cluster with the oVirt CSI Operator:
 +
 [source,terminal]
@@ -2129,7 +2130,7 @@ $ oc status
 ----
 $ oc get pods
 ----
-
+--
 +
 As a result, the oVirt CSI Driver Operator no longer continually restarts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929777[*BZ#1929777*])
 
@@ -2137,6 +2138,8 @@ As a result, the oVirt CSI Driver Operator no longer continually restarts. (link
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
 * The OVN-Kubernetes network provider does not support the `externalTrafficPolicy` feature for `NodePort`- and `LoadBalancer`-type services.  The `service.spec.externalTrafficPolicy` field determines whether traffic for a service is routed to node-local or cluster-wide endpoints. Currently, such traffic is routed by default to cluster-wide endpoints, and there is no way to limit traffic to node-local endpoints. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[*BZ#1903408*])
+
+* Currently, a Kubernetes port collision issue can cause a breakdown in pod-to-pod communication, even after pods are redeployed. For detailed information and a workaround, see the Red Hat Knowledge Base solution link:https://access.redhat.com/solutions/5940711[Port collisions between pod and cluster IPs on OpenShift 4 with OVN-Kubernetes]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939676[*BZ#1939676*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1939045[*BZ#1939045*])
 
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Partly fixes [BZ1950240](https://bugzilla.redhat.com/show_bug.cgi?id=1950240) by adding known issue to 4.7 RN. See also https://github.com/openshift/openshift-docs/pull/33043 and #33555 
* Partly fixes BZ1950240 (see also other pull request?)
* Applies only to `enterprise-4.7`
* [Direct preview link: scroll up from **Asynchronous errata updates**](https://deploy-preview-33398--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-asynchronous-errata-updates)