### PR TITLE
BZ#1946889: Add Sample YAML file for RHV

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -40,6 +40,8 @@ compared to normal instances on GCP. You can xref:../machine_management/creating
 
 include::modules/machineset-yaml-osp.adoc[leveloffset=+3]
 
+include::modules/machineset-yaml-rhv.adoc[leveloffset=+3]
+
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+3]
 
 include::modules/machineset-creating.adoc[leveloffset=+2]


### PR DESCRIPTION
For version 4.7 and later.

https://bugzilla.redhat.com/show_bug.cgi?id=1946889

Included an existing RHV Yaml file to a module. See preview here:
https://deploy-preview-33543--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets-clouds