### PR TITLE
BZ1895054: OperatorGroup CSV annotations- changed olm.operatorGroupNamespace to olm.operatorNamespace

### DIFF
--- a/modules/olm-operatorgroups-csv-annotations.adoc
+++ b/modules/olm-operatorgroups-csv-annotations.adoc
@@ -14,7 +14,7 @@ Member CSVs of an Operator group have the following annotations:
 |`olm.operatorGroup=<group_name>`
 |Contains the name of the Operator group.
 
-|`olm.operatorGroupNamespace=<group_namespace>`
+|`olm.operatorNamespace=<group_namespace>`
 |Contains the namespace of the Operator group.
 
 |`olm.targetNamespaces=<target_namespaces>`


### PR DESCRIPTION
Applies to 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1895054

Direct link to the doc preview: https://deploy-preview-33966--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups?utm_source=github&utm_campaign=bot_dp#olm-operatorgroups-csv-annotations_olm-understanding-operatorgroups

Requires QA approval from @xltian 