### PR TITLE
SRVOCF-289: Add the docs on invoking a function using 'kn func emit'

### DIFF
--- a/modules/serverless-functions-using-integrated-registry.adoc
+++ b/modules/serverless-functions-using-integrated-registry.adoc
@@ -22,3 +22,5 @@ $ kn func build -r $(oc get route -n openshift-image-registry)
 ----
 $ kn func deploy -r $(oc get route -n openshift-image-registry)
 ----
++
+You can verify that the function deployed successfully by emitting a test event to it.


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVOCF-289

Docs preview: https://deploy-preview-34410--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started?utm_source=github&utm_campaign=bot_dp#serverless-invoke-func-kn_serverless-functions-getting-started