### PR TITLE
Adds 4.8 RN bug doc text

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1183,19 +1183,46 @@ As part of the continued deprecation of the Operator package manifest format, th
 * Previously, the documentation and `oc explain` help text did not convey that the `buildArgs` field in the `BuildConfig` object does not support the `valueFrom` field of its underlying Kubernetes `EnvVar` type. As a result, users believed it was supported and tried to use it. The current release updates the documentation and help text, so it is more apparent that the `BuildConfig` object's `buildArgs` field does not support the `valueFrom` field.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1956826[*BZ#1956826*])
 
-
 * When builds interact with image registries, such as pulling base images, intermittent communications issues can produce build failures. The current release increases the number of retries to these interactions. Now, OpenShift builds are more resilient when they encounter intermittent communication issues with image registries.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937535[*BZ#1937535*])
 
-
 *Cloud Compute*
 
+* Previously, a proxy update caused a full cluster configuration update, including API server restart, during continuous integration (CI) runs. Consequently, some clusters in the Machine API Operator would time out because of unexpected API server outages. This update separates proxy tests and adds postconditions so that clusters in the Machine API Operator become stable again during CI runs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1913341[*BZ#1913341*])
 
+* Previously, deleting a machine stuck in `Insufficient disk space on datastore` took longer than expected because there was no distinction between various vCenter task types. With this update, the machine controller deletion procedure checks the vCenter task type, and no longer blocks the deletion of the machine controller. As a result, the machine controller is deleted quickly.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918101[*BZ#1918101*])
+
+* Previously, scaling from zero annotations requeued even if the instance type was missing. Consequently, there were constant requeue and error space messages in the MachineSet controller logs. With this update, users can set the annotation manually if the instance type is not resolved automatically. As a result, scaling from zero for unknown instance types works if users manually provide the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918910[*BZ#1918910*])
+
+* Previously, HTTP responses were not closed properly by the Machine API termination handler. Consequently, goroutines were leaked in `net.http` read and write loops, which led to high memory usage. This update ensures that HTTP responses are always closed properly. As a result, memory usage is now stable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1934021[*BZ#1934021*])
+
+* Previously, multiple client sets created inside of the MachineSet controller caused slow startup times, which resulted in pods failing readiness checks in some large clusters. Consequently, the MachineSet controller would get stuck in an endless loop. This update fixes the MachineSet controller so that it uses a single client. As a result, the MachineSet controller behaves as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1934216[*BZ#1934216*])
+
+* Previously, instances took longer to boot when an upgrade was performed by the Machine Config Daemon on the first boot. Consequently, worker nodes were stuck in restart loops, and machine healthchecks (MCHs) removed the worker nodes because they did not properly start. With this update, MHCs no longer remove nodes that have not started correctly. Instead, MHCs only remove nodes when explicitly requested. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939054[*BZ#1939054*])
+
+* Previously, a certificate signing request (CSR) approval was delayed for an unknown reason. Consequently, new machines appearing in the cluster during installation were not approved quickly enough, prolonging cluster installation. To mitigate occasional API server unavailability in early installation phases, this update changes the cache resync period from 10 hours to 10 minutes. As a result, master machines are now approved faster so that cluster installation is no longer prolonged. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1940972[*BZ#1940972*])
+
+* Previously, the default Google Cloud Platform (GCP) image was out of date and referenced a version from the {product-title} 4.6 release that did not support newer Ignition versions. Consequently, new machines in clusters that used the default GCP image were not able to boot {product-title} 4.7 and later. With this update, the GCP image is updated to match the release version. As a result, new machines can now boot with the default GCP image. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954597[*BZ#1954597*])
+
+* Previously, due to a strict check of the virtual machine's (VM) ProvisioningState value, the VM would sometimes fail during an existence check. With this update, the check is more lenient so that only deleted machines go into a `Failed` phase during an existence check. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957349[*BZ#1957349*])
+
+* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine.  
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1880757[*BZ#1880757*])
+
+* Previously, when deleting an unreachable machine, the vSphere Virtual Machine Disk (VMDK) that is created for persistent volumes and attached to the node was incorrectly deleted. As a result, the data on the VMDK was unrecoverable. With this release, the vSphere cloud provider checks and detaches these disks from the node if the kubelet is not reachable. With this fix, you can delete an unreachable machine without losing the VMDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883993[*BZ#1883993*])
+
+* Previously, some newer Amazon Web Services (AWS) instance types were not able to scale from zero when using the Cluster Autoscaler and MachineSets with zero replicas. Because a generated list of AWS instance types was out of date, the list of AWS instance types was updated to include newer instance types. With this fix, more instance types are available to the Cluster Autoscaler for scaling from zero replicas. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1896321[*BZ#1896321*])
+
+* Previously, pod disruption budgets did not allow draining pods on an unreachable node due to missing upstream eviction API features. As a result, machines on unreachable nodes could take excessive amounts of time to be removed after being deleted. With this update, the grace period timeout is changed to 1 second when deleting machines on unreachable nodes. With this fix, the Machine API can now successfully drain and delete nodes that are unreachable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905709[*BZ#1905709*])
 
 *Cloud Credential Operator*
 
-
-
+ * Previously, the Cloud Credential Operator repeated an `unsupported platform type: BareMetal` warning on bare metal platforms. With this update, bare metal platforms are no longer treated as unknown platforms. As a result, misleading logging messages are reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1864116[*BZ#1864116*])
+ 
+ * Previously, a recurring error message stored in the `credentialsRequest` custom resources (CRs) of the Cloud Credential Operator led to excessive CPU usage and logging in some error scenarios, such as Amazon Web Services (AWS) rate limiting. This update removes the request ID coming back from the cloud provider so that error messages are stored in conditions where users can more easily find them, and eliminates recurring error messages in the `credentialsRequest` CR. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910396[*BZ#1910396*])
+ 
+ * Previously, both the Cloud Credential Operator (CCO) and the Cluster Version Operator (CVO) reported if the CCO deployment was unhealthy. This resulted in double reporting if there was an issue. With this release, the CCO no longer reports if its deployment is unhealthy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957424[*BZ#1957424*])
+ 
 *Cluster Version Operator*
 
 
@@ -1248,7 +1275,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *kube-apiserver*
 
-
+* Previously, Google Cloud Platform (GCP) load balancer health checkers left stale conntrack entries on the host, which caused network interruptions to the API server traffic that used the GCP load balancers. The health check traffic no longer loops through the host, so there is no longer network disruption against the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925698[*BZ#1925698*])
 
 *Machine Config Operator*
 
@@ -1270,7 +1297,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *Monitoring*
 
-
+* Previously, the `mountstats` collector for the `node-exporter` daemontset caused high memory usage on nodes with NFS mount points. With this update, users can now disable the `mountstats` collector to reduce memory usage. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955467[*BZ#1955467*])
 
 *Networking*
 
@@ -1282,6 +1309,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *oauth-apiserver*
 
+* Previously, some OAuth server metrics were not initialized properly and did not appear in searches in the Prometheus UI. The missing OAuth server metrics are now initialized properly and appear in the Prometheus UI metrics searches. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1892642[*BZ#1892642*])
 
 
 *oc*


### PR DESCRIPTION
For 4.8.

No BZ. 

Preview: https://deploy-preview-34158--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-bug-fixes

This one is a bit larger than future PRs will be. We will try to keep future PRs for 4.8 RNs at ~15 entries (this one is 18 I think). 