### PR TITLE
OSSMDOC-300: Restore Jaeger config reference.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2657,16 +2657,18 @@ Topics:
     File: ossm-observability
   - Name: Performance and scalability
     File: ossm-performance-scalability
-  - Name: Extensions
-    File: ossm-extensions
   - Name: Deploying to production
     File: ossm-deploy-production
+  - Name: Extensions
+    File: ossm-extensions
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
+  - Name: SMCP configuration reference
+    File: ossm-reference-smcp
+  - Name: Jaeger configuration reference
+    File: ossm-reference-jaeger 
   - Name: Uninstalling Service Mesh
     File: removing-ossm
-  - Name: Configuration reference
-    File: ossm-reference
 - Name: Service Mesh 1.x
   Dir: v1x
   Topics:

--- a/modules/jaeger-deployment-best-practices.adoc
+++ b/modules/jaeger-deployment-best-practices.adoc
@@ -12,6 +12,6 @@ This module included in the following assemblies:
 
 * If you have a multitenant implementation and tenants are separated by namespaces, deploy a Jaeger instance to each tenant namespace.
 
-** Jaeger agent as a sidecar is the only supported configuration. Jaeger as a daemonset is not supported for multitenant installations or OpenShift Dedicated.
+** Jaeger agent as a daemonset is not supported for multitenant installations or OpenShift Dedicated. Jaeger agent as a sidecar is the only supported configuration for these use cases.
 
 * If you are installing Jaeger as part of Red Hat OpenShift Service Mesh, Jaeger resources must be installed in the same namespace as the `ServiceMeshControlPlane` resource.

--- a/modules/ossm-configuring-external-jaeger.adoc
+++ b/modules/ossm-configuring-external-jaeger.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/customizing-installation-ossm.adoc
+
+
+[id="ossm-specifying-external-jaeger_{context}"]
+= Specifying Jaeger configuration in a Jaeger custom resource
+
+You can fully customize your Jaeger deployment by configuring Jaeger in the Jaeger custom resource (CR) rather than in the `ServiceMeshControlPlane` (SMCP) resource. This configuration is sometimes referred to as an "external Jaeger" since the configuration is specified outside of the SMCP.
+
+[NOTE]
+====
+You must deploy the SMCP and Jaeger CR in the same namespace. For example, `istio-system`.
+====
+
+You can configure and deploy a standalone Jaeger instance and then specify the `name` of the Jaeger resource as the value for `spec.addons.jaeger.name` in the SMCP resource. If a Jaeger CR matching the value of `name` exists, the control plane will use the existing installation. This approach lets you fully customize your Jaeger configuration.

--- a/modules/ossm-configuring-jaeger.adoc
+++ b/modules/ossm-configuring-jaeger.adoc
@@ -6,6 +6,6 @@
 [id="ossm-specifying-jaeger-configuration_{context}"]
 = Specifying Jaeger configuration in the SMCP
 
-You configure Jaeger under the `addons` section of `ServiceMeshControlPlane` resource.
+You can configure Jaeger under the `addons` section of the `ServiceMeshControlPlane` resource. However, there are some limitations to what you can configure in the SMCP.
 
-You can specify your Jaeger configuration in the `ServiceMeshControlPlane` resource under `spec.addons.jaeger.install`.  There are some limitations with this approach.  For example, you cannot configure a `streaming` deployment strategy via the control plane.
+When the SMCP passes configuration information to the Jaeger Operator, it triggers one of three deployment strategies: `allInOne`, `production`, or `streaming`.

--- a/modules/ossm-deploying-jaeger.adoc
+++ b/modules/ossm-deploying-jaeger.adoc
@@ -5,18 +5,20 @@
 [id="ossm-deploying-jaeger_{context}"]
 = Deploying Jaeger
 
+Jaeger has predefined deployment strategies. You specify a deployment strategy in the Jaeger custom resource (CR) file. When you create a Jaeger instance, the Operator uses this configuration file to create the objects necessary for the deployment.
+
 The Jaeger Operator currently supports the following deployment strategies:
 
-* *allInOne* (Default) - This strategy is intended for development, testing, and demo purposes; it is not intended for production use. The main backend components, Agent, Collector and Query service, are all packaged into a single executable which is configured (by default) to use in-memory storage.
+* *allInOne* (default) - This strategy is intended for development, testing, and demo purposes and it is not for production use. The main back-end components, Agent, Collector and Query service, are all packaged into a single executable, which is configured (by default) to use in-memory storage. You can configure this deployment strategy in the SMCP.
 +
 [NOTE]
 ====
-In-memory storage is not persistent, which means that if the Jaeger instance shuts down, restarts, or is replaced, your trace data will be lost.  And in-memory storage cannot be scaled, since each pod has its own memory. For persistent storage, you must use the `production` or `streaming` strategies, which use Elasticsearch as the default storage.
+In-memory storage is not persistent, which means that if the Jaeger instance shuts down, restarts, or is replaced, your trace data will be lost. And in-memory storage cannot be scaled, since each pod has its own memory. For persistent storage, you must use the `production` or `streaming` strategies, which use Elasticsearch as the default storage.
 ====
 
