### PR TITLE
BZ1893086: Openshift documentation missing intermediate CA in the RHV installation.

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -311,7 +311,8 @@ https://ovirtlab.example.com/ovirt-engine/api
 ----
 endif::openshift-origin[]
 +
-... For `Is the oVirt CA trusted locally?`, enter `Yes` since you have already set up a CA certificate. Otherwise, enter `No`.
+... For `Is the oVirt CA trusted locally?`, enter `Yes`, because you have already set up a CA certificate. Otherwise, enter `No`.
+
 ... For `oVirt's CA bundle`, if you entered `Yes` for the preceding question, copy the certificate content from `/etc/pki/ca-trust/source/anchors/ca.pem` and paste it here. Then, press `Enter` twice. Otherwise, if you entered `No` for the preceding question, this question does not appear.
 ... For `oVirt engine username`, enter the user name and profile of the {rh-virtualization} administrator using this format:
 +
@@ -361,7 +362,37 @@ endif::[]
 
 ifndef::restricted[]
 . Modify the `install-config.yaml` file. You can find more information about
-the available parameters in the *Installation configuration parameters* section.
+the available parameters in the "Installation configuration parameters" section.
++
+[NOTE]
+====
+If you have any intermediate CA certificates on the engine, verify that the certificates appear in the `ovirt-config.yaml` file and the `install-config.yaml` file. If they do not appear, add them as follows:
+
+. In the `~/.ovirt/ovirt-config.yaml` file:
++
+[source,yaml]
+----
+[ovirt_ca_bundle]: |
+     -----BEGIN CERTIFICATE-----
+     <MY_TRUSTED_CA>
+     -----END CERTIFICATE-----
+     -----BEGIN CERTIFICATE-----
+     <INTERMEDIATE_CA>
+     -----END CERTIFICATE-----
+----
+. In the `install-config.yaml` file:
++
+[source,yaml]
+----
+[additionalTrustBundle]: |
+     -----BEGIN CERTIFICATE-----
+     <MY_TRUSTED_CA>
+     -----END CERTIFICATE-----
+     -----BEGIN CERTIFICATE-----
+     <INTERMEDIATE_CA>
+     -----END CERTIFICATE-----
+----
+====
 endif::restricted[]
 
 ifdef::osp+restricted[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1893086
master
enterprise-4.8
enterprise-4.7