### PR TITLE
BZ1923767: adding module to disable OperatorHub in restricted installs

### DIFF
--- a/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -62,6 +62,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
 [id="next-steps_installing-restricted-networks-aws-installer-provisioned"]
 == Next steps
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -149,6 +149,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-aws-user-infra.adoc[leveloffset=+3]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -177,6 +177,8 @@ include::modules/installation-operators-config.adoc[leveloffset=+1]
 * See xref:../../support/troubleshooting/troubleshooting-installations.adoc#installation-bootstrap-gather_troubleshooting-installations[Gathering logs from a failed installation] for details about gathering data in the event of a failed {product-title} installation.
 * See xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-operator-issues[Troubleshooting Operator issues] for steps to check Operator pod health across the cluster and gather Operator logs for diagnosis.
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-change-management-state.adoc[leveloffset=+3]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -52,6 +52,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
 [id="next-steps_installing-restricted-networks-gcp-installer-provisioned"]
 == Next steps
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -93,6 +93,8 @@ include::modules/installation-deployment-manager-worker.adoc[leveloffset=+2]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-gcp-user-infra-adding-ingress.adoc[leveloffset=+1]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -95,6 +95,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-change-management-state.adoc[leveloffset=+3]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -89,6 +89,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -92,6 +92,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-baremetal.adoc[leveloffset=+3]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -44,6 +44,7 @@ include::modules/installation-osp-accessing-api-no-floating.adoc[leveloffset=+2]
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
 
 .Next steps
 

--- a/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+++ b/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
@@ -115,6 +115,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/registry-removed.adoc[leveloffset=+2]
 
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]

--- a/installing/installing_rhv/installing-rhv-restricted-network.adoc
+++ b/installing/installing_rhv/installing-rhv-restricted-network.adoc
@@ -82,3 +82,5 @@ include::modules/installation-osp-verifying-cluster-status.adoc[leveloffset=+1]
 include::modules/installation-rhv-removing-bootstrap-machine.adoc[leveloffset=+1]
 
 include::modules/installation-rhv-creating-worker-nodes-completing-installation.adoc[leveloffset=+1]
+
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -82,6 +82,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]

--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -58,6 +58,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
 [id="installing-vmc-restricted-networks-installer-provisioned-customizations-registry"]
 == Creating registry storage
 

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -53,6 +53,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+
 [id="installing-vsphere-restricted-networks-installer-provisioned-customizations-registry"]
 == Creating registry storage
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -95,6 +95,8 @@ include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
 include::modules/installation-operators-config.adoc[leveloffset=+1]
 
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+
 include::modules/installation-registry-storage-config.adoc[leveloffset=+2]
 
 include::modules/registry-configuring-storage-vsphere.adoc[leveloffset=+3]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -79,7 +79,7 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 
 include::modules/installation-approve-csrs.adoc[leveloffset=+1]
 
-include::modules/installation-operators-config.adoc[leveloffset=+1]
+include::modules/installation-operators-config.adoc[leveloffset=+2]
 
 include::modules/registry-removed.adoc[leveloffset=+2]
 

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -1,5 +1,20 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+// * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+// * installing/installing_rhv/installing-rhv-restricted-network.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * operators/admin/olm-restricted-networks.adoc
 // * operators/admin/olm-managing-custom-catalogs.adoc
 
@@ -14,8 +29,11 @@ endif::[]
 = Disabling the default OperatorHub sources
 
 Operator catalogs that source content provided by Red Hat and community projects are configured for OperatorHub by default during an {product-title} installation.
+ifndef::olm-managing-custom-catalogs[]
+In a restricted network environment, you must disable the default catalogs as a cluster administrator.
+endif::[]
 ifdef::olm-restricted-networks[]
-Before configuring OperatorHub to instead use local catalog sources in a restricted network environment, you must disable the default catalogs as a cluster administrator.
+You can then configure OperatorHub to use local catalog sources.
 endif::[]
 ifdef::olm-managing-custom-catalogs[]
 As a cluster administrator, you can disable the set of default catalogs.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1923767

4.6+

Sample preview: https://deploy-preview-33462--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html