### PR TITLE
[enterprise-4.7] GH#33682: Updating the disk encryption section

### DIFF
--- a/modules/installation-special-config-encrypt-disk-tang.adoc
+++ b/modules/installation-special-config-encrypt-disk-tang.adoc
@@ -4,20 +4,21 @@
 
 [id="installation-special-config-encrypt-disk-tang_{context}"]
 = Enabling Tang disk encryption
-Use this procedure to enable Tang mode disk encryption during {product-title} deployment.
+Use the following procedure to enable Tang mode disk encryption during an {product-title} installation.
 
 [NOTE]
 ====
 On previous versions of {op-system}, disk encryption was configured by specifying `/etc/clevis.json` in the Ignition config. That file is not supported in clusters created with {product-title} 4.7 or above, and the LUKS device should be configured directly via the Ignition `luks` section.
 ====
 
+.Prerequisites
+
+* You have downloaded the {product-title} installation program on your installation node.
+* You have access to a {op-system-base-full} 8 machine that can be used to generate a thumbprint of the Tang exchange key.
+
 .Procedure
 
-. Access a Red Hat Enterprise Linux server from which you can configure the encryption
-settings and run `openshift-install` to install a cluster and `oc` to work with it.
-. Set up or access an existing Tang server. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening#network-bound-disk-encryption_configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption[Network-bound disk encryption]
-for instructions. See link:https://youtu.be/2uLKvB8Z5D0[Securing Automated Decryption New Cryptography and Techniques]
-for a presentation on Tang.
+. Set up a Tang server or access an existing one. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption_security-hardening#network-bound-disk-encryption_configuring-automated-unlocking-of-encrypted-volumes-using-policy-based-decryption[Network-bound disk encryption] for instructions.
 
 . Add kernel arguments to configure networking when you do the {op-system-first} installations for your cluster. For example, to configure DHCP networking, identify `ip=dhcp`, or set static networking when you add parameters to the kernel command line. For both DHCP and static networking, you also must provide the `rd.neednet=1` kernel argument.
 +
@@ -27,86 +28,62 @@ Skipping this step causes the second boot to fail.
 ====
 
 [start=4]
-. Install the `clevis` package, if it is not already installed:
+. Install the `clevis` package on a {op-system-base} 8 machine, if it is not already installed:
 +
 [source,terminal]
 ----
-$ sudo yum install clevis -y
+$ sudo yum install clevis
 ----
 
 [start=5]
-. Generate a thumbprint from the Tang server.
-
-.. In the following command, replace the value of `url` with the Tang server URL:
+. On the {op-system-base} 8 machine, run the following command to generate a thumbprint of the exchange key. Replace `\http://tang.example.com:7500` with the URL of your Tang server:
 +
 [source,terminal]
 ----
-$ echo nifty random wordwords \
-     | clevis-encrypt-tang \
-       '{"url":"https://tang.example.org"}'
+$ clevis-encrypt-tang '{"url":"http://tang.example.com:7500"}' < /dev/null > /dev/null <1>
 ----
+<1> In this example, `tangd.socket` is listening on port `7500` on the Tang server.
++
+[NOTE]
+====
+The `clevis-encrypt-tang` command is used in this step only to generate a thumbprint of the exchange key. No data is being passed to the command for encryption at this point, so `/dev/null` is provided as an input instead of plain text. The encrypted output is also sent to `/dev/null`, because it is not required for this procedure.
+====
 +
 .Example output
 [source,terminal]
 ----
 The advertisement contains the following signing keys:
 
-PLjNyRdGw03zlRoGjQYMahSZGu9
+PLjNyRdGw03zlRoGjQYMahSZGu9 <1>
 ----
-
-.. When the `Do you wish to trust these keys? [ynYN]` prompt displays, type `Y`, and the thumbprint is displayed:
+<1> The thumbprint of the exchange key.
 +
-.Example output
+When the `Do you wish to trust these keys? [ynYN]` prompt displays, type `Y`.
++
+[NOTE]
+====
+{op-system-base} 8 provides Clevis version 15, which uses the SHA-1 hash algorithm to generate thumbprints. Some other distributions provide Clevis version 17 or later, which use the SHA-256 hash algorithm for thumbprints. You must use a Clevis version that uses SHA-1 to create the thumbprint, to prevent Clevis binding issues when you install {op-system-first} on your {product-title} cluster nodes.
+====
+
+. If you have not yet generated the Kubernetes manifests, change to the directory that contains the installation program on your installation node and create them:
++
 [source,terminal]
 ----
