### PR TITLE
Correct DNS name for Prometheus Service

### DIFF
--- a/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
+++ b/modules/monitoring-exposing-custom-application-metrics-for-horizontal-pod-autoscaling.adoc
@@ -217,7 +217,7 @@ spec:
         - --tls-cert-file=/var/run/serving-cert/tls.crt
         - --tls-private-key-file=/var/run/serving-cert/tls.key
         - --logtostderr=true
-        - --prometheus-url=http://prometheus-operated.default.svc:9090/
+        - --prometheus-url=http://prometheus-operated.custom-prometheus.svc:9090/
         - --metrics-relist-interval=1m
         - --v=4
         - --config=/etc/adapter/config.yaml


### PR DESCRIPTION
* Description: This example is presumed that Prometheus was installed in a user-defined `custom-prometheus` project, so the Prometheus Service DNS name should include `custom-prometheus` namespace, not `default`.
* Reference: https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/#a-aaaa-records
```
"Normal" (not headless) Services are assigned a DNS A or AAAA record, depending on the IP family of the service, for a name of the form my-svc.my-namespace.svc.cluster-domain.example.
```