### PR TITLE
OSSMDOC-341: Standardize references to istio-system.

### DIFF
--- a/modules/jaeger-upgrading-es.adoc
+++ b/modules/jaeger-upgrading-es.adoc
@@ -10,11 +10,11 @@ When updating from Elasticsearch 5 to Elasticsearch 6, you must delete your Jaeg
 
 .Procedure if Jaeger is installed as part of Red Hat Service Mesh
 
-. Determine the name of your Jaeger custom resource file:
+. Determine the name of your Jaeger custom resource file. In this example, `istio-system` is the control plane namespace.
 +
 [source,terminal]
 ----
-$ oc get jaeger -n istio-system
+$ oc get jaeger -n <istio-system>
 ----
 +
 You should see something like the following:
@@ -29,21 +29,21 @@ jaeger   3d21h
 +
 [source,terminal]
 ----
-$ oc get jaeger jaeger -oyaml -n istio-system > /tmp/jaeger-cr.yaml
+$ oc get jaeger jaeger -oyaml -n <istio-system> > /tmp/jaeger-cr.yaml
 ----
 +
 . Delete the Jaeger instance:
 +
 [source,terminal]
 ----
-$ oc delete jaeger jaeger -n istio-system
+$ oc delete jaeger jaeger -n <istio-system>
 ----
 +
 . Recreate the Jaeger instance from your copy of the custom resource file:
 +
 [source,terminal]
 ----
-$ oc create -f /tmp/jaeger-cr.yaml -n istio-system
+$ oc create -f /tmp/jaeger-cr.yaml -n <istio-system>
 ----
 +
 . Delete the copy of the generated custom resource file:
@@ -83,6 +83,6 @@ $ oc create -f <jaeger-cr-file>
 +
 [source,terminal]
 ----
-$ oc get pods -n jaeger-system -w
+$ oc get pods -n <jaeger-system> -w
 ----
 +

--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -20,5 +20,5 @@ To collect {ProductName} data for a specific control plane namespace with `must-
 
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8 gather <namespace> 
+$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8 gather <namespace>
 ----

--- a/modules/ossm-access-grafana.adoc
+++ b/modules/ossm-access-grafana.adoc
@@ -5,13 +5,13 @@
 [id="ossm-access-grafana_{context}"]
 = Accessing Grafana
 
-Grafana is an analytics tool that you can use to view, query, and analyze your service mesh metrics. To access Grafana, do the following:
+Grafana is an analytics tool that you can use to view, query, and analyze your service mesh metrics. In this example, `istio-system` is the control plane namespace. To access Grafana, do the following:
 
 .Procedure
 
 . Log in to the {product-title} web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click *Routes*.
 

--- a/modules/ossm-access-prometheus.adoc
+++ b/modules/ossm-access-prometheus.adoc
@@ -5,13 +5,13 @@
 [id="ossm-access-prometheus_{context}"]
 = Accessing Prometheus
 
-Prometheus is a monitoring and alerting tool that you can use to collect multi-dimensional data about your microservices.
+Prometheus is a monitoring and alerting tool that you can use to collect multi-dimensional data about your microservices. In this example, `istio-system` is the control plane namespace.
 
 .Procedure
 
 . Log in to the {product-title} web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click *Routes*.
 

--- a/modules/ossm-config-enabling-controlplane.adoc
+++ b/modules/ossm-config-enabling-controlplane.adoc
@@ -18,13 +18,13 @@ spec:
       mtls: true
 ----
 
-You can also enable mTLS for the control plane by using the {product-title} web console.
+You can also enable mTLS for the control plane by using the {product-title} web console. In this example, `istio-system` is the control plane namespace.
 
 .Procedure
 
 . Log in to the web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click *Operators* -> *Installed Operators*.
 

--- a/modules/ossm-config-external-jaeger.adoc
+++ b/modules/ossm-config-external-jaeger.adoc
@@ -15,7 +15,7 @@ If you already use standalone Jaeger for distributed tracing in {product-title},
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
-. From the *Project* menu, select the project where you installed the control plane, for example `istio-system`.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane` resource, for example `basic`.
 

