### PR TITLE
RHDEVDOCS-3135 Identifying the image change trigger that triggered the most recent build

### DIFF
--- a/cicd/builds/triggering-builds-build-hooks.adoc
+++ b/cicd/builds/triggering-builds-build-hooks.adoc
@@ -23,6 +23,8 @@ include::modules/builds-displaying-webhook-urls.adoc[leveloffset=+3]
 
 include::modules/builds-using-image-change-triggers.adoc[leveloffset=+2]
 
+include::modules/builds-identifying-image-change-triggers.adoc[leveloffset=+2]
+
 include::modules/builds-configuration-change-triggers.adoc[leveloffset=+2]
 
 include::modules/builds-setting-triggers-manually.adoc[leveloffset=+3]

--- a/modules/builds-identifying-image-change-triggers.adoc
+++ b/modules/builds-identifying-image-change-triggers.adoc
@@ -1,0 +1,96 @@
+// Module included in the following assemblies:
+//
+// * builds/triggering-builds-build-hooks.adoc
+
+[id="builds-image-change-trigger-identification_{context}"]
+= Indentifying the image change trigger of a build
+
+As a developer, if you have image change triggers, you can identify which image change initiated the last build. This can be useful for debugging or troubleshooting builds.
+
+.Example `BuildConfig`
+[source,yaml]
+----
+apiVersion: build.openshift.io/v1
+kind: BuildConfig
+  metadata:
+    name: bc-ict-example
+    namespace: bc-ict-example-namespace
+  spec:
+
+    ...
+
+    triggers:
+    - imageChange:
+        from:
+          kind: ImageStreamTag
+          name: input:latest
+          namespace: bc-ict-example-namespace
+    - imageChange:
+        from:
+          kind: ImageStreamTag
+          name: input2:latest
+          namespace: bc-ict-example-namespace
+      type: ImageChange
+  status:
+    imageChangeTriggers:
+    - from:
+        name: input:latest
+        namespace: bc-ict-example-namespace
+      lastTriggerTime: "2021-06-30T13:47:53Z"
+      lastTriggeredImageID: image-registry.openshift-image-registry.svc:5000/bc-ict-example-namespace/input@sha256:0f88ffbeb9d25525720bfa3524cb1bf0908b7f791057cf1acfae917b11266a69
+    - from:
+        name: input2:latest
+        namespace: bc-ict-example-namespace
+      lastTriggeredImageID:  image-registry.openshift-image-registry.svc:5000/bc-ict-example-namespace/input2@sha256:0f88ffbeb9d25525720bfa3524cb2ce0908b7f791057cf1acfae917b11266a69
+
+    lastVersion: 1
+----
+
+[NOTE]
+====
+This example omits elements that are not related to image change triggers.
+====
+
+.Prerequisite
+
+* You have configured multiple image change triggers. These triggers have triggered one or more builds.
+
+.Procedure
+
+. In `buildConfig.status.imageChangeTriggers` to identify the `lastTriggerTime` that has the latest timestamp.
++
+This `ImageChangeTriggerStatus`
+
+
+ Then you use the `name` and `namespace` from that build to find the corresponding image change trigger in `buildConfig.spec.triggers`.
+
+. Under `imageChangeTriggers`, compare  timestamps to identify the latest
+
+.Image change triggers
+
+In your build configuration, `buildConfig.spec.triggers` is an array of build trigger policies, `BuildTriggerPolicy`.
+
+Each `BuildTriggerPolicy` has a `type` field and set of pointers fields. Each pointer field corresponds to one of the allowed values for the `type` field. As such, you can only set `BuildTriggerPolicy` to only one pointer field.
+
+For image change triggers, the value of `type` is `ImageChange`. Then, the `imageChange` field is the pointer to an `ImageChangeTrigger` object, which has the following fields:
+
+* `lastTriggeredImageID`: This field, which is not shown in the example, is deprecated in {product-title} 4.8 and will be ignored in a future release. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
+* `paused`: You can use this field, which is not shown in the example, to temporarily disable this particular image change trigger.
+* `from`: You use this field to reference the `ImageStreamTag` that drives this image change trigger. Its type is the core Kubernetes type, `OwnerReference`.
+
+The `from` field has the following fields of note:
+** `kind`: For image change triggers, the only supported value is `ImageStreamTag`.
+** `namespace`: You use this field to specify the namespace of the `ImageStreamTag`.
+** `name`: You use this field to specify the `ImageStreamTag`.
+
+.Image change trigger status
+
+In your build configuration, `buildConfig.status.imageChangeTriggers` is an array of `ImageChangeTriggerStatus` elements. Each `ImageChangeTriggerStatus` element includes the `from`, `lastTriggeredImageID`, and `lastTriggerTime` elements shown in the preceding example.
+
+The `ImageChangeTriggerStatus` that has the most recent `lastTriggerTime` triggered the most recent build. You use its `name` and `namespace` to identify the image change trigger in `buildConfig.spec.triggers` that triggered the build.
+
+The `lastTriggerTime` with the most recent timestamp signifies the `ImageChangeTriggerStatus` of the last build. This `ImageChangeTriggerStatus` has the same `name` and `namespace` as the image change trigger in `buildConfig.spec.triggers` that triggered the build.
+
+.Additional resources
+
+* link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[v1 container registries]

