### PR TITLE
Multiarch-940: z/VM updates for 4.8

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -73,9 +73,12 @@ rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 
 
 ** For installations on FCP-type disks, complete the following tasks:
 ... Use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. For multipathing repeat this step for each additional path.
-... For multipathing, set the following parameter: `rd.multipath=default`.
-... For multipathing, set the install device as: `coreos.inst.install_dev=/dev/mapper/mpatha`.
-... For single-path installation, set the install device as: `coreos.inst.install_dev=sda`.
++
+[NOTE]
+====
+When you install with multiple paths, you must enable multipathing directly after the installation, not at a later point in time, as this can cause problems.
+====
+... Set the install device as: `coreos.inst.install_dev=sda`.
 +
 [NOTE]
 ====
@@ -93,7 +96,7 @@ The following is an example parameter file `worker-1.parm` for a worker node wit
 +
 [source,terminal]
 ----
-rd.neednet=1 dfltcc=off rd.multipath=default console=ttysclp0 coreos.inst.install_dev=/dev/mapper/mpatha
+rd.neednet=1 dfltcc=off console=ttysclp0 coreos.inst.install_dev=sda
 coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
 coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
@@ -113,7 +116,7 @@ rd.zfcp=0.0.19C7,0x50050763071bc5e3,0x4008400B00000000
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to z/VM, for example with FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-installing-zvm-s390[Installing under Z/VM].
 . Punch the files to the virtual reader of the z/VM guest virtual machine that is to become your bootstrap node.
 +
-See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.dmsb4/pun.htm[PUNCH] in the IBM Knowledge Center.
+See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-punch[PUNCH] in IBM Documentation.
 +
 [TIP]
 ====
@@ -127,6 +130,6 @@ You can use the CP PUNCH command or, if you use Linux, the **vmur** command to t
 $ ipl c
 ----
 +
-See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.hcpb7/iplcommd.htm[IPL] in the IBM Knowledge Center.
+See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-ipl[IPL] in IBM Documentation.
 +
 . Repeat this procedure for the other machines in the cluster.

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -243,7 +243,7 @@ On your z/VM instances, set up:
 * 3 guest virtual machines for {product-title} control plane machines, one per z/VM instance
 * At least 6 guest virtual machines for {product-title} compute machines, distributed across the z/VM instances
 * 1 guest virtual machine for the temporary {product-title} bootstrap machine
-* To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane using the CP command `SET SHARE`. Do the same for infrastructure plane machines if they exist. See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.hcpb7/setshare.htm[SET SHARE] in the IBM Knowledge Center.
+* To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane using the CP command `SET SHARE`. Do the same for infrastructure plane machines if they exist. See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-set-share[SET SHARE] in IBM Documentation.
 
 [discrete]
 == IBM Z network connectivity requirements

--- a/modules/installation-three-node-cluster.adoc
+++ b/modules/installation-three-node-cluster.adoc
@@ -12,6 +12,21 @@
 // * installing/installing_vsphere/installing-vsphere.adoc [Eventually]
 // * installing/installing_ibm_z/installing-ibm-z.adoc [Eventually]
 
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z-kvm:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+:restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z-kvm:
+:restricted:
+endif::[]
+
 [id="installation-three-node-cluster_{context}"]
 = Configuring a three-node cluster
 
@@ -39,7 +54,13 @@ compute:
 ====
 You must set the value of the `replicas` parameter for the compute machines to `0` when you install {product-title} on user-provisioned infrastructure, regardless of the number of compute machines you are deploying. In installer-provisioned installations, the parameter controls the number of compute machines that the cluster creates and manages for you. This does not apply to user-provisioned installations, where the compute machines are deployed manually.
 ====
-
+ifdef::ibm-z,ibm-z-kvm[]
++
+[NOTE]
+====
+The minimum for control plane nodes is 21 GB. For three control plane nodes this is the memory equivalent of a minimum five node cluster.
+====
+endif::ibm-z,ibm-z-kvm[]
 .Next steps
 
 For three-node cluster installations, follow these next steps:
@@ -49,3 +70,18 @@ For three-node cluster installations, follow these next steps:
 * When you create the Kubernetes manifest files in the following procedure, ensure that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` file is set to `true`. This enables your application workloads to run on the control plane nodes.
 
 * Do not deploy any compute nodes when you create the {op-system-first} machines.
+
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z-kvm:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z-kvm:
+:!restricted:
+endif::[]


### PR DESCRIPTION
- OCP version:  4.8 and later
- JIRA issue: https://issues.redhat.com/browse/MULTIARCH-940, https://issues.redhat.com/browse/MULTIARCH-770
- Google review doc: https://docs.google.com/document/d/1Sjsq9wLSMIPh_-juUbZ-vzB3dDRGJpUGvdi3yoxHhGc/edit?usp=sharing
- Reviewer: Holger Wolf, Wolfgang Voesch, 
- Preview pages: 
   - [Installing a cluster with z/VM on IBM Z and LinuxONE](https://deploy-preview-33521--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html)
   - [Installing a cluster with z/VM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-33521--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html)