### PR TITLE
OSDOCS-2176: follow-up to remove triggers from the deployment YAML

### DIFF
--- a/modules/nw-ipfailover-configuration.adoc
+++ b/modules/nw-ipfailover-configuration.adoc
@@ -55,8 +55,6 @@ spec:
   selector:
     matchLabels:
       ipfailover: hello-openshift
-  triggers:
-    type: ConfigChange
   template:
     metadata:
       labels:


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/32538

This came up right as I hit merge, so I'm addressing it ASAP. 

Preview: https://deploy-preview-34008--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html#nw-ipfailover-configuration_configuring-ipfailover
