### PR TITLE
OSDOCS-2298: Remove quotes from kargs in mpath and other doc

### DIFF
--- a/modules/installation-special-config-kargs.adoc
+++ b/modules/installation-special-config-kargs.adoc
@@ -50,7 +50,7 @@ metadata:
   name: 99-openshift-machineconfig-master-kargs
 spec:
   kernelArguments:
-    - 'loglevel=7'
+    - loglevel=7
 EOF
 ----
 +

--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -39,8 +39,8 @@ metadata:
   name: 99-master-kargs-mpath
 spec:
   kernelArguments:
-    - 'rd.multipath=default'
-    - 'root=/dev/disk/by-label/dm-mpath-root'
+    - rd.multipath=default
+    - root=/dev/disk/by-label/dm-mpath-root
 ----
 
 . To enable multipathing on worker nodes:
@@ -57,8 +57,8 @@ metadata:
   name: 99-worker-kargs-mpath
 spec:
   kernelArguments:
-    - 'rd.multipath=default'
-    - 'root=/dev/disk/by-label/dm-mpath-root'
+    - rd.multipath=default
+    - root=/dev/disk/by-label/dm-mpath-root
 ----
 
 . Create the new machine config by using either the master or worker YAML file you previously created:


### PR DESCRIPTION
[OSDOCS-2298](https://issues.redhat.com/browse/OSDOCS-2298) - remove the single quotes from kargs in the multipath examples as it is reportedly causing problems with a customer config. The PR also removes the single quotes in "[Adding day-1 kernel arguments](https://deploy-preview-34294--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks?utm_source=github&utm_campaign=bot_dp#rhcos-enabling-multipath_post-install-machine-configuration-tasks)" doc.

**Preview links:**
- [Multipath](https://deploy-preview-34294--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks?utm_source=github&utm_campaign=bot_dp#rhcos-enabling-multipath_post-install-machine-configuration-tasks)
- [Adding day-1 kernel arguments](https://deploy-preview-34294--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-kargs_installing-customizing) 