### PR TITLE
BZ1980040: Migration rollback leftovers

### DIFF
--- a/modules/migration-rolling-back-migration-cli.adoc
+++ b/modules/migration-rolling-back-migration-cli.adoc
@@ -8,6 +8,21 @@
 
 You can roll back a migration by creating a `MigMigration` custom resource (CR) from the command line interface.
 
+[NOTE]
+====
+If you roll back a failed direct volume migration, the following resources are preserved in the namespaces specified in the `MigPlan` custom resource (CR) to help you debug the failed migration:
+
+* Config maps (source and destination clusters)
+* `Secret` CRs (source and destination clusters)
+* `Rsync` CRs (source cluster)
+* `Service` CRs (destination cluster)
+* `Route` CRs (destination cluster)
+
+These resources must be deleted manually.
+
+If you later run the same migration plan successfully, the resources from the failed migration are deleted automatically.
+====
+
 If your application was stopped during a failed migration, you must roll back the migration to prevent data corruption in the persistent volume.
 
 Rollback is not required if the application was not stopped during migration because the original application is still running on the source cluster.

--- a/modules/migration-rolling-back-migration-web-console.adoc
+++ b/modules/migration-rolling-back-migration-web-console.adoc
@@ -8,6 +8,21 @@
 
 You can roll back a migration by using the {mtc-full} ({mtc-short}) web console.
 
+[NOTE]
+====
+If you roll back a failed direct volume migration, the following resources are preserved in the namespaces specified in the migration plan to help you debug the failed migration:
+
+* Config maps (source and target clusters)
+* `Secret` CRs (source and target clusters)
+* `Rsync` CRs (source cluster)
+* `Service` CRs (target cluster)
+* `Route` CRs (target cluster)
+
+These resources must be deleted manually.
+
+If you later run the same migration plan successfully, the resources from the failed migration are deleted automatically.
+====
+
 If your application was stopped during a failed migration, you must roll back the migration to prevent data corruption in the persistent volume.
 
 Rollback is not required if the application was not stopped during migration because the original application is still running on the source cluster.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1980040

4.5+

Added note about rollback leftovers

Previews:

https://deploy-preview-34418--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/troubleshooting-mtc.html#migration-rolling-back-migration-web-console_troubleshooting-mtc

https://deploy-preview-34418--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/troubleshooting-mtc.html#migration-rolling-back-migration-cli_troubleshooting-mtc

QE approved