### PR TITLE
OSDOCS-1210: Release notes for removed API alerts

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -327,6 +327,16 @@ The Node Feature Discovery (NFD) Operator detects hardware features available on
 [id="ocp-4-8-monitoring"]
 === Monitoring
 
+[id="ocp-4-8-monitoring-removed-API-alerts"]
+==== Alerts and information on APIs in use that will be removed in the next release
+
+{product-title} 4.8 introduces two new alerts that fire when an API that will be removed in the next release is in use:
+
+* `APIRemovedInNextReleaseInUse` - for APIs that will be removed in the next {product-title} release.
+* `APIRemovedInNextEUSReleaseInUse` - for APIs that will be removed in the next {product-title} link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support] (EUS) release.
+
+You can use the new `APIRequestCount` API to track what is using the deprecated APIs. This allows you to plan whether any actions are required in order to upgrade to the next release.
+
 [id="ocp-4-8-metering"]
 === Metering
 The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled to be removed in {product-title} 4.9.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1210

Preview: https://deploy-preview-33491--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-monitoring-removed-API-alerts