### PR TITLE
OSDOCS-1795: Update bundle-upgrade to allow tradtl OLM install

### DIFF
--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -12,7 +12,7 @@ ifeval::["{context}" == "olm-installing-operators-in-namespace"]
 endif::[]
 
 [id="olm-installing-operators-from-operatorhub_{context}"]
-= Operator installation with OperatorHub
+= About Operator installation with OperatorHub
 
 OperatorHub is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 

--- a/modules/osdk-bundle-upgrade-olm.adoc
+++ b/modules/osdk-bundle-upgrade-olm.adoc
@@ -11,12 +11,19 @@ The `run bundle-upgrade` subcommand automates triggering an installed Operator t
 
 .Prerequisites
 
-- Operator installed with OLM by using the `run bundle` subcommand
+- Operator installed with OLM either by using the `run bundle` subcommand or with traditional OLM installation
 - A bundle image that represents a later version of the installed Operator
 
 .Procedure
 
-. If your Operator has not already been installed on OLM with the `run bundle` subcommand, install the earlier version of your Operator by specifying the bundle image. For example, for a Memcached Operator:
+. If your Operator has not already been installed with OLM, install the earlier version either by using the `run bundle` subcommand or with traditional OLM installation.
++
+[NOTE]
+====
+If the earlier version of the bundle was installed traditionally using OLM, the newer bundle that you intend to upgrade to must not exist in the index image referenced by the catalog source. Otherwise, running the `run bundle-upgrade` subcommand will cause the registry pod to fail because the newer bundle is already referenced by the index that provides the package and cluster service version (CSV).
+====
++
+For example, you can use the following `run bundle` subcommand for a Memcached Operator by specifying the earlier bundle image:
 +
 [source,terminal]
 ----

--- a/operators/operator_sdk/osdk-working-bundle-images.adoc
+++ b/operators/operator_sdk/osdk-working-bundle-images.adoc
@@ -9,6 +9,9 @@ You can use the Operator SDK to package, deploy, and upgrade Operators in the bu
 
 include::modules/osdk-bundle-deploy-olm.adoc[leveloffset=+1]
 include::modules/osdk-bundle-upgrade-olm.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Traditional Operator installation with OLM]
 
 [id="osdk-working-bundle-images-additional-resources"]
 == Additional resources


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1795

Updated `bundle-upgrade` procedure to mention that traditional OLM install is also valid now for the earlier Operator version. I've left the example `run bundle` command in place, however, for convenience of a complete procedure. The "traditional OLM install" example would be too lengthy to include in-procedure here, so it's mentioned as an `.Additional resources` link after the module.

Preview: [Testing an Operator upgrade on Operator Lifecycle Manager](https://deploy-preview-33721--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-working-bundle-images#osdk-bundle-upgrade-olm_osdk-working-bundle-images)