### PR TITLE
TELCODOCS-147: Release notes for KNIDEPLOY-3864. Expose BIOS Settings for workload scheduling on nodes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -309,6 +309,17 @@ With this release, when you set requests and limits for huge pages in a pod spec
 
 For more information, see xref:../scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc#consuming-huge-pages-resource-using-the-downward-api_huge-pages[Consuming huge pages resources using the Downward API].
 
+[id='ocp-4-8-nodes-nfd-operator-new-labels_{context}']
+==== New labels for the Node Feature Discovery Operator
+
+The Node Feature Discovery (NFD) Operator detects hardware features available on each node in an {product-title} cluster. Then, it modifies node objects with node labels. This enables the NFD Operator to advertise the features of specific nodes. {product-title} {product-version} supports three additional labels for the NFD Operator.
+
+- `pstate intel-pstate`: When the Intel `pstate` driver is enabled and in use, the `pstate intel-pstate` label reflects the status of the Intel `pstate` driver. The status is either `active` or `passive`.
+
+- `pstate scaling_governor`: When the Intel `pstate` driver status is `active`, the `pstate scaling_governor` label reflects the scaling governor algorithm. The algorithm is either `powersave` or `performance`.
+
+- `cstate status`: If the `intel_idle` driver has C-states or idle states, the `cstate status` label is `true`. Otherwise, it is `false`.
+
 [id="ocp-4-8-logging"]
 === Cluster logging
 


### PR DESCRIPTION
Release notes for [TELCODOCS-147](https://issues.redhat.com/browse/TELCODOCS-147).

Fixes: [TELCODOCS-147](https://issues.redhat.com/browse/TELCODOCS-147)

See http://issues.redhat.com/browse/TELCODOCS-147 for additional details.

Preview URL: https://deploy-preview-33419--osdocs.netlify.app/?utm_source=github&utm_campaign=bot_dp

Signed-off-by: John Wilkins <jowilkin@redhat.com>