### PR TITLE
Convert VFIO binding instructions to Butane

### DIFF
--- a/modules/virt-binding-devices-vfio-driver.adoc
+++ b/modules/virt-binding-devices-vfio-driver.adoc
@@ -10,48 +10,65 @@ To bind PCI devices to the VFIO (Virtual Function I/O) driver, obtain the values
 * You added kernel arguments to enable IOMMU for the CPU.
 
 .Procedure
-. Create the `MachineConfig` object to enable the binding of PCI devices to the VFIO driver.
+. Run the `lspci` command to obtain the `vendor-ID` and the `device-ID` for the PCI device.
++
+[source, terminal]
+----
+$ lspci -nnv | grep -i nvidia
+----
++
+.Example output
+[source, terminal]
+----
+02:01.0 3D controller [0302]: NVIDIA Corporation GV100GL [Tesla V100 PCIe 32GB] [10de:1eb8] (rev a1)
+----
+
+. Create a Butane config file, `100-worker-vfiopci.bu`, binding the PCI device to the VFIO driver.
++
+[NOTE]
+====
+See "Creating machine configs with Butane" for information about Butane.
+====
 +
 .Example
 [source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig <1>
+variant: openshift
+version: 4.8.0
 metadata:
+  name: 100-worker-vfiopci
   labels:
-    machineconfiguration.openshift.io/role: worker <2>
-  name: 100-worker-vfiopci-configuration <3>
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      files:
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,b3B0aW9ucyB2ZmlvLXBjaSBpZHM9MTBkZToxZWI4Cg== <4>
-        mode: 420 <5>
-        overwrite: true
-        path: /etc/modprobe.d/vfio.conf <6>
-      - contents:
-          source: data:text/plain;charset=utf-8;base64,dmZpby1wY2kK <7>
-        mode: 420
-        overwrite: true
-        path: /etc/modules-load.d/vfio-pci.conf <8>
+    machineconfiguration.openshift.io/role: worker <1>
+storage:
+  files:
+  - path: /etc/modprobe.d/vfio.conf
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: |
+        options vfio-pci ids=10de:1eb8 <2>
+  - path: /etc/modules-load.d/vfio-pci.conf <3>
+    mode: 0644
+    overwrite: true
+    contents:
+      inline: vfio-pci
 ----
-<1> The type of object being configured is `MachineConfig`.
-<2> Applies the new kernel argument only to worker nodes.
-<3> Named to identify where this `MachineConfig` object fits among the other `MachineConfig` objects.
-<4> The `echo "options vfio-pci ids=10de:1eb8" | base64` command creates the encoded text. The `vendor-ID` value (10de) and the `device-ID` value (1eb8) applies to a single device that binds to the VFIO driver. You can add a list of multiple devices for `source` with their vendor and device information.
-<5> The values specified for `mode` determine the permissions for the file.
-<6> The `/etc/modprobe.d/vfio.conf` was created by the `echo "options vfio-pci ids=10de:1eb8 > /etc/modprobe.d/vfio/conf"` command.
-<7> The `echo "dmZpby1wY2kK" | base64 -d` command and the `vfio-pci` commands create the encoded text for `source` as `dmZpby1wY2kK`. The encoded text translates to `vfio-pci`.
-<8> The file that loads the vfio-pci kernel module on the worker nodes.
+<1> Applies the new kernel argument only to worker nodes.
+<2> Specify the previously determined `vendor-ID` value (`10de`) and the `device-ID` value (`1eb8`) to bind a single device to the VFIO driver. You can add a list of multiple devices with their vendor and device information.
+<3> The file that loads the vfio-pci kernel module on the worker nodes.
 
-. Create a `MachineConfig` object that identifies the kernel argument for the IOMMU configuration:
+. Use Butane to generate a `MachineConfig` object file, `100-worker-vfiopci.yaml`, containing the configuration to be delivered to the worker nodes:
 +
 [source,terminal]
 ----
-$ oc create -f 100-worker-kernel-arg-iommu.yaml
+$ butane 100-worker-vfiopci.bu -o 100-worker-vfiopci.yaml
+----
+
+. Apply the `MachineConfig` object to the worker nodes:
++
+[source,terminal]
+----
+$ oc apply -f 100-worker-vfiopci.yaml
 ----
 
 . Verify that the `MachineConfig` object was added.
@@ -74,51 +91,6 @@ NAME                             GENERATEDBYCONTROLLER                      IGNI
 100-worker-iommu                                                            3.2.0            30s
 100-worker-vfiopci-configuration                                            3.2.0            30s
 ----
-
-. Run the `lspci` command to obtain the `vendor-ID` and the `device-ID` for the PCI device.
-+
-[source, terminal]
-----
-$ lspci -nnv | grep -i nvidia
-----
-+
-.Example output
-[source, terminal]
-----
-02:01.0 3D controller [0302]: NVIDIA Corporation GV100GL [Tesla V100 PCIe 32GB] [10de:1eb8] (rev a1)
-----
-
-. Specify the values for `vendor-ID` and `device-ID` and convert the `/etc/modprobe.d/vfio.conf` file to base64 format:
-+
-[source,terminal]
-----
-$ echo "options vfio-pci ids=10de:1eb8" | base64
-----
-These values are converted into the `base64 format` and the output is encoded.
-+
-.Example output
-[source,terminal]
-----
-b3B0aW9ucyB2ZmlvLXBjaSBpZHM9MTBkZToxZWI4Cg==
-----
-
-. Add the encoded text to `source` in the `MachineConfig` object.
-
-. Convert `vfio-pci` into base64 format and encode the text:
-+
-[source,terminal]
-----
-$ echo vfio-pci | base64
-----
-These values are converted into the `base64 format` and the output is encoded.
-+
-.Example output
-[source,terminal]
-----
-dmZpby1wY2kK
-----
-
-. Add the encoded text to `source` in the `MachineConfig` object.
 
 .Verification
 * Verify that the VFIO driver is loaded.


### PR DESCRIPTION
Avoid separately applying base64 to input files.  Reorder instructions for a more natural flow.  Remove footnotes on some routine configuration fields to help center the more relevant ones.

cc @bobfuru 