### PR TITLE
BZ1973377: Add OSDK / OCP compat notices & steps

### DIFF
--- a/modules/olm-about-catalogs.adoc
+++ b/modules/olm-about-catalogs.adoc
@@ -15,10 +15,14 @@ As a cluster administrator, you can create your own custom index image, either b
 
 [IMPORTANT]
 ====
-When creating custom catalog images, previous versions of {product-title} 4 required using the `oc adm catalog build` command, which was deprecated for several releases and is now removed. With the availability of Red Hat-provided index images starting in {product-title} 4.6, catalog builders must use the `opm index` command to manage index images.
+Kubernetes periodically deprecates certain APIs that are removed in subsequent releases. As a result, Operators are unable to use removed APIs starting with the version of {product-title} that uses the Kubernetes version that removed the API.
+
+If your cluster is using custom catalogs, see xref:../../operators/operator_sdk/osdk-working-bundle-images#osdk-control-compat_osdk-working-bundle-images[Controlling Operator compatibility with {product-title} versions] for more details about how Operator authors can update their projects to help avoid workload issues and prevent incompatible upgrades.
 ====
 
 [NOTE]
 ====
 Support for the legacy _package manifest format_ for Operators, including custom catalogs that were using the legacy format, is removed in {product-title} 4.8 and later.
+
+When creating custom catalog images, previous versions of {product-title} 4 required using the `oc adm catalog build` command, which was deprecated for several releases and is now removed. With the availability of Red Hat-provided index images starting in {product-title} 4.6, catalog builders must use the `opm index` command to manage index images.
 ====

--- a/modules/osdk-control-compat.adoc
+++ b/modules/osdk-control-compat.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-working-bundle-images.adoc
+
+[id="osdk-control-compat_{context}"]
+= Controlling Operator compatibility with {product-title} versions
+
+[IMPORTANT]
+====
+Kubernetes periodically deprecates certain APIs that are removed in subsequent releases. As a result, your Operator projects are unable to use removed APIs starting with the version of {product-title} that uses the Kubernetes version that removed the API.
+
+As an Operator author, it is strongly recommended that you review the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/[Deprecated API Migration Guide] in Kubernetes documentation and keep your projects up to date to avoid using deprecated and removed APIs. Ideally, you should update your Operator before the release of a future version of {product-title} that would make the Operator incompatible.
+====
+
+When an API is removed from an {product-title} version, Operators running on that cluster version that are still using removed APIs will no longer work properly. As an Operator author, you should plan to update your Operator projects to accommodate API deprecation and removal to avoid interruptions for users of your Operator.
+
+[TIP]
+====
+You can check the event alerts of your Operators running on {product-title} 4.8 and later to find whether there are any warnings about APIs currently in use. The following alerts fire when they detect an API in use that will be removed in the next release:
+
+`APIRemovedInNextReleaseInUse`::
+APIs that will be removed in the next OpenShift Container Platform release.
+
+`APIRemovedInNextEUSReleaseInUse`::
+APIs that will be removed in the next OpenShift Container Platform link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support (EUS)] release.
+====
+
+If a cluster administrator has installed your Operator, before they upgrade to the next version of {product-title}, they must ensure a version of your Operator is installed that is compatible with that next cluster version. While it is recommended that you update your Operator projects to no longer use deprecated or removed APIs, if you still need to publish your Operator bundles with removed APIs for continued use on earlier versions of {product-title}, ensure that the bundle is configured accordingly.
+
+The following procedure helps prevent administrators from installing versions of your Operator on an incompatible version of {product-title}. These steps also prevent administrators from upgrading to a newer version of {product-title} that is incompatible with the version of your Operator that is currently installed on their cluster.
+
+[IMPORTANT]
+====
+You should configure the following settings in your Operator project as soon as possible. Users running workloads with deprecated APIs that are planning to eventually upgrade to a future version of {product-title} must be running an Operator that has the proper configuration to avoid a cluster upgrade to an incompatible version and potentially adversely impact their critical workloads.
+====
+
+.Prerequisites
+
+- Operator SDK CLI installed on a development workstation
+- Operator project initialized by using the Operator SDK
+
+.Procedure
+
+. Configure the maximum version of {product-title} that your Operator is compatible with. In your Operator project's cluster service version (CSV), set the `olm.openShiftMaxVersion` annotation to prevent administrators from upgrading their cluster before upgrading the installed Operator to a compatible version:
++
+.Example CSV with `olm.maxOpenShiftVersion` annotation
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: ClusterServiceVersion
+metadata:
+  annotations:
+    "olm.properties": '[{"type": "olm.maxOpenShiftVersion", "value": "4.8"}]' <1>
+----
+<1> Setting `value` to `4.8` prevents cluster upgrades to {product-title} versions later than 4.8 when this bundle is installed on a cluster.
+
+. If your bundle is intended for distribution in a Red Hat-provided Operator catalog, configure the compatible versions of {product-title} for your Operator by setting the following properties. This configuration ensures your Operator is only included in catalogs that target compatible versions of {product-title}:
++
+[NOTE]
+====
+This step is only valid when publishing Operators in Red Hat-provided catalogs. If your bundle is only intended for distribution in a custom catalog, you can skip this step. For more details, see "Red Hat-provided Operator catalogs".
+====
+
+.. Set the `com.redhat.openshift.versions` annotation in your project's `bundle/metadata/annotations.yaml` file:
++
+.Example `bundle/metadata/annotations.yaml` file with compatible versions
+[source,yaml]
+----
+com.redhat.openshift.versions: "v4.6-v4.8" <1>
+----
+<1> Set to a range or single version.
+
+.. To prevent your bundle from being carried on to an incompatible version of {product-title}, ensure that the index image is generated with the proper `com.redhat.openshift.versions` label in your project's `bundle.Dockerfile`:
++
+.Example `bundle.Dockerfile` with compatible versions
++
+[source,yaml]
+----
+LABEL com.redhat.openshift.versions="v4.6-v4.8" <1>
+----
+<1> Set to a range or single version.
++
+[NOTE]
+====
+This label is also useful when you know that the current version of your Operator will not work well, for any reason, on a specific {product-title} version. By using it, you define the cluster versions where the Operator should be distributed, and the Operator does not appear in a catalog of a cluster version which is outside of the range.
+====
+
+You can now bundle a new version of your Operator and publish the updated version to a catalog for distribution.

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -12,6 +12,13 @@ This guide describes how to work with custom catalogs for Operators packaged usi
 Support for the legacy _package manifest format_ for Operators, including custom catalogs that were using the legacy format, is removed in {product-title} 4.8 and later.
 ====
 
