### PR TITLE
BZ1844236: project name to be consistent

### DIFF
--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -21,7 +21,7 @@ To expose the service:
 +
 [source,terminal]
 ----
-$ oc project project1
+$ oc project myproject
 ----
 
 ifndef::nodeport[]


### PR DESCRIPTION
Fix for bug BZ#[1844236](https://bugzilla.redhat.com/show_bug.cgi?id=1844236)
In the example given for _Configuring ingress cluster traffic using a NodePort_ and _Configuring ingress cluster traffic using a load balancer_ **project1** should be **myproject**, to remain consistent with configuration example.
This fix should be pushed in 4.5, 4.6, 4.7 and 4.8 releases.


Preview for Configuring ingress cluster traffic using a NodePort: [link](https://deploy-preview-33675--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html#nw-exposing-service_configuring-ingress-cluster-traffic-nodeport)

Preview for Configuring ingress cluster traffic using a load balancer: [link](https://deploy-preview-33675--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html#nw-exposing-service_configuring-ingress-cluster-traffic-load-balancer)