### PR TITLE
OSDOCS-2224: Added known issue for externalTrafficPolicy to 4.6RN

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2360,6 +2360,8 @@ This caused image pulls to fail against the inaccessible private registry, norma
 // TODO: This known issue should carry forward to 4.7 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
+* The OVN-Kubernetes network provider does not support the `externalTrafficPolicy` feature for `NodePort`- and `LoadBalancer`-type services.  The `service.spec.externalTrafficPolicy` field determines whether traffic for a service is routed to node-local or cluster-wide endpoints. Currently, such traffic is routed by default to cluster-wide endpoints, and there is no way to limit traffic to node-local endpoints. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[*BZ#1903408*])
+
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
With #33559 and #33560, resolves [OSDOCS-2224](https://issues.redhat.com/browse/OSDOCS-2224) by adding known issue to RN.

* applies only to `enterprise-4.6`
* [direct preview link: scroll up from **Asynchronous errata updates**](https://deploy-preview-33558--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-asynchronous-errata-updates)