### PR TITLE
Convert chrony configuration instructions to Butane

### DIFF
--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -27,75 +27,54 @@ to your nodes as a machine config.
 
 .Procedure
 
-. Create the contents of the `chrony.conf` file and encode it as base64. For example:
+. Create a Butane config including the contents of the `chrony.conf` file. For example, to configure chrony on worker nodes, create a `99-worker-chrony.bu` file.
 +
-[source,terminal]
-----
-$ cat << EOF | base64
-    pool 0.rhel.pool.ntp.org iburst <1>
-    driftfile /var/lib/chrony/drift
-    makestep 1.0 3
-    rtcsync
-    logdir /var/log/chrony
-EOF
-----
-<1> Specify any valid, reachable time source, such as the one provided by your DHCP server.
-ifndef::restricted[Alternately, you can specify any of the following NTP servers: `1.rhel.pool.ntp.org`, `2.rhel.pool.ntp.org`, or `3.rhel.pool.ntp.org`.]
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
-.Example output
-[source,terminal]
+[source,yaml]
 ----
-ICAgIHNlcnZlciBjbG9jay5yZWRoYXQuY29tIGlidXJzdAogICAgZHJpZnRmaWxlIC92YXIvbGli
-L2Nocm9ueS9kcmlmdAogICAgbWFrZXN0ZXAgMS4wIDMKICAgIHJ0Y3N5bmMKICAgIGxvZ2RpciAv
-dmFyL2xvZy9jaHJvbnkK
-----
-
-. Create the `MachineConfig` object file, replacing the base64 string with the one you just created.
-This example adds the file to `master` nodes. You can change it to `worker` or make an
-additional MachineConfig for the `worker` role. Create MachineConfig files for each type of machine that your cluster uses:
-+
-[source,terminal]
-----
-$ cat << EOF > ./99-masters-chrony-configuration.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 99-worker-chrony <1>
   labels:
-    machineconfiguration.openshift.io/role: master
-  name: 99-masters-chrony-configuration
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 3.2.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,ICAgIHNlcnZlciBjbG9jay5yZWRoYXQuY29tIGlidXJzdAogICAgZHJpZnRmaWxlIC92YXIvbGliL2Nocm9ueS9kcmlmdAogICAgbWFrZXN0ZXAgMS4wIDMKICAgIHJ0Y3N5bmMKICAgIGxvZ2RpciAvdmFyL2xvZy9jaHJvbnkK
-        mode: 420
-        overwrite: true
-        path: /etc/chrony.conf
-  osImageURL: ""
-EOF
+    machineconfiguration.openshift.io/role: worker <1>
+storage:
+  files:
+  - path: /etc/chrony.conf
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        pool 0.rhel.pool.ntp.org iburst <2>
+        driftfile /var/lib/chrony/drift
+        makestep 1.0 3
+        rtcsync
+        logdir /var/log/chrony
 ----
+<1> On control plane nodes, substitute `master` for `worker` in both of these locations.
+<2> Specify any valid, reachable time source, such as the one provided by your DHCP server.
+ifndef::restricted[Alternately, you can specify any of the following NTP servers: `1.rhel.pool.ntp.org`, `2.rhel.pool.ntp.org`, or `3.rhel.pool.ntp.org`.]
 
-. Make a backup copy of the configuration files.
+. Use Butane to generate a `MachineConfig` object file, `99-worker-chrony.yaml`, containing the configuration to be delivered to the nodes:
++
+[source,terminal]
+----
+$ butane 99-worker-chrony.bu -o 99-worker-chrony.yaml
+----
 
 . Apply the configurations in one of two ways:
 +
-* If the cluster is not up yet, after you generate manifest files, add this file to the `<installation_directory>/openshift`
-directory, and then continue to create the cluster.
+* If the cluster is not running yet, after you generate manifest files, add the `MachineConfig` object file to the `<installation_directory>/openshift` directory, and then continue to create the cluster.
 +
 * If the cluster is already running, apply the file:
 +
 [source,terminal]
 ----
- $ oc apply -f ./99-masters-chrony-configuration.yaml
+$ oc apply -f ./99-worker-chrony.yaml
 ----
 
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]

