### PR TITLE
Update 4.8 RN for pkgman format removal

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -646,7 +646,7 @@ no operators found with name <name>.<version> in channel <name> of package <name
 [id="ocp-4-8-pkgman-to-bundle"]
 ==== Migration of Operator projects from package manifest format to bundle format
 
-The bundle format is the preferred Operator packaging format for Operator Lifecycle Manager (OLM) starting in {product-title} 4.6. If you have an Operator project that was initially created in the package manifest format, which has been deprecated, you can now use the Operator SDK `pkgman-to-bundle` command to migrate the project to the bundle format.
+Support for the legacy package manifest format for Operators is removed in {product-title} 4.8 and later. The bundle format is the preferred Operator packaging format for Operator Lifecycle Manager (OLM) starting in {product-title} 4.6. If you have an Operator project that was initially created in the package manifest format, which has been deprecated, you can now use the Operator SDK `pkgman-to-bundle` command to migrate the project to the bundle format.
 
 For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format].
 
@@ -1083,7 +1083,7 @@ In the table, features are marked with the following statuses:
 |Package manifest format (Operator Framework)
 |DEP
 |DEP
-|DEP
+|REM
 
 |`oc adm catalog build`
 |DEP
@@ -1217,14 +1217,18 @@ registry.redhat.io/rhpam-7/rhpam-businesscentral-rhel8:7.9.0
 registry.redhat.io/rhpam-7/rhpam-smartrouter-rhel8:7.9.0
 ----
 
-[id="ocp-4-8-pkgman-cmds"]
-==== Operator package manifest format commands
+[id="ocp-4-8-pkgman-format"]
+==== Package manifest format for Operators no longer supported
 
-As part of the continued deprecation of the Operator package manifest format, the following commands have been removed:
+Support for the legacy package manifest format for Operators is removed in {product-title} 4.8 and later. This removal of support includes custom catalogs that were built with the legacy format and Operator projects initially created in the legacy format with the Operator SDK. The bundle format is the preferred Operator packaging format for Operator Lifecycle Manager (OLM) starting in {product-title} 4.6.
 
+For more information about working with the bundle format, see xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs] and xref:../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format].
+
+In addition, the following commands related to the format have been removed from OpenShift CLI (`oc`) and the Operator SDK CLI:
+
+* `oc adm catalog build`
 * `operator-sdk generate packagemanifest`
 * `operator-sdk run packagemanifest`
-* `oc adm catalog build`
 
 [id="ocp-4-8-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Package manifest format support is actually _removed_ now starting in 4.8, not just deprecated.

Preview:

* Updated "Package manifest format (Operator Framework)" entry in [Deprecated and removed features tracker](https://deploy-preview-34200--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-removed-features) table
* Modified an existing entry under "Removed features" that was about the related command removals to instead be more broadly about removal of support for the whole format, and renamed it [Package manifest format for Operators no longer supported](https://deploy-preview-34200--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-pkgman-format)
* Updated new feature [Migration of Operator projects from package manifest format to bundle format](https://deploy-preview-34200--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-pkgman-to-bundle) under "Operator development" to be more clear about removal vs deprecation

For reference, https://github.com/openshift/openshift-docs/pull/34198 is a related PR for cleaning up any remaining mentions of support in the rest of the docs.