### PR TITLE
Specifying that disaster recovery requires a healthy node

### DIFF
--- a/backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
+++ b/backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
@@ -11,6 +11,11 @@ how to recover from several disaster situations that might occur with their
 more of the following procedures to return your cluster to a working
 state.
 
+[IMPORTANT]
+====
+Disaster recovery requires you to have at least one healthy master host.
+====
+
 xref:../../backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]::
 This solution handles situations where you want to restore your cluster to
 a previous state, for example, if an administrator deletes something critical.

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -17,6 +17,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
+* A healthy master host to use as the recovery host.
 * SSH access to master hosts.
 * A backup directory containing both the etcd snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
 


### PR DESCRIPTION
Per @hexfusion 

https://issues.redhat.com/browse/ETCD-125

Previews:
* https://deploy-preview-34218--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/about-disaster-recovery.html
* https://deploy-preview-34218--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state