### PR TITLE
Release note: CDI uses OCP cluster-wide proxy config

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -44,6 +44,9 @@ The SVVP Certification applies to:
 +
 ** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS__.
 ** Intel and AMD CPUs.
+* The Containerized Data Importer (CDI) now uses the {product-title} xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy configuration].
+
+
 
 //CNV-8914 Microsoft's Windows Server Virtualization Validation Program (SVVP)
 


### PR DESCRIPTION
Original story: [CNV-8907](https://issues.redhat.com/browse/CNV-8907)
Release notes story: [CNV-12273](https://issues.redhat.com/browse/CNV-12273)

Preview: https://deploy-preview-33590--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes