### PR TITLE
Updating quick start references in 4.8 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -173,16 +173,16 @@ For `console` and `downloads` routes, custom routes functionality is now impleme
 For more information, see xref:../web_console/customizing-the-web-console.adoc#customizing-the-web-console-url_customizing-web-console[Customizing console routes].
 
 [id="ocp-4-8-access-code-snippet-from-quick-start"]
-==== Access a code snippet from a Quick Start
+==== Access a code snippet from a quick start
 
-You can now execute a CLI snippet when it is included in a Quick Start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
+You can now execute a CLI snippet when it is included in a quick start from the web console. To use this feature, you must first install the Web Terminal Operator. The web terminal and code snippet actions that execute in the web terminal are not present if you do not install the Web Terminal Operator. Alternatively, you can copy a code snippet to the clipboard regardless of whether you have the Web Terminal Operator installed or not.
 
 [id="ocp-4-8-improved-presentation-quick-start-prereqs"]
-==== Improved presentation of Quick Start prerequisites
+==== Improved presentation of quick start prerequisites
 
-Previously, Quick Start prerequisites were displayed as combined text instead of a list on the Quick Start card. With scalability in mind, the prerequisites are now presented in a popover rather than on the card.
+Previously, quick start prerequisites were displayed as combined text instead of a list on the quick start card. With scalability in mind, the prerequisites are now presented in a popover rather than on the card.
 
-image::quick-start-prerequisites.png[Quick Start prerequisites displayed as popover,338,336]
+image::quick-start-prerequisites.png[quick start prerequisites displayed as popover,338,336]
 
 [id="ocp-4-8-ibm-z"]
 === IBM Z and LinuxONE


### PR DESCRIPTION
Putting instances of quick start in lower case format to align with usage in the quick start docs https://docs.openshift.com/container-platform/4.7/web_console/creating-quick-start-tutorials.html