### PR TITLE
Adding decision tree to installation assembly prerequisite sections

### DIFF
--- a/installing/installing-troubleshooting.adoc
+++ b/installing/installing-troubleshooting.adoc
@@ -10,7 +10,7 @@ gather logs from the bootstrap and control plane, or master, machines. You can a
 
 == Prerequisites
 
-* You attempted to install an {product-title} cluster, and installation failed.
+* You attempted to install an {product-title} cluster and the installation failed.
 
 include::modules/installation-bootstrap-gather.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -17,30 +17,16 @@ The scope of the {product-title} installation configurations is intentionally na
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to create
-AWS resources for the entire life of the cluster, so you must use long-lived
-credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-default.adoc
+++ b/installing/installing_aws/installing-aws-default.adoc
@@ -10,30 +10,16 @@ Amazon Web Services (AWS) that uses the default configuration options.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to
-create AWS resources for the entire life of the cluster, so you must
-use key-based, long-lived credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -12,30 +12,16 @@ install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to create
-AWS resources for the entire life of the cluster, so you must use long-lived
-credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-aws-about-government-region.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -17,30 +17,16 @@ cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to
-create AWS resources for the entire life of the cluster, so you must
-use key-based, long-lived credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 // TODO
 // Concept that describes networking
 

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -10,30 +10,16 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to create
-AWS resources for the entire life of the cluster, so you must use long-lived
-credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -16,26 +16,22 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You reviewed details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* You downloaded the AWS CLI and installed it on your computer. See
-link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)]
-in the AWS documentation.
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)] in the AWS documentation.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -10,30 +10,16 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configure an AWS account]
-to host the cluster.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary
-session token that you generated while using a multi-factor authentication
-device. The cluster continues to use your current AWS credentials to create
-AWS resources for the entire life of the cluster, so you must use long-lived
-credentials. To generate appropriate keys, see
-link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users]
-in the AWS documentation. You can supply the keys when you run the installation
-program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -10,6 +10,8 @@ In {product-title} version {product-version}, you can install a cluster on Amazo
 [id="prerequisites_installing-restricted-networks-aws-installer-provisioned"]
 == Prerequisites
 
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
@@ -17,24 +19,22 @@ In {product-title} version {product-version}, you can install a cluster on Amazo
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
 * You have an existing VPC in AWS. When installing to a restricted network using installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
-** Contains the mirror registry.
-** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere.
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+** Contains the mirror registry
+** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
 * You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* You downloaded the AWS CLI and installed it on your computer. See
-link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)] in the AWS documentation.
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)] in the AWS documentation.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====
 If you are configuring a proxy, be sure to also review this site list.
 ====
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -27,34 +27,28 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry on your mirror host]
- and obtained the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you can use that computer
-to complete all installation steps.
+Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* You reviewed details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account]
-to host the cluster.
+* You xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[configured an AWS account] to host the cluster.
 +
 [IMPORTANT]
 ====
 If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use key-based, long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
-* You downloaded the AWS CLI and installed it on your computer. See
-link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)]
-in the AWS documentation.
+* You downloaded the AWS CLI and installed it on your computer. See link:https://docs.aws.amazon.com/cli/latest/userguide/install-bundle.html[Install the AWS CLI Using the Bundled Installer (Linux, macOS, or Unix)] in the AWS documentation.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====
 Be sure to also review this site list if you are configuring a proxy.
 ====
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="requirements-for-installing-ocp-on-aws"]

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -12,17 +12,11 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-default.adoc
+++ b/installing/installing_azure/installing-azure-default.adoc
@@ -10,17 +10,11 @@ Microsoft Azure that uses the default configuration options.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -12,17 +12,11 @@ cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated government region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated government region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 
 include::modules/installation-azure-about-government-region.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -17,17 +17,11 @@ cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -9,17 +9,11 @@ In {product-title} version {product-version}, you can install a private cluster 
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -16,11 +16,12 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster.
-* Download the Azure CLI and install it on your computer. See link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest[Install the Azure CLI] in the Azure documentation. The documentation below was last tested using version `2.2.0` of the Azure CLI. Azure CLI commands might perform differently based on the version you use.
-* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster.
+* You downloaded the Azure CLI and installed it on your computer. See link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest[Install the Azure CLI] in the Azure documentation. The documentation below was last tested using version `2.2.0` of the Azure CLI. Azure CLI commands might perform differently based on the version you use.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 +
 [NOTE]
 ====

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -9,17 +9,11 @@ In {product-title} version {product-version}, you can install a cluster into an 
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Configure an Azure account] to host the cluster and determine the tested and validated region to deploy the cluster to.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[configured an Azure account] to host the cluster and determined the tested and validated region to deploy the cluster to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-creating-iam-azure[manually create and maintain IAM credentials].
 
 include::modules/installation-about-custom-azure-vnet.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/preparing-to-install-on-azure.adoc
