### PR TITLE
Updating table to list scheduler policy as deprecated still

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -444,7 +444,7 @@ In the table, features are marked with the following statuses:
 |Scheduler policy
 |GA
 |DEP
-|
+|DEP
 
 |`ImageChangesInProgress` condition for Cluster Samples Operator
 |GA


### PR DESCRIPTION
Preview: https://deploy-preview-33405--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-deprecated-removed-features