### PR TITLE
[enterprise-4.5]GH#30879: Adding a note about SSH keys and FIPS-enabled clusters

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -155,7 +155,10 @@ $ eval "$(ssh-agent -s)"
 ----
 Agent pid 31874
 ----
-
+[NOTE]
+====
+If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate the SSH key. The key must be either RSA or ECDSA.
+====
 . Add your SSH private key to the `ssh-agent`:
 +
 [source,terminal]


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/30932
Conflicts:
	modules/ssh-agent-using.adoc