-eyJhbmc3SlRyMXpPenc3ajhEQ01tZVJiTi1oM...
+$ ./openshift-install create manifests --dir=<installation_directory> <1>
 ----
+<1> Replace `<installation_directory>` with the path to the directory that you want to store the installation files in.
 
-. In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
+. Create machine config files to encrypt the boot disks for the control plane or compute nodes using the Tang encryption mode. 
 +
 [IMPORTANT]
 ====
-If you are also configuring boot disk mirroring on the affected nodes, record the server thumbprint for later use, and skip this step. You will configure disk encryption when configuring boot disk mirroring.
+If you are also configuring boot disk mirroring on the affected nodes, record the exchange key thumbprint for later use, and skip this step. You will configure disk encryption when configuring boot disk mirroring.
 ====
 
-** For worker nodes, use the following command:
+** To configure encryption on the control plane nodes, save the following machine config sample to a file in the `<installation_directory>/openshift` directory. For example, name the file `99-openshift-master-tang-encryption.yaml`:
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat << EOF > ./99-openshift-worker-tang-encryption.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: worker-tang
-  labels:
-    machineconfiguration.openshift.io/role: worker
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      luks:
-        - name: root
-          device: /dev/disk/by-partlabel/root
-          clevis:
-            tang:
-              - url: https://tang.example.com
-                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
-          options: [--cipher, aes-cbc-essiv:sha256]
-          wipeVolume: true
-      filesystems:
-        - device: /dev/mapper/root
-          format: xfs
-          wipeFilesystem: true
-          label: root
-EOF
-----
-
-** For master nodes, use the following command:
-+
-[source,terminal]
-----
-$ cat << EOF > ./99-openshift-master-tang-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -123,8 +100,8 @@ spec:
           device: /dev/disk/by-partlabel/root
           clevis:
             tang:
-              - url: https://tang.example.com
-                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9
+              - url: http://tang.example.com:7500 <1>
+                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9 <2>
           options: [--cipher, aes-cbc-essiv:sha256]
           wipeVolume: true
       filesystems:
@@ -132,30 +109,52 @@ spec:
           format: xfs
           wipeFilesystem: true
           label: root
-EOF
+  kernelArguments:
+    - rd.neednet=1 <3>
 ----
-
-. Add the `rd.neednet=1` kernel argument, as shown in the following example:
+<1> Specify the URL of a Tang server. In this example, `tangd.socket` is listening on port `7500` on the Tang server.
+<2> Specify the exchange key thumbprint, which was generated in a preceding step.
+<3> Add the `rd.neednet=1` kernel argument to bring the network up in the initramfs. This argument is required.
++
+** To configure encryption on the compute nodes, save the following machine config sample to a file in the `<installation_directory>/openshift` directory. For example, name the file `99-openshift-worker-tang-encryption.yaml`:
 +
 [source,yaml]
 ----
-  apiVersion: machineconfiguration.openshift.io/v1
-  kind: MachineConfig
-  metadata:
-    name: <node_type>-tang <.>
-  spec:
-    config:
-      ignition:
-        version: 3.2.0
-    kernelArguments:
-      - rd.neednet=1 <.>
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: worker-tang
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tang:
+              - url: http://tang.example.com:7500 <1>
+                thumbprint: PLjNyRdGw03zlRoGjQYMahSZGu9 <2>
+          options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
+  kernelArguments:
+    - rd.neednet=1 <3>
 ----
-+
-<1> Use the name you defined in the previous examples based on the type of node you are configuring, for example: `name: worker-tang`.
-+
-<2> Required.
+<1> Specify the URL of a Tang server. In this example, `tangd.socket` is listening on port `7500` on the Tang server.
+<2> Specify the exchange key thumbprint, which was generated in a preceding step.
+<3> Add the `rd.neednet=1` kernel argument to bring the network up in the initramfs. This argument is required.
 
