### PR TITLE
BZ#1974403: Upgrade workaround for OVN-K

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2332,6 +2332,8 @@ scheduling:
 
 * For clusters that use the OVN-Kubernetes network provider and whose compute nodes run RHEL 7.9, upgrading from {product-title} 4.7 to {product-title} 4.8 is blocked by link:https://bugzilla.redhat.com/show_bug.cgi?id=1976232[*BZ#1976232*]. To upgrade to release 4.8, you must wait for the 4.8 patch that includes the fix for this bug. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976232[*BZ#1976232*])
 
+* For clusters that use the OVN-Kubernetes network provider and upgrade from {product-title} 4.7 to {product-title} 4.8, a bug in OVN-Kubernetes can sometimes cause the pod IP address to become stale. The bug is a rarely experienced race conditition. As a consequence, during the upgrade to the 4.8 release, nodes fail to drain and some Operators report a status of `Degraded`. As a workaround, identify the pods that are stuck in the `CrashLoopBackOff` state and that did not complete the upgrade. Delete each pod with the `oc delete <pod-name>` command. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1974403[*BZ#1974403*])
+
 * The description for the `tlsSecurityProfile` field of the `kubeletconfig` resource (for example when using the `oc explain` command) does not list the correct ciphers for the TLS security profiles. As a workaround, review the list of ciphers in the `/etc/kubernetes/kubelet.conf` file of an affected node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971899[*BZ#1971899*])
 
 * When running CNF tests in regular mode on a single node, the logic in place to understand if the cluster is ready is missing details. In particular, creating an SR-IOV network will not create a network attachment definition until at least one minute elapses. All the DPDK tests fail in cascade. Run the CNF tests in regular mode skipping the DPDK feature when running against an installation on a single node, with the `-ginkgo.skip` parameter. Run CNF tests in Discovery mode to execute tests against an installation on a single node. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970409[*BZ#1970409*])
@@ -2395,7 +2397,6 @@ spec:
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1878685[*BZ#1878685*].
 
 * Currently, in the *Search* page, the *Pipelines* resources table is not immediately updated after you apply or remove the *Name* filter. However, if you refresh the page and expand the *Pipelines* section, the *Name* filter is applied. The same behavior is seen when you remove the *Name* filter. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1901207[*BZ#1901207*]).
-
 
 * Documentation now describes that the `ProvisioningNetworkCIDR` value in the `Provisioning` custom resource. This limits the IPv6 provisioning networks to a limit of /64 due to `dnsmasq`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1947293)[*BZ#1947293*]
 


### PR DESCRIPTION
Adds a known issue for https://bugzilla.redhat.com/show_bug.cgi?id=1974403.

Document the workaround of deleting pods when
nodes fail to drain and Operators fail to upgrade.