### PR TITLE
TELCODOCS-147: KNIDEPLOY-3864, Expose BIOS Settings for workload scheduling on nodes

### DIFF
--- a/modules/nfd-op-using-the-node-feature-discovery-operator.adoc
+++ b/modules/nfd-op-using-the-node-feature-discovery-operator.adoc
@@ -1,0 +1,38 @@
+// This is included in the following assemblies:
+//
+// post_installation_configuration/node-tasks.adoc
+
+[id="using-the-node-feature-discovery-operator_{context}"]
+
+= Using the Node Feature Discovery Operator
+
+Node Feature Discovery (NFD) streamlines the process of matching {product-title} cluster workloads to node capabilities. The NFD Operator detects hardware features available on each node in an {product-title} cluster. On the control plane nodes, the NFD daemon receives labeling requests from worker nodes and modifies worker node objects with node labels. This enables the NFD Operator to advertise the features of specific nodes.
+
+.Procedure
+
+Install the NFD Operator from link:operatorhub.io/operator/nfd-operator[OperatorHub.io: Node Feature Discovery].
+
+. Install the Operator Lifecycle Manager (OLM) tool:
++
+[source,terminal]
+----
+$ curl -sL https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.18.1/install.sh | bash -s v0.18.1
+----
++
+This tool helps manage the Operators running on your cluster.
+
+. Install the NFD Operator:
++
+[source,terminal]
+----
+$ oc kubectl -f https://operatorhub.io/install/nfd-operator.yaml
+----
+
+. Watch the NFD Operator initialize:
++
+[source,terminal]
+----
+$ oc get csv -n operators
+----
+
+To use NFD, refer to the link:https://kubernetes-sigs.github.io/node-feature-discovery/v0.8/get-started/[Node Feature Discovery] documentation.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -138,3 +138,5 @@ include::modules/cluster-node-tuning-operator-default-profiles-set.adoc[leveloff
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+2]
 
 include::modules/nodes-nodes-managing-max-pods-proc.adoc[leveloffset=+1]
+
+include::modules/nfd-op-using-the-node-feature-discovery-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
Adds a module for installing the Node Feature Discovery Operator.

Fixes: [TELCODOCS-147](https://issues.redhat.com/browse/TELCODOCS-147)

See https://issues.redhat.com/browse/TELCODOCS-147 for additional details.

Preview URL: https://deploy-preview-33417--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks?utm_source=github&utm_campaign=bot_dp

Signed-off-by: John Wilkins <jowilkin@redhat.com>
