### PR TITLE
BZ1884330: Backporting mitm mitigation changes

### DIFF
--- a/dev_guide/builds/build_inputs.adoc
+++ b/dev_guide/builds/build_inputs.adoc
@@ -561,8 +561,20 @@ first:
 ----
 $ oc create secret generic <secret_name> \
     --from-file=ssh-privatekey=<path/to/ssh/private/key> \
+    --from-file=<path/to/known_hosts> \ <1>
     --type=kubernetes.io/ssh-auth
 ----
+<1> Optional: Adding this field enables strict server host key check.
++
+[WARNING]
+====
+Skipping the `known_hosts` file while creating the secret makes the build vulnerable to a potential man-in-the-middle (MITM) attack.
+====
++
+[NOTE]
+====
+Ensure that the `known_hosts` file includes an entry for the host of your source code.
+====
 
 [[source-secrets-trusted-certificate-authorities]]
 ==== Trusted Certificate Authorities


### PR DESCRIPTION
This is backporting of bug [BZ1884330](https://bugzilla.redhat.com/show_bug.cgi?id=1884330)
The [PR](https://github.com/openshift/openshift-docs/pull/34201) for 4.6+ versions is already peer, SME and QE approved.

@xiuwang / @wewang58   - Kindly review the backported changes. Marking you since the same changes were approved by you for 4.6+ versions

Here's the [preview](https://deploy-preview-34408--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/builds/build_inputs.html#source-secrets-ssh-key-authentication)