### PR TITLE
Convert journald configuration instructions to Butane

### DIFF
--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -17,45 +17,62 @@ and other settings.
 
 .Procedure
 
-. Create a `journald.conf` file with the required settings:
+. Create a Butane config file, `40-worker-custom-journald.bu`, that includes an `/etc/systemd/journald.conf` file with the required settings.
 +
-[source,terminal]
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
++
+[source,yaml]
 ----
-Compress=yes <1>
-ForwardToConsole=no <2>
-ForwardToSyslog=no
-MaxRetentionSec=1month <3>
-RateLimitBurst=10000 <4>
-RateLimitIntervalSec=30s
-Storage=persistent <5>
-SyncIntervalSec=1s <6>
-SystemMaxUse=8g <7>
-SystemKeepFree=20% <8>
-SystemMaxFileSize=10M <9>
+variant: openshift
+version: 4.8.0
+metadata:
+  name: 40-worker-custom-journald
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  files:
+  - path: /etc/systemd/journald.conf
+    mode: 0644 <1>
+    overwrite: true
+    contents:
+      inline: |
+        Compress=yes <2>
+        ForwardToConsole=no <3>
+        ForwardToSyslog=no
+        MaxRetentionSec=1month <4>
+        RateLimitBurst=10000 <5>
+        RateLimitIntervalSec=30s
+        Storage=persistent <6>
+        SyncIntervalSec=1s <7>
+        SystemMaxUse=8g <8>
+        SystemKeepFree=20% <9>
+        SystemMaxFileSize=10M <10>
 ----
 +
-<1> Specify whether you want logs compressed before they are written to the file system.
+<1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions.
+<2> Specify whether you want logs compressed before they are written to the file system.
 Specify `yes` to compress the message or `no` to not compress. The default is `yes`.
-<2> Configure whether to forward log messages. Defaults to `no` for each. Specify:
+<3> Configure whether to forward log messages. Defaults to `no` for each. Specify:
 * `ForwardToConsole` to forward logs to the system console.
 * `ForwardToKsmg` to forward logs to the kernel log buffer.
 * `ForwardToSyslog` to forward to a syslog daemon.
 * `ForwardToWall` to forward messages as wall messages to all logged-in users.
-<3> Specify the maximum time to store journal entries. Enter a number to specify seconds. Or
+<4> Specify the maximum time to store journal entries. Enter a number to specify seconds. Or
 include a unit: "year", "month", "week", "day", "h" or "m". Enter `0` to disable. The default is `1month`.
-<4> Configure rate limiting. If, during the time interval defined by `RateLimitIntervalSec`, more logs than specified in `RateLimitBurst`
-are received, all further messages within the interval are dropped until the interval is over. It is recommended to set
-`RateLimitIntervalSec=30s` and `RateLimitBurst=10000`, which are the defaults.
-<5> Specify how logs are stored. The default is `persistent`:
+<5> Configure rate limiting. If more logs are received than what is specified in `RateLimitBurst` during the time interval defined by `RateLimitIntervalSec`, all further messages within the interval are dropped until the interval is over. It is recommended to set `RateLimitIntervalSec=30s` and `RateLimitBurst=10000`, which are the defaults.
+<6> Specify how logs are stored. The default is `persistent`:
 * `volatile` to store logs in memory in `/var/log/journal/`.
-* `persistent` to store logs to disk  in `/var/log/journal/`. systemd creates the directory if it does not exist.
-* `auto` to store logs in  in `/var/log/journal/` if the directory exists. If it does not exist, systemd temporarily stores logs in `/run/systemd/journal`.
+* `persistent` to store logs to disk in `/var/log/journal/`. systemd creates the directory if it does not exist.
+* `auto` to store logs in `/var/log/journal/` if the directory exists. If it does not exist, systemd temporarily stores logs in `/run/systemd/journal`.
 * `none` to not store logs. systemd drops all logs.
-<6> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs.
+<7> Specify the timeout before synchronizing journal files to disk for *ERR*, *WARNING*, *NOTICE*, *INFO*, and *DEBUG* logs.
 systemd immediately syncs after receiving a *CRIT*, *ALERT*, or *EMERG* log. The default is `1s`.
-<7> Specify the maximum size the journal can use. The default is `8g`.
-<8> Specify how much disk space systemd must leave free. The default is `20%`.
-<9> Specify the maximum size for individual journal files stored persistently in `/var/log/journal`. The default is `10M`.
+<8> Specify the maximum size the journal can use. The default is `8g`.
+<9> Specify how much disk space systemd must leave free. The default is `20%`.
+<10> Specify the maximum size for individual journal files stored persistently in `/var/log/journal`. The default is `10M`.
 +
 [NOTE]
 ====
@@ -68,47 +85,18 @@ For more information on systemd settings, see link:https://www.freedesktop.org/s
 +
 // Defaults from https://github.com/openshift/openshift-ansible/pull/3753/files#diff-40b7a7231e77d95ca6009dc9bcc0f470R33-R34
 
