### PR TITLE
RHDEVDOCS-2423: Add container source via ODC docs for 4.6

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2752,6 +2752,8 @@ Topics:
     File: serverless-pingsource
   - Name: Using SinkBinding
     File: serverless-sinkbinding
+  - Name: Using container sources
+    File: serverless-containersource
   - Name: Using a Kafka source
     File: serverless-kafka-source
 # Channels

--- a/modules/serverless-odc-create-containersource.adoc
+++ b/modules/serverless-odc-create-containersource.adoc
@@ -17,11 +17,14 @@ To create a container source using the *Developer* perspective, ensure that:
 . In the *Developer* perspective, navigate to *+Add* → *Event Source*. The  *Event Sources* page is displayed.
 . Select *Container Source*.
 . Configure the *Container Source* settings:
-.. Enter the URI of the *Image* that you want to run in the container created by the container source.
-.. Enter the *Name* of the image.
-.. Optional. Enter any *Arguments* to be passed to the container.
+.. In the *Image* field, enter the URI of the image that you want to run in the container created by the container source.
+.. In the *Name* field, enter the name of the image.
+.. Optional: In the *Arguments* field, enter any arguments to be passed to the container.
 // Optional? Add options and what they mean.
 // Same for env variables...
-.. Optional. Add any *Environment variables* to set in the container.
-.. Add a *Sink* where events from the container source are routed to.
+.. Optional: In the *Environment variables* field, add any environment variables to set in the container.
+.. In the *Sink* section, add a sink where events from the container source are routed to.
+... Select *Resource* to use a channel, broker, or service as a sink for the event source.
+... Select *URI* to specify where the events from the container source are routed to.
+
 . After you have finished configuring the container source, click *Create*.

--- a/modules/serverless-odc-create-containersource.adoc
+++ b/modules/serverless-odc-create-containersource.adoc
@@ -1,0 +1,27 @@
+[id="serverless-odc-create-containersource_{context}"]
+= Creating a container source by using the web console
+
+You can create a container source by using the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+To create a container source using the *Developer* perspective, ensure that:
+
+* The {ServerlessOperatorName} and Knative Eventing are installed on your {product-title} cluster.
+* You have logged in to the web console.
+* You are in the *Developer* perspective.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *+Add* → *Event Source*. The  *Event Sources* page is displayed.
+. Select *Container Source*.
+. Configure the *Container Source* settings:
+.. Enter the URI of the *Image* that you want to run in the container created by the container source.
+.. Enter the *Name* of the image.
+.. Optional. Enter any *Arguments* to be passed to the container.
+// Optional? Add options and what they mean.
+// Same for env variables...
+.. Optional. Add any *Environment variables* to set in the container.
+.. Add a *Sink* where events from the container source are routed to.
+. After you have finished configuring the container source, click *Create*.

--- a/serverless/event_sources/knative-event-sources.adoc
+++ b/serverless/event_sources/knative-event-sources.adoc
@@ -12,11 +12,11 @@ Currently, {ServerlessProductName} supports the following event source types:
 
 API server source:: Connects a sink to the Kubernetes API server.
 Ping source:: Periodically sends ping events with a constant payload. It can be used as a timer.
-Sink binding:: Allows you to connect core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
-Container source:: Allows you to create a custom event source by using an image.
-Knative Kafka source:: Connect a Kafka cluster to a sink as an event source.
+Sink binding:: Connects core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
+Container source:: Creates a custom event source by using an image.
+Knative Kafka source:: Connects a Kafka cluster to a sink as an event source.
 
-You can create and manage Knative event sources using the **Developer** perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
+You can create and manage Knative event sources using the *Developer* perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
 
 * Create an xref:../../serverless/event_sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source].
 * Create an xref:../../serverless/event_sources/serverless-pingsource.adoc#serverless-pingsource[ping source].

--- a/serverless/event_sources/knative-event-sources.adoc
+++ b/serverless/event_sources/knative-event-sources.adoc
@@ -13,6 +13,7 @@ Currently, {ServerlessProductName} supports the following event source types:
 API server source:: Connects a sink to the Kubernetes API server.
 Ping source:: Periodically sends ping events with a constant payload. It can be used as a timer.
 Sink binding:: Allows you to connect core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
+Container source:: Allows you to create a custom event source by using an image.
 Knative Kafka source:: Connect a Kafka cluster to a sink as an event source.
 
 You can create and manage Knative event sources using the **Developer** perspective in the {product-title} web console, the `kn` CLI, or by applying YAML files.
@@ -20,4 +21,5 @@ You can create and manage Knative event sources using the **Developer** perspect
 * Create an xref:../../serverless/event_sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source].
 * Create an xref:../../serverless/event_sources/serverless-pingsource.adoc#serverless-pingsource[ping source].
 * Create a xref:../../serverless/event_sources/serverless-sinkbinding.adoc#serverless-sinkbinding[sink binding].
+* Create a xref:../../serverless/event_sources/serverless-containersource.adoc#serverless-containersource[container source].
 * Create a xref:../../serverless/event_sources/serverless-kafka-source.adoc#serverless-kafka-source[Kafka source].

--- a/serverless/event_sources/serverless-containersource.adoc
+++ b/serverless/event_sources/serverless-containersource.adoc
@@ -6,6 +6,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Container sources create a container image that generates events and sends events to a sink. You can use a container source to create your own, custom event source.
+Container sources create a container image that generates events and sends events to a sink. You can use a container source to create a custom event source.
 
 include::modules/serverless-odc-create-containersource.adoc[leveloffset=+1]

--- a/serverless/event_sources/serverless-containersource.adoc
+++ b/serverless/event_sources/serverless-containersource.adoc
@@ -1,0 +1,11 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-containersource"]
+= Using container sources
+include::modules/common-attributes.adoc[]
+:context: serverless-containersource
+
+toc::[]
+
+Container sources create a container image that generates events and sends events to a sink. You can use a container source to create your own, custom event source.
+
+include::modules/serverless-odc-create-containersource.adoc[leveloffset=+1]

--- a/serverless/event_sources/serverless-listing-event-sources.adoc
+++ b/serverless/event_sources/serverless-listing-event-sources.adoc
@@ -12,9 +12,9 @@ Currently, {ServerlessProductName} supports the following event source types:
 
 API server source:: Connects a sink to the Kubernetes API server.
 Ping source:: Periodically sends ping events with a constant payload. It can be used as a timer.
-Sink binding:: Allows you to connect core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
-Container source:: Allows you to create a custom event source by using an image.
-Knative Kafka source:: Connect a Kafka cluster to a sink as an event source.
+Sink binding:: Connects core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
+Container source:: Creates a custom event source by using an image.
+Knative Kafka source:: Connects a Kafka cluster to a sink as an event source.
 
 include::modules/serverless-list-source-types-kn.adoc[leveloffset=+1]
 include::modules/serverless-list-source-types-odc.adoc[leveloffset=+1]

--- a/serverless/event_sources/serverless-listing-event-sources.adoc
+++ b/serverless/event_sources/serverless-listing-event-sources.adoc
@@ -13,11 +13,8 @@ Currently, {ServerlessProductName} supports the following event source types:
 API server source:: Connects a sink to the Kubernetes API server.
 Ping source:: Periodically sends ping events with a constant payload. It can be used as a timer.
 Sink binding:: Allows you to connect core Kubernetes resource objects, such as `Deployment`, `Job`, or `StatefulSet` objects, with a sink.
+Container source:: Allows you to create a custom event source by using an image.
 Knative Kafka source:: Connect a Kafka cluster to a sink as an event source.
-
-// Additional sources can be added by the cluster administrator. For example, {ServerlessProductName} can be used with Kafka and Camel K event sources, which are installed using the Operator Hub in the {product-title} web console.
-// For more information about adding event source types as a cluster administrator, see
-// xref:../knative-client.adoc#knative-client[Installing Knative Client].
 
 include::modules/serverless-list-source-types-kn.adoc[leveloffset=+1]
 include::modules/serverless-list-source-types-odc.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies for OCP 4.6 which has a different UX to later versions. See https://github.com/openshift/openshift-docs/pull/34336 for 4.7+ docs.

Jira: https://issues.redhat.com/browse/RHDEVDOCS-2423

Direct preview:
https://deploy-preview-34337--osdocs.netlify.app/openshift-enterprise/latest/serverless/event_sources/serverless-containersource.html#serverless-containersource