### PR TITLE
GH#28781: Use SAN extension for wildcard on custom certificate

### DIFF
--- a/modules/nw-ingress-setting-a-custom-default-certificate.adoc
+++ b/modules/nw-ingress-setting-a-custom-default-certificate.adoc
@@ -15,7 +15,11 @@ custom resource (CR).
 certificate is signed by a trusted certificate authority or by a private trusted
 certificate authority that you configured in a custom PKI.
 
-* Your certificate is valid for the Ingress domain.
+* Your certificate meets the following requirements:
+
+** The certificate is valid for the ingress domain.
+
+** The certificate uses the `subjectAltName` extension to specify a wildcard domain, such as `*.apps.ocp4.example.com`.
 
 * You must have an `IngressController` CR. You may use the default one:
 +


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/28781

Worth fixing.

Preview: https://deploy-preview-34374--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-ingress-setting-a-custom-default-certificate_configuring-ingress