### PR TITLE
Fix RHEL supported version in 4.8 RNs

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -19,13 +19,13 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
-{product-title} {product-version} is supported on {op-system-base-full} 7.7 or later, as well as {op-system-first} 4.6.
+{product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as {op-system-first} 4.8.
 
-You must use {op-system} machines for the control plane, which are also known as master machines, and you can use either {op-system} or {op-system-base-full} 7.7 or later for compute machines, which are also known as worker machines.
+You must use {op-system} machines for the control plane, which are also known as master machines, and you can use either {op-system} or {op-system-base-full} 7.9 or later for compute machines, which are also known as worker machines.
 
 [IMPORTANT]
 ====
-Because only {op-system-base-full} version 7.7 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to version 8.
+Because only {op-system-base-full} version 7.9 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to version 8.
 ====
 
 //{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].


### PR DESCRIPTION
After the OCP 4.8 RNs file was cloned, https://github.com/openshift/openshift-docs/pull/31722 updated the supported RHEL version from 7.7 -> 7.9 in the OCP 4.7 RNs. This PR fixes that in the 4.8 RNs for parity.

**Preview link:** https://deploy-preview-33506--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-about-this-release