### PR TITLE
Adding Github template links

### DIFF
--- a/modules/virt-about-vm-templates.adoc
+++ b/modules/virt-about-vm-templates.adoc
@@ -22,3 +22,4 @@ In the Templates tab, you cannot edit or delete Red Hat Supported or Red Hat Pro
 Using a Red Hat template is convenient because the template is already preconfigured. When you select a Red Hat template to create your own custom template, the *Create Virtual Machine Template* wizard prompts you to add a boot source if a boot source was not added previously. Then, you can either save your custom template or continue to customize it and save it.
 
 You can also select the *Create Virtual Machine Template* wizard directly and create a custom virtual machine template. The wizard prompts you to provide configuration details for the operating system, flavor, workload type, and other settings. You can add a boot source and continue to customize your template and save it.
+If in any case a reference to the templates is needed, they can be found [here](https://github.com/kubevirt/common-templates) and can be used has guidelines to create new templates. 


### PR DESCRIPTION
Some Customers asked for the templates of the yaml to use for a baseline or for understanding how to build their own image, adding links for the yaml in the github makes sure that the data is not copied and maintained in one place for people to use. 
