### PR TITLE
Rel Notes doc text for 4.8.0 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-{product-title} (link:https://access.redhat.com/errata/RHBA-2021:1234[RHBA-2021:1234]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.21] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.21] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.8.0 as the GA version and, instead, is releasing {product-title} 4.8.z as the GA version.
 
@@ -22,7 +22,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as on {op-system-first} 4.8.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 7.9 or later for compute machines.
-release-note-bux-fix-4.8
+
 [IMPORTANT]
 ====
 Because only {op-system-base} 7.9 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to {op-system-base} 8.
@@ -1408,9 +1408,9 @@ This release removes the Prometheus Adapter, which was a Technology Preview feat
 * Previously, the Cluster Version Operator evaluated both the `Available` and `Degraded` parameters when setting the `cluster_operator_up` metric, which caused the `ClusterOperatorDown` alert to be displayed for Operators with `Available=True` or `Degraded=True`, even though `Available=True` did not match the alert description of "has not been available". With this fix, the Cluster Version Operator now ignores the `Degraded` parameter when setting the `cluster_operator_up` metric. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1834551[*BZ#1834551*])
 
 * Previously, when Prometheus was installed on the cluster, important platform topology metrics were not available and a CI error would occur if the installer metric that was generated with the invoker was set to `""`. The possible race condition in which informers were not synced before metrics were served that was causing the error has now been fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1871303[*BZ#1871303*])
-  
+
 * Previously, manifests with multiple tolerations for the same key, such as the Cluster Version Operator's own deployment), would accept only the last entry read and overwrite prior entries. This caused `in-cluster tolerations` to diverge from the manifest's listed tolerations. With this update, the Cluster Version Operator now considers tolerations matching when they are completely equal. This allows the Cluster Version Operator to keep all tolerations present in the manifest for the `in-cluster resource`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1941901[*BZ#1941901*])
-  
+
 * Previously, the Cluster Version Operator did not reconcile `env` and `envFrom` for manifests that did not set those properties. This meant the Cluster Version Operator did not properly manage container environments. This update improves the Cluster Version Operator so that it now clears `env` and `envFrom` if they are unset in the manifest. This allows the cluster to automatically recover from invalid `cluster-admin` changes to these properties. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951339[*BZ#1951339*])
 
 
@@ -2015,7 +2015,7 @@ oc create -f $PROJ-app.yaml
 +
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1812212[*BZ#1812212*].
 
-* Parsing undefined values results in a not a number (NaN) exception and the *Chart* tooltip shows a box with no values. To ensure that the results are synced and that undefined values are not parsed, specify a start date when fetching data so that the *Chart* toolip shows correct values. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1906304[*BZ#1906304*]. 
+* Parsing undefined values results in a not a number (NaN) exception and the *Chart* tooltip shows a box with no values. To ensure that the results are synced and that undefined values are not parsed, specify a start date when fetching data so that the *Chart* toolip shows correct values. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1906304[*BZ#1906304*].
 
 * Creating a passthrough route using Ingress fails when using `pathType: """"Prefix""""`. Instead, you can create a passthrough route using `pathType: ImplementationSpecific`, and `path: ''`:
 +
@@ -2028,22 +2028,22 @@ metadata:
   name: ingress7
   namespace: test-ingress
   annotations:
-    route.openshift.io/termination: passthrough 
+    route.openshift.io/termination: passthrough
 spec:
   rules:
   - host: <ingress-psql-example-test-ingress.apps>
     http:
       paths:
-      - path: '' 
+      - path: ''
         pathType: ImplementationSpecific
         backend:
           service:
             name: <ingress-psql-example>
-            port: 
+            port:
               number: 8080
 ----
 +
-For more information, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=1878685[*BZ#1878685*]). 
+For more information, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=1878685[*BZ#1878685*]).
 
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
@@ -2065,12 +2065,12 @@ For any {product-title} release, always review the instructions on xref:../updat
 ====
 
 [id="ocp-4-8-0-ga"]
-=== RHBA-2021:1234 - {product-title} 4.8.0 image release, bug fix, and security update advisory
+=== RHSA-2021:2438 - {product-title} 4.8.0 image release, bug fix, and security update advisory
 
-Issued: 2021-xx-xx
+Issued: 2021-07-12
 
-{product-title} release 4.8.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1234[RHBA-2021:1234] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5678[RHBA-2021:5678] advisory.
+{product-title} release 4.8.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2437[RHSA-2021:2437] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
-link:https://access.redhat.com/solutions/<ARTICLE_ID>[{product-title} 4.8.0 container image list]
+link:https://access.redhat.com/solutions/6164202[{product-title} 4.8.0 container image list]


### PR DESCRIPTION
For release 12 July 2021

Preview:
- [About this release](https://deploy-preview-34295--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-about-this-release)
- [RHSA-2021:2438 - OpenShift Container Platform 4.8.0 image release, bug fix, and security update advisory](https://deploy-preview-34295--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-0-ga)