### PR TITLE
BZ1974154: Update invalid OperatorGroup tshooting

### DIFF
--- a/modules/olm-operatorgroups-troubleshooting.adoc
+++ b/modules/olm-operatorgroups-troubleshooting.adoc
@@ -9,5 +9,21 @@
 [id="olm-operatorgroups-troubleshooting-membership_{context}"]
 === Membership
 
-* If more than one Operator group exists in a single namespace, any CSV created in that namespace transitions to a failure state with the reason `TooManyOperatorGroups`. CSVs in a failed state for this reason transition to pending after the number of Operator groups in their namespaces reaches one.
+* An install plan's namespace must contain only one Operator group. When attempting to generate a cluster service version (CSV) in a namespace, an install plan considers an Operator group invalid in the following scenarios:
++
+--
+** No Operator groups exist in the install plan's namespace.
+** Multiple Operator groups exist in the install plan's namespace.
+** An incorrect or non-existent service account name is specified in the Operator group.
+--
++
+If an install plan encounters an invalid Operator group, the CSV is not generated and the `InstallPlan` resource fails with a relevant message. For example, the following message is provided if more than one Operator group exists in the same namespace:
++
+[source,terminal]
+----
+attenuated service account query failed - more than one operator group(s) are managing this namespace count=2
+----
++
+where `count=` specifies the number of Operator groups in the namespace.
+
 * If the install modes of a CSV do not support the target namespace selection of the Operator group in its namespace, the CSV transitions to a failure state with the reason `UnsupportedOperatorGroup`. CSVs in a failed state for this reason transition to pending after either the target namespace selection of the Operator group changes to a supported configuration, or the install modes of the CSV are modified to support the target namespace selection.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1974154

Updated bullet for relevance with error message changes in https://issues.redhat.com/browse/OLM-2116 in 4.8+ only.

Preview: [Troubleshooting Operator groups](https://deploy-preview-34071--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups#olm-operatorgroups-troubleshooting_olm-understanding-operatorgroups)