### PR TITLE
CNV-12677: changing about-virt to placeholder

### DIFF
--- a/virt/about-virt.adoc
+++ b/virt/about-virt.adoc
@@ -2,16 +2,8 @@ include::modules/virt-document-attributes.adoc[]
 [id="about-virt"]
 = About {VirtProductName}
 :context: about-virt
-
 toc::[]
 
-Learn about {VirtProductName}'s capabilities and support scope.
+Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
-include::modules/virt-what-you-can-do-with-virt.adoc[leveloffset=+1]
-
-// This line is attached to the above `virt-what-you-can-do-with-virt` module.
-// It is included here in the assembly because of the xref ban.
-
-You can use {VirtProductName} with the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes], xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN], or one of the other certified default Container Network Interface (CNI) network providers listed in link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins].
-
-include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
+In the meantime, the https://docs.openshift.com/container-platform/4.7/virt/about-virt.html[OpenShift Virtualization 2.6 documentation] is available as part of the {product-title} 4.7 documentation.


### PR DESCRIPTION
- [CNV-12677](https://issues.redhat.com/browse/CNV-12677), part 1: creating a placeholder in the about-virt file
- no cherrypick
- preview build: https://deploy-preview-34372--osdocs.netlify.app/openshift-enterprise/latest/virt/about-virt?utm_source=github&utm_campaign=bot_dp
- to be reversed when we release CNV 4.8