### PR TITLE
OSDOCS-1997: About Butane docs

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -22,6 +22,15 @@ when installing bare-metal nodes.
 The following sections describe features that you might want to
 configure on your nodes in this way.
 
+include::modules/installation-special-config-butane.adoc[leveloffset=+1]
+include::modules/installation-special-config-butane-about.adoc[leveloffset=+2]
+include::modules/installation-special-config-butane-install.adoc[leveloffset=+2]
+include::modules/installation-special-config-butane-create.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-kmod_installing-customizing[Adding kernel modules to nodes]
+* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-storage_installing-customizing[Encrypting or mirroring disks during installation]
 
 include::modules/installation-special-config-kargs.adoc[leveloffset=+1]
 ifdef::openshift-webscale[]
@@ -31,9 +40,10 @@ include::modules/installation-special-config-kmod.adoc[leveloffset=+1]
 include::modules/installation-special-config-storage.adoc[leveloffset=+1]
 include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
-ifndef::openshift-origin[]
 == Additional resources
 
-See xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]
-for information on FIPS support.
+See xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane] for information on Butane.
+
+ifndef::openshift-origin[]
+See xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography] for information on FIPS support.
 endif::[]

--- a/modules/installation-special-config-butane-about.adoc
+++ b/modules/installation-special-config-butane-about.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-butane-about_{context}"]
+= About Butane
+
+Butane is a command-line utility that {product-title} uses to provide convenient, short-hand syntax for writing machine configs, as well as for performing additional validation of machine configs. The format of the Butane config file that Butane accepts is defined in the
+https://coreos.github.io/butane/specs/[OpenShift Butane config spec].

--- a/modules/installation-special-config-butane-create.adoc
+++ b/modules/installation-special-config-butane-create.adoc
@@ -1,0 +1,62 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-butane-create_{context}"]
+= Creating a MachineConfig object by using Butane
+
+You can use Butane to produce a `MachineConfig` object so that you can configure worker or control plane nodes at installation time or via the Machine Config Operator.
+
+.Prerequisites
+
+* You have installed the `butane` utility.
+
+.Procedure
+
+. Create a Butane config file. The following example creates a file named `99-worker-console.bu` that configures the system console to use the second serial port and specifies custom settings for the chrony time service:
++
+[source,yaml]
+----
+variant: openshift
+version: 4.8.0
+metadata:
+  name: 99-worker-console
+  labels:
+    machineconfiguration.openshift.io/role: worker
+openshift:
+  kernel_arguments:
+    - console=ttyS1,115200
+storage:
+  files:
+    - path: /etc/chrony.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          pool 0.rhel.pool.ntp.org iburst
+          driftfile /var/lib/chrony/drift
+          makestep 1.0 3
+          rtcsync
+          logdir /var/log/chrony
+----
++
+[NOTE]
+====
+The `99-worker-console.bu` file is set to create a machine config for worker nodes. To deploy on control plane nodes, change the role from `worker` to `master`. To do both, you could repeat the whole procedure using different file names for the two types of deployments.
+====
+
+. Create a `MachineConfig` object by giving Butane the file that you created in the previous step:
++
+[source,terminal]
+----
+$ butane 99-worker-console.bu -o ./99-worker-console.yaml
+----
++
+A `MachineConfig` object YAML file is created for you to finish configuring your machines.
+. Save the Butane config in case you need to update the `MachineConfig` object in the future.
+. If the cluster is not running yet, generate manifest files and add the `MachineConfig` object YAML file to the `openshift` directory. If the cluster is already running, apply the file as follows:
++
+[source,terminal]
+----
+$ oc create -f 99-worker-console.yaml
+----

--- a/modules/installation-special-config-butane-install.adoc
+++ b/modules/installation-special-config-butane-install.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-butane-install_{context}"]
+= Installing Butane
+
+You can install the Butane tool (`butane`) to create {product-title} machine configs from a command-line interface. You can install `butane` on Linux, Windows, or macOS by downloading the corresponding binary file.
+
+[TIP]
+====
+Butane releases are backwards-compatible with older releases and with the Fedora CoreOS Config Transpiler (FCCT).
+====
+
+.Procedure
+
+. Navigate to the Butane image download page at https://mirror.openshift.com/pub/openshift-v4/clients/butane/.
+. Get the `butane` binary:
+.. For the newest version of Butane, save the latest `butane` image to your current directory:
++
+[source,terminal]
+----
+$ curl https://mirror.openshift.com/pub/openshift-v4/clients/butane/latest/butane --output butane
+----
++
+.. Optional: For a specific type of architecture you are installing Butane on, such as aarch64 or ppc64le, indicate the appropriate URL. For example:
++
+[source,terminal]
+----
+$ curl https://mirror.openshift.com/pub/openshift-v4/clients/butane/latest/butane-aarch64 --output butane
+----
++
+. Make the downloaded binary file executable:
++
+[source,terminal]
+----
+$ chmod +x butane
+----
++
+. Move the `butane` binary file to a directory on your `PATH`.
++
+To check your `PATH`, open a terminal and execute the following command:
++
+[source,terminal]
+----
+$ echo $PATH
+----
+
+.Verification steps
+
+* You can now use the Butane tool by running the `butane` command:
++
+[source,terminal]
+----
+$ butane <butane_file>
+----

