### PR TITLE
SRVOCF-302: Add docs on accessing secrets and ConfigMaps from Srvls functions

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -3057,6 +3057,8 @@ Topics:
     File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
+  - Name: Accessing secrets and config maps from Serverless functions
+    File: serverless-functions-accessing-secrets-configmaps
   - Name: Functions development reference guide
     File: serverless-functions-reference-guide
 #

--- a/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc
@@ -1,0 +1,19 @@
+[id="serverless-functions-all-values-in-configmap-to-env-variables_{context}"]
+= Setting environment variables from all values defined in a config map
+
+. Open the `func.yaml` file for your function.
+
+. For every config map for which you want to import all key-value pairs as environment variables, add the following YAML to the `envs` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ configMap:myconfigmap }}' <1>
+----
+<1> Substitute `myconfigmap` with the name of the target config map.
+
+. Save the file.

--- a/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
+++ b/modules/serverless-functions-all-values-in-secret-to-env-variables.adoc
@@ -1,0 +1,19 @@
+[id="serverless-functions-all-values-in-secret-to-env-variables_{context}"]
+= Setting environment variables from all values defined in a secret
+
+. Open the `func.yaml` file for your function.
+
+. For every secret for which you want to import all key-value pairs as environment variables, add the following YAML to the `envs` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- value: '{{ secret:mysecret }}' <1>
+----
+<1> Substitute `mysecret` with the name of the target secret.
+
+. Save the configuration.

--- a/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc
@@ -1,0 +1,23 @@
+[id="serverless-functions-key-value-in-configmap-to-env-variable_{context}"]
+= Setting environment variable from a key value defined in a config map
+
+. Open the `func.yaml` file for your function.
+
+. For each value from a config map key-value pair that you want to assign to an environment variable, add the following YAML to the `envs` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- name: EXAMPLE
+  value: '{{ configMap:myconfigmap:key }}'
+----
++
+* Substitute `EXAMPLE` with the name of the environment variable.
+* Substitute `myconfigmap` with the name of the target config map.
+* Substitute `key` with the key mapped to the target value.
+
+. Save the configuration.

--- a/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
+++ b/modules/serverless-functions-key-value-in-secret-to-env-variable.adoc
@@ -1,0 +1,23 @@
+[id="serverless-functions-key-value-in-secret-to-env-variable_{context}"]
+= Setting environment variable from a key value defined in a secret
+
+. Open the `func.yaml` file for your function.
+
+. For each value from a secret key-value pair that you want to assign to an environment variable, add the following YAML to the `envs` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- name: EXAMPLE
+  value: '{{ secret:mysecret:key }}'
+----
++
+* Substitute `EXAMPLE` with the name of the environment variable.
+* Substitute `mysecret` with the name of the target secret.
+* Substitute `key` with the key mapped to the target value.
+
+. Save the configuration.

--- a/modules/serverless-functions-mounting-configmap-as-volume.adoc
+++ b/modules/serverless-functions-mounting-configmap-as-volume.adoc
@@ -1,0 +1,22 @@
+[id="serverless-functions-mounting-configmap-as-volume_{context}"]
+= Mounting a config map as a volume
+
+. Open the `func.yaml` file for your function.
+
+. For each config map you want to mount as a volume, add the following YAML to the `volumes` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+volumes:
+- configMap: myconfigmap
+  path: /workspace/configmap
+----
++
+* Substitute `myconfigmap` with the name of the target config map.
+* Substitute `/workspace/configmap` with the path where you want to mount the config map.
+
+. Save the configuration.

--- a/modules/serverless-functions-mounting-secret-as-volume.adoc
+++ b/modules/serverless-functions-mounting-secret-as-volume.adoc
@@ -1,0 +1,22 @@
+[id="serverless-functions-mounting-secret-as-volume_{context}"]
+= Mounting a secret as a volume
+
+. Open the `func.yaml` file for your function.
+
+. For each secret you want to mount as a volume, add the following YAML to the `volumes` section:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+volumes:
+- secret: mysecret
+  path: /workspace/secret
+----
++
+* Substitute `mysecret` with the name of the target secret.
+* Substitute `/workspace/secret` with the path where you want to mount the secret.
+
+. Save the configuration.

