### PR TITLE
BZ-1917280: Adding known issue for oc annotate with LDAP group names

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1804,6 +1804,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821771[*BZ#1821771*])
 
+// TODO: This known issue should carry forward to 4.6 and beyond!
+* The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
+
 [id="ocp-4-5-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Known issue from #33225 to 4.5 release notes.

https://bugzilla.redhat.com/show_bug.cgi?id=1917280

Preview: https://deploy-preview-33439--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-5-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-5-known-issues