### PR TITLE
BZ1969583: Fixing incorrect Quay path in STS create docs

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -26,7 +26,7 @@ By default, `ccoctl` creates objects in the directory in which the commands are 
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/openshift-release:__<version>__
+$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
 ----
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -79,7 +79,7 @@ This command also creates a YAML configuration file in `/_<path_to_ccoctl_output
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/openshift-release:__<version>__
+$ oc adm release extract --credentials-requests --cloud=aws --to=__<path_to_directory_with_list_of_credentials_requests>__/credrequests quay.io/__<path_to>__/ocp-release:__<version>__
 ----
 
 .. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=1969583
As mentioned in review for related content in #32722

Impacts 4.8+

**Preview:** 
- [Step 3a](https://deploy-preview-33436--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-individually_cco-mode-sts)
- [Step 1](https://deploy-preview-33436--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-creating-at-once_cco-mode-sts)