### PR TITLE
Adds enhancement to networking section for kuryr-kubernetes and OVN Octavia

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -214,6 +214,20 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-co
 
 In {product-title} {product-version}, installer-provisioned clusters can configure and deploy Network Time Protocol (NTP) servers on the control plane nodes and NTP clients on worker nodes. This enables workers to retrieve the date and time from the NTP servers on the control plane nodes, even when disconnected from a routable network. You can also configure and deploy NTP servers and NTP clients after deployment.
 
+[id="ocp-4-8-enhancements-kuryr-kubernetes"]
+==== Changes to default API load balancer management for Kuryr 
+
+In {product-title} 4.8 deployments on {rh-openstack-first} with Kuryr-Kubernetes, the API load balancer for the `default/kubernetes` service is no longer managed by the Cluster Network Operator (CNO), but instead by the kuryr-controller itself. This means that: 
+
+* When upgrading to {product-title} 4.8, the `default/kubernetes` service will have downtime.
++
+[NOTE]
+====
+In deployments where no Open Virtual Network (OVN) Octavia is available, more downtime should be expected
+====
+
+* The `default/kubernetes` load balancer is no longer required to use the Octavia Amphora driver. Instead, OVN Octavia will be used to implement the `default/kubernetes` service if it is available in the OpenStack cloud. 
+
 [id="ocp-4-8-storage"]
 === Storage
 


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-33504--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-enhancements-kuryr-kubernetes

