### PR TITLE
OSDOCS-1702: ServiceMonitor per namespace only for user-defined projects

### DIFF
--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -47,6 +47,11 @@ spec:
 +
 This defines a `ServiceMonitor` resource that scrapes the metrics exposed by the `prometheus-example-app` sample service, which includes the `version` metric.
 
+[NOTE]
+====
+A `ServiceMonitor` resource in a user-defined namespace can only discover services in the same namespace. That is, the `namespaceSelector` field of the `ServiceMonitor` resource is always ignored.
+====
+
 . Apply the configuration to the cluster:
 +
 [source,terminal]


### PR DESCRIPTION
[OSDOCS-1702](https://issues.redhat.com/browse/OSDOCS-1702) - https://issues.redhat.com/browse/OSDOCS-1702

Adds note that you can only use a service monitor for a single namespace for user-defined projects.

Preview: https://deploy-preview-33480--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics?utm_source=github&utm_campaign=bot_dp#specifying-how-a-service-is-monitored_managing-metrics