--- a/modules/ossm-config-mtls-min-max.adoc
+++ b/modules/ossm-config-mtls-min-max.adoc
@@ -29,7 +29,7 @@ The default is `TLS_AUTO` and does not specify a version of TLS.
 
 . Log in to the web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click *Operators* -> *Installed Operators*.
 

--- a/modules/ossm-config-sampling.adoc
+++ b/modules/ossm-config-sampling.adoc
@@ -9,12 +9,12 @@ The distributed tracing sampling rate is set to sample 100% of traces in your se
 
 A trace is an execution path between services in the service mesh. A trace is comprised of one or more spans. A span is a logical unit of work that has a name, start time, and duration.
 
-The sampling rate determines how often a trace is generated. Configure sampling as a scaled integer representing 0.01% increments. 
+The sampling rate determines how often a trace is generated. Configure sampling as a scaled integer representing 0.01% increments.
 
 In a basic installation, `spec.tracing.sampling` is set to `10000`, which samples 100% of traces. For example:
 
-* Setting the value to 10 samples 0.1% of traces. 
-* Setting the value to 500 samples 5% of traces. 
+* Setting the value to 10 samples 0.1% of traces.
+* Setting the value to 500 samples 5% of traces.
 
 Setting the value to `10000` is useful for debugging, but can affect performance. For production, set `spec.tracing.sampling` to `100.`
 
@@ -22,7 +22,7 @@ Setting the value to `10000` is useful for debugging, but can affect performance
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
-. From the *Project* menu, select the project where you installed the control plane, for example `istio-system`.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane` resource, for example `basic`.
 

--- a/modules/ossm-config-sec-mtls-mesh.adoc
+++ b/modules/ossm-config-sec-mtls-mesh.adoc
@@ -24,7 +24,7 @@ You can also enable mTLS by using the {product-title} web console.
 
 . Log in to the web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click *Operators* -> *Installed Operators*.
 

--- a/modules/ossm-config-web-console.adoc
+++ b/modules/ossm-config-web-console.adoc
@@ -12,7 +12,7 @@ You can configure the `ServiceMeshControlPlane` by using the {product-title} web
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
-. Select the project where you installed the control plane, for example `istio-system`, from the Project menu.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane` resource, for example `basic`.
 

--- a/modules/ossm-control-plane-deploy-1x.adoc
+++ b/modules/ossm-control-plane-deploy-1x.adoc
@@ -16,7 +16,7 @@ You can deploy the {ProductShortName} control plane by using the {product-title}
 [id="ossm-control-plane-deploy-operatorhub_{context}"]
 == Deploying the control plane from the web console
 
-Follow this procedure to deploy the {ProductName} control plane by using the web console.
+Follow this procedure to deploy the {ProductName} control plane by using the web console.  In this example, `istio-system` is the name of the control plane project.
 
 .Prerequisites
 

--- a/modules/ossm-control-plane-remove.adoc
+++ b/modules/ossm-control-plane-remove.adoc
@@ -17,7 +17,7 @@ You can remove the {ProductName} control plane by using the web console.
 
 . Log in to the {product-title} web console.
 
-. Click the *Project* menu and choose the `istio-system` project from the list.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Navigate to *Operators* -> *Installed Operators*.
 
@@ -32,7 +32,7 @@ You can remove the {ProductName} control plane by using the web console.
 [id="ossm-control-plane-remove-cli_{context}"]
 == Removing the control plane from the CLI
 
-You can remove the {ProductName} control plane by using the CLI.
+You can remove the {ProductName} control plane by using the CLI.  In this example, `istio-system` is the name of the control plane project.
 
 .Procedure
 

--- a/modules/ossm-control-plane-web.adoc
+++ b/modules/ossm-control-plane-web.adoc
@@ -5,7 +5,7 @@
 [id="ossm-control-plane-deploy-operatorhub_{context}"]
 = Deploying the control plane from the web console
 
-You can deploy a basic `ServiceMeshControlPlane` by using the web console.
+You can deploy a basic `ServiceMeshControlPlane` by using the web console.  In this example, `istio-system` is the name of the control plane project.
 
 .Prerequisites
 

