### PR TITLE
TELCODOCS-237: updating version number 4.7 to 4.8

### DIFF
--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -44,7 +44,7 @@ metadata:
 spec:
   containers:
   - name: dynamic-irq-pod
-    image: "quay.io/openshift-kni/cnf-tests:4.6"
+    image: "quay.io/openshift-kni/cnf-tests:4.8"
     command: ["sleep", "10h"]
     resources:
       requests:

--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -75,7 +75,7 @@ $ oc get packagemanifest performance-addon-operator -n openshift-marketplace -o 
 .Example output
 [source,terminal]
 ----
-4.7
+4.8
 ----
 
 .. Create the following Subscription CR and save the YAML in the `pao-sub.yaml` file:

--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -68,7 +68,7 @@ You can use the `ROLE_WORKER_CNF` variable to override the worker pool name:
 [source,terminal]
 ----
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e
-ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/test-run.sh
+ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 +
 [NOTE]
@@ -82,7 +82,7 @@ Assuming the `kubeconfig` file is in the current folder, the command for running
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 
 This allows your `kubeconfig` file to be consumed from inside the running container.
@@ -104,7 +104,7 @@ To perform the latency tests, run the following command:
 
 [source,termina]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 [NOTE]
 ====
@@ -114,7 +114,7 @@ You must run the latency test in discovery mode. For more information, see the D
 .Excerpt of a sample result of a 10-second latency test using the following command:
 [source,terminal]
 ----
-[root@cnf12-installer ~]# podman run --rm -v $KUBECONFIG:/kubeconfig:Z -e PERF_TEST_PROFILE=worker-cnf-2 -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=10 -e OSLAT_MAXIMUM_LATENCY=20 -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh
+[root@cnf12-installer ~]# podman run --rm -v $KUBECONFIG:/kubeconfig:Z -e PERF_TEST_PROFILE=worker-cnf-2 -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=10 -e OSLAT_MAXIMUM_LATENCY=20 -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 -ginkgo.focus="Latency"
 running /0_config.test -ginkgo.focus=Latency
 ----
@@ -174,7 +174,7 @@ For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the foll
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
@@ -186,7 +186,7 @@ You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
 ----
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
@@ -195,7 +195,7 @@ To run only the latency test, you must provide the `-ginkgo.focus` parameter and
 
 [source,terminal]
 ----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
 ----
 
 [NOTE]
@@ -223,7 +223,7 @@ Use this command to run in dry-run mode. This is useful for checking what is in 
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
 ----
 
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
@@ -244,7 +244,7 @@ Run this command from an intermediate machine that has access both to the cluste
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
 ----
 
 Then, follow the instructions in the following section about overriding the registry used to fetch the images.
@@ -256,7 +256,7 @@ This is done by setting the `IMAGE_REGISTRY` environment variable:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.7 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
@@ -333,7 +333,7 @@ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
 ----
 
 . Run the tests:
@@ -355,11 +355,11 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 [
     {
         "registry": "public.registry.io:5000",
-        "image": "imageforcnftests:4.7"
+        "image": "imageforcnftests:4.8"
     },
     {
         "registry": "public.registry.io:5000",
-        "image": "imagefordpdk:4.7"
+        "image": "imagefordpdk:4.8"
     }
 ]
 ----
@@ -368,7 +368,7 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
 ----
 
 [id="discovery-mode_{context}"]
@@ -561,7 +561,7 @@ A JUnit-compliant XML is produced by passing the `--junit` parameter together wi
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/test-run.sh --junit /path/to/junit
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --junit /path/to/junit
 ----
 
 [id="cnf-performing-end-to-end-tests-test-failure-report_{context}"]
@@ -571,7 +571,7 @@ A report with information about the cluster state and resources for troubleshoot
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/test-run.sh --report /path/to/report
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --report /path/to/report
 ----
 
 [id="cnf-performing-end-to-end-tests-podman_{context}"]
@@ -612,9 +612,9 @@ spec:
  hugepages:
   defaultHugepagesSize: "1G"
   pages:
-  -size: "1G"
-   count: 16
-   node: 0
+  - size: "1G"
+    count: 16
+    node: 0
  realTimeKernel:
   enabled: true
  numa:
@@ -632,7 +632,7 @@ To override the performance profile, the manifest must be mounted inside the con
 
 [source,termal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.6 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-cluster-impacts_{context}"]

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -89,7 +89,7 @@ EXTERNAL-IP   OS-IMAGE                                       	KERNEL-VERSION
 CONTAINER-RUNTIME
 cnf-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.21.0
 128.66.135.107   <none>    	        Red Hat Enterprise Linux CoreOS 46.82.202008252340-0 (Ootpa)
-4.18.0-211.rt5.23.el8.x86_64   cri-o://1.21.0-90.rhaos4.6.git4a0ac05.el8-rc.1
+4.18.0-211.rt5.23.el8.x86_64   cri-o://1.21.0-90.rhaos4.8.git4a0ac05.el8-rc.1
 [...]
 ----
 

--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -28,9 +28,9 @@ spec:
  hugepages:
   defaultHugepagesSize: "1G"
   pages:
-  -size: "1G"
-   count: 16
-   node: 0
+  - size: "1G"
+    count: 16
+    node: 0
  realTimeKernel:
   enabled: true  <3>
  numa:  <4>

--- a/modules/cnf-upgrading-performance-addon-operator.adoc
+++ b/modules/cnf-upgrading-performance-addon-operator.adoc
@@ -38,11 +38,11 @@ You can manually upgrade Performance Addon Operator to the next minor version by
 
 . Access the OpenShift web console and navigate to *Operators → Installed Operators*.
 
-. Click *Performance Addon Operator* to open the *Operator Details* page.
+. Click *Performance Addon Operator* to open the *Operator details* page.
 
-. Click the *Subscription* tab to open the *Subscription Overview* page.
+. Click the *Subscription* tab to open the *Subscription details* page.
 
-. In the *Channel* pane, click the pencil icon on the right side of the version number to open the *Change Subscription Update Channel* window.
+. In the *Update channel* pane, click the pencil icon on the right side of the version number to open the *Change Subscription update channel* window.
 
 . Select the next minor version. For example, if you want to upgrade to Performance Addon Operator 4.8, select *4.8*.
 


### PR DESCRIPTION
[TELCODOCS-237](https://issues.redhat.com/browse/TELCODOCS-237) - updating hardcoded version numbers to 4.8

Preview link:  https://deploy-preview-33875--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes

Making updates to the version number in section "Performance Addon Operator for low latency nodes"

4.7 updated to 4.8 here https://docs.openshift.com/container-platform/4.8/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#installing-the-performance-addon-operator_cnf-master 

At release time the version will report 4.8. Now if you test it will read 4.7 but at release time the PAO version to be picked up will be 4.8. 
CNF tests sections have been revised from 4.7 to 4.8 https://docs.openshift.com/container-platform/4.8/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-performing-end-to-end-tests-for-platform-verification_cnf-master