### PR TITLE
WMCO - Added link to prereqs

### DIFF
--- a/windows_containers/enabling-windows-container-workloads.adoc
+++ b/windows_containers/enabling-windows-container-workloads.adoc
@@ -20,18 +20,22 @@ Before adding Windows workloads to your cluster, you must install the Windows Ma
 
 * You are running an {product-title} cluster version 4.6.8 or later.
 
+.Additional resources
+* For the comprehensive prerequisites for the Windows Machine Config Operator, see xref:understanding-windows-container-workloads.adoc#wmco-prerequisites_understanding-windows-container-workloads[Understanding Windows container workloads].
+
 [id="installing-the-wmco"]
 == Installing the Windows Machine Config Operator
 
 You can install the Windows Machine Config Operator using either the web console or OpenShift CLI (`oc`).
 
 include::modules/installing-wmco-using-web-console.adoc[leveloffset=+2]
+
 include::modules/installing-wmco-using-cli.adoc[leveloffset=+2]
 
 include::modules/configuring-secret-for-wmco.adoc[leveloffset=+1]
 
-[discrete]
-== Additional Resources
+
+== Additional resources
 
 * xref:../installing/installing_azure/installing-azure-default.adoc#ssh-agent-using_installing-azure-default[Generating a key pair for cluster node SSH access]
 * xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster].


### PR DESCRIPTION
Added an additional resource link to the expanded prerequisites for WMCO.

Version: 4.7+

Preview: https://deploy-preview-34062--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/enabling-windows-container-workloads.html