### PR TITLE
4.8 RNs: addition for service account token volumes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -994,6 +994,16 @@ If you have a log consumer that is expecting the capnslog format, you might need
 
 In {product-title} 4.8, multiple daemon sets are merged for Local Storage Object (LSO). When you create a local volume custom resource, only `daemonset.apps/diskmaker-manager` is created.
 
+[discrete]
+[id="ocp-4-8-bound-svc-acct-token-vol"]
+==== Bound service account token volumes are enabled
+
+Previously, service account tokens were secrets that were mounted into pods. Starting with {product-title} 4.8, projected volumes are used instead. As a result of this change, service account tokens no longer have an underlying corresponding secret.
+
+Bound service account tokens are audience-bound and time-bound. For more information, see xref:../authentication/bound-service-account-tokens.adoc#bound-service-account-tokens[Using bound service account tokens].
+
+Additionally, the kubelet refreshes tokens automatically after they reach 80% of duration, and `client-go` watches for token changes and reloads automatically. The combination of these two behaviors means that most usage of bound tokens is no different from usage of legacy tokens that never expire. Non-standard usage outside of `client-go` might cause issues.
+
 [id="ocp-4-8-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
For https://github.com/openshift/openshift-docs/issues/29652#issuecomment-870662018

Removed a bit of detail and changed the reference for that additional detail to our existing docs rather than k8s docs. Cc: @bergerhoffer who wrote the docs I've linked to.

Preview: https://deploy-preview-34108--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-bound-svc-acct-token-vol