### PR TITLE
RHDEVDOCS-3133  Add deprecation notice for Jenkins Operators to OCP 4…

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1021,6 +1021,7 @@ Deprecated functionality is still included in {product-title} and continues to b
 In the table, features are marked with the following statuses:
 
 * *GA*: _General Availability_
+* *TP*: _Technology Preview_
 * *DEP*: _Deprecated_
 * *REM*: _Removed_
 
@@ -1106,7 +1107,13 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|Jenkins Operator
+|TP
+|TP
+|DEP
+
 |====
+
 
 [id="ocp-4-8-deprecated-features"]
 === Deprecated features
@@ -1134,6 +1141,13 @@ This release deprecates the `lastTriggeredImageID` in the `ImageChangeTrigger` o
 {product-title} version 4.9 will remove support for `lastTriggeredImageID` and ignore it. Then, image change triggers will not start a build based on changes to the `lastTriggeredImageID` field in the `BuildConfig` spec. Instead, the image IDs that trigger a build will be recorded in the status of the `BuildConfig` object, which most users cannot change.
 
 Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` accordingly. (link:https://issues.redhat.com/browse/BUILD-213[*BUILD-213*])
+
+[id="ocp-4-8-builds-jenkins-operator"]
+==== The Jenkins Operator (Technology Preview) is deprecated
+
+This release deprecates the Jenkins Operator, which was a Technology Preview feature. A future version of {product-title} will remove the Jenkins Operator from OperatorHub in the {product-title} web console interface. Then, upgrades for the Jenkins Operator will no longer be available, and the Operator will not be supported.
+
+Customers can continue to deploy Jenkins on {product-title} using the templates provided by the Samples Operator.
 
 [id="ocp-4-8-removed-features"]
 === Removed features
@@ -1349,6 +1363,7 @@ In the table below, features are marked with the following statuses:
 * *TP*: _Technology Preview_
 * *GA*: _General Availability_
 * *-*: _Not Available_
+* *DEP*: _Deprecated_
 
 //TODO: remove anything that has been GA since 4.6
 
@@ -1531,6 +1546,12 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 |GA
+
+|Jenkins Operator
+|TP
+|TP
+|DEP
+
 
 |====
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.8 release notes (not master)
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3133
- Direct link to doc preview: 
  - Information about this deprecation appears in the last row of this table: https://deploy-preview-34170--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-deprecated-removed-features
  - ...and in this deprecation note: https://deploy-preview-34170--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-builds-jenkins-operator

- SME review: @adambkaplan 
- Also: @siamaksade, @akram, @gabemontero, @sbose78
- QE review: @jitendar-singh 
- Peer review: @jeana-redhat 
- <All reviews complete. Please merge now>