### PR TITLE
SRVOCF-303: Update the envVars section name to env

### DIFF
--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -19,7 +19,7 @@ trigger: http
 builder: default
 builderMap:
   default: quay.io/boson/faas-nodejs-builder
-envVars: {}
+envs: {}
 ----
 
 If the image name and registry are not set in the `func.yaml` file, you must either specify the registry flag, `-r` when using the `kn func build` command, or you are prompted to provide a registry value in the terminal when building a function. An image name is then derived from the registry value that you have provided.

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -23,7 +23,7 @@ trigger: http
 builder: default
 builderMap:
   default: quay.io/boson/faas-nodejs-builder
-envVars: {}
+envs: {}
 ----
 
 .Procedure


### PR DESCRIPTION
For versions 4.6+

https://issues.redhat.com/browse/SRVOCF-303

Docs preview:
https://deploy-preview-34412--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#serverless-create-func-kn_serverless-functions-getting-started (the first YAML listing in this section)
https://deploy-preview-34412--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#serverless-build-func-kn_serverless-functions-getting-started (also the first YAML listing in this section)