### PR TITLE
TELCODOCS-128: Enable provisioning network after installation.

### DIFF
--- a/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -12,16 +12,16 @@ In {product-title} 4.8 and later, you can enable a `provisioning` network after 
 
 .Prerequisites
 
-. The `provisioning` network must exist.
-. The `provisioning` network must be enabled.
-. The cluster nodes must be connected to the `provisioning` network using the same network interface on both worker nodes and control plane nodes.
-. The cluster nodes must be homogeneous. If the cluster nodes use different network interface names for the same network interface order, such as `eth0` and `eno1` for the first network interface, the procedure fails.
+* A dedicated physical network must exist, connected to all worker and control plane nodes.
+* You must isolate the native, untagged physical network.
+* The network cannot have a DHCP server when the `provisioningNetwork` configuration setting is set to `Managed`.
+* You must connect the control plane nodes to the network with the same network interface, such as `eth0` or `eno1`.
 
 .Procedure
 
 . Identify the provisioning interface name for the cluster nodes. For example, `eth0` or `eno1`.
 
-. Enable the preboot execution environment (PXE) on the `provisioning` network interface of the cluster nodes.
+. Enable the Preboot eXecution Environment (PXE) on the `provisioning` network interface of the cluster nodes.
 
 . Retrieve the current state of the `provisioning` network and save it to a provisioning configuration resource file:
 +
@@ -59,7 +59,7 @@ items:
 +
 where:
 +
-<1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures DHCP server manually.
+<1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures the DHCP server manually.
 +
 <2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/rhcos-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
 +


### PR DESCRIPTION
Content for enabling a provisioning network as a day 2 operation. This module was already reviewed and merged. It contains additional feedback from Ramon Acedo and Steve Hardy.

Fixes: [TELCODOCS-128](https://issues.redhat.com/browse/TELCODOCS-128)

See https://issues.redhat.com/browse/TELCODOCS-128 for additional details.

Release: 4.8

Preview URL: https://deploy-preview-33586--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration?utm_source=github&utm_campaign=bot_dp

Signed-off-by: John Wilkins <jowilkin@redhat.com>
