### PR TITLE
Metering version number bumps for 4.8 GA

### DIFF
--- a/metering/metering-upgrading-metering.adoc
+++ b/metering/metering-upgrading-metering.adoc
@@ -12,7 +12,7 @@ You can upgrade metering to {product-version} by updating the Metering Operator 
 
 == Prerequisites
 
-*  The cluster is updated to 4.7.
+*  The cluster is updated to {product-version}.
 *  The xref:../metering/metering-installing-metering.adoc#metering-install-operator_installing-metering[Metering Operator] is installed from OperatorHub.
 +
 [NOTE]
@@ -46,11 +46,11 @@ Wait several seconds to allow the subscription to update before proceeding to th
 ====
 .  Click *Operators* -> *Installed Operators*.
 +
-The Metering Operator is shown as 4.7. For example:
+The Metering Operator is shown as 4.8. For example:
 +
 ----
 Metering
-4.7.0-202007012112.p0 provided by Red Hat, Inc
+4.8.0-202107012112.p0 provided by Red Hat, Inc
 ----
 
 .Verification
@@ -73,11 +73,11 @@ You can verify the metering upgrade by performing any of the following checks:
 $ oc get csv | grep metering
 ----
 +
-.Example output for metering upgrade from 4.6 to 4.7
+.Example output for metering upgrade from 4.7 to 4.8
 [source,terminal]
 ----
 NAME                                        DISPLAY                  VERSION                 REPLACES                                 PHASE
-metering-operator.4.7.0-202007012112.p0     Metering                 4.7.0-202007012112.p0   metering-operator.4.6.0-202007012112.p0  Succeeded
+metering-operator.4.8.0-202107012112.p0     Metering                 4.8.0-202107012112.p0   metering-operator.4.7.0-202007012112.p0  Succeeded
 ----
 --
 
@@ -125,21 +125,21 @@ Timestamps in the `NEWEST METRIC` column indicate that `ReportDataSource` resour
 [source,terminal]
 ----
 NAME                                         EARLIEST METRIC        NEWEST METRIC          IMPORT START           IMPORT END             LAST IMPORT TIME       AGE
-node-allocatable-cpu-cores                   2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:44Z   23h
-node-allocatable-memory-bytes                2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:07Z   23h
-node-capacity-cpu-cores                      2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:52Z   23h
-node-capacity-memory-bytes                   2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:03Z   23h
-persistentvolumeclaim-capacity-bytes         2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:56:46Z   23h
-persistentvolumeclaim-phase                  2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:36Z   23h
-persistentvolumeclaim-request-bytes          2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:03Z   23h
-persistentvolumeclaim-usage-bytes            2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:02Z   23h
-pod-limit-cpu-cores                          2020-05-18T21:10:00Z   2020-05-19T19:57:00Z   2020-05-18T19:10:00Z   2020-05-19T19:57:00Z   2020-05-19T19:57:02Z   23h
-pod-limit-memory-bytes                       2020-05-18T21:10:00Z   2020-05-19T19:58:00Z   2020-05-18T19:11:00Z   2020-05-19T19:58:00Z   2020-05-19T19:59:06Z   23h
-pod-persistentvolumeclaim-request-info       2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:52:07Z   23h
-pod-request-cpu-cores                        2020-05-18T21:10:00Z   2020-05-19T19:58:00Z   2020-05-18T19:11:00Z   2020-05-19T19:58:00Z   2020-05-19T19:58:57Z   23h
-pod-request-memory-bytes                     2020-05-18T21:10:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:55:32Z   23h
-pod-usage-cpu-cores                          2020-05-18T21:09:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:54:55Z   23h
-pod-usage-memory-bytes                       2020-05-18T21:08:00Z   2020-05-19T19:52:00Z   2020-05-18T19:11:00Z   2020-05-19T19:52:00Z   2020-05-19T19:55:00Z   23h
+node-allocatable-cpu-cores                   2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:56:44Z   23h
+node-allocatable-memory-bytes                2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:52:07Z   23h
+node-capacity-cpu-cores                      2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:56:52Z   23h
+node-capacity-memory-bytes                   2021-07-01T21:10:00Z   2021-07-02T19:57:00Z   2021-07-01T19:10:00Z   2021-07-02T19:57:00Z   2021-07-02T19:57:03Z   23h
+persistentvolumeclaim-capacity-bytes         2021-07-01T21:09:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:56:46Z   23h
+persistentvolumeclaim-phase                  2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:52:36Z   23h
+persistentvolumeclaim-request-bytes          2021-07-01T21:10:00Z   2021-07-02T19:57:00Z   2021-07-01T19:10:00Z   2021-07-02T19:57:00Z   2021-07-02T19:57:03Z   23h
+persistentvolumeclaim-usage-bytes            2021-07-01T21:09:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:52:02Z   23h
+pod-limit-cpu-cores                          2021-07-01T21:10:00Z   2021-07-02T19:57:00Z   2021-07-01T19:10:00Z   2021-07-02T19:57:00Z   2021-07-02T19:57:02Z   23h
+pod-limit-memory-bytes                       2021-07-01T21:10:00Z   2021-07-02T19:58:00Z   2021-07-01T19:11:00Z   2021-07-02T19:58:00Z   2021-07-02T19:59:06Z   23h
+pod-persistentvolumeclaim-request-info       2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:52:07Z   23h
+pod-request-cpu-cores                        2021-07-01T21:10:00Z   2021-07-02T19:58:00Z   2021-07-01T19:11:00Z   2021-07-02T19:58:00Z   2021-07-02T19:58:57Z   23h
+pod-request-memory-bytes                     2021-07-01T21:10:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:55:32Z   23h
+pod-usage-cpu-cores                          2021-07-01T21:09:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:54:55Z   23h
+pod-usage-memory-bytes                       2021-07-01T21:08:00Z   2021-07-02T19:52:00Z   2021-07-01T19:11:00Z   2021-07-02T19:52:00Z   2021-07-02T19:55:00Z   23h
 report-ns-pvc-usage                                                                                                                                             5h36m
 report-ns-pvc-usage-hourly
 ----

