### PR TITLE
Multiple BZs: Improved upgrade duration

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -83,6 +83,16 @@ You can now define an existing Route 53 private hosted zone for your cluster by 
 
 The {product-title} installation program for Google Cloud Platform (GCP) now creates subnets as large as possible within the machine CIDR. This allows the cluster to use a machine CIDR appropriately sized to accommodate the number of nodes in the cluster.
 
+[id="ocp-4-8-improved-upgrade-duration"]
+==== Improved upgrade duration
+
+With this release, the upgrade duration for cluster Operators that deploy daemon sets to all nodes is significantly reduced. For example, the upgrade duration of a 250-node test cluster is reduced from 7.5 hours to 1.5 hours, resulting in upgrade duration scaling of less than one minute per additional node.
+
+[NOTE]
+====
+This change does not affect machine config pool rollout duration.
+====
+
 [id="ocp-4-8-web-console"]
 === Web console
 


### PR DESCRIPTION
From RN tracker comment: https://github.com/openshift/openshift-docs/issues/29652#issuecomment-862641343

Multiple BZs:

- https://bugzilla.redhat.com/show_bug.cgi?id=1933159 
- https://bugzilla.redhat.com/show_bug.cgi?id=1933174 
- https://bugzilla.redhat.com/show_bug.cgi?id=1934711 
- https://bugzilla.redhat.com/show_bug.cgi?id=1933173 
- https://bugzilla.redhat.com/show_bug.cgi?id=1933179 
- https://bugzilla.redhat.com/show_bug.cgi?id=1933184

Preview: https://deploy-preview-33563--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-improved-upgrade-duration