### PR TITLE
PR33675: Followup with minor typo fix

### DIFF
--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -60,7 +60,7 @@ For example:
 $ curl 172.30.131.89:3306
 ----
 +
-The examples in this section use a MySQL service, which requires a client
+The examples in this section uses a MySQL service, which requires a client
 application. If you get a string of characters with the `Got packets out of order`
 message, you are connected to the service.
 +


### PR DESCRIPTION
In https://github.com/openshift/openshift-docs/pull/33675, Travis did not kick off a build check for the related CPs for 4.6-4.8. But it did for 4.5. This PR fixes a different typo to hopefully fix both typos.
@Cc: @snarayan-redhat 

**Preview (step 4):** Exposing the service by creating a route (https://deploy-preview-33725--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html#nw-exposing-service_configuring-ingress-cluster-traffic-load-balancer)