### PR TITLE
CNV-3735 Planning according to object maximums

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2686,6 +2686,8 @@ Topics:
   Topics:
   - Name: Preparing your OpenShift cluster for OpenShift Virtualization
     File: preparing-cluster-for-virt
+  - Name: Planning your environment according to OpenShift Virtualization object maximums
+    File: virt-planning-environment-object-maximums
   - Name: Specifying nodes for OpenShift Virtualization components
     File: virt-specifying-nodes-for-virtualization-components
   - Name: Installing OpenShift Virtualization using the web console

--- a/modules/virt-tested-cluster-maximums.adoc
+++ b/modules/virt-tested-cluster-maximums.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// virt/install/virt-planning-environment-object-maximums.adoc
+
+[id="virt-tested-cluster-maximums_{context}"]
+= Tested cluster maximums for {VirtProductName}
+
+{VirtProductName} {VirtVersion} was tested with bare metal Installer Provisioned Infrastructure (IPI). The following table shows the tested cluster maximums for the {VirtProductName} {VirtVersion} release.
+
+|===
+|Object type |{VirtProductName} {VirtVersion} cluster maximums
+
+|Number of nodes
+|10
+
+|Number of virtual machines
+|1000
+
+|Number of virtual machines per node
+|100
+|===

--- a/virt/install/virt-planning-environment-object-maximums.adoc
+++ b/virt/install/virt-planning-environment-object-maximums.adoc
@@ -1,0 +1,17 @@
+[id="virt-planning-environment-object-maximums"]
+= Planning your environment according to {VirtProductName} object maximums
+include::modules/virt-document-attributes.adoc[]
+:context: virt-planning-environment-object-maximums
+
+toc::[]
+
+You can plan your {VirtProductName} {VirtVersion} cluster by considering tested object maximums. Guidelines for object maximums are based on the largest possible cluster. For smaller clusters, the maximums are lower. In most cases, exceeding these numbers results in lower overall performance. It does not necessarily mean that the cluster will fail.
+
+The maximum number of virtual machines in a node is determined by a number of variables that include the virtual machines' CPUs, memory, and network characteristics.
+
+include::modules/virt-tested-cluster-maximums.adoc[leveloffset=+1]
+
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[Planning your environment according to object maximums]


### PR DESCRIPTION
This PR is associated with [CNV-3735](https://issues.redhat.com/browse/CNV-3735).

The objective is to provided tested object maximums for OpenShift Virtualization. At this time, there is limited data being provided but plans are in place to provide more robust information in the nearby future.