### PR TITLE
Adds 4.6.38 RNs

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3090,3 +3090,36 @@ link:https://access.redhat.com/solutions/6145452[{product-title} 4.6.36 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-38"]
+=== RHBA-2021:2641 - {product-title} 4.6.38 bug fix and security update
+
+Issued: 2021-07-13
+
+{product-title} release 4.6.38 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2641[RHBA-2021:2641] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2642[RHBA-2021:2642] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6176142[{product-title} 4.6.36 container image list]
+
+[id="ocp-4-6-38-bug-fixes"]
+==== Bug fixes
+
+* Previously, when starting a single-stack IPv6 cluster on nodes with IPv4 address, the kubelet might have used the IPv4 address instead of the IPv6 address for the node IP address. Consequently, host network pods would have IPv4 addresses rather than IPv6 addresses, which made them unreachable from IPv6-only pods. This update fixes the node-IP-picking code, which results in the kubelet using the IPv6 addresses. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942506[*BZ#1942506*])
+
+* Previously, CRI-O logs did not contain information about the source where images were pulled from. Consequently, CRI-O failed to tell if the image was pulled from the registry mirror. This update adds level log information to CRI-O about the pull source of the image. As a result, the pull source is now shown in the information level of the log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976293[*BZ#1976293*])
+
+* Previously, the authorization header created during image mirroring could exceed the header size limit for some registries. This would cause an error during the mirroring operation. Now, the `--skip-multiple-scopes` option is set to `true` for the `oc adm catalog mirror` command to help prevent the authorization header from exceeding the header size limits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1946839[*BZ#1946839*])
+
+* Before this update, the Pipeline ServiceAccount did not use secrets created during the `git import` flow for private Git repositories, which caused these Pipelines to fail. This update fixes the problem by adding annotations to the secrets and to the Pipeline ServiceAccount. Pipelines for private Git repositories now run correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970470[*BZ#1970470*])
+
+* Previously, not all options in kubeconfig were copied when switching projects. Consequently, when switching projects using `Exec` to authenticate in kubeconfig, information was lost. This update copies all the necessary information when switching projects that use `oc projects` and `Exec` to authenticate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973613[*BZ#1973613*])
+
+* Previously, when a second internal IP address was added to one or more control plane nodes, the etcd Operator degraded due to detecting the IP address change as a potential membership change. Consequently, it did not regenerate etcd serving certificates for the node. With this update, the etcd Operator differentiates between an IP address change for new and existing nodes. As a result, the etcd Operator regenerates serving certificates for changes to an existing node, and adding a new IP address no longer causes the etcd Operator to degrade. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965535[*BZ#1965535*])
+
+* Previously, the topology URLs created for deployments using the Bitbucket repository in the {product-title} web console did not work if they included a branch name that contained a backslash (\) or forward slash (/). This was due to an issue with the Bitbucket API (link:https://jira.atlassian.com/browse/BCLOUD-9969[*BCLOUD-9969*]). The current release mitigates this issue. If a branch name contains either a backslash or forward slash, the topology URLs point to the default branch page for the repository. This issue will be fixed in a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1972694[*BZ#1972694*])
+
+[id="ocp-4-6-38-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

Adds 4.6.38 release notes.

Preview: https://deploy-preview-34446--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-38