### PR TITLE
BZ 1970927: Cronjobs will be GA from OCP 4.8, so they no longer need batch/v1beta but can be batch/v1

### DIFF
--- a/api-config.yaml
+++ b/api-config.yaml
@@ -997,7 +997,7 @@ apiMap:
     namespaced: true
   - kind: CronJob
     group: batch
-    version: v1beta1
+    version: v1
     plural: cronjobs
     namespaced: true
   - kind: DaemonSet

--- a/modules/migration-updating-deprecated-gvks.adoc
+++ b/modules/migration-updating-deprecated-gvks.adoc
@@ -48,7 +48,7 @@ status:
   - gvks: <2>
     - group: batch
       kind: cronjobs
-      version: v2alpha1
+      version: v1
     - group: batch
       kind: scheduledjobs
       version: v2alpha1

--- a/modules/nodes-nodes-jobs-creating-cron.adoc
+++ b/modules/nodes-nodes-jobs-creating-cron.adoc
@@ -15,7 +15,7 @@ To create a cron job:
 +
 [source,yaml]
 ----
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: pi
@@ -83,5 +83,4 @@ $ oc create cronjob pi --image=perl --schedule='*/1 * * * *' -- perl -Mbignum=bp
 ----
 
 With `oc create cronjob`, the `--schedule` option accepts schedules in link:https://en.wikipedia.org/wiki/Cron[cron format].
-
 ====

--- a/modules/pruning-images-manual.adoc
+++ b/modules/pruning-images-manual.adoc
@@ -50,7 +50,7 @@ items:
   - kind: ServiceAccount
     name: pruner
     namespace: openshift-image-registry
-- apiVersion: batch/v1beta1
+- apiVersion: batch/v1
   kind: CronJob
   metadata:
     name: image-pruner

--- a/modules/serverless-sinkbinding-kn.adoc
+++ b/modules/serverless-sinkbinding-kn.adoc
@@ -50,7 +50,7 @@ $ kn source binding create bind-heartbeat --subject Job:batch/v1:app=heartbeat-c
 +
 [source,yaml]
 ----
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: heartbeat-cron

--- a/modules/serverless-sinkbinding-yaml.adoc
+++ b/modules/serverless-sinkbinding-yaml.adoc
@@ -90,7 +90,7 @@ $ oc apply -f sinkbinding.yaml
 +
 [source,yaml]
 ----
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: heartbeat-cron


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1970927

https://issues.redhat.com/browse/WRKLDS-229

Release note for this change: https://github.com/openshift/openshift-docs/pull/33697

Sample preview: https://deploy-preview-33441--osdocs.netlify.app/openshift-enterprise/latest/nodes/jobs/nodes-nodes-jobs.html#nodes-nodes-jobs-creating-cron_nodes-nodes-jobs
Release Note preview: https://deploy-preview-33697--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-nodes-cronjob-qa_release-notes