### PR TITLE
CNV 12346: Adding release note for Windows VMs scheduled only on HyperV capable nodes

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -53,6 +53,9 @@ The SVVP Certification applies to:
 ** Storage
 ** Guest memory swapping
 
+//CNV-12346 Windows VMs will now only be scheduled to hyper-v capable nodes
+* If a Windows virtual machine is created from a template or has predefined Hyper-V capabilities, it can now only be scheduled to Hyper-V capable nodes.
+
 //CNV-12348 Add `--proxy-only` option to `virtctl vnc` for only proxying a VNC connection to allow manual connections
 * The `--proxy-only` option for the `virtctl vnc` command allows you to xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[manually connect to a virtual machine instance] through a Virtual Network Client (VNC) connection by using any VNC viewer.
 
@@ -66,7 +69,7 @@ The SVVP Certification applies to:
 * You can use the Kubernetes NMSstate Operator to xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-example-nmstate-IP-management_virt-updating-node-network-config[configure and manage IP addresses] on your cluster nodes.
 
 //CNV-11390 OpenShift Virtualization now supports live-migration of VM connected to an SR-IOV network.
-* {VirtProductName} now supports xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[live migration of virtual machines] that are attached to an SR-IOV network interface if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR). 
+* {VirtProductName} now supports xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[live migration of virtual machines] that are attached to an SR-IOV network interface if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR).
 
 [id="virt-4-8-storage-new"]
 === Storage


### PR DESCRIPTION
This PR addresses JIRA story [CNV-12346](https://issues.redhat.com/browse/CNV-12346) ( https://issues.redhat.com/browse/CNV-12346 ).

The story is a release note about Windows VMs now only being able to be schedule on HyperV capable nodes.

CP: 4.8

Preview: https://deploy-preview-34388--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-new