### PR TITLE
BZ1941060: adding explicit admin login command

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -185,6 +185,14 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 
+. In a separate terminal window, log in to the cluster as a user with the `cluster-admin` role by using the following command:
++
+[source,terminal]
+----
+# oc login -u <cluster-admin> <1>
+----
+<1> For `<cluster-admin>`, specify a user name with the `cluster-admin` role.
+
 . Force etcd redeployment.
 +
 In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1941060

4.7+

Preview: https://deploy-preview-34127--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html