### PR TITLE
BZ1891806: Removing SSL Bridge for load balancing

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -58,7 +58,7 @@ The load balancing infrastructure must meet the following requirements:
 . *API load balancer*: Provides a common endpoint for users, both human and machine, to interact with and configure the platform. Configure the following conditions:
 +
 --
-  ** Layer 4 load balancing only. This can be referred to as Raw TCP, SSL Passthrough, or SSL Bridge mode. If you use SSL Bridge mode, you must enable Server Name Indication (SNI) for the API routes.
+  ** Layer 4 load balancing only. This can be referred to as Raw TCP or SSL Passthrough mode.
   ** A stateless load balancing algorithm. The options vary based on the load balancer implementation.
 --
 +
@@ -109,7 +109,7 @@ to become unhealthy, are well-tested values.
 . *Application ingress load balancer*: Provides an ingress point for application traffic flowing in from outside the cluster. Configure the following conditions:
 +
 --
-  ** Layer 4 load balancing only. This can be referred to as Raw TCP, SSL Passthrough, or SSL Bridge mode. If you use SSL Bridge mode, you must enable Server Name Indication (SNI) for the ingress routes.
+  ** Layer 4 load balancing only. This can be referred to as Raw TCP or SSL Passthrough mode. 
   ** A connection-based or session-based persistence is recommended, based on the options available and types of applications that will be hosted on the platform.
 --
 +
@@ -251,7 +251,7 @@ If you are using HAProxy as a load balancer, you can check that the `haproxy` pr
 
 [NOTE]
 ====
-If you are using HAProxy as a load balancer and SELinux is set to `enforcing`, you must ensure that the HAProxy service can bind to the configured TCP port by running `setsebool -P haproxy_connect_any=1`. 
+If you are using HAProxy as a load balancer and SELinux is set to `enforcing`, you must ensure that the HAProxy service can bind to the configured TCP port by running `setsebool -P haproxy_connect_any=1`.
 ====
 
 ifeval::["{context}" == "installing-ibm-z"]


### PR DESCRIPTION
Applies to 4.5+ (the location of the doc may have changed from release to release)
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1891806
Preview Link:

- [Load balancing requirements for user-provisioned infrastructure](https://deploy-preview-33757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-load-balancing-user-infra_installing-bare-metal) for bare metal
- [Load balancing requirements for user-provisioned infrastructure](https://deploy-preview-33757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#installation-load-balancing-user-infra_installing-ibm-z-kvm) for IBM Z and LinuxONE
- [Load balancing requirements for user-provisioned infrastructure](https://deploy-preview-33757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#installation-load-balancing-user-infra_installing-restricted-networks-vsphere) for vSphere in a restricted network

Received ack from PM, Eng, and Docs. 

Need approval from @gpei and @sferich888 @xltian 

CC'ing @EricPonvelle 