### PR TITLE
BZ187655 wording change

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -318,7 +318,7 @@ Note that it might take several minutes after completing this procedure for all 
 [id="dr-scenario-cluster-state-issues_{context}"]
 = Issues and workarounds for restoring a persistent storage state
 
-If your {product-title} cluster uses persistent storage of any form, a state of the world is typically stored outside etcd. It might be an Elasticsearch cluster running in a pod or a database running in a `StatefulSet` object. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
+If your {product-title} cluster uses persistent storage of any form, a state of the cluster is typically stored outside etcd. It might be an Elasticsearch cluster running in a pod or a database running in a `StatefulSet` object. When you restore from an etcd backup, the status of the workloads in {product-title} is also restored. However, if the etcd snapshot is old, the status might be invalid or outdated.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
**4.7+**

https://bugzilla.redhat.com/show_bug.cgi?id=1876855

Small wording change to the original PR (https://github.com/openshift/openshift-docs/pull/33930 ) that fixed the above bug: "state of the world" changed to "state of the cluster" in 1st sentence.

**Preview**: https://deploy-preview-33978--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#dr-scenario-cluster-state-issues_post-install-cluster-tasks

**PTAL** @gnufied @bobfuru 