### PR TITLE
Add clarity to our support limitations for remote worker nodes

### DIFF
--- a/nodes/edge/nodes-edge-remote-workers.adoc
+++ b/nodes/edge/nodes-edge-remote-workers.adoc
@@ -20,9 +20,11 @@ However, having remote worker nodes can introduce higher latency, intermittent l
 
 Note the following limitations when planning a cluster with remote worker nodes:
 
-* Remote worker nodes are supported on only bare metal clusters with user-provisioned infrastructure.
+* Remote worker nodes are only supported on bare metal clusters with user-provisioned infrastructure (UPI), which is a generic, non-platform specific installation ('platform: none').
 
-* {product-title} does not support remote worker nodes that use a different cloud provider than the on-premise cluster uses.
+* {product-title} does not support remote worker nodes that use a different cloud provider than the on-premise cluster uses, hence the whole cluster will have to be set to 'platform: none'.
+
+* Remote Worker nodes are otherwise supported on any environments where {product-title} is supported.
 
 * Moving workloads from one Kubernetes zone to a different Kubernetes zone can be problematic due to system and environment issues, such as a specific type of memory not being available in a different zone.
 


### PR DESCRIPTION
In a previous iteration the wording for remote worker nodes caused
confusion with regards to the support of bare metal clusters. We
need to be explicit that the platform type must be set to none, as
there are different types of baremetal cluster now supported, it's
not possible to mix and match provider types in a remote worker
node configuration and therefore we have to utilise the generic
non-platform specific user provisioned infrastructure model.

Fixes #34367