### PR TITLE
OSDOCS-1839: Add release note for configurable tune.maxrewrite and tune.bufsize for HAProxy

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -536,6 +536,13 @@ For more information, see xref:../networking/dns-operator.adoc#nw-controlling-dn
 ==== Provider networks support for clusters that run on {rh-openstack}
 {product-title} clusters on {rh-openstack-first} now support provider networks for all deployment types.
 
+[id="ocp-4-8-configurable-headerBufferMaxRewriteByte-headerBufferBytes-parameters"]
+==== Configurable tune.maxrewrite and tune.bufsize for HAProxy
+
+Cluster Administrators can now set `headerBufferMaxRewriteByte` and `headerBufferBytes` Ingress Controller tuning parameters to configure `tune.maxrewrite `and `tune.bufsize` HAProxy memory options per-Ingress Controller.
+
+See xref:../networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters] for more information.
+
 [id="ocp-4-8-storage"]
 === Storage
 [id="ocp-4-8-storage-gcp-pd-csi-ga"]
@@ -1241,7 +1248,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 * Previously, due to a strict check of the virtual machine's (VM) ProvisioningState value, the VM would sometimes fail during an existence check. With this update, the check is more lenient so that only deleted machines go into a `Failed` phase during an existence check. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957349[*BZ#1957349*])
 
-* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine.  
+* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880757[*BZ#1880757*])
 
 * Previously, when deleting an unreachable machine, the vSphere Virtual Machine Disk (VMDK) that is created for persistent volumes and attached to the node was incorrectly deleted. As a result, the data on the VMDK was unrecoverable. With this release, the vSphere cloud provider checks and detaches these disks from the node if the kubelet is not reachable. With this fix, you can delete an unreachable machine without losing the VMDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883993[*BZ#1883993*])
@@ -1253,11 +1260,11 @@ As part of the continued deprecation of the Operator package manifest format, th
 *Cloud Credential Operator*
 
  * Previously, the Cloud Credential Operator repeated an `unsupported platform type: BareMetal` warning on bare metal platforms. With this update, bare metal platforms are no longer treated as unknown platforms. As a result, misleading logging messages are reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1864116[*BZ#1864116*])
- 
+
  * Previously, a recurring error message stored in the `credentialsRequest` custom resources (CRs) of the Cloud Credential Operator led to excessive CPU usage and logging in some error scenarios, such as Amazon Web Services (AWS) rate limiting. This update removes the request ID coming back from the cloud provider so that error messages are stored in conditions where users can more easily find them, and eliminates recurring error messages in the `credentialsRequest` CR. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910396[*BZ#1910396*])
- 
+
  * Previously, both the Cloud Credential Operator (CCO) and the Cluster Version Operator (CVO) reported if the CCO deployment was unhealthy. This resulted in double reporting if there was an issue. With this release, the CCO no longer reports if its deployment is unhealthy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957424[*BZ#1957424*])
- 
+
 *Cluster Version Operator*
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1839

Preview: https://deploy-preview-34175--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-configurable-headerBufferMaxRewriteByte-headerBufferBytes-parameters