--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -23,216 +23,154 @@ image::152_OpenShift_Config_NTP_0421.svg[Configuring NTP for disconnected cluste
 
 .Procedure
 
-. Create a `~/control-plane-chrony.conf` configuration file for the control plane nodes.
+. Create a Butane config, `99-master-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the control plane nodes.
 +
-[source,terminal]
-.Configuration file example
-----
-# Use public servers from the pool.ntp.org project.
-# Please consider joining the pool (https://www.pool.ntp.org/join.html).
-
-# The Machine Config Operator manages this file
-server openshift-master-0.<cluster-name>.<domain> iburst <1>
-server openshift-master-1.<cluster-name>.<domain> iburst
-server openshift-master-2.<cluster-name>.<domain> iburst
-
-stratumweight 0
-driftfile /var/lib/chrony/drift
-rtcsync
-makestep 10 3
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
-keyfile /etc/chrony.keys
-commandkey 1
-generatecommandkey
-noclientlog
-logchange 0.5
-logdir /var/log/chrony
-
-# Configure the control plane nodes to serve as local NTP servers
-# for all worker nodes, even if they are not in sync with an
-# upstream NTP server.
-
-# Allow NTP client access from the local network.
-allow all
-# Serve time even if not synchronized to a time source.
-local stratum 3 orphan
-----
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
-<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
-
-. Create a `~/worker-chrony.conf` configuration file for the worker nodes such that worker nodes reference the NTP servers on the control plane nodes.
-+
-[source,terminal]
-.Configuration file example
+[source,yaml]
+.Butane config example
 ----
-# The Machine Config Operator manages this file.
-server openshift-master-0.<cluster-name>.<domain> iburst <1>
-server openshift-master-1.<cluster-name>.<domain> iburst
-server openshift-master-2.<cluster-name>.<domain> iburst
-
-stratumweight 0
-driftfile /var/lib/chrony/drift
-rtcsync
-makestep 10 3
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
-keyfile /etc/chrony.keys
-commandkey 1
-generatecommandkey
-noclientlog
-logchange 0.5
-logdir /var/log/chrony
-----
-+
-<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
-
-. Create a `~/ntp-server.yaml` configuration file for telling the Machine Configuration Operator to apply the `~/control-plane-chrony.conf` settings to the NTP servers on the control plane nodes.
-+
-[source,terminal]
-.Configuration file example
-----
-# This example MachineConfig replaces ~/control-plane-chrony.conf
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 99-master-chrony-conf-override
   labels:
     machineconfiguration.openshift.io/role: master
-  name: 99-master-etc-chrony-conf-override-to-server
-spec:
-  config:
-    ignition:
-      version: 2.2.0
-    storage:
-      files:
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,BASE64ENCODEDCONFIGFILE<1>
-          filesystem: root
-          mode: 0644
-          path: /etc/control-plane-chrony.conf
-----
-+
-<1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64-encoded string of the `~/control-plane-chrony.conf` file in the subsequent step.
+storage:
+  files:
+    - path: /etc/chrony.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # Use public servers from the pool.ntp.org project.
+          # Please consider joining the pool (https://www.pool.ntp.org/join.html).
 
-. Generate a base64 string of the `~/control-plane-chrony.conf` file.
-+
-[source,terminal]
-----
-$ base64 ~/control-plane-chrony.conf
-----
-+
-[source,terminal]
-.Example output
-----
-IyBVc2UgcHVibGljIHNlcnZlcnMgZnJvbSB0aGUgcG9vbC5udHAub3JnIHByb2plY3QuCiMgUGxl
-YXNlIGNvbnNpZGVyIGpvaW5pbmcgdGhlIHBvb2wgKGh0dHBzOi8vd3d3LnBvb2wubnRwLm9yZy9q
-b2luLmh0bWwpLgoKIyBUaGlzIGZpbGUgaXMgbWFuYWdlZCBieSB0aGUgbWFjaGluZSBjb25maWcg
-b3BlcmF0b3IKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMC48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
-PiBpYnVyc3QKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMS48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
-PiBpYnVyc3QKc2VydmVyIG9wZW5zaGlmdC1tYXN0ZXItMi48Y2x1c3Rlci1uYW1lPi48ZG9tYWlu
-PiBpYnVyc3QKCnN0cmF0dW13ZWlnaHQgMApkcmlmdGZpbGUgL3Zhci9saWIvY2hyb255L2RyaWZ0
-CnJ0Y3N5bmMKbWFrZXN0ZXAgMTAgMwpiaW5kY21kYWRkcmVzcyAxMjcuMC4wLjEKYmluZGNtZGFk
-ZHJlc3MgOjoxCmtleWZpbGUgL2V0Yy9jaHJvbnkua2V5cwpjb21tYW5ka2V5IDEKZ2VuZXJhdGVj
-b21tYW5ka2V5Cm5vY2xpZW50bG9nCmxvZ2NoYW5nZSAwLjUKbG9nZGlyIC92YXIvbG9nL2Nocm9u
-eQoKIyBDb25maWd1cmUgdGhlIGNvbnRyb2wgcGxhbmUgbm9kZXMgdG8gc2VydmUgYXMgbG9jYWwg
-TlRQIHNlcnZlcnMKIyBmb3IgYWxsIHdvcmtlciBub2RlcywgZXZlbiBpZiB0aGV5IGFyZSBub3Qg
-aW4gc3luYyB3aXRoIGFuCiMgdXBzdHJlYW0gTlRQIHNlcnZlci4KCiMgQWxsb3cgTlRQIGNsaWVu
-dCBhY2Nlc3MgZnJvbSB0aGUgbG9jYWwgbmV0d29yay4KYWxsb3cgYWxsCiMgU2VydmUgdGltZSBl
-dmVuIGlmIG5vdCBzeW5jaHJvbml6ZWQgdG8gYSB0aW1lIHNvdXJjZS4KbG9jYWwgc3RyYXR1bSAz
-IG9ycGhhbgo=
-----
-+
-Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-server.yaml` with the base64-encoded string.
+          # The Machine Config Operator manages this file
+          server openshift-master-0.<cluster-name>.<domain> iburst <1>
+          server openshift-master-1.<cluster-name>.<domain> iburst
+          server openshift-master-2.<cluster-name>.<domain> iburst
 
-. Create a `~/ntp-client.yaml` configuration file for telling the Machine Configuration Operator to apply the `~/worker-chrony.conf` settings to the NTP clients on the worker nodes.
+          stratumweight 0
+          driftfile /var/lib/chrony/drift
+          rtcsync
+          makestep 10 3
+          bindcmdaddress 127.0.0.1
+          bindcmdaddress ::1
+          keyfile /etc/chrony.keys
+          commandkey 1
+          generatecommandkey
+          noclientlog
+          logchange 0.5
+          logdir /var/log/chrony
+
+          # Configure the control plane nodes to serve as local NTP servers
+          # for all worker nodes, even if they are not in sync with an
+          # upstream NTP server.
+
+          # Allow NTP client access from the local network.
+          allow all
+          # Serve time even if not synchronized to a time source.
+          local stratum 3 orphan
+----
++
+<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
+
+. Use Butane to generate a `MachineConfig` object file, `99-master-chrony-conf-override.yaml`, containing the configuration to be delivered to the control plane nodes:
 +
 [source,terminal]
-.Configuration file example
 ----
-# This example MachineConfig replaces ~/worker-chrony.conf
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+$ butane 99-master-chrony-conf-override.bu -o 99-master-chrony-conf-override.yaml
+----
+
+. Create a Butane config, `99-worker-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the worker nodes that references the NTP servers on the control plane nodes.
++
+[source,yaml]
+.Butane config example
+----
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 99-worker-chrony-conf-override
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 99-master-etc-chrony-conf-override-for-worker
-spec:
-  config:
-    ignition:
-      version: 2.2.0
-    storage:
-      files:
-        - contents:
-            source: data:text/plain;charset=utf-8;base64,BASE64ENCODEDCONFIGFILE<1>
-          filesystem: root
-          mode: 0644
-          path: /etc/worker-chrony.conf
+storage:
+  files:
+    - path: /etc/chrony.conf
+      mode: 0644
+      overwrite: true
+      contents:
+        inline: |
+          # The Machine Config Operator manages this file.
+          server openshift-master-0.<cluster-name>.<domain> iburst <1>
+          server openshift-master-1.<cluster-name>.<domain> iburst
+          server openshift-master-2.<cluster-name>.<domain> iburst
+
+          stratumweight 0
+          driftfile /var/lib/chrony/drift
+          rtcsync
+          makestep 10 3
+          bindcmdaddress 127.0.0.1
+          bindcmdaddress ::1
+          keyfile /etc/chrony.keys
+          commandkey 1
+          generatecommandkey
+          noclientlog
+          logchange 0.5
+          logdir /var/log/chrony
 ----
 +
-<1> You must replace the `BASE64ENCODEDCONFIGFILE` string with the base64-encoded string of the `~/worker-chrony.conf` file in the subsequent step.
+<1> You must replace `<cluster-name>` with the name of the cluster and replace `<domain>` with the fully qualified domain name.
 
-
-. Generate a base64-encoded string of the `~/worker-chrony.conf` file.
+. Use Butane to generate a `MachineConfig` object file, `99-worker-chrony-conf-override.yaml`, containing the configuration to be delivered to the worker nodes:
 +
 [source,terminal]
 ----
-$ base64 ~/worker-chrony.conf
+$ butane 99-worker-chrony-conf-override.bu -o 99-worker-chrony-conf-override.yaml
 ----
-+
-[source,terminal]
-.Example output
-----
-IyBUaGlzIGZpbGUgaXMgbWFuYWdlZCBieSB0aGUgbWFjaGluZSBjb25maWcgb3BlcmF0b3IKc2Vy
-dmVyIG9wZW5zaGlmdC1tYXN0ZXItMC48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKc2Vy
-dmVyIG9wZW5zaGlmdC1tYXN0ZXItMS48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKc2Vy
-dmVyIG9wZW5zaGlmdC1tYXN0ZXItMi48Y2x1c3Rlci1uYW1lPi48ZG9tYWluPiBpYnVyc3QKCnN0
-cmF0dW13ZWlnaHQgMApkcmlmdGZpbGUgL3Zhci9saWIvY2hyb255L2RyaWZ0CnJ0Y3N5bmMKbWFr
-ZXN0ZXAgMTAgMwpiaW5kY21kYWRkcmVzcyAxMjcuMC4wLjEKYmluZGNtZGFkZHJlc3MgOjoxCmtl
-eWZpbGUgL2V0Yy9jaHJvbnkua2V5cwpjb21tYW5ka2V5IDEKZ2VuZXJhdGVjb21tYW5ka2V5Cm5v
-Y2xpZW50bG9nCmxvZ2NoYW5nZSAwLjUKbG9nZGlyIC92YXIvbG9nL2Nocm9ueQo=
-----
-+
-Replace the `BASE64ENCODEDCONFIGFILE` string in the `~/ntp-client.yaml` file with the base64-encoded string.
 
 ifeval::["{context}" == "ipi-install-configuration-files"]
-. Copy the `~/ntp-server.yaml` file to the `~/clusterconfigs/manifests` directory.
+. Copy the `99-master-chrony-conf-override.yaml` file to the `~/clusterconfigs/manifests` directory.
 +
 ----
-$ cp ~/ntp-server.yaml ~/clusterconfigs/manifests
+$ cp 99-master-chrony-conf-override.yaml ~/clusterconfigs/manifests
 ----
 
-. Copy the `~/ntp-client.yaml` file to the `~/clusterconfigs/manifests` directory.
+. Copy the `99-worker-chrony-conf-override.yaml` file to the `~/clusterconfigs/manifests` directory.
 +
 ----
-$ cp ~/ntp-client.yaml ~/clusterconfigs/manifests
+$ cp 99-worker-chrony-conf-override.yaml ~/clusterconfigs/manifests
 ----
 endif::[]
 
 ifeval::["{context}" == "ipi-install-post-installation-configuration"]
-. Apply the `ntp-server.yaml` policy to the control plane nodes.
+. Apply the `99-master-chrony-conf-override.yaml` policy to the control plane nodes.
 +
 [source,terminal]
 ----
-$ oc apply -f ~/ntp-server.yaml
+$ oc apply -f 99-master-chrony-conf-override.yaml
 ----
 +
 [source,terminal]
 .Example output
 ----
-machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-server created
+machineconfig.machineconfiguration.openshift.io/99-master-chrony-conf-override created
 ----
 
-. Apply the `~/ntp-client.yaml` policy to the worker nodes.
+. Apply the `99-worker-chrony-conf-override.yaml` policy to the worker nodes.
 +
 [source,terminal]
 ----
-$ oc apply -f ~/worker-chrony.conf
+$ oc apply -f 99-worker-chrony-conf-override.yaml
 ----
 +
 [source,terminal]
 .Example output
 ----
-machineconfig.machineconfiguration.openshift.io/99-master-etc-chrony-conf-override-for-worker created
+machineconfig.machineconfiguration.openshift.io/99-worker-chrony-conf-override created
 ----
 
 . Check the status of the applied NTP settings.

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -55,82 +55,55 @@ System clock synchronized: no
 
 .Addressing clock drift in existing clusters
 
-. Create a `chrony.conf` file and encode it as `base64` string. For example:
+. Create a Butane config file including the contents of the `chrony.conf` file to be delivered to the nodes. In the following example, create `99-master-chrony.bu` to add the file to the control plane nodes. You can modify the file for worker nodes or repeat this procedure for the worker role.
 +
-[source,terminal]
-----
-$ cat << EOF | base 64
-server <NTP-server> iburst<1>
-stratumweight 0
-driftfile /var/lib/chrony/drift
-rtcsync
-makestep 10 3
-bindcmdaddress 127.0.0.1
-bindcmdaddress ::1
-keyfile /etc/chrony.keys
-commandkey 1
-generatecommandkey
-noclientlog
-logchange 0.5
-logdir /var/log/chrony
-EOF
-----
-<1> Replace `<NTP-server>` with the IP address of the NTP server. Copy the output.
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
+[source,yaml]
 ----
-[text-in-base-64]
-----
-
-. Create a `MachineConfig` object, replacing the `base64` string with
-the `[text-in-base-64]` string generated in the output of the previous step. The following example adds the file to the control plane (master) nodes. You can modify the file for worker nodes or make an additional machine config for the worker role.
-+
-[source,terminal]
-----
-$ cat << EOF > ./99_masters-chrony-configuration.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
-  creationTimestamp: null
+  name: 99-master-chrony
   labels:
     machineconfiguration.openshift.io/role: master
-  name: 99-master-etc-chrony-conf
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 3.1.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,[text-in-base-64]<1>
-        group:
-          name: root
-        mode: 420
-        overwrite: true
-        path: /etc/chrony.conf
-        user:
-          name: root
-  osImageURL: ""
+storage:
+  files:
+  - path: /etc/chrony.conf
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        server <NTP-server> iburst <1>
+        stratumweight 0
+        driftfile /var/lib/chrony/drift
+        rtcsync
+        makestep 10 3
+        bindcmdaddress 127.0.0.1
+        bindcmdaddress ::1
+        keyfile /etc/chrony.keys
+        commandkey 1
+        generatecommandkey
+        noclientlog
+        logchange 0.5
+        logdir /var/log/chrony
 ----
-<1> Replace `[text-in-base-64]` with the base64 string.
+<1> Replace `<NTP-server>` with the IP address of the NTP server.
 
-. Make a backup copy of the configuration file. For example:
+. Use Butane to generate a `MachineConfig` object file, `99-master-chrony.yaml`, containing the configuration to be delivered to the nodes:
 +
 [source,terminal]
 ----
-$ cp 99_masters-chrony-configuration.yaml 99_masters-chrony-configuration.yaml.backup
+$ butane 99-master-chrony.bu -o 99-master-chrony.yaml
 ----
-
-. Apply the configuration file:
+. Apply the `MachineConfig` object file:
 +
 [source,terminal]
 ----
-$ oc apply -f ./masters-chrony-configuration.yaml
+$ oc apply -f 99-master-chrony.yaml
 ----
 
 . Ensure the `System clock synchronized` value is **yes**:


### PR DESCRIPTION
Avoid separately applying base64 to input files.

cc @bobfuru @miabbott 