### PR TITLE
Add Local Storage Operator must-gather image

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -44,6 +44,9 @@ ifndef::openshift-origin[]
 |`registry.redhat.io/openshift4/ose-cluster-logging-operator`
 |Data collection for OpenShift Logging.
 
+|`registry.redhat.io/openshift4/ose-local-storage-mustgather-rhel8`
+|Data collection for Local Storage Operator.
+
 |===
 
 endif::openshift-origin[]
@@ -72,6 +75,9 @@ ifdef::openshift-origin[]
 
 |`quay.io/openshift/origin-cluster-logging-operator`
 |Data collection for OpenShift Logging.
+
+|`quay.io/openshift/origin-local-storage-mustgather`
+|Data collection for Local Storage Operator.
 
 |===
 


### PR DESCRIPTION
Local Storage Operator has its own must-gather image and it should be mentioned on the list.

It should be probably propagated to all supported OCP versions.

cc @gnufied
/assign @lpettyjo 

Fixes #30292

Preview: https://deploy-preview-33403--osdocs.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data