### PR TITLE
Fix callouts in samples of machineset

### DIFF
--- a/modules/installation-osp-configuring-sr-iov.adoc
+++ b/modules/installation-osp-configuring-sr-iov.adoc
@@ -58,7 +58,7 @@ $ openstack subnet create --network uplink --subnet-range <uplink_network_subnet
 // +
 // [source,terminal]
 // ----
-// $ openstack port os_port_worker_0 --network <infrastructure_ID>-network --security-group <infrastructure_ID>-worker --fixed-ip subnet=<infrastructure_ID>-nodes,ip-address=<fixed_IP_address> --allowed-address ip-address=<infrastructure_ID>-ingress-port
+// $ openstack port os_port_worker_0 --network <infrastructure_id>-network --security-group <infrastructure_id>-worker --fixed-ip subnet=<infrastructure_id>-nodes,ip-address=<fixed_IP_address> --allowed-address ip-address=<infrastructure_ID>-ingress-port
 // ----
 
 // . Create a port for SR-IOV traffic:
@@ -72,5 +72,5 @@ $ openstack subnet create --network uplink --subnet-range <uplink_network_subnet
 // +
 // [source,terminal]
 // ----
-// $ openstack server create --image <infrastructure_ID>-rhcos --flavor ocp --user-data <ocp project>/build-artifacts/worker.ign --nic port-id=<os_port_worker_0 ID> --nic port-id=<radio_port_ID> --config-drive true worker-<worker_ID>.<cluster_name>.<cluster_domain>
+// $ openstack server create --image <infrastructure_id>-rhcos --flavor ocp --user-data <ocp project>/build-artifacts/worker.ign --nic port-id=<os_port_worker_0 ID> --nic port-id=<radio_port_ID> --config-drive true worker-<worker_ID>.<cluster_name>.<cluster_domain>
 // ----

--- a/modules/machineset-osp-adding-bare-metal.adoc
+++ b/modules/machineset-osp-adding-bare-metal.adoc
@@ -35,24 +35,24 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
     machine.openshift.io/cluster-api-machine-role: <node_role>
     machine.openshift.io/cluster-api-machine-type: <node_role>
-  name: <infrastructure_ID>-<node_role>
+  name: <infrastructure_id>-<node_role>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
         machine.openshift.io/cluster-api-machine-role: <node_role>
         machine.openshift.io/cluster-api-machine-type: <node_role>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
     spec:
       providerSpec:
         value:
@@ -69,15 +69,15 @@ spec:
             subnets:
             - filter:
                 name: <subnet_name>
-                tags: openshiftClusterID=<infrastructure_ID>
+                tags: openshiftClusterID=<infrastructure_id>
           securityGroups:
           - filter: {}
-            name: <infrastructure_ID>-<node_role>
+            name: <infrastructure_id>-<node_role>
           serverMetadata:
-            Name: <infrastructure_ID>-<node_role>
-            openshiftClusterID: <infrastructure_ID>
+            Name: <infrastructure_id>-<node_role>
+            openshiftClusterID: <infrastructure_id>
           tags:
-          - openshiftClusterID=<infrastructure_ID>
+          - openshiftClusterID=<infrastructure_id>
           trunk: true
           userDataSecret:
             name: <node_role>-user-data

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -18,9 +18,9 @@ This sample YAML defines a machine set that runs in the `us-east-1a` Amazon Web 
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
-In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`infra`]
+ifdef::infra[`<infra>`]
 is the node label to add.
 
 [source,yaml]
@@ -29,42 +29,42 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-  name: <infrastructureID>-<role>-<zone> <2>
+  name: <infrastructure_id>-<role>-<zone> <2>
 endif::infra[]
 ifdef::infra[]
-  name: <infrastructureID>-infra-<zone> <2>
+  name: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-infra-<zone> <2>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
         machine.openshift.io/cluster-api-machine-type: <role> <3>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra <3>
+        machine.openshift.io/cluster-api-machine-role: <infra> <3>
+        machine.openshift.io/cluster-api-machine-type: <infra> <3>
 endif::infra[]
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<zone> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-infra-<zone> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
     spec:
       metadata:
@@ -97,7 +97,7 @@ endif::infra[]
             name: aws-cloud-credentials
           deviceIndex: 0
           iamInstanceProfile:
