### PR TITLE
[enterprise-4.7] installation-special-config-kmod: update wording to "control plane node"

### DIFF
--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -281,7 +281,7 @@ This must include new kernel packages as they are needed to match newly installe
 === Provision kernel modules via a `MachineConfig` object
 
 By packaging kernel module software with a `MachineConfig` object, you can
-deliver that software to worker or master nodes at installation time
+deliver that software to worker or control plane nodes at installation time
 or via the Machine Config Operator.
 
 First create a base Ignition config that you would like to use.


### PR DESCRIPTION
Cherry-picked from 1617e085a25c410c74e1411ee20a303e6881a353 | xref: https://github.com/openshift/openshift-docs/pull/33735