--- a/modules/metering-cluster-usage-examples.adoc
+++ b/modules/metering-cluster-usage-examples.adoc
@@ -14,10 +14,10 @@ The following report measures cluster usage from a specific starting date forwar
 apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
-  name: cluster-cpu-usage-2019 <1>
+  name: cluster-cpu-usage-2020 <1>
 spec:
-  reportingStart: '2019-01-01T00:00:00Z' <2>
-  reportingEnd: '2019-12-30T23:59:59Z'
+  reportingStart: '2020-01-01T00:00:00Z' <2>
+  reportingEnd: '2020-12-30T23:59:59Z'
   query: cluster-cpu-usage <3>
   runImmediately: true <4>
 ----

--- a/modules/metering-debugging.adoc
+++ b/modules/metering-debugging.adoc
@@ -79,7 +79,7 @@ $ presto:default> show tables from metering;
  datasource_your_namespace_pod_usage_memory_bytes
 (32 rows)
 
-Query 20190503_175727_00107_3venm, FINISHED, 1 node
+Query 20210503_175727_00107_3venm, FINISHED, 1 node
 Splits: 19 total, 19 done (100.00%)
 0:02 [32 rows, 2.23KB] [19 rows/s, 1.37KB/s]
 

--- a/modules/metering-reports.adoc
+++ b/modules/metering-reports.adoc
@@ -21,7 +21,7 @@ metadata:
   name: pod-cpu-request-hourly
 spec:
   query: "pod-cpu-request"
-  reportingStart: "2019-07-01T00:00:00Z"
+  reportingStart: "2021-07-01T00:00:00Z"
   schedule:
     period: "hourly"
     hourly:
@@ -42,8 +42,8 @@ metadata:
   name: pod-cpu-request-hourly
 spec:
   query: "pod-cpu-request"
-  reportingStart: "2019-07-01T00:00:00Z"
-  reportingEnd: "2019-07-31T00:00:00Z"
+  reportingStart: "2021-07-01T00:00:00Z"
+  reportingEnd: "2021-07-31T00:00:00Z"
 ----
 
 [id="metering-query_{context}"]
@@ -234,7 +234,7 @@ spec:
   query: "pod-cpu-request"
   schedule:
     period: "hourly"
-  reportingStart: "2019-01-01T00:00:00Z"
+  reportingStart: "2021-01-01T00:00:00Z"
 ----
 
 [id="metering-reportingEnd_{context}"]
@@ -256,8 +256,8 @@ spec:
   query: "pod-cpu-request"
   schedule:
     period: "weekly"
-  reportingStart: "2019-07-01T00:00:00Z"
-  reportingEnd: "2019-07-31T00:00:00Z"
+  reportingStart: "2021-07-01T00:00:00Z"
+  reportingEnd: "2021-07-31T00:00:00Z"
 ----
 
 [id="metering-expiration_{context}"]
@@ -282,7 +282,7 @@ spec:
   query: "pod-cpu-request"
   schedule:
     period: "weekly"
