### PR TITLE
OSDOCS-2097: Release note for etcd using zap logger

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -398,10 +398,31 @@ In {product-title} 4.8, the `rhcos4-moderate` profile is now complete. The `ocp4
 
 The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.13.
 
+[discrete]
 [id="ocp-4-8-coreDNS-version-update"]
 ==== CoreDNS update to version 1.8.1
 
 In {product-title} 4.8, CoreDNS uses version 1.8.1, which has several bug fixes, renamed metrics, and dual-stack IPv6 enablement.
+
+[discrete]
+[id="ocp-4-8-etcd-zap-logger"]
+==== etcd now uses the zap logger
+
+In {product-title} 4.8, etcd now uses zap as the default logger instead of capnslog. Zap is a structured logger that provides machine consumable JSON log messages. You can use `jq` to easily parse these log messages.
+
+If you have a log consumer that is expecting the capnslog format, you might need to adjust it for the zap logger format.
+
+.Example capnslog format ({product-title} 4.7)
+[source,terminal]
+----
+2021-06-03 22:40:16.984470 W | etcdserver: read-only range request "key:\"/kubernetes.io/operator.openshift.io/clustercsidrivers/\" range_end:\"/kubernetes.io/operator.openshift.io/clustercsidrivers0\" count_only:true " with result "range_response_count:0 size:8" took too long (100.498102ms) to execute
+----
+
+.Example zap format ({product-title} 4.8)
+[source,terminal]
+----
+{"level":"warn","ts":"2021-06-14T13:13:23.243Z","caller":"etcdserver/util.go:163","msg":"apply request took too long","took":"163.262994ms","expected-duration":"100ms","prefix":"read-only range ","request":"key:\"/kubernetes.io/namespaces/default\" serializable:true keys_only:true ","response":"range_response_count:1 size:53"}
+----
 
 [id="ocp-4-8-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2097

Preview: https://deploy-preview-33501--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-etcd-zap-logger