### PR TITLE
Clarify CS object namespace usage

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -6,10 +6,12 @@
 ifdef::openshift-origin[]
 :index-image: catalog
 :tag: latest
+:namespace: olm
 endif::[]
 ifndef::openshift-origin[]
 :index-image: redhat-operator-index
 :tag: v{product-version}
+:namespace: openshift-marketplace
 endif::[]
 ifeval::["{context}" == "olm-restricted-networks"]
 :olm-restricted-networks:
@@ -44,7 +46,7 @@ endif::[]
 ifndef::olm-restricted-networks[]
   name: my-operator-catalog
 endif::[]
-  namespace: openshift-marketplace
+  namespace: {namespace} <.>
 spec:
   sourceType: grpc
   image: <registry>:<port>/<namespace>/{index-image}:{tag} <.>
@@ -54,6 +56,7 @@ spec:
     registryPoll: <.>
       interval: 30m
 ----
+<.> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
 ifdef::olm-restricted-networks[]
 <.> If you mirrored content to local files before uploading to a registry, remove any backslash (`/`) characters from the `metadata.name` field to avoid an "invalid resource name" error when you create the object.
 endif::[]
@@ -72,9 +75,9 @@ $ oc apply -f catalogSource.yaml
 
 .. Check the pods:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get pods -n openshift-marketplace
+$ oc get pods -n {namespace}
 ----
 +
 .Example output
@@ -87,9 +90,9 @@ marketplace-operator-d9f549946-96sgr    1/1     Running   0         26h
 
 .. Check the catalog source:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get catalogsource -n openshift-marketplace
+$ oc get catalogsource -n {namespace}
 ----
 +
 .Example output
@@ -101,9 +104,9 @@ my-operator-catalog   My Operator Catalog   grpc            5s
 
 .. Check the package manifest:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get packagemanifest -n openshift-marketplace
+$ oc get packagemanifest -n {namespace}
 ----
 +
 .Example output
@@ -117,6 +120,7 @@ You can now install the Operators from the *OperatorHub* page on your {product-t
 
 :!index-image:
 :!tag:
+:!namespace:
 ifeval::["{context}" == "olm-restricted-networks"]
 :!olm-restricted-networks:
 endif::[]


### PR DESCRIPTION
* Adds description for the namespace where a catalog source is created.
* Updates the default namespace for OLM to be a replaceable attribute based on upstream (the `olm` namespace for the `openshift-origin` distro) vs downstream (the `openshift-marketplace` namespace for any other distro).

Preview: 

* Step 1a in [Creating a catalog from an index image](https://deploy-preview-34403--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-catalog-from-index_olm-managing-custom-catalogs)