-. Convert the `journal.conf` file to base64:
+. Use Butane to generate a `MachineConfig` object file, `40-worker-custom-journald.yaml`, containing the configuration to be delivered to the nodes:
 +
 [source,terminal]
 ----
-$ export jrnl_cnf=$( cat /journald.conf | base64 -w0 )
+$ butane 40-worker-custom-journald.bu -o 40-worker-custom-journald.yaml
 ----
 
-. Create a `MachineConfig` object that includes the `jrnl_cnf` variable, which is the encoded contents of the `journald.conf` you created in the previous step.
-+
-For example:
+. Apply the machine config. For example:
 +
 [source,terminal]
 ----
-$ cat > /tmp/40-worker-custom-journald.yaml <<EOF
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: worker
-  name: 50-corp-journald
-spec:
-  config:
-    ignition:
-      version: 3.1.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${jrnl_cnf}
-        mode: 0644 <1>
-        overwrite: true
-        path: /etc/systemd/journald.conf <2>
-EOF
-----
-<1> Set the permissions for the `journal.conf` file. It is recommended to set `0644` permissions.
-<2> Specify the path to the base64-encoded `journal.conf` file.
-
-. Create the machine config. For example:
-+
-[source,terminal]
-----
-$ oc apply -f /tmp/40-worker-custom-journald.yaml
+$ oc apply -f 40-worker-custom-journald.yaml
 ----
 +
 The controller detects the new `MachineConfig` object and generates a new `rendered-worker-<hash>` version.

--- a/modules/machineconfig-modify-journald.adoc
+++ b/modules/machineconfig-modify-journald.adoc
@@ -11,73 +11,53 @@ If you need to configure settings for the `journald` service on {product-title} 
 This procedure describes how to modify `journald` rate limiting settings in the `/etc/systemd/journald.conf` file and apply them to worker nodes. See the `journald.conf` man page for information on how to use that file.
 
 .Prerequisites
-* Have a running {product-title} cluster (version 4.4 or later).
+* Have a running {product-title} cluster.
 * Log in to the cluster as a user with administrative privileges.
 
 .Procedure
 
-. Create the contents of the `/etc/systemd/journald.conf` file and encode it as base64. For example:
+. Create a Butane config file, `40-worker-custom-journald.bu`, that includes an `/etc/systemd/journald.conf` file with the required settings.
 +
-[source,terminal]
-----
-$ cat > /tmp/jrnl.conf <<EOF
-# Disable rate limiting
-RateLimitInterval=1s
-RateLimitBurst=10000
-Storage=volatile
-Compress=no
-MaxRetentionSec=30s
-EOF
-----
-
-. Convert the temporary `journal.conf` file to base64 and save it into a variable (`jrnl_cnf`):
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
-[source,terminal]
+[source,yaml]
 ----
-$ export jrnl_cnf=$( cat /tmp/jrnl.conf | base64 -w0 )
-$ echo $jrnl_cnf
-IyBEaXNhYmxlIHJhdGUgbGltaXRpbmcKUmF0ZUxpbWl0SW50ZXJ2YWw9MXMKUmF0ZUxpbWl0QnVyc3Q9MTAwMDAKU3RvcmFnZT12b2xhdGlsZQpDb21wcmVzcz1ubwpNYXhSZXRlbnRpb25TZWM9MzBzCg==
-----
-
-. Create the machine config, including the encoded contents of `journald.conf` (`jrnl_cnf` variable):
-+
-[source,terminal]
-----
-$ cat > /tmp/40-worker-custom-journald.yaml <<EOF
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 40-worker-custom-journald
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 40-worker-custom-journald
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 3.1.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${jrnl_cnf}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/systemd/journald.conf
-    systemd: {}
-  osImageURL: ""
-EOF
+storage:
+  files:
+  - path: /etc/systemd/journald.conf
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        # Disable rate limiting
+        RateLimitInterval=1s
+        RateLimitBurst=10000
+        Storage=volatile
+        Compress=no
+        MaxRetentionSec=30s
+----
+
+. Use Butane to generate a `MachineConfig` object file, `40-worker-custom-journald.yaml`, containing the configuration to be delivered to the worker nodes:
++
+[source,terminal]
+----
+$ butane 40-worker-custom-journald.bu -o 40-worker-custom-journald.yaml
 ----
 
 . Apply the machine config to the pool:
 +
 [source,terminal]
 ----
-$ oc apply -f /tmp/40-worker-custom-journald.yaml
+$ oc apply -f 40-worker-custom-journald.yaml
 ----
 
 . Check that the new machine config is applied and that the nodes are not in a degraded state. It might take a few minutes. The worker pool will show the updates in progress, as each node successfully has the new machine config applied:


### PR DESCRIPTION
Avoid separately applying base64 to input files.

cc @bobfuru @miabbott 