### PR TITLE
4.8 RNs: TP/GA and dep/rem feature tables

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1162,17 +1162,17 @@ In the table, features are marked with the following statuses:
 |`--filter-by-os` flag for `oc adm catalog mirror`
 |GA
 |DEP
-|DEP
+|REM
 
 |v1beta1 CRDs
 |DEP
 |DEP
-|
+|DEP
 
 |Docker Registry v1 API
 |DEP
 |DEP
-|
+|DEP
 
 |Metering Operator
 |DEP
@@ -1187,17 +1187,17 @@ In the table, features are marked with the following statuses:
 |`ImageChangesInProgress` condition for Cluster Samples Operator
 |GA
 |DEP
-|
+|DEP
 
 |`MigrationInProgress` condition for Cluster Samples Operator
 |GA
 |DEP
-|
+|DEP
 
 |Use of `v1` in `apiVersion` for {product-title} resources
 |GA
 |DEP
-|
+|DEP
 
 |Use of `dhclient` in {op-system-first}
 |DEP
@@ -1223,6 +1223,11 @@ In the table, features are marked with the following statuses:
 |TP
 |TP
 |DEP
+
+|HPA custom metrics adapter based on Prometheus
+|TP
+|TP
+|REM
 
 |====
 
@@ -1298,6 +1303,11 @@ In addition, the following commands related to the format have been removed from
 * `oc adm catalog build`
 * `operator-sdk generate packagemanifest`
 * `operator-sdk run packagemanifest`
+
+[id="ocp-4-8-hpa-prometheus"]
+==== Support for HPA custom metrics adapter based on Prometheus is removed
+
+This release removes the Prometheus Adapter, which was a Technology Preview feature.
 
 [id="ocp-4-8-bug-fixes"]
 == Bug fixes
@@ -1403,9 +1413,9 @@ In addition, the following commands related to the format have been removed from
 
 * Previously, a drop-down list in the web console was obscured by button elements, leaving users unable to select certain operating systems when creating a virtual machine. This fix includes an adjustment to the button elements' `z-index` value, which corrects the error and lets users select any of the available operating systems. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930015[*BZ#1930015*])
 
-* Previously, if you used the web console's new virtual machine wizard on a cluster with no defined storage classes, the web console got stuck in an infinite loop and crashed. This fix removes the storage class drop-down list in instances where no storage classes are defined. As a result, the web console does not crash. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930064[*BZ#1930064*]) 
+* Previously, if you used the web console's new virtual machine wizard on a cluster with no defined storage classes, the web console got stuck in an infinite loop and crashed. This fix removes the storage class drop-down list in instances where no storage classes are defined. As a result, the web console does not crash. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930064[*BZ#1930064*])
 
-* Previously, text in a button element did not clearly describe the button's function, which is to remove a VM template from a list of favorites. This fix updates the text to clarify what the button does. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937941[*BZ#1937941*]) 
+* Previously, text in a button element did not clearly describe the button's function, which is to remove a VM template from a list of favorites. This fix updates the text to clarify what the button does. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937941[*BZ#1937941*])
 
 * Previously, for virtual machines that have a `RerunOnFailure` run strategy, stopping the virtual machine resulted in several UI elements becoming unresponsive, preventing users from reading status information or restarting the virtual machines. This update fixes the unresponsive elements so users can use those features. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951209[*BZ#1951209*])
 
@@ -1607,7 +1617,7 @@ In the table below, features are marked with the following statuses:
 |Precision Time Protocol (PTP)
 |TP
 |TP
-|
+|TP
 
 |`oc` CLI plug-ins
 |TP
@@ -1622,17 +1632,12 @@ In the table below, features are marked with the following statuses:
 |OVN-Kubernetes Pod network provider
 |GA
 |GA
-|
-
-|HPA custom metrics adapter based on Prometheus
-|TP
-|TP
-|
+|GA
 
 |HPA for memory utilization
 |TP
 |GA
-|
+|GA
 
 |Service Binding
 |TP
@@ -1642,12 +1647,12 @@ In the table below, features are marked with the following statuses:
 |Log forwarding
 |GA
 |GA
-|
+|GA
 
 |Monitoring for user-defined projects
 |GA
 |GA
-|
+|GA
 
 |Raw Block with Cinder
 |TP
@@ -1722,12 +1727,12 @@ In the table below, features are marked with the following statuses:
 |OpenShift Pipelines
 |TP
 |TP
-|
+|GA
 
 |OpenShift GitOps
 |TP
 |TP
-|
+|GA
 
 |OpenShift sandboxed containers
 |-
@@ -1739,15 +1744,25 @@ In the table below, features are marked with the following statuses:
 |TP
 |GA
 
+|Cron jobs
+|TP
+|TP
+|GA
+
+|PodDisruptionBudget
+|TP
+|TP
+|GA
+
 |Operator API
 |GA
 |GA
-|
+|GA
 
-|Adding kernel modules to nodes
+|Adding kernel modules to nodes with kvc
 |TP
 |TP
-|
+|TP
 
 |Egress router CNI plug-in
 |-
@@ -1772,18 +1787,32 @@ In the table below, features are marked with the following statuses:
 |Assisted Installer
 |-
 |TP
-|
+|TP
 
 |AWS Security Token Service (STS)
 |-
 |TP
 |GA
 
+|Kdump
+|-
+|TP
+|TP
+
+|OpenShift Serverless
+|-
+|-
+|GA
+
+|Serverless functions
+|-
+|-
+|TP
+
 |Jenkins Operator
 |TP
 |TP
 |DEP
-
 
 |====
 


### PR DESCRIPTION
Working from https://docs.google.com/spreadsheets/d/1N1JJi7roK0BUFYo-PKI6wT3EMG5XD1j3eFNNEhmVnJc/ and https://docs.google.com/presentation/d/1fUustlGBqzxkca8iC-IzZqyB9h_SKcVNqnJwYf6jc3g/edit#slide=id.p

Previews:
- [Deprecated and removed features](https://deploy-preview-34286--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-removed-features)
- [Technology Preview features](https://deploy-preview-34286--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-technology-preview)

(Re-do of #34068, which got messed up and it was easier to restart this one)