### PR TITLE
Removing TP warning for CLI plugins

### DIFF
--- a/modules/cli-extending-plugins-installing.adoc
+++ b/modules/cli-extending-plugins-installing.adoc
@@ -8,21 +8,6 @@
 After you write a custom plug-in for the {product-title} CLI, you must install
 it to use the functionality that it provides.
 
-[IMPORTANT]
-====
-OpenShift CLI plug-ins are currently a Technology Preview feature.
-ifdef::openshift-enterprise,openshift-webscale[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
-Technology Preview features support scope] for more information.
-endif::[]
-====
-
 .Prerequisites
 
 * You must have the `oc` CLI tool installed.

--- a/modules/cli-extending-plugins-writing.adoc
+++ b/modules/cli-extending-plugins-writing.adoc
@@ -9,21 +9,6 @@ You can write a plug-in for the {product-title} CLI in any programming language
 or script that allows you to write command-line commands. Note that you can not
 use a plug-in to overwrite an existing `oc` command.
 
-[IMPORTANT]
-====
-OpenShift CLI plug-ins are currently a Technology Preview feature.
-ifdef::openshift-enterprise,openshift-webscale[]
-Technology Preview features are not supported with Red Hat production service
-level agreements (SLAs), might not be functionally complete, and Red Hat does
-not recommend to use them for production. These features provide early access to
-upcoming product features, enabling customers to test functionality and provide
-feedback during the development process.
-
-See the link:https://access.redhat.com/support/offerings/techpreview/[Red Hat
-Technology Preview features support scope] for more information.
-endif::[]
-====
-
 .Procedure
 
 This procedure creates a simple Bash plug-in that prints a message to the


### PR DESCRIPTION
Per @soltysh / @gauravsingh85 CLI plugins are no longer tech preview

Preview: https://deploy-preview-34097--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/extending-cli-plugins.html