### PR TITLE
Update install/uninstall docs for Web Terminal Operator

### DIFF
--- a/modules/odc-installing-web-terminal.adoc
+++ b/modules/odc-installing-web-terminal.adoc
@@ -16,11 +16,17 @@ You can install the web terminal using the Web Terminal Operator listed in the {
 . Read the brief description about the Operator on the *Web Terminal*  page, and then click *Install*.
 . On the *Install Operator* page, retain the default values for all fields.
 
-** The *alpha* option in the *Update Channel* menu enables installation of the latest release of the Web Terminal Operator.
+** The *fast* option in the *Update Channel* menu enables installation of the latest release of the Web Terminal Operator.
 ** The *All namespaces on the cluster* option in the *Installation Mode* menu  enables the Operator to watch and be available to all namespaces in the cluster.
 ** The *openshift-operators* option in the *Installed Namespace* menu installs the Operator in the default `openshift-operators` namespace.
 ** The *Automatic* option in the *Approval Strategy* menu ensures that the future upgrades to the Operator are handled automatically by the Operator Lifecycle Manager.
 
 . Click *Install*.
-. In the *Installed Operators* page, click the *View operator* to verify that the Operator is listed on the *Installed Operators* page.
+. In the *Installed Operators* page, click the *View Operator* to verify that the Operator is listed on the *Installed Operators* page.
++
+[NOTE]
+====
+Prior to {product-title} 4.8, the Web Terminal Operator bundled all its functionality in a single Operator. As of {product-title} 4.8, the Web Terminal Operator installs the DevWorkspace Operator as a dependency to provide the same features.
+====
+
 . After the Operator is installed, refresh your page to see the command line terminal icon on the upper right of the console.

--- a/modules/odc-uninstalling-web-terminal.adoc
+++ b/modules/odc-uninstalling-web-terminal.adoc
@@ -7,17 +7,52 @@
 
 Uninstalling the web terminal is a two-step process:
 
-. Delete the components and custom resources (CRs) that were added when you installed the Operator.
-. Uninstall the Web Terminal Operator.
+. Uninstall the Web Terminal Operator and related custom resources (CRs) that were added when you installed the Operator.
+. Uninstall the DevWorkspace Operator and its related custom resources that were added as a dependency of the Web Terminal Operator.
 
 Uninstalling the Web Terminal Operator does not remove any of its custom resource definitions (CRDs) or managed resources that are created when the Operator is installed. These components must be manually uninstalled for security purposes. Removing these components also allows you to save cluster resources by ensuring that terminals do not idle when the Operator is uninstalled.
 
 .Prerequisites
 * Access to an {product-title} cluster using an account with `cluster-admin` permissions.
 
-== Deleting the web terminal components and custom resources
+== Removing the Web Terminal Operator and the custom resources that support it
 
-Use the CLI to delete the CRs that are created during installation of the  Web Terminal Operator.
+Use the console and the CLI to delete any existing web terminals and CRs that were created during the installation of the Web Terminal Operator.
+
+[NOTE]
+====
+Prior to {product-title} 4.8, the Web Terminal Operator used different CRDs to provide Web Terminal capabilities. To uninstall versions 1.2.1 and below of the Web Terminal Operator, refer to the documentation for {product-title} 4.7.
+====
+
+.Procedure
+. Uninstall the Web Terminal Operator using the web console:
+.. In the *Administrator* perspective of the web console, navigate to *Operators -> Installed Operators*.
+.. Scroll the filter list or type a keyword into the *Filter by name* box to find the *Web Terminal* Operator.
+.. Click the Options menu {kebab} for the Web Terminal Operator, and then select *Uninstall Operator*.
+.. In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.
++
+. Run the following commands to ensure that all `DevWorkspace` CRs created for the Web Terminals are removed.
++
+[source,terminal]
+----
+$ oc delete devworkspaces.workspace.devfile.io --all-namespaces \
+    --selector 'console.openshift.io/terminal=true' --wait
+----
++
+[source,terminal]
+----
+$ oc delete devworkspacetemplates.workspace.devfile.io --all-namespaces \
+    --selector 'console.openshift.io/terminal=true' --wait
+----
+
+== Deleting the DevWorkspace Operator dependency
+
+Use the CLI to delete the custom resource definitions (CRDs) and additional resources that are created during installation of the Web Terminal Operator.
+
+[IMPORTANT]
+====
+The DevWorkspace Operator functions as a standalone Operator and may be required as a dependency for other Operators installed on the cluster (for example, the CodeReady Workspaces Operator may depend on it). Follow the steps below only if you are sure the DevWorkspace Operator is no longer needed.
+====
 
 .Procedure
 . Run the following commands to ensure that all `DevWorkspace` CRs are removed along with their related Kubernetes objects, such as deployments.
@@ -29,12 +64,7 @@ $ oc delete devworkspaces.workspace.devfile.io --all-namespaces --all --wait
 +
 [source,terminal]
 ----
-$ oc delete workspaceroutings.controller.devfile.io --all-namespaces --all --wait
-----
-+
-[source,terminal]
-----
-$ oc delete components.controller.devfile.io --all-namespaces --all --wait
+$ oc delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --wait
 ----
 +
 [WARNING]
@@ -46,12 +76,7 @@ If this step is not complete, finalizers make it difficult to fully uninstall th
 +
 [source,terminal]
 ----
-$ oc delete customresourcedefinitions.apiextensions.k8s.io workspaceroutings.controller.devfile.io
-----
-+
-[source,terminal]
-----
-$ oc delete customresourcedefinitions.apiextensions.k8s.io components.controller.devfile.io
+$ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.controller.devfile.io
 ----
 +
 [source,terminal]
@@ -59,16 +84,26 @@ $ oc delete customresourcedefinitions.apiextensions.k8s.io components.controller
 $ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 ----
 +
-. Remove the `DevWorkspace-Webhook-Server` deployment:
+. Remove the `DevWorkspace-Webhook-Server` deployment, mutating, and validating webhooks:
 +
 [source,terminal]
 ----
 $ oc delete deployment/devworkspace-webhook-server -n openshift-operators
 ----
 +
+[source,terminal]
+----
+$ oc delete mutatingwebhookconfigurations controller.devfile.io
+----
++
+[source,terminal]
+----
+$ oc delete validatingwebhookconfigurations controller.devfile.io
+----
++
 [NOTE]
 ====
-When you run this and the following steps, you cannot use the `oc exec` commands to run commands in a container. After you remove the webhooks you will be able to use the `oc exec` commands again.
+If you remove the `devworkspace-webhook-server` deployment without removing the mutating and validating webhooks, you will not be able use `oc exec` commands to run commands in a container on the cluster. After you remove the webhooks you will be able to use the `oc exec` commands again.
 ====
 +
 . Run the following commands to remove any lingering services, secrets, and config maps:
@@ -98,23 +133,8 @@ $ oc delete clusterrole devworkspace-webhook-server
 $ oc delete clusterrolebinding devworkspace-webhook-server
 ----
 +
-. Run the following commands to remove mutating or validating webhook configurations:
-+
-[source,terminal]
-----
-$ oc delete mutatingwebhookconfigurations controller.devfile.io
-----
-+
-[source,terminal]
-----
-$ oc delete validatingwebhookconfigurations controller.devfile.io
-----
-
-== Uninstalling the Operator using the web console
-
-.Procedure
-
-. In the *Administrator* perspective of the web console, navigate to *Operators -> Installed Operators*.
-. Scroll the filter list or type a keyword into the *Filter by name* box to find the *Web Terminal* Operator.
-. Click the Options menu {kebab} for the Web Terminal Operator, and then select *Uninstall Operator*.
-. In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.
+. Uninstall the Operator using the web console:
+.. In the *Administrator* perspective of the web console, navigate to *Operators -> Installed Operators*.
+.. Scroll the filter list or type a keyword into the *Filter by name* box to find the *DevWorkspace* Operator.
+.. Click the Options menu {kebab} for the DevWorkspace Operator, and then select *Uninstall Operator*.
+.. In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.


### PR DESCRIPTION
This PR updates the Web Terminal documentation to reflect the coming release on OpenShift 4.8.

For background, the (upcoming) 1.3.0 release of the Web Terminal Operator is slightly different under-the-hood compared to the (current) 1.2.1 release. Whereas 1.2.1 bundles the DevWorkspace Operator directly, 1.3.0 will install the DevWorkspace Operator as an OLM dependency. In addition, one subresource CRD is removed in 1.3.0 and another is renamed.

These docs reflect the expected uninstall/install flow on OpenShift 4.8. Since the uninstall process is different for earlier versions, I've tried to reference these earler iterations of the docs for people looking to uninstall the 1.2.1 operator after 4.8 is released.