### PR TITLE
BZ-1917280: Adding known issue for oc annotate with LDAP group names

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2357,6 +2357,9 @@ rpc error: code = Unknown desc = error pinging docker registry registry.stage.re
 +
 This caused image pulls to fail against the inaccessible private registry, normally intended for internal Red Hat testing, and related Operator installations and upgrades would never succeed. See xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-refresh-subs_olm-deleting-operators-from-a-cluster[Refreshing failing subscriptions] for a workaround to clean up this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1909152[*BZ#1909152*])
 
+// TODO: This known issue should carry forward to 4.7 and beyond!
+* The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Known issue from #33225 to 4.6 release notes.

https://bugzilla.redhat.com/show_bug.cgi?id=1917280

Preview: https://deploy-preview-33438--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-known-issues