### PR TITLE
Adds 6th batch of 4.8 RNs bug doc text

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1561,12 +1561,19 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19485
 
 
 *Installer*
-//section 1
 
 * Previously, the installer did not take into account the region where the bootstrap Ignition config should be located when generating its URL. Consequently, the bootstrap machine could not fetch the config from the provided URL because it was incorrect. This update takes the user's region into account when generating the URL and selects the correct public endpoint. As a result, the installer always generates correct bootstrap Ignition URLs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1934123[*BZ#1934123*])
 
 * Previously, the default version of Azure's Minimum TLS was 1.0 when creating a storage account. Consequently, policy checks would fail. This update configures the openshift-installer Azure client to set the Minimum TLS version to 1.2 when creating a storage account. As a result, policy checks now pass. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1943157[*BZ#1943157*])
 //section 2
+* Previously, private clusters deployed using IPI on Azure had an inbound NSG rule that allowed SSH to the bootstrap node. This allowance could trigger Azure's security policy. With this update, that NSG rule has been removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1943219)[*BZ#1943219*])
+
+* Previously, the installer did not recognize the `ap-northeast-3` AWS region. With this update, the installer allows installs to unknown regions that fit the pattern for known partitions, which allows users to create infrastructure in the `ap-northeast-3` AWS region. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1944268)[*BZ#1944268*])
+
+* Previously, on-premise platforms lacked the capability to create internal load balancers. With this update, a check has been added when users create manfiests to ensure that this strategy is only used on cloud platforms such as AWS, Azure, and GCP. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953035)[*BZ#1953035*])
+
+* Previously, when naming GCP resources, a filter prevented certain names using the word `Google` from being used. This update adds a check in the installer on the cluster name that allows some variations of the word `Google` to be used when setting a name. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1955336)[*BZ#1955336*])
+
 * Previously, a bare metal installation with installer-provisioned infrastructure required that the installer process was able to communicate with the provisioning network. Now, the installer process can communicate with the virtual IP for the API server. This change enables cases when the provisioning network is not routable and the installer process is run from a remote location, such as Hive for {rh-openstack-first} or Red Hat Advanced Cluster Management. You might need to adjust your firewall rules to allow communication with TCP ports 6385 and 5050 on virtual IP for the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932799[*BZ#1932799*])
 
 * Previously, when you installed on {rh-openstack-first} and specified the ID of a subnet that did not exist in the `platform.openstack.machinesSubnet` field, the `openshift-install` command produced a SIGSEGV and backtrace. Now, the `openshift-install` command is revised so that it produces an error message like the following: `FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.openstack.machinesSubnet: Not found: "<network-ID>"`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957809[*BZ#1957809*])
@@ -1619,12 +1626,18 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19485
 
 * Previously, the web console showed times in the 12-hour format in most places, and the 24-hour format in others. Additionally, the year was not displayed for dates more than one year in the past. With this release, dates and times are formatted consistently and match the user locale and language preference settings, and the year is displayed for dates more than one year in the past. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862984[*BZ#1862084*])
 
-* Previously, the fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*] to properly create RoleBinding links consistently resulted in the inability to select the binding type when a namespace was selected. Consequently, users with an active namespace could not create a cluster RoleBinding without changing the active namespace to `All namespaces`. This update reverts part of the changes for BZ#1871996 so that users can create a cluster role binding regardless of active namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927882[*BZ#1927882*])
+* Previously, the web console was polling the `ClusterVersion` resource for users who didn't have the authority to view those events. This would output large numbers of errors in the console pod log. To avoid this, checking the user's persmissions before polling the resource is required, which eliminates unnecessary errors in the console pod log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1848151[*BZ#1848151*])
+
+* Previously, keyboard users of the YAML editor were unable to exit the editor. The `view shortcuts` popover outside of the editor was unavailable inside the editor for access by the user. With this update, users can display `Accessibility help` above the editor using the `opt + F1` keystrokes. This change allows keyboard users of the YAML editor to exit the editor using the correct keystrokes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874931[*BZ#1874931*])
+
+* After the 4.x release of {product-title} (OCP), binary secret files uploaded to the OCP 4 web console failed to load. This caused the installation to fail. With {product-title} 4.8, this capability has been restored to the OCP 4 web console. Input of the required secret can now be accomplished using binary file format. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879638[*BZ#1879638*])
+
 //section 3
 * Previously, an API server could fail to create a resource, which would return a 409 status code when there was a conflict updating a `resource quota` resource. Consequently, the resource would fail to create, and you might have had to retry the API request. With this update, the `OpenShift Console` web application attempts to retry the request 3 times when receiving a 409 status code, which is often sufficient for completing the request. In the event that a 409 status code continues to occur, an error will be displayed in the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1920699[*BZ#1920699*])
 
 * Previously, when selecting the *YAML* tab, the `metadata.managedFields` section was not collapsing immediately. This was due to an issue with the Form or YAML switcher for pages such as *Pipeline Builder* and *Edit HorizontalPodAutoscaler* (HPA). As a result, any part wherein the user tried to type in the document collapsed. The `metadata.managedFields` section remained as is and the cursor was reset to the starting position to the top left of the YAML editor. The current release fixes this issue. Now, when loading the YAML, the `metadata.managedFields` section is immediately collapsed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932472[*BZ#1932472*])
-//section 4
+
+* Previously, the fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*] to properly create RoleBinding links consistently resulted in the inability to select the binding type when a namespace was selected. Consequently, users with an active namespace could not create a cluster RoleBinding without changing the active namespace to `All namespaces`. This update reverts part of the changes for BZ#1871996 so that users can create a cluster role binding regardless of active namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927882[*BZ#1927882*])
 
 *Metering Operator*
 
@@ -1637,6 +1650,27 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19485
 *Networking*
 
 * Due to iptables rewriting rules, clients that used a fixed source port to connect to a service via both the service IP and a pod IP might have encountered problems with port conflicts. With this update, an additional OVS rule is inserted to notice when port conflicts occur and to do an extra SNAT to avoid said conflicts. As a result, there are no longer port conflicts when connecting to a service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910378[*BZ#1910378*])
+
+* Previously, IP port 9 between master nodes and egress-assigned nodes was blocked by the internal firewall. This caused the assignment of IP addresses to egress nodes to fail. This update enables access between master and egress nodes via IP port 9. As a result, the assignment of IP addresses to egress nodes is now successfully permitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942856[*BZ#1942856*]) 
+
+* Previously, UDP services traffic could be blocked because of stale connection tracking entries that were no longer valid. This pevented access to a server pod after it was cycled for `NodePort` service. With this update, the connection tracking entries are purged in the case of `NodePort` service cycling, which allows new network traffic to reach cycled endpoints. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949063[*BZ#1949063*])
+
+* Previously, OVN-Kubernetes network provider ignored network policies with multiple `ipBlocks`. Every ipBlock after the first one was ignored, resulting in pods being unable to reach all of the configured IP addresses. The code for generating OVN ACLs from Kubernetes network policies has been corrected. As a result, network policies with multiple `ipBlocks` now work correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953680[*BZ#1953680*]) 
+
+* Previously, when using the OVN-Kubernetes cluster network provider, a Kubernetes service without any endpoints erroneously accepted connections. With this update, a load balancer is no longer created for services without endpoints and therefore traffic is no longer accepted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918442[*BZ#1918442*])
+
+* Previously, the Container Network Interface (CNI) plug-in for Multus did not understand IPv6 addresses that started with any number of zeros. With this update, the CNI plug-in works with IPv6 that start with values greater than zero. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1919048[*BZ#1919048*])
+
+* Previously, a race condition might be triggered if the SR-IOV Network Operator initiated a reboot when a change in the machine config policy also triggered a reboot. If this occurred, the node was left in an indeterminate state. With this update, that situation is avoided. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921321[*BZ#1921321*])
+
+* Previously, when creating a new user-provisioned cluster with the Kuryr cluster network provider, the OpenStack subset used by the cluster nodes might be undetected, which caused the cluster installation to time out. With this update, the subnet is correctly detected and a user-provisioned installation succeeds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927244[*BZ#1927244*])
+
+* Previously, when upgrading from {product-title} 4.6 to {product-title} 4.7, the Cluster Network Operator (CNO) incorrectly marked itself as having completed its upgrade to the next version. If the upgrade subsequently failed then the CNO reported itself as `degraded`, but erroneously as being at version 4.7. With this update, the CNO waits for the cluster network provider images to upgrade successfully before reporting the CNO upgrade as successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1928157[*BZ#1928157*])
+
+* Previously, when using the OVN-Kubernetes cluster network provider, the endpoint slice controller might not run if the Kubernetes version included a minor version that contained non-numeric characters. With this update, the endpoint slice controller is enabled by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929314[*BZ#1929314*])
+
+* When using the Kuryr cluster network provider, Neutron Ports created subsequent to the installation were named with a different pattern than Neutron Ports created during installation. As a result, Neutron Ports created after installation were not added to the default load balancer. With this update, Kuryr detects Neutron Ports created with either naming convention. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1933269[*BZ#1933269*])
+
 
 * Previously, Open Virtual Network (OVN) changed the source IP addresses of hairpin traffic packets to the IP address of the load balancer, which sometimes blocked traffic when a network policy was in use. With this update, Kuryr opens traffic to the IP addresses of all services in a network policy's namespace, and hairpin traffic flows freely. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1920532[*BZ#1920532*])
 
@@ -2218,6 +2252,10 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=18786
 
 * Currently, in the *Search Page*, the *Pipelines* resources table is not immediately updated after the *Name* filter is applied or removed. However, if you refresh the page or close and expand the *Pipelines* section, the *Name* filter is applied. The same behavior is seen when you remove the *Name* filter. This will be resolved in a future release. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1901207[*BZ#1901207*]. 
 
+
+* Documentation now describes that the `ProvisioningNetworkCIDR` value in the `Provisioning` custom resource. This limits the IPv6 provisioning networks to a limit of /64 due to `dnsmasq`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1947293)[*BZ#1947293*]
+
+* To assist with troubleshooting, logs collected on boostratp failures by the installer now include IP addresses and routes for the control plane and bootstrap hosts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1956079)[*BZ#1956079*])
 
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Adds 6th batch of 4.8 RN bug doc text. 

No BZ.

Preview: https://deploy-preview-34305--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp

