### PR TITLE
OSDOCS-2113: PROXY Protocol Ingress configuration, new branch

### DIFF
--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * ingress/configure-ingress-operator.adoc
+
+[id="nw-ingress-controller-configuration-proxy-protocol_{context}"]
+= Configuring the PROXY protocol for an Ingress Controller
+
+A cluster administrator can configure https://www.haproxy.org/download/1.8/doc/proxy-protocol.txt[the PROXY protocol] when an Ingress Controller uses either the `HostNetwork` or `NodePortService` endpoint publishing strategy types. The PROXY protocol enables the load balancer to preserve the original client addresses for connections that the Ingress Controller receives. The original client addresses are useful for logging, filtering, and injecting HTTP headers. In the default configuration, the connections that the Ingress Controller receives only contain the source address that is associated with the load balancer.
+
+This feature is not supported in cloud deployments. This restriction is because when {product-title} runs in a cloud platform, and an IngressController specifies that a service load balancer should be used, the Ingress Operator configures the load balancer service and enables the PROXY protocol based on the platform requirement for preserving source addresses.
+
+[WARNING]
+====
+To prevent connection failure, configure both the Ingress Controller and the load balancer to use the PROXY protocol.
+====
+
+.Prerequisites
+* You created an Ingress Controller.
+
+.Procedure
+. Edit the Ingress Controller resource:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator edit ingresscontroller/default
+----
+
+. Set the PROXY configuration:
++
+* If your Ingress Controller uses the hostNetwork endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.hostNetwork.protocol` subfield to `PROXY`:
++
+.Sample `hostNetwork` configuration to `PROXY`
+[source,yaml]
+----
+  spec:
+    endpointPublishingStrategy:
+      hostNetwork:
+        protocol: PROXY
+      type: NodePortService
+----
+* If your Ingress Controller uses the NodePortService endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.nodePort.protocol` subfield to `PROXY`:
++
+.Sample `nodePort` configuration to `PROXY`
+[source,yaml]
+----
+  spec:
+    endpointPublishingStrategy:
+      nodePort:
+        protocol: PROXY
+      type: NodePortService
+----

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -60,6 +60,8 @@ include::modules/nw-using-ingress-forwarded.adoc[leveloffset=+2]
 
 include::modules/nw-http2-haproxy.adoc[leveloffset=+2]
 
+include::modules/nw-ingress-controller-configuration-proxy-protocol.adoc[leveloffset=+2]
+
 include::modules/nw-ingress-configuring-application-domain.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-converting-http-header-case.adoc[leveloffset=+2]


### PR DESCRIPTION
Please see this [PR](https://github.com/openshift/openshift-docs/pull/32484) for tech review, peer review, and QA feedback. Opened a new branch because other branch was in the wrong distro.

Added topic about configuring PROXY protocol on Ingress Controllers

link to doc preview: https://deploy-preview-32484--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress

https://issues.redhat.com/browse/OSDOCS-2113
https://issues.redhat.com/browse/NE-330