### PR TITLE
OSSMDOC-207: Federation Overview topics

### DIFF
--- a/modules/ossm-architecture.adoc
+++ b/modules/ossm-architecture.adoc
@@ -3,18 +3,47 @@
 // -service_mesh/v2x/ossm-architecture.adoc
 
 [id="ossm-architecture_{context}"]
-= {ProductName} Architecture
+= Service Mesh architecture
 
-{ProductName} is logically split into a data plane and a control plane:
+Service mesh technology operates at the network communication level. That is, service mesh components capture or intercept traffic to and from microservices, either modifying requests, redirecting them, or creating new requests to other services.
 
-The *data plane* is a set of intelligent proxies deployed as sidecars. These proxies intercept and control all inbound and outbound network communication between microservices in the service mesh.
+At a high level, {ProductName} consists of a data plane and a control plane:
 
-* *Envoy proxy* intercepts all inbound and outbound traffic for all services in the service mesh. Envoy is deployed as a sidecar to the relevant service in the same pod.
+The *data plane* is a set of intelligent proxies, running alongside application containers in a pod, that intercept and control all inbound and outbound network communication between microservices in the service mesh.
+The data plane is implemented in such a way that it intercepts all inbound (ingress) and outbound (egress) network traffic. The Istio data plane is composed of Envoy containers running along side application containers in a pod. The Envoy container acts as a proxy, controlling all network communication into and out of the pod.
 
-The *control plane* manages and configures Istiod to enforce proxies to route traffic.
+* *Envoy proxies* are the only Istio components that interact with data plane traffic. All incoming (ingress) and outgoing (egress) network traffic between services flows through the proxies. The Envoy proxy also collects all metrics related to services traffic within the mesh. Envoy proxies are deployed as sidecars, running in the same pod as services. Envoy proxies are also used to implement mesh gateways.
 
-Istiod provides service discovery, configuration and certificate management. It converts high-level routing rules to Envoy configurations and propagates them to the sidecars at runtime.
+** *Sidecar proxies* manage inbound and outbound communication to the workload instance it is attached to.
 
-Secret Discovery Service (SDS) distributes certificates and keys to sidecars directly from Istiod.
+** *Gateways* are proxies operating as load balancers receiving incoming or outgoing HTTP/TCP connections. Gateway configurations are applied to standalone Envoy proxies that are running at the edge of the mesh, rather than sidecar Envoy proxies running alongside your service workloads. You use a Gateway to manage inbound and outbound traffic for your mesh, letting you specify which traffic you want to enter or leave the mesh.
 
-{ProductName} also uses the *istio-operator* to manage the installation of the control plane. An _Operator_ is a piece of software that enables you to implement and automate common activities in your {product-title} cluster. It acts as a controller, allowing you to set or change the desired state of objects in your cluster.
+*** *Ingress-gateway* - Also known as an ingress controller, the Ingress Gateway is a dedicated Envoy proxy that receives and controls traffic entering the service mesh. An Ingress Gateway allows features such as monitoring and route rules to be applied to traffic entering the cluster.
+
+*** *Egress-gateway* - Also known as an egress controller, the Egress Gateway is a dedicated Envoy proxy that manages traffic leaving the service mesh. An Egress Gateway allows features such as monitoring and route rules to be applied to traffic exiting the mesh.
+
+The *control plane* manages and configures the proxies that make up the data plane. It is the authoritative source for configuration, manages access control and usage policies, and collects metrics from the proxies in the service mesh.
+
+* The Istio control plane is composed of *Istiod* which consolidates several previous control plane components (Citadel, Galley, Pilot) into a single binary. Istiod provides service discovery, configuration, and certificate management. It converts high-level routing rules to Envoy configurations and propagates them to the sidecars at runtime.
+
+** Istiod can act as a Certificate Authority (CA), generating certificates supporting secure mTLS communication in the data plane. You can also use an external CA for this purpose.
+
+** Istiod is responsible for injecting sidecar proxy containers into workloads deployed to an OpenShift cluster.
+
+{ProductName} uses the *istio-operator* to manage the installation of the control plane. An _Operator_ is a piece of software that enables you to implement and automate common activities in your OpenShift cluster. It acts as a controller, allowing you to set or change the desired state of objects in your cluster, in this case, a {ProductName} installation.
+
+{ProductName} also bundles the following Istio add-ons as part of the product:
+
+* *Kiali* - Kiali is the management console for {ProductName}. It provides dashboards, observability, and robust configuration and validation capabilities. It shows the structure of your service mesh by inferring traffic topology and displays the health of your mesh. Kiali provides detailed metrics, powerful validation, access to Grafana, and strong integration for distributed tracing with Jaeger.
+
+* *Prometheus* - {ProductName} uses Prometheus to store telemetry information from services. Kiali depends on Prometheus to obtain metrics, health status, and mesh topology.
+
+* *Jaeger* - {ProductName} supports Jaeger for distributed tracing. Jaeger is an open source traceability server that centralizes and displays traces associated with a single request between multiple services. Using Jaeger you can monitor and troubleshoot your microservices-based distributed systems.
+
+* *Elasticsearch* - ElasticSearch is an open source, distributed, JSON-based search and analytics engine. Jaeger uses ElasticSearch for distributed storage and indexing for logging and tracing data.
+
+* *Grafana* - Grafana provides mesh administrators with advanced query and metrics analysis and dashboards for Istio data. Optionally, Grafana can be used to analyze service mesh metrics.
+
+The following Istio adapters are supported with {ProductName}:
+
+* *3scale* - The 3scale Istio adapter is an optional component that integrates {ProductName} with Red Hat 3scale API Management solutions. The default {ProductName} installation does not include this component.

