### PR TITLE
BZ1978241: Bump remaining OSDK ver for 4.8

### DIFF
--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -11,7 +11,7 @@ See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Oper
 
 [NOTE]
 ====
-{product-title} 4.7 and later supports Operator SDK v1.3.0.
+{product-title} 4.8 and later supports Operator SDK v1.8.0.
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]

--- a/modules/osdk-ansible-inside-operator-local.adoc
+++ b/modules/osdk-ansible-inside-operator-local.adoc
@@ -45,7 +45,7 @@ $ make run
 [source,terminal]
 ----
 /home/user/memcached-operator/bin/ansible-operator run
-{"level":"info","ts":1612739145.2871568,"logger":"cmd","msg":"Version","Go Version":"go1.15.5","GOOS":"linux","GOARCH":"amd64","ansible-operator":"v1.3.0","commit":"1abf57985b43bf6a59dcd18147b3c574fa57d3f6"}
+{"level":"info","ts":1612739145.2871568,"logger":"cmd","msg":"Version","Go Version":"go1.15.5","GOOS":"linux","GOARCH":"amd64","ansible-operator":"v1.8.0","commit":"1abf57985b43bf6a59dcd18147b3c574fa57d3f6"}
 ...
 {"level":"info","ts":1612739148.347306,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":":8080"}
 {"level":"info","ts":1612739148.3488882,"logger":"watches","msg":"Environment variable not set; using default value","envVar":"ANSIBLE_VERBOSITY_MEMCACHED_CACHE_EXAMPLE_COM","default":2}

--- a/modules/osdk-ansible-inside-operator-logs-view.adoc
+++ b/modules/osdk-ansible-inside-operator-logs-view.adoc
@@ -25,7 +25,7 @@ $ oc logs deployment/<project_name>-controller-manager \
 .Example output
 [source,terminal]
 ----
-{"level":"info","ts":1612732105.0579333,"logger":"cmd","msg":"Version","Go Version":"go1.15.5","GOOS":"linux","GOARCH":"amd64","ansible-operator":"v1.3.0","commit":"1abf57985b43bf6a59dcd18147b3c574fa57d3f6"}
+{"level":"info","ts":1612732105.0579333,"logger":"cmd","msg":"Version","Go Version":"go1.15.5","GOOS":"linux","GOARCH":"amd64","ansible-operator":"v1.8.0","commit":"1abf57985b43bf6a59dcd18147b3c574fa57d3f6"}
 {"level":"info","ts":1612732105.0587437,"logger":"cmd","msg":"WATCH_NAMESPACE environment variable not set. Watching all namespaces.","Namespace":""}
 I0207 21:08:26.110949       7 request.go:645] Throttling request took 1.035521578s, request: GET:https://172.30.0.1:443/apis/flowcontrol.apiserver.k8s.io/v1alpha1?timeout=32s
 {"level":"info","ts":1612732107.768025,"logger":"controller-runtime.metrics","msg":"metrics server is starting to listen","addr":"127.0.0.1:8080"}

--- a/modules/osdk-operatorconditions.adoc
+++ b/modules/osdk-operatorconditions.adoc
@@ -24,7 +24,7 @@ The Operator is allowed to modify only the `status` subresource of the CR. Opera
 
 [NOTE]
 ====
-Operator SDK v1.3.0 supports `operator-lib` v0.3.0.
+Operator SDK v1.8.0 supports `operator-lib` v0.3.0.
 ====
 
 .Prerequisites

--- a/modules/osdk-scorecard-parallel.adoc
+++ b/modules/osdk-scorecard-parallel.adoc
@@ -2,6 +2,8 @@
 //
 // * operators/operator_sdk/osdk-scorecard.adoc
 
+:osdk_ver: v1.8.0
+
 [id="osdk-scorecard-parallel_{context}"]
 = Enabling parallel testing
 
@@ -15,7 +17,7 @@ However, if tests are designed to be fully isolated, they can be parallelized.
 
 * To run a set of isolated tests in parallel, include them in the same stage and set `parallel` to `true`:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 apiVersion: scorecard.operatorframework.io/v1alpha3
 kind: Configuration
@@ -27,14 +29,14 @@ stages:
   - entrypoint:
     - scorecard-test
     - basic-check-spec
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:{osdk_ver}
     labels:
       suite: basic
       test: basic-check-spec-test
   - entrypoint:
     - scorecard-test
     - olm-bundle-validation
-    image: quay.io/operator-framework/scorecard-test:v1.3.0
+    image: quay.io/operator-framework/scorecard-test:{osdk_ver}
     labels:
       suite: olm
       test: olm-bundle-validation-test
@@ -42,3 +44,5 @@ stages:
 <1> Enables parallel testing
 +
 All tests in a parallel stage are executed simultaneously, and scorecard waits for all of them to finish before proceding to the next stage. This can make your tests run much faster.
+
+:!osdk_ver:

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -27,7 +27,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} 4.8 supports Operator SDK v1.3.0 or later.
+{product-title} 4.8 supports Operator SDK v1.8.0 or later.
 ====
 
 [id="osdk-about-what-are-operators"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1978241

Just a few lingering spots that needed version bumps.

The only interesting page to preview might be [Enabling parallel testing](https://deploy-preview-34231--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-scorecard.html#osdk-scorecard-parallel_osdk-scorecard), where I switched the hard-coded tag in the code block to an `{osdk_ver}` attribute.