### PR TITLE
OSDOCS-1811: Omit network policy Ingress Controller exception

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -47,11 +47,6 @@ spec:
 +
 To make a project allow only connections from the {product-title} Ingress Controller, add the following `NetworkPolicy` object.
 +
-[IMPORTANT]
-====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
-====
-+
 [source,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -68,11 +63,6 @@ spec:
   policyTypes:
   - Ingress
 ----
-+
-If the Ingress Controller is configured with `endpointPublishingStrategy: HostNetwork`, then the Ingress Controller pod runs on the host network.
-When running on the host network, the traffic from the Ingress Controller is assigned the `netid:0` Virtual Network ID (VNID).
-The `netid` for the namespace that is associated with the Ingress Operator is different, so the `matchLabel` in the `allow-from-openshift-ingress` network policy does not match traffic from the `default` Ingress Controller.
-With OpenShift SDN, the `default` namespace is assigned the `netid:0` VNID and you can allow traffic from the `default` Ingress Controller by labeling your `default` namespace with `network.openshift.io/policy-group: ingress`.
 
 * Only accept connections from pods within a project:
 +


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1811

This is necessary if https://github.com/openshift/openshift-docs/pull/33350 does not land, which is possible.