### PR TITLE
CNV-9055: RN - Added note about NMState IP management support

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -58,6 +58,7 @@ The SVVP Certification applies to:
 
 
 //CNV-9055 Kubernetes NMState now supports new IP configuration options.
+* You can use the Kubernetes NMSstate Operator to xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-example-nmstate-IP-management_virt-updating-node-network-config[configure and manage IP addresses] on your cluster nodes.
 
 //CNV-11390 OpenShift Virtualization now supports live-migration of VM connected to an SR-IOV network.
 


### PR DESCRIPTION
This PR addresses [CNV-9055](https://issues.redhat.com/browse/CNV-9055)

Added note about Kubernetes NMState IP configuration options

Preview build: https://deploy-preview-33479--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes.html#virt-4-8-networking-new