### PR TITLE
SRVOCF-290: Add docs on function project configuration in func.yaml

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -3130,6 +3130,8 @@ Topics:
     File: serverless-developing-quarkus-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
+  - Name: Function project configuration in func.yaml
+    File: serverless-functions-yaml
   - Name: Accessing secrets and config maps from Serverless functions
     File: serverless-functions-accessing-secrets-configmaps
   - Name: Functions development reference guide

--- a/modules/serverless-functions-func-yaml-environment-variables.adoc
+++ b/modules/serverless-functions-func-yaml-environment-variables.adoc
@@ -1,0 +1,28 @@
+[id="serverless-functions-func-yaml-environment-variables_{context}"]
+= Referencing local environment variables from func.yaml fields
+
+In the `envs` field in the `func.yaml`, you can put a reference to an environment variable available in the local environment. This can be useful for avoiding storing sensitive information, such as an API key in the function configuration.
+
+.Procedure
+
+* To refer to a local environment variable, use the following syntax:
++
+[source]
+----
+{{ env:ENV_VAR }}
+----
++
+Substitute `ENV_VAR` with the name of the variable in the local environment that you want to use.
++
+For example, you might have the `API_KEY` variable available in the local environment. You can assign its value to the `MY_API_KEY` variable, which you can then directly use within your function:
++
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- name: MY_API_KEY
+  value: '{{ env:API_KEY }}'
+----

--- a/modules/serverless-functions-func-yaml-fields.adoc
+++ b/modules/serverless-functions-func-yaml-fields.adoc
@@ -1,0 +1,137 @@
+[id="serverless-functions-func-yaml_{context}"]
+= Configurable fields in func.yaml
+
+Many of the fields in `func.yaml` are generated automatically when you create, build, and deploy your function. However, there are also fields that you modify manually to change things, such as the function name or the image name.
+
+== builder
+
+The `builder` field specifies the Buildpack builder image to use when building the function. In most cases, this value should not be changed. When you do change it, use a value that is listed in the `builderMap` field.
+
+== builderMap
+
+Some function runtimes can be built in multiple ways. For example, a Quarkus function can be built for the JVM or as a native binary. The `builderMap` field contains all of the builders available for a given runtime.
+
+== envs
+
+The `envs` field enables you to set environment variables to be available to your function at runtime. You can set an environment variable in several different ways:
+
+. Directly from a value.
+. From a value assigned to a local environment variable. See the section "Referencing local environment variables from func.yaml fields" for more information.
+. From a key-value pair stored in a secret or config map.
+. You can also import all key-value pairs stored in a secret or config map, with keys used as names of the created environment variables.
+
+This examples demonstrates the different ways to set an environment variable:
+
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+envs:
+- name: EXAMPLE1 <1>
+  value: value
+- name: EXAMPLE2 <2>
+  value: '{{ env:LOCAL_ENV_VALUE }}'
+- name: EXAMPLE3 <3>
+  value: '{{ secret:mysecret:key }}'
+- name: EXAMPLE4 <4>
+  value: '{{ configMap:myconfigmap:key }}'
+- value: '{{ secret:mysecret2 }}' <5>
+- value: '{{ configMap:myconfigmap2 }}' <6>
+----
+<1> An environment variable set directly from a value.
+<2> An environment variable set from a value assigned to a local environment variable.
+<3> An environment variable assigned from a key-value pair stored in a secret.
+<4> An environment variable assigned from a key-value pair stored in a config map.
+<5> A set of environment variables imported from key-value pairs of a secret.
+<6> A set of environment variables imported from key-value pairs of a config map.
+
+== volumes
+
+The `volumes` field enables you to mount secrets and config maps as a volume accessible to the function at the specified path, as shown in the following example:
+
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+volumes:
+- secret: mysecret <1>
+  path: /workspace/secret
+- configMap: myconfigmap <2>
+  path: /workspace/configmap
+----
+<1> The `mysecret` secret is mounted as a volume residing at `/workspace/secret`.
+<2> The `myconfigmap` config map is mounted as a volume residing at `/workspace/configmap`.
+
+== options
+
+The `options` field enables you to modify Knative Service properties for the deployed function, such as autoscaling. If these options are not set, the default ones are used.
+
+These options are available:
+
+* `scale`
+** `min`: The minimum number of replicas. Must be a non-negative integer. The default is 0.
+** `max`: The maximum number of replicas. Must be a non-negative integer. The default is 0, which means no limit.
+** `metric`: Defines which metric type is watched by the Autoscaler. It can be set to `concurrency`, which is the default, or `rps`.
+** `target`: Recommendation for when to scale up based on the number of concurrently incoming requests. The `target` option can be a float value greater than 0.01. The default is 100, unless the `options.resources.limits.concurrency` is set, in which case `target` defaults to its value.
+** `utilization`: Percentage of concurrent requests utilization allowed before scaling up. It can be a float value between 1 and 100. The default is 70.
+* `resources`
+** `requests`
+*** `cpu`: A CPU resource request for the container with deployed function.
+*** `memory`: A memory resource request for the container with deployed function.
+** `limits`
+*** `cpu`: A CPU resource limit for the container with deployed function.
+*** `memory`: A memory resource limit for the container with deployed function.
+*** `concurrency`: Hard Limit of concurrent requests to be processed by a single replica. It can be integer value greater than or equal to 0, default is 0 - meaning no limit.
+
+This is an example configuration of the `scale` options:
+
+[source,yaml]
+----
+name: test
+namespace: ""
+runtime: go
+...
+options:
+  scale:
+    min: 0
+    max: 10
+    metric: concurrency
+    target: 75
+    utilization: 75
+  resources:
+    requests:
+      cpu: 100m
+      memory: 128Mi
+    limits:
+      cpu: 1000m
+      memory: 256Mi
+      concurrency: 100
+----
+
+== image
+
+The `image` field sets the image name for your function after it has been built. You can modify this field. If you do, the next time you run `kn func build` or `kn func deploy`, the function image will be created with the new name.
+
+== imageDigest
+
+The `imageDigest` field contains the SHA256 hash of the image manifest when the function is deployed. Do not modify this value.
+
+== name
+
+The `name` field defines the name of your function. This value is used as the name of your Knative service when it is deployed. You can change this field to rename the function on subsequent deployments.
+
+== namespace
+
+The `namespace` field specifies the namespace in which your function is deployed.
+
+== runtime
+
+The `runtime` field specifies the language runtime for your function, for example, `python`.
+
+== template
+
+The `template` field specifies the type of the invocation event that triggers your function. You can set it to `http` for triggering with plain HTTP requests or to `events` for triggering with CloudEvents.

