### PR TITLE
CNV-9518: Release Note for calico for vms

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -60,6 +60,10 @@ The SVVP Certification applies to:
 //CNV-12348 Add `--proxy-only` option to `virtctl vnc` for only proxying a VNC connection to allow manual connections
 * The `--proxy-only` option for the `virtctl vnc` command allows you to xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[manually connect to a virtual machine instance] through a Virtual Network Client (VNC) connection by using any VNC viewer.
 
+//CNV-9518 Release Note for calico
+
+* {VirtProductName} now supports third-party Container Network Interface (CNI) plug-ins that are link:https://access.redhat.com/articles/5436171[certified by Red Hat] for use with {product-title}.
+
 [id="virt-4-8-installation-new"]
 === Installation
 


### PR DESCRIPTION
This PR is associated with the Jira card: Release note for calico (supported third-party CNI plugins) in the CNV 4.8 release.
https://issues.redhat.com/browse/CNV-9518
