### PR TITLE
SRVKS-753: Add deprecated note to serverless metering doc

### DIFF
--- a/serverless/admin_guide/serverless-metering.adoc
+++ b/serverless/admin_guide/serverless-metering.adoc
@@ -6,6 +6,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Metering
+include::modules/deprecated-feature.adoc[leveloffset=+1]
+
 As a cluster administrator, you can use metering to analyze what is happening in your {ServerlessProductName} cluster.
 
 For more information about metering on {product-title}, see xref:../../metering/metering-about-metering.adoc#about-metering[About metering].


### PR DESCRIPTION
Applies for OCP 4.6+

Jira: https://issues.redhat.com/browse/SRVKS-753

Direct preview link: https://deploy-preview-33754--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-metering.html