### PR TITLE
[enterprise-4.6] Fix-revert PR34126

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -152,8 +152,3 @@ EOF
 <2> Required.
 
 . Continue with the remainder of the {product-title} deployment.
-
-[IMPORTANT]
-====
-If you configure additional data partitions, they will not be encrypted unless encryption is explicitly requested.
-====

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -72,8 +72,3 @@ EOF
 . Make a backup copy of the YAML file. You should do this because the file will be deleted when you create the cluster.
 
 . Continue with the remainder of the {product-title} deployment.
-
-[IMPORTANT]
-====
-If you configure additional data partitions, they will not be encrypted unless encryption is explicitly requested.
-====


### PR DESCRIPTION
Woops...this reverts changes introduced in https://github.com/openshift/openshift-docs/pull/34126 because the parent PR (https://github.com/openshift/openshift-docs/pull/34016) should have only been applied back to 4.7 and not 4.6. This restores 4.6 to the previous and correct state.