### PR TITLE
Changed Service Binding to TP in 4.7

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1807,7 +1807,7 @@ In the table below, features are marked with the following statuses:
 |Service Binding
 |TP
 |TP
-|GA
+|TP
 
 |Log forwarding
 |TP


### PR DESCRIPTION
The Service Binding feature was mistakenly labeled GA for 4.7. I'm changing it back to TP status.

* applies only to `enterprise-4.7`
* [Direct Preview Link](https://deploy-preview-34359--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-technology-preview)