### PR TITLE
BZ1937392: OVN bug causes persistent connectivity issues to Octavia load balancers

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -797,6 +797,8 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 You can attempt to resolve the issue with the steps in this link:https://kb.vmware.com/s/article/2002779[VMware KBase article]. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5785341[[UPI vSphere\] Node scale-up doesn't work as expected]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918383[*BZ#1918383*])
 
+* An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace, at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. To track this issue, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*]). 
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Adds small known issue for Kuryr, for branch/enterprise 4.8. 

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1937392#

Preview: https://deploy-preview-33525--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-known-issues