### PR TITLE
BZ1978250: Rm image prep from OSDK Ansible/Helm guide

### DIFF
--- a/modules/osdk-prepare-supported-images.adoc
+++ b/modules/osdk-prepare-supported-images.adoc
@@ -9,16 +9,6 @@ ifeval::["{context}" == "osdk-golang-tutorial"]
 :golang:
 :type: Go
 endif::[]
-ifeval::["{context}" == "osdk-ansible-tutorial"]
-:ansible:
-:type: Ansible
-:type_lc: ansible
-endif::[]
-ifeval::["{context}" == "osdk-helm-tutorial"]
-:helm:
-:type: Helm
-:type_lc: helm
-endif::[]
 
 [id="osdk-prepare-supported-images_{context}"]
 = Preparing your Operator to use supported images
@@ -45,27 +35,6 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 . Depending on the Go project version, your Dockerfile might contain a `USER 65532:65532` or `USER nonroot:nonroot` directive. In either case, remove the line, as it is not required by the supported runner image.
 endif::[]
 
-ifdef::ansible,helm[]
-. Update the project root-level Dockerfile to use supported images. Change the default builder image reference from:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM quay.io/operator-framework/{type_lc}-operator:{osdk_ver}
-----
-+
-to:
-+
-[source,terminal,subs="attributes+"]
-----
-FROM registry.redhat.io/openshift4/ose-{type_lc}-operator:v{product-version}
-----
-+
-[IMPORTANT]
-====
-Use the builder image version that matches your Operator SDK version. Failure to do so can result in problems due to project layout, or _scaffolding_, differences, particularly when mixing newer upstream versions of the Operator SDK with downstream {product-title} builder images.
-====
-endif::[]
-
 . In the `config/default/manager_auth_proxy_patch.yaml` file, change the `image` value from:
 +
 [source,terminal]
@@ -84,14 +53,4 @@ registry.redhat.io/openshift4/ose-kube-rbac-proxy:v{product-version}
 ifeval::["{context}" == "osdk-golang-tutorial"]
 :!golang:
 :!type:
-endif::[]
-ifeval::["{context}" == "osdk-ansible-tutorial"]
-:!ansible:
-:!type:
-:!type_lc:
-endif::[]
-ifeval::["{context}" == "osdk-helm-tutorial"]
-:!helm:
-:!type:
-:!type_lc:
 endif::[]

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -32,7 +32,6 @@ include::modules/osdk-ansible-modify-manager.adoc[leveloffset=+1]
 
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
-include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 
 [id="osdk-bundle-deploy-olm_{context}"]

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -34,7 +34,6 @@ include::modules/osdk-helm-modify-cr.adoc[leveloffset=+2]
 
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
-include::modules/osdk-prepare-supported-images.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
 
 [id="osdk-bundle-deploy-olm_{context}"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1978250

Rm "Preparing your Operator to use supported images" from the Ansible- and Helm-based tutorials, but leave the module in for the Go-based tutorial because there was still a Go-relevant step in there.

Preview:

* Removed from [Ansible tutorial](https://deploy-preview-34233--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html)
* Removed from [Helm tutorial](https://deploy-preview-34233--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html)
* Still in [Go tutorial](https://deploy-preview-34233--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-prepare-supported-images_osdk-golang-tutorial)