### PR TITLE
4.8 RNs: removing 4.7 RNs inclusive lang text

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -32,11 +32,6 @@ Because only {op-system-base} 7.9 or later is supported for compute machines, yo
 
 With the release of {product-title} 4.8, version 4.5 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
-[id="ocp-4-8-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
-
 [id="ocp-4-8-new-features-and-enhancements"]
 == New features and enhancements
 


### PR DESCRIPTION
Not needed for 4.8+

Preview: https://deploy-preview-34193--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-about-this-release