### PR TITLE
GH#33524: Fix asciibinder build warnings in install modules

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -161,7 +161,12 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}' <1>
 endif::restricted[]
 ifdef::restricted[]
+ifndef::openshift-origin[]
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <13>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::gov[]
 ifndef::openshift-origin[]
@@ -185,6 +190,7 @@ additionalTrustBundle: | <13>
 endif::openshift-origin[]
 endif::gov[]
 ifdef::restricted[]
+ifndef::openshift-origin[]
 additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
@@ -195,7 +201,21 @@ imageContentSources: <15>
   source: quay.io/openshift-release-dev/ocp-release
 - mirrors:
   - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+additionalTrustBundle: | <13>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+imageContentSources: <14>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
   source: registry.svc.ci.openshift.org/ocp/release
+endif::openshift-origin[]
 endif::restricted[]
 
 
@@ -282,18 +302,38 @@ endif::vpc,restricted[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifdef::private[]
+ifndef::openshift-origin[]
 <13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
 endif::private[]
 ifdef::gov[]
+ifndef::openshift-origin[]
 <14> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<13> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+endif::openshift-origin[]
 endif::gov[]
 ifdef::restricted[]
+ifndef::openshift-origin[]
 <13> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 <14> Provide the contents of the certificate file that you used for your mirror registry.
 <15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<12> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+endif::openshift-origin[]
 endif::restricted[]
 
 ifeval::["{context}" == "installing-aws-network-customizations"]

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -110,9 +110,7 @@ endif::gov[]
 pullSecret: '{"auths": ...}' <1>
 ifdef::vnet[]
 ifndef::openshift-origin[]
-fips: false <12>
-endif::openshift-origin[]
-ifndef::openshift-origin[]
+fips: false <13>
 sshKey: ssh-ed25519 AAAA... <14>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -121,7 +119,7 @@ endif::openshift-origin[]
 endif::vnet[]
 ifdef::private[]
 ifndef::openshift-origin[]
-fips: false <13>
+fips: false <14>
 sshKey: ssh-ed25519 AAAA... <15>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -259,10 +257,20 @@ endif::vnet,private,gov[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifdef::private[]
+ifndef::openshift-origin[]
 <16> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<15> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
 endif::private[]
 ifdef::gov[]
+ifndef::openshift-origin[]
 <17> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<16> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
 endif::gov[]
 
 ifeval::["{context}" == "installing-azure-network-customizations"]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -263,16 +263,32 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 ====
 endif::openshift-origin[]
 ifndef::restricted[]
+ifndef::openshift-origin[]
 <12> The pull secret that you obtained from the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}] site.
 This pull secret allows you to authenticate with the services that are
 provided by the included authorities, including Quay.io, which serves the
 container images for {product-title} components.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<11> The pull secret that you obtained from the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}] site.
+This pull secret allows you to authenticate with the services that are
+provided by the included authorities, including Quay.io, which serves the
+container images for {product-title} components.
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
+ifndef::openshift-origin[]
 <12> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example,
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<11> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example,
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
 <13> The SSH public key for the `core` user in
@@ -289,14 +305,26 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::restricted[]
 ifndef::ibm-z,ibm-z-kvm[]
+ifndef::openshift-origin[]
 <14> Provide the contents of the certificate file that you used for your mirror
 registry.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<13> Provide the contents of the certificate file that you used for your mirror
+registry.
+endif::openshift-origin[]
 endif::ibm-z,ibm-z-kvm[]
 ifdef::ibm-z,ibm-z-kvm[]
 <14> Add the `additionalTrustBundle` parameter and value. The value must be the contents of the certificate file that you used for your mirror registry, which can be an exiting, trusted certificate authority or the self-signed certificate that you generated for the mirror registry.
 endif::ibm-z,ibm-z-kvm[]
+ifndef::openshift-origin[]
 <15> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<14> Provide the `imageContentSources` section from the output of the command to
+mirror the repository.
+endif::openshift-origin[]
 endif::restricted[]
 
 

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -241,7 +241,12 @@ endif::vpc,restricted[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 ifdef::private[]
+ifndef::openshift-origin[]
 <11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the Internet. The default value is `External`.
+endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -153,6 +153,8 @@ ifndef::openshift-origin[]
 link:https://cloud.redhat.com/openshift/install/pull-secret[Pull Secret] page on the {cloud-redhat-com} site. This pull secret allows you to authenticate with the services that are
 provided by the included authorities, including Quay.io, which serves the
 container images for {product-title} components.
+<15> The public portion of the default SSH key for the `core` user in
+{op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 <13> The pull secret that you obtained from the
@@ -168,7 +170,12 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::openshift-origin[]
 endif::restricted[]
+ifdef::restricted[]
 ifndef::openshift-origin[]
+<14> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
 <15> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
@@ -177,13 +184,12 @@ ifndef::openshift-origin[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 endif::openshift-origin[]
-ifdef::restricted[]
 ifdef::openshift-origin[]
-<14> For `<local_registry>`, specify the registry domain name, and optionally the
+<13> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
-<15> The public portion of the default SSH key for the `core` user in
+<14> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
 [NOTE]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/33524#issuecomment-862606352

When I removed the `fips` parameter from the OKD docs in https://github.com/openshift/openshift-docs/pull/28954, I made some errors with the `ifdef` statements resulting in some build warnings in the _asciibinder build_ output. I am attempting to correct these errors. 