+[IMPORTANT]
+====
+Kubernetes periodically deprecates certain APIs that are removed in subsequent releases. As a result, Operators are unable to use removed APIs starting with the version of {product-title} that uses the Kubernetes version that removed the API.
+
+If your cluster is using custom catalogs, see xref:../../operators/operator_sdk/osdk-working-bundle-images#osdk-control-compat_osdk-working-bundle-images[Controlling Operator compatibility with {product-title} versions] for more details about how Operator authors can update their projects to help avoid workload issues and prevent incompatible upgrades.
+====
+
 .Additional resources
 
 * xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]

--- a/operators/operator_sdk/osdk-working-bundle-images.adoc
+++ b/operators/operator_sdk/osdk-working-bundle-images.adoc
@@ -19,6 +19,13 @@ include::modules/osdk-bundle-upgrade-olm.adoc[leveloffset=+1]
 
 * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Traditional Operator installation with OLM]
 
+include::modules/osdk-control-compat.adoc[leveloffset=+1]
+.Additional resources
+
+* link:https://redhat-connect.gitbook.io/certified-operator-guide/ocp-deployment/operator-metadata/bundle-directory/managing-openshift-versions[Managing OpenShift Versions] in the _Certified Operator Build Guide_
+* xref:../../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators]
+* xref:../../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
+
 [id="osdk-working-bundle-images-additional-resources"]
 == Additional resources
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1973377

Preview:

* New section/procedure: [Controlling Operator compatibility with OpenShift Container Platform versions](https://deploy-preview-34166--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-working-bundle-images#osdk-control-compat_osdk-working-bundle-images)
* Small related admonitions also appear in [Managing custom catalogs](https://deploy-preview-34166--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html) and [About Operator catalogs](https://deploy-preview-34166--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-rh-catalogs.html#olm-about-catalogs_olm-rh-catalogs)

NOTE: This will be manually cherry-picked to 4.6 and 4.7 so that I can adjust some of the 4.8-specific language.