### PR TITLE
CNV-9054: RN - Added note that KubeMacPool is enabled by default

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -55,7 +55,7 @@ The SVVP Certification applies to:
 [id="virt-4-8-networking-new"]
 === Networking
 
-//CNV-9054 MAC address pool is now enabled on all namespaces by default.
+
 
 //CNV-9055 Kubernetes NMState now supports new IP configuration options.
 
@@ -95,6 +95,9 @@ Deprecated features are included in the current release and supported. However, 
 == Notable technical changes
 
 //CNV-9052 OpenShift Virtualization now automatically automatically configures IPv6 IP when running on dual-stack clusters.
+
+//CNV-9054 MAC address pool is now enabled on all namespaces by default.
+* KubeMacPool is now enabled by default when you install {VirtProductName}. You can xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[disable a MAC address pool] for a namespace by adding the `mutatevirtualmachines.kubemacpool.io=ignore` label to the namespace. Re-enable KubeMacPool for the namespace by removing the label.
 
 [id="virt-4-8-known-issues"]
 == Known issues


### PR DESCRIPTION
This PR addresses [CNV-9054](https://issues.redhat.com/browse/CNV-9054)

Added note in the Notable technical changes section that KubeMacPool is now enabled by default

Preview: https://deploy-preview-33422--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-changes