### PR TITLE
RHDEVDOCS-3008 At OL 5.1 GA, revert RHDEVDOCS-3007 to republish topic

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 By default, OpenShift Logging sends container and infrastructure logs to the default internal Elasticsearch log store defined in the `ClusterLogging` custom resource. However, it does not send audit logs to the internal store because it does not provide secure storage. If this default configuration meets your needs, you do not need to configure the Cluster Log Forwarder.
 
-To send logs to other log aggregators, you use the {product-title} Cluster Log Forwarder. This API enables you to send container, infrastructure, and audit logs to specific endpoints within or outside your cluster. You can send different types of logs to various systems, so various individuals can access each type. You can also enable TLS support to send logs securely, as required by your organization.
+To send logs to other log aggregators, you use the {product-title} Cluster Log Forwarder. This API enables you to send container, infrastructure, and audit logs to specific endpoints within or outside your cluster. In addition, you can send different types of logs to various systems so that various individuals can access each type. You can also enable TLS support to send logs securely, as required by your organization.
 
 [NOTE]
 ====
@@ -35,6 +35,6 @@ include::modules/cluster-logging-collector-log-forward-fluentd.adoc[leveloffset=
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-kafka.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-project.adoc[leveloffset=+1]
-//include::modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-legacy-fluentd.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-legacy-syslog.adoc[leveloffset=+1]


### PR DESCRIPTION
For OpenShift 5.1, revert [RHDEVDOCS-3007](https://issues.redhat.com/browse/RHDEVDOCS-3007) to republish topic cluster-logging-collector-log-forward-logs-from-application-pods.adoc

This PR reverts commit 87a184564d94bd44fd48be9def2eb142d928da2d from https://github.com/openshift/openshift-docs/pull/32541 (https://issues.redhat.com/browse/RHDEVDOCS-3007)

I had previously published this content too early with https://github.com/openshift/openshift-docs/pull/32334, and then unpublished it by commenting-out the file include in https://github.com/openshift/openshift-docs/pull/32541.

- Aligned team: Dev Tools
- For branches: LOGGING 5.1 (OpenShift version 4.7+)
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3007
- Direct link to doc preview: See the "Forwarding application logs from specific pods" section only, in https://deploy-preview-34053--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-log-forward-logs-from-application-pods_cluster-logging-external
- SME review: @alanconway 
- QE review: @kabirbhartiRH in https://github.com/openshift/openshift-docs/pull/32334
- Peer review: @jc-berger 
- All reviews complete. Ready for merge.