### PR TITLE
BZ1808776: Fixed incorrect route in step 3 of the blue-green deployment procedure

### DIFF
--- a/modules/deployments-blue-green.adoc
+++ b/modules/deployments-blue-green.adoc
@@ -49,7 +49,7 @@ $ oc new-app openshift/deployment-example:v2 --name=example-green
 $ oc expose svc/example-blue --name=bluegreen-example
 ----
 
-. Browse to the application at `example-blue.<project>.<router_domain>` to verify you see the `v1` image.
+. Browse to the application at `bluegreen-example-<project>.<router_domain>` to verify you see the `v1` image.
 
 . Edit the route and change the service name to `example-green`:
 +


### PR DESCRIPTION
Applies to 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1808776

Doc preview link: https://deploy-preview-33809--osdocs.netlify.app/openshift-enterprise/latest/applications/deployments/route-based-deployment-strategies?utm_source=github&utm_campaign=bot_dp#deployments-blue-green-setting-up_route-based-deployment-strategies

Requires QE approval from @wzheng1 @zhouying7780 
