### PR TITLE
BZ1946255: removed the title and procedure from the VMware vSphere backup section and made the snapshot limitation paragraph a note

### DIFF
--- a/storage/persistent_storage/persistent-storage-vsphere.adoc
+++ b/storage/persistent_storage/persistent-storage-vsphere.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 VMware vSphere volumes can be provisioned dynamically. {product-title} creates the disk in vSphere and attaches this disk to the correct image.
 
+[NOTE]
+====
+{product-title} provisions new volumes as independent persistent disks that can freely attach and detach the volume on any node in the cluster. Consequently, you cannot back up volumes that use snapshots, or restore volumes from snapshots. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vm_admin.doc/GUID-53F65726-A23B-4CF0-A7D5-48E584B88613.html[Snapshot Limitations] for more information.
+====
+
 The Kubernetes persistent volume framework allows administrators to provision a
 cluster with persistent storage and gives users a way to request those
 resources without having any knowledge of the underlying infrastructure.
@@ -47,5 +52,3 @@ include::modules/persistent-storage-vsphere-dynamic-provisioning-cli.adoc[levelo
 include::modules/persistent-storage-vsphere-static-provisioning.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-vsphere-formatting.adoc[leveloffset=+2]
-
-include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]


### PR DESCRIPTION
Applicable for 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1946255

Doc preview link: https://deploy-preview-34356--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-vsphere?utm_source=github&utm_campaign=bot_dp


Requires QA approval from @duanwei33 
Requires engineering approval from @jsafrane