### PR TITLE
GH#32641: Fixes the address for the image sources in AWS documentation.

### DIFF
--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -101,7 +101,7 @@ imageContentSources:
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
   - <local_registry>/<local_repository_name>/release
-  source: registry.svc.ci.openshift.org/ocp/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 ----
 +
 Use the `imageContentSources` section from the output of the command to mirror the repository or the values that you used when you mirrored the content from the media that you brought into your restricted network.


### PR DESCRIPTION
This ticket fixes #32641 where the Image source link was incorrect.

Version: 4.5+

Preview: https://deploy-preview-33408--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws?utm_source=github&utm_campaign=bot_dp#installation-generate-aws-user-infra-install-config_installing-restricted-networks-aws