### PR TITLE
[enterprise-4.8] RHDEVDOCS-2866: Document ability to filter by the certification level of the Helm Chart

### DIFF
--- a/modules/helm-filtering-helm-charts-by-certification-level.adoc
+++ b/modules/helm-filtering-helm-charts-by-certification-level.adoc
@@ -15,7 +15,7 @@ You can filter Helm charts based on their certification level in the *Developer 
 
 . Use the filters to the left of the list of Helm charts to filter the required charts:
 * Use the *Chart Repositories* filter to filter charts provided by *Red Hat Certification Charts* or *OpenShift Helm Charts*.
-* Use the *Source* filter to filter charts sourced from *Partners*, *Community* or *Red Hat*. Certified charts are indicated with the (image:odc_verified_icon.png[title="Certified icon"]) icon.
+* Use the *Source* filter to filter charts sourced from *Partners*, *Community*, or *Red Hat*. Certified charts are indicated with the (image:odc_verified_icon.png[title="Certified icon"]) icon.
 
 [NOTE]
 ====


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/commit/08d301a66f70c2cb3d636ed389eec882ac8fd4bc

Aligned Team: DevTools

This PR is for the OCP 4.8 Release.