### PR TITLE
OSDOCS-2111 Add release note for Power of Two Random Choices balancing algorithm for Ingress Controller

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -504,6 +504,18 @@ IP failover is now supported on {product-title} clusters on bare metal. IP failo
 
 For more information, see xref:../networking/configuring-ipfailover.adoc#configuring-ipfailover[Configuring IP failover].
 
+[id="ocp-4-8-ingress-controller-power-of-two-random-choices"]
+==== Power of Two Random Choices balancing algorithm for Ingress Controller
+
+{product-title} Ingress Controllers now use the link:https://www.haproxy.com/blog/power-of-two-load-balancing/[Power of Two Random Choices] balancing algorithm by default for more even balancing after reloading. As in earlier releases, the balancing algorithm for a specific route can still be configured using the `haproxy.router.openshift.io/balance` route annotation. For more information, see xref:../networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].
+
+To revert the Ingress Controller back to use the Least Corrections balancing algorithm, use the following `oc patch` command to specify `leastconn` as the default:
+
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge --patch='{"spec":{"unsupportedConfigOverrides":{"loadBalancingAlgorithm":"leastconn"}}}'
+----
+
 [id="ocp-4-8-storage"]
 === Storage
 [id="ocp-4-8-storage-gcp-pd-csi-ga"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2111

Preview: https://deploy-preview-33847--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-ingress-controller-power-of-two-random-choices