-* *production* - The production strategy is intended for production environments, where long term storage of trace data is important, as well as a more scalable and highly available architecture is required. Each of the backend components is therefore deployed separately.  The Agent can be injected as a sidecar on the instrumented application. The Query and Collector services are configured with a supported storage type - currently Elasticsearch. Multiple instances of each of these components can be provisioned as required for performance and resilience purposes.
+* *production* - The production strategy is intended for production environments, where long term storage of trace data is important, and a more scalable and highly available architecture is required. Each back-end component is therefore deployed separately. The Agent can be injected as a sidecar on the instrumented application. The Query and Collector services are configured with a supported storage type, which is currently Elasticsearch. Multiple instances of each of these components can be provisioned as required for performance and resilience purposes. You can configure this deployment strategy in the SMCP, but in order to be fully customized, you must specify your configuration in the Jaeger CR and link that to the SMCP.
 
-* *streaming* - The streaming strategy is designed to augment the production strategy by providing a streaming capability that effectively sits between the Collector and the backend storage (Elasticsearch). This provides the benefit of reducing the pressure on the backend storage, under high load situations, and enables other trace post-processing capabilities to tap into the real time span data directly from the streaming platform (https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_streams_on_openshift/index[AMQ Streams]/ https://kafka.apache.org/documentation/[Kafka]).
+* *streaming* - The streaming strategy is designed to augment the production strategy by providing a streaming capability that sits between the Collector and the Elasticsearch back-end storage. This provides the benefit of reducing the pressure on the back-end storage, under high load situations, and enables other trace post-processing capabilities to tap into the real-time span data directly from the streaming platform (https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/using_amq_streams_on_openshift/index[AMQ Streams]/ https://kafka.apache.org/documentation/[Kafka]). You cannot configure this deployment strategy in the SMCP; you must configure a Jaeger CR and link that to the SMCP.
 
 [NOTE]
 ====
@@ -26,9 +28,9 @@ The streaming strategy requires an additional Red Hat subscription for AMQ Strea
 [id="ossm-deploying-jaeger-default_{context}"]
 == Default Jaeger deployment
 
-To use the default `allInOne` Jaeger deployment strategy set `spec.addons.jaeger.install.storage.type` to `Memory`. You can accept the defaults or specify additional configuration options under `install`.  If you do not specify Jaeger configuration options, the Control Plane will use the `allInOne` deployment strategy by default.
+If you do not specify Jaeger configuration options, the `ServiceMeshControlPlane` resource will use the `allInOne` Jaeger deployment strategy by default. When using the default `allInOne` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Memory`. You can accept the defaults or specify additional configuration options under `install`.
 
-.Control Plane default Jaeger parameters (Memory)
+.Control plane default Jaeger parameters (Memory)
 [source,yaml]
 ----
 apiVersion: maistra.io/v2
@@ -48,12 +50,12 @@ spec:
           type: Memory
 ----
 
-[id="ossm-deploying-jaeger-production_{context}"]
-== Production Jaeger deployment
+[id="ossm-deploying-jaeger-production-min_{context}"]
+== Production Jaeger deployment (minimal)
 
-To use the `production` deployment strategy, set  `spec.addons.jaeger.install.storage.type` to 'Elasticsearch' and specify additional configuration options under `install`.   Or you can create and configure your Jaeger instance and set  `spec.addons.jaeger.name` to the name of the Jaeger instance, for example  `jaeger-production`.
+To use the default settings for the `production` deployment strategy, set `spec.addons.jaeger.install.storage.type` to `Elasticsearch` and specify additional configuration options under `install`. Note that the SMCP only supports configuring Elasticsearch resources and image name.
 
-.Control Plane default Jaeger parameters (Elasticsearch)
+.Control plane default Jaeger parameters (Elasticsearch)
 [source,yaml]
 ----
 apiVersion: maistra.io/v2
@@ -80,12 +82,15 @@ spec:
           resources: {}
 ----
 
-[id="ossm-deploying-jaeger-streaming_{context}"]
-== Streaming Jaeger deployment
 
-To use the `streaming` deployment strategy you create and configure your Jaeger instance first, then set  `spec.addons.jaeger.name` to the name of the Jaeger instance, for example, `jaeger-streaming`.
+[id="ossm-deploying-jaeger-production_{context}"]
+== Production Jaeger deployment (fully customized)
 
-.Sample connection to an existing Jaeger instance
+The SMCP supports only minimal Elasticsearch parameters. To fully customize your production environment and access all of the Elasticsearch configuration parameters, use the Jaeger custom resource (CR) to configure Jaeger.
+
+Create and configure your Jaeger instance and set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `jaeger-production-cr`.
+
+.Control plane with linked Jaeger production CR
 [source,yaml]
 ----
 apiVersion: maistra.io/v2
@@ -95,9 +100,36 @@ metadata:
 spec:
   version: v2.0
   tracing:
-    sampling: 10
+    sampling: 1000
     type: Jaeger
   addons:
     jaeger:
-      name: jaeger-streaming
+      name: jaeger-production-cr #name of Jaeger CR
+      install:
+        storage:
+          type: Elasticsearch
+        ingress:
+          enabled: true
+----
+
+[id="ossm-deploying-jaeger-streaming_{context}"]
+== Streaming Jaeger deployment
+
+To use the `streaming` deployment strategy, you create and configure your Jaeger instance first, then set `spec.addons.jaeger.name` to the name of the Jaeger instance, in this example: `jaeger-streaming-cr`.
+
+.Control plane with linked Jaeger streaming CR
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+spec:
+  version: v2.0
+  tracing:
+    sampling: 1000
+    type: Jaeger
+  addons:
+    jaeger:
+      name: jaeger-streaming-cr  #name of Jaeger CR
 ----

--- a/modules/ossm-enabling-jaeger.adoc
+++ b/modules/ossm-enabling-jaeger.adoc
@@ -6,7 +6,7 @@
 [id="ossm-enabling-tracing_{context}"]
 = Enabling and disabling tracing
 
-You enable tracing by specifying a tracing type and a sampling rate.
+You enable distributed tracing by specifying a tracing type and a sampling rate in the `ServiceMeshControlPlane` resource.
 
 .Default `all-in-one` Jaeger parameters
 [source,yaml]
@@ -22,6 +22,13 @@ spec:
     type: Jaeger
 ----
 
-Currently the only tracing type that is supported is `Jaeger`.   Jaeger is enabled by default.  To disable tracing, set `type` to `None`.
+Currently, the only tracing type that is supported is `Jaeger`.
 
-The sampling rate determines how often a trace is generated. You configure `sampling` as a scaled integer representing 0.01% increments.  For example, setting the value to `10` samples 0.1% of traces, setting the value to `500` samples 5% of traces, and a setting of `10000` samples 100% of traces.
+Jaeger is enabled by default. To disable tracing, set `type` to `None`.
+
+The sampling rate determines how often the Envoy proxy generates a trace. You can use the sampling rate option to control what percentage of requests get reported to your tracing system. You can configure this setting based upon your traffic in the mesh and the amount of tracing data you want to collect. You configure `sampling` as a scaled integer representing 0.01% increments. For example, setting the value to `10` samples 0.1% of traces, setting the value to `500` samples 5% of traces, and a setting of `10000` samples 100% of traces.
+
+[NOTE]
+====
+The SMCP sampling configuration option controls the Envoy sampling rate. You configure the Jaeger trace sampling rate in the Jaeger custom resource.
+====

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -1,0 +1,34 @@
+[id="jaeger-config-ref"]
+= Jaeger configuration reference
+include::modules/ossm-document-attributes.adoc[]
+:context: jaeger-config-ref
+
+toc::[]
+
+When the {ProductShortName} Operator deploys the `ServiceMeshControlPlane` resource, it can also create the resources for distributed tracing. {ProductShortName} uses Jaeger for distributed tracing.
+
+include::modules/ossm-enabling-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-configuring-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-deploying-jaeger.adoc[leveloffset=+1]
+
+include::modules/ossm-configuring-external-jaeger.adoc[leveloffset=+1]
+
+include::modules/jaeger-deployment-best-practices.adoc[leveloffset=+2]
+
+include::modules/jaeger-config-default.adoc[leveloffset=+2]
+
+include::modules/jaeger-config-collector.adoc[leveloffset=+2]
+
+include::modules/jaeger-config-sampling.adoc[leveloffset=+2]
+
+include::modules/jaeger-config-storage.adoc[leveloffset=+2]
+
+For more information about configuring Elasticsearch with {product-title}, see  xref:../../logging/config/cluster-logging-log-store.adoc[Configuring the log store] or xref:../../jaeger/jaeger_install/rhbjaeger-deploying.adoc[Configuring and deploying Jaeger].
+
+For information about connecting to an external Elasticsearch instance, see xref:../../jaeger/jaeger_install/rhbjaeger-deploying.adoc#jaeger-config-external-es_jaeger-deploying[Connecting to an existing Elasticsearch instance].
+
+include::modules/jaeger-config-query.adoc[leveloffset=+2]
+
+include::modules/jaeger-config-ingester.adoc[leveloffset=+2]

--- a/service_mesh/v2x/ossm-reference-smcp.adoc
+++ b/service_mesh/v2x/ossm-reference-smcp.adoc
@@ -1,5 +1,5 @@
 [id="ossm-reference"]
-= Configuration reference
+= SMCP configuration reference
 include::modules/ossm-document-attributes.adoc[]
 :context: ossm-reference
 


### PR DESCRIPTION
Restores previously approved Jaeger configuration reference topics to Service Mesh doc set as a separate configuration reference topic.

I did make some changes to the flow of the overview of the deployment options and added details to clarify how to configure each option. But the vast majority of this PR is re-linking to already reviewed/approved and merged content.

Addresses [OSSMDOC-247](https://issues.redhat.com/browse/OSSMDOC-247) and [OSSMDOC-299](https://issues.redhat.com/browse/OSSMDOC-299).

Preview is here -> https://deploy-preview-34112--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-reference-jaeger.html

Eng review - jpkrohling, rkukura
QE review - FilipB, iblancasa