### PR TITLE
Remove sts:AssumeRole from instance profile policies

### DIFF
--- a/modules/rosa-sts-creating-roles.adoc
+++ b/modules/rosa-sts-creating-roles.adoc
@@ -285,7 +285,6 @@ $ cat << EOM > ManagedOpenShift_ControlPlane_Role_Policy.json
         {
             "Effect": "Allow",
             "Action": [
-                "sts:AssumeRole",
                 "ec2:AttachVolume",
                 "ec2:AuthorizeSecurityGroupIngress",
                 "ec2:CreateSecurityGroup",
@@ -384,7 +383,6 @@ $ cat << EOM > ManagedOpenShift_Worker_Role_Policy.json
         {
             "Effect": "Allow",
             "Action": [
-                "sts:AssumeRole",
                 "ec2:DescribeInstances",
                 "ec2:DescribeRegions"
             ],


### PR DESCRIPTION
`sts:AssumeRole` is not required for the instance profile policies. OCP documentation also doesn't [have](https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-user-infra.html#installation-cloudformation-security_installing-aws-user-infra) it here and ROSA doesn't require it.