### PR TITLE
OSDOCS-1854: Adding overview of TLS security profiles

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -728,8 +728,8 @@ Topics:
   File: audit-log-view
 - Name: Configuring the audit log policy
   File: audit-log-policy-config
-# - Name: Configuring TLS security profiles
-#   File: tls-security-profiles
+- Name: Configuring TLS security profiles
+  File: tls-security-profiles
 - Name: Allowing JavaScript-based access to the API server from additional hosts
   File: allowing-javascript-access-api-server
   Distros: openshift-enterprise,openshift-origin

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+// * security/tls-security-profiles.adoc
+
+[id="tls-profiles-ingress-understanding_{context}"]
+= Understanding TLS security profiles
+
+You can use a TLS (Transport Layer Security) security profile to define which TLS ciphers are required by various {product-title} components. The {product-title} TLS security profiles are based on link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla recommended configurations].
+
+You can specify one of the following TLS security profiles:
+
+.TLS security profiles
+[cols="1,2a",options="header"]
+|===
+|Profile
+|Description
+
+|`Old`
+|This profile is intended for use with legacy clients or libraries. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility[Old backward compatibility] recommended configuration.
+
+The `Old` profile requires a minimum TLS version of 1.0.
+
+[NOTE]
+====
+For the Ingress Controller, the minimum TLS version is converted from 1.0 to 1.1.
+====
+
+|`Intermediate`
+|This profile is the recommended configuration for the majority of clients. It is the  default TLS security profile for the Ingress Controller, kubelet, and Kubernetes control plane. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29[Intermediate compatibility] recommended configuration.
+
+The `Intermediate` profile requires a minimum TLS version of 1.2.
+
+|`Modern`
+|This profile is intended for use with modern clients that have no need for backwards compatibility. This profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility[Modern compatibility] recommended configuration.
+
+The `Modern` profile requires a minimum TLS version of 1.3.
+
+[IMPORTANT]
+====
+The `Modern` profile is currently not supported.
+====
+
+|`Custom`
+|This profile allows you to define the TLS version and ciphers to use.
+
+[WARNING]
+====
+Use caution when using a `Custom` profile, because invalid configurations can cause problems.
+====
+
+|===
+
+[NOTE]
+====
+When using one of the predefined profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 may cause a new profile configuration to be applied, resulting in a rollout.
+====
+
+// TODO: Make sure all this is captured somewhere as necessary
+// [IMPORTANT]
+// ====
+// The HAProxy Ingress controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+//
+// The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
+// ====

--- a/modules/tls-profiles-view-details.adoc
+++ b/modules/tls-profiles-view-details.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * security/tls-security-profiles.adoc
+
+[id="tls-profiles-view-details_{context}"]
+= Viewing TLS security profile details
+
+You can view the minimum TLS version and ciphers for the predefined TLS security profiles for each of the following components: Ingress Controller, Kubernetes control plane, and kubelet.
+
+[IMPORTANT]
+====
+The effective configuration of minimum TLS version and list of ciphers for a profile might differ between components.
+====
+
+.Procedure
+
+* View details for a specific TLS security profile:
++
+[source,terminal]
+----
+$ oc explain <component>.spec.tlsSecurityProfile.<profile> <1>
+----
+<1> For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`. For `<profile>`, specify `old`, `intermediate`, or `custom`.
++
+For example, to check the ciphers included for the `intermediate` profile for the Kubernetes control plane:
++
+[source,terminal]
+----
+$ oc explain apiserver.spec.tlsSecurityProfile.intermediate
+----
++
+.Example output
+[source,terminal]
+----
+KIND:     APIServer
+VERSION:  config.openshift.io/v1
+
+DESCRIPTION:
+    intermediate is a TLS security profile based on:
+    https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+    and looks like this (yaml):
+    ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 -
+    TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 -
+    ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 -
+    ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 -
+    ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 -
+    DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2
+----
+
+* View all details for the `tlsSecurityProfile` field of a component:
++
+[source,terminal]
+----
+$ oc explain <component>.spec.tlsSecurityProfile <1>
+----
+<1> For `<component>`, specify `ingresscontroller`, `apiserver`, or `kubeletconfig`.
++
+For example, to check all details for the `tlsSecurityProfile` field for the Ingress Controller:
++
+[source,terminal]
+----
+$ oc explain ingresscontroller.spec.tlsSecurityProfile
+----
++
+.Example output
+[source,terminal]
+----
+KIND:     IngressController
+VERSION:  operator.openshift.io/v1
+
+RESOURCE: tlsSecurityProfile <Object>
+
+DESCRIPTION:
+     ...
+
+FIELDS:
+   custom	<>
+     custom is a user-defined TLS security profile. Be extremely careful using a
+     custom profile as invalid configurations can be catastrophic. An example
+     custom profile looks like this:
+     ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 -
+     ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion:
+     TLSv1.1
+
+   intermediate	<>
+     intermediate is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+     and looks like this (yaml):
+     ... <1>
+
+   modern	<>
+     modern is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility and
+     looks like this (yaml):
+     ... <2>
+     NOTE: Currently unsupported.
+
+   old	<>
+     old is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+     and looks like this (yaml):
+     ... <3>
+
+   type	<string>
+     ...
+----
+<1> Lists ciphers and minimum version for the `intermediate` profile here.
+<2> Lists ciphers and minimum version for the `modern` profile here.
+<3> Lists ciphers and minimum version for the `old` profile here.

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -5,10 +5,22 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-TODO
+TLS security profiles provide a way for servers to regulate which ciphers a connecting client can use when connecting to the server. This ensures that {product-title} components use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
 
-// TODO: The overview
-// include::modules/todo.adoc[leveloffset=+1]
+Cluster administrators can choose which TLS security profile to use for each of the following components:
+
+* the Ingress controller
+* the Kubernetes control plane (Kubernetes API server, Kubernetes controller manager, and Kubernetes scheduler)
+* the kubelet, when it acts as an HTTP server for the Kubernetes API server
+// TODO: add links once the procedures have been added?
+
+// Understanding TLS security profiles
+include::modules/tls-profiles-understanding.adoc[leveloffset=+1]
+
+// Viewing TLS security profile details
+include::modules/tls-profiles-view-details.adoc[leveloffset=+1]
+
+////
 
 // TODO: Configuring for ingress
 // include::modules/todo.adoc[leveloffset=+1]
@@ -18,3 +30,5 @@ TODO
 
 // TODO: Configuring for kubelet
 // include::modules/todo.adoc[leveloffset=+1]
+
+////


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1854

Preview: https://deploy-preview-33601--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html