### PR TITLE
OSDOCS-2293: Document HAProxy tunable buffer sizes parameters

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -3,7 +3,7 @@
 // * ingress/configure-ingress-operator.adoc
 
 [id="nw-ingress-controller-configuration-parameters_{context}"]
-= Ingress controller configuration parameters
+= Ingress Controller configuration parameters
 
 The `ingresscontrollers.operator.openshift.io` resource offers the following
 configuration parameters.
@@ -13,7 +13,7 @@ configuration parameters.
 |Parameter |Description
 
 |`domain`
-|`domain` is a DNS name serviced by the Ingress controller and is used to configure multiple features:
+|`domain` is a DNS name serviced by the Ingress Controller and is used to configure multiple features:
 
 * For the `LoadBalancerService` endpoint publishing strategy, `domain` is used to configure DNS records. See `endpointPublishingStrategy`.
 
@@ -21,7 +21,7 @@ configuration parameters.
 
 * The value is published to individual Route statuses so that users know where to target external DNS records.
 
-The `domain` value must be unique among all Ingress controllers and cannot be updated.
+The `domain` value must be unique among all Ingress Controllers and cannot be updated.
 
 If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.domain`.
 
@@ -29,10 +29,10 @@ If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.doma
 |`appsDomain` is an optional domain for AWS infrastructure to use instead of the one specified in the `domain` field when a Route is created without specifying an explicit host. If a value is entered for `appsDomain`, this value is used to generate default host values for the Route. Unlike `domain`, `appsDomain` can be modified after installation. You can use this parameter only if you set up a new Ingress Controller that uses a wildcard certificate.
 
 |`replicas`
-|`replicas` is the desired number of Ingress controller replicas. If not set, the default value is `2`.
+|`replicas` is the desired number of Ingress Controller replicas. If not set, the default value is `2`.
 
 |`endpointPublishingStrategy`
-|`endpointPublishingStrategy` is used to publish the Ingress controller endpoints to other networks, enable load balancer integrations, and provide access to other systems.
+|`endpointPublishingStrategy` is used to publish the Ingress Controller endpoints to other networks, enable load balancer integrations, and provide access to other systems.
 
 If not set, the default value is based on `infrastructure.config.openshift.io/cluster` `.status.platform`:
 
@@ -45,13 +45,13 @@ If not set, the default value is based on `infrastructure.config.openshift.io/cl
 For most platforms, the `endpointPublishingStrategy` value cannot be updated. However, on GCP, you can configure the `loadbalancer.providerParameters.gcp.clientAccess` subfield.
 
 |`defaultCertificate`
-|The `defaultCertificate` value is a reference to a secret that contains the default certificate that is served by the Ingress controller. When Routes do not specify their own certificate, `defaultCertificate` is used.
+|The `defaultCertificate` value is a reference to a secret that contains the default certificate that is served by the Ingress Controller. When Routes do not specify their own certificate, `defaultCertificate` is used.
 
 The secret must contain the following keys and data:
 * `tls.crt`: certificate file contents
 * `tls.key`: key file contents
 
-If not set, a wildcard certificate is automatically generated and used. The certificate is valid for the Ingress controller `domain` and `subdomains`, and
+If not set, a wildcard certificate is automatically generated and used. The certificate is valid for the Ingress Controller `domain` and `subdomains`, and
 the generated certificate's CA is automatically integrated with the
 cluster's trust store.
 
@@ -59,13 +59,13 @@ The in-use certificate, whether generated or user-specified, is automatically in
 
 |`namespaceSelector`
 |`namespaceSelector` is used to filter the set of namespaces serviced by the
-Ingress controller. This is useful for implementing shards.
+Ingress Controller. This is useful for implementing shards.
 
 |`routeSelector`
-|`routeSelector` is used to filter the set of Routes serviced by the Ingress controller. This is useful for implementing shards.
+|`routeSelector` is used to filter the set of Routes serviced by the Ingress Controller. This is useful for implementing shards.
 
 |`nodePlacement`
-|`nodePlacement` enables explicit control over the scheduling of the Ingress controller.
+|`nodePlacement` enables explicit control over the scheduling of the Ingress Controller.
 
 If not set, the defaults values are used.
 
@@ -86,17 +86,17 @@ nodePlacement:
 ====
 
 |`tlsSecurityProfile`
-|`tlsSecurityProfile` specifies settings for TLS connections for Ingress controllers.
+|`tlsSecurityProfile` specifies settings for TLS connections for Ingress Controllers.
 
 If not set, the default value is based on the `apiservers.config.openshift.io/cluster` resource.
 
-When using the `Old`, `Intermediate`, and `Modern` profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the `Intermediate` profile deployed on release `X.Y.Z`, an upgrade to release `X.Y.Z+1` may cause a new profile configuration to be applied to the Ingress controller, resulting in a rollout.
+When using the `Old`, `Intermediate`, and `Modern` profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the `Intermediate` profile deployed on release `X.Y.Z`, an upgrade to release `X.Y.Z+1` may cause a new profile configuration to be applied to the Ingress Controller, resulting in a rollout.
 
-The minimum TLS version for Ingress controllers is `1.1`, and the maximum TLS version is `1.2`.
+The minimum TLS version for Ingress Controllers is `1.1`, and the maximum TLS version is `1.2`.
 
 [IMPORTANT]
 ====
-The HAProxy Ingress controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
 
 The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
 ====
@@ -152,6 +152,16 @@ By setting `headerNameCaseAdjustments`, you can specify case adjustments that ca
 These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1.
 
 For request headers, these adjustments are applied only for routes that have the `haproxy.router.openshift.io/h1-adjust-case=true` annotation. For response headers, these adjustments are applied to all HTTP responses. If this field is empty, no request headers are adjusted.
+
+|`tuningOptions`
+|`tuningOptions` specifies options for tuning the performance of Ingress Controller pods.
+
+* `headerBufferBytes` specifies how much memory is reserved, in bytes, for Ingress Controller connection sessions. This value must be at least `16384` if HTTP/2 is enabled for the Ingress Controller. If not set, the default value is `32768` bytes. Setting this field not recommended because `headerBufferBytes` values that are too small can break the Ingress Controller, and `headerBufferBytes` values that are too large could cause the Ingress Controller to use significantly more memory than necessary.
+
+* `headerBufferMaxRewriteBytes` specifies how much memory should be reserved, in bytes, from `headerBufferBytes` for HTTP header rewriting and appending for Ingress Controller connection sessions. The minimum value for `headerBufferMaxRewriteBytes` is `4096`. `headerBufferBytes` must be greater than `headerBufferMaxRewriteBytes` for incoming HTTP requests. If not set, the default value is `8192` bytes. Setting this field not recommended because `headerBufferMaxRewriteBytes` values that are too small can break the Ingress Controller and `headerBufferMaxRewriteBytes` values that are too large could cause the Ingress Controller to use significantly more memory than necessary.
+
+* `threadCount` specifies the number of threads to create per HAProxy process. Creating more threads allows each Ingress Controller pod to handle more connections, at the cost of more system resources being used. HAProxy
+supports up to `64` threads. If this field is empty, the Ingress Controller uses the default value of `4` threads. The default value can change in future releases. Setting this field is not recommended because increasing the number of HAProxy threads allows Ingress Controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform. Reducing the number of threads can cause the Ingress Controller to perform poorly.
 
 |===
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2293

Preview: https://deploy-preview-34171--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress