### PR TITLE
Added a note to the backup etcd topic.

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -43,6 +43,11 @@ sh-4.2# chroot /host
 
 . Run the `cluster-backup.sh` script and pass in the location to save the backup to.
 +
+[TIP]
+====
+The `cluster-backup.sh` script is maintained as a component of the etcd Cluster Operator and is a wrapper around the `etcdctl snapshot save` command.
+====
++
 [source,terminal]
 ----
 sh-4.4# /usr/local/bin/cluster-backup.sh /home/core/assets/backup


### PR DESCRIPTION
This ticket fixes #33367 by adding a note around the process of backing up etcd data.

Version: 4.5+

Preview:  https://deploy-preview-33472--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#backing-up-etcd-data_post-install-cluster-tasks