-. Continue with the remainder of the {product-title} deployment.
+. Create a backup copy of the YAML files. The original YAML files are consumed when you create the Ignition config files.
+
+. Continue with the remainder of the {product-title} installation.
 
 [IMPORTANT]
 ====

--- a/modules/installation-special-config-encrypt-disk-tpm2.adoc
+++ b/modules/installation-special-config-encrypt-disk-tpm2.adoc
@@ -4,67 +4,40 @@
 
 [id="installation-special-config-encrypt-disk-tpm2_{context}"]
 = Enabling TPM v2 disk encryption
-Use this procedure to enable TPM v2 mode disk encryption during {product-title} deployment.
+Use the following procedure to enable TPM v2 mode disk encryption during an {product-title} installation.
 
 [NOTE]
 ====
 On previous versions of {op-system}, disk encryption was configured by specifying `/etc/clevis.json` in the Ignition config. That file is not supported in clusters created with {product-title} 4.7 or above, and the LUKS device should be configured directly via the Ignition `luks` section.
 ====
 
+.Prerequisites
+
+* You have downloaded the {product-title} installation program on your installation node.
+
 .Procedure
 
-. Check to see if TPM v2 encryption needs to be enabled in the BIOS on each node.
-This is required on most Dell systems. Check the manual for your computer.
+. Check to see if TPM v2 encryption needs to be enabled in the BIOS on each node. This is required on most Dell systems. Check the manual for your computer.
 
-. Change to the directory that contains the installation program and generate the Kubernetes manifests for the cluster:
+. On your installation node, change to the directory that contains the installation program and generate the Kubernetes manifests for the cluster:
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir=<installation_directory> <1>
 ----
+<1> Replace `<installation_directory>` with the path to the directory that you want to store the installation files in.
 
-. In the `openshift` directory, create master or worker files to encrypt disks for those nodes.
-
+. Create machine config files to encrypt the boot disks for the control plane or compute nodes using the TPM v2 encryption mode. 
++
 [IMPORTANT]
 ====
 If you are also configuring boot disk mirroring on the affected nodes, skip this step. You will configure disk encryption when configuring boot disk mirroring.
 ====
 
-** To create a worker file, run the following command:
+** To configure encryption on the control plane nodes, save the following machine config sample to a file in the `<installation_directory>/openshift` directory. For example, name the file `99-openshift-master-tpmv2-encryption.yaml`:
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat << EOF > ./99-openshift-worker-tpmv2-encryption.yaml
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
-metadata:
-  name: worker-tpm
-  labels:
-    machineconfiguration.openshift.io/role: worker
-spec:
-  config:
-    ignition:
-      version: 3.2.0
-    storage:
-      luks:
-        - name: root
-          device: /dev/disk/by-partlabel/root
-          clevis:
-            tpm2: true
-          options: [--cipher, aes-cbc-essiv:sha256]
-          wipeVolume: true
-      filesystems:
-        - device: /dev/mapper/root
-          format: xfs
-          wipeFilesystem: true
-          label: root
-EOF
-----
-** To create a master file, run the following command:
-+
-[source,terminal]
-----
-$ cat << EOF > ./99-openshift-master-tpmv2-encryption.yaml
 apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
@@ -80,7 +53,7 @@ spec:
         - name: root
           device: /dev/disk/by-partlabel/root
           clevis:
-            tpm2: true
+            tpm2: true <1>
           options: [--cipher, aes-cbc-essiv:sha256]
           wipeVolume: true
       filesystems:
@@ -88,10 +61,40 @@ spec:
           format: xfs
           wipeFilesystem: true
           label: root
-EOF
 ----
+<1> Set this attribute to `true` to use a Trusted Platform Module (TPM) secure cryptoprocessor to encrypt the root file system.
++
+** To configure encryption on the compute nodes, save the following machine config sample to a file in the `<installation_directory>/openshift` directory. For example, name the file `99-openshift-worker-tpmv2-encryption.yaml`:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  name: worker-tpm
+  labels:
+    machineconfiguration.openshift.io/role: worker
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      luks:
+        - name: root
+          device: /dev/disk/by-partlabel/root
+          clevis:
+            tpm2: true <1>
+          options: [--cipher, aes-cbc-essiv:sha256]
+          wipeVolume: true
+      filesystems:
+        - device: /dev/mapper/root
+          format: xfs
+          wipeFilesystem: true
+          label: root
+----
+<1> Set this attribute to `true` to use a Trusted Platform Module (TPM) secure cryptoprocessor to encrypt the root file system.
 
