### PR TITLE
Fixing a few more build warnings

### DIFF
--- a/modules/identity-provider-htpasswd-update-users.adoc
+++ b/modules/identity-provider-htpasswd-update-users.adoc
@@ -72,6 +72,7 @@ metadata:
 type: Opaque
 data:
   htpasswd: <base64_encoded_htpasswd_file_contents>
+----
 ====
 
 . If you removed one or more users, you must additionally remove existing resources for each user.

--- a/modules/migration-mtc-cr-manifests.adoc
+++ b/modules/migration-mtc-cr-manifests.adoc
@@ -28,7 +28,7 @@ spec:
   destMigClusterRef:
     name: <destination_cluster_ref>
     namespace: openshift-migration
-  namespaces:
+  namespaces: <1>
     - <source_namespace_1>
     - <source_namespace_2>:<destination_namespace_3> <2>
 ----

--- a/modules/migration-updating-deprecated-internal-images.adoc
+++ b/modules/migration-updating-deprecated-internal-images.adoc
@@ -59,7 +59,7 @@ $ podman tag <registry_url>:<port>/openshift/<image> \ <1>
 +
 [source,terminal]
 ----
-$ podman push <registry_url>:<port>/openshift/<image>
+$ podman push <registry_url>:<port>/openshift/<image> <1>
 ----
 <1> Specify the {product-title} 4 cluster.
 

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -38,8 +38,8 @@ include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
 
-include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
-include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
+include::modules/osdk-bundle-operator.adoc[leveloffset=+3]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+3]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -47,8 +47,8 @@ include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
 
-include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
-include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
+include::modules/osdk-bundle-operator.adoc[leveloffset=+3]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+3]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -40,8 +40,8 @@ include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
 
-include::modules/osdk-bundle-operator.adoc[leveloffset=+4]
-include::modules/osdk-deploy-olm.adoc[leveloffset=+4]
+include::modules/osdk-bundle-operator.adoc[leveloffset=+3]
+include::modules/osdk-deploy-olm.adoc[leveloffset=+3]
 
 include::modules/osdk-create-cr.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fixing these build warnings:

```
asciidoctor: WARNING: modules/identity-provider-htpasswd-update-users.adoc: line 66: unterminated listing block
asciidoctor: WARNING: modules/osdk-bundle-operator.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/osdk-deploy-olm.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/osdk-bundle-operator.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/osdk-deploy-olm.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/osdk-bundle-operator.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/osdk-deploy-olm.adoc: line 16: section title out of sequence: expected level 3, got level 4
asciidoctor: WARNING: modules/migration-mtc-cr-manifests.adoc: line 35: no callout found for <1>
asciidoctor: WARNING: modules/migration-updating-deprecated-internal-images.adoc: line 64: no callout found for <1>
```

Preview:
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-bundle-deploy-olm_osdk-golang-tutorial
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-bundle-deploy-olm_osdk-ansible-tutorial
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-bundle-deploy-olm_osdk-helm-tutorial
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html#migration-mtc-cr-manifests_advanced-migration-options-3-4
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#migration-updating-deprecated-internal-images_troubleshooting-3-4
* https://deploy-preview-33876--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-htpasswd-identity-provider.html#identity-provider-htpasswd-update-users_configuring-htpasswd-identity-provider