### PR TITLE
Add Butane link and minor RN edits

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -19,13 +19,13 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
-{product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as {op-system-first} 4.8.
+{product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as on {op-system-first} 4.8.
 
-You must use {op-system} machines for the control plane, which are also known as master machines, and you can use either {op-system} or {op-system-base-full} 7.9 or later for compute machines, which are also known as worker machines.
+You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 7.9 or later for compute machines.
 
 [IMPORTANT]
 ====
-Because only {op-system-base-full} version 7.9 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to version 8.
+Because only {op-system-base} 7.9 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to {op-system-base} 8.
 ====
 
 //{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
@@ -63,6 +63,8 @@ For more information, see xref:../installing/installing_aws/installing-aws-user-
 ==== Butane config transpiler simplifies creation of machine configs
 
 {product-title} now includes the Butane config transpiler to assist with producing and validating machine configs. Documentation now recommends using Butane to create machine configs for LUKS disk encryption, boot disk mirroring, and custom kernel modules.
+
+For more information, see xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane].
 
 [id="ocp-4-8-rhcos-chrony-default"]
 ==== Change to custom chrony.conf default on cloud platforms


### PR DESCRIPTION
Now that https://github.com/openshift/openshift-docs/pull/33794 has merged, we can add a link to the newly available doc in 4.8 as part of [OSDOCS-2080](https://issues.redhat.com/browse/OSDOCS-2080) work.

Preview links:

- [About this release](https://deploy-preview-34005--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-about-this-release)
- [Butane RN](https://deploy-preview-34005--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-rhcos-butane) 