### PR TITLE
CNV-10989: updating version attributes for OpenShift Virtualization 4.8

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -12,9 +12,9 @@
 :VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
-:VirtVersion: 2.6
-:KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.5
+:VirtVersion: 4.8
+:KubeVirtVersion: v0.41.0
+:HCOVersion: 4.8.0
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- [CNV-10989](https://issues.redhat.com/browse/CNV-10989)
- CP to enterprise-4.8 only
- [Preview build with KubeVirtVersion example](https://deploy-preview-34222--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#additional-resources)
- [Preview build with VirtVersion example](https://deploy-preview-34222--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-planning-environment-object-maximums.html)
- [Preview build with HCOVersion example](https://deploy-preview-34222--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components)