### PR TITLE
CNV-12677: placing redirects to prevent CNV from releasing with OCP

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -160,6 +160,13 @@ AddType text/vtt                            vtt
 
     RewriteRule ^container-platform/(4\.5|4\.6|4\.7)/migration/migrating_4_2_4/upgrading-migration-tool-4-2-4.html /container-platform/$1/migration/migrating_4_2_4/deploying-cam-4-2-4.html#upgrading-the-mtc_migrating-4-2-4 [NE,R=301]
 
+    # 4.8 redirects
+
+    # CNV redirects for 4.8 GA till CNV GAs
+    RewriteRule container-platform/4\.8/virt/(?!about-virt\.html) /container-platform/4.8/virt/about-virt.html [NE,R=302]
+
+    # end 4.8 redirects
+
     # 4.7 redirects
 
     # builds and pipelines books moved to be under the cicd table from 4.7


### PR DESCRIPTION
- [CNV-12677](https://issues.redhat.com/browse/CNV-12677)
- to be reversed when CNV 4.8 GAs (after merging placeholder reversal)