### PR TITLE
4.8 RN: Added known issue for BZ1977184

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2313,6 +2313,8 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=18786
 
 * Previously, the topology URLs created for deployments using Bitbucket repository in the {product-title} web console did not work if they included a branch name that contained a slash character. This was due to an issue with the Bitbucket API (link:https://jira.atlassian.com/browse/BCLOUD-9969[BCLOUD-9969]). The current release mitigates this issue. If a branch name contains a slash, the topology URLs point to the default branch page for the repository. This issue will be fixed in a future release of {product-title}. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1970470[*BZ#1970470*].
 
+* The AWS Security Token Service is not supported for clusters installed on AWS in a restricted network. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1977184[*BZ#1977184*].
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Added a known issue to 4.8 RN.
* applies only to `enterprise-4.8`
* See [BZ#1977184](https://bugzilla.redhat.com/show_bug.cgi?id=1977184)
* Needs QE @lwan-wanglin 
* [Direct Preview Link](https://deploy-preview-34357--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-asynchronous-errata-updates) (scroll up from _Asynchronous errata updates_)