### PR TITLE
4.8 RNs: OSUS GA blurb try 2

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -151,6 +151,13 @@ Installing a cluster on OpenStack that supports SR-IOV-connected compute machine
 
 With this update, the Ironic Python Agent now reports VLAN interfaces in the list of interfaces during introspection. Additionally, the IP address is included on the interfaces, which allows for proper creation of a CSR. As a result, a CSR can be obtained for all interfaces, including VLAN interfaces. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1888712[BZ#1888712].
 
+[id="ocp-4-8-osus"]
+==== Over-the-air updates with the OpenShift Update Service
+
+The OpenShift Update Service (OSUS) provides over-the-air updates to {product-title}, including Red Hat Enterprise Linux CoreOS (RHCOS). It was previously only accessible as a Red Hat hosted service located behind public APIs, but can now be installed locally. The OpenShift Update Service is composed of an Operator and one or more application instances and is now generally available in {product-title} 4.6 and higher.
+
+For more information, see xref:../updating/understanding-the-update-service.adoc#understanding-the-update-service[Understanding the OpenShift Update Service].
+
 [id="ocp-4-8-web-console"]
 === Web console
 [id="ocp-4-8-custom-console-routes-use-custom-domains-cluster-api"]


### PR DESCRIPTION
GitHub ate the previous PR, #34120. This is the same content.

Preview: https://deploy-preview-34217--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-osus