### PR TITLE
fix: Put tag directive in a comment

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -230,7 +230,7 @@ The maximum transmission unit (MTU) for the Geneve (Generic Network Virtualizati
 
 If the auto-detected value is not what you expect it to be, confirm that the MTU on the primary network interface on your nodes is correct. You cannot use this option to change the MTU value of the primary network interface on the nodes.
 
-If your cluster requires different MTU values for different nodes, you must set this value to `100` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`. 
+If your cluster requires different MTU values for different nodes, you must set this value to `100` less than the lowest MTU value in your cluster. For example, if some nodes in your cluster have an MTU of `9001`, and some have an MTU of `1500`, you must set this value to `1400`.
 
 This value cannot be changed after cluster installation.
 endif::operator[]
@@ -265,7 +265,7 @@ endif::operator[]
 
 |====
 
-tag::policy-audit[]
+// tag::policy-audit[]
 .`policyAuditConfig` object
 [cols=".^2,.^2,.^6a",options="header"]
 |====
@@ -294,7 +294,7 @@ One of the following additional audit log targets:
 |The syslog facility, such as `kern`, as defined by RFC5424. The default value is `local0`.
 
 |====
-end::policy-audit[]
+// end::policy-audit[]
 
 ifdef::operator[]
 NOTE: You can only change the configuration for your cluster network provider during cluster installation.


### PR DESCRIPTION
Without this change, we show the foll text in the HTML:

"tag::policy-audit[] .policyAuditConfig object"

For the before, ctrl+F for "tag::" on the [existing 4.8](https://docs.openshift.com/container-platform/4.8/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#nw-operator-cr-cno-object_installing-bare-metal-network-customizations) page.

For the after, ctrl+F for "table 15" on the [preview](https://deploy-preview-34063--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#nw-operator-cr-cno-object_installing-bare-metal-network-customizations) page.

The included content remains visible in the reuse location: [network policy audit location](https://deploy-preview-34063--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/logging-network-policy.html#network-policy-audit-configuration)

If only there were a higher quality of peer review, these things wouldn't happen.

---
Applies to enterprise-4.8.