### PR TITLE
Minor cleanup to 4.8 RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1410,7 +1410,7 @@ This error happens because the `docker.io` login they used to call the `oc new-a
 
 * Previously, a proxy update caused a full cluster configuration update, including API server restart, during continuous integration (CI) runs. Consequently, some clusters in the Machine API Operator would time out because of unexpected API server outages. This update separates proxy tests and adds postconditions so that clusters in the Machine API Operator become stable again during CI runs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1913341[*BZ#1913341*])
 
-* Previously, deleting a machine stuck in `Insufficient disk space on datastore` took longer than expected because there was no distinction between various vCenter task types. With this update, the machine controller deletion procedure checks the vCenter task type, and no longer blocks the deletion of the machine controller. As a result, the machine controller is deleted quickly.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918101[*BZ#1918101*])
+* Previously, deleting a machine stuck in `Insufficient disk space on datastore` took longer than expected because there was no distinction between various vCenter task types. With this update, the machine controller deletion procedure checks the vCenter task type, and no longer blocks the deletion of the machine controller. As a result, the machine controller is deleted quickly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918101[*BZ#1918101*])
 
 * Previously, scaling from zero annotations requeued even if the instance type was missing. Consequently, there were constant requeue and error space messages in the MachineSet controller logs. With this update, users can set the annotation manually if the instance type is not resolved automatically. As a result, scaling from zero for unknown instance types works if users manually provide the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1918910[*BZ#1918910*])
 
@@ -1571,7 +1571,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957809[*BZ#1957809*])
 
-* Previously, the installation on {rh-openstack-first} failed unless the RHOSP HTTPS certificate was imported to the hosting device. Now, a successful installation occurs when the `cacert` value in `cloud.yaml` is set to the RHOSP HTTPS certificate. Importing the certificate to the host is no longer required.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1786314[*BZ#1786314*])
+* Previously, the installation on {rh-openstack-first} failed unless the RHOSP HTTPS certificate was imported to the hosting device. Now, a successful installation occurs when the `cacert` value in `cloud.yaml` is set to the RHOSP HTTPS certificate. Importing the certificate to the host is no longer required. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1786314[*BZ#1786314*])
 
 * Previously, an installation might fail due to inaccurate external network entries in `proxy.config.openshift.io`. A validation check now identifies these inaccuracies to enable correction. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1873649[*BZ#1873649*])
 
@@ -1579,7 +1579,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * A previous change to gophercloud/utils introduced a custom HTTP client that used a self-signed certificate. Because this change removed settings from `DefaultTransport`, including those for proxy environment variables, this caused failures for installations that used both self-signed certificates and proxies. In this update, the custom HTTP client inherits settings from `DefaultTransport`, so now {product-title} can be installed with self-signed certificates and proxies. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925216[*BZ#1925216*])
 
-* Previously, the installer did not take into account `defaultMachineSet` values in the install config during its validation which caused the installer to fail. This update applies the default values to the install config and starts validating empty fields.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903055[*BZ#1903055*])
+* Previously, the installer did not take into account `defaultMachineSet` values in the install config during its validation which caused the installer to fail. This update applies the default values to the install config and starts validating empty fields. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903055[*BZ#1903055*])
 
 * Previously, `soft-anti-affinity` required the client to set a minimum Nova microversion. Most versions of Ansible OS server module did not automatically require the client to set a minimum. As a result, the soft-anti-affinity commands were likely to fail. This update fixes the use of the Python OpenStack client to set a Nova microversion when dealing with soft-anti-affinity. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910067[*BZ#1910067*])
 
@@ -1635,7 +1635,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Due to iptables rewriting rules, clients that used a fixed source port to connect to a service via both the service IP and a pod IP might have encountered problems with port conflicts. With this update, an additional OVS rule is inserted to notice when port conflicts occur and to do an extra SNAT to avoid said conflicts. As a result, there are no longer port conflicts when connecting to a service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910378[*BZ#1910378*])
 
-* Previously, IP port 9 between control plane nodes and egress-assigned nodes was blocked by the internal firewall. This caused the assignment of IP addresses to egress nodes to fail. This update enables access between control plane and egress nodes via IP port 9. As a result, the assignment of IP addresses to egress nodes is now successfully permitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942856[*BZ#1942856*]) 
+* Previously, IP port 9 between control plane nodes and egress-assigned nodes was blocked by the internal firewall. This caused the assignment of IP addresses to egress nodes to fail. This update enables access between control plane and egress nodes via IP port 9. As a result, the assignment of IP addresses to egress nodes is now successfully permitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942856[*BZ#1942856*])
 
 * Previously, UDP services traffic could be blocked because of stale connection tracking entries that were no longer valid. This pevented access to a server pod after it was cycled for `NodePort` service. With this update, the connection tracking entries are purged in the case of `NodePort` service cycling, which allows new network traffic to reach cycled endpoints. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1949063[*BZ#1949063*])
 
@@ -1702,7 +1702,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Previously, the `oc image extract` command did not extract files from the root directory of an image. The command has been updated and can now be used to extract files from the image root directory. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1919032[*BZ#1919032*])
 
-* Previously, the `oc apply` command would fetch the OpenAPI specification on each invocation. The OpenAPI specification is now cached when the command is first run. The cached OpenAPI specification is reused when the `oc apply` command is run multiple times and the network load is reduced.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921885[*BZ#1921885*])
+* Previously, the `oc apply` command would fetch the OpenAPI specification on each invocation. The OpenAPI specification is now cached when the command is first run. The cached OpenAPI specification is reused when the `oc apply` command is run multiple times and the network load is reduced. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921885[*BZ#1921885*])
 
 * Previously, the authorization header created during image mirroring could exceed the header size limit for some registries. This would cause an error during the mirroring operation. Now, the `--skip-multiple-scopes` option is set to `true` for the `oc adm catalog mirror` command, to help prevent the authorization header from exceeding the header size limits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946839[*BZ#1946839*])
 
@@ -1863,11 +1863,11 @@ uid=1001(1001) gid=1001 groups=1001
 
 * Previously, some text and warning messages for the *Add HorizontalPodAutoscaler* page were not internationalized. The text is now internationalized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1926131[*BZ#1926131*])
 
-* Previously, when users created an Operator with the Operator SDK and specified an annotation like `xDescriptors={"urn:alm:<...>:hidden"}` to hide a field from the Operator instance creation page, the field might still be visible on the page. Now, the hidden fields are omitted from the Operator instance creation page.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966077[*BZ#1966007*])
+* Previously, when users created an Operator with the Operator SDK and specified an annotation like `xDescriptors={"urn:alm:<...>:hidden"}` to hide a field from the Operator instance creation page, the field might still be visible on the page. Now, the hidden fields are omitted from the Operator instance creation page. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966077[*BZ#1966007*])
 
 * Previously, tables displayed incorrectly on mobile devices. With this update, tables now display correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927013[*BZ#1927013*])
 
-* Previously, launching the {product-title} web console may be slow. With this update, the web console launches quicker. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927310[*BZ#19273*])
+* Previously, launching the {product-title} web console may be slow. With this update, the web console launches quicker. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927310[*BZ#1927310*])
 
 * Previously, a lack of internationalized notifications to {product-title} administrators detracted from the user experience. Now, internationalization is possible. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927898[*BZ#1927898*])
 
@@ -1878,14 +1878,14 @@ uid=1001(1001) gid=1001 groups=1001
 * The following {product-title} web console views now support multi-faceted filtering:
 +
 --
-** Home > Search (the Resources tab)
-** Home > Events (the Resources tab)
-** Workloads > Pods (the Filter tab)
+** *Home* -> *Search* (the *Resources* tab)
+** *Home* -> *Events* (the *Resources* tab)
+** *Workloads* -> *Pods* (the *Filter* tab)
 --
 +
 For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1930007[*BZ#1930007*].
 
-* The following bug fixes address various translation issues for the {product-title} web console: 
+* The following bug fixes address various translation issues for the {product-title} web console:
 
 ** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921780[*BZ#1921780*]
 ** link:https://bugzilla.redhat.com/show_bug.cgi?id=1921781[*BZ#1921781*]
@@ -1896,7 +1896,7 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19300
 
 * Previously, the web console relied on hard-coded channel strings to populate the channel modal dropdown. As a result, users could see channel values that may not be correct for their current version. Now, if the Cluster Version Operator does not supply the correct channels for a given version, the channel modal dropdown changes to a text input field and suggests channels and help text for the user. The console no longer relies on hard coded channel string. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932281[*BZ#1932281*])
 
-* Previously, timestamps were not correctly formatted for Chinese or Japnaese languages. As a result, timestamps were harder to read, which provided a bad user experience. With this update, default timestamp formats are used for Chinese and Japanese in `Moment.js`, which provides a better user experience. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932453[*BZ#1932453*])
+* Previously, timestamps were not correctly formatted for Chinese or Japanese languages. As a result, timestamps were harder to read, which provided a bad user experience. With this update, default timestamp formats are used for Chinese and Japanese in `Moment.js`, which provides a better user experience. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1932453[*BZ#1932453*])
 
 * Previously, the `rowFilters` prop in the FilterToolbar component did not accept the `null` value. So if the `rowFilters` prop was undefined, the uncaught exception was thrown. Now, when the `rowFilters` prop is referenced in the FilterToolbar component, the `null` value is accepted. As a result, the FilterToolbar does not throw exceptions when `rowFilters` prop is undefined. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937018[*BZ#1937018*])
 
@@ -1920,7 +1920,7 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19300
 
 * CSI provisioners were not listed when creating a storage class on the Google Cloud Platform. With this bug fix, the issue is resolved. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1910500[*BZ#1910500*])
 
-* Previously, if the user clicked into a *Cluster Role* from the *User Management -> Roles* list view, the back link from the details page is *Cluster Roles*, which provides a generic list view of *Cluster Roles*. This caused backward web console navigation to redirect to the incorrect page. With this release, the back link directs the user to the *Role/Bindings* list view from the *Cluster Role/RoleBinding* details page. This allows the user to correctly navigate backward in the web console.  (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915971[*BZ#1915971*])
+* Previously, if the user clicked into a *Cluster Role* from the *User Management -> Roles* list view, the back link from the details page is *Cluster Roles*, which provides a generic list view of *Cluster Roles*. This caused backward web console navigation to redirect to the incorrect page. With this release, the back link directs the user to the *Role/Bindings* list view from the *Cluster Role/RoleBinding* details page. This allows the user to correctly navigate backward in the web console. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915971[*BZ#1915971*])
 
 * Previously, *Created date time* was not displayed in a readable format, which made it difficult to understand and use the time shown in UTC. With this release, the displayed time is reformatted so that UTC is readable and understandable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917241[*BZ#1917241*])
 
@@ -1941,9 +1941,6 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19300
 * After the 4.x release of {product-title} (OCP), binary secret files uploaded to the OCP 4 web console failed to load. This caused the installation to fail. With {product-title} 4.8, this capability has been restored to the OCP 4 web console. Input of the required secret can now be accomplished using binary file format. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1879638[*BZ#1879638*])
 
 * Previously, the fix for link:https://bugzilla.redhat.com/show_bug.cgi?id=1871996[*BZ#1871996*] to properly create RoleBinding links consistently resulted in the inability to select the binding type when a namespace was selected. Consequently, users with an active namespace could not create a cluster RoleBinding without changing the active namespace to `All namespaces`. This update reverts part of the changes for BZ#1871996 so that users can create a cluster role binding regardless of active namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927882[*BZ#1927882*])
-* Previously, annotations were passed to specification of knative service metadata. As a result, decorators were shown for associated revisions of knative service in *Topology*. This release fixes this issue by passing annotations only to knative service metadata. Now, decorators are shown only for knative service in *Topology* and not associated revisions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954959[*BZ#1954959*])
-
-* Previously, if you created a pipeline with parameters that had empty strings, for example, `”`, the fields in the {product-title} web console would not accept the empty strings. The current release fixes this issue. Now, `”` is supported as a valid default property within the parameters section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1951043[*BZ#1951043*]))
 
 *Web console (Developer perspective)*
 


### PR DESCRIPTION
Changes include:

* Removed some extra white spaces
* Removed 2 dupe BZ entries
* Marked-up GUI elements
* Fixed a BZ link
* Fixed typo for "Japanese"

Preview: https://deploy-preview-34423--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes