### PR TITLE
[Enterprise-4.6]: Fixed malformed cherry pick within the NTP Configurations.

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -302,17 +302,12 @@ ifndef::azure,gcp[]
 [discrete]
 == NTP configuration
 
-<<<<<<< HEAD
-An {product-title} cluster that is installed in a restricted network is configured to use a public Network Time Protocol (NTP) server by default. To avoid clock skew, reconfigure the cluster to use a private NTP server instead. For more information, see the documentation for _Configuring chrony time service_.
-=======
 {product-title} clusters are configured to use a public Network Time Protocol (NTP) server by default. If you want to use a local enterprise NTP server, or if your cluster is being deployed in a disconnected network, you can configure the cluster to use a specific time server. For more information, see the documentation for _Configuring chrony time service_.
 
 ifndef::ibm-z[]
 If a DHCP server provides NTP server information, the chrony time service on the {op-system-first} machines read the information and can sync the clock with the NTP servers.
 endif::ibm-z[]
 endif::azure,gcp[]
->>>>>>> af7d0cc4e... Add networking and port info for Azure/GCP UPI
-
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]


### PR DESCRIPTION
This pull request fixes a module that had artifacts from a bad cherry pick.

Follow-up to https://github.com/openshift/openshift-docs/pull/33705