### PR TITLE
OSDOCS-2271: Changed docs.openshift URLs to Customer Portal URLs

### DIFF
--- a/monitoring/osd-understanding-the-monitoring-stack.adoc
+++ b/monitoring/osd-understanding-the-monitoring-stack.adoc
@@ -21,8 +21,8 @@ include::modules/osd-monitoring-targets-for-user-defined-projects.adoc[leveloffs
 == Additional resources
 
 * xref:../monitoring/osd-accessing-monitoring-for-user-defined-projects.adoc#osd-accessing-monitoring-for-user-defined-projects[Accessing monitoring for user-defined projects]
-* link:https://docs.openshift.com/container-platform/4.7/monitoring/understanding-the-monitoring-stack.html#default-monitoring-components_understanding-the-monitoring-stack[Default monitoring components]
-* link:https://docs.openshift.com/container-platform/4.7/monitoring/understanding-the-monitoring-stack.html#default-monitoring-targets_understanding-the-monitoring-stack[Default monitoring targets]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/monitoring/understanding-the-monitoring-stack#default-monitoring-components_understanding-the-monitoring-stack[Default monitoring components]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/monitoring/understanding-the-monitoring-stack#default-monitoring-targets_understanding-the-monitoring-stack[Default monitoring targets]
 // TODO: When there is a link to the OCP docs, should that be explicit, so they're not surprised when they find themselves in another doc set?
 
 [id="understanding-the-monitoring-stack-next-steps"]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2271

**Previews:**

- https://deploy-preview-33835--osdocs.netlify.app/openshift-rosa/latest/welcome/index.html

- https://deploy-preview-33835--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/osd-aws-privatelink-creating-cluster.html#osd-aws-privatelink-create-cluster.adoc_rosa-getting-started

- https://deploy-preview-33835--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites

- https://deploy-preview-33835--osdocs.netlify.app/openshift-rosa/latest/monitoring/osd-understanding-the-monitoring-stack.html

- https://deploy-preview-33835--osdocs.netlify.app/openshift-rosa/latest/monitoring/osd-configuring-the-monitoring-stack.html

**Note:** The Cloud Infrastructure Access section will be completely replaced by new topics and the URLs are updated in the new topics. That work is part of another JIRA card so not part of the scope of this PR. Thanks.

Please merge to branch: dedicated (or it might be named dedicated-4)

No QE required as these are not content changes.