### PR TITLE
Small fixes to MTC RN

### DIFF
--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -17,10 +17,10 @@ This release has the following new features and enhancements:
 * A source namespace can be mapped to a different target namespace in a migration plan. Previously, the source namespace was mapped to a target namespace with the same name.
 * Hook phases with status information are displayed in the web console during a migration.
 * The number of Rsync retry attempts is displayed in the web console during direct volume migration.
-* Persistent volume (PV) resizing can be enabled during direct volume migration to ensure that the target cluster does not run out of disk space.
+* Persistent volume (PV) resizing can be enabled for direct volume migration to ensure that the target cluster does not run out of disk space.
 * The threshold that triggers PV resizing is configurable. Previously, PV resizing occurred when the disk usage exceeded 97%.
 * Velero has been updated to version 1.6, which provides numerous fixes and enhancements.
-* A cached Kubernetes client can be enabled to provide improved performance.
+* Cached Kubernetes clients can be enabled to provide improved performance.
 
 [id="known-issues-1-5_{context}"]
 == Known issues


### PR DESCRIPTION
No BZ or Jira.

4.8

Does not require QE.

Preview: https://deploy-preview-34208--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/mtc-release-notes?utm_source=github&utm_campaign=bot_dp#new-features-and-enhancements-1-5_mtc-release-notes