### PR TITLE
MIG-677: Network requirements

### DIFF
--- a/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
@@ -9,11 +9,20 @@ toc::[]
 You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the command line.
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
+
+[discrete]
+[id="additional-resources-for-migration-prerequisites_{context}"]
+=== Additional resources for migration prerequisites
+
+* link:https://docs.openshift.com/container-platform/3.11/install_config/registry/securing_and_exposing_registry.html#exposing-the-registry[Manually exposing a secure registry for {product-title} 3]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-updating-deprecated-internal-images_troubleshooting-3-4[Updating deprecated internal images]
+
 include::modules/migration-configuring-proxy-for-dvm.adoc[leveloffset=+2]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
 [discrete]
-=== Additional resources
+[id="additional-resources-for-migration-hooks_{context}"]
+=== Additional resources for migration hooks
 
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-about-migration-hooks_about-mtc-3-4[About migration hooks]
 * xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#mighook_migrating-applications-3-4[MigHook custom resource]
@@ -28,6 +37,14 @@ include::modules/migration-launching-cam.adoc[leveloffset=+2]
 include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+2]
 include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+2]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+2]
+
+[discrete]
+[id="additional-resources-for-persistent-volume-copy-methods_{context}"]
+=== Additional resources for persistent volume copy methods
+
+* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#file-system-copy-method_about-mtc-3-4[{mtc-short} file system copy method]
+* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#snapshot-copy-method_about-mtc-3-4[{mtc-short} snapshot copy method]
+
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+2]
 
 [id="migrating-applications-mtc-cli_{context}"]
@@ -38,7 +55,8 @@ You can migrate your applications on the command line by creating or editing the
 You can migrate applications from a local cluster to a remote cluster, from a remote cluster to a local cluster, and between remote clusters.
 
 [discrete]
-=== {mtc-short} terminology
+[id="cluster-terminology_{context}"]
+=== Cluster terminology
 
 The following terms are relevant for configuring clusters:
 
@@ -59,11 +77,9 @@ include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
 include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
 
 [discrete]
-== Additional resources
+[id="additional-resources-for-custom-resources_{context}"]
+=== Additional resources for custom resources
 
-* xref:../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually on an {product-title} 4 cluster]
-* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#file-system-copy-method_about-mtc-3-4[{mtc-short} file system copy method]
-* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#snapshot-copy-method_about-mtc-3-4[{mtc-short} snapshot copy method]
 * xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-viewing-migration-crs_troubleshooting-3-4[Viewing migration custom resources]
 
 [id="configuring-migration-plan_{context}"]

--- a/migrating_from_ocp_3_to_4/premigration-checklists.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists.adoc
@@ -41,6 +41,13 @@ $ oc get pods --all-namespaces --field-selector=status.phase=Running \
 +
 Even if the pods are in a *Running* state, a high restart count might indicate underlying problems.
 
+* [ ] You have deleted old images by running the following command:
++
+[source,terminal]
+----
+$ oc adm prune images
+----
+
 * [ ] The internal container image registry uses a link:https://docs.openshift.com/container-platform/3.11/scaling_performance/optimizing_storage.html#registry[supported storage type].
 * [ ] You can read and write images to the registry.
 * [ ] The link:https://access.redhat.com/articles/3093761[etcd cluster] is healthy.

--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -20,7 +20,8 @@ include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
 
 [discrete]
-=== Additional resources
+[id="additional-resources-for-debugging-tools_{context}"]
+=== Additional resources for debugging tools
 
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-custom-resources_about-mtc-3-4[{mtc-short} custom resources]

--- a/migration-toolkit-for-containers/migrating-applications-with-mtc.adoc
+++ b/migration-toolkit-for-containers/migrating-applications-with-mtc.adoc
@@ -12,7 +12,8 @@ include::modules/migration-configuring-proxy-for-dvm.adoc[leveloffset=+2]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
 [discrete]
