### PR TITLE
OSDOCS-2269: Deleting a ROSA cluster applies to PrivateLink clusters

### DIFF
--- a/rosa_getting_started/osd-aws-privatelink-creating-cluster.adoc
+++ b/rosa_getting_started/osd-aws-privatelink-creating-cluster.adoc
@@ -15,3 +15,5 @@ xref:../rosa_getting_started/rosa-config-identity-providers.adoc#rosa-config-ide
 
 == Additional resources
 * See xref:../rosa_getting_started/rosa-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites[AWS PrivateLink firewall prerequisites].
+
+* To delete an AWS PrivateLink cluster, see xref:../rosa_getting_started/rosa-sts-deleting-cluster.adoc#rosa-sts-deleting-cluster[Deleting a ROSA cluster].


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2269

Additional Resource section updated here:
https://deploy-preview-33744--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/osd-aws-privatelink-creating-cluster?utm_source=github&utm_campaign=bot_dp#additional-resources