### PR TITLE
CNF doc: remove runlevel example

### DIFF
--- a/modules/cnf-installing-the-operators.adoc
+++ b/modules/cnf-installing-the-operators.adoc
@@ -98,7 +98,6 @@ metadata:
   annotations:
     workload.openshift.io/allowed: management
   labels:
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
 
 EOF
@@ -193,8 +192,6 @@ metadata:
   name: openshift-sriov-network-operator
   annotations:
     workload.openshift.io/allowed: management
-  labels:
-    openshift.io/run-level: "1"
 
 EOF
 ----


### PR DESCRIPTION
As per https://github.com/openshift/ptp-operator/pull/55/files the `runlevel` specification is no longer required and is a security risk if present.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1830496