### PR TITLE
[WIP] OSDOCS-2193: AWS EBS TP->GA

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -16,9 +16,9 @@ The following table describes the CSI drivers that are installed with {product-t
 |===
 |CSI driver  |CSI volume snapshots  |CSI cloning  |CSI resize
 
-|AWS EBS (Tech Preview) | ✅ | - | ✅
+|AWS EBS | ✅ | - | ✅
 |Google Cloud Platform (GCP) persistent disk (PD) (Tech Preview)| ✅ | - | ✅
-|Microsoft Azure Disk (Tech Preview) | ✅ | ✅ | ✅ 
+|Microsoft Azure Disk (Tech Preview) | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅
 |OpenStack Manila | ✅ | ✅ | ✅
 |Red Hat Virtualization (oVirt) | - | - | -

--- a/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ebs.adoc
@@ -9,9 +9,6 @@ toc::[]
 
 {product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic Block Store (EBS).
 
-:FeatureName: AWS EBS CSI Driver Operator
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a Container Storage Interface (CSI) Operator and driver.
 
 To create CSI-provisioned PVs that mount to AWS EBS storage assets, {product-title} installs the AWS EBS CSI Driver Operator and the AWS EBS CSI driver by default in the `openshift-cluster-csi-drivers` namespace.


### PR DESCRIPTION
4.9+

[OSDOCS-2193:](https://issues.redhat.com/browse/OSDOCS-2193) AWS EBS moves from Tech Preview (TP) to General Availability (GA).

**Preview**: 
https://deploy-preview-34465--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ebs.html
https://deploy-preview-34465--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

PTAL: @tsmetana, @chao007
