### PR TITLE
OSSMDOC-310: Clarify external Elasticsearch instance.

### DIFF
--- a/modules/jaeger-config-storage.adoc
+++ b/modules/jaeger-config-storage.adoc
@@ -69,8 +69,8 @@ When the `storage:type` is set to `elasticsearch` but there is no value set for 
 
 .Restrictions
 
+* You can have only one Jaeger with self-provisioned Elasticsearch instance per namespace. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 * There can be only one Elasticsearch per namespace.
-* You cannot share or reuse a {ProductName} logging Elasticsearch instance with Jaeger. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 
 [NOTE]
 ====
@@ -189,18 +189,18 @@ spec:
 [id="jaeger-config-external-es_{context}"]
 == Connecting to an existing Elasticsearch instance
 
-Jaeger also allows you to use an existing (self-provisioned) Elasticsearch cluster for storage. You do this by specifying the URL of the existing cluster as the `spec:storage:options:es:server-urls` value in your configuration.
+You can use an existing Elasticsearch cluster for storage with Jaeger, that is, an instance that was not auto-provisioned by the Jaeger Operator. You do this by specifying the URL of the existing cluster as the `spec:storage:options:es:server-urls` value in your configuration.
 
 .Restrictions
 
-* There can be only one Jaeger with self-provisioned Elasticsearch instance per namespace.
+* You cannot share or reuse a {ProductName} logging Elasticsearch instance with Jaeger. The Elasticsearch cluster is meant to be dedicated for a single Jaeger instance.
 
 [NOTE]
 ====
 Red Hat does not provide support for your external Elasticsearch instance. You can review the tested integrations matrix on the link:https://access.redhat.com/articles/5381021[Customer Portal].
 ====
 
-The following configuration parameters are for an _external_ Elasticsearch instance, that is, an instance that was not created using the OpenShift Elasticsearch Operator. You specify configuration options for external Elasticsearch under `spec:storage:options:es` in your configuration file.
+The following configuration parameters are for an already existing Elasticsearch instance, also known as an _external_  Elasticsearch instance. In this case, you specify configuration options for Elasticsearch under `spec:storage:options:es` in your custom resource file.
 
 .General ES configuration parameters
 [options="header"]


### PR DESCRIPTION
Correcting definition of an external Elasticsearch instance.

Preview is here ->  https://deploy-preview-34263--osdocs.netlify.app/openshift-enterprise/latest/jaeger/jaeger_install/rhbjaeger-deploying.html#jaeger-config-external-es_jaeger-deploying

Eng Review - jpkrohling, pavelloffay
QE Review - jkandasa, iblancasa
Peer Review - jc-berger