### PR TITLE
Fix secret field reference for the custom console routes docs

### DIFF
--- a/modules/customizing-the-web-console-URL.adoc
+++ b/modules/customizing-the-web-console-URL.adoc
@@ -29,8 +29,8 @@ spec:
     - name: console
       namespace: openshift-console
       hostname: <custom-hostname>
-       secret:
-         name: <secret-name>
+      servingCertKeyPairSecret:
+        name: <secret-name>
 ----
 +
 If the domain for the custom hostname suffix does not match the cluster domain suffix, then a secret that contains a TLS certificate and key must exist in the `openshift-config` namespace and must be referenced in the `ingress` config. If the domain for the custom hostname suffix matches the cluster domain suffix, then the secret is optional. The secret must contain `tls.crt` and `tls.key` data keys, where the certificate and key are stored, and both must be in a valid format.
@@ -57,6 +57,6 @@ spec:
     - name: downloads
       namespace: openshift-console
       hostname: <custom-hostname>
-       secret:
-         name: <secret-name>
+      servingCertKeyPairSecret:
+        name: <secret-name>
 ----


### PR DESCRIPTION
@ahardin-rh sorry I've mismatched the old field name with the new one, in my review.
PTAL

/assign @ahardin-rh 

This is a follow-up to https://github.com/openshift/openshift-docs/pull/33161