--- a/modules/builds-image-change-trigger-identification.adoc
+++ b/modules/builds-image-change-trigger-identification.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * builds/triggering-builds-build-hooks.adoc
+
+[id="builds-image-change-trigger-identification_{context}"]
+= Image change trigger identification
+
+As a developer, if you have configured image change triggers, you can identify which image change initiated the last build.
+
+To accomplish this, you must identify elements in your build configuration's specification and status that are related to image change triggers.
+
+This way, you can use the timestamp in `buildConfig.status.imageChangeTriggers` to identify the most recent build. Then you can use the name and namespace of the image stream that triggered this build to find the corresponding image change trigger in the `buildConfig.spec.triggers`.
+
+
+== Image change trigger elements in the specification
+
+In your build configuration specification, `buildConfig.spec.triggers` is an array of build trigger policies, `BuildTriggerPolicy`.
+
+Each `BuildTriggerPolicy` has a `type` field and set of pointers fields, where each pointer field corresponds to one of the allowed values for the `type` field. As such, only one pointer field can be set for a given `BuildTriggerPolicy`.
+
+So for image change triggers, the value of `type` is `ImageChange`.
+
+Then, the `imageChange` field is the pointer to an `ImageChangeTrigger` object. So this will be set. It has the following fields:
+
+* `lastTriggeredImageID`: This field is deprecated in {product-title} 4.8, but is still being set. It will be ignored in a future release. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
+* `paused`: This field is used to temporarily disable this particular image change trigger.
+* `from`: This field is used to reference the `ImageStreamTag` that drives this image change trigger. Its type is the core Kubernetes type, `OwnerReference`. The `from` field has the following fields of note:
+  * `kind`: In this case, the only supported value is `ImageStreamTag`.
+  * `namespace`: The namespace where the `ImageStreamTag` lives.
+  * `name`: The name of the `ImageStreamTag`.
+
+The following example shows the relative location of the elements mentioned in the preceding list and omits unrelated elements, such as `name`, `source`, and `strategy`.
+
+.Example `BuildConfig.spec`
+[source,yaml]
+----
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+spec:
+  triggers:
+  - imageChange:
+      from:
+        kind: ImageStreamTag
+        name: <1>
+        namespace: <2>
+    type: ImageChange
+----
+<1> The name of an image stream, such as `input:latest`.
+<2> A namespace, such as `my-namespace`.
+
+== Image change trigger elements in the status
+
+In your build configuration status, `buildConfig.status.imageChangeTriggers` is an array of `ImageChangeTriggerStatus` elements. Each `ImageChangeTriggerStatus` element includes the `from`, `lastTriggeredImageID`, and `lastTriggerTime` elements shown in the following example. This example omits elements that are not related to image change triggers.
+
+.Example `BuildConfig.status`
+[source,yaml]
+----
+kind: BuildConfig
+apiVersion: build.openshift.io/v1
+status:
+  imageChangeTriggers:
+     - from:
+          name: <1>
+          namespace: <2>
+       lastTriggeredImageID: <3>
+       lastTriggerTime: <4>
+----
+<1> The name of an image stream, such as `input:latest`.
+<2> A namespace, such as `my-namespace`.
+<3> The SHA or ID of the `ImageStreamTag` when a build started. Its value is updated each time a build is started, even if this `ImageStreamTag` is not the reason the build started.
+<4> The last time this particular `ImageStreamTag` triggered a build to start. Its value is only updated when this trigger specifically started a Build.
+
+== Identification of image change triggers
+
+The `ImageChangeTriggerStatus` that has the most recent `lastTriggerTime` triggered the most recent build. You can use its `name` and `namespace` to correlate it with the `ImageStreamTag` of one of the image change triggers you defined in the `buildConfig.spec.triggers`.
+
+.Additional resources
+
+* link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[v1 container registries]

