### PR TITLE
OSDOCS-2081: Stream metadata release note 4-8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -50,13 +50,22 @@ This release adds improvements related to the following components and concepts.
 
 {op-system} is now using {op-system-base-full} 8.4 packages. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates. {product-title} 4.7 is currently using {op-system-base} 8.3 packages and will upgrade to {op-system-base} 8.4 in a future update. {product-title} 4.6 is an Extended Update Support (EUS) release that will continue to use {op-system-base} 8.2 EUS packages for the entirety of its lifecycle.
 
+[id="ocp-4-8-stream-metadata"]
+==== Using stream metadata for improved boot image automation
+
+Stream metadata provides a standardized JSON format for injecting metadata into the cluster during {product-title} installation. For improved automation, the new `openshift-install coreos print-stream-json` command provides a method for printing stream metadata in a scriptable, machine-readable format.
+
+For user-provisioned installations, the `openshift-install` binary contains references to the version of {op-system} boot images that are tested for use with {product-title}, such as the AWS AMI. You can now parse the stream metadata from a Go program by using the official `stream-metadata-go` library at https://github.com/coreos/stream-metadata-go.
+
+For more information, see xref:../installing/installing_aws/installing-aws-user-infra.adoc#installation-aws-ami-stream-metadata_installing-aws-user-infra[Accessing {op-system} AMIs with stream metadata].
+
 [id="ocp-4-8-rhcos-butane"]
 ==== Butane config transpiler simplifies creation of machine configs
 
 {product-title} now includes the Butane config transpiler to assist with producing and validating machine configs. Documentation now recommends using Butane to create machine configs for LUKS disk encryption, boot disk mirroring, and custom kernel modules.
 
 [id="ocp-4-8-rhcos-chrony-default"]
-==== Change to custom `chrony.conf` default on cloud platforms
+==== Change to custom chrony.conf default on cloud platforms
 
 If a cloud administrator has already set a custom `/etc/chrony.conf` configuration, {op-system} no longer sets the `PEERNTP=no` option by default on cloud platforms. Otherwise, the `PEERNTP=no` option is still set by default. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1924869[BZ#1924869] for more information.
 


### PR DESCRIPTION
[OSDOCS-2081](https://issues.redhat.com/browse/OSDOCS-2081) -  Adds 4.8 Release Note for new stream metadata sub-command for `openshift-install` in UPI clusters. Relates to https://github.com/openshift/openshift-docs/pull/33415, which is currently under review.

@cgwalters and @miabbott PTAL for Eng/QE review. Thanks!

**Preview link:** https://deploy-preview-33424--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-stream-metadata