--- a/modules/ossm-extensions-wasm-deploy.adoc
+++ b/modules/ossm-extensions-wasm-deploy.adoc
@@ -1,7 +1,7 @@
 [id="ossm-extensions-deploy_{context}"]
 = Deploying extensions
 
-{ProductName} extensions can be enabled using the `ServiceMeshExtension` resource. 
+{ProductName} extensions can be enabled using the `ServiceMeshExtension` resource. In this example, `istio-system` is the name of the control plane project.
 
 .Procedure
 
@@ -26,7 +26,7 @@ spec:
 ----
 
 . Apply the `extension.yaml` file with the following command:
-+ 
++
 [source,terminal]
 ----
 $ oc apply -f extension.yaml

--- a/modules/ossm-extensions-wasm-support.adoc
+++ b/modules/ossm-extensions-wasm-support.adoc
@@ -1,7 +1,7 @@
 [id="ossm-extensions-support_{context}"]
 = Enabling WebAssembly extension support
 
-Support for WebAssembly extensions to {ProductName} is currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview], so it must be explicitly enabled for your `ServiceMeshControlPlane`. 
+Support for WebAssembly extensions to {ProductName} is currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview], so it must be explicitly enabled for your `ServiceMeshControlPlane`. In this example, `istio-system` is the name of the control plane project.
 
 .Procedure
 

--- a/modules/ossm-member-roll-create.adoc
+++ b/modules/ossm-member-roll-create.adoc
@@ -13,7 +13,7 @@ You must create a `ServiceMeshMemberRoll` resource named `default` in the same p
 [id="ossm-member-roll-create-console_{context}"]
 == Creating the member roll from the web console
 
-You can add one or more projects to the {ProductShortName} member roll from the web console.
+You can add one or more projects to the {ProductShortName} member roll from the web console. In this example, `istio-system` is the name of the control plane project.
 
 .Prerequisites
 * An installed, verified {ProductName} Operator.
@@ -23,7 +23,7 @@ You can add one or more projects to the {ProductShortName} member roll from the 
 
 . Log in to the {product-title} web console.
 
-. If you do not already have services for your mesh, or you are starting from scratch, create a project. It must be different from `istio-system`.
+. If you do not already have services for your mesh, or you are starting from scratch, create a project for your applications. It must be different from the project where you installed the control plane.
 
 .. Navigate to *Home* -> *Projects*.
 
@@ -65,14 +65,14 @@ You can add a project to the `ServiceMeshMemberRoll` from the command line.
 $ oc login https://{HOSTNAME}:6443
 ----
 
-. If you do not already have services for your mesh, or you are starting from scratch, create a project. It must be different from `istio-system`.
+. If you do not already have services for your mesh, or you are starting from scratch, create a project for your applications. It must be different from the project where you installed the control plane.
 +
 [source,terminal]
 ----
 $ oc new-project {your-project}
 ----
 
-. To add your projects as members, modify the following example YAML. You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource.
+. To add your projects as members, modify the following example YAML. You can add any number of projects, but a project can only belong to *one* `ServiceMeshMemberRoll` resource. In this example, `istio-system` is the name of the control plane project.
 +
 .Example servicemeshmemberroll-default.yaml
 [source,yaml]

--- a/modules/ossm-member-roll-modify.adoc
+++ b/modules/ossm-member-roll-modify.adoc
@@ -80,7 +80,7 @@ apiVersion: maistra.io/v1
 kind: ServiceMeshMemberRoll
 metadata:
   name: default
-  namespace: istio-system
+  namespace: istio-system #control plane project
 spec:
   members:
     # a list of projects joined into the service mesh

--- a/modules/ossm-members.adoc
+++ b/modules/ossm-members.adoc
@@ -6,7 +6,7 @@
 [id="ossm-members_{context}"]
 = Creating the {ProductName} members
 
