### PR TITLE
OSDOCS-1931: Add catalog-build / catalog-push to OSDK docs

### DIFF
--- a/modules/osdk-bundle-operator.adoc
+++ b/modules/osdk-bundle-operator.adoc
@@ -12,22 +12,18 @@ ifeval::["{context}" == "osdk-working-bundle-images"]
 :golang:
 endif::[]
 
-[id="osdk-bundle-deploy-olm_{context}"]
-= Bundling an Operator and deploying with Operator Lifecycle Manager
+[id="osdk-bundle-operator_{context}"]
+= Bundling an Operator
 
-Operator Lifecycle Manager (OLM) helps you to install, update, and generally manage the lifecycle of Operators and their associated services on a Kubernetes cluster. OLM is installed by default on {product-title} and runs as a Kubernetes extension so that you can use the web console and the OpenShift CLI (`oc`) for all Operator lifecycle management functions without any additional tools.
-
-The Operator bundle format is the default packaging method for Operator SDK and OLM. You can get your Operator ready for OLM by using the Operator SDK to build, push, validate, and run a bundle image with OLM.
+The Operator bundle format is the default packaging method for Operator SDK and Operator Lifecycle Manager (OLM). You can get your Operator ready for use on OLM by using the Operator SDK to build and push your Operator project as a bundle image.
 
 .Prerequisites
 
 - Operator SDK CLI installed on a development workstation
 - OpenShift CLI (`oc`) v{product-version}+ installed
-- Operator Lifecycle Manager (OLM) installed on a Kubernetes-based cluster (v1.16.0 or later if you use `apiextensions.k8s.io/v1` CRDs, for example {product-title} {product-version})
-- Logged into the cluster with `oc` using an account with `cluster-admin` permissions
 - Operator project initialized by using the Operator SDK
 ifdef::golang[]
-- If your Operator is Go-based, your project must have been updated to use supported images for running on {product-title}
+- If your Operator is Go-based, your project must be updated to use supported images for running on {product-title}
 endif::[]
 
 .Procedure
