### PR TITLE
[BZ-1879394]: Restructured the post-installation instructions for clarity

### DIFF
--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -46,7 +46,7 @@ cluster on infrastructure that you provide.
 
 .Procedure
 
-. Confirm that all the cluster components are online:
+. Confirm that all the cluster components are online with the following command:
 +
 [source,terminal]
 ----
@@ -90,9 +90,7 @@ service-ca                                 4.7.0   True        False         Fal
 storage                                    4.7.0   True        False         False      4h30m
 ----
 +
-When all of the cluster Operators are `AVAILABLE`, you can complete the installation.
-
-. Monitor for cluster completion:
+Alternatively, the following command notifies you when all of the clusters are available. It also retrieves and displays credentials:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
For this PR, there was documented ambiguity since the installation is complete when the cluster operators are available, and the described commands allow for monitoring, retrieving, and displaying of the credentials.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1879394

Version: 4.5+

Preview: https://deploy-preview-33657--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-complete-user-infra_installing-restricted-networks-bare-metal