--- a/modules/ossm-federation-features.adoc
+++ b/modules/ossm-federation-features.adoc
@@ -1,0 +1,26 @@
+////
+This module included in the following assemblies:
+* service_mesh/v2x/ossm-federation.adoc
+////
+
+[id="ossm-federation-features_{context}"]
+= Federation features
+
+[role="_abstract"]
+Features of the {ProductName} federated approach to joining meshes include the following:
+
+* Supports common root certificates for each mesh.
+* Supports different root certificates for each mesh.
+* Mesh administrators manually configure certificate chains, service discovery endpoints, trust domains, and gateways used for interacting with each mesh in the federation.
+* Only export/import the services that you want to share between meshes.
+** Details about deployed workloads are not visible to other meshes in the federation.
+** A service can be *exported* to make it visible to other meshes, allowing requests from workloads in other meshes in the federation.
+** A service that has been exported by one mesh in the federation can be *imported* by another mesh, enabling its workloads to send requests to the imported service.
+* All communication between meshes is encrypted and utilizes mutual TLS for client verification.
+//* Supports configuring failover for a service to a workload that is deployed in another mesh within the federation.
+* Supports configuring load balancing across workloads deployed locally and workloads that are deployed in another mesh in the federation.
+
+When a mesh is joined to another mesh it can do the following:
+
+* Provides information to peers in the federated mesh about its own exported services.
+* Discover information about services exported by peers in the federated mesh.

--- a/modules/ossm-federation-overview.adoc
+++ b/modules/ossm-federation-overview.adoc
@@ -1,0 +1,16 @@
+////
+This module included in the following assemblies:
+- ossm-federation.adoc
+////
+
+
+[id="ossm-federation-overview_{context}"]
+= Federation overview
+
+Federation is a set of features that let you connect services between separate meshes, allowing the use of {ProductShortName} features such as authentication, authorization, and traffic management across multiple, distinct administrative domains.
+
+Implementing a federated mesh lets you run, manage, and observe a single service mesh running across multiple OpenShift clusters.  {ProductName} federation takes an opinionated approach to a multi-cluster implementation of Service Mesh that assumes _minimal_ trust between meshes.
+
+Service Mesh federation assumes that each mesh is managed individually and retains its own administrator.  The default behavior is that no communication is permitted and no information is shared between meshes. The sharing of information between meshes is on an explicit opt-in basis.  Nothing is shared in a federated mesh unless it has been configured for sharing. Support functions such as certificate generation, metrics and trace collection remain local in their respective meshes.
+
+You configure each mesh control plane to allow federation.  The federation between two meshes is declared by a `ServiceMeshPeer` resource that defines the federation from one mesh to the other. Each service that is shared between meshes must also be declared explicitly with new `ExportedServiceSet` and `ImportedServiceSet` resources. Status fields are populated on each object, which can be used to monitor the state of connections and imported/exported services between meshes.

--- a/service_mesh/v2x/ossm-architecture.adoc
+++ b/service_mesh/v2x/ossm-architecture.adoc
@@ -11,6 +11,8 @@ include::modules/ossm-understanding-service-mesh.adoc[leveloffset=+1]
 
 include::modules/ossm-architecture.adoc[leveloffset=+1]
 
+For information about how to install the 3scale adapter, refer to the xref:../../service_mesh/v2x/threescale-adapter.adoc#threescale-adapter[3scale Istio adapter documentation]
+
 == Understanding Kiali
 
 Kiali provides visibility into your service mesh by showing you the microservices in your service mesh, and how they are connected.

--- a/service_mesh/v2x/ossm-federation-overview.adoc
+++ b/service_mesh/v2x/ossm-federation-overview.adoc
@@ -1,0 +1,16 @@
+[id="ossm-federation-overview"]
+= Federation overview
+include::modules/ossm-document-attributes.adoc[]
+:context: federation-overview
+
+toc::[]
+
+//Temporary file until location of topics is finalized
+
+include::modules/ossm-architecture.adoc[leveloffset=+2]
+
+include::modules/ossm-deploy-multi-mesh.adoc[leveloffset=+2]
+
+include::modules/ossm-federation-overview.adoc[leveloffset=+2]
+
+include::modules/ossm-federation-features.adoc[leveloffset=+2]


### PR DESCRIPTION
Federation overview in a temporary assembly until I figure out where the topics actually belong in the new document structure.

Includes update to SM architecture topic so that when we talk about configuring FederationGateways there is context.

Preview https://deploy-preview-34035--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation-overview.html

Eng review - rcernich, dgn, brian-avery
QE review- yxun
Peer review - EricPonvelle