### PR TITLE
modules/update-service-mirror-release: Use 'oc image mirror ...' for the release image

### DIFF
--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -137,31 +137,21 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
 ----
 $ oc adm release mirror -a ${LOCAL_SECRET_JSON} --to-dir=${REMOVABLE_MEDIA_PATH}/mirror quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE}
 ----
-... Export a local temporary repository name:
+... Take the media to the restricted network environment and upload the images to the local container registry:
 +
 [source,terminal]
 ----
-$ TEMP_REPOSITORY='<temp_repository_name>'
+$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} <1>
 ----
 +
-For `<temp_repository_name>`, specify the name of a temporary repository to create in your
-registry, such as `ocp4/temp`.
-... Take the media to the restricted network environment and upload the images to the temporary repository in the local container registry. By uploading the images to the temporary repository, you can then mirror them to the final repositories so that the release images are mirrored to a separate repository.
+<1> For `REMOVABLE_MEDIA_PATH`, you must use the path where you mounted the removable media.
 +
-[source,terminal]
-----
-$ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mirror "file://openshift/release:${OCP_RELEASE}*" ${LOCAL_REGISTRY}/${TEMP_REPOSITORY} <1>
-----
+... Mirror the release image to a separate repository:
 +
 [source,terminal]
 ----
-$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
-     --from=${LOCAL_REGISTRY}/${TEMP_REPOSITORY} \
-     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
-     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+$ oc image mirror -a ${LOCAL_SECRET_JSON} ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} ${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
 ----
-+
-<1> For `REMOVABLE_MEDIA_PATH`, you must use the same path that you specified when you mirrored the images.
 
 ** If the local container registry is connected to the mirror host, push the release images directly to the local registry:
 +


### PR DESCRIPTION
We can't use:

```console
$ oc adm release mirror ...
```

to split the release image out into `LOCAL_RELEASE_IMAGES_REPOSITORY`, because `oc` does not currently understand mirroring.  So there's no way to tell it "the referenced images you're looking for are actually in `${LOCAL_REGISTRY}/${TEMP_REPOSITORY}`", and it fails with:

    error: unable to connect to quay.io/openshift-release-dev/ocp-v4.0-art-dev: Get "https://quay.io/v2/"...
    error: an error occurred during planning

Instead, send the images from disk directly to the target repositoy for referenced images, and then use `oc image mirror` again to copy the release image over to the release-image repository without worrying about referenced images.  We still need the release images in that separate repository to avoid Cincinnati consuming excessive memory trying to load referenced-image layers as if they were release images ([comment][1], [rhbz#1850781][2]).

I've also softened some `REMOVABLE_MEDIA_PATH` wording.  The important point is that `REMOVABLE_MEDIA_PATH` points to where the removable media is mounted for both commands, not that you use the same path string.  For example, maybe you mounted to `/mnt/a` on your external machine, and then mounted that media to `/mnt/b` on your internal machine.  You'd want to use `/mnt/b` for REMOVABLE_MEDIA_PATH when mirroring from disk, not `/mnt/a`.

[1]: https://github.com/openshift/openshift-docs/pull/29630#issuecomment-807921826
[2]: https://bugzilla.redhat.com/show_bug.cgi?id=1850781