### PR TITLE
OSDOCS-1565: Add troubleshooting with the Prometheus UI Status page

### DIFF
--- a/modules/monitoring-accessing-third-party-uis-using-the-web-console.adoc
+++ b/modules/monitoring-accessing-third-party-uis-using-the-web-console.adoc
@@ -20,7 +20,7 @@ You can access the Alertmanager, Grafana, Prometheus, and Thanos Querier web UIs
 Access to the third-party Alertmanager, Grafana, Prometheus, and Thanos Querier UIs is not available from the Developer perspective. Instead, use the Metrics UI link in the Developer perspective, which includes some predefined CPU, memory, bandwidth, and network packet queries for the selected project.
 ====
 
-. Select the `openshift-monitoring` project in the *Project:* list.
+. Select the `openshift-monitoring` project in the *Project* list.
 
 . Access a third-party monitoring UI:
 
@@ -32,4 +32,4 @@ Access to the third-party Alertmanager, Grafana, Prometheus, and Thanos Querier 
 
 * Select the URL in the `thanos-querier` row to open the login page for the Thanos Querier UI.
 
-. Choose *Log in with OpenShift* to log in using your OpenShift credentials.
+. Choose *Log in with OpenShift* to log in using your {product-title} credentials.

--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -13,6 +13,9 @@ Every assigned key-value pair has a unique time series. The use of many unbound 
 You can use the following measures when Prometheus consumes a lot of disk:
 
 * *Check the number of scrape samples* that are being collected.
+
+* *Check the time series database (TSDB) status in the Prometheus UI* for more information on which labels are creating the most time series. This requires cluster administrator privileges.
+
 * *Reduce the number of unique time series that are created* by reducing the number of unbound attributes that are assigned to user-defined metrics.
 +
 [NOTE]
@@ -42,3 +45,10 @@ topk(10,count by (job)({__name__=~".+"}))
 ** *If the metrics relate to a user-defined project*, review the metrics key-value pairs assigned to your workload. These are implemented through Prometheus client libraries at the application level. Try to limit the number of unbound attributes referenced in your labels.
 
 ** *If the metrics relate to a core {product-title} project*, create a Red Hat support case on the link:https://access.redhat.com/[Red Hat Customer Portal].
+
+. Check the TSDB status in the Prometheus UI.
+.. In the *Administrator* perspective, navigate to *Networking* -> *Routes*.
+.. Select the `openshift-monitoring` project in the *Project* list.
+.. Select the URL in the `prometheus-k8s` row to open the login page for the Prometheus UI.
+.. Choose *Log in with OpenShift* to log in using your {product-title} credentials.
+.. In the Prometheus UI, navigate to *Status* -> *TSDB Status*.


### PR DESCRIPTION
[OSDOCS-1565](https://issues.redhat.com/browse/OSDOCS-1565) - https://issues.redhat.com/browse/OSDOCS-1565

Preview: https://deploy-preview-33425--osdocs.netlify.app/openshift-enterprise/latest/monitoring/troubleshooting-monitoring-issues.html#determining-why-prometheus-is-consuming-disk-space_troubleshooting-monitoring-issues