@@ -78,7 +74,7 @@ These files are then automatically validated by using `operator-sdk bundle valid
 
 . Build and push your bundle image by running the following commands. OLM consumes Operator bundles using an index image, which reference one or more bundle images.
 
-.. Build the bundle image. Set `BUNDLE_IMAGE` with the details for the registry, user namespace, and image tag where you intend to push the image:
+.. Build the bundle image. Set `BUNDLE_IMG` with the details for the registry, user namespace, and image tag where you intend to push the image:
 +
 [source,terminal]
 ----
@@ -91,32 +87,6 @@ $ make bundle-build BUNDLE_IMG=<registry>/<user>/<bundle_image_name>:<tag>
 ----
 $ docker push <registry>/<user>/<bundle_image_name>:<tag>
 ----
-
-. Check the status of OLM on your cluster by using the following Operator SDK command:
-+
-[source,terminal]
-----
-$ operator-sdk olm status \
-    --olm-namespace=openshift-operator-lifecycle-manager
-----
-
-. Run the Operator on your cluster by using the OLM integration in Operator SDK:
-+
-[source,terminal]
-----
-$ operator-sdk run bundle \
-    [-n <namespace>] \//<1>
-    <registry>/<user>/<bundle_image_name>:<tag>
-----
-<1> By default, the command installs the Operator in the currently active project in your `~/.kube/config` file. You can add the `-n` flag to set a different namespace scope for the installation.
-+
-This command performs the following actions:
-+
---
-* Create an index image with your bundle image injected.
-* Create a catalog source that points to your new index image, which enables OperatorHub to discover your Operator.
-* Deploy your Operator to your cluster by creating an Operator group, subscription, install plan, and all other required objects, including RBAC.
---
 
 ifeval::["{context}" == "osdk-golang-tutorial"]
 :!golang:

--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -31,7 +31,7 @@ ifdef::ansible[]
 - link:https://pypi.org/project/openshift/[OpenShift Python client] version v0.11.2+
 endif::[]
 - Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
-- To allow the cluster pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret.
+- To allow the cluster pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret
 
 ifeval::["{context}" == "osdk-ansible-quickstart"]
 :!ansible:

--- a/modules/osdk-deploy-olm.adoc
+++ b/modules/osdk-deploy-olm.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+// * operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+// * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+// * operators/operator_sdk/osdk-working-bundle-images.adoc
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:golang:
+endif::[]
+ifeval::["{context}" == "osdk-working-bundle-images"]
+:golang:
+endif::[]
+
+[id="osdk-deploy-olm_{context}"]
+= Deploying an Operator with Operator Lifecycle Manager
+
+Operator Lifecycle Manager (OLM) helps you to install, update, and manage the lifecycle of Operators and their associated services on a Kubernetes cluster. OLM is installed by default on {product-title} and runs as a Kubernetes extension so that you can use the web console and the OpenShift CLI (`oc`) for all Operator lifecycle management functions without any additional tools.
+
+The Operator bundle format is the default packaging method for Operator SDK and OLM. You can use the Operator SDK to quickly run a bundle image on OLM to ensure that it runs properly.
+
+.Prerequisites
+
+- Operator SDK CLI installed on a development workstation
+- Operator bundle image built and pushed to a registry
+- OLM installed on a Kubernetes-based cluster (v1.16.0 or later if you use `apiextensions.k8s.io/v1` CRDs, for example {product-title} {product-version})
+- Logged in to the cluster with `oc` using an account with `cluster-admin` permissions
+ifdef::golang[]
+- If your Operator is Go-based, your project must be updated to use supported images for running on {product-title}
+endif::[]
+
+.Procedure
+
+. Check the status of OLM on your cluster by using the following Operator SDK command:
++
+[source,terminal]
+----
+$ operator-sdk olm status \
+    --olm-namespace=openshift-operator-lifecycle-manager
+----
+
+. Run the Operator on your cluster by using the OLM integration in Operator SDK:
++
+[source,terminal]
+----
+$ operator-sdk run bundle \
+    [-n <namespace>] \//<1>
+    <registry>/<user>/<bundle_image_name>:<tag>
+----
+<1> By default, the command installs the Operator in the currently active project in your `~/.kube/config` file. You can add the `-n` flag to set a different namespace scope for the installation.
++
+This command performs the following actions:
++
+--
+* Create an index image referencing your bundle image. The index image is opaque and ephemeral, but accurately reflects how a bundle would be added to a catalog in production.
+* Create a catalog source that points to your new index image, which enables OperatorHub to discover your Operator.
+* Deploy your Operator to your cluster by creating an `OperatorGroup`, `Subscription`, `InstallPlan`, and all other required objects, including RBAC.
+--
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:!golang:
+endif::[]
+ifeval::["{context}" == "osdk-working-bundle-images"]
+:!golang:
+endif::[]

--- a/modules/osdk-publish-catalog.adoc
+++ b/modules/osdk-publish-catalog.adoc
@@ -1,0 +1,183 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-working-bundle-images.adoc
+
+[id="osdk-publish-catalog_{context}"]
+= Publishing a catalog containing a bundled Operator
+
+To install and manage Operators, Operator Lifecycle Manager (OLM) requires that Operator bundles are listed in an index image, which is referenced by a catalog on the cluster. As an Operator author, you can use the Operator SDK to create an index containing the bundle for your Operator and all of its dependencies. This is useful for testing on remote clusters and publishing to container registries.
+
+[NOTE]
+====
+The Operator SDK uses the `opm` CLI to facilitate index image creation. Experience with the `opm` command is not required. For advanced use cases, the `opm` command can be used directly instead of the Operator SDK.
+====
+
+.Prerequisites
+
+- Operator SDK CLI installed on a development workstation
+- Operator bundle image built and pushed to a registry
+- OLM installed on a Kubernetes-based cluster (v1.16.0 or later if you use `apiextensions.k8s.io/v1` CRDs, for example {product-title} {product-version})
+- Logged in to the cluster with `oc` using an account with `cluster-admin` permissions
+
+.Procedure
+
+. Run the following `make` command in your Operator project directory to build an index image containing your Operator bundle:
++
+[source,terminal]
+----
+$ make catalog-build CATALOG_IMG=<registry>/<user>/<index_image_name>:<tag>
+----
++
+where the `CATALOG_IMG` argument references a repository that you have access to. You can obtain an account for storing containers at repository sites such as Quay.io.
+
+. Push the built index image to a repository:
++
+[source,terminal]
+----
+$ make catalog-push CATALOG_IMG=<registry>/<user>/<index_image_name>:<tag>
+----
++
+[TIP]
+====
+You can use Operator SDK `make` commands together if you would rather perform multiple actions in sequence at once. For example, if you had not yet built a bundle image for your Operator project, you can build and push both a bundle image and an index image with the following syntax:
+
+[source,terminal]
+----
+$ make bundle-build bundle-push catalog-build catalog-push \
+    BUNDLE_IMG=<bundle_image_pull_spec> \
+    CATALOG_IMG=<index_image_pull_spec>
+----
+
+Alternatively, you can set the `IMAGE_TAG_BASE` field in your `Makefile`  to an existing repository:
+
+[source,terminal]
+----
+IMAGE_TAG_BASE=quay.io/example/my-operator
+----
+
+You can then use the following syntax to build and push images with automatically-generated names, such as `quay.io/example/my-operator-bundle:v0.0.1` for the bundle image and `quay.io/example/my-operator-catalog:v0.0.1` for the index image:
+
+[source,terminal]
+----
+$ make bundle-build bundle-push catalog-build catalog-push
+----
+====
+
+. Define a `CatalogSource` object that references the index image you just generated, and then create the object by using the `oc apply` command or web console:
++
+.Example `CatalogSource` YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: cs-memcached
+  namespace: default
+spec:
+  displayName: My Test
+  publisher: Company
+  sourceType: grpc
+  image: quay.io/example/memcached-catalog:v0.0.1 <1>
+  updateStrategy:
+    registryPoll:
+      interval: 10m
+----
+<1> Set `image` to the image pull spec you used previously with the `CATALOG_IMG` argument.
+
+. Check the catalog source:
++
+[source,terminal]
+----
+$ oc get catalogsource
+----
++
+.Example output
+[source,terminal]
+----
+NAME           DISPLAY     TYPE   PUBLISHER   AGE
+cs-memcached   My Test     grpc   Company     4h31m
+----
+
+.Verification
+
+. Install the Operator using your catalog:
+
+.. Define an `OperatorGroup` object and create it by using the `oc apply` command or web console:
++
+.Example `OperatorGroup` YAML
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: my-test
+  namespace: default
+spec:
+  targetNamespaces:
+  - default
+----
+
+.. Define a `Subscription` object and create it by using the `oc apply` command or web console:
++
+.Example `Subscription` YAML
+[source,yaml]
+----
+﻿apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: catalogtest
+  namespace: default
+spec:
+  channel: "alpha"
+  installPlanApproval: Manual
+  name: catalog
+  source: cs-memcached
+  sourceNamespace: default
+  startingCSV: memcached-operator.v0.0.1
+----
+
+. Verify the installed Operator is running:
+
+.. Check the Operator group:
++
+[source,terminal]
+----
+$ oc get og
+----
++
+.Example output
+[source,terminal]
+----
+NAME             AGE
+my-test           4h40m
+----
+
+.. Check the cluster service version (CSV):
++
+[source,terminal]
+----
+$ oc get csv
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        DISPLAY   VERSION   REPLACES   PHASE
+memcached-operator.v0.0.1   Test      0.0.1                Succeeded
+----
+
+.. Check the pods for the Operator:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                              READY   STATUS      RESTARTS   AGE
+9098d908802769fbde8bd45255e69710a9f8420a8f3d814abe88b68f8ervdj6   0/1     Completed   0          4h33m
+catalog-controller-manager-7fd5b7b987-69s4n                       2/2     Running     0          4h32m
+cs-memcached-7622r                                                1/1     Running     0          4h33m
+----

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -34,7 +34,12 @@ include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
-include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+2]
+
+[id="osdk-bundle-deploy-olm_{context}"]
+=== Bundling an Operator and deploying with Operator Lifecycle Manager
+
+include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -43,7 +43,12 @@ include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
-include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+2]
+
+[id="osdk-bundle-deploy-olm_{context}"]
+=== Bundling an Operator and deploying with Operator Lifecycle Manager
+
+include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -36,7 +36,12 @@ include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
-include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+2]
+
+[id="osdk-bundle-deploy-olm_{context}"]
+=== Bundling an Operator and deploying with Operator Lifecycle Manager
+
+include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/osdk-cli-ref.adoc
+++ b/operators/operator_sdk/osdk-cli-ref.adoc
@@ -23,7 +23,7 @@ include::modules/osdk-cli-ref-generate.adoc[leveloffset=+1]
 include::modules/osdk-cli-ref-generate-bundle.adoc[leveloffset=+2]
 .Additional resources
 
-* See xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-deploy-olm_osdk-working-bundle-images[Bundling an Operator and deploying with Operator Lifecycle Manager] for a full procedure that includes using the `make bundle` command to call the `generate bundle` subcommand.
+* See xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-operator_osdk-working-bundle-images[Bundling an Operator] for a full procedure that includes using the `make bundle` command to call the `generate bundle` subcommand.
 
 include::modules/osdk-cli-ref-generate-kustomize.adoc[leveloffset=+2]
 

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -14,7 +14,7 @@ A CSV-generating command removes the responsibility of Operator authors having i
 include::modules/osdk-how-csv-gen-works.adoc[leveloffset=+1]
 .Additional resources
 
-* See xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-deploy-olm_osdk-working-bundle-images[Bundling an Operator and deploying with Operator Lifecycle Manager] for a full procedure that includes generating a bundle and CSV.
+* See xref:../../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-operator_osdk-working-bundle-images[Bundling an Operator] for a full procedure that includes generating a bundle and CSV.
 
 include::modules/osdk-csv-bundle-files.adoc[leveloffset=+2]
 include::modules/osdk-csv-ver.adoc[leveloffset=+2]

--- a/operators/operator_sdk/osdk-working-bundle-images.adoc
+++ b/operators/operator_sdk/osdk-working-bundle-images.adoc
@@ -5,9 +5,15 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can use the Operator SDK to package, deploy, and upgrade Operators in the bundle format on Operator Lifecycle Manager (OLM).
+You can use the Operator SDK to package, deploy, and upgrade Operators in the bundle format for use on Operator Lifecycle Manager (OLM).
 
-include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+1]
+include::modules/osdk-bundle-operator.adoc[leveloffset=+1]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+1]
+include::modules/osdk-publish-catalog.adoc[leveloffset=+1]
+.Additional resources
+
+* See xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-bundle-format[Custom catalogs using the bundle format] for details on direct usage of the `opm` CLI for more advanced use cases.
+
 include::modules/osdk-bundle-upgrade-olm.adoc[leveloffset=+1]
 
 [id="osdk-working-bundle-images-additional-resources"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1931

* Breaks up `modules/osdk-bundle-deploy-olm.adoc` into separate `modules/osdk-bundle-operator.adoc` and `modules/osdk-deploy-olm.adoc` to make better logical room for...
* ... a new `modules/osdk-publish-catalog.adoc` to show `catalog-build` and `catalog-push` usage (only added to the `operators/operator_sdk/osdk-working-bundle-images.adoc` assembly)

Preview:

* Example of broken-up modules in place: [Operator SDK tutorial for Go-based Operators](https://deploy-preview-33483--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial)
  * Same treatment for [Ansible](https://deploy-preview-33483--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html)
  * Same treatment for [Helm](https://deploy-preview-33483--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html)
* New procedure: [Publishing a catalog containing a bundled Operator](https://deploy-preview-33483--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-working-bundle-images.html#osdk-publish-catalog_osdk-working-bundle-images)