### PR TITLE
OSDOCS-2185: GCE Auto Migration (TP)

### DIFF
--- a/modules/persistent-storage-csi-migration-enable.adoc
+++ b/modules/persistent-storage-csi-migration-enable.adoc
@@ -41,6 +41,8 @@ You can specify CSI automatic migration for a selected CSI driver by setting `Cu
 * CSIMigrationOpenStack
 
 * CSIMigrationAzure
+
+* CSIMigrationGCE
 --
 +
 The following configuration example enables automatic migration to the AWS EBS CSI driver only:

--- a/modules/persistent-storage-csi-migration-overview.adoc
+++ b/modules/persistent-storage-csi-migration-overview.adoc
@@ -15,6 +15,8 @@ The following drivers are supported:
 
 * Azure Disk
 
+* Google Compute Engine Persistent Disk (in-tree) and Google Cloud Platform Persistent Disk (CSI)
+
 CSI automatic migration should be seamless. Enabling this feature does not change how you use all existing API objects (for example, `PersistentVolumes`, `PersistentVolumeClaims`, and `StorageClasses`).
 
 By default, automatic migration is disabled.


### PR DESCRIPTION
4.9+

[OSDOCS-2185:](https://issues.redhat.com/browse/OSDOCS-2185) GCE added to auto migration feature (Tech Preview).

**Preview**: https://deploy-preview-34443--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-migration?utm_source=github&utm_campaign=bot_dp

PTAL @bertinatto, @chao007 