### PR TITLE
BZ1875952: Fixed vague information about cpu resource limits (number of cores and GPUs)

### DIFF
--- a/modules/cluster-autoscaler-cr.adoc
+++ b/modules/cluster-autoscaler-cr.adoc
@@ -41,13 +41,13 @@ spec:
 ----
 <1> Specify the priority that a pod must exceed to cause the cluster autoscaler to deploy additional nodes. Enter a 32-bit integer value. The `podPriorityThreshold` value is compared to the value of the `PriorityClass` that you assign to each pod.
 <2> Specify the maximum number of nodes to deploy. This value is the total number of machines that are deployed in your cluster, not just the ones that the autoscaler controls. Ensure that this value is large enough to account for all of your control plane and compute machines and the total number of replicas that you specify in your `MachineAutoscaler` resources.
-<3> Specify the minimum number of cores to deploy.
-<4> Specify the maximum number of cores to deploy.
+<3> Specify the minimum number of cores to deploy in the cluster.
+<4> Specify the maximum number of cores to deploy in the cluster.
 <5> Specify the minimum amount of memory, in GiB, in the cluster.
 <6> Specify the maximum amount of memory, in GiB, in the cluster.
 <7> Optionally, specify the type of GPU node to deploy. Only `nvidia.com/gpu` and `amd.com/gpu` are valid types.
-<8> Specify the minimum number of GPUs to deploy.
-<9> Specify the maximum number of GPUs to deploy.
+<8> Specify the minimum number of GPUs to deploy in the cluster.
+<9> Specify the maximum number of GPUs to deploy in the cluster.
 <10> In this section, you can specify the period to wait for each action by using any valid link:https://golang.org/pkg/time/#ParseDuration[ParseDuration] interval, including `ns`, `us`, `ms`, `s`, `m`, and `h`.
 <11> Specify whether the cluster autoscaler can remove unnecessary nodes.
 <12> Optionally, specify the period to wait before deleting a node after a node has recently been _added_. If you do not specify a value, the default value of `10m` is used.


### PR DESCRIPTION
For versions 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1875952

Direct link to doc preview: https://deploy-preview-33750--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#configuring-clusterautoscaler

Ready for QA: @sunzhaohua2