### PR TITLE
BZ1978248: Rm fixed OSDK Golang workaround

### DIFF
--- a/modules/osdk-create-project.adoc
+++ b/modules/osdk-create-project.adoc
@@ -73,25 +73,6 @@ The `operator-sdk init` command uses the Go plug-in by default.
 ====
 +
 The `operator-sdk init` command generates a `go.mod` file to be used with link:https://golang.org/ref/mod[Go modules]. The `--repo` flag is required when creating a project outside of `$GOPATH/src/`, because generated files require a valid module path.
-
-. To enable your Go-based Operator to run on {product-title}, edit the `config/manager/manager.yaml` file and replace the following line:
-+
-[source,yaml]
-----
-runAsUser: 65532
-----
-+
-with:
-+
-[source,yaml]
-----
-runAsNonRoot: true
-----
-+
-[NOTE]
-====
-This step is a temporary workaround required for Go-based Operators only. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1914406#c1[BZ#1914406].
-====
 endif::[]
 ifdef::ansible[]
 ----

--- a/modules/osdk-quickstart.adoc
+++ b/modules/osdk-quickstart.adoc
@@ -82,27 +82,6 @@ $ operator-sdk init \
 ----
 endif::[]
 
-ifdef::golang[]
-.. To enable your Go-based Operator to run on {product-title}, edit the `config/manager/manager.yaml` file and replace the following line:
-+
-[source,yaml]
-----
-runAsUser: 65532
-----
-+
-with:
-+
-[source,yaml]
-----
-runAsNonRoot: true
-----
-+
-[NOTE]
-====
-This step is a temporary workaround required for Go-based Operators only. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1914406#c1[BZ#1914406].
-====
-endif::[]
-
 . *Create an API.*
 +
 Create a simple {app-proper} API:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1978248

Preview:

* Step no longer in the [Getting started](https://deploy-preview-34232--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-quickstart.html#osdk-quickstart_osdk-golang-quickstart) assembly
* Step no longer in the [Tutorial](https://deploy-preview-34232--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-create-project_osdk-golang-tutorial) assembly