### PR TITLE
TELCODOCS-284: Content for enabling dual stack networking with installer-provisioned clusters.

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -17,6 +17,10 @@ include::modules/ipi-install-modifying-install-config-for-no-provisioning-networ
 endif::[]
 
 ifeval::[{product-version} > 4.7]
+include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+1]
+endif::[]
+
+ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+1]
 endif::[]
 

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -1,0 +1,44 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+
+[id='modifying-install-config-for-dual-stack-network_{context}']
+
+= Modifying the `install-config.yaml` file for dual-stack network (optional)
+
+To deploy an {product-title} cluster with dual-stack networking, make the following changes to the `install-config.yaml` file.
+
+[source,yaml]
+----
+machineNetwork:
+- cidr: {{ extcidrnet }}
+- cidr: {{ extcidrnet6 }}
+clusterNetwork:
+- cidr: 10.128.0.0/14
+  hostPrefix: 23
+- cidr: fd02::/48
+  hostPrefix: 64
+serviceNetwork:
+- 172.30.0.0/16
+- fd03::/112
+----
+
+NOTE: In the above snippet, the network settings must match the settings for the cluster's network environment. The `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings must have two CIDR entries each. The first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
+
+[IMPORTANT]
+====
+The IPv4 entries must go *before* the IPv6 entries.
+====
+
+ifeval::[{product-version} < 4.8]
+To deploy an {product-title} cluster with dual-stack, create an additional manifest to enable the `FeatureGate` with the following contents:
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: IPv6DualStackNoUpgrade
+----
+endif::[]


### PR DESCRIPTION
Content for enabling dual stack networking with installer-provisioned clusters.

Fixes: [TELCODOCS-284](https://issues.redhat.com/browse/TELCODOCS-284)

See https://issues.redhat.com/browse/TELCODOCS-284 for additional details.

Preview URL: https://deploy-preview-33652--osdocs.netlify.app/?utm_source=github&utm_campaign=bot_dp

For release(s): 4.8
Signed-off-by: John Wilkins <jowilkin@redhat.com>
