### PR TITLE
BZ1934587: Accessing registry with existing registry project

### DIFF
--- a/modules/registry-exposing-secure-registry-manually.adoc
+++ b/modules/registry-exposing-secure-registry-manually.adoc
@@ -9,7 +9,7 @@
 Instead of logging in to the {product-title} registry from within the cluster,
 you can gain external access to it by exposing it with a route. This allows you
 to log in to the registry from outside the cluster using the route address, and
-to tag and push images using the route host.
+to tag and push images to an existing project by using the route host.
 
 .Prerequisites:
 

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -25,20 +25,22 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 
 * You must have configured an identity provider (IDP).
 * For pulling images, for example when using the `podman pull` command,
-the user must have the `registry-viewer` role. To add this role:
+the user must have the `registry-viewer` role. To add this role, run the following command:
 +
 [source,terminal]
 ----
 $ oc policy add-role-to-user registry-viewer <user_name>
 ----
 
-* For writing or pushing images, for example when using the `podman push` command,
-the user must have the `registry-editor` role. To add this role:
+* For writing or pushing images, for example when using the `podman push` command:
+** The user must have the `registry-editor` role. To add this role, run the following command:
 +
 [source,terminal]
 ----
 $ oc policy add-role-to-user registry-editor <user_name>
 ----
++
+** Your cluster must have an existing project where the images can be pushed to.
 endif::[]
 
 include::modules/registry-accessing-directly.adoc[leveloffset=+1]


### PR DESCRIPTION
This fix is related to bug BZ[1934587](https://bugzilla.redhat.com/show_bug.cgi?id=1934587)

To preview fix for Accessing the registry, click [here](https://deploy-preview-34316--osdocs.netlify.app/openshift-enterprise/latest/registry/accessing-the-registry.html#prerequisites)

To preview fix for Exposing the registry, click [here](https://deploy-preview-34316--osdocs.netlify.app/openshift-enterprise/latest/registry/securing-exposing-registry.html)

@dmage and @ricardomaraschini  - Kindly review the changes.

@wzheng1 - Kindly review the fix

This fix needs to be merged with 4.6, 4.7, 4.8