### PR TITLE
investigating-kernel-crashes: switch to Butane

### DIFF
--- a/modules/investigating-kernel-crashes.adoc
+++ b/modules/investigating-kernel-crashes.adoc
@@ -69,76 +69,62 @@ If you are aware of the downsides and trade-offs of having the `kdump` service e
 
 Create a `MachineConfig` object for cluster-wide configuration:
 
-. Optional: If you change the `/etc/kdump.conf` configuration from the default, you can encode it into base64 format to include its content in your `MachineConfig` object:
+. Create a Butane config file, `99-worker-kdump.bu`, that configures and enables kdump:
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat << EOF | base64
-path /var/crash
-core_collector makedumpfile -l --message-level 7 -d 31
-EOF
-----
-
-. Optional: Create a content of the `/etc/sysconfig/kdump` file and encode it as base64 if you change the configuration from the default:
-+
-[source,terminal]
-----
-$ cat << EOF | base64
-KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug quiet log_buf_len swiotlb"
-KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off numa=off udev.children-max=2 panic=10 rootflags=nofail acpi_no_memhotplug transparent_hugepage=never nokaslr novmcoredd hest_disable"
-KEXEC_ARGS="-s"
-KDUMP_IMG="vmlinuz"
-EOF
-----
-
-. Create the `MachineConfig` object file:
-+
-[source,terminal]
-----
-$ cat << EOF > ./99-master-kdump-configuration.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 99-worker-kdump <1>
   labels:
-    machineconfiguration.openshift.io/role: master <1>
-  name: 99-master-kdump-configuration
-spec:
-  kernelArguments:
-    - 'crashkernel=256M' <2>
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,ICAgIHBhdGggL3Zhci9jcmFzaAogICAgY2...  <3>
-          mode: 420
-          overwrite: true
-          path: /etc/kdump.conf
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,S0RVTVBfQ09NTUFORExJTkVfUkVNT1ZFPS...  <4>
-          mode: 420
-          overwrite: true
-          path: /etc/sysconfig/kdump
-    systemd:
-      units:
-        - enabled: true
-          name: kdump.service
-EOF
+    machineconfiguration.openshift.io/role: worker <1>
+openshift:
+  kernel_arguments: <2>
+    - crashkernel=256M
+storage:
+  files:
+    - path: /etc/kdump.conf <3>
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          path /var/crash
+          core_collector makedumpfile -l --message-level 7 -d 31
+
+    - path: /etc/sysconfig/kdump <4>
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          KDUMP_COMMANDLINE_REMOVE="hugepages hugepagesz slub_debug quiet log_buf_len swiotlb"
+          KDUMP_COMMANDLINE_APPEND="irqpoll nr_cpus=1 reset_devices cgroup_disable=memory mce=off numa=off udev.children-max=2 panic=10 rootflags=nofail acpi_no_memhotplug transparent_hugepage=never nokaslr novmcoredd hest_disable"
+          KEXEC_ARGS="-s"
+          KDUMP_IMG="vmlinuz"
+
+systemd:
+  units:
+    - name: kdump.service
+      enabled: true
 ----
 +
-<1> Replace `master` with `worker` for creating a `MachineConfig` object for the `worker` role.
+<1> Replace `worker` with `master` in both locations when creating a `MachineConfig` object for control plane nodes.
 <2> Provide kernel arguments to reserve memory for the crash kernel. You can add other kernel arguments if necessary.
-<3> Replace the base64 content with the one you created for `/etc/kdump.conf`.
-<4> Replace the base64 content with the one you created for `/etc/sysconfig/kdump`.
+<3> If you want to change the contents of `/etc/kdump.conf` from the default, include this section and modify the `inline` subsection accordingly.
+<4> If you want to change the contents of `/etc/sysconfig/kdump` from the default, include this section and modify the `inline` subsection accordingly.
+
+. Use Butane to generate a machine config YAML file, `99-worker-kdump.yaml`, containing the configuration to be delivered to the nodes:
 +
+[source,terminal]
+----
+$ butane 99-worker-kdump.bu -o 99-worker-kdump.yaml
+----
 
 . Put the YAML file into manifests during cluster setup. You can also create this `MachineConfig` object after cluster setup with the YAML file:
-
 +
 [source,terminal]
 ----
- $ oc create -f ./99-master-kdump-configuration.yaml
+ $ oc create -f ./99-worker-kdump.yaml
 ----
 
 == Testing the kdump configuration


### PR DESCRIPTION
Use Butane to generate the machine config so we don't have to manually base64 the input files.

Also switch the example from a control plane node to a worker node, to reduce the number of times we need to say `master`.

cc @bobfuru