### PR TITLE
CNV-12269: Adding release note for VM storage discard passthroughs

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -46,8 +46,6 @@ The SVVP Certification applies to:
 ** Intel and AMD CPUs.
 * The Containerized Data Importer (CDI) now uses the {product-title} xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy configuration].
 
-
-
 //CNV-12323 OpenShift Virtualization is exposing additional metrics
 * {VirtProductName} now provides metrics for monitoring how infrastructure resources are consumed in the cluster. You can use the {product-title} monitoring dashboard to xref:../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-prometheus-queries[query metrics] for the following resources:
 +
@@ -77,7 +75,9 @@ The SVVP Certification applies to:
 * Cloning a data volume into a different namespace is now faster and more efficient when using storage that supports Container Storage Interface (CSI) snapshots. The Containerized Data Importer (CDI) uses CSI snapshots, when they are available, to improve performance when you create a virtual machine from a template.
 
 //CNV-12269 When a VM frees space on a virtual disk the discard requests are passed to the underlying storage device which may free up real storage capacity.
+* When the `fstrim` or `blkdiscard` commands are run on a virtual disk, the discard requests are passed to the underlying storage device. If the storage provider supports the Pass Discard feature, the discard requests free up storage capacity.
 
+//CNV-12270 CDI can now automatically choose preferred accessMode and volumeMode settings when importing VM disk images.
 * You can now specify data volumes by using the storage API. The storage API, unlike the PVC API, allows the system to optimize `accessModes`, `volumeMode`, and storage capacity when allocating storage.
 
 //CNV-12272 It is now possible to clone virtual machine disks from a Filesystem PVC to a Block PVC and visa versa.
@@ -85,7 +85,7 @@ The SVVP Certification applies to:
 
 //CNV-12273 CDI now follows the OpenShift cluster-wide proxy configuration when importing virtual machine disk images.
 
-* You can xref:../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-a-custom-disk-image-boot-source-web_virt-creating-and-using-boot-sources[create a custom disk image as a boot source] for any template that has a defined source by running a wizard in the {VirtProductName} console. 
+* You can xref:../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-a-custom-disk-image-boot-source-web_virt-creating-and-using-boot-sources[create a custom disk image as a boot source] for any template that has a defined source by running a wizard in the {VirtProductName} console.
 
 [id="virt-4-8-web-new"]
 === Web console


### PR DESCRIPTION
This PR addresses JIRA story [CNV-12269](https://issues.redhat.com/browse/CNV-12269) ( https://issues.redhat.com/browse/CNV-12269 ).

The story is a release note about discard requests passing to an underlying storage device when a VM frees up space on a virtual disk

CP: 4.8

Preview: https://deploy-preview-34385--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-storage-new