### PR TITLE
Added technology preview feature statuses for 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1951,8 +1951,8 @@ In the table below, features are marked with the following statuses:
 
 |Service Binding
 |TP
-|GA
-|
+|TP
+|TP
 
 |Log forwarding
 |GA
@@ -1967,7 +1967,7 @@ In the table below, features are marked with the following statuses:
 |Raw Block with Cinder
 |TP
 |TP
-|
+|GA
 
 |CSI volume snapshots
 |TP
@@ -2092,7 +2092,7 @@ In the table below, features are marked with the following statuses:
 |Kubernetes NMState Operator
 |-
 |TP
-|
+|TP
 
 |Assisted Installer
 |-


### PR DESCRIPTION
A few small changes to the TP table.

direct link: https://deploy-preview-34369--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-technology-preview