-  reportingStart: "2020-09-01T00:00:00Z"
+  reportingStart: "2021-07-01T00:00:00Z"
   expiration: "30m" <1>
 ----
 <1> Valid time units for the `expiration` duration are `ns`, `us` (or `µs`), `ms`, `s`, `m`, and `h`.

--- a/modules/metering-viewing-report-results.adoc
+++ b/modules/metering-viewing-report-results.adoc
@@ -46,7 +46,7 @@ $ token="$(oc whoami -t)"
 +
 [source,terminal]
 ----
-$ reportName=namespace-cpu-request-2019
+$ reportName=namespace-cpu-request-2020
 ----
 
 .. Set `reportFormat` to one of `csv`, `json`, or `tabular` to specify the output format of the API response:
@@ -63,39 +63,39 @@ $ reportFormat=csv
 $ curl --insecure -H "Authorization: Bearer ${token}" "https://${meteringRoute}/api/v1/reports/get?name=${reportName}&namespace=openshift-metering&format=$reportFormat"
 ----
 +
-.Example output with `reportName=namespace-cpu-request-2019` and `reportFormat=csv`
+.Example output with `reportName=namespace-cpu-request-2020` and `reportFormat=csv`
 [source,terminal]
 ----
 period_start,period_end,namespace,pod_request_cpu_core_seconds
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-apiserver,11745.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-apiserver-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-authentication,522.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-authentication-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cloud-credential-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-machine-approver,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-node-tuning-operator,3385.800000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-samples-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-cluster-version,522.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-console,522.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-console-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-controller-manager,7830.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-controller-manager-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-dns,34372.800000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-dns-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-etcd,23490.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-image-registry,5993.400000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-ingress,5220.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-ingress-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver,12528.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager,8613.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-machine-api,1305.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-machine-config-operator,9637.800000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-metering,19575.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-monitoring,6256.800000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-network-operator,261.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-sdn,94503.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-service-ca,783.000000
-2019-01-01 00:00:00 +0000 UTC,2019-12-30 23:59:59 +0000 UTC,openshift-service-ca-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-apiserver,11745.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-apiserver-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-authentication,522.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-authentication-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-cloud-credential-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-cluster-machine-approver,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-cluster-node-tuning-operator,3385.800000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-cluster-samples-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-cluster-version,522.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-console,522.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-console-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-controller-manager,7830.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-controller-manager-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-dns,34372.800000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-dns-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-etcd,23490.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-image-registry,5993.400000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-ingress,5220.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-ingress-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver,12528.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-kube-apiserver-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager,8613.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-kube-controller-manager-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-machine-api,1305.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-machine-config-operator,9637.800000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-metering,19575.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-monitoring,6256.800000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-network-operator,261.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-sdn,94503.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-service-ca,783.000000
+2020-01-01 00:00:00 +0000 UTC,2020-12-30 23:59:59 +0000 UTC,openshift-service-ca-operator,261.000000
 ----

--- a/modules/metering-writing-reports.adoc
+++ b/modules/metering-writing-reports.adoc
@@ -30,11 +30,11 @@ $ oc project openshift-metering
 apiVersion: metering.openshift.io/v1
 kind: Report
 metadata:
-  name: namespace-cpu-request-2019 <2>
+  name: namespace-cpu-request-2020 <2>
   namespace: openshift-metering
 spec:
-  reportingStart: '2019-01-01T00:00:00Z'
-  reportingEnd: '2019-12-30T23:59:59Z'
+  reportingStart: '2020-01-01T00:00:00Z'
+  reportingEnd: '2020-12-30T23:59:59Z'
   query: namespace-cpu-request <1>
   runImmediately: true <3>
 ----
@@ -52,7 +52,7 @@ $ oc create -f <file-name>.yaml
 .Example output
 [source,terminal]
 ----
-report.metering.openshift.io/namespace-cpu-request-2019 created
+report.metering.openshift.io/namespace-cpu-request-2020 created
 ----
 +
 
@@ -67,5 +67,5 @@ $ oc get reports
 [source,terminal]
 ----
 NAME                         QUERY                   SCHEDULE   RUNNING    FAILED   LAST REPORT TIME       AGE
-namespace-cpu-request-2019   namespace-cpu-request              Finished            2019-12-30T23:59:59Z   26s
+namespace-cpu-request-2020   namespace-cpu-request              Finished            2020-12-30T23:59:59Z   26s
 ----


### PR DESCRIPTION
Version bumps in the Metering book for 4.8 GA. I also updated the year in some of the output examples from 2019 to 2020 or 2021.
Relates to https://github.com/openshift/openshift-docs/pull/33189

Preview: https://deploy-preview-33768--osdocs.netlify.app/openshift-enterprise/latest/metering/metering-upgrading-metering.html