### PR TITLE
BZ1973057: Removed erroneous hyphen from Yaml example

### DIFF
--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -48,7 +48,7 @@ spec:
   package: etcd
   channel: alpha
   config: <1>
-  - selector:
+    selector:
       matchLabels:
         <labels_for_pods> <2>
     volumes: <3>


### PR DESCRIPTION
CP to 4.5, 4.6, 4.7, and 4.8

https://bugzilla.redhat.com/show_bug.cgi?id=1973057

Under Injecting a custom CA certificate, updated the Yaml example in step 2 to remove an erroneous hyphen from "selector".

 https://deploy-preview-33629--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-configuring-proxy-support