### PR TITLE
BZ1878685: Updates to Creating a route via Ingress for passthrough routes

### DIFF
--- a/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
+++ b/modules/nw-ingress-creating-a-route-via-an-ingress.adoc
@@ -41,6 +41,22 @@ spec:
 as `Ingress` has no field for this. The accepted values are `edge`, `passthrough` and `reencrypt`. All
 other values are silently ignored. When unset, `edge` is used.
 
+.. If you specify the `passthrough` value in the `route.openshift.io/termination` annotation, set `path` to `''` and `pathType` to `ImplementationSpecific` in the spec:
++
+[source,yaml]
+----
+  spec:
+    rules:
+    - host: www.example.com
+      http:
+        paths:
+        - path: ''
+          pathType: ImplementationSpecific
+        - backend:
+            serviceName: frontend
+            servicePort: 443
+----
+
 +
 [source,terminal]
 ----


### PR DESCRIPTION
If a user specifies the `passthrough` value in the `route.openshift.io/termination` annotation, they need to set additional values in the spec: path, pathType

https://bugzilla.redhat.com/show_bug.cgi?id=1878685

For 4.6+