### PR TITLE
Cleanup work for 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -112,7 +112,7 @@ This change does not affect machine config pool rollout duration.
 [id="ocp-4-8-mco-upgrade-complete"]
 ==== MCO waits for all machine config pools to update before reporting the update is complete
 
-When updating, the Machine Config Operator (MCO) now reports an `Upgradeable=False` condition in the machine-config Cluster Operator if any machine config pool has not completed updating. This status blocks future minor updates, but does not block future patch updates, or the current update. Previously, the MCO reported the `Upgradeable` status based only on the state of the master machine config pool, even if the worker pools were not done updating.
+When updating, the Machine Config Operator (MCO) now reports an `Upgradeable=False` condition in the machine-config Cluster Operator if any machine config pool has not completed updating. This status blocks future minor updates, but does not block future patch updates, or the current update. Previously, the MCO reported the `Upgradeable` status based only on the state of the control plane machine config pool, even if the worker pools were not done updating.
 
 [id="ocp-4-8-installation-fujitsu-irmc"]
 ==== Using Fujitsu iRMC for installation on bare metal nodes
@@ -942,11 +942,11 @@ The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled 
 [id="ocp-4-8-scale-running-in-a-single-node-cluster"]
 ==== Running on a single node cluster
 
-Running tests on a single node cluster causes longer timeouts for certain tests, including SR-IOV and SCTP tests, and tests requiring master and worker nodes are skipped. Reconfiguration requiring node reboots causes a reboot of the entire environment, including the OpenShift control plane, and therefore takes longer to complete. All PTP tests requiring a master and worker node are skipped. No additional configuration is needed because the tests check for the number of nodes at startup and adjust test behavior accordingly.
+Running tests on a single node cluster causes longer timeouts for certain tests, including SR-IOV and SCTP tests, and tests requiring control plane and worker nodes are skipped. Reconfiguration requiring node reboots causes a reboot of the entire environment, including the OpenShift control plane, and therefore takes longer to complete. All PTP tests requiring a control plane node and a worker node are skipped. No additional configuration is needed because the tests check for the number of nodes at startup and adjust test behavior accordingly.
 
-PTP tests can run in Discovery mode. The tests look for a PTP master configured outside of the cluster. The following parameters are required:
+PTP tests can run in Discovery mode. The tests look for a PTP control plane configured outside of the cluster. The following parameters are required:
 
-* `ROLE_WORKER_CNF=master` - Required because master is the only machine pool to which the node will belong.
+* `ROLE_WORKER_CNF=master` - Required because the control plane (`master`) is the only machine pool to which the node will belong.
 * `XT_U32TEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the `xt_u32` negative test to skip because there are only nodes where the module is loaded.
 * `SCTPTEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the SCTP negative test to skip because there are only nodes where the module is loaded.
 
