### PR TITLE
TELCODOCS-111: Content for Fujitsu iRMC baseboard management controller

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -24,9 +24,13 @@ include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffs
 
 include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+1]
 
-include::modules/ipi-install-bmc-addressing-for-dell.adoc[leveloffset=+1]
+include::modules/ipi-install-bmc-addressing-for-dell-idrac.adoc[leveloffset=+1]
 
-include::modules/ipi-install-bmc-addressing-for-hpe.adoc[leveloffset=+1]
+include::modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc[leveloffset=+1]
+
+ifeval::[{product-version} > 4.7]
+include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2]
+endif::[]
 
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
 

--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -1,9 +1,9 @@
 // This is included in the following assemblies:
 //
 // installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
-[id='bmc-addressing-for-dell_{context}']
 
-= BMC addressing for Dell
+[id='bmc-addressing-for-dell-idrac_{context}']
+= BMC addressing for Dell iDRAC
 
 The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
 
@@ -15,18 +15,19 @@ platform:
       - name: <host name>
         role: <master | worker>
         bmc:
-          address: <address>
+          address: <address> <1>
           username: <user>
           password: <password>
 ----
+<1> The `address` configuration setting specifies the protocol.
 
-For Dell hardware, Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
+For Dell hardware, Red Hat supports integrated Dell Remote Access Controller (iDRAC) virtual media, Redfish network boot, and IPMI.
 
-.BMC address formats for Dell hardware
+.BMC address formats for Dell iDRAC
 [frame="topbot",options="header"]
 |====
 |Protocol|Address Format
-|Redfish virtual media| `idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
+|iDRAC virtual media| `idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
 |Redfish network boot|`redfish://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
 |IPMI|`ipmi://<out-of-band-ip>`
 |====
@@ -38,7 +39,7 @@ Use `idrac-virtualmedia` as the protocol for Redfish virtual media. `redfish-vir
 
 See the following sections for additional details.
 
-.Redfish virtual media for Dell
+.Redfish virtual media for Dell iDRAC
 
 For Redfish virtual media on Dell servers, use `idrac-virtualmedia://` in the `address` setting. Using `redfish-virtualmedia://` will not work.
 
@@ -93,7 +94,7 @@ Use `idrac-virtualmedia://` as the protocol for Redfish virtual media. Using `re
 ====
 
 
-.Redfish network boot for Dell
+.Redfish network boot for iDRAC
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable transport layer security (TLS). The installer requires both the host name or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 
@@ -128,7 +129,7 @@ platform:
 
 [NOTE]
 ====
-Currently, Redfish is only supported on Dell with iDRAC firmware versions `4.20.20.20` through `04.40.00.00` for installer-provisioned installations on bare metal deployments. There is a known issue with version `04.40.00.00`. With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
+Currently, Redfish is only supported on Dell hardware with iDRAC firmware versions `4.20.20.20` through `04.40.00.00` for installer-provisioned installations on bare metal deployments. There is a known issue with version `04.40.00.00`. With iDRAC 9 firmware version `04.40.00.00`, the Virtual Console plug-in defaults to `eHTML5`, which causes problems with the *InsertVirtualMedia* workflow. Set the plug-in to `HTML5` to avoid this issue. The menu path is: *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 
 Ensure the {product-title} cluster nodes have AutoAttach Enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* .
 

--- a/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
@@ -1,0 +1,54 @@
+// This is included in the following assemblies:
+//
+// installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+
+[id='bmc-addressing-for-fujitsu-irmc_{context}']
+= BMC addressing for Fujitsu iRMC
+
+The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: <host name>
+        role: <master | worker>
+        bmc:
+          address: <address> <1>
+          username: <user>
+          password: <password>
+----
+<1> The `address` configuration setting specifies the protocol.
+
+For Fujitsu hardware, Red Hat supports integrated Remote Management Controller (iRMC) and IPMI.
+
+.BMC address formats for Fujitsu iRMC
+[frame="topbot",options="header"]
+|====
+|Protocol|Address Format
+|iRMC| `irmc://<out-of-band-ip>`
+|IPMI| `ipmi://<out-of-band-ip>`
+|====
+
+.iRMC
+
+Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `623`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
+
+[source,yaml]
+----
+platform:
+  baremetal:
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: irmc://<out-of-band-ip>
+          username: <user>
+          password: <password>
+----
+
+[NOTE]
+====
+Currently Fujitsu supports iRMC S5 firmware version 3.05P and above for installer-provisioned installation on bare metal.
+====

--- a/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
+++ b/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
@@ -1,9 +1,9 @@
 // This is included in the following assemblies:
 //
 // installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
-[id='bmc-addressing-for-hpe_{context}']
 
-= BMC addressing for HPE
+[id='bmc-addressing-for-hpe-ilo_{context}']
+= BMC addressing for HPE iLO
 
 The `address` field for each `bmc` entry is a URL for connecting to the {product-title} cluster nodes, including the type of controller in the URL scheme and its location on the network.
 
@@ -15,14 +15,15 @@ platform:
       - name: <host name>
         role: <master | worker>
         bmc:
-          address: <address>
+          address: <address> <1>
           username: <user>
           password: <password>
 ----
+<1> The `address` configuration setting specifies the protocol.
 
-For HPE hardware, Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
+For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
 
-.BMC address formats for HPE hardware
+.BMC address formats for HPE iLO
 [frame="topbot",options="header"]
 |====
 |Protocol|Address Format
@@ -33,7 +34,7 @@ For HPE hardware, Red Hat supports Redfish virtual media, Redfish network boot, 
 
 See the following sections for additional details.
 
-.Redfish virtual media for HPE
+.Redfish virtual media for HPE iLO
 
 To enable Redfish virtual media for HPE servers, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
 
@@ -72,7 +73,7 @@ Redfish virtual media is not supported on 9th generation systems running iLO4, b
 ====
 
 
-.Redfish network boot for HPE
+.Redfish network boot for HPE iLO
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the host name or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 


### PR DESCRIPTION
Contains iRMC docs for Fujitsu BMC. Docs reviewed by Fujitsu.

Fixes: [TELCODOCS-111](https://issues.redhat.com/browse/TELCODOCS-111)

See https://issues.redhat.com/browse/TELCODOCS-111 for additional details.

Preview URL: https://deploy-preview-33751--osdocs.netlify.app/?utm_source=github&utm_campaign=bot_dp

For release(s): 4.8
Signed-off-by: John Wilkins <jowilkin@redhat.com>