--- a/modules/installation-special-config-butane.adoc
+++ b/modules/installation-special-config-butane.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-butane_{context}"]
+= Creating machine configs with Butane
+
+Machine configs are used to configure control plane and worker machines by instructing machines how to create users and file systems, set up the network, install systemd units, and more.
+
+Because modifying machine configs can be difficult, you can use Butane configs to create machine configs for you, thereby making node configuration much easier.

--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -278,7 +278,7 @@ when you build your Ignition config.
 This must include new kernel packages as they are needed to match newly installed kernels.
 
 [id="provision-kernel-modules-via-machineconfig_{context}"]
-=== Provision kernel modules via a `MachineConfig` object
+=== Provision kernel modules via a MachineConfig object
 
 By packaging kernel module software with a `MachineConfig` object, you can
 deliver that software to worker or control plane nodes at installation time
@@ -377,7 +377,12 @@ $ make install DESTDIR=${FAKEROOT}/usr/local CONFDIR=${FAKEROOT}/etc/
 $ cd .. && rm -rf kmod-tree && cp -Lpr ${FAKEROOT} kmod-tree
 ----
 
-. Create a Butane config file, `99-simple-kmod.bu`, that embeds the kernel module tree and enables the systemd service:
+. Create a Butane config file, `99-simple-kmod.bu`, that embeds the kernel module tree and enables the systemd service.
++
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
 [source,yaml]
 ----

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -107,7 +107,12 @@ Some methods for configuring static IPs do not affect the initramfs after the fi
 $ ./openshift-install create manifests --dir=<installation_directory>
 ----
 
-. Create a Butane config that configures disk encryption, mirroring, or both. For example, to configure storage for worker nodes, create a `$HOME/clusterconfig/worker-storage.bu` file:
+. Create a Butane config that configures disk encryption, mirroring, or both. For example, to configure storage for worker nodes, create a `$HOME/clusterconfig/worker-storage.bu` file.
++
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
 [source,yaml]
 .Butane config example

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -89,7 +89,7 @@ The Ignition facility runs only when the {op-system} system is first set up. Aft
 
 Ignition is the utility that is used by {op-system} to manipulate disks during initial configuration. It completes common disk tasks, including partitioning disks, formatting partitions, writing files, and configuring users. On first boot, Ignition reads its configuration from the installation media or the location that you specify and applies the configuration to the machines.
 
-Whether you are installing your cluster or adding machines to it, Ignition always performs the initial configuration of the {product-title} cluster machines. Most of the actual system setup happens on each machine itself. For each machine, Ignition takes the {op-system} image and boots the {op-system} kernel. Options on the kernel command line, identify the type of deployment and the location of the Ignition-enabled initial Ram disk (initramfs).
+Whether you are installing your cluster or adding machines to it, Ignition always performs the initial configuration of the {product-title} cluster machines. Most of the actual system setup happens on each machine itself. For each machine, Ignition takes the {op-system} image and boots the {op-system} kernel. Options on the kernel command line identify the type of deployment and the location of the Ignition-enabled initial RAM disk (initramfs).
 
 ////
 ////