-`ServiceMeshMember` resources provide a way for {ProductName} administrators to delegate permissions to add projects to a service mesh, even when the respective users don't have direct access to the service mesh project or member roll. While project administrators are automatically given permission to create the `ServiceMeshMember` resource in their project, they cannot point it to any `ServiceMeshControlPlane` until the service mesh administrator explicitly grants access to the service mesh. Administrators can grant users permissions to access the mesh by granting them the `mesh-user` user role. In this example, `istio-system` is the control plane namespace.
+`ServiceMeshMember` resources provide a way for {ProductName} administrators to delegate permissions to add projects to a service mesh, even when the respective users don't have direct access to the service mesh project or member roll. While project administrators are automatically given permission to create the `ServiceMeshMember` resource in their project, they cannot point it to any `ServiceMeshControlPlane` until the service mesh administrator explicitly grants access to the service mesh. Administrators can grant users permissions to access the mesh by granting them the `mesh-user` user role. In this example, `istio-system` is the name of the control plane project.
 
 [source,terminal]
 ----

--- a/modules/ossm-mixer-policy-1x.adoc
+++ b/modules/ossm-mixer-policy-1x.adoc
@@ -10,7 +10,7 @@ In previous versions of {ProductName}, Mixer's policy enforcement was enabled by
 .Prerequisites
 * Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
 
-NOTE: The examples use <istio-system> as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
+NOTE: The examples use `<istio-system>` as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
 
 .Procedure
 

--- a/modules/ossm-mixer-policy.adoc
+++ b/modules/ossm-mixer-policy.adoc
@@ -10,7 +10,10 @@ In previous versions of {ProductName}, Mixer's policy enforcement was enabled by
 .Prerequisites
 * Access to the {product-title} Command-line Interface (CLI) also known as `oc`.
 
-NOTE: The examples use <istio-system> as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
+[NOTE]
+====
+The examples use `<istio-system>` as the control plane namespace. Replace this value with the namespace where you deployed the Service Mesh Control Plane (SMCP).
+====
 
 .Procedure
 

--- a/modules/ossm-recommended-resources.adoc
+++ b/modules/ossm-recommended-resources.adoc
@@ -14,7 +14,7 @@ The settings in the following example are based on 1,000 services and 1,000 requ
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
-. From the Project menu, select the project where you installed the `ServiceMeshControlPlane` resource, for example `istio-system`.
+. Click the *Project* menu and select the project where you installed the control plane, for example *istio-system*.
 
 . Click the {ProductName} Operator. In the *Istio Service Mesh Control Plane* column, click the name of your `ServiceMeshControlPlane`, for example `basic`.
 
@@ -22,7 +22,7 @@ The settings in the following example are based on 1,000 services and 1,000 requ
 +
 .. Click the *YAML* tab.
 +
-.. Set the values for `spec.proxy.runtime.container.resources.requests.cpu` and `spec.proxy.runtime.container.resources.requests.memory` in your `ServiceMeshControlPlane` resource. 
+.. Set the values for `spec.proxy.runtime.container.resources.requests.cpu` and `spec.proxy.runtime.container.resources.requests.memory` in your `ServiceMeshControlPlane` resource.
 +
 .Example version 2.0 ServiceMeshControlPlane
 [source,yaml]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -172,7 +172,7 @@ spec:
 In some environments, it may be useful to have paths in authorization policies compared in a case insensitive manner.
 For example, treating `https://myurl/get` and `https://myurl/GeT` as equivalent.
 In those cases, you can use the `EnvoyFilter` shown below.
-This filter will change both the path used for comparison and the path presented to the application.
+This filter will change both the path used for comparison and the path presented to the application.  In this example, `istio-system` is the name of the control plane project.
 
 Save the `EnvoyFilter` to a file and execute the following command:
 

--- a/modules/ossm-routing-gateways.adoc
+++ b/modules/ossm-routing-gateways.adoc
@@ -6,7 +6,7 @@
 [id="ossm-routing-gateways_{context}"]
 = Configuring ingress using a gateway
 
-An ingress gateway is a load balancer operating at the edge of the mesh that receives incoming HTTP/TCP connections. It configures exposed ports and protocols but does not include any traffic routing configuration. Traffic routing for ingress traffic is instead configured with routing rules, the same way as for internal service requests. 
+An ingress gateway is a load balancer operating at the edge of the mesh that receives incoming HTTP/TCP connections. It configures exposed ports and protocols but does not include any traffic routing configuration. Traffic routing for ingress traffic is instead configured with routing rules, the same way as for internal service requests.
 
 The following steps show how to create a gateway and configure a `VirtualService` to expose a service in the Bookinfo sample application to outside traffic for paths `/productpage` and `/login`.
 
