### PR TITLE
CNV-9052: RN - Added note about dual-stack support in 4.8

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -94,7 +94,8 @@ Deprecated features are included in the current release and supported. However, 
 [id="virt-4-8-changes"]
 == Notable technical changes
 
-//CNV-9052 OpenShift Virtualization now automatically automatically configures IPv6 IP when running on dual-stack clusters.
+//CNV-9052 OpenShift Virtualization now automatically configures IPv6 IP when running on dual-stack clusters.
+* {VirtProductName} now configures IPv6 addresses when running on clusters that have dual-stack networking enabled. You can xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt[create a service] that uses IPv4, IPv6, or both IP address families, if dual-stack networking is enabled for the underlying {product-title} cluster.
 
 [id="virt-4-8-known-issues"]
 == Known issues


### PR DESCRIPTION
This PR address [CNV-9052](https://issues.redhat.com/browse/CNV-9052)

Added release note about OpenShift Virtualization now supporting IPv4 and IPv6 addresses on dual-stack clusters

Preview build: https://deploy-preview-33466--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes.html#virt-4-8-changes