### PR TITLE
OSSMDOC-352: OVN TP for OCP 4.6

### DIFF
--- a/modules/jaeger-rn-fixed-issues.adoc
+++ b/modules/jaeger-rn-fixed-issues.adoc
@@ -6,7 +6,7 @@ Module included in the following assemblies:
 ////
 
 [id="jaeger-rn-fixed-issues_{context}"]
-= Jaeger Fixed issues
+= Jaeger fixed issues
 ////
 Provide the following info for each issue if possible:
 Consequence - What user action or situation would make this problem appear  (If you have the foo option enabled and did x)? What did the customer experience as a result of the issue? What was the symptom?

--- a/modules/ossm-rn-technology-preview.adoc
+++ b/modules/ossm-rn-technology-preview.adoc
@@ -9,14 +9,14 @@ Module included in the following assemblies:
 [IMPORTANT]
 ====
 Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production.
-These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process. For more information about the support scope of Red Hat Technology Preview features, see the link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Support Scope].
 ====
 
-== OVNKubernetes Technology Preview
+== OVN-Kubernetes technology preview
 
-{ProductName} 2.0.1 introduces support for the OVN-Kubernetes network type on {product-title} 4.7.
+{ProductName} 2.0.1 introduces technology preview support for the OVN-Kubernetes network type on {product-title} 4.6 and 4.7.
 
-== WebAssembly Technology Preview
+== WebAsssembly technology preview
 
 {ProductName} 2.0.0 introduces support for WebAssembly extensions to Envoy Proxy.
 


### PR DESCRIPTION
Adding OCP 4.6 to the technology preview notice for OVN.

(Also updating heading levels and capitalization errors and porting fix for [OSSMDOC-333](https://issues.redhat.com/browse/OSSMDOC-333) to this PR in case it merges before #33716)