### PR TITLE
Reorganize mtc troubleshooting assemblies

### DIFF
--- a/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc
+++ b/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 To successfully transition from {product-title} 3 to {product-title} 4, it is important that you review the following information:
 
-xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[Planning your transition]::
+xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[Differences between {product-title} 3 and 4]::
 Learn about the differences between {product-title} versions 3 and 4. Prior to transitioning, be sure that you have reviewed and prepared for storage, networking, logging, security, and monitoring considerations.
 
 xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#about-mtc-3-4[About the {mtc-full}]::

--- a/migrating_from_ocp_3_to_4/about-mtc-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/about-mtc-3-4.adoc
@@ -11,7 +11,7 @@ You can migrate from {product-title} 3.7, 3.9, 3.10, or 3.11 to {product-version
 
 [IMPORTANT]
 ====
-Before you begin your migration, be sure to review the information on xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[planning your migration].
+Before you begin your migration, be sure to review the xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[differences between {product-title} 3 and 4].
 ====
 
 The {mtc-short} console is installed on the target cluster by default. You can configure the {mtc-full} Operator to install the console on an link:https://access.redhat.com/articles/5064151[{product-title} 3 source cluster or on a remote cluster].

--- a/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
@@ -9,12 +9,10 @@ toc::[]
 You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the command line.
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
-include::modules/migration-updating-deprecated-internal-images.adoc[leveloffset=+2]
-include::modules/migration-creating-ca-bundle.adoc[leveloffset=+2]
 include::modules/migration-configuring-proxy-for-dvm.adoc[leveloffset=+2]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
-[id="migrating-applications-additional-resources_{context}"]
+[discrete]
 === Additional resources
 
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-about-migration-hooks_about-mtc-3-4[About migration hooks]
@@ -60,7 +58,7 @@ The following terms are relevant for performing a migration:
 include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
 include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
 
-[id="migrating-applications-mtc-cli-additional-resources_{context}"]
+[discrete]
 == Additional resources
 
 * xref:../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually on an {product-title} 4 cluster]

--- a/migrating_from_ocp_3_to_4/premigration-checklists.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists.adoc
@@ -72,7 +72,7 @@ NFS does not require a defined storage class.
 * [ ] External applications and services that use services provided by the cluster have the correct network configuration and permissions to access the cluster.
 * [ ] Internal container image dependencies are met.
 +
-If an application uses an internal image in the `openshift` namespace that is not supported by {product-title} {product-version}, you can manually update the xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#migration-updating-deprecated-internal-images_migrating-applications-3-4[{product-title} 3 image stream tag] with `podman`.
+If an application uses an internal image in the `openshift` namespace that is not supported by {product-title} {product-version}, you can manually update the xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-updating-deprecated-internal-images_troubleshooting-3-4[{product-title} 3 image stream tag] with `podman`.
 * [ ] The target cluster and the replication repository have sufficient storage space.
 * [ ] The xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[identity provider] is working.
 

--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -5,24 +5,36 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can view the {mtc-full} ({mtc-short}) custom resources and download logs to troubleshoot a failed migration.
+This section describes resources for troubleshooting the {mtc-full} ({mtc-short}).
 
-If the application was stopped during the failed migration, you must roll it back manually to prevent data corruption.
+[id="logs-and-debugging-tools_{context}"]
+== Logs and debugging tools
 
-[NOTE]
-====
-Manual rollback is not required if the application was not stopped during migration because the original application is still running on the source cluster.
-====
+This section describes logs and debugging tools that you can use for troubleshooting.
 
