### PR TITLE
Adds fourth batch of 4.8 RN bug doc text

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1307,9 +1307,19 @@ In addition, the following commands related to the format have been removed from
 
 *assisted-installer*
 
-
+* Previously, the `assisted-service` container did not wait for `postgres` to start up and be ready to accept connections. The `assisted-service` container attempted to establish a database connection, failed, and the `assisted-service` container failed and restarted. This issue has been fixed by the `assisted-service` container attempting to connect to the database for up to 10 seconds. If `postgres` starts and is ready to accept connection within 10 seconds, the `assisted-service` container connects without going into an error state. If the `assisted-service` container is unable to connect to `postgres` within 10 seconds, it goes into an error state, restarts, and tries again. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941859[*BZ#1941859*])
 
 *Bare Metal Hardware Provisioning*
+
+* Previously, Ironic failed to download an image for installation because Ironic uses HTTPS by default and did not have the correct certificate bundle available. This issue is fixed by setting the image download as insecure to request a transfer without the certificate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953795[*BZ#1953795*])
+
+* Previously, when using dual-stack networking, worker node host names sometimes did not match the host name that Ironic inspected before deployment. This caused nodes to need manual approval. This has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955114[*BZ#1955114*])
+
+* Previously, in UEFI mode, the `ironic-python-agent` created a UEFI bootloader entry after downloading the RHCOS image. When using an RHCOS image based on RHEL 8.4, the image could fail to boot using this entry. If the entry installed by Ironic was used when booting the image, the boot could fail and output a BIOS error screen. This is fixed by the `ironic-python-agent` configuring the boot entry based on a CSV file located in the image, instead of using a fixed boot entry. The image boots properly without error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966129[*BZ#1966129*])
+
+* Previously, a node sometimes selected the incorrect IP version upon startup (IPv6 instead of IPv4, or vice versa). The node would fail to start because it did not receive an IP address. This is fixed by the Cluster Bare Metal Operator passing the IP option to the downloader (`ip=dhcp` or `ip=dhcp6`), so this is set correctly at startup and the node starts as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946079[*BZ#1946079*])
+
+* Previously, the image caching mechanism in Ironic was disabled to enable a direct connection to the HTTP server that hosts the virtualmedial iso to prevent local storage issues. Non-standard compliant HTTP clients and redfish implementations caused failures on BMC connections. This has been fixed by reverting to the default Ironic behavior where the virtualmedia iso is cached and served from the Ironic conductor node. Issues caused by non-standard compliant HTTP clients and redfish implementations have been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962905[*BZ#1962905*])
 
 * Previously, the machine instance `state` annotation was not set. Consequently, the `STATE` column was empty. With this update, the machine instance `state` annotation is now set, and information in the `STATE` column automatically populates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1857008[*BZ#1857008*])
 
@@ -1385,6 +1395,12 @@ In addition, the following commands related to the format have been removed from
 
 *Cluster Version Operator*
 
+* Previously, the Cluster Version Operator evaluated both the `Available` and `Degraded` parameters when setting the `cluster_operator_up` metric, which caused the `ClusterOperatorDown` alert to be displayed for Operators with `Available=True` or `Degraded=True`, even though `Available=True` did not match the alert description of "has not been available". With this fix, the Cluster Version Operator now ignores the `Degraded` parameter when setting the `cluster_operator_up` metric. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1834551[*BZ#1834551*])
+
+* Previously, when Prometheus was installed on the cluster, important platform topology metrics were not available and a CI error would occur if the installer metric that was generated with the invoker was set to `""`. The possible race condition in which informers were not synced before metrics were served that was causing the error has now been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871303[*BZ#1871303*])
+  
+* Previously, manifests with multiple tolerations for the same key, such as the Cluster Version Operator's own deployment), would accept only the last entry read and overwrite prior entries. This caused `in-cluster tolerations` to diverge from the manifest's listed tolerations. With this update, the Cluster Version Operator now considers tolerations matching when they are completely equal. This allows the Cluster Version Operator to keep all tolerations present in the manifest for the `in-cluster resource`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941901[*BZ#1941901*])
+  
 
 
 *Compliance Operator*
@@ -1425,7 +1441,20 @@ In addition, the following commands related to the format have been removed from
 
 *etcd*
 
+* Previously, there was a transport leak in the etcd Operator, which caused memory usage to grow over time. The memory leak has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925586[*BZ#1925586*])
 
+* Previously, the `etcdInsufficientMembers` alert fired incorrectly. With this release, the alert is updated to include the pod label in addition to the instance label, so that the alert only fires when quorum is lost. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929944[*BZ#1929944*])
+
+* Previously, the readiness probe was not reporting the correct readiness due to the introduction of SO_REUSEADDR socket options, which caused the etcd pod to show as ready even though the etcd-quorum-guard failed. The readiness probe checks were updated to account for these options, and the etcd readiness probe now properly reflects the readiness of the operand. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946607[*BZ#1946607*])
+
+* Previously, the `spec.loglevel` field did not set the `log-level` flag on the etcd operand, so users could not change the etcd log level. Users can now set the log levels as follows:
++
+--
+** `Debug`, `Trace`, and `TraceAll` log levels map to the etcd `debug` log level
+** `Default` or `Normal` log levels map to the etcd `info` log level
+--
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1948553[*BZ#1948553*])
 
 *Image Registry*
 
@@ -1469,6 +1498,17 @@ In addition, the following commands related to the format have been removed from
 *Web console (Administrator perspective)*
 
 //section 1
+* The *Completions* column of the *Jobs* table sorted by the number of *Desired* completions instead of the number of *Succeeded* completions. The data is presented as *# Succeeded of # Desired*, so when sorting by that column the results looked confusing because the data was sorted by the second number. The *Jobs* *Completions* column now sorts on the *# Succeeded* for better understanding. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1902003[*BZ#1902003*])
+
+* The input labels in the *Manage Columns* modal were not clickable buttons, so you could not click them to manage the columns. With this bug fix, the labels are now clickable buttons that you can use to manage columns. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1908343[*BZ#1908343*])
+
+* CSI provisioners were not listed when creating a storage class on the Google Cloud Platform. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910500[*BZ#1910500*])
+
+* Previously, if the user clicked into a *Cluster Role* from the *User Management -> Roles* list view, the back link from the details page is *Cluster Roles*, which provides a generic list view of *Cluster Roles*. This caused backward web console navigation to redirect to the incorrect page. With this release, the back link directs the user to the *Role/Bindings* list view from the *Cluster Role/RoleBinding* details page. This allows the user to correctly navigate backward in the web console.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915971[*BZ#1915971*])
+
+* Previously, *Created date time* was not displayed in a format that a person could read, which made it difficult to understand and use the time shown in UTC. With this release, the displayed time is reformatted so that UTC is readable and understandable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917241[*BZ#1917241*])
+
+* Previously, pod requests and limit calculations in the web console were incorrect. This was a result of not excluding completed pods or init containers. With this release, pods that are not needed in the calculation are excluded, which improves the accuracy of the results of the web console calculation for pod requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918785[*BZ#1918785*])
 
 //section 2
 
@@ -1563,25 +1603,6 @@ uid=1001(1001) gid=1001 groups=1001
 * Previously, the Local Storage Operator (LSO) was not cleaning up persistent volumes (PVs) since the deleter was not being enqueued correctly. This caused PVs to remain in the `released` state. PVs are now enqueued correctly so that they delete properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937145[*BZ#1937145*])
 
 * Previously, the Fibre Channel volume was incorrectly unmounted from a node when a pod was deleted. This happened when a different pod that used the volume was deleted in the API server when the kubelet on the node was not running. With this update, Fibre Channel volumes correctly unmount when a new kubelet starts. Additionally, the volume cannot be mounted to multiple nodes until the new kubelet fully starts and cofnrims that the volume is unmounted, which ensures that Fibre Channel volumes are uncorrupted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954509[*BZ#1954509*])
-
-
-[id="ocp-4-8-bug-fixes-bare-metal-hardware-provisioning"]
-=== Bare metal hardware provisioning
-
-* Previously, Ironic failed to download an image for installation because Ironic uses HTTPS by default and did not have the correct certificate bundle available. This issue is fixed by setting the image download as insecure to request a transfer without the certificate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953795[*BZ#1953795*])
-
-* Previously, when using dual-stack networking, worker node host names sometimes did not match the host name that Ironic inspected before deployment. This caused nodes to need manual approval. This has been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955114[*BZ#1955114*])
-
-* Previously, in UEFI mode, the `ironic-python-agent` created a UEFI bootloader entry after downloading the RHCOS image. When using an RHCOS image based on RHEL 8.4, the image could fail to boot using this entry. If the entry installed by Ironic was used when booting the image, the boot could fail and output a BIOS error screen. This is fixed by the `ironic-python-agent` configuring the boot entry based on a CSV file located in the image, instead of using a fixed boot entry. The image boots properly without error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966129[*BZ#1966129*])
-
-* Previously, a node sometimes selected the incorrect IP version upon startup (IPv6 instead of IPv4, or vice versa). The node would fail to start because it did not receive an IP address. This is fixed by the Cluster Bare Metal Operator passing the IP option to the downloader (`ip=dhcp` or `ip=dhcp6`), so this is set correctly at startup and the node starts as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946079[*BZ#1946079*])
-
-* Previously, the image caching mechanism in Ironic was disabled to enable a direct connection to the HTTP server that hosts the virtualmedial iso to prevent local storage issues. Non-standard compliant HTTP clients and redfish implementations caused failures on BMC connections. This has been fixed by reverting to the default Ironic behavior where the virtualmedia iso is cached and served from the Ironic conductor node. Issues caused by non-standard compliant HTTP clients and redfish implementations have been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962905[*BZ#1962905*])
-
-[id="ocp-4-8-bug-fixes-assisted-installer"]
-=== Assisted Installer
-
-* Previously, the `assisted-service` container did not wait for `postgres` to start up and be ready to accept connections. The `assisted-service` container attempted to establish a database connection, failed, and the `assisted-service` container failed and restarted. This issue has been fixed by the `assisted-service` container attempting to connect to the database for up to 10 seconds. If `postgres` starts and is ready to accept connection within 10 seconds, the `assisted-service` container connects without going into an error state. If the `assisted-service` container is unable to connect to `postgres` within 10 seconds, it goes into an error state, restarts, and tries again. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941859[*BZ#1941859*])
 
 [id="ocp-4-8-technology-preview"]
 == Technology Preview features
@@ -1933,6 +1954,8 @@ oc create -f $PROJ-app.yaml
 ----
 +
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1812212[*BZ#1812212*].
+
+* Parsing undefined values results in a not a number (NaN) exception and the *Chart* tooltip shows a box with no values. To ensure that the results are synced and that undefined values are not parsed, specify a start date when fetching data so that the *Chart* toolip shows correct values. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1906304[*BZ#1906304*]. 
 
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Fourth batch of 4.8 RN bug doc text.

No BZ. 

Preview: https://deploy-preview-34257--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

Thanks! 