-            id: <infrastructureID>-worker-profile <1>
+            id: <infrastructure_id>-worker-profile <1>
           instanceType: m4.large
           kind: AWSMachineProviderConfig
           placement:
@@ -107,14 +107,14 @@ endif::infra[]
             - filters:
                 - name: tag:Name
                   values:
-                    - <infrastructureID>-worker-sg <1>
+                    - <infrastructure_id>-worker-sg <1>
           subnet:
             filters:
               - name: tag:Name
                 values:
-                  - <infrastructureID>-private-us-east-1a <1>
+                  - <infrastructure_id>-private-us-east-1a <1>
           tags:
-            - name: kubernetes.io/cluster/<infrastructureID> <1>
+            - name: kubernetes.io/cluster/<infrastructure_id> <1>
               value: owned
           userDataSecret:
             name: worker-user-data
@@ -125,7 +125,7 @@ endif::infra[]
 ----
 $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.ami.id}{"\n"}' \
-    get machineset/<infrastructureID>-worker-us-east-1a
+    get machineset/<infrastructure_id>-worker-us-east-1a
 ----
 ifndef::infra[]
 <2> Specify the infrastructure ID, node label, and zone.
@@ -133,8 +133,8 @@ ifndef::infra[]
 <4> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID, `infra` node label, and zone.
-<3> Specify the `infra` node label.
+<2> Specify the infrastructure ID, `<infra>` node label, and zone.
+<3> Specify the `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 <5> Specify a valid {op-system-first} AMI for your AWS zone for your {product-title} nodes.
 endif::infra[]

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -18,9 +18,9 @@ This sample YAML defines a machine set that runs in the `1` Microsoft Azure zone
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
-In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`infra`]
+ifdef::infra[`<infra>`]
 is the node label to add.
 
 [source,yaml]
@@ -29,43 +29,43 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
     machine.openshift.io/cluster-api-machine-role: <role> <2>
     machine.openshift.io/cluster-api-machine-type: <role> <2>
-  name: <infrastructureID>-<role>-<region> <3>
+  name: <infrastructure_id>-<role>-<region> <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: infra <2>
-    machine.openshift.io/cluster-api-machine-type: infra <2>
-  name: <infrastructureID>-infra-<region> <3>
+    machine.openshift.io/cluster-api-machine-role: <infra> <2>
+    machine.openshift.io/cluster-api-machine-type: <infra> <2>
+  name: <infrastructure_id>-infra-<region> <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-infra-<region> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
 endif::infra[]
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
         machine.openshift.io/cluster-api-machine-role: <role> <2>
         machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-<role>-<region> <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<region> <3>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <2>
-        machine.openshift.io/cluster-api-machine-type: infra <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-infra-<region> <3>
+        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-type: <infra> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<region> <3>
 endif::infra[]
     spec:
       metadata:
@@ -89,13 +89,13 @@ endif::infra[]
           image:
             offer: ""
             publisher: ""
-            resourceID: /resourceGroups/<infrastructureID>-rg/providers/Microsoft.Compute/images/<infrastructureID>
+            resourceID: /resourceGroups/<infrastructure_id>-rg/providers/Microsoft.Compute/images/<infrastructure_id> <1>
             sku: ""
             version: ""
           internalLoadBalancer: ""
           kind: AzureMachineProviderSpec
           location: centralus
-          managedIdentity: <infrastructureID>-identity <1>
+          managedIdentity: <infrastructure_id>-identity <1>
           metadata:
             creationTimestamp: null
           natRule: null
@@ -107,14 +107,14 @@ endif::infra[]
             osType: Linux
           publicIP: false
           publicLoadBalancer: ""
-          resourceGroup: <infrastructureID>-rg <1>
+          resourceGroup: <infrastructure_id>-rg <1>
           sshPrivateKey: ""
           sshPublicKey: ""
-          subnet: <infrastructureID>-<role>-subnet <1> <2>
+          subnet: <infrastructure_id>-<role>-subnet <1> <2>
           userDataSecret:
             name: worker-user-data <2>
           vmSize: qeci-22538-vnet
-          vnet: <infrastructureID>-vnet <1>
+          vnet: <infrastructure_id>-vnet <1>
 ifndef::infra[]
           zone: "1" <4>
 endif::infra[]
@@ -135,7 +135,7 @@ You can obtain the subnet by running the following command:
 ----
 $  oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.subnet}{"\n"}' \
-    get machineset/<infrastructureID>-worker-centralus1
+    get machineset/<infrastructure_id>-worker-centralus1
 ----
 You can obtain the vnet by running the following command:
 +
@@ -143,7 +143,7 @@ You can obtain the vnet by running the following command:
 ----
 $  oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.vnet}{"\n"}' \
-    get machineset/<infrastructureID>-worker-centralus1
+    get machineset/<infrastructure_id>-worker-centralus1
 ----
 ifndef::infra[]
 <2> Specify the node label to add.
@@ -151,8 +151,8 @@ ifndef::infra[]
 <4> Specify the zone within your region to place Machines on. Be sure that your region supports the zone that you specify.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `infra` node label.
-<3> Specify the infrastructure ID, `infra` node label, and region.
+<2> Specify the `<infra>` node label.
+<3> Specify the infrastructure ID, `<infra>` node label, and region.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 <5> Specify the zone within your region to place Machines on. Be sure that your region supports the zone that you specify.
 endif::infra[]

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -18,9 +18,9 @@ This sample YAML defines a machine set that runs in Google Cloud Platform (GCP) 
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
-In this sample, `<infrastructureID>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`infra`]
+ifdef::infra[`<infra>`]
 is the node label to add.
 
 [source,yaml]
