### PR TITLE
CNV 12272: Adding 4.8 release note for cloning between data volume modes

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -81,6 +81,7 @@ The SVVP Certification applies to:
 //CNV-12270 CDI can now automatically choose preferred accessMode and volumeMode settings when importing VM disk images.
 
 //CNV-12272 It is now possible to clone virtual machine disks from a Filesystem PVC to a Block PVC and visa versa.
+* You can now xref:../virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume#virt-cloning-vm-disk-into-new-datavolume[clone virtual machine disks between different data volume modes] if they have the content type `kubevirt`. For example, you can clone a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem.`
 
 //CNV-12273 CDI now follows the OpenShift cluster-wide proxy configuration when importing virtual machine disk images.
 
@@ -117,7 +118,7 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-* You can now xref:../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[hot-plug and hot-unplug virtual disks] when you want to add or remove them from your virtual machine without stopping the virtual machine instance. 
+* You can now xref:../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[hot-plug and hot-unplug virtual disks] when you want to add or remove them from your virtual machine without stopping the virtual machine instance.
 
 [id="virt-4-8-known-issues"]
 == Known issues


### PR DESCRIPTION
This PR addresses JIRA story [CNV-12272](https://issues.redhat.com/browse/CNV-12272) ( https://issues.redhat.com/browse/CNV-12272 ).

The story is a release note about the ability to clone virtual machine disks between data volume modes such as from Block to FIlesystem and vice versa

CP: 4.8

Preview: https://deploy-preview-34287--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-storage-new