--- a/modules/builds-using-image-change-triggers.adoc
+++ b/modules/builds-using-image-change-triggers.adoc
@@ -5,7 +5,9 @@
 [id="builds-using-image-change-triggers_{context}"]
 = Using image change triggers
 
-Image change triggers allow your build to be automatically invoked when a new version of an upstream image is available. For example, if a build is based on top of a RHEL image, then you can trigger that build to run any time the RHEL image changes. As a result, the application image is always running on the latest RHEL base image.
+As a developer, you can configure your build to run automatically every time a base image changes.
+
+You can use image change triggers to automatically invoke your build when a new version of an upstream image is available. For example, if a build is based on a RHEL image, you can trigger that build to run any time the RHEL image changes. As a result, the application image is always running on the latest RHEL base image.
 
 [NOTE]
 ====
@@ -14,9 +16,7 @@ Image streams that point to container images in link:http://docs.docker.com/v1.7
 
 .Procedure
 
-Configuring an image change trigger requires the following actions:
-
-. Define an `ImageStream` that points to the upstream image you want to trigger on:
+. Define an `ImageStream` that points to the upstream image you want to use as a trigger:
 +
 [source,yaml]
 ----
@@ -26,9 +26,9 @@ metadata:
   name: "ruby-20-centos7"
 ----
 +
-This defines the image stream that is tied to a container image repository located at `<system-registry>_/_<namespace>_/ruby-20-centos7`. The `<system-registry>` is defined as a service with the name `docker-registry` running in {product-title}.
+This defines the image stream that is tied to a container image repository located at `_<system-registry>_/_<namespace>_/ruby-20-centos7`. The `<system-registry>` is defined as a service with the name `docker-registry` running in {product-title}.
 
-. If an image stream is the base image for the build, set the from field in the build strategy to point to the `ImageStream`:
+. If an image stream is the base image for the build, set the `from` field in the build strategy to point to the `ImageStream`:
 +
 [source,yaml]
 ----
@@ -54,7 +54,7 @@ imageChange:
     name: "custom-image:latest"
 ----
 <1> An image change trigger that monitors the `ImageStream` and `Tag` as defined by the build strategy's `from` field. The `imageChange` object here must be empty.
-<2> An image change trigger that monitors an arbitrary imagestream. The `imageChange` part in this case must include a `from` field that references the `ImageStreamTag` to monitor.
+<2> An image change trigger that monitors an arbitrary image stream. The `imageChange` part, in this case, must include a `from` field that references the `ImageStreamTag` to monitor.
 
 When using an image change trigger for the strategy image stream, the generated build is supplied with an immutable docker tag that points to the latest image corresponding to that tag. This new image reference is used by the strategy when it executes for the build.
 
@@ -87,7 +87,7 @@ imageChange:
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated[]
 In addition to setting the image field for all `Strategy` types, for custom builds, the `OPENSHIFT_CUSTOM_BUILD_BASE_IMAGE` environment variable is checked.
-If it does not exist, then it is created with the immutable image reference. If it does exist then it is updated with the immutable image reference.
+If it does not exist, then it is created with the immutable image reference. If it does exist, then it is updated with the immutable image reference.
 endif::[]
 
 If a build is triggered due to a webhook trigger or manual request, the build that is created uses the `<immutableid>` resolved from the `ImageStream` referenced by the `Strategy`. This ensures that builds are performed using consistent image tags for ease of reproduction.


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-4.8+ 
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3135
- Direct link to doc preview: https://deploy-preview-34102--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/triggering-builds-build-hooks.html#builds-image-change-trigger-identification_triggering-builds-build-hooks
- SME review: @gabemontero 
- QE review: @jitendar-singh   
- Peer review: @JStickler 
- All reviews complete. Please merge now.