### PR TITLE
[enterprise-4.6] Bug 1907885: clarify what configuration is copied by --copy-network

### DIFF
--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -50,6 +50,11 @@ system using available RHEL tools, such as `nmcli` or `nmtui`.
 $ coreos-installer install --copy-network \
      --ignition-url=http://host/worker.ign /dev/sda
 ----
++
+[IMPORTANT]
+====
+The `--copy-network` option only copies networking configuration found under `/etc/NetworkManager/system-connections`. In particular, it does not copy the system hostname.
+====
 
 . Reboot into the installed system.
 
@@ -58,7 +63,7 @@ $ coreos-installer install --copy-network \
 
 // This content is not modularized, so any updates to this "Disk partitioning" section should be checked against the module created for vSphere UPI parity in the module file named `installation-disk-partitioning.adoc` for consistency until such time as this large assembly can be modularized.
 
-In most cases, data partitions are originally created by installing {op-system}, rather than by installing another operating system. In such cases, the {product-title} installer should be allowed to configure your disk partitions.
+The disk partitions are created on {product-title} cluster nodes during the {op-system-first} installation. Each {op-system} node of a particular architecture uses the same partition layout, unless the default partitioning configuration is overridden. During the {op-system} installation, the size of the root file system is increased to use the remaining available space on the target device.
 
 However, there are two cases where you might want to intervene to override the default partitioning when installing an
 {product-title} node:

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -75,7 +75,7 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
 a|Optional: You can configure VLANs on individual interfaces by using the `vlan=` parameter.
-a| 
+a|
 To configure a VLAN on a network interface and use a static IP address:
 
 ----
@@ -245,6 +245,11 @@ a|Delete the default kernel argument.
 
 a|`-n`, `--copy-network`
 a|Copy the network configuration from the install environment.
++
+[IMPORTANT]
+====
+The `--copy-network` option only copies networking configuration found under `/etc/NetworkManager/system-connections`. In particular, it does not copy the system hostname.
+====
 
 a|`--network-dir <path>`
 a|For use with `-n`. Default is `/etc/NetworkManager/system-connections/`.


### PR DESCRIPTION
Cherry-picked from 928bb32 | xref: #33538