### PR TITLE
CCO-21: followup - adding links to STS content in a few key places

### DIFF
--- a/installing/installing_aws/manually-creating-iam.adoc
+++ b/installing/installing_aws/manually-creating-iam.adoc
@@ -13,10 +13,13 @@ include::modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc[level
 
 .Additional resources
 
-// Not supported in Azure. Condition out if combining topic for AWS/Azure/GCP.
-To learn how to rotate or remove the administrator-level credential secret after installing {product-title}, see xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials].
+// AWS only. Condition out if combining topic for AWS/Azure/GCP.
+* To learn how to use the CCO utility (`ccoctl`) to configure the CCO to use the AWS STS, see xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[Using manual mode with STS].
 
-For a detailed description of all available CCO credential modes and their supported platforms, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc[About the Cloud Credential Operator].
+// Not supported in Azure. Condition out if combining topic for AWS/Azure/GCP.
+* To learn how to rotate or remove the administrator-level credential secret after installing {product-title}, see xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-rotate-remove-cloud-creds[Rotating or removing cloud provider credentials].
+
+* For a detailed description of all available CCO credential modes and their supported platforms, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc[About the Cloud Credential Operator].
 
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -16,7 +16,7 @@ toc::[]
 
 Before installing {product-title} on Amazon Web Services (AWS), you must create an AWS account. See xref:../../installing/installing_aws/installing-aws-account.adoc#installing-aws-account[Configuring an AWS account] for details about configuring an account, account limits, account permissions, IAM user setup, and supported AWS regions.
 
-If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS] for other options.
+If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, see xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[Manually creating IAM for AWS] for other options, including xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-mode-sts[configuring the Cloud Credential Operator (CCO) to use the Amazon Web Services Security Token Service (AWS STS)].
 
 [id="choosing-an-method-to-install-ocp-on-aws"]
 == Choosing a method to install {product-title} on AWS
@@ -32,7 +32,7 @@ You can install a cluster on AWS infrastructure that is provisioned by the {prod
 
 * **xref:../../installing/installing_aws/installing-aws-default.adoc#installing-aws-default[Installing a cluster quickly on AWS]**: You can install {product-title} on AWS infrastructure that is provisioned by the {product-title} installation program. You can install a cluster quickly by using the default configuration options.
 
-* **xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS]**: You can install a customized cluster on AWS infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation]. 
+* **xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS]**: You can install a customized cluster on AWS infrastructure that the installation program provisions. The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
 
 * **xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-network-customizations[Installing a cluster on AWS with network customizations]**: You can customize your {product-title} network configuration during installation, so that your cluster can coexist with your existing IP address allocations and adhere to your network requirements.
 

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -22,6 +22,16 @@ The Cloud Credential Operator (CCO) manages cloud provider credentials as Kubern
 ifdef::aws,google-cloud-platform[]
 If you prefer not to store an administrator-level credential secret in the cluster `kube-system` project, you can choose one of the following options when installing {product-title}:
 
+endif::aws,google-cloud-platform[]
+
+ifdef::aws[]
+* *Use the Amazon Web Services Security Token Service*:
++
+You can use the CCO utility (`ccoctl`) to configure the cluster to use the Amazon Web Services Security Token Service (AWS STS). When the CCO utility is used to configure the cluster for STS, it assigns IAM roles that provide short-term, limited-privilege security credentials to components.
+
+endif::aws[]
+
+ifdef::aws,google-cloud-platform[]
 * *Manage cloud credentials manually*:
 +
 You can set the `credentialsMode` parameter for the CCO to `Manual` to manage cloud credentials manually. Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. You can also use this mode if your environment does not have connectivity to the cloud provider public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade. You must also manually supply credentials for every component that requests them.


### PR DESCRIPTION
Adding some links to AWS install content to make STS option easier to find.

Previews:
- [Requirements for installing OpenShift Container Platform on AWS](https://deploy-preview-34224--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/preparing-to-install-on-aws.html#requirements-for-installing-ocp-on-aws)
- [Alternatives to storing administrator-level secrets in the kube-system project](https://deploy-preview-34224--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-aws)
- Additional resources, same page (first bullet)