### PR TITLE
Remove unprintable character from YAML

### DIFF
--- a/modules/olm-installing-specific-version-cli.adoc
+++ b/modules/olm-installing-specific-version-cli.adoc
@@ -39,7 +39,7 @@ For example, the following `sub.yaml` file can be used to install the Red Hat Qu
 .Subscription with a specific starting Operator version
 [source,yaml]
 ----
-﻿apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: quay-operator


### PR DESCRIPTION
No idea. From `diff`:

```
-<U+FEFF>apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1alpha1
```

This: https://www.compart.com/en/unicode/U+FEFF