### PR TITLE
Convert container signature verification instructions to Butane

### DIFF
--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -4,125 +4,70 @@
 
 [id="containers-signature-verify-enable_{context}"]
 = Enabling signature verification for Red Hat Container Registries
-Enabling container signature validation requires files that link the registry URLs to the sigstore and then specifies the keys which verify the images.
+Enabling container signature validation for Red Hat Container Registries requires writing a signature verification policy file specifying the keys to verify images from these registries. The registries are already defined in `/etc/containers/registries.d` by default.
 
 .Procedure
-. Create the files that link the registry URLs to the sigstore and that specifies the key to verify the image.
-
-** Create the `policy.json` file:
+. Create a Butane config file, `51-worker-rh-registry-trust.bu`, containing the necessary configuration for the worker nodes.
 +
-[source,terminal]
-----
-$ cat > policy.json <<EOF
-{
-  "default": [
-    {
-      "type": "insecureAcceptAnything"
-    }
-  ],
-  "transports": {
-    "docker": {
-      "registry.access.redhat.com": [
-        {
-          "type": "signedBy",
-          "keyType": "GPGKeys",
-          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-        }
-      ],
-      "registry.redhat.io": [
-        {
-          "type": "signedBy",
-          "keyType": "GPGKeys",
-          "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
-        }
-      ]
-    },
-    "docker-daemon": {
-      "": [
-        {
-          "type": "insecureAcceptAnything"
-        }
-      ]
-    }
-  }
-}
-EOF
-----
-
-** Create the `registry.access.redhat.com.yaml` file:
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat <<EOF > registry.access.redhat.com.yaml
-docker:
-     registry.access.redhat.com:
-         sigstore: https://access.redhat.com/webassets/docker/content/sigstore
-EOF
-----
-
-** Create the `registry.redhat.io.yaml` file:
-+
-[source,terminal]
-----
-$ cat <<EOF > registry.redhat.io.yaml
-docker:
-     registry.redhat.io:
-         sigstore: https://registry.redhat.io/containers/sigstore
-EOF
-----
-
-. Set the files with a `base64` encode format that will be used for the machine config template:
-+
-[source,terminal]
-----
-$ export ARC_REG=$( cat registry.access.redhat.com.yaml | base64 -w0 )
-$ export RIO_REG=$( cat registry.redhat.io.yaml | base64 -w0 )
-$ export POLICY_CONFIG=$( cat policy.json | base64 -w0 )
-----
-
-. Create a machine config that writes the exported files to disk on the worker nodes:
-+
-[source,terminal]
-----
-$ cat > 51-worker-rh-registry-trust.yaml <<EOF
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 51-worker-rh-registry-trust
   labels:
     machineconfiguration.openshift.io/role: worker
-  name: 51-worker-rh-registry-trust
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 2.2.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${ARC_REG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/registries.d/registry.access.redhat.com.yaml
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${RIO_REG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/registries.d/registry.redhat.io.yaml
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${POLICY_CONFIG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/policy.json
-  osImageURL: ""
-EOF
+storage:
+  files:
+  - path: /etc/containers/policy.json
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        {
+          "default": [
+            {
+              "type": "insecureAcceptAnything"
+            }
+          ],
+          "transports": {
+            "docker": {
+              "registry.access.redhat.com": [
+                {
+                  "type": "signedBy",
+                  "keyType": "GPGKeys",
+                  "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+              ],
+              "registry.redhat.io": [
+                {
+                  "type": "signedBy",
+                  "keyType": "GPGKeys",
+                  "keyPath": "/etc/pki/rpm-gpg/RPM-GPG-KEY-redhat-release"
+                }
+              ]
+            },
+            "docker-daemon": {
+              "": [
+                {
+                  "type": "insecureAcceptAnything"
+                }
+              ]
+            }
+          }
+        }
+----
+
+. Use Butane to generate a machine config YAML file, `51-worker-rh-registry-trust.yaml`, containing the file to be written to disk on the worker nodes:
++
+[source,terminal]
+----
+$ butane 51-worker-rh-registry-trust.bu -o 51-worker-rh-registry-trust.yaml
 ----
 
 . Apply the created machine config:
@@ -132,52 +77,17 @@ EOF
 $ oc apply -f 51-worker-rh-registry-trust.yaml
 ----
 
-. Create a machine config, which writes the exported files to disk on the master nodes:
+. Create a Butane config and corresponding machine config which writes the configuration to disk on the control plane nodes:
 +
 [source,terminal]
 ----
-$ cat > 51-master-rh-registry-trust.yaml <<EOF
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  labels:
-    machineconfiguration.openshift.io/role: master
-  name: 51-master-rh-registry-trust
-spec:
-  config:
-    ignition:
-      config: {}
-      security:
-        tls: {}
-      timeouts: {}
-      version: 2.2.0
-    networkd: {}
-    passwd: {}
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${ARC_REG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/registries.d/registry.access.redhat.com.yaml
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${RIO_REG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/registries.d/registry.redhat.io.yaml
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,${POLICY_CONFIG}
-          verification: {}
-        filesystem: root
-        mode: 420
-        path: /etc/containers/policy.json
-  osImageURL: ""
-EOF
+$ sed -e 's,\(machineconfiguration.openshift.io/role: \)worker,\1master,' \
+    -e 's,\(name: 51-\)worker,\1master,' 51-worker-rh-registry-trust.bu \
+    > 51-master-rh-registry-trust.bu
+$ butane 51-master-rh-registry-trust.bu -o 51-master-rh-registry-trust.yaml
 ----
 
-. Apply the master machine config changes to the cluster:
+. Apply the control plane machine config to the cluster:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Avoid separately applying base64 to input files.  Generate the control plane config from the worker config to avoid repetition.  Stop writing the files in `/etc/containers/registries.d`, since they exist by default, but add language indicating their significance to reduce confusion.

cc @bobfuru 