### PR TITLE
BZ1950240: Added known issue to 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1377,6 +1377,8 @@ scheduling:
 
 * The OVN-Kubernetes network provider does not support the `externalTrafficPolicy` feature for `NodePort`- and `LoadBalancer`-type services.  The `service.spec.externalTrafficPolicy` field determines whether traffic for a service is routed to node-local or cluster-wide endpoints. Currently, such traffic is routed by default to cluster-wide endpoints, and there is no way to limit traffic to node-local endpoints. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[*BZ#1903408*])
 
+* Currently, a Kubernetes port collision issue can cause a breakdown in pod-to-pod communication, even after pods are redeployed. For detailed information and a workaround, see the Red Hat Knowledge Base solution link:https://access.redhat.com/solutions/5940711[Port collisions between pod and cluster IPs on OpenShift 4 with OVN-Kubernetes]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939676[*BZ#1939676*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1939045[*BZ#1939045*])
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Partly fixes [BZ1950240](https://bugzilla.redhat.com/show_bug.cgi?id=1950240) by adding known issue to 4.8 RN. See also https://github.com/openshift/openshift-docs/pull/33398 and #33043 

* Partly fixes BZ1950240 (see also other pull request?)
* Applies only to `enterprise-4.8`
* [Direct preview link -- scroll up from **Asynchronous errata updates**](https://deploy-preview-33555--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-asynchronous-errata-updates)