### PR TITLE
Rename MTC checklist assemblies

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1946,7 +1946,7 @@ Topics:
 - Name: Upgrading MTC
   File: upgrading-3-4
 - Name: Premigration checklists
-  File: premigration-checklists
+  File: premigration-checklists-3-4
 - Name: Migrating your applications
   File: migrating-applications-3-4
 - Name: Advanced migration options
@@ -1967,7 +1967,7 @@ Topics:
 - Name: Upgrading MTC
   File: upgrading-mtc
 - Name: Premigration checklists
-  File: premigration-checklists
+  File: premigration-checklists-mtc
 - Name: Migrating your applications
   File: migrating-applications-with-mtc
 - Name: Advanced migration options

--- a/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
@@ -1,7 +1,7 @@
-[id="premigration-checks"]
+[id="premigration-checklists-3-4"]
 = Premigration checklists
 include::modules/common-attributes.adoc[]
-:context: premigration-checks
+:context: premigration-checklists-3-4
 
 toc::[]
 

--- a/migration-toolkit-for-containers/premigration-checklists-mtc.adoc
+++ b/migration-toolkit-for-containers/premigration-checklists-mtc.adoc
@@ -1,7 +1,7 @@
-[id="premigration-checks"]
+[id="premigration-checklists-mtc"]
 = Premigration checklists
 include::modules/common-attributes.adoc[]
-:context: premigration-checks
+:context: premigration-checklists-mtc
 
 toc::[]
 


### PR DESCRIPTION
No BZ or Jira.

Renaming a couple assemblies. I did this for master and 4.8 as part of a different PM. This is to apply the file name changes to the other branches.

4.5, 4.6, 4.7

No preview link because this change does not affect the appearance of the docs.

Does not need QE. Does need peer review.