### PR TITLE
CNV-12465: creating deprecated feature module for virt

### DIFF
--- a/modules/virt-deprecated-feature.adoc
+++ b/modules/virt-deprecated-feature.adoc
@@ -1,0 +1,11 @@
+// When including this file, ensure that {FeatureName} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+{FeatureName} is a deprecated feature. Deprecated functionality is still included in {VirtProductName} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+For the most recent list of major functionality that has been deprecated or removed within {VirtProductName}, refer to the _Deprecated and removed features_ section of the {VirtProductName} release notes.
+====
+// Undefine {FeatureName} attribute, so that any mistakes are easily spotted
+:!FeatureName:

--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can import a single Red Hat Virtualization (RHV) virtual machine into {VirtProductName} by using the VM Import wizard or the CLI.
 
 :FeatureName: Importing a RHV VM
-include::modules/deprecated-feature.adoc[leveloffset=+1]
+include::modules/virt-deprecated-feature.adoc[leveloffset=+1]
 
 This feature will be replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
 

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -9,7 +9,7 @@ toc::[]
 You can import a VMware vSphere 6.5, 6.7, or 7.0 VM or VM template into {VirtProductName} by using the VM Import wizard. If you import a VM template, {VirtProductName} creates a virtual machine based on the template.
 
 :FeatureName: Importing a VMware VM
-include::modules/deprecated-feature.adoc[leveloffset=+1]
+include::modules/virt-deprecated-feature.adoc[leveloffset=+1]
 
 This feature will be replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
 


### PR DESCRIPTION
- Related to [CNV-12465](https://issues.redhat.com/browse/CNV-12465)
- Adding duplicate of OCP deprecated feature module for OpenShift Virtualization
- Also updates two assemblies so that they use the virt module instead of the OCP module
- cherrypick to enterprise-4.8
- Preview build: https://deploy-preview-34346--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html