-=== Additional resources
+[id="additional-resources-for-migration-hooks_{context}"]
+=== Additional resources for migration hooks
 
 * xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-about-migration-hooks_about-mtc[About migration hooks]
 * xref:../migration-toolkit-for-containers/migrating-applications-with-mtc.adoc#mighook_migrating-applications-with-mtc[MigHook custom resource]
@@ -27,6 +28,14 @@ include::modules/migration-launching-cam.adoc[leveloffset=+2]
 include::modules/migration-adding-cluster-to-cam.adoc[leveloffset=+2]
 include::modules/migration-adding-replication-repository-to-cam.adoc[leveloffset=+2]
 include::modules/migration-creating-migration-plan-cam.adoc[leveloffset=+2]
+
+[discrete]
+[id="additional-resources-for-persistent-volume-copy-methods_{context}"]
+=== Additional resources for persistent volume copy methods
+
+* xref:../migration-toolkit-for-containers/about-mtc.adoc#file-system-copy-method_about-mtc[{mtc-short} file system copy method]
+* xref:../migration-toolkit-for-containers/about-mtc.adoc#snapshot-copy-method_about-mtc[{mtc-short} snapshot copy method]
+
 include::modules/migration-running-migration-plan-cam.adoc[leveloffset=+2]
 
 [id="migrating-applications-mtc-cli_{context}"]
@@ -37,7 +46,8 @@ You can migrate your applications on the command line by creating or editing the
 You can migrate applications from a local cluster to a remote cluster, from a remote cluster to a local cluster, and between remote clusters.
 
 [discrete]
-=== {mtc-short} terminology
+[id="cluster-terminology_{context}"]
+=== Cluster terminology
 
 The following terms are relevant for configuring clusters:
 
@@ -58,11 +68,9 @@ include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
 include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
 
 [discrete]
-== Additional resources
+[id="additional-resources-for-custom-resources_{context}"]
+=== Additional resources for custom resources
 
-* xref:../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually]
-* xref:../migration-toolkit-for-containers/about-mtc.adoc#file-system-copy-method_about-mtc[{mtc-short} file system copy method]
-* xref:../migration-toolkit-for-containers/about-mtc.adoc#snapshot-copy-method_about-mtc[{mtc-short} snapshot copy method]
 * xref:../migration-toolkit-for-containers/troubleshooting-mtc.adoc#migration-viewing-migration-crs_troubleshooting-mtc[Viewing migration custom resources]
 
 [id="configuring-migration-plan_{context}"]

--- a/migration-toolkit-for-containers/troubleshooting-mtc.adoc
+++ b/migration-toolkit-for-containers/troubleshooting-mtc.adoc
@@ -20,11 +20,11 @@ include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
 
 [discrete]
-=== Additional resources
+[id="additional-resources-for-debugging-tools_{context}"]
+=== Additional resources for debugging tools
 
 * xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
 * xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-custom-resources_about-mtc[{mtc-short} custom resources]
-[id="rolling-back-migration_{context}"]
 
 [id="common-issues-and-concerns_{context}"]
 == Common issues and concerns

--- a/modules/migration-prerequisites.adoc
+++ b/modules/migration-prerequisites.adoc
@@ -6,35 +6,51 @@
 [id="migration-prerequisites_{context}"]
 = Prerequisites
 
-The {mtc-full} ({mtc-short}) has the following prerequisites:
-
 * You must be logged in as a user with `cluster-admin` privileges on all clusters.
-* The {mtc-short} version must be the same on all clusters.
-ifdef::migrating-3-4[]
+
+.Direct image migration
+
+* You must ensure that the secure registry of the source cluster is exposed.
+
+.Direct volume migration
+
+* If your clusters use proxies, you must configure an Stunnel TCP proxy.
+
+ifdef::migrating-applications-3-4[]
+.Internal images
+
 * If your application uses internal images from the `openshift` namespace, you must ensure that the required versions of the images are present on the target cluster.
 +
 You can manually update an image stream tag in order to use a deprecated {product-title} 3 image on an {product-title} {product-version} cluster.
 endif::[]
