### PR TITLE
RHDEVDOCS-3119 Remove old warnings from modules/installation-initiali…

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -152,17 +152,6 @@ VMware vSphere.
 endif::vsphere,vmc[]
 ifdef::rhv[]
 {rh-virtualization-first}.
-
-[WARNING]
-====
-Due to a known issue with installing {product-title} versions 4.4 and 4.5 on {rh-virtualization-first} 4.4.1, you must customize `install-config.yaml` as described in link:https://access.redhat.com/solutions/5374251[OpenShift IPI installation on {rh-virtualization}-4.x failed with "Error: timeout while waiting for state to become 'up' (last state: 'down', timeout: 10m0s)"].  This defect is fixed in {rh-virtualization} 4.4.2.
-====
-ifndef::openshift-origin[]
-[WARNING]
-====
-Installing OpenShift Container Platform (OCP) version 4.6 on Red Hat Virtualization (RHV) requires RHV version 4.4. If you are running an earlier version of OCP on RHV 4.3, do not update it to OCP version 4.6. Red Hat has not tested running OCP version 4.6 on RHV version 4.3 and does not support this combination. Also see link:https://access.redhat.com/articles/4763741[{product-title} 4.x Tested Integrations (for x86_x64)].
-====
-endif::openshift-origin[]
 endif::rhv[]
 
 .Prerequisites


### PR DESCRIPTION
…zing.adoc in master

- Aligned team: Dev Tools
- For branches: master ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3119
- Direct link to doc preview:  https://deploy-preview-33862--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installation-initializing_installing-rhv-customizations
- SME review: @Gal-Zaidman 
- QE review: Removing obsolete content from master, not the current docs. QE review not required. 
- Peer review: @bergerhoffer @stoobie
- <All reviews complete. Please merge now>
