### PR TITLE
Bz1964901 add bpg failed migration cleanup to mtc

### DIFF
--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -47,3 +47,4 @@ You can roll back a migration by using the {mtc-short} web console or the CLI.
 
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
+include::modules/migration-cleaning-up-failed-migration.adoc[leveloffset=+2]

--- a/migration-toolkit-for-containers/troubleshooting-mtc.adoc
+++ b/migration-toolkit-for-containers/troubleshooting-mtc.adoc
@@ -45,3 +45,4 @@ You can roll back a migration by using the {mtc-short} web console or the CLI.
 
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
+include::modules/migration-cleaning-up-failed-migration.adoc[leveloffset=+2]

--- a/modules/migration-cleaning-up-failed-migration.adoc
+++ b/modules/migration-cleaning-up-failed-migration.adoc
@@ -1,0 +1,132 @@
+
+
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+// * migration-toolkit-for-containers/troubleshooting-mtc
+
+
+:_module-type: PROCEDURE
+
+[id="cleanup-of-failed-migration_{context}"]
+= Cleaning up a failed migration
+
+.Prerequisites
+* You must be logged in to the {product-title} cluster as a user with the `cluster-admin` role.
+* You must have the OpenShift CLI installed.
+
+
+.Procedure
+
+
+. Deleting resources
++
+If a migration fails during Stage or Copy, some resources are retained to allow debugging and need to be cleaned up.
++
+The following resources must be deleted:
+
+* rsync/stunnel pods, both in the source and target namespaces
+* Secrets and configmap, both in the source and target namespaces
+* Route and service only in the target namespaces
+
+
+
+
+. Unquiescing applications
++
+If your application was quiesced during migration, you must unquiesce it by scaling it back to its initial replica count. The original replica count is indicated in a label that MTC adds to the `deployment` resource when a source application is quiesced during migration:
+
++
+----
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+ annotations:
+    deployment.kubernetes.io/revision: "1"
+    migration.openshift.io/preQuiesceReplicas: "1"
+----
+Unquiesce the application in either of the following two ways:
+
+** Manually edit the deployment primitive (`Deployment`, `DeploymentConfig`, etc.) and set the `spec.replicas` field back to its original, non-zero value:
++
+----
+$ oc edit deployment <deployment_name>
+----
+
+** Scale your deployment with the `oc scale` command:
++
+----
+$ oc scale deployment <deployment_name> --replicas=<desired_replicas>
+----
+
+
+. Deleting the MTC Operator and cluster-scoped resources
+
++
+CAUTION: This procedure entirely removes Velero. Perform it only if there are no more Velero instances employed on the cluster.
+
+.. Delete the Migration Controller and its resources:
++
+[source,terminal]
+----
+$ oc delete migrationcontroller <resource_name>
+----
++
+Wait for the MTC Operator to finish deleting the resources.
+
+.. Uninstall the MTC Operator:
+
+   ** OpenShift 4: Uninstall the Operator in the [web console](https://docs.openshift.com/container-platform/4.7/operators/olm-deleting-operators-from-cluster.html) LINK ERROR or by running the following command:
++
+----
+$ oc delete ns openshift-migration
+----
+
+   ** OpenShift 3: Uninstall the operator by deleting it:
++
+----
+$ oc delete -f operator.yml
+----
+
+.. Delete the cluster-scoped resources:
+
+   ** Migration custom resource definition:
++
+----
+$ oc delete $(oc get crds -o name | grep 'migration.openshift.io')
+----
+   ** Velero custom resource definition:
++
+----
+$ oc delete $(oc get crds -o name | grep 'velero')
+----
+   ** Migration cluster role:
++
+----
+$ oc delete $(oc get clusterroles -o name | grep 'migration.openshift.io')
+----
+   ** Migration-operator cluster role:
++
+----
+$ oc delete clusterrole migration-operator
+----
+   ** Velero cluster role:
++
+----
+$ oc delete $(oc get clusterroles -o name | grep 'velero')
+----
+   ** Migration cluster role bindings:
++
+----
+$ oc delete $(oc get clusterrolebindings -o name | grep 'migration.openshift.io')
+----
+   ** Migration-operator cluster role bindings:
++
+----
+$ oc delete clusterrolebindings migration-operator
+----
+   ** Velero cluster role bindings:
++
+----
+$ oc delete $(oc get clusterrolebindings -o name | grep 'velero')
+----

--- a/modules/migration-cleaning-up-failed-migration.adoc
+++ b/modules/migration-cleaning-up-failed-migration.adoc
@@ -1,40 +1,32 @@
-
-
 // Module included in the following assemblies:
 //
 // * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
-// * migration-toolkit-for-containers/troubleshooting-mtc
+// * migration-toolkit-for-containers/troubleshooting-mtc.adoc
 
 
-:_module-type: PROCEDURE
-
-[id="cleanup-of-failed-migration_{context}"]
+[id="migration-cleaning-up-failed-migration_{context}"]
 = Cleaning up a failed migration
 
 .Prerequisites
+
 * You must be logged in to the {product-title} cluster as a user with the `cluster-admin` role.
 * You must have the OpenShift CLI installed.
 
-
 .Procedure
 
-
-. Deleting resources
+.  Delete resources
 +
-If a migration fails during Stage or Copy, some resources are retained to allow debugging and need to be cleaned up.
+If a direct volume migration (DVM) fails during Stage or Copy, some resources are preserved to allow debugging and need to be removed manually.
 +
 The following resources must be deleted:
 
-* rsync/stunnel pods, both in the source and target namespaces
-* Secrets and configmap, both in the source and target namespaces
-* Route and service only in the target namespaces
+* `Rsync` and `Stunnel` pods, both in the source and target namespaces
+* Secret CRs and config maps, both in the source and target namespaces
+* Route and services only in the target namespaces
 
-
-
-
-. Unquiescing applications
+. Unquiesce applications
 +
-If your application was quiesced during migration, you must unquiesce it by scaling it back to its initial replica count. The original replica count is indicated in a label that MTC adds to the `deployment` resource when a source application is quiesced during migration:
+If your application was quiesced during migration, you must unquiesce it by scaling it back to its initial replica count. The original replica count is indicated in a label that {mtc-short} adds to the `deployment` custom resource when an application is quiesced during migration:
 
 +
 ----
@@ -45,57 +37,52 @@ metadata:
     deployment.kubernetes.io/revision: "1"
     migration.openshift.io/preQuiesceReplicas: "1"
 ----
-Unquiesce the application in either of the following two ways:
-
-** Manually edit the deployment primitive (`Deployment`, `DeploymentConfig`, etc.) and set the `spec.replicas` field back to its original, non-zero value:
 +
-----
-$ oc edit deployment <deployment_name>
-----
-
-** Scale your deployment with the `oc scale` command:
+Scale your deployment back as follows:
 +
 ----
 $ oc scale deployment <deployment_name> --replicas=<desired_replicas>
 ----
 
 
-. Deleting the MTC Operator and cluster-scoped resources
+. Delete the MTC Operator and cluster-scoped resources
 
 +
-CAUTION: This procedure entirely removes Velero. Perform it only if there are no more Velero instances employed on the cluster.
+NOTE: This procedure entirely removes Velero. Perform it only if there are no more Velero instances deployed on the cluster.
 
-.. Delete the Migration Controller and its resources:
+.. Delete the *Migration Controller* CR and its resources:
 +
 [source,terminal]
 ----
 $ oc delete migrationcontroller <resource_name>
 ----
 +
-Wait for the MTC Operator to finish deleting the resources.
+Wait for the {mtc-short} Operator to finish deleting the resources.
 
 .. Uninstall the MTC Operator:
 
-   ** OpenShift 4: Uninstall the Operator in the [web console](https://docs.openshift.com/container-platform/4.7/operators/olm-deleting-operators-from-cluster.html) LINK ERROR or by running the following command:
+   ** OpenShift 4: Uninstall the Operator in the https://docs.openshift.com/container-platform/4.7/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[web console] or by running the following command:
 +
+[source,terminal]
 ----
 $ oc delete ns openshift-migration
 ----
 
    ** OpenShift 3: Uninstall the operator by deleting it:
 +
+[source,terminal]
 ----
 $ oc delete -f operator.yml
 ----
 
 .. Delete the cluster-scoped resources:
 
-   ** Migration custom resource definition:
+   ** `Migration` custom resource definition:
 +
 ----
 $ oc delete $(oc get crds -o name | grep 'migration.openshift.io')
 ----
-   ** Velero custom resource definition:
+   ** `Velero` custom resource definition:
 +
 ----
 $ oc delete $(oc get crds -o name | grep 'velero')


### PR DESCRIPTION
For versions 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1964901

The procedure for cleaning up a failed migration added to Troubleshooting

Doc preview: https://deploy-preview-34449--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#cleanup-of-failed-migration_troubleshooting-3-4