### PR TITLE
CNV-11843: bumping HCO version variable for 2.4.9

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.4
 :KubeVirtVersion: v0.30.5
-:HCOVersion: 2.4.8
+:HCOVersion: 2.4.9
 :product-build:
 :DownloadURL: registry.access.redhat.com
 :kebab: image:kebab.png[title="Options menu"]


### PR DESCRIPTION
- [CNV-11843](https://issues.redhat.com/browse/CNV-11843)
- no cherrypick
- attn @tiraboschi 