### PR TITLE
Telcodocs 85 update: Fixing a minor grammar error in original PR 32785

### DIFF
--- a/modules/cnf-verify-sriov-operator-n3000.adoc
+++ b/modules/cnf-verify-sriov-operator-n3000.adoc
@@ -83,7 +83,7 @@ spec:
 <1> Specify the `namespace` you created in step 1.
 <2> This defines the test image containing the compiled DPDK.
 <3> Make the container execute internally as the root user.
-<4> Specify hugepage size `hugepages-1Gi` and the quantity of hugepages that will be allocated to the pod. Hugepages and isolated CPUs needs to be configure using the Performance Addon Operator.
+<4> Specify hugepage size `hugepages-1Gi` and the quantity of hugepages that will be allocated to the pod. Hugepages and isolated CPUs need to be configured using the Performance Addon Operator.
 <5> Specify the number of CPUs.
 <6> Testing of the N3000 5G FEC configuration is supported by `intel.com/intel_fec_5g`.
 +


### PR DESCRIPTION
The original PR https://github.com/openshift/openshift-docs/pull/32785 went through many cycles of review and just after merging another minor issue was noticed which is addressed here

Preview: https://deploy-preview-34415--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-optimize-data-performance-n3000.html