### PR TITLE
Described to open port 54322 when doing RHV install

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -159,6 +159,8 @@ You can run the `create cluster` command of the installation program only once, 
 
 ifndef::osp,rhv,vsphere[* Configure an account with the cloud platform that hosts your cluster.]
 
+ifdef::rhv[* Open the `ovirt-imageio` port to the Engine from the machine running the installer. By default, the port is `54322`.]
+
 * Obtain the {product-title} installation program and the pull secret for your
 cluster.
 


### PR DESCRIPTION
- For branches: 4.X
- https://bugzilla.redhat.com/show_bug.cgi?id=1974504
- Direct link to doc preview: https://deploy-preview-33726--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-default.html
- SME review: Waiting for review by @janoszen 
- Peer review: Waiting for review
