### PR TITLE
[Enterprise-4.7+]: Removed a duplicated sentence in the NTP Configuration module.

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -225,8 +225,6 @@ ifndef::azure,gcp[]
 [discrete]
 == NTP configuration for user-provisioned infrastructure
 
-Each {product-title} node in the cluster must have access to a Network Time Protocol (NTP) server.
-
 {product-title} clusters are configured to use a public Network Time Protocol (NTP) server by default. If you want to use a local enterprise NTP server, or if your cluster is being deployed in a disconnected network, you can configure the cluster to use a specific time server. For more information, see the documentation for _Configuring chrony time service_.
 
 ifndef::ibm-z[]


### PR DESCRIPTION
This pull request removes a redundant line in the NTP Configuration module.