### PR TITLE
OSDOCS-2224: Added known issue for externalTrafficPolicy to 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -820,6 +820,8 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 You can attempt to resolve the issue with the steps in this link:https://kb.vmware.com/s/article/2002779[VMware KBase article]. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5785341[[UPI vSphere\] Node scale-up doesn't work as expected]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918383[*BZ#1918383*])
 
+* The OVN-Kubernetes network provider does not support the `externalTrafficPolicy` feature for `NodePort`- and `LoadBalancer`-type services.  The `service.spec.externalTrafficPolicy` field determines whether traffic for a service is routed to node-local or cluster-wide endpoints. Currently, such traffic is routed by default to cluster-wide endpoints, and there is no way to limit traffic to node-local endpoints. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[*BZ#1903408*])
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
With #33558 and #33560, resolves [OSDOCS-2224](https://issues.redhat.com/browse/OSDOCS-2224) by adding known issue to RN.

* applies only to `enterprise-4.6`
* [direct preview link: scroll up from **Asynchronous errata updates**](https://deploy-preview-33559--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-asynchronous-errata-updates)