### PR TITLE
TELCODOCS-111: Release notes for Fujitsu iRMC

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -98,6 +98,34 @@ With this release, the upgrade duration for cluster Operators that deploy daemon
 This change does not affect machine config pool rollout duration.
 ====
 
+[id="ocp-4-8-installation-fujitsu-irmc"]
+==== Using Fujitsu iRMC for installation on bare metal nodes
+
+In {product-title} 4.8, you can use Fujitsu hardware and the Fujitsu iRMC base board management controller protocol when deploying installer-provisioned clusters on bare metal. Currently Fujitsu supports iRMC S5 firmware version `3.05P` and above for installer-provisioned installation on bare metal. Enhancements and bug fixes for {product-title} 4.8 include:
+
+* Supporting soft power-off on iRMC hardware.
+
+* Stopping the provisioning services once the installer deploys the control plane on the bare metal nodes. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1949859[BZ#1949859] for more information.
+
+* Adding an Ironic health check to the bootstrap `keepalived` checks. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1949859[BZ#1949859] for more information.
+
+* Verifying that the unicast peers list isn't empty on the control plane nodes. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1957708[BZ#1957708] for more information.
+
+* Updating the Bare Metal Operator to align the iRMC PowerInterface. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1957869[BZ#1957869] for more information.
+
+* Updating the `pyghmi` library version. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1920294[BZ#1920294] for more information.
+
+* Updating the Bare Metal Operator to address missing IPMI credentials. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1965182[BZ#1965182] for more information.
+
+* Removing iRMC from `enabled_bios_interfaces`. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1969212[BZ#1969212] for more information.
+
+* Adding `ironicTlsMount` and `inspectorTlsMount` to the
+the bare metal pod definition. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1968701[BZ#1968701] for more information.
+
+* Disabling the RAID feature for iRMC server. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1969487[BZ#1969487] for more information.
+
+* Disabling RAID for all drivers. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1969487[BZ#1969487] for more information.
+
 [id="ocp-4-8-web-console"]
 === Web console
 [id="ocp-4-8-custom-console-routes-use-custom-domains-cluster-api"]


### PR DESCRIPTION
Contains release notes for deploying installer-provisioned clusters on bare metal nodes using Fujitsu hardware and the iRMC base board management protocol. 

Fixes: [TELCODOCS-111](https://issues.redhat.com/browse/TELCODOCS-111)

Release: 4.8

Preview: https://deploy-preview-33772--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

Signed-off-by: John Wilkins <jowilkin@redhat.com>