### PR TITLE
Bz1964321 bpg route host names section added to mtc

### DIFF
--- a/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc
@@ -83,6 +83,7 @@ NFS does not require a defined storage class.
 If an application uses an internal image in the `openshift` namespace that is not supported by {product-title} {product-version}, you can manually update the xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-updating-deprecated-internal-images_troubleshooting-3-4[{product-title} 3 image stream tag] with `podman`.
 * [ ] The target cluster and the replication repository have sufficient storage space.
 * [ ] The xref:../authentication/understanding-identity-provider.adoc#supported-identity-providers[identity provider] is working.
+* [ ] Set the value of the `annotation.openshift.io/host.generated` parameter to `true` for each {product-title} route to update its host name for the target cluster. Otherwise, the migrated routes retain the source cluster host name.
 
 [id="performance-checklist_{context}"]
 == Performance checklist


### PR DESCRIPTION
For versions 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1964321

A checkbox for route host names added to Premigration checklist.

https://deploy-preview-34450--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/premigration-checklists-3-4.html#target-cluster-checklist_premigration-checklists-3-4

Merged