### PR TITLE
BZ1967492: Replaced link with current OCS release notes

### DIFF
--- a/modules/deploy-red-hat-openshift-container-storage.adoc
+++ b/modules/deploy-red-hat-openshift-container-storage.adoc
@@ -9,7 +9,7 @@
 |See the following Red Hat OpenShift Container Storage documentation:
 
 |What's new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/4.5_release_notes/[OpenShift Container Storage 4.5 Release Notes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/4.7_release_notes/index[OpenShift Container Storage 4.7 Release Notes]
 
 |Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
 |link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.5/html/planning_your_deployment/index[Planning your  OpenShift Container Storage 4.5 deployment]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1967492

4.6+

https://deploy-preview-34421--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/storage-configuration?utm_source=github&utm_campaign=bot_dp#post-install-deploy-OCS
