### PR TITLE
Added bugs to 4.8 RN for Console Storage Plugin

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1439,6 +1439,15 @@ This release removes the Prometheus Adapter, which was a Technology Preview feat
 
 *Console Storage Plugin*
 
+* Previously, the OpenShift Container Storage Operator displayed an error message when the correct storage class was not available. This update removes the error message and disables the *Next* button until the correct storage class is available. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1924641[*BZ#1924641*])
+
+* Previously, when a user clicked the browser's back button while creating an internal-attached storage cluster, the installation wizard restarted the process. This update fixes the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1928008[*BZ#1928008*])
+
+* When you add a node to local volume discovery, you can now see a list of existing nodes, which reduces unnecessary navigation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1947311[*BZ#1947311*])
+
+* Previously, the *Create Storage Cluster* wizard let you enable an arbiter zone that had an undefined value. The fix in this update filters out undefined values so arbiter zones can be created only with defined values. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926798[*BZ#1926798*])
+
+* Previously, quick start cards were displayed incorrectly in the web console because of inconsistencies in how product titles were spelled and how the registered trade mark symbol was used. In this update, the product names are spelled correctly, and the registered trademark symbol appears consistently in the first card only. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1931760[*BZ#1931760*])
 
 
 *Web console (Developer perspective)*


### PR DESCRIPTION
Added bugs for the Console Storage Plugin.

* applies only to `enterprise-4.8`
* [direct preview--Ctrl+F your way to Console Storage Plugin](https://deploy-preview-34292--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-bug-fixes)