### PR TITLE
[enterprise-4.6]Bug 1978057, removed mention of annotation to force reconciliation of the fileintegrity object

### DIFF
--- a/modules/file-integrity-operator-changing-custom-config.adoc
+++ b/modules/file-integrity-operator-changing-custom-config.adoc
@@ -8,16 +8,3 @@
 To change the File Integrity configuration, never change the generated
 config map. Instead, change the config map that is linked to the `FileIntegrity`
 object through the `spec.name`, `namespace`, and `key` attributes.
-
-Currently, you must also annotate the `FileIntegrity` object in order to force
-reconciliation of the object and its config map. For example:
-
-[source,terminal]
-----
-$ oc annotate fileintegrities/worker-fileintegrity file-integrity.openshift.io/config-version=2
-----
-
-The value of the annotation or whether it is an annotation does not really
-matter; the purpose is of this operation is to force reconciliation of the
-`FileIntegrity` object and re-render the processed config map with the generated
-configuration.


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/34213