### PR TITLE
OSSMDOC-356: Remove Accessing Prometheus topic.

### DIFF
--- a/modules/ossm-config-sampling.adoc
+++ b/modules/ossm-config-sampling.adoc
@@ -5,16 +5,16 @@
 [id="ossm-config-sampling_{context}"]
 = Adjusting the sampling rate
 
-The distributed tracing sampling rate is set to sample 100% of traces in your service mesh by default. A high sampling rate consumes cluster resources and performance but is useful when debugging issues. Before you deploy {ProductName} in production, set the value to a smaller proportion of traces.
+The Envoy sampling rate is set to sample 100% of traces in your service mesh by default. A high sampling rate consumes cluster resources and performance but is useful when debugging issues. Before you deploy {ProductName} in production, set the value to a smaller proportion of traces.
 
 A trace is an execution path between services in the service mesh. A trace is comprised of one or more spans. A span is a logical unit of work that has a name, start time, and duration.
 
-The sampling rate determines how often a trace is generated. Configure sampling as a scaled integer representing 0.01% increments. 
+The sampling rate determines how often the Envoy proxy generates a trace. Configure sampling as a scaled integer representing 0.01% increments.
 
 In a basic installation, `spec.tracing.sampling` is set to `10000`, which samples 100% of traces. For example:
 
-* Setting the value to 10 samples 0.1% of traces. 
-* Setting the value to 500 samples 5% of traces. 
+* Setting the value to 10 samples 0.1% of traces.
+* Setting the value to 500 samples 5% of traces.
 
 Setting the value to `10000` is useful for debugging, but can affect performance. For production, set `spec.tracing.sampling` to `100.`
 

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -5,7 +5,7 @@ include::modules/ossm-document-attributes.adoc[]
 
 toc::[]
 
-You can view your application's topology, health, and metrics in the Kiali console. If your service is experiencing problems, the Kiali console allows you to view the data flow through your service. You can view insights about the mesh components at different levels, including abstract applications, services, and workloads. It also provides an interactive graph view of your namespace in real time.
+You can view your application's topology, health, and metrics in the Kiali console. If your service is experiencing problems, the Kiali console lets you view the data flow through your service. You can view insights about the mesh components at different levels, including abstract applications, services, and workloads. It also provides an interactive graph view of your namespace in real time.
 
 You can observe the data flow through your application if you have an application installed. If you do not have your own application installed, you can see how observability works in {ProductName} by installing the xref:../../service_mesh/v2x/prepare-to-deploy-applications-ossm.adoc#ossm-tutorial-bookinfo-overview_ossm-create-mesh[Bookinfo sample application].
 
@@ -26,5 +26,3 @@ include::modules/ossm-config-external-jaeger.adoc[leveloffset=+2]
 For more information about configuring Jaeger, see the xref:../../jaeger/jaeger_install/rhbjaeger-deploying.adoc#jaeger-deploy-default_jaeger-deploying[Jaeger documentation].
 
 include::modules/ossm-access-grafana.adoc[leveloffset=+1]
-
-include::modules/ossm-access-prometheus.adoc[leveloffset=+1]


### PR DESCRIPTION
The Prometheus instance that is installed as part of Service Mesh is a backend, there isn't actually a customer use case for accessing this Prometheus instance.  They only reason they should need to access Prometheus is for troubleshooting purposes.

In addition, when Service Mesh installs Prometheus, it's behind an authentication proxy.  Customers cannot access it via the route as currently documented.

(Also attempted to clarify the sampling rate while I was in there.)

Preview is here https://deploy-preview-34451--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability?utm_source=github&utm_campaign=bot_dp

Verify that there is not an "Accessing Prometheus" topic under the "Accessing Grafana" topic.