### PR TITLE
CNV-12348: RN - Added note about new virtctl vnc sub-command

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -49,6 +49,9 @@ The SVVP Certification applies to:
 
 //CNV-12271 A new tech preview feature allows VM owners to hot-plug and hot-unplug disks with a running virtual machine
 
+//CNV-12348 Add `--proxy-only` option to `virtctl vnc` for only proxying a VNC connection to allow manual connections
+* The `--proxy-only` option for the `virtctl vnc` command allows you to xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[manually connect to a virtual machine instance] through a Virtual Network Client (VNC) connection by using any VNC viewer.
+
 [id="virt-4-8-installation-new"]
 === Installation
 


### PR DESCRIPTION
This PR addresses [CNV-12348](https://issues.redhat.com/browse/CNV-12348)

Added note about the `--proxy-only` option for the `virtctl vnc` command

Preview: https://deploy-preview-33718--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes.html#virt-4-8-new