### PR TITLE
CNV 10440/10441: Adding additional details on Workload Types and Flavors VM wizard fields

### DIFF
--- a/modules/virt-vm-wizard-fields-web.adoc
+++ b/modules/virt-vm-wizard-fields-web.adoc
@@ -84,9 +84,16 @@ endif::[]
 
 |Flavor
 |Tiny, Small, Medium, Large, Custom
-|Presets that determine the amount of CPU and memory allocated to the virtual machine. The presets displayed for *Flavor* are determined by the operating system.
+|Presets the amount of CPU and memory in a virtual machine template with predefined values that are allocated to the virtual machine, depending on the operating system associated with that template.
 
-.3+|Workload Type
+If you choose a default template, you can override the `cpus` and `memsize` values in the template using custom values to create a custom template. Alternatively, you can create a custom template by modifying the `cpus` and `memsize` values in the *Details* tab on the *Workloads* -> *Virtualization* page.
+
+.3+a|Workload Type
+
+[NOTE]
+====
+If you choose the incorrect *Workload Type*, there could be performance or resource utilization issues (such as a slow UI).
+====
 
 |Desktop
 |A virtual machine configuration for use on a desktop. Ideal for consumption on a small scale. Recommended for use with the web console.


### PR DESCRIPTION
This PR covers Jira stories [CNV-10440](https://issues.redhat.com/browse/CNV-10440) ( https://issues.redhat.com/browse/CNV-10440 ) based on Bug 1888834 ( https://bugzilla.redhat.com/show_bug.cgi?id=1888834 )and [CNV-10441](https://issues.redhat.com/browse/CNV-10441) ( https://issues.redhat.com/browse/CNV-10441 ) based on Bug 1888835 ( https://bugzilla.redhat.com/show_bug.cgi?id=1888835 ).

These stories/bugs deals with asking for some additional details on the Workload Types and Flavors fields in the VM wizard

CP: 4.8

Preview: https://deploy-preview-33625--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-vm-wizard-fields-web_virt-create-vms