### PR TITLE
OSDOCS-1854: Adding release notes for TLS security profile updates

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -297,11 +297,25 @@ Because the generated certificates contain wildcard subjects for headless servic
 For more information, see xref:../security/certificates/service-serving-certificate.adoc#add-service-certificate_service-serving-certificate[Add a service certificate].
 
 [id="ocp-4-8-security-oc-compliance-plug-in"]
-==== The oc-compliance Plug-in is now available
+==== The oc-compliance plug-in is now available
 
-The xref:../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Compliance Operator] automates many of the checks and remediations for an {product-title} cluster. However, the full process of bringing a cluster into compliance often requires administrator interaction with the Compliance Operator API and other components. The `oc-compliance` Plug-in is now available and makes the process easier.
+The xref:../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Compliance Operator] automates many of the checks and remediations for an {product-title} cluster. However, the full process of bringing a cluster into compliance often requires administrator interaction with the Compliance Operator API and other components. The `oc-compliance` plug-in is now available and makes the process easier.
 
-For more information, see xref:../security/oc_compliance_plug_in/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[Using the `oc-compliance` Plug-in]
+For more information, see xref:../security/oc_compliance_plug_in/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[Using the `oc-compliance` plug-in]
+
+[id="ocp-4-8-security-tls-security-profile-control-plane"]
+==== TLS security profile for the Kubernetes control plane
+
+The Kubernetes API server TLS security profile setting is now also honored by the Kubernetes scheduler and Kubernetes controller manager.
+
+For more information, see xref:../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles].
+
+[id="ocp-4-8-security-tls-security-profile-kubelet"]
+==== TLS security profile for the kubelet as a server
+
+You can now set a TLS security profile for kubelet when it acts as an HTTP server for the Kubernetes API server.
+
+For more information, see xref:../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles].
 
 [id="ocp-4-8-networking"]
 === Networking


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1854

Preview: https://deploy-preview-33763--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-security-tls-security-profile-control-plane