@@ -93,7 +93,7 @@ $ oc apply -f vs.yaml
 export GATEWAY_URL=$(oc -n istio-system get route istio-ingressgateway -o jsonpath='{.spec.host}')
 ----
 +
-.. Set the port number.
+.. Set the port number. In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----
@@ -104,7 +104,7 @@ export TARGET_PORT=$(oc -n istio-system get route istio-ingressgateway -o jsonpa
 +
 [source,terminal]
 ----
-curl -s -I "$GATEWAY_URL/productpage" 
+curl -s -I "$GATEWAY_URL/productpage"
 ----
 +
 The expected result is `200`.

--- a/modules/ossm-routing-ingress.adoc
+++ b/modules/ossm-routing-ingress.adoc
@@ -11,7 +11,7 @@ In {ProductName}, the Ingress Gateway enables features such as monitoring, secur
 [id="ossm-routing-determine-ingress_{context}"]
 == Determining the ingress IP and ports
 
-Ingress configuration differs depending on if your environment supports an external load balancer. An external load balancer is set in the ingress IP and ports for the cluster. To determine if your cluster's IP and ports are configured for external load balancers, run the following command.
+Ingress configuration differs depending on if your environment supports an external load balancer. An external load balancer is set in the ingress IP and ports for the cluster. To determine if your cluster's IP and ports are configured for external load balancers, run the following command. In this example, `istio-system` is the name of the control plane project.
 
 [source,terminal]
 ----
@@ -33,7 +33,7 @@ Follow these instructions if your environment has an external load balancer.
 
 .Procedure
 
-. Run the following command to set the ingress IP and ports. This command sets a variable in your terminal 
+. Run the following command to set the ingress IP and ports. This command sets a variable in your terminal.
 +
 [source,terminal]
 ----
@@ -100,5 +100,3 @@ $ export SECURE_INGRESS_PORT=$(oc -n istio-system get service istio-ingressgatew
 ----
 $ export TCP_INGRESS_PORT=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.spec.ports[?(@.name=="tcp")].nodePort}')
 ----
-
-

--- a/modules/ossm-routing-sc.adoc
+++ b/modules/ossm-routing-sc.adoc
@@ -11,7 +11,7 @@ By default, {ProductName} configures every Envoy proxy to accept traffic on all 
 To optimize performance of your service mesh, consider limiting Envoy proxy configurations.
 ====
 
-In the Bookinfo sample application, configure a Sidecar so all services can reach other services running in the same namespace and control plane. This Sidecar configuration is required for using {ProductName} policy and telemetry features. 
+In the Bookinfo sample application, configure a Sidecar so all services can reach other services running in the same namespace and control plane. This Sidecar configuration is required for using {ProductName} policy and telemetry features.
 
 .Procedure
 

--- a/modules/ossm-security-auth-policy.adoc
+++ b/modules/ossm-security-auth-policy.adoc
@@ -6,9 +6,9 @@ Module included in the following assemblies:
 [id="ossm-vs-istio_{context}"]
 = Configuring Role Based Access Control (RBAC)
 
-Role-based access control (RBAC) objects determine whether a user or service is allowed to perform a given action within a project. You can define mesh-, namespace-, and workload-wide access control for your workloads in the mesh. 
+Role-based access control (RBAC) objects determine whether a user or service is allowed to perform a given action within a project. You can define mesh-, namespace-, and workload-wide access control for your workloads in the mesh.
 
-To configure RBAC, create an `AuthorizationPolicy` resource in the namespace for which you are configuring access. If you are configuring mesh-wide access, use `istio-system`.
+To configure RBAC, create an `AuthorizationPolicy` resource in the namespace for which you are configuring access. If you are configuring mesh-wide access, use the project where you installed the control plane, for example `istio-system`.
 
 For example, with RBAC, you can create policies that:
 
@@ -52,7 +52,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -n istio-system -f <filename> 
+$ oc create -n istio-system -f <filename>
 ----
 
 .Next steps

--- a/modules/ossm-security-cert-manage.adoc
+++ b/modules/ossm-security-cert-manage.adoc
@@ -148,7 +148,7 @@ $ openssl verify -CAfile <(cat <path>/ca-cert.pem <path>/root-cert.pem) /tmp/pod
 
 To remove the certificates you added, follow these steps.
 
-. Remove the secret `cacerts`.
+. Remove the secret `cacerts`. In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -67,7 +67,7 @@ spec:
   members:
   - bookinfo
 ----
-.. Run the following command to upload that file and create the `ServiceMeshMemberRoll` resource in the `istio-system` namespace.
+.. Run the following command to upload that file and create the `ServiceMeshMemberRoll` resource in the `istio-system` namespace.   In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----

--- a/modules/ossm-tutorial-grafana-accessing.adoc
+++ b/modules/ossm-tutorial-grafana-accessing.adoc
@@ -14,10 +14,8 @@ The Grafana dashboard's web-based interface lets you visualize your metrics data
 * {ProductName} {ProductVersion} installed.
 * `Bookinfo` demonstration application installed.
 
-
-
 .Procedure
-. A route to access the Grafana dashboard already exists. Query for details of the route:
+. A route to access the Grafana dashboard already exists. In this example, `istio-system` is the name of the control plane project. Query for details of the route:
 +
 ----
   $ export GRAFANA_URL=$(oc get route -n istio-system grafana -o jsonpath='{.spec.host}')

--- a/modules/ossm-tutorial-prometheus-querying-metrics.adoc
+++ b/modules/ossm-tutorial-prometheus-querying-metrics.adoc
@@ -18,7 +18,7 @@ After you have verified the Bookinfo application has deployed, you will need to 
 
 .Procedure
 
-. Verify that the `prometheus` Service is running in your cluster. In Kubernetes environments, execute the following command:
+. Verify that the `prometheus` Service is running in your cluster. In this example, `istio-system` is the name of the control plane project. Execute the following command:
 +
 [source,terminal]
 ----

--- a/service_mesh/v1x/installing-ossm.adoc
+++ b/service_mesh/v1x/installing-ossm.adoc
@@ -19,7 +19,7 @@ Multi-tenant control plane installations are the default configuration starting 
 
 [NOTE]
 ====
-The {ProductShortName} documentation uses `istio-system` as the example project, but you may deploy the service mesh to any project.
+The {ProductShortName} documentation uses `istio-system` as the example project, but you can deploy the service mesh to any project.
 ====
 
 == Prerequisites

--- a/service_mesh/v2x/ossm-create-smcp.adoc
+++ b/service_mesh/v2x/ossm-create-smcp.adoc
@@ -5,6 +5,11 @@ include::modules/ossm-document-attributes.adoc[]
 
 You can deploy a basic installation of the `ServiceMeshControlPlane` by using either the {product-title} web console or from the command line using the `oc` client tool.
 
+[NOTE]
+====
+The {ProductShortName} documentation uses `istio-system` as the example project, but you can deploy the service mesh to any project.
+====
+
 include::modules/ossm-control-plane-web.adoc[leveloffset=+1]
 
 include::modules/ossm-control-plane-cli.adoc[leveloffset=+1]

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -55,7 +55,7 @@ $ oc patch smcp.v1.maistra.io <smcp_name> --type json --patch '[{"op": "replace"
 $ oc edit smcp.v1.maistra.io <smcp_name>
 ----
 +
-. Back up your control plane configuration. Switch to the project that contains your `ServiceMeshControlPlane` resource.
+. Back up your control plane configuration. Switch to the project that contains your `ServiceMeshControlPlane` resource.  In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
We use `istio-system` throughout the documentation, but customers can deploy their control plane to any project as long as it is separate from the project that contains their services.  

This PR:
* restores the note in the Creating the SMCP topic that " The documentation uses `istio-system` as the example project, but you may deploy the service mesh to any project."
* adds a line that `istio-system` is an example project
* standardizes the language around `istio-system` being an example project (so that localization doesn't have multiple strings saying the same thing)
Preview covers a lot of topics, but the main note being restored is here https://deploy-preview-34453--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp.html