-include::modules/migration-viewing-migration-crs.adoc[leveloffset=+1]
-include::modules/migration-using-mig-log-reader.adoc[leveloffset=+1]
-include::modules/migration-downloading-logs.adoc[leveloffset=+1]
-include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+1]
-include::modules/migration-error-messages.adoc[leveloffset=+1]
-include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+1]
-include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
+include::modules/migration-downloading-logs.adoc[leveloffset=+2]
+include::modules/migration-using-mig-log-reader.adoc[leveloffset=+2]
+include::modules/migration-using-must-gather.adoc[leveloffset=+2]
+include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
-include::modules/migration-using-must-gather.adoc[leveloffset=+1]
+include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
+
+[discrete]
+=== Additional resources
+
+* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
+* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-custom-resources_about-mtc-3-4[{mtc-short} custom resources]
+
+[id="common-issues-and-concerns_{context}"]
+== Common issues and concerns
+
+This section describes common issues and concerns that can cause issues during migration.
+
+include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+2]
+include::modules/migration-updating-deprecated-internal-images.adoc[leveloffset=+2]
+include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+2]
+include::modules/migration-error-messages.adoc[leveloffset=+2]
+include::modules/migration-known-issues.adoc[leveloffset=+2]
 
 [id="rolling-back-migration_{context}"]
 == Rolling back a migration
@@ -31,11 +43,3 @@ You can roll back a migration by using the {mtc-short} web console or the CLI.
 
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
-
-include::modules/migration-known-issues.adoc[leveloffset=+1]
-
-[id="troubleshooting-additional-resources_{context}"]
-== Additional resources
-
-* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
-* xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-custom-resources_about-mtc-3-4[{mtc-short} custom resources]

--- a/migration-toolkit-for-containers/migrating-applications-with-mtc.adoc
+++ b/migration-toolkit-for-containers/migrating-applications-with-mtc.adoc
@@ -8,12 +8,10 @@ toc::[]
 You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the command line.
 
 include::modules/migration-prerequisites.adoc[leveloffset=+1]
-include::modules/migration-updating-deprecated-internal-images.adoc[leveloffset=+2]
-include::modules/migration-creating-ca-bundle.adoc[leveloffset=+2]
 include::modules/migration-configuring-proxy-for-dvm.adoc[leveloffset=+2]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
-[id="migrating-applications-additional-resources_{context}"]
+[discrete]
 === Additional resources
 
 * xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-about-migration-hooks_about-mtc[About migration hooks]
@@ -59,7 +57,7 @@ The following terms are relevant for performing a migration:
 include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
 include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
 
-[id="migrating-applications-mtc-cli-additional-resources_{context}"]
+[discrete]
 == Additional resources
 
 * xref:../registry/securing-exposing-registry.adoc#registry-exposing-secure-registry-manually_securing-exposing-registry[Exposing a secure registry manually]

--- a/migration-toolkit-for-containers/troubleshooting-mtc.adoc
+++ b/migration-toolkit-for-containers/troubleshooting-mtc.adoc
@@ -5,24 +5,36 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can view the {mtc-full} ({mtc-short}) custom resources and download logs to troubleshoot a failed migration.
+This section describes resources for troubleshooting the {mtc-full} ({mtc-short}).
 
-If the application was stopped during the failed migration, you must roll it back manually to prevent data corruption.
+[id="logs-and-debugging-tools_{context}"]
+== Logs and debugging tools
 
-[NOTE]
-====
-Manual rollback is not required if the application was not stopped during migration because the original application is still running on the source cluster.
-====
+This section describes logs and debugging tools that you can use for troubleshooting.
 
-include::modules/migration-viewing-migration-crs.adoc[leveloffset=+1]
-include::modules/migration-using-mig-log-reader.adoc[leveloffset=+1]
-include::modules/migration-downloading-logs.adoc[leveloffset=+1]
-include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+1]
-include::modules/migration-error-messages.adoc[leveloffset=+1]
-include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+1]
-include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
+include::modules/migration-downloading-logs.adoc[leveloffset=+2]
+include::modules/migration-using-mig-log-reader.adoc[leveloffset=+2]
+include::modules/migration-using-must-gather.adoc[leveloffset=+2]
+include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
-include::modules/migration-using-must-gather.adoc[leveloffset=+1]
+include::modules/migration-viewing-migration-crs.adoc[leveloffset=+2]
+
+[discrete]
+=== Additional resources
+
+* xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
+* xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-custom-resources_about-mtc[{mtc-short} custom resources]
+[id="rolling-back-migration_{context}"]
+
+[id="common-issues-and-concerns_{context}"]
+== Common issues and concerns
+
+This section describes common issues and concerns that can cause issues during migration.
+
+include::modules/migration-updating-deprecated-gvks.adoc[leveloffset=+2]
+include::modules/migration-dvm-error-node-selectors.adoc[leveloffset=+2]
+include::modules/migration-error-messages.adoc[leveloffset=+2]
+include::modules/migration-known-issues.adoc[leveloffset=+2]
 
 [id="rolling-back-migration_{context}"]
 == Rolling back a migration
