### PR TITLE
MON-1229: Use our own prometheus-example-app image

### DIFF
--- a/modules/monitoring-configuring-monitoring-for-an-application.adoc
+++ b/modules/monitoring-configuring-monitoring-for-an-application.adoc
@@ -36,7 +36,7 @@ spec:
     spec:
       containers:
       - name: example-app
-        image: quay.io/brancz/prometheus-example-app:v0.2.0
+        image: ghcr.io/rhobs/prometheus-example-app:0.3.0
         ports:
         - name: web
           containerPort: 8080

--- a/modules/monitoring-deploying-a-sample-service.adoc
+++ b/modules/monitoring-deploying-a-sample-service.adoc
@@ -38,7 +38,7 @@ spec:
         app: prometheus-example-app
     spec:
       containers:
-      - image: quay.io/brancz/prometheus-example-app:v0.2.0
+      - image: ghcr.io/rhobs/prometheus-example-app:0.3.0
         imagePullPolicy: IfNotPresent
         name: prometheus-example-app
 ---


### PR DESCRIPTION
We've moved away from using an image for prometheus-example-app hosted
in a private namespace.  We're now building the images and hosting
them under the RHOBS GitHub organizaiton.  This updates the examples
to use this new image.