### PR TITLE
BZ1881856: why you shouldn't modify the default SCCs

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -52,8 +52,7 @@ effectively root on the cluster and must be trusted accordingly.
 
 [IMPORTANT]
 ====
-Do not modify the default SCCs. Customizing the default SCCs can lead to issues
-when {product-title} is upgraded.
+Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or {product-title} is upgraded. During upgrades between some versions of {product-title}, the values of the default SCCs are reset to the default values, which discards all customizations to those SCCs.
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 Instead, create new SCCs.
 endif::[]

--- a/modules/security-context-constraints-command-reference.adoc
+++ b/modules/security-context-constraints-command-reference.adoc
@@ -15,8 +15,7 @@ You must have `cluster-admin` privileges to manage SCCs.
 
 [IMPORTANT]
 ====
-Do not modify the default SCCs. Customizing the default SCCs can lead to issues
-when upgrading. Instead, create new SCCs.
+Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or {product-title} is upgraded. During upgrades between some versions of {product-title}, the values of the default SCCs are reset to the default values, which discards all customizations to those SCCs.
 ====
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1881856

4.5+

Preview: https://deploy-preview-33416--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints?utm_source=github&utm_campaign=bot_dp#security-context-constraints-about_configuring-internal-oauth