### PR TITLE
BZ1871254 - Add software RAID proc

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -38,6 +38,7 @@ include::modules/installation-special-config-rtkernel.adoc[leveloffset=+1]
 endif::openshift-webscale[]
 include::modules/installation-special-config-kmod.adoc[leveloffset=+1]
 include::modules/installation-special-config-storage.adoc[leveloffset=+1]
+include::modules/installation-special-config-raid.adoc[leveloffset=+1]
 include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
 == Additional resources

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-raid_{context}"]
+== Configuring a RAID-enabled data volume
+
+You can enable software RAID partitioning to provide an external data volume. {product-title} supports RAID 0, RAID 1, RAID 4, RAID 5, RAID 6, and RAID 10 for data protection and fault tolerance. See "About disk mirroring" for more details.
+
+. Create a Butane config that configures a data volume by using software RAID.
+
+* To configure a data volume with RAID 1 on the same disks that are used for a mirrored boot disk, create a `$HOME/clusterconfig/raid1-storage.bu` file, for example:
++
+.RAID 1 on mirrored boot disk
+[source,yaml]
+----
+variant: openshift
+version: 4.8.0
+metadata:
+  name: raid1-storage
+  labels:
+    machineconfiguration.openshift.io/role: worker
+boot_device:
+  mirror:
+    devices:
+      - /dev/sda
+      - /dev/sdb
+storage:
+  disks:
+    - device: /dev/sda
+      partitions:
+        - label: root-1
+          size_mib: 25000 <1>
+        - label: var-1
+    - device: /dev/sdb
+      partitions:
+        - label: root-2
+          size_mib: 25000 <1>
+        - label: var-2
+  raid:
+    - name: md-var
+      level: raid1
+      devices:
+        - /dev/disk/by-partlabel/var-1
+        - /dev/disk/by-partlabel/var-2
+  filesystems:
+    - device: /dev/md/md-var
+      path: /var
+      format: xfs
+      wipe_filesystem: true
+      with_mount_unit: true
+----
+<1> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+
+* To configure a data volume with RAID 1 on secondary disks, create a `$HOME/clusterconfig/raid1-alt-storage.bu` file, for example:
++
+.RAID 1 on secondary disks
+[source,yaml]
+----
+variant: openshift
+version: 4.8.0
+metadata:
+  name: raid1-alt-storage
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  disks:
+    - device: /dev/sdc
+      wipe_table: true
+      partitions:
+        - label: data-1
+    - device: /dev/sdd
+      wipe_table: true
+      partitions:
+        - label: data-2
+  raid:
+    - name: md-var-lib-containers
+      level: raid1
+      devices:
+        - /dev/disk/by-partlabel/data-1
+        - /dev/disk/by-partlabel/data-2
+  filesystems:
+    - device: /dev/md/md-var-lib-containers
+      path: /var/lib/containers
+      format: xfs
+      wipe_filesystem: true
+      with_mount_unit: true
+----
+
+. Run Butane to create a RAID manifest from the Butane config you created in the previous step, for example:
++
+[source,terminal]
+----
+$ butane $HOME/clusterconfig/<butane_file> -o ./<manifest_name>.yaml <1>
+----
+<1> Replace `<butane_file>` and `<manifest_name>` with the file names from the previous step. For example, `raid1-alt-storage.bu` and `raid1-alt-storage.yaml` for secondary disks.
+
+. Apply the manifest to your cluster by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <manifest_name>.yaml
+----
+
+. Save the Butane config in case you need to update the manifest in the future.

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -36,7 +36,7 @@ On previous versions of {op-system}, disk encryption was configured by specifyin
 [id="installation-special-config-mirrored-disk_{context}"]
 == About disk mirroring
 
-During {product-title} installation on control plane and worker nodes, you can enable mirroring of the boot disk to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
+During {product-title} installation on control plane and worker nodes, you can enable mirroring of the boot and other disks to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
 
 Mirroring does not support replacement of a failed disk. To restore the mirror to a pristine, non-degraded state, reprovision the node.
 
@@ -114,7 +114,7 @@ See "Creating machine configs with Butane" for information about Butane.
 ====
 +
 [source,yaml]
-.Butane config example
+.Butane config example for a boot device
 ----
 variant: openshift
 version: 4.8.0


### PR DESCRIPTION
An attempt to address [BZ1871254](https://bugzilla.redhat.com/show_bug.cgi?id=1871254). It didn't seem to fit quite right in the existing step 4 of "Configuring disk encryption or mirroring" so trying this as a standalone (albeit short) procedure. Code example based on a partial version of an upstream example: https://coreos.github.io/butane/examples/#mirrored-boot-disk
Not sure how much else should be included here.

**PREVIEW LINK:**
Configuring a RAID-enabled data volume: https://deploy-preview-34341--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing?utm_source=github&utm_campaign=bot_dp#installation-special-config-raid_installing-customizing