### PR TITLE
Since version compliance-operator-0.1.35 and file-integrity-operator-0.1.16, the channel is release-0.1

### DIFF
--- a/modules/compliance-operator-cli-installation.adoc
+++ b/modules/compliance-operator-cli-installation.adoc
@@ -47,13 +47,6 @@ spec:
   - openshift-compliance
 ----
 
-. Set the {product-title} major and minor version as an environment variable, which is used as the channel value in the next step:
-+
-[source,terminal]
-----
-$ OC_VERSION=$(oc version -o yaml | grep openshiftVersion | grep -o '[0-9]*[.][0-9]*' | head -1)
-----
-
 . Create the `Subscription` object YAML file by running:
 +
 [source,terminal]
@@ -70,7 +63,7 @@ metadata:
   name: compliance-operator-sub
   namespace: openshift-compliance
 spec:
-  channel: "${OC_VERSION}"
+  channel: "release-0.1"
   installPlanApproval: Automatic
   name: compliance-operator
   source: redhat-operators

--- a/modules/file-integrity-operator-installing-cli.adoc
+++ b/modules/file-integrity-operator-installing-cli.adoc
@@ -47,13 +47,6 @@ spec:
   - openshift-file-integrity
 ----
 
-. Set the {product-title} major and minor version as an environment variable, which is used as the channel value in the next step:
-+
-[source,terminal]
-----
-$ OC_VERSION=$(oc version -o yaml | grep openshiftVersion | grep -o '[0-9]*[.][0-9]*' | head -1)
-----
-
 . Create the `Subscription` object YAML file:
 +
 [source,terminal]
@@ -70,7 +63,7 @@ metadata:
   name: file-integrity-operator
   namespace: openshift-file-integrity
 spec:
-  channel: "${OC_VERSION}"
+  channel: "release-0.1"
   installPlanApproval: Automatic
   name: file-integrity-operator
   source: redhat-operators


### PR DESCRIPTION
Updated per discussion with @xiaojiey 

Preview builds:
https://deploy-preview-33852--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-cli_compliance-operator-installation

https://deploy-preview-33852--osdocs.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-installation.html#installing-file-integrity-operator-using-cli_file-integrity-operator-installation