### PR TITLE
Update Ignition spec 2.2.0 configs; clean up some configs

### DIFF
--- a/modules/cnf-installing-the-operators.adoc
+++ b/modules/cnf-installing-the-operators.adoc
@@ -151,27 +151,25 @@ cat <<EOF | oc apply -f -
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  name: load-sctp-module
   labels:
     machineconfiguration.openshift.io/role: worker-cnf
-  name: load-sctp-module
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.1.0
     storage:
       files:
-        - contents:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          mode: 0644
+          overwrite: true
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
-          mode: 420
-          path: /etc/modprobe.d/sctp-blacklist.conf
-        - contents:
-            source: data:text/plain;charset=utf-8,sctp
-          filesystem: root
-          mode: 420
-          path: /etc/modules-load.d/sctp-load.conf
-
+        - path: /etc/modules-load.d/sctp-load.conf
+          mode: 0644
+          overwrite: true
+          contents:
+            source: data:,sctp
 EOF
 ----
 

--- a/modules/compliance-review.adoc
+++ b/modules/compliance-review.adoc
@@ -20,14 +20,13 @@ spec:
     spec:
       config:
         ignition:
-          version: 2.2.0
+          version: 3.1.0
         storage:
           files:
-            - contents:
-              source: data:,net.ipv4.conf.all.accept_redirects%3D0
-              filesystem: root
-              mode: 420
-              path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_accept_redirects.conf
+            - path: /etc/sysctl.d/75-sysctl_net_ipv4_conf_all_accept_redirects.conf
+              mode: 0644
+              contents:
+                source: data:,net.ipv4.conf.all.accept_redirects%3D0
   outdated: {}
 status:
   applicationState: NotApplied

--- a/modules/creating-infra-machines.adoc
+++ b/modules/creating-infra-machines.adoc
@@ -88,20 +88,19 @@ $ cat infra.mc.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  name: 51-infra
   labels:
     machineconfiguration.openshift.io/role: infra
-  name: 51-infra
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.1.0
     storage:
       files:
-      - contents:
-          source: data:,infra
-        filesystem: root
+      - path: /etc/infratest
         mode: 0644
-        path: /etc/infratest
+        contents:
+          source: data:,infra
 ----
 
 .  Apply the machine config, then verify that the infra-labeled nodes are updated with the configuration file:

--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -61,24 +61,18 @@ spec:
           WantedBy=multi-user.target
     storage:
       files:
-        - contents:
+        - path: /etc/kubernetes/manifests/keepalived.yaml
+          mode: 0644
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
-          mode: 420
-          path: /etc/kubernetes/manifests/keepalived.yaml
-        - contents:
+        - path: /etc/kubernetes/manifests/mdns-publisher.yaml
+          mode: 0644
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
-          mode: 420
-          path: /etc/kubernetes/manifests/mdns-publisher.yaml
-        - contents:
+        - path: /etc/kubernetes/manifests/coredns.yaml
+          mode: 0644
+          contents:
             source: data:,
-            verification: {}
-          filesystem: root
-          mode: 420
-          path: /etc/kubernetes/manifests/coredns.yaml
 ----
 +
 This manifest places the `apiVIP` and `ingressVIP` virtual IP addresses on the control plane nodes. Additionally, this manifest deploys the following processes on the control plane nodes only:

--- a/modules/networking-osp-enabling-metadata.adoc
+++ b/modules/networking-osp-enabling-metadata.adoc
@@ -27,10 +27,9 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
 spec:
-  osImageURL: ''
   config:
     ignition:
-      version: 2.2.0
+      version: 3.1.0
     systemd:
       units:
         - name: create-mountpoint-var-config.service

--- a/modules/networking-osp-enabling-vfio-noiommu.adoc
+++ b/modules/networking-osp-enabling-vfio-noiommu.adoc
@@ -22,18 +22,15 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
 spec:
-  osImageURL: ''
   config:
     ignition:
-      version: 2.2.0
+      version: 3.1.0
     storage:
       files:
-      - filesystem: root
-        path: "/etc/modprobe.d/vfio-noiommu.conf"
-        contents:
-          source: data:text/plain;charset=utf-8;base64,b3B0aW9ucyB2ZmlvIGVuYWJsZV91bnNhZmVfbm9pb21tdV9tb2RlPTEK
-          verification: {}
+      - path: /etc/modprobe.d/vfio-noiommu.conf
         mode: 0644
+        contents:
+          source: data:;base64,b3B0aW9ucyB2ZmlvIGVuYWJsZV91bnNhZmVfbm9pb21tdV9tb2RlPTEK
 ----
 <1> You can substitute a name of your choice.
 

--- a/modules/nw-sctp-enabling.adoc
+++ b/modules/nw-sctp-enabling.adoc
@@ -21,25 +21,25 @@ As a cluster administrator, you can load and enable the blacklisted SCTP kernel 
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
+  name: load-sctp-module
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: load-sctp-module
 spec:
   config:
     ignition:
       version: 3.1.0
     storage:
       files:
-        - contents:
+        - path: /etc/modprobe.d/sctp-blacklist.conf
+          mode: 0644
+          overwrite: true
+          contents:
             source: data:,
-          mode: 420
+        - path: /etc/modules-load.d/sctp-load.conf
+          mode: 0644
           overwrite: true
-          path: /etc/modprobe.d/sctp-blacklist.conf
-        - contents:
-            source: data:text/plain;charset=utf-8,sctp
-          mode: 420
-          overwrite: true
-          path: /etc/modules-load.d/sctp-load.conf
+          contents:
+            source: data:,sctp
 ----
 
 . To create the `MachineConfig` object, enter the following command:

--- a/modules/persistent-kubelet-log-level-configuration.adoc
+++ b/modules/persistent-kubelet-log-level-configuration.adoc
@@ -16,15 +16,11 @@ kind: MachineConfig
  spec:
    config:
      ignition:
-       config: {}
-       security:
-         tls: {}
-       timeouts: {}
-       version: 2.2.0
+       version: 3.1.0
      systemd:
        units:
          - name: kubelet.service
-           enable: true
+           enabled: true
            dropins:
              - name: 30-logging.conf
                contents: |


### PR DESCRIPTION
- Update remaining Ignition spec 2.2.0 configs to 3.1.0
- Drop obsolete or empty fields
- Sort some sections into a more logical field order
- Convert decimal file modes to octal
- Drop media type from data URLs
- Unquote file path
- Consistently use `overwrite: true` in SCTP docs

cc @bobfuru @miabbott 