+++ b/installing/installing_azure/preparing-to-install-on-azure.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="requirements-for-installing-ocp-on-azure"]

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -16,11 +16,9 @@ cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -19,11 +19,9 @@ before you attempt to install an {product-title} cluster in such an environment.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -19,22 +19,16 @@ before you attempt to install an {product-title} cluster in such an environment.
 
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you can use that computer
-to complete all installation steps.
+Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
-ReadWriteMany access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide ReadWriteMany access modes.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You have read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-a-method-to-install-ocp-on-bare-metal"]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -12,18 +12,11 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
-to host the cluster.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-default.adoc
+++ b/installing/installing_gcp/installing-gcp-default.adoc
@@ -11,18 +11,11 @@ Google Cloud Platform (GCP) that uses the default configuration options.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
-to host the cluster.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -19,18 +19,11 @@ cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
-to host the cluster.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -10,18 +10,11 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
-to host the cluster.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -21,16 +21,10 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 +
 [NOTE]
 ====

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -16,9 +16,10 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 +
 [NOTE]
 ====

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -10,18 +10,11 @@ parameters in the `install-config.yaml` file before you install the cluster.
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Configure a GCP account]
-to host the cluster.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* If you do not allow the system to manage identity and access management (IAM),
-then a cluster administrator can
-xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually
-create and maintain IAM credentials]. Manual mode can also be used in
-environments where the cloud IAM APIs are not reachable.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -15,6 +15,8 @@ You can install an {product-title} cluster by using mirrored installation releas
 [id="prerequisites_installing-restricted-networks-gcp-installer-provisioned"]
 == Prerequisites
 
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You xref:../../installing/installing-mirroring-installation-images.adoc#installation-about-mirror-registry_installing-mirroring-installation-images[mirrored the images for a disconnected installation] to your registry and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
@@ -24,9 +26,8 @@ Because the installation media is on the mirror host, you can use that computer 
 * You have an existing VPC in GCP. While installing a cluster in a restricted network that uses installer-provisioned infrastructure, you cannot use the installer-provisioned VPC. You must use a user-provisioned VPC that satisfies one of the following requirements:
 ** Contains the mirror registry
 ** Has firewall rules or a peering connection to access the mirror registry hosted elsewhere
-* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -21,15 +21,16 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
-* If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
+* If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 
 [id="installation-restricted-networks-gcp-user-infra-config-project"]
 == Configuring your GCP project

--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -14,18 +14,14 @@ Additional considerations exist for non-bare metal platforms. Review the informa
 link:https://access.redhat.com/articles/4207611[guidelines for deploying {product-title} on non-tested platforms] before you install an {product-title} cluster.
 ====
 
-.Prerequisites
+== Prerequisites
 
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-* Provision
-xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS]
-for your cluster. To deploy a private image registry, your storage must provide
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -14,24 +14,20 @@ Additional considerations exist for non-bare metal platforms. Review the informa
 link:https://access.redhat.com/articles/4207611[guidelines for deploying {product-title} on non-tested platforms] before you install an {product-title} cluster.
 ====
 
-.Prerequisites
+== Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a mirror registry for installation in a restricted network] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageContentSources` data for your version of {product-title}.
 * Before you begin the installation process, you must move or remove any existing installation files. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]
 ====
 Ensure that installation steps are performed on a machine with access to the installation media.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
+++ b/installing/installing_ibm_power/preparing-to-install-on-ibm-power.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-ibm-power"]

--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -21,18 +21,12 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 == Prerequisites
 
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-
-* Provision
-xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS]
-for your cluster. To deploy a private image registry, your storage must provide
-ReadWriteMany access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage must provide ReadWriteMany access modes.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You provisioned a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher.
 +
 [NOTE]
 ====

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -21,17 +21,12 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 == Prerequisites
 
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * Before you begin the installation process, you must clean the installation directory. This ensures that the required installation files are created and updated during the installation process.
-
-* Provision
-xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS]
-for your cluster. To deploy a private image registry, your storage must provide
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 [NOTE]
 ====

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -21,23 +21,19 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
-* Move or remove any existing installation files, before you begin the installation process. This ensures that the required installation files are created and updated during the installation process.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You must move or remove any existing installation files, before you begin the installation process. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]
 ====
 Ensure that installation steps are done from a machine with access to the installation media.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-using NFS for your cluster. To deploy a private image registry, your storage
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage
 must provide `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
