### PR TITLE
Add 4.8 RN for OSDK compat section

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -688,6 +688,13 @@ The Operator SDK's `run bundle-upgrade` subcommand automates triggering an insta
 
 For more information, see xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-bundle-upgrade-olm_osdk-working-bundle-images[Testing an Operator upgrade on Operator Lifecycle Manager].
 
+[id="ocp-4-8-osdk-compat"]
+==== Controlling Operator compatibility with {product-title} versions
+
+When an API is removed from an {product-title} version, Operators running on that cluster version that are still using removed APIs will no longer work properly. As an Operator author, you should plan to update your Operator projects to accommodate API deprecation and removal to avoid interruptions for users of your Operator.
+
+For more deatils, see xref:../operators/operator_sdk/osdk-working-bundle-images.adoc#osdk-control-compat_osdk-working-bundle-images[Controlling Operator compatibility with {product-title} versions].
+
 [discrete]
 [id="ocp-4-8-builds"]
 === Builds


### PR DESCRIPTION
Related 4.8 release note for https://github.com/openshift/openshift-docs/pull/34166.

Preview:

* [Controlling Operator compatibility with OpenShift Container Platform versions](https://deploy-preview-34258--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-osdk)

