### PR TITLE
Fix source block delimiters for terminal output.

### DIFF
--- a/modules/serverless-kafka-source-yaml.adoc
+++ b/modules/serverless-kafka-source-yaml.adoc
@@ -78,7 +78,7 @@ $ oc get pods
 +
 .Example output
 [source, terminal]
----
+----
 NAME                                    READY     STATUS    RESTARTS   AGE
 kafkasource-kafka-source-5ca0248f-...   1/1       Running   0          13m
----
+----


### PR DESCRIPTION
4 or more dashes are required for AsciiDoc to recognize a block delimiter. Otherwise, the block will default to no delimiter and print the "---" in the output before and after the content.

Old rendered output:

 
![image](https://user-images.githubusercontent.com/3957921/124750569-eabd7180-df25-11eb-8d37-834946871fc0.png)
