### PR TITLE
The route name should be less than 63 characters

### DIFF
--- a/updating/installing-update-service.adoc
+++ b/updating/installing-update-service.adoc
@@ -51,6 +51,12 @@ include::modules/update-service-create-service-web-console.adoc[leveloffset=+2]
 
 include::modules/update-service-create-service-cli.adoc[leveloffset=+2]
 
+[NOTE]
+====
+The policy engine route name must not be more than 63 characters based on RFC-1123. If you see `ReconcileCompleted` status as `false`  with the reason `CreateRouteFailed` caused by `host must conform to DNS 1123 naming convention
+and must be no more than 63 characters`, try creating the Update Service with a shorter name.
+====
+
 include::modules/update-service-configure-cvo.adoc[leveloffset=+2]
 
 [id="update-service-delete-service"]


### PR DESCRIPTION
As the route name must conform to DNS 1123 naming conventions

Signed-off-by: Lalatendu Mohanty <lmohanty@redhat.com>