### PR TITLE
Added notes for release 4.7.20

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2618,3 +2618,24 @@ link:https://access.redhat.com/solutions/6163712[{product-title} 4.7.19 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-20"]
+=== RHBA-2021:2646 - {product-title} 4.7.20 bug fix update
+
+Issued: 2021-07-12
+
+{product-title} release 4.7.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2646[RHBA-2021:2646] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2647[RHBA-2021:2647] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6176122[{product-title} 4.7.20 container image list]
+
+[id="ocp-4-7-20-bug-fixes"]
+==== Bug fixes
+
+* Previously, an incorrect `keepalived` setting sometimes resulted in the VIP ending up on an incorrect system and unable to move back to the correct system. With this update, the incorrect `keepalived` setting is removed so that the VIP ends up on the correct system. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971864[*BZ#1971864*])
+
+[id="ocp-4-7-20-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the release notes for OCP 4.7.20.

* applies only to `enterprise-4.7`
* [direct preview link](https://deploy-preview-34419--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-20)