### PR TITLE
OSDOCS-2114-RN Add Control DNS pod placement release note

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -516,6 +516,13 @@ To revert the Ingress Controller back to use the Least Connections balancing alg
 $ oc -n openshift-ingress-operator patch ingresscontroller/default --type=merge --patch='{"spec":{"unsupportedConfigOverrides":{"loadBalancingAlgorithm":"leastconn"}}}'
 ----
 
+[id="ocp-4-8-control-dns-pod-placement"]
+==== Control DNS pod placement
+
+In {product-title} 4.8, you can use a custom node selector and tolerations to configure the daemon set for CoreDNS to run or not run on certain nodes.
+
+For more information, see xref:../networking/dns-operator.adoc#nw-controlling-dns-pod-placement_dns-operator[Controlling DNS pod placement].
+
 [id="ocp-4-8-storage"]
 === Storage
 [id="ocp-4-8-storage-gcp-pd-csi-ga"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2114

Must merge after https://github.com/openshift/openshift-docs/pull/33237. (Checks will be broken until #33237 merges.)

Preview: https://deploy-preview-33853--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-control-dns-pod-placement