### PR TITLE
Added notes for release 4.7.19

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2587,3 +2587,28 @@ In this update, Telemetry includes a new `openshift:build_by_strategy:sum` gauge
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-19"]
+=== RHBA-2021:2554 - {product-title} 4.7.19 bug fix and security update
+
+Issued: 2021-07-06
+
+{product-title} release 4.7.19, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2554[RHBA-2021:2554] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2555[RHSA-2021:2555] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6163712[{product-title} 4.7.19 container image list]
+
+[id="ocp-4-7-19-bug-fixes"]
+==== Bug fixes
+
+*  Previously, a CoreDNS plugin did not forward queries if they could not be answered by the local cluster server. In some circumstances, this caused queries for DNS names in the cluster to fail. This fix changes the plugin to one that can correctly forward all queries. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1962288[*BZ#1962288*])
+
+* Before this update, some options from the `kubeconfig` file were not copied over when switching from one project to another. If you used the `exec` plugin to authenticate with a proxy to access your cluster, that authentication information could be lost. In this update, all necessary information is copied so users can continue to use a proxy after switching projects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1963784[*BZ#1963784*])
+
+* Previously, the authorization header created during image mirroring could exceed the header size limit for some registries. This would cause an error during the mirroring operation. Now, the `--skip-multiple-scopes` option is set to `true` for the `oc adm catalog mirror` command, to help prevent the authorization header from exceeding the header size limits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976284[*BZ#1976284*])
+
+[id="ocp-4-7-19-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the asynchronous release notes for OpenShift Container Platform 4.7.19.
* applies only to `enterprise-4.7`
* [direct link here](https://deploy-preview-34326--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-19)