### PR TITLE
TELCODOCS-204: release notes. Enabling managed Secure Boot.

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -354,6 +354,11 @@ For more information, see xref:../security/tls-security-profiles.adoc#tls-securi
 
 Previously, the `oauth-proxy` command only allowed the use of SHA-1 hashed passwords in `htpasswd` files used for authentication. `oauth-proxy` now includes support for `htpasswd` entries that use `bcrypt` password hashing. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1874322[BZ#1874322].
 
+[id="ocp-4-8-managed-secure-boot"]
+==== Enabling managed Secure Boot with installer-provisioned clusters
+
+{product-title} 4.8 supports automatically turning on UEFI Secure Boot mode for provisioned control plane and worker nodes and turning it back off when removing the nodes. To use this feature, set the node's `bootMode` configuration setting to `UEFISecureBoot` in the `install-config.yaml` file. Red Hat only supports installer-provisioned installation with managed Secure Boot on 10th generation HPE hardware or 13th generation Dell hardware running firmware version `2.75.75.75` or greater. For additional details, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-managed-secure-boot-in-the-install-config-file_ipi-install-configuration-files[Configuring managed Secure Boot in the install-config.yaml file].
+
 [id="ocp-4-8-networking"]
 === Networking
 


### PR DESCRIPTION
This PR contains release notes for enabling managed Secure Boot.

Fixes: [TELCODOCS-204](https://issues.redhat.com/browse/TELCODOCS-204)
Release: 4.8
Preview: https://deploy-preview-34235--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-managed-secure-boot

Signed-off-by: John Wilkins <jowilkin@redhat.com>