### PR TITLE
BZ1884330: Missing MITM mitigation

### DIFF
--- a/modules/builds-source-secret-ssh-key-auth.adoc
+++ b/modules/builds-source-secret-ssh-key-auth.adoc
@@ -32,5 +32,17 @@ the public key. The private key is used to access your private repository.
 ----
 $ oc create secret generic <secret_name> \
     --from-file=ssh-privatekey=<path/to/ssh/private/key> \
+    --from-file=<path/to/known_hosts> \ <1>
     --type=kubernetes.io/ssh-auth
 ----
+<1> Optional: Adding this field enables strict server host key check.
++
+[WARNING]
+====
+Skipping the `known_hosts` file while creating the secret makes the build vulnerable to a potential man-in-the-middle (MITM) attack.
+====
++
+[NOTE]
+====
+Ensure that the `known_hosts` file includes an entry for the host of your source code.
+====


### PR DESCRIPTION
Changes related to bug [BZ1884330](https://bugzilla.redhat.com/show_bug.cgi?id=1884330) to add MITM mitigation solution in documentation.
This fix is targeted for releases 4.6, 4.7 and 4.8

@xiuwang @gabemontero Kindly review the fix and provide your comments. Here is the  [preview link](https://deploy-preview-34201--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs.html#builds-source-secret-ssh-key-auth_creating-build-inputs)

