### PR TITLE
4.8 RNs: enhancements for 2nd L10N drop deadline

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -151,6 +151,11 @@ See xref:../installing/installing_openstack/installing-openstack-installer-sr-io
 Installing a cluster on OpenStack that supports SR-IOV-connected compute machines
 ] for more information.
 
+[id="installation-ironic-agent-vlan-support"]
+==== Ironic Python Agent support for VLAN interfaces
+
+With this update, the Ironic Python Agent now reports VLAN interfaces in the list of interfaces during introspection. Additionally, the IP address is included on the interfaces, which allows for proper creation of a CSR. As a result, a CSR can be obtained for all interfaces, including VLAN interfaces. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1888712[BZ#1888712].
+
 [id="ocp-4-8-web-console"]
 === Web console
 [id="ocp-4-8-custom-console-routes-use-custom-domains-cluster-api"]
@@ -341,6 +346,11 @@ For more information, see xref:../security/tls-security-profiles.adoc#tls-securi
 You can now set a TLS security profile for kubelet when it acts as an HTTP server for the Kubernetes API server.
 
 For more information, see xref:../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles].
+
+[id="ocp-4-8-security-bcrypt-hashing"]
+==== Support for `bcrypt` password hashing
+
+Previously, the `oauth-proxy` command only allowed the use of SHA-1 hashed passwords in `htpasswd` files used for authentication. `oauth-proxy` now includes support for `htpasswd` entries that use `bcrypt` password hashing. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1874322[BZ#1874322].
 
 [id="ocp-4-8-networking"]
 === Networking
@@ -687,6 +697,16 @@ When the MCO detects any of these changes, it applies the changes and uncordons 
 
 For more information, see xref:../architecture/control-plane.adoc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
 
+[id="ocp-4-8-machine-set-policy-enhancement"]
+==== Machine set policy enhancement
+
+Previously, creating machine sets required users to manually configure their CPU pinning settings, NUMA pinning settings, and CPU topology changes to get better performance from the host. With this enhancement, users can select a policy in the `MachineSet` resource to populate settings automatically. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1941334[BZ#1941334].
+
+[id="ocp-4-8-machine-set-hugepage-enhancement"]
+==== Machine set hugepage enhancement
+
+Providing a `hugepages` property into the `MachineSet` resource is now possible. This enhancement creates the `MachineSet` resource's nodes with a custom property in oVirt and instructs those nodes to use the `hugepages` of the hypervisor. For more information, see  link:https://bugzilla.redhat.com/show_bug.cgi?id=1948963[BZ#1948963].
+
 [id="ocp-4-8-nodes"]
 === Nodes
 
@@ -937,6 +957,16 @@ In {product-title} 4.8, the Insights Operator collects the following additional 
 * Information about the `cluster-version` pods and events from the `openshift-cluster-operator` namespace to debug issues with the `cluster-version` Operator.
 
 With this additional information, Red Hat can provide improved remediation steps in Insights Advisor.
+
+[id="ocp-4-8-insights-operator-gathering-sap"]
+==== Insights Operator enhancement for unhealthy SAP pods
+
+The Insights Operator can now gather data for unhealthy SAP pods. When the SDI installation fails, it is possible to detect the problem by looking at which of the initialization pods have failed. The Insights Operator now gathers information about failed pods in the SAP/SDI namespaces. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1930393[BZ#1930393].
+
+[id="ocp-4-8-gathering-sap-datahubs"]
+==== Insights Operator enhancement for gathering SAP pod data
+
+The Insights Operator can now gather `Datahubs` resources from SAP clusters. This data allows SAP clusters to be distinguished from non-SAP clusters in the Insights Operator archives, even in situations in which all of the data gathered exclusively from SAP clusters is missing and it would otherwise be impossible to determine if a cluster has an SDI installation. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1940432[BZ#1940432].
 
 [id="ocp-4-8-auth"]
 === Authentication and authorization
@@ -1255,7 +1285,7 @@ As part of the continued deprecation of the Operator package manifest format, th
 
 * Previously, due to a strict check of the virtual machine's (VM) ProvisioningState value, the VM would sometimes fail during an existence check. With this update, the check is more lenient so that only deleted machines go into a `Failed` phase during an existence check. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957349[*BZ#1957349*])
 
-* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine.  
+* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880757[*BZ#1880757*])
 
 * Previously, when deleting an unreachable machine, the vSphere Virtual Machine Disk (VMDK) that is created for persistent volumes and attached to the node was incorrectly deleted. As a result, the data on the VMDK was unrecoverable. With this release, the vSphere cloud provider checks and detaches these disks from the node if the kubelet is not reachable. With this fix, you can delete an unreachable machine without losing the VMDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883993[*BZ#1883993*])
@@ -1267,11 +1297,11 @@ As part of the continued deprecation of the Operator package manifest format, th
 *Cloud Credential Operator*
 
  * Previously, the Cloud Credential Operator repeated an `unsupported platform type: BareMetal` warning on bare metal platforms. With this update, bare metal platforms are no longer treated as unknown platforms. As a result, misleading logging messages are reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1864116[*BZ#1864116*])
- 
+
  * Previously, a recurring error message stored in the `credentialsRequest` custom resources (CRs) of the Cloud Credential Operator led to excessive CPU usage and logging in some error scenarios, such as Amazon Web Services (AWS) rate limiting. This update removes the request ID coming back from the cloud provider so that error messages are stored in conditions where users can more easily find them, and eliminates recurring error messages in the `credentialsRequest` CR. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910396[*BZ#1910396*])
- 
+
  * Previously, both the Cloud Credential Operator (CCO) and the Cluster Version Operator (CVO) reported if the CCO deployment was unhealthy. This resulted in double reporting if there was an issue. With this release, the CCO no longer reports if its deployment is unhealthy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957424[*BZ#1957424*])
- 
+
 *Cluster Version Operator*
 
 


### PR DESCRIPTION
Previews: 
- [Ironic Python Agent support for vlan interfaces](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#installation-ironic-agent-vlan-support)
- [Support for bcrypt password hashing
](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-security-bcrypt-hashing)
- [Machine set policy enhancement](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-machine-set-policy-enhancement)
- [Machine set hugepage enhancement](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-machine-set-hugepage-enhancement)
- [Insights Operator enhancement for unhealthy SAP pods](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-insights-operator-gathering-sap)
- [Insights Operator enhancement for gathering SAP pod data](https://deploy-preview-34184--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-gathering-sap-datahubs)