### PR TITLE
Noting that old OAuth token format can no longer be used

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -215,9 +215,9 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 In {product-title} {product-version}, installer-provisioned clusters can configure and deploy Network Time Protocol (NTP) servers on the control plane nodes and NTP clients on worker nodes. This enables workers to retrieve the date and time from the NTP servers on the control plane nodes, even when disconnected from a routable network. You can also configure and deploy NTP servers and NTP clients after deployment.
 
 [id="ocp-4-8-enhancements-kuryr-kubernetes"]
-==== Changes to default API load balancer management for Kuryr 
+==== Changes to default API load balancer management for Kuryr
 
-In {product-title} 4.8 deployments on {rh-openstack-first} with Kuryr-Kubernetes, the API load balancer for the `default/kubernetes` service is no longer managed by the Cluster Network Operator (CNO), but instead by the kuryr-controller itself. This means that: 
+In {product-title} 4.8 deployments on {rh-openstack-first} with Kuryr-Kubernetes, the API load balancer for the `default/kubernetes` service is no longer managed by the Cluster Network Operator (CNO), but instead by the kuryr-controller itself. This means that:
 
 * When upgrading to {product-title} 4.8, the `default/kubernetes` service will have downtime.
 +
@@ -226,7 +226,7 @@ In {product-title} 4.8 deployments on {rh-openstack-first} with Kuryr-Kubernetes
 In deployments where no Open Virtual Network (OVN) Octavia is available, more downtime should be expected
 ====
 
-* The `default/kubernetes` load balancer is no longer required to use the Octavia Amphora driver. Instead, OVN Octavia will be used to implement the `default/kubernetes` service if it is available in the OpenStack cloud. 
+* The `default/kubernetes` load balancer is no longer required to use the Octavia Amphora driver. Instead, OVN Octavia will be used to implement the `default/kubernetes` service if it is available in the OpenStack cloud.
 
 [id="ocp-4-8-storage"]
 === Storage
@@ -424,6 +424,14 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 {product-title} 4.8 introduces the following notable technical changes.
 
 [discrete]
+[id="ocp-4-8-oauth-tokens"]
+==== OAuth tokens without a SHA-256 prefix can no longer be used
+
+Prior to {product-title} 4.6, OAuth access and authorize tokens used secret information for the object names.
+
+Starting with {product-title} 4.6, OAuth access token and authorize token object names are stored as non-sensitive object names, with a SHA-256 prefix. OAuth tokens that do not contain a SHA-256 prefix can no longer be used or created in {product-title} 4.8.
+
+[discrete]
 [id="ocp-4-8-moderate-profiles"]
 ==== The Federal Risk and Authorization Management Program (FedRAMP) moderate controls
 
@@ -435,6 +443,7 @@ In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4
 
 The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.13.
 
+[discrete]
 [id="ocp-4-8-coreDNS-version-update"]
 ==== CoreDNS update to version 1.8.1
 


### PR DESCRIPTION
Addressing item for the RN tracker.

Preview: https://deploy-preview-33471--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-notable-technical-changes