-* Provision a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You provisioned a {op-system-base} Kernel Virtual Machine (KVM) system that is hosted on the logical partition (LPAR) and based on {op-system-base} 8.3 or higher.
 +
 [NOTE]
 ====

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -21,22 +21,18 @@ link:https://access.redhat.com/articles/4207611[guidelines for deploying {produc
 
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a mirror registry for installation in a restricted network] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a mirror registry for installation in a restricted network] and obtained the `imageContentSources` data for your version of {product-title}.
 * Before you begin the installation process, you must move or remove any existing installation files. This ensures that the required installation files are created and updated during the installation process.
 +
 [IMPORTANT]
 ====
 Ensure that installation steps are done from a machine with access to the installation media.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-using NFS for your cluster. To deploy a private image registry, your storage
+* You provisioned xref:../../storage/persistent_storage/persistent-storage-nfs.adoc#persistent-storage-nfs[persistent storage using NFS] for your cluster. To deploy a private image registry, your storage
 must provide `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z-kvm.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-ibm-z-kvm"]

--- a/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
+++ b/installing/installing_ibm_z/preparing-to-install-on-ibm-z.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-ibm-z"]

--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -10,16 +10,12 @@ In {product-title} version {product-version}, you can install a customized clust
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have a storage service installed in {rh-openstack}, like block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
-
-* Have metadata service enabled in {rh-openstack}
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have a storage service installed in {rh-openstack}, such as block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
+* You have the metadata service enabled in {rh-openstack}.
 
 include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]
 include::modules/installation-osp-control-compute-machines.adoc[leveloffset=+2]

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -10,14 +10,11 @@ In {product-title} version {product-version}, you can install a customized clust
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have a storage service installed in {rh-openstack}, like block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have a storage service installed in {rh-openstack}, such as block storage (Cinder) or object storage (Swift). Object storage is the recommended storage technology for {product-title} registry cluster deployment. For more information, see xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage].
 
 include::modules/installation-osp-about-kuryr.adoc[leveloffset=+1]
 include::modules/installation-osp-default-kuryr-deployment.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -8,23 +8,19 @@ toc::[]
 In {product-title} {product-version}, you can install a cluster on
 {rh-openstack-first} in a restricted network by creating an internal mirror of the installation release content.
 
-.Prerequisites
+== Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host]
- and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update processes].
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have the metadata service enabled in {rh-openstack}.
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have the metadata service enabled in {rh-openstack}.
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/installation-osp-default-deployment.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer.adoc
+++ b/installing/installing_openstack/installing-openstack-installer.adoc
@@ -10,13 +10,10 @@ In {product-title} version {product-version}, you can install a cluster on
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* On {rh-openstack}, have access to an external network that does not overlap these CIDR ranges:
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* On {rh-openstack}, you have access to an external network that does not overlap these CIDR ranges:
 ** `10.0.0.0/16`
 ** `172.30.0.0/16`
 ** `10.128.0.0/14`

--- a/installing/installing_openstack/installing-openstack-user-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-kuryr.adoc
@@ -12,15 +12,12 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have an {rh-openstack} account where you want to install {product-title}.
-
-* On the machine from which you run the installation program, have:
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have an {rh-openstack} account where you want to install {product-title}.
+* On the machine from which you run the installation program, you have:
 ** A single directory in which you can keep the files you create during the installation process
 ** Python 3
 

--- a/installing/installing_openstack/installing-openstack-user-sr-iov-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-user-sr-iov-kuryr.adoc
@@ -14,15 +14,12 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have a {rh-openstack} account where you want to install {product-title}.
-
-* On the machine where you run the installation program, have:
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have a {rh-openstack} account where you want to install {product-title}.
+* On the machine where you run the installation program, you have:
 ** A single directory in which you can keep the files you create during the installation process
 ** Python 3
 

--- a/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
+++ b/installing/installing_openstack/installing-openstack-user-sr-iov.adoc
@@ -12,15 +12,12 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have an {rh-openstack} account where you want to install {product-title}.
-
-* On the machine where you run the installation program, have:
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have an {rh-openstack} account where you want to install {product-title}.
+* On the machine where you run the installation program, you have:
 ** A single directory in which you can keep the files you create during the installation process
 ** Python 3
 

--- a/installing/installing_openstack/installing-openstack-user.adoc
+++ b/installing/installing_openstack/installing-openstack-user.adoc
@@ -12,15 +12,12 @@ Using your own infrastructure allows you to integrate your cluster with existing
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-** Verify that {product-title} {product-version} is compatible with your {rh-openstack} version by using the "Supported platforms for OpenShift clusters" section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
-
-* Verify that your network configuration does not rely on a provider network. Provider networks are not supported.
-
-* Have an {rh-openstack} account where you want to install {product-title}.
-
-* On the machine from which you run the installation program, have:
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You verified that {product-title} {product-version} is compatible with your {rh-openstack} version by using the xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters] section. You can also compare platform support across different versions by viewing the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
+* Your network configuration does not rely on a provider network. Provider networks are not supported.
+* You have an {rh-openstack} account where you want to install {product-title}.
+* On the machine from which you run the installation program, you have:
 ** A single directory in which you can keep the files you create during the installation process
 ** Python 3
 

--- a/installing/installing_openstack/preparing-to-install-on-openstack.adoc
+++ b/installing/installing_openstack/preparing-to-install-on-openstack.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-openstack"]

--- a/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+++ b/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
@@ -15,11 +15,9 @@ Review the information in the link:https://access.redhat.com/articles/4207611[gu
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -30,10 +30,8 @@ This installation program is available for Linux and macOS only.
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-* If you use a firewall, xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[you configured it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -23,10 +23,8 @@ This installation program is available for Linux and macOS only.
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-* If you use a firewall, xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[you configured it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_rhv/installing-rhv-restricted-network.adoc
+++ b/installing/installing_rhv/installing-rhv-restricted-network.adoc
@@ -12,13 +12,10 @@ customized {product-title} cluster on {rh-virtualization-first} in a restricted 
 
 The following items are required to install an {product-title} cluster on a {rh-virtualization} environment.
 
-* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization}].
-
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[You created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization}].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
@@ -26,8 +23,7 @@ Because the installation media is on the mirror host, you can use that computer 
 ====
 +
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide ReadWriteMany access modes.
-
-* If you use a firewall and plan to use telemetry, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_rhv/installing-rhv-user-infra.adoc
+++ b/installing/installing_rhv/installing-rhv-user-infra.adoc
@@ -16,11 +16,9 @@ image::92_OpenShift_Cluster_Install_RHV_0520.png[Diagram of an {product-title} c
 
 The following items are required to install an {product-title} cluster on a {rh-virtualization} environment.
 
-* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization}].
-
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization}].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_rhv/preparing-to-install-on-rhv.adoc
+++ b/installing/installing_rhv/preparing-to-install-on-rhv.adoc
@@ -9,7 +9,6 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-rhv"]

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -14,16 +14,17 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer
 to complete all installation steps.
 ====
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -15,15 +15,16 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 [id="vsphere-prerequisites_installing-restricted-networks-vmc"]
 == vSphere prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -16,9 +16,10 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -16,9 +16,10 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -16,9 +16,10 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -14,9 +14,10 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vmc/installing-vmc.adoc
+++ b/installing/installing_vmc/installing-vmc.adoc
@@ -14,9 +14,10 @@ include::modules/vmc-sizer-tool.adoc[leveloffset=+2]
 
 == vSphere prerequisites
 
-* Provision xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere[block registry storage]. For more information on persistent storage, see xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[Understanding persistent storage].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -10,15 +10,16 @@ In {product-title} {product-version}, you can install a cluster on VMware vSpher
 [id="prerequisites_installing-restricted-networks-installer-provisioned-vsphere"]
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* Provision xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide the ReadWriteMany access mode.
-* Review details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall and plan to use telemetry, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide the ReadWriteMany access mode.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -15,22 +15,17 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host] and obtain the `imageContentSources` data for your version of {product-title}.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[created a registry on your mirror host] and obtained the `imageContentSources` data for your version of {product-title}.
 +
 [IMPORTANT]
 ====
-Because the installation media is on the mirror host, you can use that computer
-to complete all installation steps.
+Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall and plan to use telemetry, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure the firewall to allow the sites] that your cluster requires access to.
+* If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -10,15 +10,10 @@ VMware vSphere instance by using installer-provisioned infrastructure. To custom
 
 == Prerequisites
 
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
-`ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide `ReadWriteMany` access modes.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -12,15 +12,11 @@ You must set most of the network configuration parameters during installation, a
 
 == Prerequisites
 
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -10,15 +10,11 @@ VMware vSphere instance by using installer-provisioned infrastructure.
 
 == Prerequisites
 
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -22,11 +22,9 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to access Red Hat Insights].
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -15,15 +15,10 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 == Prerequisites
 
-* Provision
-xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage]
-for your cluster. To deploy a private image registry, your storage must provide
-`ReadWriteMany` access modes.
-* Review details about the
-xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update]
-processes.
-* If you use a firewall, you must
-xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to.
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide `ReadWriteMany` access modes.
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]
 ====


### PR DESCRIPTION
This applies to master and branch/enterprise-4.8.

The PR adds a prerequisite in all of the top level "Prerequisites" sections in all installation assemblies to read the "Selecting a cluster installation method and preparing it for users" section. I have also enhanced the parallelism for all of the prerequisites in those top level "Prerequisite" sections. In a later PR, I might do the same for all prerequisites in modules across the Installing book.