### PR TITLE
[virt] fixing repo names for 2.6

### DIFF
--- a/modules/virt-enabling-virt-repos.adoc
+++ b/modules/virt-enabling-virt-repos.adoc
@@ -8,9 +8,9 @@
 Red Hat offers {VirtProductName} repositories for both Red Hat Enterprise Linux 8
 and Red Hat Enterprise Linux 7:
 
-* Red Hat Enterprise Linux 8 repository: `cnv-2.5-for-rhel-8-x86_64-rpms`
+* Red Hat Enterprise Linux 8 repository: `cnv-2.6-for-rhel-8-x86_64-rpms`
 
-* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.5-rpms`
+* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.6-rpms`
 
 The process for enabling the repository in `subscription-manager` is the same
 in both platforms.


### PR DESCRIPTION
- no BZ or Jira, just noticed that this was not updated for 2.6
- CP to enterprise-4.7 and 4.8 (to be overwritten shortly in 4.8)
- [Preview build](https://deploy-preview-33860--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-installing-virtctl?utm_source=github&utm_campaign=bot_dp#virt-enabling-virt-repos_virt-installing-virtctl)