### PR TITLE
SRVCOM-1334: Add 1.16.0 serverless release notes

### DIFF
--- a/_unused_topics/serverless-rn-template-module.adoc
+++ b/_unused_topics/serverless-rn-template-module.adoc
@@ -1,12 +1,7 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-<version>_{context}"]
-//update the <version> to match the filename
-
 = Release Notes for Red Hat {ServerlessProductName} <VERSION>
 // add a version, e.g. Technology Preview 1.0.0
+//update the <version> to match the filename
 
 [id="new-features-<VERSION>_{context}"]
 == New features

--- a/modules/serverless-rn-1-10-0.adoc
+++ b/modules/serverless-rn-1-10-0.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-10-0_{context}"]
 = Release Notes for Red Hat {ServerlessProductName} 1.10.0
 
@@ -18,6 +14,3 @@
 [id="fixed-issues-1-10-0_{context}"]
 == Fixed issues
 * In previous releases, Knative Serving had a fixed, minimum CPU request of 25m for `queue-proxy`. If your cluster had any value set that conflicted with this, for example, if you had set a minimum CPU request for `defaultRequest` of more than `25m`, the Knative Service failed to deploy. This issue is fixed in 1.10.0.
-
-// [id="known-issues-1-10-0_{context}"]
-// == Known issues

--- a/modules/serverless-rn-1-11-0.adoc
+++ b/modules/serverless-rn-1-11-0.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-11-0_{context}"]
 
 = Release Notes for Red Hat {ServerlessProductName} 1.11.0

--- a/modules/serverless-rn-1-12-0.adoc
+++ b/modules/serverless-rn-1-12-0.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-12-0_{context}"]
 
 = Release Notes for Red Hat {ServerlessProductName} 1.12.0

--- a/modules/serverless-rn-1-13-0.adoc
+++ b/modules/serverless-rn-1-13-0.adoc
@@ -1,10 +1,4 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-13-0_{context}"]
-//update the <version> to match the filename
-
 = Release Notes for Red Hat {ServerlessProductName} 1.13.0
 
 [id="new-features-1-13-0_{context}"]

--- a/modules/serverless-rn-1-14-0.adoc
+++ b/modules/serverless-rn-1-14-0.adoc
@@ -1,9 +1,4 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-14-0_{context}"]
-
 = Release Notes for Red Hat {ServerlessProductName} 1.14.0
 
 [id="new-features-1-14-0_{context}"]

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/release-notes.adoc
-
 [id="serverless-rn-1-15-0_{context}"]
 = Release Notes for Red Hat {ServerlessProductName} 1.15.0
 

