### PR TITLE
Adds 4.5.41 release notes

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -2672,3 +2672,19 @@ link:https://access.redhat.com/solutions/6075411[{product-title} 4.5.40 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
+
+[id="ocp-4-5-41"]
+=== RHBA-2021:2430 - {product-title} 4.5.41 bug fix and security update
+
+Issued: 2021-06-30
+
+{product-title} release 4.5.41 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2430[RHBA-2021:2430] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2431[RHSA-2021:2431] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6145472[{product-title} 4.5.41 container image list]
+
+[id="ocp-4-5-41-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]


### PR DESCRIPTION
The *last* release notes to be added to 4.5! 

No BZ.

Preview: https://deploy-preview-34150--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-5-release-notes.html#ocp-4-5-41

Can be merged when approved! 