@@ -31,11 +43,3 @@ You can roll back a migration by using the {mtc-short} web console or the CLI.
 
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
-
-include::modules/migration-known-issues.adoc[leveloffset=+1]
-
-[id="troubleshooting-additional-resources_{context}"]
-== Additional resources
-
-* xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
-* xref:../migration-toolkit-for-containers/about-mtc.adoc#migration-mtc-custom-resources_about-mtc[{mtc-short} custom resources]

--- a/modules/migration-creating-ca-bundle.adoc
+++ b/modules/migration-creating-ca-bundle.adoc
@@ -4,7 +4,7 @@
 // * migration-toolkit-for-containers/migrating-applications-with-mtc
 
 [id="creating-ca-bundle_{context}"]
-= Creating a CA certificate bundle file
+= Creating a CA certificate bundle file for self-signed certificates
 
 If you use a self-signed certificate to secure a cluster or a replication repository for the {mtc-full} ({mtc-short}), certificate verification might fail with the following error message: `Certificate signed by unknown authority`.
 

--- a/modules/migration-downloading-logs.adoc
+++ b/modules/migration-downloading-logs.adoc
@@ -4,7 +4,7 @@
 // * migration-toolkit-for-containers/troubleshooting-mtc
 
 [id="migration-downloading-logs_{context}"]
-= Downloading migration logs
+= Downloading migration logs by using the {mtc-short} web console
 
 You can download the `Velero`, `Restic`, and `MigrationController` pod logs in the {mtc-full} ({mtc-short}) web console to troubleshoot a failed migration.
 

--- a/modules/migration-dvm-error-node-selectors.adoc
+++ b/modules/migration-dvm-error-node-selectors.adoc
@@ -26,9 +26,7 @@ The output includes the following status message:
 .Example output
 [source,terminal]
 ----
-...
 Some or all transfer pods are not running for more than 10 mins on destination cluster
-...
 ----
 
 . On the source cluster, obtain the details of a migrated namespace:
@@ -46,7 +44,7 @@ $ oc get namespace <namespace> -o yaml <1>
 $ oc edit namespace <namespace>
 ----
 
-. Add missing `openshift.io/node-selector` annotations to the migrated namespace as in the following example:
+. Add the missing `openshift.io/node-selector` annotations to the migrated namespace as in the following example:
 +
 [source,yaml]
 ----

--- a/modules/migration-error-messages.adoc
+++ b/modules/migration-error-messages.adoc
@@ -8,8 +8,8 @@
 
 This section describes common error messages you might encounter with the {mtc-full} ({mtc-short}) and how to resolve their underlying causes.
 
-[id="ca-certificate-error-in-console_{context}"]
-== CA certificate error in the {mtc-short} console
+[discrete]
+== CA certificate error displayed when accessing the {mtc-short} console for the first time
 
 If the {mtc-short} console displays a `CA certificate error` message the first time you try to access it, the likely cause is that a cluster uses self-signed CA certificates.
 
@@ -17,7 +17,7 @@ Navigate to the `oauth-authorization-server` URL in the error message and accept
 
 If the browser displays an `Unauthorized` message after you have accepted the CA certificate, navigate to the {mtc-short} console and then refresh the web page.
 
-[id="oauth-timeout-error-in-console_{context}"]
+[discrete]
 == OAuth timeout error in the {mtc-short} console
 
 If the {mtc-short} console displays a `connection has timed out` message after you have accepted a self-signed certificate, the cause is likely to be one of the following:
