### PR TITLE
Add warning about runlevels.

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -127,6 +127,16 @@ CRI-O has the following default list of capabilities that are allowed for each c
 
 The containers use the capabilities from this default list, but pod manifest authors can alter it by requesting additional capabilities or removing some of the default behaviors. Use the `allowedCapabilities`, `defaultAddCapabilities`, and `requiredDropCapabilities` parameters to control such requests from the pods and to dictate which capabilities can be requested, which ones must be added to each container, and which ones must be forbidden.
 
+[IMPORTANT]
+====
+In an OpenShift namespace, labels such as `runlevel: 0` or `runlevel: 1`, 
+*SHOULD NOT* be used. The purpose of runlevels is to help manage the startup of 
+major API groups such as the kube-apiserver and openshift-apiserver. As such for 
+any pods running in such namespaces no SCCs are applied. Meaning that any 
+workload running in that namespace may be highly privileged, a level reserved 
+for trusted workloads only. 
+====
+
 [id="authorization-SCC-strategies_{context}"]
 == SCC Strategies
 


### PR DESCRIPTION
Missing entirely is a warning about runlevels and the fact that they disable SCCs on a given namespace. This adds a short notice of the dangers of adding runlevels.