--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -1,0 +1,116 @@
+[id="serverless-rn-1-16-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.16.0
+
+[id="new-features-1-16-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.22.0.
+* {ServerlessProductName} now uses Knative Eventing 0.22.0.
+* {ServerlessProductName} now uses Kourier 0.22.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.22.0.
+* {ServerlessProductName} now uses Knative Kafka 0.22.0.
+* The `kn func` CLI plug-in now uses `func` 0.16.0.
+* The `kn func emit` command has been added to the functions `kn` plug-in. You can use this command to send events to test locally deployed functions.
+
+[id="fixed-issues-1-16-0_{context}"]
+== Fixed issues
+
+[id="known-issues-1-16-0_{context}"]
+== Known issues
+
+// Add a note about the following to the mTLS docs when they're ready to merge
+* If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
++
+If you want to enable Knative Serving metrics for use with Service Mesh and mTLS, you must complete the following steps:
+
+.. Specify `prometheus` as the `metrics.backend-destination` in the `observability` spec of the Knative Serving custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    observability:
+      metrics.backend-destination: "prometheus"
+----
++
+This step prevents metrics from being disabled by default.
+
+.. Apply the following network policy to allow traffic from the Prometheus namespace:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring-ns
+  namespace: knative-serving
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: "openshift-monitoring"
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----
+
+.. Modify and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
++
+[source,yaml]
+----
+spec:
+  proxy:
+    networking:
+      trafficControl:
+        inbound:
+          excludedPorts:
+          - 8444
+----
+
+* If you deploy Service Mesh CRs with the Istio ingress enabled, you might see the following warning in the `istio-ingressgateway` pod:
++
+[source,terminal]
+----
+2021-05-02T12:56:17.700398Z warning envoy config [external/envoy/source/common/config/grpc_subscription_impl.cc:101] gRPC config for type.googleapis.com/envoy.api.v2.Listener rejected: Error adding/updating listener(s) 0.0.0.0_8081: duplicate listener 0.0.0.0_8081 found
+----
++
+Your Knative services might also not be accessible.
++
+You can use the following workaround to fix this issue by recreating the `knative-local-gateway` service:
+
+.. Delete the existing `knative-local-gateway` service in the `istio-system` namespace:
++
+[source,terminal]
+----
+$ oc delete services -n istio-system knative-local-gateway
+----
+
+.. Create and apply a `knative-local-gateway` service that contains the following YAML:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Service
+metadata:
+ name: knative-local-gateway
+ namespace: istio-system
+ labels:
+   experimental.istio.io/disable-gateway-port-translation: "true"
+spec:
+ type: ClusterIP
+ selector:
+   istio: ingressgateway
+ ports:
+   - name: http2
+     port: 80
+     targetPort: 8081
+----
+
+* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there is a delay when you create the first new service after the `KnativeServing` custom resource definition (CRD) becomes `Ready`.
++
+The `3scale-kourier-control` service reconciles all previously existing Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state updates to `Ready`.

--- a/serverless/cli_tools/kn-serving-ref.adoc
+++ b/serverless/cli_tools/kn-serving-ref.adoc
@@ -18,11 +18,10 @@ include::modules/kn-service-update.adoc[leveloffset=+2]
 include::modules/kn-service-apply.adoc[leveloffset=+2]
 include::modules/kn-service-describe.adoc[leveloffset=+2]
 
-// Uncomment at 1.16.0 release
-// [id="kn-serving-ref-domain-mapping"]
-// == kn domain commands
+[id="kn-serving-ref-domain-mapping"]
+== kn domain commands
 
-// You can use the following commands to create and manage domain mappings.
+You can use the following commands to create and manage domain mappings.
 
-// include::modules/serverless-create-domain-mapping-kn.adoc[leveloffset=+2]
-// include::modules/serverless-manage-domain-mapping-kn.adoc[leveloffset=+2]
+include::modules/serverless-create-domain-mapping-kn.adoc[leveloffset=+2]
+include::modules/serverless-manage-domain-mapping-kn.adoc[leveloffset=+2]

--- a/serverless/knative_serving/serverless-custom-domains.adoc
+++ b/serverless/knative_serving/serverless-custom-domains.adoc
@@ -25,6 +25,7 @@ You can use `DomainMapping` resources to map custom domains either with or witho
 ====
 
 include::modules/serverless-create-domain-mapping.adoc[leveloffset=+1]
+include::modules/serverless-create-domain-mapping-kn.adoc[leveloffset=+1]
 
 [id="serverless-custom-domains-private-services"]
 == Configuring custom domains for private Knative services

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -8,21 +8,19 @@ toc::[]
 
 For an overview of {ServerlessProductName} functionality, see xref:../serverless/serverless-getting-started.adoc#serverless-getting-started[Getting started with OpenShift Serverless].
 
+[NOTE]
+====
+{ServerlessProductName} is based on the open source Knative project.
+
+For details about the latest Knative component releases, see the link:https://knative.dev/blog/releases[Knative releases blog].
+====
+
 // Modules included, most to least recent
+include::modules/serverless-rn-1-16-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-15-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-14-0.adoc[leveloffset=+1]
+// delete older relnotes?
 include::modules/serverless-rn-1-13-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-12-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-11-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-10-0.adoc[leveloffset=+1]
-
-[id="additional-resources_serverless-release-notes"]
-== Additional resources
-
-{ServerlessProductName} is based on the open source Knative project.
-
-* For details about the latest Knative Serving release, see the link:https://github.com/knative/serving/releases[Knative Serving releases page].
-* For details about the latest Knative Serving Operator release, see the link:https://github.com/knative/serving-operator/releases[Knative Serving Operator releases page].
-* For details about the latest Knative CLI release, see the link:https://github.com/knative/client/releases[Knative CLI releases page].
-* For details about the latest Knative Eventing release, see the link:https://github.com/knative/eventing/releases[Knative Eventing releases page].
-* link:https://openshift-knative.github.io/docs/docs/functions/about-functions.html[{ServerlessProductName} Functions Developer Preview documentation].


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1334

Applies for OCP 4.6+

Direct preview link: https://deploy-preview-33701--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-16-0_serverless-release-notes