@@ -101,24 +101,20 @@ To create machines by using Ignition, you need Ignition config files. The {produ
 
 The way that Ignition configures machines is similar to how tools like https://cloud-init.io/[cloud-init] or Linux Anaconda https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index#chap-kickstart-installations[kickstart] configure systems, but with some important differences:
 
-////
-The order of information in those files does not matter. For example, if a file needs a directory several levels deep, if another file needs a directory along that path, the later file is created first. Ignition sorts and creates all files, directories, and links by depth.
-////
-
-* Ignition runs from an initial RAM disk that is separate from the system you are installing to. Because of that, Ignition can repartition disks, set up file systems, and perform other changes to the machine’s permanent file system. In contrast, cloud-init runs as part of a machine’s init system when the system boots, so making foundational changes to things like disk partitions cannot be done as easily. With cloud-init, it is also difficult to reconfigure the boot process while you are in the middle of the node's boot process.
+* Ignition runs from an initial RAM disk that is separate from the system you are installing to. Because of that, Ignition can repartition disks, set up file systems, and perform other changes to the machine’s permanent file system. In contrast, cloud-init runs as part of a machine init system when the system boots, so making foundational changes to things like disk partitions cannot be done as easily. With cloud-init, it is also difficult to reconfigure the boot process while you are in the middle of the node boot process.
 
 * Ignition is meant to initialize systems, not change existing systems. After a machine initializes and the kernel is running from the installed system, the Machine Config Operator from the {product-title} cluster completes all future machine configuration.
 * Instead of completing a defined set of actions, Ignition implements a declarative configuration. It checks that all partitions, files, services, and other items are in place before the new machine starts. It then makes the changes, like copying files to disk that are necessary for the new machine to meet the specified configuration.
 
 * After Ignition finishes configuring a machine, the kernel keeps running but discards the initial RAM disk and pivots to the installed system on disk. All of the new system services and other features start without requiring a system reboot.
 
-* Because Ignition confirms that all new machines meet the declared configuration, you cannot have a partially-configured machine. If a machine’s setup fails, the initialization process does not finish, and Ignition does not start the new machine. Your cluster will never contain partially-configured machines. If Ignition cannot complete, the machine is not added to the cluster. You must add a new machine instead. This behavior prevents the difficult case of debugging a machine when the results of a failed configuration task are not known until something that depended on it fails at a later date.
+* Because Ignition confirms that all new machines meet the declared configuration, you cannot have a partially configured machine. If a machine setup fails, the initialization process does not finish, and Ignition does not start the new machine. Your cluster will never contain partially configured machines. If Ignition cannot complete, the machine is not added to the cluster. You must add a new machine instead. This behavior prevents the difficult case of debugging a machine when the results of a failed configuration task are not known until something that depended on it fails at a later date.
 
-* If there is a problem with an Ignition config that causes the setup of a machine to fail, Ignition will not try to use the same config to set up another machine. For example, a failure could result from an Ignition config made up of a parent and child config that both want to create the same file. A failure in such a case would prevent that Ignition config from being used again to set up an other machines, until the problem is resolved.
+* If there is a problem with an Ignition config that causes the setup of a machine to fail, Ignition will not try to use the same config to set up another machine. For example, a failure could result from an Ignition config made up of a parent and child config that both want to create the same file. A failure in such a case would prevent that Ignition config from being used again to set up an other machines until the problem is resolved.
 
-* If you have multiple Ignition config files, you get a union of that set of configs.  Because Ignition is declarative, conflicts between the configs could cause Ignition to fail to set up the machine. The order of information in those files does not matter. Ignition will sort and implement each setting in ways that make the most sense. For example, if a file needs a directory several levels deep, if another file needs a directory along that path, the later file is created first. Ignition sorts and creates all files, directories, and links by depth.
+* If you have multiple Ignition config files, you get a union of that set of configs. Because Ignition is declarative, conflicts between the configs could cause Ignition to fail to set up the machine. The order of information in those files does not matter. Ignition will sort and implement each setting in ways that make the most sense. For example, if a file needs a directory several levels deep, if another file needs a directory along that path, the later file is created first. Ignition sorts and creates all files, directories, and links by depth.
 
-* Because Ignition can start with a completely empty hard disk, it can do something cloud-init cannot do: set up systems on bare metal from scratch (using features such as PXE boot). In the bare metal case, the Ignition config is injected into the boot partition so Ignition can find it and configure the system correctly.
+* Because Ignition can start with a completely empty hard disk, it can do something cloud-init cannot do: set up systems on bare metal from scratch using features such as PXE boot. In the bare metal case, the Ignition config is injected into the boot partition so that Ignition can find it and configure the system correctly.
 
 
 [id="ignition-sequence_{context}"]
@@ -133,9 +129,9 @@ The Ignition process for an {op-system} machine in an {product-title} cluster in
 * Ignition runs `systemd` temporary files to populate required files in the `/var` directory.
 * Ignition runs the Ignition config files to set up users, systemd unit files, and other configuration files.
 * Ignition unmounts all components in the permanent system that were mounted in the initramfs.
-* Ignition starts up new machine’s init process which, in turn, starts up all other services on the machine that run during system boot.
+* Ignition starts up the init process of the new machine, which in turn starts up all other services on the machine that run during system boot.
 
-The machine is then ready to join the cluster and does not require a reboot.
+At the end of this process, the machine is ready to join the cluster and does not require a reboot.
 
 ////
 After Ignition finishes its work on an individual machine, the kernel pivots to the installed system. The initial RAM disk is no longer used and the kernel goes on to run the init service to start up everything on the host from the installed disk. When the last machine under the bootstrap machine’s control is completed, and the services on those machines come up, the work of the bootstrap machine is over.


### PR DESCRIPTION
[OSDOCS-1997](https://issues.redhat.com/browse/OSDOCS-1997) - Adds a new module for an overview of Butane, including download instructions from mirror.openshift.com and a basic YAML example based on information from coreos/butane (https://coreos.github.io/butane/getting-started/). 

**Preview link:**
_Configuring machine configs with Butane_
https://deploy-preview-33794--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-butane_installing-customizing