### PR TITLE
CNV 10760: Updating information about referencing NAD definitions in different namespaces

### DIFF
--- a/modules/virt-attaching-vm-secondary-network-cli.adoc
+++ b/modules/virt-attaching-vm-secondary-network-cli.adoc
@@ -37,18 +37,14 @@ spec:
       networks:
         - name: default
           pod: {}
-        - name: bridge-net <1>
+        - name: bridge-net <2>
           multus:
-            networkName: <network-namespace/a-bridge-network> <2>
+            networkName: <network-namespace>/<a-bridge-network> <3>
 ...
 ----
-<1> The name of the bridge interface. This value must match the `name` value of the corresponding `spec.template.spec.networks` entry.
-<2> The name of the network attachment definition.
-+
-[NOTE]
-====
-The example virtual machine is connected to both the `default` pod network and `bridge-net`, which is defined by a network attachment definition named `a-bridge-network`. If the network attachment definition is not in the same namespace as the VM, you must combine the namespace and the network name to create the network attachment definition name.
-====
+<1> The name of the bridge interface.
+<2> The name of the bridge interface. This value must match the `name` value of the corresponding `spec.template.spec.networks` entry.
+<3> The name of the network attachment definition, prefixed by the namespace where it exists. The namespace must be either the `default` namespace or the same namespace where the VM is to be created.
 
 . Apply the configuration:
 +


### PR DESCRIPTION
This PR addresses JIRA story [CNV-10760](https://issues.redhat.com/browse/CNV-10760) ( https://issues.redhat.com/browse/CNV-10760 ) and Bug 1935549 ( https://bugzilla.redhat.com/show_bug.cgi?id=1935549 ).

The story/bug deals with adding information about being able to reference NAD definitions in a different namespace of a VM. The changes made in the initial PR ( https://github.com/openshift/openshift-docs/pull/31951 ) failed in QA testing, necessitating these additional changes.

CP: 4.8

Preview: https://deploy-preview-33975--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks?utm_source=github&utm_campaign=bot_dp#virt-attaching-vm-secondary-network-cli_virt-attaching-multiple-networks