@@ -1420,13 +1420,13 @@ This error happens because the `docker.io` login they used to call the `oc new-a
 
 * Previously, instances took longer to boot when an upgrade was performed by the Machine Config Daemon on the first boot. Consequently, worker nodes were stuck in restart loops, and machine healthchecks (MCHs) removed the worker nodes because they did not properly start. With this update, MHCs no longer remove nodes that have not started correctly. Instead, MHCs only remove nodes when explicitly requested. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939054[*BZ#1939054*])
 
-* Previously, a certificate signing request (CSR) approval was delayed for an unknown reason. Consequently, new machines appearing in the cluster during installation were not approved quickly enough, prolonging cluster installation. To mitigate occasional API server unavailability in early installation phases, this update changes the cache resync period from 10 hours to 10 minutes. As a result, master machines are now approved faster so that cluster installation is no longer prolonged. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1940972[*BZ#1940972*])
+* Previously, a certificate signing request (CSR) approval was delayed for an unknown reason. Consequently, new machines appearing in the cluster during installation were not approved quickly enough, prolonging cluster installation. To mitigate occasional API server unavailability in early installation phases, this update changes the cache resync period from 10 hours to 10 minutes. As a result, control plane machines are now approved faster so that cluster installation is no longer prolonged. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1940972[*BZ#1940972*])
 
 * Previously, the default Google Cloud Platform (GCP) image was out of date and referenced a version from the {product-title} 4.6 release that did not support newer Ignition versions. Consequently, new machines in clusters that used the default GCP image were not able to boot {product-title} 4.7 and later. With this update, the GCP image is updated to match the release version. As a result, new machines can now boot with the default GCP image. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954597[*BZ#1954597*])
 
 * Previously, due to a strict check of the virtual machine's (VM) ProvisioningState value, the VM would sometimes fail during an existence check. With this update, the check is more lenient so that only deleted machines go into a `Failed` phase during an existence check. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957349[*BZ#1957349*])
 
-* Previously, if you deleted a master machine using `oc delete machine` in an AWS cluster, the machine was not removed from the load balancers. As a result, the load balancer continued to serve requests to the removed master machine. With this fix, when you remove a master machine, the load balancer no longer serves requests to the machine. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880757[*BZ#1880757*])
+* Previously, if you deleted a control plane machine using `oc delete machine` in an AWS cluster, the machine was not removed from the load balancers. As a result, the load balancer continued to serve requests to the removed control plane machine. With this fix, when you remove a control plane machine, the load balancer no longer serves requests to the machine. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1880757[*BZ#1880757*])
 
 * Previously, when deleting an unreachable machine, the vSphere Virtual Machine Disk (VMDK) that is created for persistent volumes and attached to the node was incorrectly deleted. As a result, the data on the VMDK was unrecoverable. With this fix, the vSphere cloud provider checks for and detaches these disks from the node if the kubelet is not reachable. As a result, you can delete an unreachable machine without losing the VMDK. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1883993[*BZ#1883993*])
 
@@ -1491,80 +1491,6 @@ This error happens because the `docker.io` login they used to call the `oc new-a
 * Previously, the *Create Storage Cluster* wizard let you enable an arbiter zone that had an undefined value. The fix in this update filters out undefined values so arbiter zones can be created only with defined values. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926798[*BZ#1926798*])
 
 * Previously, quick start cards were displayed incorrectly in the web console because of inconsistencies in how product titles were spelled and how the registered trade mark symbol was used. In this update, the product names are spelled correctly, and the registered trademark symbol appears consistently in the first card only. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1931760[*BZ#1931760*])
-
-
-*Web console (Developer perspective)*
-
-* Previously, when attempting to delete a custom resource within the CNV namespace in the console UI in developer mode, clicking *Delete* in resulted in the *Delete* button hanging in a stuck state. Additionally, an error message that appears when performing the same action in the CLI was not displaying. With this update, the error message displays as expected and the *Delete* button does not stick. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939753[*BZ#1939753*])
-
-* This update fixes the sort order and color of `ImageManifestVuln` objects for the Quay Security Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942716[*BZ#1942716*])
-
-* Previously, the *Topology* view in the Developer perspective did not load if OpenShift namespace templates were not available because the Samples Operator was not installed. This update fixes the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949810[*BZ#1949810*])
-
-* Previously, when you created a quick start tutorial in the web console and specified prerequisites, the prerequisites were displayed as a paragraph instead of a list. Lists are now displayed correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905147[*BZ#1905147*])
-
-* Previously, after importing a devfile, the container did not start successfully. This occurred due to the invalid inclusion of `buildguidanceimage-placeholder` into the deployment. When only the correct container image is included, that image opens as expected. With the latest version, a placeholder image can also be used. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952214[*BZ#1952214*])
-
-* Previously, when switching Developer perspective in another tab and reloading the project details, the routes tied to a perspective were not rendered and resulted in a `404` error. This update loads all inactive routes and switches to the correct perspective. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929769[*BZ#1929769*])
-
-* Previously, OperatorHub Provider Type `filter` property did not clearly show the relationship to `CatalogSource`. Because of this problem, users could not tell what the `filter` criteria meant. This patch updates the Provider Type `filter` to `Source`. This more clearly shows the relationship between `filter` and `CatalogSource`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1919406[*BZ#1919406*])
-
-* Previously, the *ResourceListDropdown* component in the *Resources* menu was not internationalized for some languages. With this update, the *Resources* menu is updated to better the user experience for non-English speakers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921267[*BZ#1921267*])
-
-* Previously, some menu items, such as *Delete Persistent Volume Claim*, were not internationalized correctly. Now, more menu items are correctly internationalized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926126[*BZ#1926126*])
-
-* Previously, some text and warning messages for the *Add HorizontalPodAutoscaler* page were not internationalized. The text is now internationalized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926131[*BZ#1926131*])
-
-* Previously, when users created an Operator with the Operator SDK and specified an annotation like `xDescriptors={"urn:alm:<...>:hidden"}` to hide a field from the Operator instance creation page, the field might still be visible on the page. Now, the hidden fields are omitted from the Operator instance creation page.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966077[*BZ#1966007*])
-
-* Previously, tables displayed incorrectly on mobile devices. With this update, tables now display correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927013[*BZ#1927013*])
-
-* Previously, launching the {product-title} web console may be slow. With this update, the web console launches quicker. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927310[*BZ#19273*])
-
-* Previously, a lack of internationalized notifications to {product-title} administrators detracted from the user experience. Now, internationalization is possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927898[*BZ#1927898*])
-
-* Previously, a lack of internationalized duration times on the *Cluster Utilization* dashboard detracted from the user experience. Now, internationalization is possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927902[*BZ#1927902*])
-
-* Previously, errors occurred when Operator Lifecycle Manager (OLM) status descriptors in the {product-title} web console were assigned incompatible data types. Validation has been added, eliminating incompatible data types from processing, thus avoiding errors. Logged warnings also identify the incompatible status types. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927941[*BZ#1927941*])
-
-* The following {product-title} web console views now support multi-faceted filtering:
-+
---
-** *Home* -> *Search* (the *Resources* tab)
-** *Home* -> *Events* (the *Resources* tab)
-** *Workloads* -> *Pods* (the *Filter* tab)
---
-+
-For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1930007[*BZ#1930007*].
-
-* The following bug fixes address various translation issues for the {product-title} web console:
-
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921780[*BZ#1921780*]
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921781[*BZ#1921781*]
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1922992[*BZ#1922992*]
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1924585[*BZ#1924585*]
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1924747[*BZ#1924747*]
-** link:https://bugzilla.redhat.com/show_bug.cgi?id=1925083[*BZ#1925083*]
-
-* Previously, the web console relied on hard-coded channel strings to populate the channel modal dropdown. As a result, users could see channel values that may not be correct for their current version. Now, if the Cluster Version Operator does not supply the correct channels for a given version, the channel modal dropdown changes to a text input field and suggests channels and help text for the user. The console no longer relies on hard coded channel string. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932281[*BZ#1932281*])
-
-* Previously, timestamps were not correctly formatted for Chinese or Japanese languages. As a result, timestamps were harder to read, which provided a bad user experience. With this update, default timestamp formats are used for Chinese and Japanese in `Moment.js`, which provides a better user experience. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932453[*BZ#1932453*])
-
-* Previously, the `rowFilters` prop in the FilterToolbar component did not accept the `null` value. So if the `rowFilters` prop was undefined, the uncaught exception was thrown. Now, when the `rowFilters` prop is referenced in the FilterToolbar component, the `null` value is accepted. As a result, the FilterToolbar does not throw exceptions when `rowFilters` prop is undefined. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937018[*BZ#1937018*])
-
-* Previously, the pod Containers text was not internationalized, so there was a poor user experience. Now the pod Containers text has been internationalized, so the user experience is improved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937102[*BZ#1937102*])
-
-* Previously, the `PackageManifest` list page items did not link to the details page, so users could not easily drill down into individual `PackageManifest` items from the list page. Now, each `PackageManifest` item is linked to the details page that matches the convention of the other list pages. Users can easily access the PackageManifest details page from the list page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1938321[*BZ#1938321*])
-
-* Previously, the wrong style of help text was applied to the field level help instances. Now, the correct style of help text is shown for the field level help instances and is consistent across the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942749[*BZ#1942749*]).
-
-* Previously, the Operator Lifecycle Manamgent (OLM) status conditions descriptors were rendered as normal detail items on the resource details page. As a result, the *Conditions* table was rendered at half width. With this update, conditions descriptors are rendered as a full-width table below the normal *Conditions* table on the *Operand* details page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1943238[*BZ#1943238*])
-
-* Previously, the word "Ingresses" was translated for Chinese users, but the user experience was bad. Now the word "Ingress" is not translated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945816[*BZ#1945816*])
-
-* Previously, the word "Operators" was translated for Chinese users, but the plural translation resulted in a bad user experience. Now the word "Operators" is not translated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945818[*BZ#1945818*])
-
-* Previously, an incorrect code was causing `User` and `Group` details to show unrelated subjects. Now, a code has been added to filter by `User` or `Group`, so the `User` and `Group` details show related subjects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951212[*BZ#1951212*])
 
 *DNS*
 
@@ -1671,9 +1597,6 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Previously, the Azure clusters were created with the disk type of Premium_LRS and with an instance type that did not support PremiumIO capabilities which caused the cluster to fail. This update checks to see if the instance type picked has the PremiumIO capabilities only if the disk type is Premium_LRS which is the default disk type. The code queries the Azure subscription and region to get the information required and returns an error if the conditions are not met. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1931115[*BZ#1931115*])
 
-*ISV Operators*
-
-
 *kube-apiserver*
 
 * Previously, Google Cloud Platform (GCP) load balancer health checkers left stale conntrack entries on the host, which caused network interruptions to the API server traffic that used the GCP load balancers. The health check traffic no longer loops through the host, so there is no longer network disruption against the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925698[*BZ#1925698*])
@@ -1697,49 +1620,6 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Previously, empty static pod files were being written to the `/etc/kubernetes/manifests` directory. As a result, the kubelet log was reporting errors that could cause confusion with some users. Empty manifests are now moved to a different location when they are not needed. As a result, the errors do not appear in the kubelet log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927042[*BZ#1927042*])
 
-*Web console (Administrator perspective)*
-
-* This update adds an error message to the *Workloads* menu of the monitoring dashboard if a user does not have access privileges. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930546[*BZ#1930546*])
-
-
-* The *Completions* column of the *Jobs* table sorted by the number of *Desired* completions instead of the number of *Succeeded* completions. The data is presented as *# Succeeded of # Desired*, so when sorting by that column the results looked confusing because the data was sorted by the second number. The *Jobs* *Completions* column now sorts on the *# Succeeded* for better understanding. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1902003[*BZ#1902003*])
-
-* The input labels in the *Manage Columns* modal were not clickable buttons, so you could not click them to manage the columns. With this bug fix, the labels are now clickable buttons that you can use to manage columns. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1908343[*BZ#1908343*])
-
-* CSI provisioners were not listed when creating a storage class on the Google Cloud Platform. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910500[*BZ#1910500*])
-
-* Previously, if the user clicked into a *Cluster Role* from the *User Management -> Roles* list view, the back link from the details page is *Cluster Roles*, which provides a generic list view of *Cluster Roles*. This caused backward web console navigation to redirect to the incorrect page. With this release, the back link directs the user to the *Role/Bindings* list view from the *Cluster Role/RoleBinding* details page. This allows the user to correctly navigate backward in the web console.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915971[*BZ#1915971*])
-
-* Previously, *Created date time* was not displayed in a readable format, which made it difficult to understand and use the time shown in UTC. With this release, the displayed time is reformatted so that UTC is readable and understandable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917241[*BZ#1917241*])
-
-* Previously, pod requests and limit calculations in the web console were incorrect. This was a result of not excluding completed pods or init containers. With this release, pods that are not needed in the calculation are excluded, which improves the accuracy of the results of the web console calculation for pod requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918785[*BZ#1918785*])
-
-* Previously, parsing undefined values resulted in a not a number (NaN) exception and the *Chart* tooltip showed a box with no values. With this release, a start date is specified when fetching data so that the *Chart* toolip shows correct values. This change ensures that the results are synced and that undefined values are not parsed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1906304[*BZ#1906304*])
-//section 2
-* During a previous bug fix, the download link for pod logs was changed to a standard HTML anchor element with an empty download attribute. Consequently, the download file lost the default file name format. This update adds a file name to the anchor element download attribute so that a default file name, formatted as `<pod-name>-<container-name>.log`, is used when downloading pod logs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945630[*BZ#1945630*])
-
-* Previously, when a user had permission to create a resource but not permission to edit it, the web console YAML editor was incorrectly set to read-only mode. The editor content is now editable by users with create access for the resource. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824911[*BZ#1824911*])
-
-* Previously, the web console showed times in the 12-hour format in most places, and the 24-hour format in others. Additionally, the year was not displayed for dates more than one year in the past. With this release, dates and times are formatted consistently and match the user locale and language preference settings, and the year is displayed for dates more than one year in the past. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862984[*BZ#1862084*])
-
-* Previously, the web console was polling the `ClusterVersion` resource for users who didn't have the authority to view those events. This would output large numbers of errors in the console pod log. To avoid this, checking the user's persmissions before polling the resource is required, which eliminates unnecessary errors in the console pod log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1848151[*BZ#1848151*])
-
-* Previously, keyboard users of the YAML editor were unable to exit the editor. The `view shortcuts` popover outside of the editor was unavailable inside the editor for access by the user. With this update, users can display `Accessibility help` above the editor using the `opt + F1` keystrokes. This change allows keyboard users of the YAML editor to exit the editor using the correct keystrokes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874931[*BZ#1874931*])
-
-* After the 4.x release of {product-title} (OCP), binary secret files uploaded to the OCP 4 web console failed to load. This caused the installation to fail. With {product-title} 4.8, this capability has been restored to the OCP 4 web console. Input of the required secret can now be accomplished using binary file format. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879638[*BZ#1879638*])
-
-//section 3
-* Previously, an API server could fail to create a resource, which would return a 409 status code when there was a conflict updating a `resource quota` resource. Consequently, the resource would fail to create, and you might have had to retry the API request. With this update, the `OpenShift Console` web application attempts to retry the request 3 times when receiving a 409 status code, which is often sufficient for completing the request. In the event that a 409 status code continues to occur, an error will be displayed in the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1920699[*BZ#1920699*])
-
-* Previously, when selecting the *YAML* tab, the `metadata.managedFields` section was not collapsing immediately. This was due to an issue with the Form or YAML switcher for pages such as *Pipeline Builder* and *Edit HorizontalPodAutoscaler* (HPA). As a result, any part wherein the user tried to type in the document collapsed. The `metadata.managedFields` section remained as is and the cursor was reset to the starting position to the top left of the YAML editor. The current release fixes this issue. Now, when loading the YAML, the `metadata.managedFields` section is immediately collapsed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932472[*BZ#1932472*])
-
-* Previously, the fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*] to properly create RoleBinding links consistently resulted in the inability to select the binding type when a namespace was selected. Consequently, users with an active namespace could not create a cluster RoleBinding without changing the active namespace to `All namespaces`. This update reverts part of the changes for BZ#1871996 so that users can create a cluster role binding regardless of active namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927882[*BZ#1927882*])
-
-* Before this update, the Pipeline `ServiceAccount` did not use secrets created during the `git import` flow for private Git repositories, which caused these Pipelines to fail. This update fixes the problem by adding annotations to the secrets and to the Pipeline `ServiceAccount`. Pipelines for private Git repositories now run correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970470[*BZ#1970470*])
-
-* Previously, annotations were passed to specification of knative service metadata. As a result, decorators were shown for associated revisions of knative service in *Topology*. This release fixes this issue by passing annotations only to knative service metadata. Now, decorators are shown only for knative service in *Topology* and not associated revisions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954959[*BZ#1954959*])
-
-* Previously, if you created a pipeline with parameters that had empty strings, for example, `”`, the fields in the {product-title} web console would not accept the empty strings. The current release fixes this issue. Now, `”` is supported as a valid default property within the parameters section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951043[*BZ#1951043*])
 
 *Metering Operator*
 
@@ -1755,7 +1635,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Due to iptables rewriting rules, clients that used a fixed source port to connect to a service via both the service IP and a pod IP might have encountered problems with port conflicts. With this update, an additional OVS rule is inserted to notice when port conflicts occur and to do an extra SNAT to avoid said conflicts. As a result, there are no longer port conflicts when connecting to a service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910378[*BZ#1910378*])
 
-* Previously, IP port 9 between master nodes and egress-assigned nodes was blocked by the internal firewall. This caused the assignment of IP addresses to egress nodes to fail. This update enables access between master and egress nodes via IP port 9. As a result, the assignment of IP addresses to egress nodes is now successfully permitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942856[*BZ#1942856*])
+* Previously, IP port 9 between control plane nodes and egress-assigned nodes was blocked by the internal firewall. This caused the assignment of IP addresses to egress nodes to fail. This update enables access between control plane and egress nodes via IP port 9. As a result, the assignment of IP addresses to egress nodes is now successfully permitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942856[*BZ#1942856*]) 
 
 * Previously, UDP services traffic could be blocked because of stale connection tracking entries that were no longer valid. This pevented access to a server pod after it was cycled for `NodePort` service. With this update, the connection tracking entries are purged in the case of `NodePort` service cycling, which allows new network traffic to reach cycled endpoints. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949063[*BZ#1949063*])
 
@@ -1970,6 +1850,124 @@ uid=1001(1001) gid=1001 groups=1001
 * Previously, the Local Storage Operator (LSO) was not cleaning up persistent volumes (PVs) since the deleter was not being enqueued correctly. This caused PVs to remain in the `released` state. PVs are now enqueued correctly so that they delete properly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937145[*BZ#1937145*])
 
 * Previously, the Fibre Channel volume was incorrectly unmounted from a node when a pod was deleted. This happened when a different pod that used the volume was deleted in the API server when the kubelet on the node was not running. With this update, Fibre Channel volumes correctly unmount when a new kubelet starts. Additionally, the volume cannot be mounted to multiple nodes until the new kubelet fully starts and cofnrims that the volume is unmounted, which ensures that Fibre Channel volumes are uncorrupted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954509[*BZ#1954509*])
+
+*Web console (Administrator perspective)*
+
+* Previously, when attempting to delete a custom resource within the CNV namespace in the console UI in developer mode, clicking *Delete* in resulted in the *Delete* button hanging in a stuck state. Additionally, an error message that appears when performing the same action in the CLI was not displaying. With this update, the error message displays as expected and the *Delete* button does not stick. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939753[*BZ#1939753*])
+
+* Previously, OperatorHub Provider Type `filter` property did not clearly show the relationship to `CatalogSource`. Because of this problem, users could not tell what the `filter` criteria meant. This patch updates the Provider Type `filter` to `Source`. This more clearly shows the relationship between `filter` and `CatalogSource`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1919406[*BZ#1919406*])
+
+* Previously, the *ResourceListDropdown* component in the *Resources* menu was not internationalized for some languages. With this update, the *Resources* menu is updated to better the user experience for non-English speakers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921267[*BZ#1921267*])
+
+* Previously, some menu items, such as *Delete Persistent Volume Claim*, were not internationalized correctly. Now, more menu items are correctly internationalized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926126[*BZ#1926126*])
+
+* Previously, some text and warning messages for the *Add HorizontalPodAutoscaler* page were not internationalized. The text is now internationalized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926131[*BZ#1926131*])
+
+* Previously, when users created an Operator with the Operator SDK and specified an annotation like `xDescriptors={"urn:alm:<...>:hidden"}` to hide a field from the Operator instance creation page, the field might still be visible on the page. Now, the hidden fields are omitted from the Operator instance creation page.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966077[*BZ#1966007*])
+
+* Previously, tables displayed incorrectly on mobile devices. With this update, tables now display correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927013[*BZ#1927013*])
+
+* Previously, launching the {product-title} web console may be slow. With this update, the web console launches quicker. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927310[*BZ#19273*])
+
+* Previously, a lack of internationalized notifications to {product-title} administrators detracted from the user experience. Now, internationalization is possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927898[*BZ#1927898*])
+
+* Previously, a lack of internationalized duration times on the *Cluster Utilization* dashboard detracted from the user experience. Now, internationalization is possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927902[*BZ#1927902*])
+
+* Previously, errors occurred when Operator Lifecycle Manager (OLM) status descriptors in the {product-title} web console were assigned incompatible data types. Validation has been added, eliminating incompatible data types from processing, thus avoiding errors. Logged warnings also identify the incompatible status types. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927941[*BZ#1927941*])
+
+* The following {product-title} web console views now support multi-faceted filtering:
++
+--
+** Home > Search (the Resources tab)
+** Home > Events (the Resources tab)
+** Workloads > Pods (the Filter tab)
+--
++
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1930007[*BZ#1930007*].
+
+* The following bug fixes address various translation issues for the {product-title} web console: 
+
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921780[*BZ#1921780*]
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921781[*BZ#1921781*]
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1922992[*BZ#1922992*]
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1924585[*BZ#1924585*]
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1924747[*BZ#1924747*]
+** link:https://bugzilla.redhat.com/show_bug.cgi?id=1925083[*BZ#1925083*]
+
+* Previously, the web console relied on hard-coded channel strings to populate the channel modal dropdown. As a result, users could see channel values that may not be correct for their current version. Now, if the Cluster Version Operator does not supply the correct channels for a given version, the channel modal dropdown changes to a text input field and suggests channels and help text for the user. The console no longer relies on hard coded channel string. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932281[*BZ#1932281*])
+
+* Previously, timestamps were not correctly formatted for Chinese or Japnaese languages. As a result, timestamps were harder to read, which provided a bad user experience. With this update, default timestamp formats are used for Chinese and Japanese in `Moment.js`, which provides a better user experience. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932453[*BZ#1932453*])
+
+* Previously, the `rowFilters` prop in the FilterToolbar component did not accept the `null` value. So if the `rowFilters` prop was undefined, the uncaught exception was thrown. Now, when the `rowFilters` prop is referenced in the FilterToolbar component, the `null` value is accepted. As a result, the FilterToolbar does not throw exceptions when `rowFilters` prop is undefined. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937018[*BZ#1937018*])
+
+* Previously, the wrong style of help text was applied to the field level help instances. Now, the correct style of help text is shown for the field level help instances and is consistent across the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942749[*BZ#1942749*]).
+
+* Previously, the Operator Lifecycle Manamgent (OLM) status conditions descriptors were rendered as normal detail items on the resource details page. As a result, the *Conditions* table was rendered at half width. With this update, conditions descriptors are rendered as a full-width table below the normal *Conditions* table on the *Operand* details page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1943238[*BZ#1943238*])
+
+* Previously, the word "Ingresses" was translated for Chinese users, but the user experience was bad. Now the word "Ingress" is not translated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945816[*BZ#1945816*])
+
+* Previously, the word "Operators" was translated for Chinese users, but the plural translation resulted in a bad user experience. Now the word "Operators" is not translated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945818[*BZ#1945818*])
+
+* Previously, an incorrect code was causing `User` and `Group` details to show unrelated subjects. Now, a code has been added to filter by `User` or `Group`, so the `User` and `Group` details show related subjects. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951212[*BZ#1951212*])
+
+* Previously, the pod Containers text was not internationalized, so there was a poor user experience. Now the pod Containers text has been internationalized, so the user experience is improved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937102[*BZ#1937102*])
+
+* Previously, the `PackageManifest` list page items did not link to the details page, so users could not easily drill down into individual `PackageManifest` items from the list page. Now, each `PackageManifest` item is linked to the details page that matches the convention of the other list pages. Users can easily access the PackageManifest details page from the list page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1938321[*BZ#1938321*])
+
+* The *Completions* column of the *Jobs* table sorted by the number of *Desired* completions instead of the number of *Succeeded* completions. The data is presented as *# Succeeded of # Desired*, so when sorting by that column the results looked confusing because the data was sorted by the second number. The *Jobs* *Completions* column now sorts on the *# Succeeded* for better understanding. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1902003[*BZ#1902003*])
+
+* The input labels in the *Manage Columns* modal were not clickable buttons, so you could not click them to manage the columns. With this bug fix, the labels are now clickable buttons that you can use to manage columns. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1908343[*BZ#1908343*])
+
+* CSI provisioners were not listed when creating a storage class on the Google Cloud Platform. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910500[*BZ#1910500*])
+
+* Previously, if the user clicked into a *Cluster Role* from the *User Management -> Roles* list view, the back link from the details page is *Cluster Roles*, which provides a generic list view of *Cluster Roles*. This caused backward web console navigation to redirect to the incorrect page. With this release, the back link directs the user to the *Role/Bindings* list view from the *Cluster Role/RoleBinding* details page. This allows the user to correctly navigate backward in the web console.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915971[*BZ#1915971*])
+
+* Previously, *Created date time* was not displayed in a readable format, which made it difficult to understand and use the time shown in UTC. With this release, the displayed time is reformatted so that UTC is readable and understandable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917241[*BZ#1917241*])
+
+* Previously, pod requests and limit calculations in the web console were incorrect. This was a result of not excluding completed pods or init containers. With this release, pods that are not needed in the calculation are excluded, which improves the accuracy of the results of the web console calculation for pod requests. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918785[*BZ#1918785*])
+
+* Previously, parsing undefined values resulted in a not a number (NaN) exception and the *Chart* tooltip showed a box with no values. With this release, a start date is specified when fetching data so that the *Chart* toolip shows correct values. This change ensures that the results are synced and that undefined values are not parsed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1906304[*BZ#1906304*])
+
+* During a previous bug fix, the download link for pod logs was changed to a standard HTML anchor element with an empty download attribute. Consequently, the download file lost the default file name format. This update adds a file name to the anchor element download attribute so that a default file name, formatted as `<pod-name>-<container-name>.log`, is used when downloading pod logs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1945630[*BZ#1945630*])
+
+* Previously, when a user had permission to create a resource but not permission to edit it, the web console YAML editor was incorrectly set to read-only mode. The editor content is now editable by users with create access for the resource. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1824911[*BZ#1824911*])
+
+* Previously, the web console showed times in the 12-hour format in most places, and the 24-hour format in others. Additionally, the year was not displayed for dates more than one year in the past. With this release, dates and times are formatted consistently and match the user locale and language preference settings, and the year is displayed for dates more than one year in the past. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862084[*BZ#1862084*])
+
+* Previously, the web console was polling the `ClusterVersion` resource for users who didn't have the authority to view those events. This would output large numbers of errors in the console pod log. To avoid this, checking the user's persmissions before polling the resource is required, which eliminates unnecessary errors in the console pod log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1848151[*BZ#1848151*])
+
+* Previously, keyboard users of the YAML editor were unable to exit the editor. The `view shortcuts` popover outside of the editor was unavailable inside the editor for access by the user. With this update, users can display `Accessibility help` above the editor using the `opt + F1` keystrokes. This change allows keyboard users of the YAML editor to exit the editor using the correct keystrokes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874931[*BZ#1874931*])
+
+* After the 4.x release of {product-title} (OCP), binary secret files uploaded to the OCP 4 web console failed to load. This caused the installation to fail. With {product-title} 4.8, this capability has been restored to the OCP 4 web console. Input of the required secret can now be accomplished using binary file format. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879638[*BZ#1879638*])
+
+* Previously, the fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*] to properly create RoleBinding links consistently resulted in the inability to select the binding type when a namespace was selected. Consequently, users with an active namespace could not create a cluster RoleBinding without changing the active namespace to `All namespaces`. This update reverts part of the changes for BZ#1871996 so that users can create a cluster role binding regardless of active namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927882[*BZ#1927882*])
+* Previously, annotations were passed to specification of knative service metadata. As a result, decorators were shown for associated revisions of knative service in *Topology*. This release fixes this issue by passing annotations only to knative service metadata. Now, decorators are shown only for knative service in *Topology* and not associated revisions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954959[*BZ#1954959*])
+
+* Previously, if you created a pipeline with parameters that had empty strings, for example, `”`, the fields in the {product-title} web console would not accept the empty strings. The current release fixes this issue. Now, `”` is supported as a valid default property within the parameters section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951043[*BZ#1951043*]))
+
+*Web console (Developer perspective)*
+
+* This update fixes the sort order and color of `ImageManifestVuln` objects for the Quay Security Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942716[*BZ#1942716*])
+
+* Previously, the *Topology* view in the Developer perspective did not load if OpenShift namespace templates were not available because the Samples Operator was not installed. This update fixes the issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949810[*BZ#1949810*])
+
+* Previously, when you created a quick start tutorial in the web console and specified prerequisites, the prerequisites were displayed as a paragraph instead of a list. Lists are now displayed correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905147[*BZ#1905147*])
+
+* Previously, after importing a devfile, the container did not start successfully. This occurred due to the invalid inclusion of `buildguidanceimage-placeholder` into the deployment. When only the correct container image is included, that image opens as expected. With the latest version, a placeholder image can also be used. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952214[*BZ#1952214*])
+
+* Previously, when switching Developer perspective in another tab and reloading the project details, the routes tied to a perspective were not rendered and resulted in a `404` error. This update loads all inactive routes and switches to the correct perspective. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929769[*BZ#1929769*])
+
+* This update adds an error message to the *Workloads* menu of the monitoring dashboard if a user does not have access privileges. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1930546[*BZ#1930546*])
+
+* Previously, an API server could fail to create a resource, which would return a 409 status code when there was a conflict updating a `resource quota` resource. Consequently, the resource would fail to create, and you might have had to retry the API request. With this update, the `OpenShift Console` web application attempts to retry the request 3 times when receiving a 409 status code, which is often sufficient for completing the request. In the event that a 409 status code continues to occur, an error will be displayed in the console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1920699[*BZ#1920699*])
+
+* Previously, when selecting the *YAML* tab, the `metadata.managedFields` section was not collapsing immediately. This was due to an issue with the Form or YAML switcher for pages such as *Pipeline Builder* and *Edit HorizontalPodAutoscaler* (HPA). As a result, any part wherein the user tried to type in the document collapsed. The `metadata.managedFields` section remained as is and the cursor was reset to the starting position to the top left of the YAML editor. The current release fixes this issue. Now, when loading the YAML, the `metadata.managedFields` section is immediately collapsed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932472[*BZ#1932472*])
+
+* Before this update, the Pipeline `ServiceAccount` did not use secrets created during the `git import` flow for private Git repositories, which caused these Pipelines to fail. This update fixes the problem by adding annotations to the secrets and to the Pipeline `ServiceAccount`. Pipelines for private Git repositories now run correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970470[*BZ#1970470*]
+
+* Previously, annotations were passed to specification of knative service metadata. As a result, decorators were shown for associated revisions of knative service in *Topology*. This release fixes this issue by passing annotations only to knative service metadata. Now, decorators are shown only for knative service in *Topology* and not associated revisions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954959[*BZ#1954959*])
+
+* Previously, if you created a pipeline with parameters that had empty strings, for example, `”`, the fields in the {product-title} web console would not accept the empty strings. The current release fixes this issue. Now, `”` is supported as a valid default property within the parameters section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951043[*BZ#1951043*])
 
 *Windows Containers*
 


### PR DESCRIPTION
I did a bit of cleanup work on the release notes:
* changed 'master' to 'control plane'
* reorganized bugs for the web console according to BZ component type: 'management console' or 'dev console' 
* moved web console bug sections

For the peer reviewer:
* Question: In LINE 947, is it clear enough that 'control plane' refers to the parameter value `master`? This seemed concise and sufficient, but more explanation may be necessary.
* Applies only to `enterprise-4.8`
* [Direct preview link](https://deploy-preview-34417--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html)