-* Clusters:
-** The source cluster must be upgraded to the latest {mtc-short} z-stream release.
-** The cluster on which the `migration-controller` pod is running must have unrestricted network access to the other clusters.
-** The clusters must have unrestricted network access to each other.
-** The clusters must have unrestricted network access to the replication repository.
-** The clusters must be able to communicate using OpenShift routes on port 443.
-** The clusters must have no critical conditions.
-** The clusters must be in a ready state.
 
-* Volume migration:
-** The persistent volumes (PVs) must be valid.
-** The PVs must be bound to persistent volume claims.
-** If you copy the PVs by using the _move_ method, the clusters must have unrestricted network access to the remote volume.
-** If you copy the PVs by using the _snapshot_ copy method, the following prerequisites apply:
-*** The cloud provider must support snapshots.
-*** The volumes must have the same cloud provider.
-*** The volumes must be located in the same geographic region.
-*** The volumes must have the same storage class.
+.Clusters
 
-* If you perform a direct volume migration in a proxy environment, you must configure an Stunnel TCP proxy.
-ifndef::migrating-applications-3-4[]
-* If you perform a direct image migration, you must expose the secure registry of the source cluster to external traffic.
+* The source cluster must be upgraded to the latest {mtc-short} z-stream release.
+* The {mtc-short} version must be the same on all clusters.
+
+.Network
+
+* The clusters have unrestricted network access to each other and to the replication repository.
+* If you copy the persistent volumes with `move`, the clusters must have unrestricted network access to the remote volumes.
+ifdef::migrating-applications-3-4[]
+* You must enable the following ports on an {product-title} 3 cluster:
+** `8443` (API server)
+** `443` (routes)
+** `53` (DNS)
 endif::[]
+* You must enable the following ports on an {product-title} 4 cluster:
+** `6443` (API server)
+** `443` (routes)
+** `53` (DNS)
+* You must enable port `443` on the replication repository if you are using TLS.
+
+.Persistent volumes (PVs)
+
+* The PVs must be valid.
+* The PVs must be bound to persistent volume claims.
+* If you use snapshots to copy the PVs, the following additional prerequisites apply:
+** The cloud provider must support snapshots.
+** The PVs must have the same cloud provider.
+** The PVs must be located in the same geographic region.
+** The PVs must have the same storage class.

--- a/modules/migration-running-migration-plan-cam.adoc
+++ b/modules/migration-running-migration-plan-cam.adoc
@@ -26,14 +26,6 @@ The {mtc-short} web console must contain the following:
 
 .Procedure
 
-. Log in to the source cluster.
-. Delete old images:
-+
-[source,terminal]
-----
-$ oc adm prune images
-----
-
 . Log in to the {mtc-short} web console and click *Migration plans*.
 . Click the *Options* menu {kebab} next to a migration plan and select *Stage* to copy data from the source cluster to the target cluster without stopping the application.
 +

--- a/modules/migration-updating-deprecated-internal-images.adoc
+++ b/modules/migration-updating-deprecated-internal-images.adoc
@@ -19,6 +19,11 @@ If an {product-title} 3 image is deprecated in {product-title} {product-version}
 
 .Procedure
 
+. Ensure that the internal registries are exposed on the {product-title} 3 and 4 clusters.
++
+The internal registry is exposed by default on {product-title} 4.
+
+. If you are using insecure registries, add your registry host values to the `[registries.insecure]` section of `/etc/container/registries.conf` to ensure that `podman` does not encounter a TLS verification error.
 . Log in to the {product-title} 3 registry:
 +
 [source,terminal]
@@ -56,6 +61,7 @@ $ podman tag <registry_url>:<port>/openshift/<image> \ <1>
 ----
 $ podman push <registry_url>:<port>/openshift/<image>
 ----
+<1> Specify the {product-title} 4 cluster.
 
 . Verify that the image has a valid image stream:
 +


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-677

Network requirements for MTC added to prerequisites. Couple small cleanup tasks.

4.5+

Previews:

https://deploy-preview-33431--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/migrating-applications-3-4.html#migration-prerequisites_migrating-applications-3-4

https://deploy-preview-33431--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/migrating-applications-with-mtc.html#migration-prerequisites_migrating-applications-with-mtc

