### PR TITLE
RHDEVDOCS-3018 Document: [Logging 5.1]EO shouldn't try to upgrade ES …

### DIFF
--- a/modules/cluster-logging-log-store-status-viewing.adoc
+++ b/modules/cluster-logging-log-store-status-viewing.adoc
@@ -100,10 +100,10 @@ status: <1>
   shardAllocationEnabled: all
 ----
 <1> In the output, the cluster status fields appear in the `status` stanza.
-<2> The status of the log store: 
+<2> The status of the log store:
 +
 * The number of active primary shards.
-* The number of active shards. 
+* The number of active shards.
 * The number of shards that are initializing.
 * The number of log store data nodes.
 * The total number of log store nodes.
@@ -114,9 +114,9 @@ status: <1>
 * Container Waiting for both the log store and proxy containers.
 * Container Terminated for both the log store and proxy containers.
 * Pod unschedulable.
-Also, a condition is shown for a number of issues, see *Example condition messages*.
-<4> The log store nodes in the cluster, with `upgradeStatus`. 
-<5> The log store client, data, and master pods in the cluster, listed under 'failed`, `notReady` or `ready` state.
+Also, a condition is shown for a number of issues; see *Example condition messages*.
+<4> The log store nodes in the cluster, with `upgradeStatus`.
+<5> The log store client, data, and master pods in the cluster, listed under 'failed`, `notReady`, or `ready` state.
 
 [id="cluster-logging-elasticsearch-status-message_{context}"]
 == Example condition messages
@@ -125,7 +125,7 @@ The following are examples of some condition messages from the `Status` section 
 
 // https://github.com/openshift/elasticsearch-operator/pull/92
 
-This status message indicates a node has exceeded the configured low watermark and no shard will be allocated to this node.
+The following status message indicates that a node has exceeded the configured low watermark, and no shard will be allocated to this node.
 
 [source,yaml]
 ----
@@ -142,7 +142,7 @@ status:
     upgradeStatus: {}
 ----
 
-This status message indicates a node has exceeded the configured high watermark and shards will be relocated to other nodes.
+The following status message indicates that a node has exceeded the configured high watermark, and shards will be relocated to other nodes.
 
 [source,yaml]
 ----
@@ -159,7 +159,7 @@ status:
     upgradeStatus: {}
 ----
 
-This status message indicates the log store node selector in the CR does not match any nodes in the cluster:
+The following status message indicates that the log store node selector in the CR does not match any nodes in the cluster:
 
 [source,yaml]
 ----
@@ -173,7 +173,7 @@ status:
         type: Unschedulable
 ----
 
-This status message indicates that the log store CR uses a non-existent PVC.
+The following status message indicates that the log store CR uses a non-existent persistent volume claim (PVC).
 
 [source,yaml]
 ----
@@ -187,7 +187,7 @@ status:
        type:                  Unschedulable
 ----
 
-This status message indicates that your log store cluster does not have enough nodes to support your log store redundancy policy.
+The following status message indicates that your log store cluster does not have enough nodes to support the redundancy policy.
 
 [source,yaml]
 ----
@@ -217,3 +217,30 @@ status:
       status: 'True'
       type: InvalidMasters
 ----
+
+
+The following status message indicates that Elasticsearch storage does not support the change you tried to make.
+
+For example:
+[source,yaml]
+----
+status:
+  clusterHealth: green
+  conditions:
+    - lastTransitionTime: "2021-05-07T01:05:13Z"
+      message: Changing the storage structure for a custom resource is not supported
+      reason: StorageStructureChangeIgnored
+      status: 'True'
+      type: StorageStructureChangeIgnored
+----
+
+The `reason` and `type` fields specify the type of unsupported change:
+
+`StorageClassNameChangeIgnored`:: Unsupported change to the storage class name.
+`StorageSizeChangeIgnored`:: Unsupported change the storage size.
+`StorageStructureChangeIgnored`:: Unsupported change between ephemeral and persistent storage structures.
++
+[IMPORTANT]
+====
+If you try to configure the `ClusterLogging` custom resource (CR) to switch from ephemeral to persistent storage, the OpenShift Elasticsearch Operator creates a persistent volume claim (PVC) but does not create a persistent volume (PV). To clear the `StorageStructureChangeIgnored` status, you must revert the change to the `ClusterLogging` CR and delete the PVC.
+====


### PR DESCRIPTION
…cluster after adding/removing storage.

- Aligned team: Dev Tools
- For branches: OpenShift Logging 5.1 (enterprise-4.7+)
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3018
- Direct link to doc preview: https://deploy-preview-34430--osdocs.netlify.app/openshift-enterprise/latest/logging/troubleshooting/cluster-logging-log-store-status?utm_source=github&utm_campaign=bot_dp#cluster-logging-elasticsearch-status-message_cluster-logging-elasticsearch
- SME review: Approved by @Red-GV 
- QE review: Approved by @kabirbhartiRH 
- Peer review: Approved by @Srivaralakshmi 
- All reviews complete. Ready to merge.