### PR TITLE
RHDEVDOCS-3023 Clean up trailing instances of CLO

### DIFF
--- a/administering_a_cluster/dedicated-admin-role.adoc
+++ b/administering_a_cluster/dedicated-admin-role.adoc
@@ -44,7 +44,7 @@ Privileged and custom Operators cannot be installed.
 ====
 
 Administrators can only install Operators to the default `openshift-operators`
-namespace, except for the Cluster Logging Operator, which requires the
+namespace, except for the Red Hat OpenShift Logging Operator, which requires the
 `openshift-logging` namespace.
 
 .Additional resources

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1257,7 +1257,7 @@ An Operator's full name must be a proper noun, with each word initially
 capitalized. If it includes a product name, defer the product's capitalization
 style guidelines. For example:
 
-- Cluster Logging Operator
+- Red Hat OpenShift Logging Operator
 - Prometheus Operator
 - etcd Operator
 - Node Tuning Operator

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 After updating the {product-title} cluster from 4.6 to 4.7, you can update the OpenShift Elasticsearch Operator and Cluster Logging Operator from 4.6 to 5.0.
 
+[NOTE]
+====
+In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator.
+====
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other

--- a/modules/cluster-logging-release-notes-5.0.0.adoc
+++ b/modules/cluster-logging-release-notes-5.0.0.adoc
@@ -136,6 +136,11 @@ In the table below, features are marked with the following statuses:
 
 * Previously, when the Cluster Logging Operator (CLO) scaled down the number of Elasticsearch nodes in the `clusterlogging` CR to three nodes, it omitted previously-created nodes that had unique IDs. The OpenShift Elasticsearch Operator rejected the update because it has safeguards that prevent nodes with unique IDs from being removed. Now, when the CLO scales down the number of nodes and updates the Elasticsearch CR, it marks nodes with unique IDs as count 0 instead of omitting them. As a result, users can scale down their cluster to 3 nodes by using the `clusterlogging` CR. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879150[*BZ#1879150*])
 
+[NOTE]
+====
+In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator.
+====
+
 * Previously, the Fluentd collector pod went into a crash loop when the `ClusterLogForwarder` had an incorrectly-configured secret. The current release fixes this issue. Now, the `ClusterLogForwarder` validates the secrets and reports any errors in its status field. As a result, it does not cause the Fluentd collector pod to crash. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1888943[*BZ#1888943*])
 
 * Previously, if you updated the Kibana resource configuration in the `clusterlogging` instance to `resource{}`, the resulting nil map caused a panic and changed the status of the OpenShift Elasticsearch Operator to `CrashLoopBackOff`. The current release fixes this issue by initializing the map. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1889573[*BZ#1889573*])

--- a/modules/cluster-logging-updating-logging.adoc
+++ b/modules/cluster-logging-updating-logging.adoc
@@ -7,6 +7,11 @@
 
 After updating the {product-title} cluster, you can update from cluster logging 4.6 to Red Hat OpenShift Logging 5.0 by changing the subscription for the OpenShift Elasticsearch Operator and the Cluster Logging Operator.
 
+[NOTE]
+====
+In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator.
+====
+
 When you update:
 
 * You must update the OpenShift Elasticsearch Operator before updating the Cluster Logging Operator.

--- a/security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc
+++ b/security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc
@@ -1,5 +1,5 @@
 [id="cert-types-monitoring-and-cluster-logging-operator-component-certificates"]
-= Monitoring and Cluster Logging Operator component certificates
+= Monitoring and OpenShift Logging Operator component certificates
 include::modules/common-attributes.adoc[]
 :context: cert-types-monitoring-and-cluster-logging-operator-component-certificates
 

--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -249,7 +249,7 @@ The following table is a summary of the feature availability in {oke} and {produ
 | Vertical Pod Autoscaler | Included | Included | Vertical Pod Autoscaler
 | Cluster Monitoring (Prometheus) | Included | Included | Cluster Monitoring
 | Device Manager (for example, GPU) | Included | Included | N/A
-| Log Forwarding (with fluentd) | Included | Included | Cluster Logging Operator (for log forwarding with fluentd)
+| Log Forwarding (with fluentd) | Included | Included | Red Hat OpenShift Logging Operator (for log forwarding with fluentd)
 | Telemeter and Insights Connected Experience | Included | Included | N/A
 s| Feature s| {oke} s| {product-title} s| Operator name
 | OpenShift Cloud Manager(OCM) SaaS Service | Included | Included | N/A
@@ -274,7 +274,7 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Helm | Included | Included | N/A
 | User Workload Monitoring | Not Included | Included | N/A
 | Metering and Cost Management SaaS Service | Not Included | Included | N/A
-| Platform Logging | Not Included | Included | Cluster Logging Operator
+| Platform Logging | Not Included | Included | Red Hat OpenShift Logging Operator
 | OpenShift Elasticsearch Operator provided by Red Hat | Not Included | Cannot be run standalone | N/A
 | Developer Web Console | Not Included | Included | N/A
 | Developer Application Catalog | Not Included | Included | N/A
@@ -319,9 +319,9 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Red Hat Integration - 3Scale provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 3scale
 | Red Hat Integration - 3Scale APICast gateway provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 3scale APIcast
 | Red Hat Integration - AMQ Broker | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Broker
-| Red Hat Integration - AMQ Broker LTS | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 
+| Red Hat Integration - AMQ Broker LTS | Not Included - Requires separate subscription | Not Included - Requires separate subscription |
 | Red Hat Integration - AMQ Interconnect | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Interconnect
-| Red Hat Integration - AMQ Online | Not Included - Requires separate subscription | Not Included - Requires separate subscription | 
+| Red Hat Integration - AMQ Online | Not Included - Requires separate subscription | Not Included - Requires separate subscription |
 | Red Hat Integration - AMQ Streams | Not Included - Requires separate subscription | Not Included - Requires separate subscription | AMQ Streams
 | Red Hat Integration - Camel K | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Camel K
 | Red Hat Integration - Fuse Console | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Fuse Console


### PR DESCRIPTION
In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator. This PR replaces a few instances of the old name or, where it makes sense to keep the old name, comments on them.

- Aligned team: Dev Tools
- For branches: 4.7+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3023
- Direct link to doc preview: https://deploy-preview-34422--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-0-bug-fixes

Approved by:

- SME review: @periklis 
- QE review: @anpingli 
- Peer review: @jc-berger 

All reviews complete. Ready to merge.