@@ -31,12 +31,30 @@ To determine the cause:
 * Inspect the {mtc-short} console web page with a browser web inspector.
 * Check the `Migration UI` pod log for errors.
 
-[id="backup-storage-location-errors-in-velero-pod-log_{context}"]
+[discrete]
+== Certificate signed by unknown authority error
+
+If you use a self-signed certificate to secure a cluster or a replication repository for the {mtc-full} ({mtc-short}), certificate verification might fail with the following error message: `Certificate signed by unknown authority`.
+
+You can create a custom CA certificate bundle file and upload it in the {mtc-short} web console when you add a cluster or a replication repository.
+
+.Procedure
+
+Download a CA certificate from a remote endpoint and save it as a CA bundle file:
+
+[source,terminal]
+----
+$ echo -n | openssl s_client -connect <host_FQDN>:<port> \ <1>
+  | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' > <ca_bundle.cert> <2>
+----
+<1> Specify the host FQDN and port of the endpoint, for example, `api.my-cluster.example.com:6443`.
+<2> Specify the name of the CA bundle file.
+
+[discrete]
 == Backup storage location errors in the Velero pod log
 
 If a `Velero` `Backup` custom resource contains a reference to a backup storage location (BSL) that does not exist, the `Velero` pod log might display the following error messages:
 
-.BSL error messages
 [source,terminal]
 ----
 Error checking repository for stale locks
@@ -46,12 +64,11 @@ Error getting backup storage location: backupstoragelocation.velero.io \"my-bsl\
 
 You can ignore these error messages. A missing BSL cannot cause a migration to fail.
 
