### PR TITLE
Add 4.8 RN for catalog-build & bundle-upgrade

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -669,9 +669,19 @@ Support for the legacy package manifest format for Operators is removed in {prod
 
 For more information, see xref:../operators/operator_sdk/osdk-pkgman-to-bundle.adoc#osdk-pkgman-to-bundle[Migrating package manifest projects to bundle format].
 
-[id="ocp-4-8-service-ca-operator-enhancement"]
-==== Service-ca Operator enhancement
-{product-title} 4.8 allows users to run `service-ca-operator` pods as a non-root user to suit their organization's needs. When run as a non-root user, the `service-ca-operator runs with an user ID of `UID=1001(1001) GID =1001 groups=1001`. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1914446[*BZ#1914446*]. 
+[id="ocp-4-8-catalog-build-push"]
+==== Publishing a catalog containing a bundled Operator
+
+To install and manage Operators, Operator Lifecycle Manager (OLM) requires that Operator bundles are listed in an index image, which is referenced by a catalog on the cluster. As an Operator author, you can use the Operator SDK to create an index containing the bundle for your Operator and all of its dependencies. This is useful for testing on remote clusters and publishing to container registries.
+
+For more information, see xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-publish-catalog_osdk-working-bundle-images[Publishing a catalog containing a bundled Operator].
+
+[id="ocp-4-8-bundle-upgrade"]
+==== Enhanced Operator upgrade testing
+
+The Operator SDK's `run bundle-upgrade` subcommand automates triggering an installed Operator to upgrade to a later version by specifying a bundle image for the later version. Previously, the subcommand could only upgrade Operators that were initially installed using the `run bundle` subcommand. With this enhancement, the `run bundle-upgrade` now also works with Operators that were initially installed with the traditional Operator Lifecycle Manager (OLM) workflow.
+
+For more information, see xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-upgrade-olm_osdk-working-bundle-images[Testing an Operator upgrade on Operator Lifecycle Manager].
 
 [discrete]
 [id="ocp-4-8-builds"]
@@ -1478,7 +1488,7 @@ In addition, the following commands related to the format have been removed from
 
 *Routing*
 
-* Previously, the HAProxyDown alert message was vague. Consequently, end users thought the alert meant that router pods, instead of just HAProxy pods, were unavailable. This update makes the HAProxyDown alert message clearer. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941592[*BZ#1941592*]) 
+* Previously, the HAProxyDown alert message was vague. Consequently, end users thought the alert meant that router pods, instead of just HAProxy pods, were unavailable. This update makes the HAProxyDown alert message clearer. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941592[*BZ#1941592*])
 
 * Previously, HAProxy's helper function template that was responsible for generating a file for whitelist IPs expected a wrong argument type. Consequently, no whitelist ACL was applied for the backend in long IP lists. With this update, argument types of the helper function template are changed so that whitelist ACL is applied to the backend of long IP lists. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1964486[*BZ#1964486*])
 
@@ -1489,6 +1499,14 @@ In addition, the following commands related to the format have been removed from
 
 *service-ca*
 
+* {product-title} 4.8 allows users to run `service-ca-operator` pods as a non-root user to suit their organization's needs. When run as a non-root user, the `service-ca-operator` runs as the following UID and GID:
++
+[source,terminal]
+----
+uid=1001(1001) gid=1001 groups=1001
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1914446[*BZ#1914446*])
 
 
 *Storage*
@@ -1862,7 +1880,7 @@ EOF
 oc create -f $PROJ-app.yaml
 ----
 
-For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1812212[*BZ#1812212*]. 
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1812212[*BZ#1812212*].
 
 
 [id="ocp-4-8-asynchronous-errata-updates"]


### PR DESCRIPTION
Related 4.8 release notes for https://github.com/openshift/openshift-docs/pull/33483 and https://github.com/openshift/openshift-docs/pull/33721.

Preview:

* "Publishing a catalog containing a bundled Operator" and "Enhanced Operator upgrade testing" in [Operator development](https://deploy-preview-34251--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-osdk) new features