### PR TITLE
OSSMDOC-328: istio differences

### DIFF
--- a/modules/ossm-multitenant.adoc
+++ b/modules/ossm-multitenant.adoc
@@ -4,7 +4,7 @@ Module included in the following assemblies:
 ////
 
 [id="ossm-multitenant-install_{context}"]
-= {ProductName} multitenant installation
+= Multitenant installations
 
 Whereas upstream Istio takes a single tenant approach, {ProductName} supports multiple independent control planes within the cluster. {ProductName} uses a multitenant operator to manage the control plane lifecycle.
 

--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -4,9 +4,9 @@ Module included in the following assemblies:
 ////
 
 [id="ossm-vs-istio_{context}"]
-= Differences between Istio and {ProductName}
+= Service Mesh features
 
-An installation of {ProductName} differs from an installation of Istio in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on OpenShift.
+The following features are different in {ProductShortName} and Istio.
 
 [id="ossm-cli-tool_{context}"]
 == Command line tool
@@ -90,7 +90,7 @@ spec:
 [id="ossm-envoy-services_{context}"]
 == Envoy services
 
-* {ProductName} does not support QUIC-based services.
+{ProductName} does not support QUIC-based services.
 
 [id="ossm-cni_{context}"]
 == Istio Container Network Interface (CNI) plug-in

--- a/service_mesh/v2x/ossm-vs-community.adoc
+++ b/service_mesh/v2x/ossm-vs-community.adoc
@@ -5,13 +5,9 @@ include::modules/ossm-document-attributes.adoc[]
 
 toc::[]
 
-An installation of {ProductName} differs from upstream Istio community installations in multiple ways. The modifications to {ProductName} are sometimes necessary to resolve issues, provide additional features, or to handle differences when deploying on {product-title}.
-
-The current release of {ProductName} differs from the current upstream Istio community release in the following ways:
+{ProductName} differs from an installation of Istio to provide additional features or to handle differences when deploying on {product-title}.
 
 // The following include statements pull in the module files that comprise the assembly.
-
-include::modules/ossm-multitenant.adoc[leveloffset=+1]
 
 include::modules/ossm-vs-istio.adoc[leveloffset=+1]
 [discrete]
@@ -19,6 +15,8 @@ include::modules/ossm-vs-istio.adoc[leveloffset=+1]
 ==== Additional resources
 
 * xref:../../service_mesh/v2x/ossm-traffic-manage.adoc#ossm-auto-route_routing-traffic[Automatic route creation]
+
+include::modules/ossm-multitenant.adoc[leveloffset=+1]
 
 include::modules/ossm-kiali-service-mesh.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- Aligned team: Service mesh
- For branches: 4.6, 4.7, 4.8
- https://issues.redhat.com/browse/OSSMDOC-328
- https://deploy-preview-33842--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-vs-community.html
- Mostly style updates. Switched the order of modules and renamed one.
- SME review: knrc
- QE review: yxun
- Peer review