### PR TITLE
[enterprise-4.9] Custom certs for the oAuth server route

### DIFF
--- a/authentication/configuring-internal-oauth.adoc
+++ b/authentication/configuring-internal-oauth.adoc
@@ -17,4 +17,6 @@ include::modules/oauth-configuring-token-inactivity-timeout.adoc[leveloffset=+1]
 
 include::modules/oauth-server-metadata.adoc[leveloffset=+1]
 
+include::modules/oauth-customizing-the-oauth-server-URL.adoc[leveloffset=+1]
+
 include::modules/oauth-troubleshooting-api-events.adoc[leveloffset=+1]

--- a/modules/oauth-customizing-the-oauth-server-URL.adoc
+++ b/modules/oauth-customizing-the-oauth-server-URL.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * authentication/configuring-internal-oauth.adoc
+
+[id="customizing-the-oauth-server-url_{context}"]
+= Customizing OAuth server URL
+
+The OAuth server route can be customized using the `ingress` config route configuration API. A custom hostname and a TLS certificate can be set using the `spec.componentRoutes` part of the configuration.
+
+[id="customizing-the-openshift-integrated-oauth-server-route_{context}"]
+== Customising the OpenShift integrated OAuth server route
+
+.Prerequisites
+
+* Log in to the cluster as a user with administrative privileges.
+
+.Procedure
+
+* Set the custom hostname and optionally configure the serving certificate and key.
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  componentRoutes:
+    - name: oauth-openshift
+      namespace: openshift-authentication
+      hostname: <custom-hostname>
+      servingCertKeyPairSecret:
+        name: <secret-name>
+----
++
+If the domain for the custom hostname suffix does not match the cluster domain suffix, then a secret that contains a TLS certificate and key must exist in the `openshift-config` namespace and must be referenced in the `ingress` config. If the domain for the custom hostname suffix matches the cluster domain suffix then the secret is optional. The secret must contain `tls.crt` and `tls.key` data keys, where the certificate and key are stored, and both must be in a valid format. The best way to ensure that is to use the TLS Secret.


### PR DESCRIPTION
https://issues.redhat.com/browse/AUTH-13
https://issues.redhat.com/browse/OSDOCS-2366

This Pull Request introduces documentation bits for the Custom hostname and certificate for the oAuth server. It documents https://github.com/openshift/cluster-authentication-operator/pull/430

The documentation has been created based on https://github.com/openshift/openshift-docs/blob/master/modules/customizing-the-web-console-URL.adoc﻿
