### PR TITLE
OSDOCS-2283: Added troubleshooting for expired offline access tokens.

### DIFF
--- a/modules/rosa-troubleshooting-expired-token.adoc
+++ b/modules/rosa-troubleshooting-expired-token.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+// cli_reference/rosa_cli/rosa-troubleshooting-expired-token.adoc
+
+
+[id="rosa-troubleshooting-expired-token_{context}"]
+= Troubleshooting an expired offline access token
+
+If you use the `rosa` CLI and your api.openshift.com offline access token expires, an error message appears. This happens when sso.redhat.com invalidates the token.
+
+.Example output
+[source,terminal]
+----
+Can't get tokens ....
+Can't get access tokens ....
+----
+
+.Procedure
+* Generate a new offline access token at the following URL. A new offline access token is generated every time you visit the URL.
+
+** {product-title} (ROSA): https://cloud.redhat.com/openshift/token/rosa

--- a/rosa_cli/rosa-troubleshoot-cli.adoc
+++ b/rosa_cli/rosa-troubleshoot-cli.adoc
@@ -8,3 +8,4 @@ Using `rosa` commands and accessing log files to troubleshoot issues.
 
 include::modules/rosa-troubleshooting-commands.adoc[leveloffset=+1]
 include::modules/rosa-logs.adoc[leveloffset=+1]
+include::modules/rosa-troubleshooting-expired-token.adoc[leveloffset=+1]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2283

Preview: https://deploy-preview-34242--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-troubleshoot-cli.html#rosa-troubleshooting-expired-token_rosa-troubleshooting-cli

Please merge to dedicated-4 branch. No CP needed.