### PR TITLE
WMCO-3.0: Hide WMCO from the general 4.8 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -747,6 +747,7 @@ Previously, creating machine sets required users to manually configure their CPU
 
 Providing a `hugepages` property into the `MachineSet` resource is now possible. This enhancement creates the `MachineSet` resource's nodes with a custom property in oVirt and instructs those nodes to use the `hugepages` of the hypervisor. For more information, see  link:https://bugzilla.redhat.com/show_bug.cgi?id=1948963[*BZ#1948963*].
 
+////
 [id="ocp-4-8-machine-config-operator-image-content-source-object-enhancement"]
 ==== Machine Config Operator ImageContentSourcePolicy object enhancement
 
@@ -757,6 +758,7 @@ Providing a `hugepages` property into the `MachineSet` resource is now possible.
 * Appending items in `unqualified-search-registries` list
 
 For any other changes in `/etc/containers/registries.conf` files, the Machine Config Operator will default to draining nodes to apply changes. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1943315[*BZ#1943315*].
+////
 
 [id="ocp-4-8-nodes"]
 === Nodes
@@ -1700,6 +1702,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Previously, Google Cloud Platform (GCP) load balancer health checkers left stale conntrack entries on the host, which caused network interruptions to the API server traffic that used the GCP load balancers. The health check traffic no longer loops through the host, so there is no longer network disruption against the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925698[*BZ#1925698*])
 
+////
 *Machine Config Operator*
 
 * Previously,  the `drain timeout` and pool degrading period was too short and would cause alerts prematurely on a normal cluster that needed more time. With this update, the time needed before a timeout reports a failure is extended. This provides the Cluster Operator with more realistic and useful alerts without prematurely degrading performance of a normal cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1968019[*BZ#1968019*])
@@ -1718,7 +1721,7 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 * Previously, rpm-ostree related operations were not handled properly on non-CoreOS nodes such as {op-system-first}. As a result, {op-system-base} nodes were degraded when an operation, such as kernel switching, was applied in the pool that contained {op-system-base} nodes. With this update, the Machine Config Daemon logs a message whenever a non-supported operation is performed on non-CoreOS nodes. After logging the message, it returns nil instead of an error. {op-system-base} nodes in the pool now proceed as expected when an unsupported operation is performed by the Machine Config Daemon. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952368[*BZ#1952368*])
 
 * Previously, empty static pod files were being written to the `/etc/kubernetes/manifests` directory. As a result, the kubelet log was reporting errors that could cause confusion with some users. Empty manifests are now moved to a different location when they are not needed. As a result, the errors do not appear in the kubelet log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927042[*BZ#1927042*])
-
+////
 
 *Metering Operator*
 


### PR DESCRIPTION
Temporarily hiding the references to the changes in WMCO 3.0 for the OCP 4.8 release due to a release delay between the components.