### PR TITLE
Revert PR33774 4-5 CP

### DIFF
--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -289,7 +289,7 @@ This must include new kernel packages as they are needed to match newly installe
 === Provision kernel modules via a `MachineConfig` object
 
 By packaging kernel module software with a `MachineConfig` object, you can
-deliver that software to worker or control plane nodes at installation time
+deliver that software to worker or master nodes at installation time
 or via the Machine Config Operator.
 
 First create a base Ignition config that you would like to use.


### PR DESCRIPTION
This is an undo of the manual 4.5 CP in https://github.com/openshift/openshift-docs/pull/33774/files because this change should only apply to 4.8. | Original PR xref: https://github.com/openshift/openshift-docs/pull/33735