### PR TITLE
Updating Red Hat Quay links

### DIFF
--- a/installing/installing-mirroring-installation-images.adoc
+++ b/installing/installing-mirroring-installation-images.adoc
@@ -27,7 +27,7 @@ can move across network boundaries with.
 ** link:https://www.sonatype.com/products/repository-oss?topnav=true[Sonatype Nexus Repository]
 ** link:https://goharbor.io/[Harbor]
 --
-If you have an entitlement to Red Hat Quay, see link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html-single/manage_red_hat_quay/index#repo-mirroring-in-red-hat-quay[Introduction to repository mirroring in Red Hat Quay] for background and installation information. If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
+If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/[by using the Quay Operator]. If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR applies to master, branch/enterprise-4.5, branch-enterprise-4.6, branch/enterprise-4.7 and branch/enterprise-4.8.

The PR updates the Quay link in **Installing** -> **Mirroring images for a disconnected installation** because Quay repository mirroring is not applicable to OpenShift mirroring.

The preview is [here](https://deploy-preview-33622--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images?utm_source=github&utm_campaign=bot_dp).