### PR TITLE
OSDOCS-2024: Remove rootfs encrypt bullet

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -15,7 +15,6 @@ This feature:
 * Is available for installer-provisioned infrastructure and user-provisioned infrastructure deployments
 * Is supported on {op-system-first} systems only
 * Sets up disk encryption during the manifest installation phase so all data written to disk, from first boot forward, is encrypted
-* Encrypts data on the root filesystem only (`/dev/mapper/root` on `/`)
 * Requires no user intervention for providing passphrases
 * Uses AES-256-XTS encryption, or AES-256-CBC if FIPS mode is enabled
 
@@ -164,3 +163,8 @@ $ butane $HOME/clusterconfig/worker-storage.bu -o ./99-worker-storage.yaml
 . Save the Butane config in case you need to update the manifest in the future.
 
 . Continue with the remainder of the {product-title} deployment.
+
+[IMPORTANT]
+====
+If you configure additional data partitions, they will not be encrypted unless encryption is explicitly requested.
+====


### PR DESCRIPTION
As noted in [OSDOCS-2024](https://issues.redhat.com/browse/OSDOCS-2024):

> As of 4.7, PM reports that this is no longer true and can be removed: “Encrypts data on the root filesystem only (/dev/mapper/coreos-luks-root on /)”

**PREVIEW LINK:**
[About disk encryption](https://deploy-preview-34016--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing?utm_source=github&utm_campaign=bot_dp#installation-special-config-encrypt-disk_installing-customizing)
https://deploy-preview-34016--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing?utm_source=github&utm_campaign=bot_dp#installation-special-config-encrypt-disk_installing-customizing

@bgilbert and @miabbott PTAL and let me know if you concur. Thanks.