### PR TITLE
TELCODOCS-216: Release notes. Setting apiVIP and ingressVIP to run on control plane nodes.

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -243,6 +243,11 @@ In deployments where no Open Virtual Network (OVN) Octavia is available, more do
 
 The assisted installer and installer-provisioned installation for bare metal clusters provide the ability to deploy a cluster without a `provisioning` network. In {product-title} 4.8 and later, you can enable a `provisioning` network after installation by using the Cluster Baremetal Operator (CBO).
 
+[id="ocp-4-8-configure-vips-to-run-on-control-plane"]
+==== Configure network components to run on the control plane
+
+In {product-title} 4.8, for installer-provisioned installations, you must configure the `apiVIP` and `ingressVIP` virtual IP addresses to run exclusively on the control plane nodes. By default, {product-title} allows any node in the machine configuration pool to host the `apiVIP` and `ingressVIP` virtual IP addresses. Since many environments deploy worker nodes in separate subnets from the control plane nodes, configuring the `apiVIP` and `ingressVIP` virtual IP addresses to run exclusively on the control plane nodes prevents issues from arising due to deploying worker nodes in separate subnets.
+
 [id="ocp-4-8-storage"]
 === Storage
 


### PR DESCRIPTION
Release notes for [TELCODOCS-216](https://issues.redhat.com/browse/TELCODOCS-216). Setting apiVIP and ingressVIP to run on control plane nodes.

Fixes: [TELCODOCS-216](https://issues.redhat.com/browse/TELCODOCS-216)

Preview: https://deploy-preview-33610--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

Signed-off-by: John Wilkins <jowilkin@redhat.com>