### PR TITLE
Adds third batch of 4.8 doc text

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1291,6 +1291,19 @@ In addition, the following commands related to the format have been removed from
 
 * Previously, the machine instance `state` annotation was not set. Consequently, the `STATE` column was empty. With this update, the machine instance `state` annotation is now set, and information in the `STATE` column automatically populates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857008[*BZ#1857008*])
 
+* Because newer ipmitool packages default to using cipher suite 17, older hardware that does not support cipher suite 17 fails during deployment. When cipher suite 17 is not supported by the hardware, Ironic now uses cipher suite 3 so that deployments on older hardware using ipmitool should succeed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1897415[*BZ#1897415*])
+
+* Previously, in some cases, adoption occurred before the image cache was populated, which resulted in permanent adoption failure, and no retry was attempted. This caused the control plane bare metal hosts to report `adoption failed.` With this update, adoption of externally provisioned hosts automatically retries after adoption failure until control plane hosts are correctly adopted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905577[*BZ#1905577*])
+
+* Previously, the Custom Resource (CR) required the Baseboard Management Controller (BMC) details. However, with assisted installers this information was not provided. This update allows the CR to bypass the BMC details when the operator is not creating the nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1913112[*BZ#1913112*])
+
+* When provisioning an image to nodes, qemu-image was restricted to 1G of RAM, which could cause the qemu-img to crash. This fix increases the limit to 2G so that qemu-img now completes provisioning reliably. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917482[*BZ#1917482*])
+
+* Because the redfish/v1/SessionService URL requires authentication, Ironic would generate an authentication error when accessing the site. Because there was no functional problem when this error message was reported by Ironic, it has been removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1924816[*BZ#1924816*])
+
+* For some drives, the partition, for example `/dev/sda1`, did not have a read-only (RO) file. The base device, for example, `/dev/sda` had this file, however. Therefore, Ironic could not determine that the partition was read-only, which could cause metadata cleaning to fail on that drive. This update ensures that the partition is detected as read-only, and includes an additional check for the base device. As a result, metadata cleaning is not performed on the read-only partition and metadata cleaning no longer fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1935419[*BZ#1935419*])
+
+* When a bare metal API was deployed with a proxy configured, the internal machine-os image download was directed through the proxy. This corrupted the image and prevented it from being downloaded. This update fixes the Internal image traffic to `no_proxy`, so that the image download no longer uses a proxy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962592[*BZ#1962592*])
 
 *Builds*
 
@@ -1411,6 +1424,8 @@ In addition, the following commands related to the format have been removed from
 
 * Due to a bug in Keepalived 2.0.10, if a liveness probe killed a Keepalived container, any virtual IP addresses (VIPs) that were assigned to the system remained and were not cleaned up when Keepalived restarted. As a result, multiple nodes could hold the same VIP. Now, the VIPs are removed when Keepalived is started. As a result, VIPs are held by a single node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1931505[*BZ#1931505*])
 
+* Previously, rpm-ostree related operations were not handled properly on non-CoreOS nodes such as {op-system-first}. As a result, {op-system-base} nodes were degraded when an operation, such as kernel switching, was applied in the pool that contained {op-system-base} nodes. With this update, the Machine Config Daemon logs a message whenever a non-supported operation is performed on non-CoreOS nodes. After logging the message, it returns nil instead of an error. {op-system-base} nodes in the pool now proceed as expected when an unsupported operation is performed by the Machine Config Daemon. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952368[*BZ#1952368*])
+
 * Previously, empty static pod files were being written to the `/etc/kubernetes/manifests` directory. As a result, the kubelet log was reporting errors that could cause confusion with some users. Empty manifests are now moved to a different location when they are not needed. As a result, the errors do not appear in the kubelet log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927042[*BZ#1927042*])
 
 *Web console (Administrator perspective)*
@@ -1466,7 +1481,7 @@ In addition, the following commands related to the format have been removed from
 
 *openshift-apiserver*
 
-
+* Previously, custom security context constraints (SCCs) could have a higher priority than others in a default set. Consequently, those SSCs were sometimes matched to `openshift-apiserver` pods, which broke their ability to write in their root filesystem. This bug also caused an outage of some OpenShift APIs. This fix explicitly mentions in the `openshift-apiserver` pods that the root filesystem should be writable. As a result, custom SCCs should not prevent `openshift-apiserver` pods from running. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942725[*BZ#1942725*])
 
 *Performance Addon Operator*
 
@@ -1493,6 +1508,15 @@ In addition, the following commands related to the format have been removed from
 
 *Storage*
 
+* Previously, the recycler-pod template was incorrectly placed in the kubelet static manifest directory. This incorrect location produced static pod log messages that indicated a recycler static pod start failure. With this update, the misplaced recycler-pod template has been removed from the static pod manifest directory. As a result, the error messages no longer appear. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1896226[*BZ#1896226*])
+
+* Previously, the Local Storage Operator (LSO) could claim disks belonging to other provisioners because busy disks were erroneously detected as free. Disks are now checked for bind-mounts so that the LSO cannot claim those disks. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929175[*BZ#1929175*])
+
+* Previously, the Local Storage Operator (LSO) would attempt to create a persistent volume (PV) with an invalid label value, because the device-id contained unsupported characters such as `:`. This has been corrected by moving the device information from labels to annotations. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1933630[*BZ#1933630*])
+
+* Previously, the Local Storage Operator (LSO) was not cleaning up persistent volumes (PVs) since the deleter was not being enqueued correctly. This caused PVs to remain in the `released` state. PVs are now enqueued correctly so that they delete properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937145[*BZ#1937145*])
+
+* Previously, the Fibre Channel volume was incorrectly unmounted from a node when a pod was deleted. This happened when a different pod that used the volume was deleted in the API server when the kubelet on the node was not running. With this update, Fibre Channel volumes correctly unmount when a new kubelet starts. Additionally, the volume cannot be mounted to multiple nodes until the new kubelet fully starts and cofnrims that the volume is unmounted, which ensures that Fibre Channel volumes are uncorrupted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954509[*BZ#1954509*])
 
 
 [id="ocp-4-8-bug-fixes-bare-metal-hardware-provisioning"]


### PR DESCRIPTION
Adds third batch of 4.8 RNs doc text. 

No BZ.

Preview: https://deploy-preview-34241--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

Thanks! 