-. Make a backup copy of the YAML file. You should do this because the file will be deleted when you create the cluster.
+. Create a backup copy of the YAML files. The original YAML files are consumed when you create the Ignition config files.
 
 . Continue with the remainder of the {product-title} deployment.
 

--- a/modules/installation-special-config-encrypt-disk.adoc
+++ b/modules/installation-special-config-encrypt-disk.adoc
@@ -5,26 +5,24 @@
 [id="installation-special-config-encrypt-disk_{context}"]
 = Encrypting disks during installation
 
-During {product-title} installation, you can enable disk encryption on all master and worker nodes.
-This feature:
+You can enable encryption for the boot disks on the control plane and compute nodes at installation time. {product-title} supports the Trusted Platform Module (TPM) v2 and Tang encryption modes.
 
-* Is available for installer-provisioned infrastructure
-and user-provisioned infrastructure deployments
-* Is supported on {op-system-first} systems only
-* Sets up disk encryption during the manifest installation phase so all data written to disk, from first boot forward, is encrypted
-* Requires no user intervention for providing passphrases
-* Uses AES-256-CBC encryption
-
-There are two different supported encryption modes:
-
-* TPM v2: This is the preferred mode. TPM v2 stores passphrases in a secure cryptoprocessor.
-To implement TPM v2 disk encryption, create an Ignition config file as described below.
-
-* Tang: To use Tang to encrypt your cluster, you need to use a Tang server. Clevis implements decryption on the client side.
+* TPM v2: This is the preferred mode. TPM v2 stores passphrases in a secure cryptoprocessor contained within a server. You can use this mode to prevent the boot disk data on a cluster node from being decrypted if the disk is removed from the server.
+* Tang: Tang and Clevis are server and client components that enable network-bound disk encryption (NBDE). You can bind the boot disk data on your cluster nodes to a Tang server. This prevents the data from being decrypted unless the nodes are on a secure network where the Tang server can be accessed. Clevis is an automated decryption framework that is used to implement the decryption on the client side.
 
 [IMPORTANT]
 ====
 The use of Tang encryption mode to encrypt your disks is only supported for bare metal and vSphere installations on user-provisioned infrastructure.
 ====
+
+When the TPM v2 or Tang encryption modes are enabled, the {op-system} boot disks are encrypted using the LUKS2 format.
+
+This feature:
+
+* Is available for installer-provisioned infrastructure and user-provisioned infrastructure deployments
+* Is supported on {op-system-first} systems only
+* Sets up disk encryption during the manifest installation phase so all data written to disk, from first boot forward, is encrypted
+* Requires no user intervention for providing passphrases
+* Uses AES-256-CBC encryption
 
 Follow one of the two procedures to enable disk encryption for the nodes in your cluster.

--- a/modules/installation-special-config-mirrored-disk.adoc
+++ b/modules/installation-special-config-mirrored-disk.adoc
@@ -5,7 +5,7 @@
 [id="installation-special-config-mirrored-disk_{context}"]
 = Mirroring disks during installation
 
-During {product-title} installation on master and worker nodes, you can enable mirroring of the boot disk to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
+During {product-title} installation on control plane and compute nodes, you can enable mirroring of the boot disk to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
 
 Mirroring does not support replacement of a failed disk. To restore the mirror to a pristine, non-degraded state, reprovision the node.
 
@@ -61,7 +61,7 @@ boot_device:
   luks: <3>
     tpm2: true <4>
     tang: <5>
-      - url: https://tang.example.com
+      - url: http://tang.example.com:7500
         thumbprint: <tang_thumbprint>
 storage: <6>
   luks:


### PR DESCRIPTION
This applies to branch/enterprise-4.7 only.

This relates to https://github.com/openshift/openshift-docs/issues/33682 and https://bugzilla.redhat.com/show_bug.cgi?id=1937763.

The PR back-ports some of the changes in https://github.com/openshift/openshift-docs/pull/34317 to branch/enterprise-4.7, where relevant.

The preview is [here](https://deploy-preview-34425--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing).