### PR TITLE
SRVCOM-1410: Adding serverless metrics

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -3010,6 +3010,9 @@ Topics:
     # Monitoring
   - Name: Monitoring serverless components
     File: serverless-admin-monitoring
+    # Metrics
+  - Name: Metrics
+    File: serverless-admin-metrics
     # Metering
   - Name: Using metering with OpenShift Serverless
     File: serverless-metering
@@ -3050,6 +3053,9 @@ Topics:
     # Routes
   - Name: Configuring routes for Knative services
     File: serverless-configuring-routes
+  # Metrics
+  - Name: Metrics
+    File: serverless-serving-metrics
 #
 # Knative Eventing
 - Name: Knative Eventing

--- a/modules/serverless-activator-metrics.adoc
+++ b/modules/serverless-activator-metrics.adoc
@@ -1,0 +1,30 @@
+[id="serverless-activator-metrics_{context}"]
+= Activator metrics
+
+You can use the following metrics to understand how applications respond when traffic passes through the activator.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`request_concurrency`
+|The number of concurrent requests that are routed to the activator, or average concurrency over a reporting period.
+|Gauge
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`request_count`
+|The number of requests that are routed to activator. These are requests that have been fulfilled from the activator handler.
+|Counter
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`, |Integer (no units)
+
+|`request_latencies`
+|The response time in milliseconds for a fulfilled, routed request.
+|Histogram
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Milliseconds
+|===

--- a/modules/serverless-autoscaler-metrics.adoc
+++ b/modules/serverless-autoscaler-metrics.adoc
@@ -1,0 +1,97 @@
+[id="serverless-autoscaler-metrics_{context}"]
+= Autoscaler metrics
+
+The autoscaler component exposes a number of metrics related to autoscaler behavior for each revision. For example, at any given time, you can monitor the targeted number of pods the autoscaler tries to allocate for a service, the average number of requests per second during the stable window, or whether the autoscaler is in panic mode if you are using the Knative pod autoscaler (KPA).
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`desired_pods`
+|The number of pods the autoscaler tries to allocate for a service.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`excess_burst_capacity`
+|The excess burst capacity served over the stable window.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`stable_request_concurrency`
+|The average number of requests for each observed pod over the stable window.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`panic_request_concurrency`
+|The average number of requests for each observed pod over the panic window.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`target_concurrency_per_pod`
+|The number of concurrent requests that the autoscaler tries to send to each pod.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`stable_requests_per_second`
+|The average number of requests-per-second for each observed pod over the stable window.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`panic_requests_per_second`
+|The average number of requests-per-second for each observed pod over the panic window.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`target_requests_per_second`
+|The number of requests-per-second that the autoscaler targets for each pod.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`panic_mode`
+|This value is `1` if the autoscaler is in panic mode, or `0` if the autoscaler is not in panic mode.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`requested_pods`
+|The number of pods that the autoscaler has requested from the Kubernetes cluster.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`actual_pods`
+|The number of pods that are allocated and currently have a ready state.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`not_ready_pods`
+|The number of pods that have a not ready state.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`pending_pods`
+|The number of pods that are currently pending.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`terminating_pods`
+|The number of pods that are currently terminating.
+|Gauge
+|`configuration_name`, `namespace_name`, `revision_name`, `service_name`
+|Integer (no units)
+|===

--- a/modules/serverless-broker-filter-metrics.adoc
+++ b/modules/serverless-broker-filter-metrics.adoc
@@ -1,0 +1,31 @@
+[id="serverless-broker-filter-metrics_{context}"]
+= Broker filter metrics
+
+You can use the following metrics to debug broker filters, see how they are performing, and see which events are being dispatched by the filters. You can also measure the latency of the filtering action on an event.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count`
+|Number of events received by a broker.
+|Counter
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
+|Integer (no units)
+
+|`event_dispatch_latencies`
+|The time taken to dispatch an event to a channel.
+|Histogram
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
+|Milliseconds
+
+|`event_processing_latencies`
+|The time it takes to process an event before it is dispatched to a trigger subscriber.
+|Histogram
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `trigger_name`, `unique_name`
+|Milliseconds
+|===

--- a/modules/serverless-broker-ingress-metrics.adoc
+++ b/modules/serverless-broker-ingress-metrics.adoc
@@ -1,0 +1,25 @@
+[id="serverless-broker-ingress-metrics_{context}"]
+= Broker ingress metrics
+
+You can use the following metrics to debug the broker ingress, see how it is performing, and see which events are being dispatched by the ingress component.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count`
+|Number of events received by a broker.
+|Counter
+|`broker_name`, `event_type`, `namespace_name`, `response_code`, `response_code_class`, `unique_name`
+|Integer (no units)
+
+|`event_dispatch_latencies`
+|The time taken to dispatch an event to a channel.
+|Histogram
+|`broker_name`, `event_type`, `namespace_name`, `response_code`, `response_code_class`, `unique_name`
+|Milliseconds
+|===

--- a/modules/serverless-controller-metrics.adoc
+++ b/modules/serverless-controller-metrics.adoc
@@ -1,0 +1,67 @@
+[id="serverless-controller-metrics_{context}"]
+= Controller metrics
+
+The following metrics are emitted by any component that implements a controller logic. These metrics show details about reconciliation operations and the work queue behavior upon which reconciliation requests are added to the work queue.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`work_queue_depth`
+|The depth of the work queue.
+|Gauge
+|`reconciler`
+|Integer (no units)
+
+|`reconcile_count`
+|The number of reconcile operations.
+|Counter
+|`reconciler`, `success`
+|Integer (no units)
+
+|`reconcile_latency`
+|The latency of reconcile operations.
+|Histogram
+|`reconciler`, `success`
+|Milliseconds
+
+|`workqueue_adds_total`
+|The total number of add actions handled by the work queue.
+|Counter
+|`name`
+|Integer (no units)
+
+|`workqueue_queue_latency_seconds`
+|The length of time an item stays in the work queue before being requested.
+|Histogram
+|`name`
+|Seconds
+
+|`workqueue_retries_total`
+|The total number of retries that have been handled by the work queue.
+|Counter
+|`name`
+|Integer (no units)
+
+|`workqueue_work_duration_seconds`
+|The length of time it takes to process and item from the work queue.
+|Histogram
+|`name`
+|Seconds
+
+|`workqueue_unfinished_work_seconds`
+|The length of time that outstanding work queue items have been in progress.
+|Histogram
+|`name`
+|Seconds
+
+|`workqueue_longest_running_processor_seconds`
+|The length of time that the longest outstanding work queue items has been in progress.
+|Histogram
+|`name`
+|Seconds
+|===

--- a/modules/serverless-event-source-metrics.adoc
+++ b/modules/serverless-event-source-metrics.adoc
@@ -1,0 +1,24 @@
+[id="serverless-event-source-metrics_{context}"]
+= Event source metrics
+
+You can use the following metrics to verify that events have been delivered from the event source to the connected event sink.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count`
+|Number of events sent by the event source.
+|Counter
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
+|Integer (no units)
+
+|`retry_event_count`
+|Number of retried events sent by the event source after initially failing to be delivered.
+|Counter
+|`event_source`, `event_type`, `name`, `namespace_name`, `resource_group`, `response_code`, `response_code_class`, `response_error`, `response_timeout` |Integer (no units)
+|===

--- a/modules/serverless-go-metrics.adoc
+++ b/modules/serverless-go-metrics.adoc
@@ -1,0 +1,180 @@
+[id="serverless-go-metrics_{context}"]
+= Go runtime metrics
+
+Each Knative Serving control plane process emits a number of Go runtime memory statistics (link:https://golang.org/pkg/runtime/#MemStats[MemStats]).
+
+[NOTE]
+====
+The `name` tag for each metric is an empty tag.
+====
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`go_alloc`
+|The number of bytes of allocated heap objects. This metric is the same as `heap_alloc`.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_total_alloc`
+|The cumulative bytes allocated for heap objects.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_sys`
+|The total bytes of memory obtained from the operating system.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_lookups`
+|The number of pointer lookups performed by the runtime.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_mallocs`
+|The cumulative count of heap objects allocated.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_frees`
+|The cumulative count of heap objects that have been freed.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_alloc`
+|The number of bytes of allocated heap objects.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_sys`
+|The number of bytes of heap memory obtained from the operating system.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_idle`
+|The number of bytes in idle, unused spans.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_in_use`
+|The number of bytes in spans that are currently in use.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_released`
+|The number of bytes of physical memory returned to the operating system.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_heap_objects`
+|The number of allocated heap objects.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_stack_in_use`
+|The number of bytes in stack spans that are currently in use.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_stack_sys`
+|The number of bytes of stack memory obtained from the operating system.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_mspan_in_use`
+|The number of bytes of allocated `mspan` structures.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_mspan_sys`
+|The number of bytes of memory obtained from the operating system for `mspan` structures.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_mcache_in_use`
+|The number of bytes of allocated `mcache` structures.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_mcache_sys`
+|The number of bytes of memory obtained from the operating system for `mcache` structures.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_bucket_hash_sys`
+|The number of bytes of memory in profiling bucket hash tables.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_gc_sys`
+|The number of bytes of memory in garbage collection metadata.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_other_sys`
+|The number of bytes of memory in miscellaneous, off-heap runtime allocations.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_next_gc`
+|The target heap size of the next garbage collection cycle.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_last_gc`
+|The time that the last garbage collection was completed in link:https://en.wikipedia.org/wiki/Unix_time[_Epoch_ or Unix time].
+|Gauge
+|`name`
+|Nanoseconds
+
+|`go_total_gc_pause_ns`
+|The cumulative time in garbage collection _stop-the-world_ pauses since the program started.
+|Gauge
+|`name`
+|Nanoseconds
+
+|`go_num_gc`
+|The number of completed garbage collection cycles.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_num_forced_gc`
+|The number of garbage collection cycles that were forced due to an application calling the garbage collection function.
+|Gauge
+|`name`
+|Integer (no units)
+
+|`go_gc_cpu_fraction`
+|The fraction of the available CPU time of the program that has been used by the garbage collector since the program started.
+|Gauge
+|`name`
+|Integer (no units)
+|===

--- a/modules/serverless-inmemory-dispatch-metrics.adoc
+++ b/modules/serverless-inmemory-dispatch-metrics.adoc
@@ -1,0 +1,25 @@
+[id="serverless-inmemory-dispatch-metrics_{context}"]
+= InMemoryChannel dispatcher metrics
+
+You can use the following metrics to debug `InMemoryChannel` channels, see how they are performing, and see which events are being dispatched by the channels.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`event_count`
+|Number of events dispatched by `InMemoryChannel` channels.
+|Counter
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
+|Integer (no units)
+
+|`event_dispatch_latencies`
+|The time taken to dispatch an event from an `InMemoryChannel` channel.
+|Histogram
+|`broker_name`, `container_name`, `filter_type`, `namespace_name`, `response_code`, `response_code_class`, `trigger_name`, `unique_name`
+|Milliseconds
+|===

--- a/modules/serverless-queue-proxy-metrics.adoc
+++ b/modules/serverless-queue-proxy-metrics.adoc
@@ -1,0 +1,45 @@
+[id="serverless-queue-proxy-metrics_{context}"]
+= Queue proxy metrics
+
+Each Knative service has a proxy container that proxies the connections to the application container. A number of metrics are reported for the queue proxy performance.
+
+You can use the following metrics to measure if requests are queued at the proxy side and the actual delay in serving requests at the application side.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`revision_request_count`
+|The number of requests that are routed to `queue-proxy` pod.
+|Counter
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`revision_request_latencies`
+|The response time of revision requests.
+|Histogram
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Milliseconds
+
+|`revision_app_request_count`
+|The number of requests that are routed to the `user-container` pod.
+|Counter
+|`configuration_name`, `container_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+
+|`revision_app_request_latencies`
+|The response time of revision app requests.
+|Histogram
+|`configuration_name`, `namespace_name`, `pod_name`, `response_code`, `response_code_class`, `revision_name`, `service_name`
+|Milliseconds
+
+|`revision_queue_depth`
+| The current number of items in the `serving` and `waiting` queues. This metric is not reported if unlimited concurrency is configured.
+|Gauge
+|`configuration_name`, `event-display`, `container_name`, `namespace_name`, `pod_name`, `response_code_class`, `revision_name`, `service_name`
+|Integer (no units)
+|===

--- a/modules/serverless-webhook-metrics.adoc
+++ b/modules/serverless-webhook-metrics.adoc
@@ -1,0 +1,25 @@
+[id="serverless-webhook-metrics_{context}"]
+= Webhook metrics
+
+Webhook metrics report useful information about operations. For example, if a large number of operations fail, this might indicate an issue with a user-created resource.
+
+[cols=5*,options="header"]
+|===
+|Metric name
+|Description
+|Type
+|Tags
+|Unit
+
+|`request_count`
+|The number of requests that are routed to the webhook.
+|Counter
+|`admission_allowed`, `kind_group`, `kind_kind`, `kind_version`, `request_operation`, `resource_group`, `resource_namespace`, `resource_resource`, `resource_version`
+|Integer (no units)
+
+|`request_latencies`
+|The response time for a webhook request.
+|Histogram
+|`admission_allowed`, `kind_group`, `kind_kind`, `kind_version`, `request_operation`, `resource_group`, `resource_namespace`, `resource_resource`, `resource_version`
+|Milliseconds
+|===

--- a/modules/serverless-workflow-autoscaling-kn.adoc
+++ b/modules/serverless-workflow-autoscaling-kn.adoc
@@ -5,20 +5,20 @@ You can edit autoscaling capabilities for your cluster by using `kn` to modify K
 
 You can use the `kn service create` and `kn service update` commands with the appropriate flags as described below to configure autoscaling behavior.
 
-[cols="1,3",options="header"]
+[cols=2*,options="header"]
 |===
-| Flag
-| Description
+|Flag
+|Description
 
-| `--concurrency-limit int`
-| Sets a hard limit of concurrent requests to be processed by a single revision.
+|`--concurrency-limit int`
+|Sets a hard limit of concurrent requests to be processed by a single revision.
 
-| `--concurrency-target int`
-| Provides a recommendation for when to scale up revisions, based on the concurrent number of incoming requests. Defaults to `--concurrency-limit`.
+|`--concurrency-target int`
+|Provides a recommendation for when to scale up revisions, based on the concurrent number of incoming requests. Defaults to `--concurrency-limit`.
 
-| `--max-scale int`
-| Maximum number of revisions.
+|`--max-scale int`
+|Maximum number of revisions.
 
-| `--min-scale int`
-| Minimum number of revisions.
+|`--min-scale int`
+|Minimum number of revisions.
 |===

--- a/modules/serverless-workflow-traffic-splitting-flags.adoc
+++ b/modules/serverless-workflow-traffic-splitting-flags.adoc
@@ -1,49 +1,44 @@
-// Module is included in the following assemblies:
-//
-//serverless/knative-client.adoc
-
 [id="traffice-splitting-flags_{context}"]
-= Traffic splitting flags
+= Traffic splitting flags by using the Knative CLI
 
-`kn` supports traffic operations on the traffic block of a service as part of the `kn service update` command.
+The `kn` CLI supports traffic operations on the traffic block of a service as part of the `kn service update` command.
 
 The following table displays a summary of traffic splitting flags, value formats, and the operation the flag performs. The *Repetition* column denotes whether repeating the particular value of flag is allowed in a `kn service update` command.
 
-[cols="1,1,2,1",options="header"]
+[cols=4*,options="header"]
 |===
-| Flag
-| Value(s)
-| Operation
-| Repetition
+|Flag
+|Value(s)
+|Operation
+|Repetition
 
 |`--traffic`
-| `RevisionName=Percent`
-| Gives `Percent` traffic to `RevisionName`
-| Yes
+|`RevisionName=Percent`
+|Gives `Percent` traffic to `RevisionName`
+|Yes
 
 |`--traffic`
-| `Tag=Percent`
-| Gives `Percent` traffic to the revision having `Tag`
-| Yes
+|`Tag=Percent`
+|Gives `Percent` traffic to the revision having `Tag`
+|Yes
 
 |`--traffic`
-| `@latest=Percent`
-| Gives `Percent` traffic to the latest ready revision
-| No
+|`@latest=Percent`
+|Gives `Percent` traffic to the latest ready revision
+|No
 
 |`--tag`
-| `RevisionName=Tag`
-| Gives `Tag` to `RevisionName`
-| Yes
+|`RevisionName=Tag`
+|Gives `Tag` to `RevisionName`
+|Yes
 
 |`--tag`
-| `@latest=Tag`
-| Gives `Tag` to the latest ready revision
-| No
+|`@latest=Tag`
+|Gives `Tag` to the latest ready revision
+|No
 
 |`--untag`
-| `Tag`
-| Removes `Tag` from revision
-| Yes
-
+|`Tag`
+|Removes `Tag` from revision
+|Yes
 |===

--- a/serverless/admin_guide/serverless-admin-metrics.adoc
+++ b/serverless/admin_guide/serverless-admin-metrics.adoc
@@ -1,0 +1,40 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-admin-metrics"]
+= Metrics
+include::modules/common-attributes.adoc[]
+:context: serverless-admin-metrics
+
+toc::[]
+
+Metrics enable cluster administrators to monitor how {ServerlessProductName} cluster components and workloads are performing.
+
+[id="prerequisites_serverless-admin-metrics"]
+== Prerequisites
+
+* See the {product-title} documentation on xref:../../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics] for information about enabling metrics for your cluster.
+* To view metrics for Knative components on {product-title}, you need cluster administrator permissions, and access to the web console *Administrator* perspective.
+
+// Common metrics
+include::modules/serverless-controller-metrics.adoc[leveloffset=+1]
+include::modules/serverless-webhook-metrics.adoc[leveloffset=+1]
+
+[id="serverless-admin-metrics-eventing"]
+== Knative Eventing metrics
+
+Cluster administrators can view the following metrics for Knative Eventing components.
+
+By aggregating the metrics from HTTP code, events can be separated into two categories; successful events (2xx) and failed events (5xx).
+
+include::modules/serverless-broker-ingress-metrics.adoc[leveloffset=+2]
+include::modules/serverless-broker-filter-metrics.adoc[leveloffset=+2]
+include::modules/serverless-inmemory-dispatch-metrics.adoc[leveloffset=+2]
+include::modules/serverless-event-source-metrics.adoc[leveloffset=+2]
+
+[id="serverless-admin-metrics-serving"]
+== Knative Serving metrics
+
+Cluster administrators can view the following metrics for Knative Serving components.
+
+include::modules/serverless-activator-metrics.adoc[leveloffset=+2]
+include::modules/serverless-autoscaler-metrics.adoc[leveloffset=+2]
+include::modules/serverless-go-metrics.adoc[leveloffset=+2]

--- a/serverless/knative_serving/serverless-serving-metrics.adoc
+++ b/serverless/knative_serving/serverless-serving-metrics.adoc
@@ -1,0 +1,16 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-serving-metrics"]
+= Metrics
+include::modules/common-attributes.adoc[]
+:context: serverless-serving-metrics
+
+toc::[]
+
+Metrics enable developers to monitor how Knative services are performing.
+
+[id="prerequisites_serverless-metrics"]
+== Prerequisites
+
+* To view metrics for Knative components on {product-title}, you need access to the web console *Developer* perspective.
+
+include::modules/serverless-queue-proxy-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies for OCP 4.6+

Jira: https://issues.redhat.com/browse/SRVCOM-1410

Direct preview links:
- Admin metrics: https://deploy-preview-33760--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-admin-metrics.html
- Developer serving metrics: https://deploy-preview-33760--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-serving-metrics.html