--- a/modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc
+++ b/modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc
@@ -1,0 +1,46 @@
+[id="serverless-functions-secrets-configmaps-interactively-specialized_{context}"]
+= Modifying function access to secrets and config maps interactively with specialized commands
+
+Every time you run the `kn func config` utility, you need to navigate the entire dialogue to select the operation you need, as shown in the previous section. To save steps, you can directly execute a specific operation by running a more specific form of the `kn func config` command:
+
+* To list configured environment variables:
++
+[source,terminal]
+----
+$ kn func config envs [-p <function-project-path>]
+----
+
+* To add environment variables to the function configuration:
++
+[source,terminal]
+----
+$ kn func config envs add [-p <function-project-path>]
+----
+
+* To remove environment variables from the function configuration:
++
+[source,terminal]
+----
+$ kn func config envs remove [-p <function-project-path>]
+----
+
+* To list configured volumes:
++
+[source,terminal]
+----
+$ kn func config volumes [-p <function-project-path>]
+----
+
+* To add a volume to the function configuration:
++
+[source,terminal]
+----
+$ kn func config volumes add [-p <function-project-path>]
+----
+
+* To remove a volume from the function configuration:
++
+[source,terminal]
+----
+$ kn func config volumes remove [-p <function-project-path>]
+----

--- a/modules/serverless-functions-secrets-configmaps-interactively.adoc
+++ b/modules/serverless-functions-secrets-configmaps-interactively.adoc
@@ -1,0 +1,55 @@
+[id="serverless-functions-secrets-configmaps-interactively_{context}"]
+= Modifying function access to secrets and config maps interactively
+
+You can manage the secrets and config maps accessed by your function by using the `kn func config` interactive utility.
+
+.Procedure
+
+. Run the following command in the function project directory:
++
+[source,terminal]
+----
+$ kn func config
+----
++
+Alternatively, you can specify the function project directory using the `--path` or `-p` option.
+
+. Use the interactive interface to perform the necessary operation. For example, using the utility to list configured volumes produces an output similar to this:
++
+[source,terminal]
+----
+$ kn func config
+? What do you want to configure? Volumes
+? What operation do you want to perform? List
+Configured Volumes mounts:
+- Secret "mysecret" mounted at path: "/workspace/secret"
+- Secret "mysecret2" mounted at path: "/workspace/secret2"
+----
++
+This scheme shows all operations available in the interactive utility and how to navigate to them:
++
+[source]
+----
+kn func config
+   ├─> Environment variables
+   │               ├─> Add
+   │               │    ├─> ConfigMap: Add all key-value pairs from a config map
+   │               │    ├─> ConfigMap: Add value from a key in a config map
+   │               │    ├─> Secret: Add all key-value pairs from a secret
+   │               │    └─> Secret: Add value from a key in a secret
+   │               ├─> List: List all configured environment variables
+   │               └─> Remove: Remove a configured environment variable
+   └─> Volumes
+           ├─> Add
+           │    ├─> ConfigMap: Mount a config map as a volume
+           │    └─> Secret: Mount a secret as a volume
+           ├─> List: List all configured volumes
+           └─> Remove: Remove a configured volume
+----
+
+. Optional. Deploy the function to make the changes take effect:
++
+[source,terminal]
+----
+$ kn func deploy -p test
+----

--- a/serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
+++ b/serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc
@@ -1,0 +1,31 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-functions-accessing-secrets-configmaps"]
+= Accessing secrets and config maps from Serverless functions
+include::modules/common-attributes.adoc[]
+:context: serverless-functions-secrets
+
+toc::[]
+
+Your functions, after deployed to the cluster, can access data stored in secrets and config maps. This data can be mounted as volumes, or assigned to environment variables. You can configure this access interactively by using the Knative CLI `kn func` commands or manually by editing the function configuration file.
+
+[IMPORTANT]
+====
+To access secrets and config maps, the function needs to be deployed on the cluster. This functionality is not available to a function running locally.
+
+If a secret or config map value cannot be accessed, the deployment fails with an error message specifying the inaccessible values.
+====
+
+include::modules/serverless-functions-secrets-configmaps-interactively.adoc[leveloffset=+1]
+include::modules/serverless-functions-secrets-configmaps-interactively-specialized.adoc[leveloffset=+1]
+
+[id="serverless-functions-secrets-configmaps-manually_{context}"]
+== Adding function access to secrets and config maps manually
+
+You can manually add configuration for accessing secrets and config maps to your function.
+
+include::modules/serverless-functions-mounting-secret-as-volume.adoc[leveloffset=+2]
+include::modules/serverless-functions-mounting-configmap-as-volume.adoc[leveloffset=+2]
+include::modules/serverless-functions-key-value-in-secret-to-env-variable.adoc[leveloffset=+2]
+include::modules/serverless-functions-key-value-in-configmap-to-env-variable.adoc[leveloffset=+2]
+include::modules/serverless-functions-all-values-in-secret-to-env-variables.adoc[leveloffset=+2]
+include::modules/serverless-functions-all-values-in-configmap-to-env-variables.adoc[leveloffset=+2]


### PR DESCRIPTION
For versions 4.6+
https://issues.redhat.com/browse/SRVOCF-302
Docs preview: https://deploy-preview-34089--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-accessing-secrets-configmaps