### PR TITLE
CNV-12628: updating repo names for virt 4.8

### DIFF
--- a/modules/virt-enabling-virt-repos.adoc
+++ b/modules/virt-enabling-virt-repos.adoc
@@ -8,9 +8,9 @@
 Red Hat offers {VirtProductName} repositories for both Red Hat Enterprise Linux 8
 and Red Hat Enterprise Linux 7:
 
-* Red Hat Enterprise Linux 8 repository: `cnv-2.6-for-rhel-8-x86_64-rpms`
+* Red Hat Enterprise Linux 8 repository: `cnv-4.8-for-rhel-8-x86_64-rpms`
 
-* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-2.6-rpms`
+* Red Hat Enterprise Linux 7 repository: `rhel-7-server-cnv-4.8-rpms`
 
 The process for enabling the repository in `subscription-manager` is the same
 in both platforms.


### PR DESCRIPTION
- [CNV-12628](https://issues.redhat.com/browse/CNV-12628)
- enterprise-4.8 only
- [Preview build](https://deploy-preview-34223--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-installing-virtctl?utm_source=github&utm_campaign=bot_dp#virt-enabling-virt-repos_virt-installing-virtctl)