### PR TITLE
Adding note about custom SCCs and restricted volume types

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1004,6 +1004,11 @@ Bound service account tokens are audience-bound and time-bound. For more informa
 
 Additionally, the kubelet refreshes tokens automatically after they reach 80% of duration, and `client-go` watches for token changes and reloads automatically. The combination of these two behaviors means that most usage of bound tokens is no different from usage of legacy tokens that never expire. Non-standard usage outside of `client-go` might cause issues.
 
+[IMPORTANT]
+====
+If you use custom security context constraints (SCCs) that restrict volume usage in the `volumes` field, you might need to add `projected` to the list of volume types allowed by the SCCs. This is because every pod is now injected with a projected volume.
+====
+
 [id="ocp-4-8-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Per @s-urbaniak.

Preview: https://deploy-preview-34161--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-bound-svc-acct-token-vol