--- a/serverless/functions/serverless-functions-yaml.adoc
+++ b/serverless/functions/serverless-functions-yaml.adoc
@@ -1,0 +1,26 @@
+include::modules/serverless-document-attributes.adoc[]
+[id="serverless-functions-project-configuration"]
+= Function project configuration in func.yaml
+include::modules/common-attributes.adoc[]
+:context: serverless-functions-yaml
+
+toc::[]
+
+The `func.yaml` file contains the configuration for your function project.
+
+Generally, these values are used when you execute a `kn func` command. For example, when you run the `kn func build` command, the value in the `builder` field is used.
+
+[NOTE]
+====
+In many cases, you can override these values with command line flags or environment variables.
+====
+
+include::modules/serverless-functions-func-yaml-fields.adoc[leveloffset=+1]
+include::modules/serverless-functions-func-yaml-environment-variables.adoc[leveloffset=+1]
+
+.Additional resources
+
+* For information on overriding values in the `func.yaml` file, see xref:serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].
+* For more information on accessing data in secrets and config maps, see xref:serverless-functions-accessing-secrets-configmaps.adoc#serverless-functions-accessing-secrets-configmaps[Accessing secrets and config maps from Serverless functions].
+* For more information on the `scale` set of options, see the link:https://knative.dev/docs/serving/autoscaling/[Knative documentation on Autoscaling].
+* For more information on the `resources` set of options, see the https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers] and the https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency].


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVOCF-290
Docs preview: https://deploy-preview-34442--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-yaml