### PR TITLE
OSDOCS-1846: Adding known issue for docs for kubeletconfig TLS securi…

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1245,6 +1245,8 @@ You can attempt to resolve the issue with the steps in this link:https://kb.vmwa
 
 * An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace, at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. To track this issue, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*]).
 
+* The description for the `tlsSecurityProfile` field of the `kubeletconfig` resource (for example when using the `oc explain` command) does not list the correct ciphers for the TLS security profiles. As a workaround, review the list of ciphers in the `/etc/kubernetes/kubelet.conf` file of an affected node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971899[*BZ#1971899*])
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
…ty profiles

https://issues.redhat.com/browse/OSDOCS-1846

Preview: https://deploy-preview-33829--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-known-issues