### PR TITLE
BZ1977658: Adding known issue related to No registered model warning message appearing in the VM creation wizard

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -117,7 +117,7 @@ Some features in this release are currently in Technology Preview. These experim
 
 link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
 
-* You can now xref:../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[hot-plug and hot-unplug virtual disks] when you want to add or remove them from your virtual machine without stopping the virtual machine instance. 
+* You can now xref:../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[hot-plug and hot-unplug virtual disks] when you want to add or remove them from your virtual machine without stopping the virtual machine instance.
 
 [id="virt-4-8-known-issues"]
 == Known issues
@@ -176,3 +176,5 @@ $ ovirt-aaa-jdbc-tool user unlock admin
 
 // fix targeted for 4.8.1
 * RHV VM import fails if the VM affinity policy is `Migratable` even when live migration is enabled in {VirtProductName}. VM import succeeds if the affinity policy is `Pinned`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977277[*BZ#1977277*])
+
+* If you create a VM by using the wizard, a "No registered model" warning appears when you customize the VM. You can safely ignore this warning. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1974689[*BZ#1974689*])


### PR DESCRIPTION
This PR addresses Bug 1977658( https://bugzilla.redhat.com/show_bug.cgi?id=1977658 ).

The bug is about a Known Issue release note where a warning message saying "No registered model" appears if a user tries to customize a VM when creating a VM using the VM creation wizard.

CP: 4.8

Preview: https://deploy-preview-34390--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-known-issues