### PR TITLE
RHDEVDOCS-2886: Docs for using custom pipeline template in Git import workflows

### DIFF
--- a/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+++ b/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
@@ -35,6 +35,8 @@ To create pipelines along with applications, use the *From Git* option in the *A
 
 include::modules/op-interacting-with-pipelines-using-the-developer-perspective.adoc[leveloffset=+1]
 
+include::modules/op-using-custom-pipeline-template-for-git-import.adoc[leveloffset=+1]
+
 include::modules/op-starting-pipelines.adoc[leveloffset=+1]
 
 include::modules/op-editing-pipelines.adoc[leveloffset=+1]

--- a/modules/op-using-custom-pipeline-template-for-git-import.adoc
+++ b/modules/op-using-custom-pipeline-template-for-git-import.adoc
@@ -1,0 +1,96 @@
+// This module is included in the following assembly:
+//
+// *openshift-docs/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+
+[id='using-custom-pipeline-template-for-git-import']
+= Using a custom pipeline template for creating and deploying an application from a Git repository
+
+:context: using-custom-pipeline-template-for-git-import
+
+toc::[]
+
+As a cluster administrator, to create and deploy an application from a Git repository, you can use custom pipeline templates that override the default pipeline templates provided by {pipelines-title} 1.5 and later.
+
+[NOTE]
+====
+This feature is unavailable in {pipelines-title} 1.4 and earlier versions.
+====
+
+.Prerequisites
+
+Ensure that the {pipelines-title} 1.5 or later is installed and available in all namespaces.
+
+.Procedure
+
+. Log in to the {product-title} web console as a cluster administrator.
+. In the *Administrator* perspective, use the left navigation panel to go to the _Pipelines_ section.
+.. From the *Project* drop-down, select the *openshift* project. This ensures that the subsequent steps are performed in the `openshift` namespace.
+.. From the list of available pipelines, select a pipeline that is appropriate for building and deploying your application. For example, if your application requires a `node.js` runtime environment, select the *s2i-nodejs* pipeline.
++
+[NOTE]
+====
+Do not edit the default pipeline template. It may become incompatible with the UI and the back-end.
+====
++
+.. Under the *YAML* tab of the selected pipeline, click *Download* and save the YAML file to your local machine. If your custom configuration file fails, you can use this copy to restore a working configuration.
+
+. Disable (delete) the default pipeline templates:
+.. Use the left navigation panel to go to **Operators** -> **Installed Operators**.
+.. Click *{pipelines-title}* -> *Tekton Configuration* tab -> *config* -> *YAML* tab.
+.. To disable (delete) the default pipeline templates in the `openshift` namespace, set the `pipelineTemplates` parameter to `false`  in the `TektonConfig` custom resource YAML, and save it.
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+profile: all
+targetNamespace: openshift-pipelines
+addon:
+  params:
+  - name: clusterTasks
+    value: "true"
+  - name: pipelineTemplates
+    value: "false"
+...
+----
++
+[NOTE]
+====
+If you manually delete the default pipeline templates, the operator will restore the defaults during an upgrade.
+====
++
+[WARNING]
+====
+As a cluster admin, you can disable installation of the default pipeline templates in the operator configuration. However, such a configuration will disable (delete) all default pipeline templates, and not only the one you want to customize.
+====
++
+
+. Create a custom pipeline template:
+.. Use the left navigation panel to go to the _Pipelines_ section.
+.. From the *Create* drop-down, select *Pipeline*.
+.. Create the required pipeline in the `openshift` namespace. Give it a different name than the default one (for example, `custom-nodejs`). You can use the downloaded default pipeline template as a starting point and customize it.
++
+[NOTE]
+====
+Because `openshift` is the default namespace used by the operator-installed pipeline templates, you must create the custom pipeline template in the `openshift` namespace. When an application uses a pipeline template, the template is automatically copied to the respective project’s namespace.
+====
++
+.. Under the *Details* tab of the created pipeline, ensure that the *Labels* in the custom template match the labels in the default pipeline. The custom pipeline template must have the correct labels for the runtime, type, and strategy of the application. For example, the required labels for a `node.js` application deployed on {product-title} are as follows:
++
+[source,yaml]
+----
+...
+pipeline.openshift.io/runtime: nodejs
+pipeline.openshift.io/type: openshift
+...
+----
++
+[NOTE]
+====
+You can use only one pipeline template for each combination of runtime environment and deployment type.
+====
++
+. In the *Developer* perspective, use the *+Add* -> *Git Repository* -> *From Git* option to select the kind of application you want to create and deploy. Based on the required runtime and type of the application, your custom template is automatically selected.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `4.8`
- **JIRA issues**: [RHDEVDOCS-2886](https://issues.redhat.com/browse/RHDEVDOCS-2886)
- **Preview pages**: [Using a custom pipeline template for creating and deploying an application from a Git repository](https://deploy-preview-33967--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/working-with-pipelines-using-the-developer-perspective?utm_source=github&utm_campaign=bot_dp#using-custom-pipeline-template-for-git-import)
- **Reviewer**: Nikhil Thomas, Pradeep Kumar, Andrew Ballantyne, Veeresh Aradhya, Pavol Pitonak

**NOTE**: The merge in OCP-4.7 has been reverted - https://github.com/openshift/openshift-docs/pull/34043