### PR TITLE
BZ 1970927: Release Note for Cronjobs will be GA from OCP 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -560,9 +560,13 @@ You can now specify an individual repository within a registry when creating lis
 
 For more information, see xref:../openshift_images/image-configuration.adoc#images-configuration-allowed_image-configuration[Adding specific registries] and xref:../openshift_images/image-configuration.adoc#images-configuration-blocked_image-configuration[Blocking specific registries].
 
+[id="ocp-4-8-nodes-cronjob-qa_{context}"]
+==== Cron jobs are generally available
+
+The cron job custom resource is now generally available. As part of this change, a new controller has been implemented that substantially improves the performance of cron jobs. For more information on cron jobs, see xref:../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs-about_nodes-nodes-jobs[Understanding jobs and cron jobs].
+
 [id="ocp-4-8-logging"]
 === Cluster logging
-
 
 [id="ocp-4-8-monitoring"]
 === Monitoring


### PR DESCRIPTION
Release note for https://github.com/openshift/openshift-docs/pull/33441

Preview: https://deploy-preview-33697--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-nodes-cronjob-qa_release-notes