### PR TITLE
Adds second batch of 4.8 bug fix summaries and enhancements

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -650,6 +650,10 @@ The bundle format is the preferred Operator packaging format for Operator Lifecy
 
 For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format].
 
+[id="ocp-4-8-service-ca-operator-enhancement"]
+==== Service-ca Operator enhancement
+{product-title} 4.8 allows users to run `service-ca-operator` pods as a non-root user to suit their organization's needs. When run as a non-root user, the `service-ca-operator runs with an user ID of `UID=1001(1001) GID =1001 groups=1001`. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1914446[*BZ#1914446*]. 
+
 [discrete]
 [id="ocp-4-8-builds"]
 === Builds
@@ -1249,6 +1253,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *Bare Metal Hardware Provisioning*
 
+* Previously, the machine instance `state` annotation was not set. Consequently, the `STATE` column was empty. With this update, the machine instance `state` annotation is now set, and information in the `STATE` column automatically populates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857008[*BZ#1857008*])
 
 
 *Builds*
@@ -1352,10 +1357,12 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 //section 1
 
+* Previously, the installer did not take into account the region where the bootstrap Ignition config should be located when generating its URL. Consequently, the bootstrap machine could not fetch the config from the provided URL because it was incorrect. This update takes the user's region into account when generating the URL and selects the correct public endpoint. As a result, the installer always generates correct bootstrap Ignition URLs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1934123[*BZ#1934123*])
+
+* Previously, the default version of Azure's Minimum TLS was 1.0 when creating a storage account. Consequently, policy checks would fail. This update configures the openshift-installer Azure client to set the Minimum TLS version to 1.2 when creating a storage account. As a result, policy checks now pass. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1943157[*BZ#1943157*])
 //section 2
 
 *ISV Operators*
-
 
 
 *kube-apiserver*
@@ -1363,7 +1370,6 @@ As part of the continued deprecation of the Operator package manifest format, th
 * Previously, Google Cloud Platform (GCP) load balancer health checkers left stale conntrack entries on the host, which caused network interruptions to the API server traffic that used the GCP load balancers. The health check traffic no longer loops through the host, so there is no longer network disruption against the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925698[*BZ#1925698*])
 
 *Machine Config Operator*
-
 
 
 *Web console (Administrator perspective)*
@@ -1378,7 +1384,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *Metering Operator*
 
-
+* Previously, the Reporting Operator incorrectly handled `Report` custom resources (CRs) that contained a user-provided retention period when reconciling events. Consequently, an expired `Report` CR would cause the Reporting Operator to continually loop, as the affected custom resources are requeued indefinitely.  This update avoids requeueing expired `Report` CRs that have specified a retention period. As a result, the Reporting Operator correctly handles events for expired `Report` CRs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926984[*BZ#1926984*])
 
 *Monitoring*
 
@@ -1403,7 +1409,9 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *OLM*
 
+* Previously, `CustomResourceDefinition` (CRD) objects applied as part of an Operator installation could sometimes satisfy the installation requirements of a newer version of the same Operator. Consequently, during an Operator upgrade, the version being replaced could be prematurely removed. In some cases, the upgrade would stop. With this update, the CRDs that are created or updated as part of the Operator bundle installation are annotated to indicate their bundle of origin. These annotations are used by the `ClusterServiceVersion` (CSV) object to distinguish between pre-existing CRDs and same-bundle CRDs. As a result, upgrades will not complete until the current version's CRDs have been applied. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1947946[*BZ#1947946*])
 
+* Previously, pods that ran an index referenced by a `CatalogSource` object did not have `readOnlyRootFileSystem: false` explicitly set in their `securityContext` field. Consequently, if an SCC existed that enforced `readOnlyRootFileSystem: true` and matched the `securityContext` of the that pod, it would be assigned to that pod and cause it to fail repeatedly. This update explicitly sets `readOnlyRootFileSystem: false` in the `securityContext` field. As a result, pods that are referenced by a `CatalogSource` object are no longer matched to SCCs that enforce a read-only root filesystem and no longer fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1961472[*BZ#1961472*])
 
 *openshift-apiserver*
 
@@ -1419,6 +1427,9 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 *Routing*
 
+* Previously, the HAProxyDown alert message was vague. Consequently, end users thought the alert meant that router pods, instead of just HAProxy pods, were unavailable. This update makes the HAProxyDown alert message clearer. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941592[*BZ#1941592*]) 
+
+* Previously, HAProxy's helper function template that was responsible for generating a file for whitelist IPs expected a wrong argument type. Consequently, no whitelist ACL was applied for the backend in long IP lists. With this update, argument types of the helper function template are changed so that whitelist ACL is applied to the backend of long IP lists. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1964486[*BZ#1964486*])
 
 
 *Samples*
@@ -1775,6 +1786,33 @@ scheduling:
 * When running CNF tests in regular mode on a single node, the logic in place to understand if the cluster is ready is missing details. In particular, creating an SR-IOV network will not create a network attachment definition until at least one minute elapses. All the DPDK tests fail in cascade. Run the CNF tests in regular mode skipping the DPDK feature when running against an installation on a single node, with the `-ginkgo.skip` parameter. Run CNF tests in Discovery mode to execute tests against an installation on a single node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970409[*BZ#1970409*])
 
 * Currently, CNF-tests does not support secure boot with MLX NICs for SR-IOV and DPDK tests. You can run the CNF tests skipping the SR-IOV feature when running against a secure boot enabled environment in regular mode, with the `-ginkgo.skip` parameter. Running in Discovery mode is the recommended way to execute tests against a secure boot enabled environment with MLX cards. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975216[*BZ#1975216*])
+
+* When the `ArgoCD` Operator is subscribed to and an ArgoCD and AppProject are started, launching the example application named `guestbook` fails because the image does not work in more restrictive {product-title} environments. As a temporary workaround, users can ensure the `ArgoCD` Operator works properly by deploying the following example:
++
+[source,yaml]
+----
+PROJ=younamespace
+cat > $PROJ-app.yaml <<EOF
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: simple-restricted-webserver
+  namespace: $PROJ
+spec:
+  destination:
+    namespace: $PROJ
+    server: https://kubernetes.default.svc
+  project: default
+  source:
+    path: basic-nginx
+    repoURL: 'https://github.com/opdev/argocd-example-restricted-apps.git'
+    targetRevision: HEAD
+EOF
+oc create -f $PROJ-app.yaml
+----
+
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1812212[*BZ#1812212*]. 
+
 
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Second match of RN bug fix summaries for 4.8. 

No BZ.

Preview: https://deploy-preview-34179--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

They're kind of everywhere ^ 