### PR TITLE
MIG-760: 1.2/1.3 images deprecated

### DIFF
--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -22,6 +22,12 @@ This release has the following new features and enhancements:
 * Velero has been updated to version 1.6, which provides numerous fixes and enhancements.
 * Cached Kubernetes clients can be enabled to provide improved performance.
 
+[id="deprecated-features-1-5_{context}"]
+== Deprecated features
+
+// https://issues.redhat.com/browse/MIG-623
+* {mtc-short} versions 1.2 and 1.3 are no longer supported.
+
 [id="known-issues-1-5_{context}"]
 == Known issues
 


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-623

Add deprecation of 1.2/1.3 to MTC 1.5.0 RN

4.8

Preview: https://deploy-preview-34354--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/mtc-release-notes?utm_source=github&utm_campaign=bot_dp#deprecated-features-1-5_mtc-release-notes

QE approved. Ready for peer review.