### PR TITLE
Fix links for registries

### DIFF
--- a/modules/images-imagestream-import-images-private-registry.adoc
+++ b/modules/images-imagestream-import-images-private-registry.adoc
@@ -4,7 +4,7 @@
 [id="images-imagestream-import-images-private-registry_{context}"]
 = Importing images and image streams from private registries
 
-An image stream can be configured to import tag and image metadata from private image registries requiring authentication. This procedures applies if you change the registry that the Cluster Samples Operator uses to pull content from to something other than link:registry.redhat.io[registry.redhat.io].
+An image stream can be configured to import tag and image metadata from private image registries requiring authentication. This procedures applies if you change the registry that the Cluster Samples Operator uses to pull content from to something other than link:https://registry.redhat.io[registry.redhat.io].
 
 [NOTE]
 ====

--- a/modules/images-other-jenkins-agent-images.adoc
+++ b/modules/images-other-jenkins-agent-images.adoc
@@ -5,7 +5,7 @@
 [id="images-other-jenkins-agent-images_{context}"]
 = Jenkins agent images
 
-The {product-title} Jenkins agent images are available on link:quay.io[Quay.io] or link:registry.redhat.io[registry.redhat.io].
+The {product-title} Jenkins agent images are available on link:https://quay.io[Quay.io] or link:https://registry.redhat.io[registry.redhat.io].
 
 Jenkins images are available through the Red Hat Registry:
 
@@ -34,4 +34,4 @@ $ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-maven:<v4.5.0>
 $ docker pull registry.redhat.io/openshift4/ose-jenkins-agent-base:<v4.5.0>
 ----
 
-To use these images, you can either access them directly from link:quay.io[Quay.io] or link:registry.redhat.io[registry.redhat.io]` or push them into your {product-title} container image registry.
+To use these images, you can either access them directly from link:https://quay.io[Quay.io] or link:https://registry.redhat.io[registry.redhat.io]` or push them into your {product-title} container image registry.


### PR DESCRIPTION
All links in AsciiDoc need a schema prefix, otherwise they will be shown as local links to a file.

Using same format like in other places in these docs for links to Quay.io.