### PR TITLE
4.8 RNs: bumping up IBM P/Z heading one level

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -151,8 +151,20 @@ For `console` and `downloads` routes, custom routes functionality is now impleme
 
 For more information, see xref:../web_console/customizing-the-web-console.adoc#customizing-the-web-console-url_customizing-web-console[Customizing console routes].
 
+[id="ocp-4-8-access-code-snippet-from-quick-start"]
+==== Access a code snippet from a Quick Start
+
+You can now execute a CLI snippet when it is included in a Quick Start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
+
+[id="ocp-4-8-improved-presentation-quick-start-prereqs"]
+==== Improved presentation of Quick Start prerequisites
+
+Previously, Quick Start prerequisites were displayed as combined text instead of a list on the Quick Start card. With scalability in mind, the prerequisites are now presented in a popover rather than on the card.
+
+image::quick-start-prerequisites.png[Quick Start prerequisites displayed as popover,338,336]
+
 [id="ocp-4-8-ibm-z"]
-==== IBM Z and LinuxONE
+=== IBM Z and LinuxONE
 
 With this release, IBM Z and LinuxONE are now compatible with {product-title} {product-version}. The installation can be performed with z/VM or {op-system-base} KVM. For installation instructions, see the following documentation:
 
@@ -162,7 +174,7 @@ With this release, IBM Z and LinuxONE are now compatible with {product-title} {p
 * xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[Installing a cluster with RHEL KVM on IBM Z and LinuxONE in a restricted network]
 
 [discrete]
-===== Notable enhancements
+==== Notable enhancements
 
 The following new features are supported on IBM Z and LinuxONE with {product-title} {product-version}:
 
@@ -172,7 +184,7 @@ The following new features are supported on IBM Z and LinuxONE with {product-tit
 * Three-node cluster support.
 
 [discrete]
-===== Supported features
+==== Supported features
 
 The following features are also supported on IBM Z and LinuxONE:
 
@@ -190,7 +202,7 @@ These features are available only for {product-title} on IBM Z for {product-vers
 * HyperPAV enabled on IBM Z /LinuxONE for the virtual machines for FICON attached ECKD storage
 
 [discrete]
-===== Restrictions
+==== Restrictions
 
 Note the following restrictions for {product-title} on IBM Z and LinuxONE:
 
@@ -216,7 +228,7 @@ Note the following restrictions for {product-title} on IBM Z and LinuxONE:
 * Persistent non-shared storage must be provisioned using local storage, like iSCSI, FC, or using LSO with DASD, FCP, or EDEV/FBA
 
 [id="ocp-4-8-ibm-power"]
-==== IBM Power Systems
+=== IBM Power Systems
 
 With this release, IBM Power Systems are now compatible with {product-title} {product-version}. For installation instructions, see the following documentation:
 
@@ -224,7 +236,7 @@ With this release, IBM Power Systems are now compatible with {product-title} {pr
 * xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power_installing-restricted-networks-ibm-power[Installing a cluster on IBM Power Systems in a restricted network]
 
 [discrete]
-===== Notable enhancements
+==== Notable enhancements
 
 The following new features are supported on IBM Power Systems with {product-title} {product-version}:
 
@@ -233,7 +245,7 @@ The following new features are supported on IBM Power Systems with {product-titl
 * Multus SR-IOV
 
 [discrete]
-===== Supported features
+==== Supported features
 
 The following features are also supported on IBM Power Systems:
 
@@ -255,7 +267,7 @@ The following features are also supported on IBM Power Systems:
 * NVMe
 
 [discrete]
-===== Restrictions
+==== Restrictions
 
 Note the following restrictions for {product-title} on IBM Power Systems:
 
@@ -274,18 +286,6 @@ Note the following restrictions for {product-title} on IBM Power Systems:
 
 * Worker nodes must run {op-system-first}
 * Persistent storage must be of the Filesystem type that uses local volumes, Network File System (NFS), or Container Storage Interface (CSI)
-
-[id="ocp-4-8-access-code-snippet-from-quick-start"]
-==== Access a code snippet from a Quick Start
-
-You can now execute a CLI snippet when it is included in a Quick Start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
-
-[id="ocp-4-8-improved-presentation-quick-start-prereqs"]
-==== Improved presentation of Quick Start prerequisites
-
-Previously, Quick Start prerequisites were displayed as combined text instead of a list on the Quick Start card. With scalability in mind, the prerequisites are now presented in a popover rather than on the card.
-
-image::quick-start-prerequisites.png[Quick Start prerequisites displayed as popover,338,336]
 
 [id="ocp-4-8-security"]
 === Security and compliance


### PR DESCRIPTION
Per discussion with Tania, these are a level lower than intended. Bumping up.

Preview: https://deploy-preview-34131--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes (see TOC)
Content starts here: https://deploy-preview-34131--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-ibm-z