### PR TITLE
BZ1975352: Update documentation about the rotation of kubelet-ca.crt 

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco.adoc
@@ -5,17 +5,19 @@
 [id="troubleshooting-disabling-autoreboot-mco_{context}"]
 = Disabling the Machine Config Operator from automatically rebooting
 
-When configuration changes are made by the Machine Config Operator (MCO), {op-system-first} must reboot for the changes to take effect. Whether the configuration change is automatic, such as when a `kube-apiserver-to-kubelet-signer` certificate authority (CA) is rotated, or manual, an {op-system} node reboots automatically unless it is paused.
+When configuration changes are made by the Machine Config Operator (MCO), {op-system-first} must reboot for the changes to take effect. Whether the configuration change is automatic or manual, an {op-system} node reboots automatically unless it is paused.
 
 [NOTE]
 ====
 The following modifications do not trigger a node reboot:
 
-* changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config
-* changes to the global pull secret or pull secret in the `openshift-config` namespace
-* changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object
+* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
 
-When the MCO detects any of these changes, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
+** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
+** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
+** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
+
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
 ====
 
 To avoid unwanted disruptions, you can modify the machine config pool (MCP) to prevent automatic rebooting after the Operator makes changes to the machine config.
@@ -24,4 +26,3 @@ To avoid unwanted disruptions, you can modify the machine config pool (MCP) to p
 ====
 Pausing a machine config pool stops all system reboot processes and all configuration changes from being applied.
 ====
-

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -47,10 +47,11 @@ To prevent the nodes from automatically rebooting after machine configuration ch
 
 The following modifications do not trigger a node reboot:
 
-* changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config
-* changes to the global pull secret or pull secret in the `openshift-config` namespace
-* changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object
+* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
 
-When the MCO detects any of these changes, it drains the corresponding nodes, applies the changes, and uncordons the nodes. 
+** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
+** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
+** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
+
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
 ====
-


### PR DESCRIPTION
This fix is for the bug BZ [1975352](https://bugzilla.redhat.com/show_bug.cgi?id=1975352)

Understanding MCO plane - [link](https://deploy-preview-34406--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#understanding-machine-config-operator_control-plane)

Disabling MCO autoreboot - [link](https://deploy-preview-34406--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues)

@rioliu-rh  - Kindly review