### PR TITLE
OSDOCS-2082: Add coreos print-stream-json sub-command to AWS AMI install

### DIFF
--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -95,6 +95,8 @@ include::modules/installation-cloudformation-security.adoc[leveloffset=+2]
 
 * You can view details about the CloudFormation stacks that you create by navigating to the link:https://console.aws.amazon.com/cloudformation/[AWS CloudFormation console].
 
+include::modules/installation-aws-ami-stream-metadata.adoc[leveloffset=+1]
+
 include::modules/installation-aws-user-infra-rhcos-ami.adoc[leveloffset=+1]
 
 include::modules/installation-aws-regions-with-no-ami.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -102,6 +102,8 @@ include::modules/installation-creating-aws-security.adoc[leveloffset=+1]
 
 include::modules/installation-cloudformation-security.adoc[leveloffset=+2]
 
+include::modules/installation-aws-ami-stream-metadata.adoc[leveloffset=+1]
+
 include::modules/installation-aws-user-infra-rhcos-ami.adoc[leveloffset=+1]
 
 include::modules/installation-creating-aws-bootstrap.adoc[leveloffset=+1]

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -1,0 +1,41 @@
+//TODO: Add the module include to the following assemblies
+//TODO: Create related modules for OpenStack (QCOW2) and Bare Metal (ISO)
+
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-user-infra.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+
+[id="installation-aws-ami-stream-metadata_{context}"]
+= Accessing {op-system} AMIs with stream metadata
+
+In {product-title}, _stream metadata_ provides standardized metadata about {op-system} in the JSON format and injects the metadata into the cluster. Stream metadata is a stable format that supports multiple architectures and is intended to be self-documenting for maintaining automation.
+
+You can use the `coreos print-stream-json` sub-command of `openshift-install` to access information about the boot images in the stream metadata format. This command provides a method for printing stream metadata in a scriptable, machine-readable format.
+
+For user-provisioned installations, the `openshift-install` binary contains references to the version of {op-system} boot images that are tested for use with {product-title}, such as the AWS AMI.
+
+.Procedure
+
+To parse the stream metadata, use one of the following methods:
+
+* From a Go program, use the official `stream-metadata-go` library at https://github.com/coreos/stream-metadata-go. You can also view example code in the library.
+
+* From another programming language, such as Python or Ruby, use the JSON library of your preferred programming language.
+
+* From a command-line utility that handles JSON data, such as `jq`:
+
+** Print the current `x86_64` AMI for an AWS region, such as `us-west-1`:
++
+[source,terminal]
+----
+$ openshift-install coreos print-stream-json | jq -r '.architectures.x86_64.images.aws.regions["us-west-1"].image'
+----
++
+.Example output
+[source,terminal]
+----
+ami-0d3e625f84626bbda
+----
++
+The output of this command is the AWS AMI ID for the `us-west-1` region. The AMI must belong to the same region as the cluster.

--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -6,13 +6,11 @@
 [id="installation-aws-user-infra-rhcos-ami_{context}"]
 = {op-system} AMIs for the AWS infrastructure
 
-Red Hat provides {op-system-first} AMIs valid for the various Amazon Web
-Services (AWS) zones you can specify for your {product-title} nodes.
+Red Hat provides {op-system-first} AMIs that are valid for the various AWS regions that you can manually specify for your {product-title} nodes.
 
 [NOTE]
 ====
-You can also install to regions that do not have a {op-system} AMI published by
-importing your own AMI.
+By importing your own AMI, you can also install to regions that do not have a published {op-system} AMI.
 ====
 
 ifndef::openshift-origin[]


### PR DESCRIPTION
[OSDOCS-2082](https://issues.redhat.com/browse/OSDOCS-2082)
In this example, we want to give admins a better way than the current workflow of hardcoding AMIs that are copy-pasted from the openshift-installer. This PR documents how to run the new coreos sub-command of the installer so that users can avoid having to manually parse the HTML in `modules/installation-aws-user-infra-rhcos-ami.adoc`.

**Preview links:**
- [Printing RHCOS AMIs for AWS zones by using stream metadata](https://deploy-preview-33415--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-ami-stream-metadata_installing-restricted-networks-aws) (AWS UPI install in restricted network)
- [ Printing RHCOS AMIs for AWS zones by using stream metadata ](https://deploy-preview-33415--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-ami-stream-metadata_installing-aws-user-infra)(AWS UPI install with CloudFormation templates)