### PR TITLE
BZ-1917280: Adding known issue for oc annotate with LDAP group names

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2130,7 +2130,11 @@ $ oc status
 $ oc get pods
 ----
 
++
 As a result, the oVirt CSI Driver Operator no longer continually restarts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929777[*BZ#1929777*])
+
+// TODO: This known issue should carry forward to 4.8 and beyond!
+* The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Known issue from #33225 to 4.7 release notes.

https://bugzilla.redhat.com/show_bug.cgi?id=1917280

Preview: https://deploy-preview-33437--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-known-issues