@@ -29,29 +29,29 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
-  name: <infrastructureID>-w-a <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+  name: <infrastructure_id>-w-a <1>
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
-      machine.openshift.io/cluster-api-machineset: <infrastructureID>-w-a <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a <1>
   template:
     metadata:
       creationTimestamp: null
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructureID> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
         machine.openshift.io/cluster-api-machine-role: <role> <2>
         machine.openshift.io/cluster-api-machine-type: <role> <2>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <2>
-        machine.openshift.io/cluster-api-machine-type: infra <2>
+        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-type: <infra> <2>
 endif::infra[]
-        machine.openshift.io/cluster-api-machineset: <infrastructureID>-w-a <1>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a <1>
     spec:
       metadata:
         labels:
@@ -88,8 +88,8 @@ endif::infra[]
           metadata:
             creationTimestamp: null
           networkInterfaces:
-          - network: <infrastructureID>-network <1>
-            subnetwork: <infrastructureID>-worker-subnet <1>
+          - network: <infrastructure_id>-network <1>
+            subnetwork: <infrastructure_id>-worker-subnet <1>
 ifndef::infra[]
           projectID: <project_name> <4>
 endif::infra[]
@@ -99,15 +99,15 @@ endif::infra[]
           region: us-central1
           serviceAccounts:
 ifndef::infra[]
-          - email: <infrastructureID>-w@<project_name>.iam.gserviceaccount.com <1> <4>
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <4>
 endif::infra[]
 ifdef::infra[]
-          - email: <infrastructureID>-w@<project_name>.iam.gserviceaccount.com <1> <5>
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com <1> <5>
 endif::infra[]
             scopes:
             - https://www.googleapis.com/auth/cloud-platform
           tags:
-          - <infrastructureID>-worker <1>
+          - <infrastructure_id>-worker <1>
           userDataSecret:
             name: worker-user-data
           zone: us-central1-a
@@ -126,12 +126,12 @@ ifndef::infra[]
 ----
 $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
-    get machineset/<infrastructureID>-worker-a
+    get machineset/<infrastructure_id>-worker-a
 ----
 <4> Specify the name of the GCP project that you use for your cluster.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `infra` node label.
+<2> Specify the `<infra>` node label.
 <3> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 <4> Specify the path to the image that is used in current machine sets. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
 +
@@ -139,7 +139,7 @@ ifdef::infra[]
 ----
 $ oc -n openshift-machine-api \
     -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
-    get machineset/<infrastructureID>-worker-a
+    get machineset/<infrastructure_id>-worker-a
 ----
 <5> Specify the name of the GCP project that you use for your cluster.
 endif::infra[]

--- a/modules/machineset-yaml-osp-sr-iov-port-security.adoc
+++ b/modules/machineset-yaml-osp-sr-iov-port-security.adoc
@@ -25,24 +25,24 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
     machine.openshift.io/cluster-api-machine-role: <node_role>
     machine.openshift.io/cluster-api-machine-type: <node_role>
-  name: <infrastructure_ID>-<node_role>
+  name: <infrastructure_id>-<node_role>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
         machine.openshift.io/cluster-api-machine-role: <node_role>
         machine.openshift.io/cluster-api-machine-type: <node_role>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
     spec:
       metadata: {}
       providerSpec:
@@ -76,9 +76,9 @@ spec:
           primarySubnet: <machines_subnet_UUID>
           serverMetadata:
             Name: <infrastructure_ID>-<node_role>
-            openshiftClusterID: <infrastructure_ID>
+            openshiftClusterID: <infrastructure_id>
           tags:
-          - openshiftClusterID=<infrastructure_ID>
+          - openshiftClusterID=<infrastructure_id>
           trunk: false
           userDataSecret:
             name: worker-user-data
@@ -121,5 +121,5 @@ If your cluster uses Kuryr and the {rh-openstack} SR-IOV network has port securi
 In that case, you can apply the compute security group to the primary VM interface after the VM is created. For example, from a command line:
 [source,terminal]
 ----
-$ openstack port set --enable-port-security --security-group <infrastructure_ID>-<node_role> <main_port_ID>
+$ openstack port set --enable-port-security --security-group <infrastructure_id>-<node_role> <main_port_ID>
 ----

--- a/modules/machineset-yaml-osp-sr-iov.adoc
+++ b/modules/machineset-yaml-osp-sr-iov.adoc
@@ -9,7 +9,7 @@ If you configured your cluster for single-root I/O virtualization (SR-IOV), you 
 
 This sample YAML defines a machine set that uses SR-IOV networks. The nodes that it creates are labeled with `node-role.openshift.io/<node_role>: ""`
 
-In this sample, `infrastructure_ID` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `node_role` is the node label to add.
+In this sample, `infrastructure_id` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and `node_role` is the node label to add.
 
 The sample assumes two SR-IOV networks that are named "radio" and "uplink". The networks are used in port definitions in the `spec.template.spec.providerSpec.value.ports` list.
 
@@ -25,24 +25,24 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
     machine.openshift.io/cluster-api-machine-role: <node_role>
     machine.openshift.io/cluster-api-machine-type: <node_role>
-  name: <infrastructure_ID>-<node_role>
+  name: <infrastructure_id>-<node_role>
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_ID>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
         machine.openshift.io/cluster-api-machine-role: <node_role>
         machine.openshift.io/cluster-api-machine-type: <node_role>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<node_role>
     spec:
       metadata:
       providerSpec:
@@ -81,12 +81,12 @@ spec:
           primarySubnet: <machines_subnet_UUID>
           securityGroups:
           - filter: {}
-            name: <infrastructure_ID>-<node_role>
+            name: <infrastructure_id>-<node_role>
           serverMetadata:
-            Name: <infrastructure_ID>-<node_role>
-            openshiftClusterID: <infrastructure_ID>
+            Name: <infrastructure_id>-<node_role>
+            openshiftClusterID: <infrastructure_id>
           tags:
-          - openshiftClusterID=<infrastructure_ID>
+          - openshiftClusterID=<infrastructure_id>
           trunk: true
           userDataSecret:
             name: <node_role>-user-data

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -18,9 +18,9 @@ This sample YAML defines a machine set that runs on {rh-openstack-first} and cre
 ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
-In this sample, `infrastructure_ID` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
-ifndef::infra[`node_role`]
-ifdef::infra[`infra`]
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+ifndef::infra[`<role>`]
+ifdef::infra[`<infra>`]
 is the node label to add.
 
 [source,yaml]
@@ -29,43 +29,43 @@ apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
   labels:
-    machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-    machine.openshift.io/cluster-api-machine-role: <node_role> <2>
-    machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-  name: <infrastructure_ID>-<node_role> <3>
+    machine.openshift.io/cluster-api-machine-role: <role> <2>
+    machine.openshift.io/cluster-api-machine-type: <role> <2>
+  name: <infrastructure_id>-<role> <3>
 endif::infra[]
 ifdef::infra[]
-    machine.openshift.io/cluster-api-machine-role: infra <2>
-    machine.openshift.io/cluster-api-machine-type: infra <2>
-  name: <infrastructure_ID>-infra <3>
+    machine.openshift.io/cluster-api-machine-role: <infra> <2>
+    machine.openshift.io/cluster-api-machine-type: <infra> <2>
+  name: <infrastructure_id>-infra <3>
 endif::infra[]
   namespace: openshift-machine-api
 spec:
   replicas: <number_of_replicas>
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-infra <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_ID> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <node_role> <2>
-        machine.openshift.io/cluster-api-machine-type: <node_role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-<node_role> <3>
+        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <3>
     spec:
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <2>
-        machine.openshift.io/cluster-api-machine-type: infra <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_ID>-infra <3>
+        machine.openshift.io/cluster-api-machine-role: <infra> <2>
+        machine.openshift.io/cluster-api-machine-type: <infra> <2>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <3>
     spec:
     metadata:
       creationTimestamp: null
@@ -101,7 +101,7 @@ endif::infra[]
             subnets:
             - filter:
                 name: <subnet_name>
-                tags: openshiftClusterID=<infrastructure_ID>
+                tags: openshiftClusterID=<infrastructure_id> <1>
 ifndef::infra[]
           primarySubnet: <rhosp_subnet_UUID> <6>
 endif::infra[]
@@ -110,12 +110,12 @@ ifdef::infra[]
 endif::infra[]
           securityGroups:
           - filter: {}
-            name: <infrastructure_ID>-worker
+            name: <infrastructure_id>-worker <1>
           serverMetadata:
-            Name: <infrastructure_ID>-worker
-            openshiftClusterID: <infrastructure_ID>
+            Name: <infrastructure_id>-worker <1>
+            openshiftClusterID: <infrastructure_id> <1>
           tags:
-          - openshiftClusterID=<infrastructure_ID>
+          - openshiftClusterID=<infrastructure_id> <1>
           trunk: true
           userDataSecret:
             name: worker-user-data <2>
@@ -136,8 +136,8 @@ link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16
 <6> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the `infra` node label.
-<3> Specify the infrastructure ID and `infra` node label.
+<2> Specify the `<infra>` node label.
+<3> Specify the infrastructure ID and `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 <5> To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -20,7 +20,7 @@ ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
 ifndef::infra[`<role>`]
-ifdef::infra[`infra`]
+ifdef::infra[`<infra>`]
 is the node label to add.
 
 [source,yaml]
@@ -60,8 +60,8 @@ ifndef::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: infra <3>
-        machine.openshift.io/cluster-api-machine-type: infra <3>
+        machine.openshift.io/cluster-api-machine-role: <infra> <3>
+        machine.openshift.io/cluster-api-machine-type: <infra> <3>
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
 endif::infra[]
     spec:
@@ -146,8 +146,8 @@ Do not specify the original VM template. The VM template must remain off and mus
 <10> Specify the vCenter server IP or fully qualified domain name.
 endif::infra[]
 ifdef::infra[]
-<2> Specify the infrastructure ID and `infra` node label.
-<3> Specify the `infra` node label.
+<2> Specify the infrastructure ID and `<infra>` node label.
+<3> Specify the `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 <5> Specify the vSphere VM network to deploy the machine set to.
 <6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.

--- a/modules/private-clusters-setting-dns-private.adoc
+++ b/modules/private-clusters-setting-dns-private.adoc
@@ -33,8 +33,8 @@ spec:
   baseDomain: <base_domain>
   privateZone:
     tags:
-      Name: <infrastructureID>-int
-      kubernetes.io/cluster/<infrastructureID>: owned
+      Name: <infrastructure_id>-int
+      kubernetes.io/cluster/<infrastructure_id>: owned
   publicZone:
     id: Z2XXXXXXXXXXA4
 status: {}
@@ -80,7 +80,7 @@ spec:
   baseDomain: <base_domain>
   privateZone:
     tags:
-      Name: <infrastructureID>-int
-      kubernetes.io/cluster/<infrastructureID>-wfpg4: owned
+      Name: <infrastructure_id>-int
+      kubernetes.io/cluster/<infrastructure_id>-wfpg4: owned
 status: {}
 ----


### PR DESCRIPTION
@vikram-redhat There are some callouts issues on the examples of machineset, minimum version that the change applies to should be 4.5 in my opinion, could you arrange someone to review them? Thanks.

Major changes on my commit:
1. Unify below callouts, ensure different platform using the same ones.
   `<infrastructureID>` changed to `<infrastructure_id>`
   `<node_role>` changed to `<role>`
2. Add some missing callouts on the samples, e.g. <1>. To fix the issue[#34284](https://github.com/openshift/openshift-docs/issues/34284) too.