### PR TITLE
BZ1979803: Importing RHV VM fails if migratable

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -66,7 +66,7 @@ The SVVP Certification applies to:
 * You can use the Kubernetes NMSstate Operator to xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-example-nmstate-IP-management_virt-updating-node-network-config[configure and manage IP addresses] on your cluster nodes.
 
 //CNV-11390 OpenShift Virtualization now supports live-migration of VM connected to an SR-IOV network.
-* {VirtProductName} now supports xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[live migration of virtual machines] that are attached to an SR-IOV network interface if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR). 
+* {VirtProductName} now supports xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[live migration of virtual machines] that are attached to an SR-IOV network interface if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR).
 
 [id="virt-4-8-storage-new"]
 === Storage
@@ -93,7 +93,7 @@ The SVVP Certification applies to:
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 //CNV-11468 Single VM import from RHV/VMware deprecated
-* Importing a single virtual machine from Red Hat Virtualization or VMware is deprecated in the current release and will be removed in {VirtProductName} 4.9. This feature is replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
+* Importing a single virtual machine from Red Hat Virtualization (RHV) or VMware is deprecated in the current release and will be removed in {VirtProductName} 4.9. This feature is replaced by the link:https://access.redhat.com/documentation/en-us/migration_toolkit_for_virtualization[Migration Toolkit for Virtualization].
 
 // [id="virt-4-8-removed"]
 // === Removed features
@@ -170,3 +170,6 @@ data:
 ----
 $ ovirt-aaa-jdbc-tool user unlock admin
 ----
+
+// fix targeted for 4.8.1
+* RHV VM import fails if the VM affinity policy is `Migratable` even when live migration is enabled in {VirtProductName}. VM import succeeds if the affinity policy is `Pinned`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977277[*BZ#1977277*])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1979803

CNV 4.8 release notes, known issues. RHV VM cannot be imported if `affinity:Migratable` even when live migration is enabled in CNV. Can be imported if `affinity:Pinned`.

4.8 only

Preview: https://deploy-preview-34353--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-known-issues

QE approved.