### PR TITLE
OSDOCS-1838 IP failover support release note

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -495,6 +495,13 @@ The egress router CNI plug-in is generally available. The Cluster Network Operat
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/using-an-egress-router-ovn.adoc[Considerations for the use of an egress router pod].
 
+[id="ocp-4-8-ip-failover-support"]
+==== IP failover support on {product-title}
+
+IP failover is now supported on {product-title} clusters on bare metal. IP failover uses Keepalived to host a set of externally accessible VIP addresses on a set of hosts. Each VIP is only serviced by a single host at a time. Keepalived uses the Virtual Router Redundancy Protocol (VRRP) to determine which host, from the set of hosts, services which VIP. If a host becomes unavailable, or if the service that Keepalived is watching does not respond, the VIP is switched to another host from the set. This means a VIP is always serviced as long as a host is available.
+
+For more information, see xref:../networking/configuring-ipfailover.adoc#configuring-ipfailover[Configuring IP failover].
+
 [id="ocp-4-8-storage"]
 === Storage
 [id="ocp-4-8-storage-gcp-pd-csi-ga"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1838

Must merge after https://github.com/openshift/openshift-docs/pull/32538. Checks will fail until #32538 is merged. 

Preview: https://deploy-preview-33953--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-ip-failover-support
