### PR TITLE
CNV-12323: RN - Added note about querying virt infrastructure metrics

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -37,15 +37,21 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 
 [id="virt-4-8-new"]
 == New and changed features
-
-* OpenShift Virtualization is certified in Microsoft’s Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
+//CNV-8914 Microsoft's Windows Server Virtualization Validation Program (SVVP)
+* {VirtProductName} is certified in Microsoft’s Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
 +
 The SVVP Certification applies to:
 +
 ** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS__.
 ** Intel and AMD CPUs.
 
-//CNV-8914 Microsoft's Windows Server Virtualization Validation Program (SVVP)
+//CNV-12323 OpenShift Virtualization is exposing additional metrics
+* {VirtProductName} now provides metrics for monitoring how infrastructure resources are consumed in the cluster. You can use the {product-title} monitoring dashboard to xref:../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-prometheus-queries[query metrics] for the following resources:
++
+** vCPU
+** Network
+** Storage
+** Guest memory swapping
 
 //CNV-12271 A new tech preview feature allows VM owners to hot-plug and hot-unplug disks with a running virtual machine
 


### PR DESCRIPTION
This PR addresses [CNV-12323](https://issues.redhat.com/browse/CNV-12323)

4.8 release note to highlight new virtualization metrics

Preview build: https://deploy-preview-33592--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-new