### PR TITLE
Adds 4-6-35 release notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3009,7 +3009,42 @@ link:https://access.redhat.com/solutions/6114681[{product-title} 4.6.34 containe
 
 With this update, users can now collect the `virt_platform` metric. The `virt_platform` metric is needed for the Insights Operator's rules to determine the virtual platform of a cluster. This information is stored in the Insights Operator archive of the `config/metric` file.  For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1965219[*BZ#1965219*].
 
-[id="ocp-44-6-34-upgrading"]
+[id="ocp-4-6-34-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-35"]
+=== RHBA-2021:2410 - {product-title} 4.6.35 bug fix update
+
+Issued: 2021-06-22
+
+{product-title} release 4.6.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2410[RHBA-2021:2410] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2407[RHBA-2021:2407] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6128971[{product-title} 4.6.35 container image list]
+
+[id="ocp-4-6-35-features"]
+==== Features
+
+[id="ocp-4-6-35-cluster-operator-gatherer-enhancement"]
+===== Insights Operator enhancement
+
+With this update, the Insights Operator `Gather` method can now collect logs from pods that are related to unhealthy Operators, and pods that are co-located in the same namespace as the Operator. This allows the Insights Operator to determine the namespace associated with the Operator and include pod logs in the bundle. As a result, the Insights Operator is now collecting logs from unhealthy pods not only related to the Operator, but from every pod that lives in the operator namespace.  
+
+[id="ocp-4-6-35-bug-fixes"]
+==== Bug fixes
+
+* Previously, when starting a single-stack IPv6 cluster on nodes with IPv4 address, the kubelet might have used the IPv4 IP instead of the IPv6 IP for the node IP. Consequently, host network pods would have IPv4 IPs rather than IPv6 IPs, which made them unreachable from IPv6-only pods. This update fixes the node-IP-picking code, which results in the kubelet using the IPv6 IPs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942488[*BZ#1942488*])
+
+* The fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1953097[*BZ#1953097*] enabled the CoreDNS `bufsize` plug-in with a size of 1232 bytes. Some primitive DNS resolvers are not capable of receiving DNS response messages over UDP that are greater than 512 bytes. Consequently, some DNS resolvers, such as Go's internal DNS library, are unable to receive verbose DNS responses from the DNS Operator. This update sets the CoreDNS `bufsize` to 512 bytes for all servers. As a result, UDP DNS messages are now properly received. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970140[*BZ#1970140*]) 
+
+* Previously, a lack of proper timeouts when executing HTTP connections left connections opened. As a result, these connections accumulated until reaching the maximum limit, and consequently the Operator would become incapable of processing incoming events. This update adds timeouts to the HTTP client used by the Operator, which ensures that open connections are closed after the timeout is reached. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1959563[*BZ#1959563*]) 
+
+* Previously, removing `selector` from a service exposed via a route resulted in the duplication of `endpointslices` that would be created for the service's pods, which would trigger HAProxy reload errors due to duplicate server entries. This update filters out accidental duplicate server lines when writing out the HAProxy config file, so that deleting the selector from a service no longer causes the router to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965329[*BZ#1965329*]) 
+
+[id="ocp-4-6-35-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Adds 4.6.35 release notes. Do not merge until 06-22. 

No BZ. 

Preview: https://deploy-preview-33686--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-35
