### PR TITLE
CNV-11390: RN - Added note about live migration support on SR-IOV network

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -53,20 +53,17 @@ The SVVP Certification applies to:
 ** Storage
 ** Guest memory swapping
 
-//CNV-12271 A new tech preview feature allows VM owners to hot-plug and hot-unplug disks with a running virtual machine
-
 [id="virt-4-8-installation-new"]
 === Installation
 
 [id="virt-4-8-networking-new"]
 === Networking
 
-
-
 //CNV-9055 Kubernetes NMState now supports new IP configuration options.
 * You can use the Kubernetes NMSstate Operator to xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-example-nmstate-IP-management_virt-updating-node-network-config[configure and manage IP addresses] on your cluster nodes.
 
 //CNV-11390 OpenShift Virtualization now supports live-migration of VM connected to an SR-IOV network.
+* {VirtProductName} now supports xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[live migration of virtual machines] that are attached to an SR-IOV network interface if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR). 
 
 [id="virt-4-8-storage-new"]
 === Storage
@@ -106,6 +103,15 @@ Deprecated features are included in the current release and supported. However, 
 
 //CNV-9054 MAC address pool is now enabled on all namespaces by default.
 * KubeMacPool is now enabled by default when you install {VirtProductName}. You can xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[disable a MAC address pool] for a namespace by adding the `mutatevirtualmachines.kubemacpool.io=ignore` label to the namespace. Re-enable KubeMacPool for the namespace by removing the label.
+
+[id="virt-4-8-technology-preview"]
+== Technology Preview features
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+//CNV-12271 A new tech preview feature allows VM owners to hot-plug and hot-unplug disks with a running virtual machine
 
 [id="virt-4-8-known-issues"]
 == Known issues


### PR DESCRIPTION
This PR addresses [CNV-11390](https://issues.redhat.com/browse/CNV-11390)

Added note in the 4.8 release notes about support for VM live migration on SR-IOV network interface.

I also added a section in the release notes about Technology Preview features which is one of the tasks described in [CNV-12465](https://issues.redhat.com/browse/CNV-12465)

Preview: https://deploy-preview-33418--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes.html#virt-4-8-networking-new