-[id="podvolumebackups-timeout-error-in-velero-log_{context}""]
+[discrete]
 == Pod volume backup timeout error in the Velero pod log
 
 If a migration fails because `Restic` times out, the `Velero` pod log displays the following error:
 
-.Pod volume backup timeout error
 [source,terminal]
 ----
 level=error msg="Error backing up item" backup=velero/monitoring error="timed out
@@ -78,7 +95,7 @@ spec:
 
 . Click *Save*.
 
-[id="resticverifyerrors-in-the-migmigration-custom-resource_{context}""]
+[discrete]
 == Restic verification errors in the MigMigration custom resource
 
 If data verification fails when migrating a persistent volume with the file system data copy method, the `MigMigration` CR displays the following error:
@@ -118,7 +135,7 @@ $ oc describe <registry-example-migration-rvwcm> -n openshift-migration
 +
 The output identifies the persistent volume with `PodVolumeRestore` errors.
 +
-.Restore CR with pod volume restore error
+.Example output
 [source,yaml]
 ----
 status:
@@ -159,7 +176,7 @@ The output identifies the `Restic` pod that logged the errors.
 $ oc logs -f <restic-nr2v5>
 ----
 
-[id="restic-permission-denied-error-for-nfs-storage_{context}"]
+[discrete]
 == Restic permission error when migrating from NFS storage with root_squash enabled
 
 If you are migrating data from NFS storage and `root_squash` is enabled, `Restic` maps to `nfsnobody` and does not have permission to perform the migration. The `Restic` pod log displays the following error:

--- a/modules/migration-rolling-back-migration-cli.adoc
+++ b/modules/migration-rolling-back-migration-cli.adoc
@@ -4,9 +4,9 @@
 // * migration-toolkit-for-containers/troubleshooting-mtc
 
 [id="migration-rolling-back-migration-cli_{context}"]
-== Rolling back a migration from the CLI
+= Rolling back a migration from the command line interface
 
-You can roll back a migration by creating a `MigMigration` custom resource (CR) from the CLI.
+You can roll back a migration by creating a `MigMigration` custom resource (CR) from the command line interface.
 
 If your application was stopped during a failed migration, you must roll back the migration to prevent data corruption in the persistent volume.
 

--- a/modules/migration-rolling-back-migration-web-console.adoc
+++ b/modules/migration-rolling-back-migration-web-console.adoc
@@ -4,7 +4,7 @@
 // * migration-toolkit-for-containers/troubleshooting-mtc
 
 [id="migration-rolling-back-migration-web-console_{context}"]
-= Rolling back a migration in the {mtc-short} web console
+= Rolling back a migration by using the {mtc-short} web console
 
 You can roll back a migration by using the {mtc-full} ({mtc-short}) web console.
 

--- a/modules/migration-updating-deprecated-internal-images.adoc
+++ b/modules/migration-updating-deprecated-internal-images.adoc
@@ -4,57 +4,60 @@
 // * migration-toolkit-for-containers/migrating-applications-with-mtc
 
 [id="migration-updating-deprecated-internal-images_{context}"]
-= Updating deprecated internal images with podman
+= Updating deprecated internal images
 
 If your application uses images from the `openshift` namespace, the required versions of the images must be present on the target cluster.
 
-If the {product-title} 3 image is deprecated in {product-title} {product-version}, you can manually update the image stream tag by using `podman`.
+If an {product-title} 3 image is deprecated in {product-title} {product-version}, you can manually update the image stream tag by using `podman`.
 
 .Prerequisites
 
 * You must have `podman` installed.
 * You must be logged in as a user with `cluster-admin` privileges.
+* If you are using insecure registries, add your registry host values to the `[registries.insecure]` section of `/etc/container/registries.conf` to ensure that `podman` does not encounter a TLS verification error.
+* The internal registries must be exposed on the source and target clusters.
 
 .Procedure
 
-. Expose the internal registries on the source and target clusters.
-. If you are using insecure registries, add your registry host values to the `[registries.insecure]` section of `/etc/container/registries.conf` to ensure that `podman` does not encounter a TLS verification error.
-. Log in to the source cluster registry:
+. Log in to the {product-title} 3 registry:
 +
 [source,terminal]
 ----
-$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <source_cluster>
+$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <registry_url>:<port>
 ----
 
-. Log in to the target cluster registry:
+. Log in to the {product-title} 4 registry:
 +
 [source,terminal]
 ----
-$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <target_cluster>
+$ podman login -u $(oc whoami) -p $(oc whoami -t) --tls-verify=false <registry_url>:<port>
 ----
 
-. Pull the deprecated image:
+. Pull the {product-title} 3 image:
 +
 [source,terminal]
 ----
-$ podman pull <source_cluster>/openshift/<image>
+$ podman pull <registry_url>:<port>/openshift/<image>
 ----
 
-. Tag the image for the target cluster registry:
+. Tag the {product-title} 3 image for the {product-title} 4 registry:
 +
 [source,terminal]
 ----
-$ podman tag <source_cluster>/openshift/<image> <target_cluster>/openshift/<image>
+$ podman tag <registry_url>:<port>/openshift/<image> \ <1>
+  <registry_url>:<port>/openshift/<image> <2>
 ----
+<1> Specify the registry URL and port for the {product-title} 3 cluster.
+<2> Specify the registry URL and port for the {product-title} 4 cluster.
 
-. Push the image to the target cluster 4 registry:
+. Push the image to the {product-title} 4 registry:
 +
 [source,terminal]
 ----
-$ podman push <target_cluster>/openshift/<image>
+$ podman push <registry_url>:<port>/openshift/<image>
 ----
 
-. Verify that the image has a valid image stream on the target cluster:
+. Verify that the image has a valid image stream:
 +
 [source,terminal]
 ----
@@ -64,6 +67,6 @@ $ oc get imagestream -n openshift | grep <image>
 .Example output
 [source,terminal]
 ----
-<image>    <target_cluster>/openshift/<image>     <versions>
-more...      6 seconds ago
+NAME      IMAGE REPOSITORY                                                      TAGS    UPDATED
+my_image  image-registry.openshift-image-registry.svc:5000/openshift/my_image  latest  32 seconds ago
 ----


### PR DESCRIPTION
No Jira or BZ ID.

Reorganized the Troubleshooting assemblies in OCP3>4 migration and MTC because they were getting messy.

4.5+

Previews:

https://deploy-preview-33561--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html

https://deploy-preview-33561--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/troubleshooting-mtc.html

Does not require QE. Ready for peer review.