### PR TITLE
BZ1973539:Updated terminal examples

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -73,7 +73,7 @@ $ oc adm catalog mirror \
 <2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
 <6> Optional: Generate only the manifests required for mirroring, and do not actually mirror the image content to a registry. This option can be useful for reviewing what will be mirrored, and it allows you to make any changes to the mapping list if you require only a subset of packages. You can then use the `mapping.txt` file with the `oc image mirror` command to mirror the modified list of images in a later step. This flag is intended for only advanced selective mirroring of content from the catalog; the `opm index prune` command, if you used it previously to prune the index image, is suitable for most catalog management use cases.
 +
 .Example output
@@ -98,7 +98,8 @@ $ oc adm catalog mirror \
     <index_image> \//<1>
     file:///local/index \//<2>
     [-a ${REG_CREDS}] \
-    [--insecure]
+    [--insecure] \
+    [--index-filter-by-os='<platform>/<arch>']
 ----
 <1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
 <2> Mirrors content to local files in your current directory.
@@ -136,7 +137,8 @@ $ oc adm catalog mirror \
     file://local/index/<repo>/<index_image>:<tag> \//<1>
     <mirror_registry>:<port>/<namespace> \//<2>
     [-a ${REG_CREDS}] \
-    [--insecure]
+    [--insecure] \
+    [--index-filter-by-os='<platform>/<arch>']
 ----
 <1> Specify the `file://` path from the previous command output.
 <2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -34,7 +34,7 @@ endif::[]
 [source,terminal]
 ----
 $ opm index add \
-    --bundles <registry>/<namespace>/<new_bundle_image>:<tag> \//<1>
+    --bundles <registry>/<namespace>/<new_bundle_image>@sha256:<digest> \//<1>
     --from-index <registry>/<namespace>/<existing_index_image>:<tag> \//<2>
     --tag <registry>/<namespace>/<existing_index_image>:<tag> <3>
 ----


### PR DESCRIPTION
CP 4.8

https://bugzilla.redhat.com/show_bug.cgi?id=1973539

- Updating an index image > Step 1. Updated the terminal source for the first callout to read `--bundles <registry>/<namespace>/<new_bundle_image>@sha256:<digest>`
- Mirroring an Operator catalog > Step 2 > Option A. Added `.*` to the 5th callout.
- Mirroring an Operator catalog > Step 2 > Option B. Added `[--index-filter-by-os='<platform>/<arch>']` to the terminal source for step a and step e.

https://deploy-preview-33793--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html