### PR TITLE
OSDOCS1834: Adding Ingress Global Access config topic to UPI/IPI GCP install

### DIFF
--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -35,6 +35,9 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
+include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
+
+
 == Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -44,6 +44,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
+include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
+
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]

--- a/modules/nw-gcp-installing-global-access-configuration.adoc
+++ b/modules/nw-gcp-installing-global-access-configuration.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-gcp-vpc.adoc
+// * installing/installing-restricted-networks-gcp
+
+[id="nw-gcp-global-access-configuration_{context}"]
+= Create an Ingress Controller with global access on GCP
+You can create an Ingress Controller with global access on a new GCP cluster when your. Global access is only available to Ingress Controllers using internal load balancers.
+
+.Prerequisites
+
+* You created the `install-config.yaml` and complete any modifications to it.
+
+.Procedure
+
+Create an Ingress Controller with global access on a new GCP cluster.
+
+. Change to the directory that contains the installation program and create a manifest file:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir=<installation_directory> <1>
+----
+<1> For `<installation_directory>`, specify the name of the directory that
+contains the `install-config.yaml` file for your cluster.
++
+After creating the file, several network configuration files are in the
+`manifests/` directory, as shown:
++
+[source,terminal]
+----
+$ ls <installation_directory>/manifests/cluster-ingress-default-ingresscontroller.yaml
+----
++
+.Example output
+[source,terminal]
+----
+cluster-ingress-default-ingresscontroller.yaml
+----
+
+. Open the `cluster-ingress-default-ingresscontroller.yaml` file in an editor and enter a custom resource (CR) that describes the Operator configuration you want:
++
+.Sample `clientAccess` configuration to `Global`
+[source,yaml]
+----
+  spec:
+    endpointPublishingStrategy:
+      loadBalancer:
+        providerParameters:
+          gcp:
+            clientAccess: Global <1>
+          type: GCP
+        scope: Internal          <2>
+      type: LoadBalancerService
+----
+<1> Set `gcp.clientAccess` to `Global`.
+<2> Global access is only available to Ingress Controllers using internal load balancers.

--- a/modules/nw-ingress-controller-configuration-gcp-global-access.adoc
+++ b/modules/nw-ingress-controller-configuration-gcp-global-access.adoc
@@ -54,7 +54,7 @@ $ oc -n openshift-ingress-operator edit ingresscontroller/default
 +
 [source,terminal]
 ----
-$ oc -n openshift-ingress operator edit svc/router-default -o yaml
+$ oc -n openshift-ingress edit svc/router-default -o yaml
 ----
 +
 The output shows that global access is enabled for GCP with the annotation, `networking.gke.io/internal-load-balancer-allow-global-access`.


### PR DESCRIPTION
Adding Ingress Global Access config topic to UPI/IPI GCP Install docs

https://issues.redhat.com/browse/OSDOCS-1834

Preview: 
- https://deploy-preview-33611--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned?utm_source=github&utm_campaign=bot_dp

- https://deploy-preview-33611--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc.html#nw-ingress-controller-configuration-gcp-global-access_installing-gcp-vpc

Minor correction here as well:
-https://deploy-preview-33611--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration-gcp-global-access_configuring-ingress
