### PR TITLE
BZ1908125 ip_whitelist for console routes is not supported

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -5,7 +5,7 @@
 [id="nw-route-specific-annotations_{context}"]
 = Route-specific annotations
 
-The Ingress Controller can set the default options for all the routes it exposes. An individual route can override some of these defaults by providing specific configurations in its annotations.
+The Ingress Controller can set the default options for all the routes it exposes. An individual route can override some of these defaults by providing specific configurations in its annotations. Red Hat does not support adding a route annotation to an operator-managed route.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
4.5+

- BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1908125

- Direct link to docs preview: https://deploy-preview-33407--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration