### PR TITLE
BZ1932466: added missing namespace for PVC

### DIFF
--- a/modules/installation-registry-storage-block-recreate-rollout.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout.adoc
@@ -45,16 +45,18 @@ kind: PersistentVolumeClaim
 apiVersion: v1
 metadata:
   name: image-registry-storage <1>
+  namespace: openshift-image-registry <2>
 spec:
   accessModes:
-  - ReadWriteOnce <2>
+  - ReadWriteOnce <3>
   resources:
     requests:
-      storage: 100Gi <3>
+      storage: 100Gi <4>
 ----
 <1> A unique name that represents the `PersistentVolumeClaim` object.
-<2> The access mode of the PersistentVolumeClaim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
-<3> The size of the PersistentVolumeClaim.
+<2> The namespace for the `PersistentVolumeClaim` object, which is `openshift-image-registry`.
+<3> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
+<4> The size of the persistent volume claim.
 
 .. Create the `PersistentVolumeClaim` object from the file:
 +


### PR DESCRIPTION
Applicable for 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1932466

Doc preview link: https://deploy-preview-34315--osdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-vsphere.html#installation-registry-storage-block-recreate-rollout_configuring-registry-storage-vsphere

Requires QA approval from @RazTamir 