### PR TITLE
BZ1980340: [DOC-OCPRHV] Add resize to ovirt CSI driver

### DIFF
--- a/modules/dynamic-provisioning-aws-definition.adoc
+++ b/modules/dynamic-provisioning-aws-definition.adoc
@@ -25,20 +25,20 @@ parameters:
 See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for valid Amazon Resource Name (ARN) values.
-<2> (optional) Only for *io1* volumes. I/O operations per second per GiB.
+<2> Optional: Only for *io1* volumes. I/O operations per second per GiB.
 The AWS volume plug-in multiplies this with the size of the requested
 volume to compute IOPS of the volume. The value cap is 20,000 IOPS, which
 is the maximum supported by AWS. See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for further details.
-<3> (optional) Denotes whether to encrypt the EBS volume. Valid values
+<3> Optional: Denotes whether to encrypt the EBS volume. Valid values
 are `true` or `false`.
-<4> (optional) The full ARN of the key to use when encrypting the volume.
+<4> Optional: The full ARN of the key to use when encrypting the volume.
 If none is supplied, but `encypted` is set to `true`, then AWS generates a
 key. See the
 link:http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html[AWS documentation]
 for a valid ARN value.
-<5> (optional) File system that is created on dynamically provisioned
+<5> Optional: File system that is created on dynamically provisioned
 volumes. This value is copied to the `fsType` field of dynamically
 provisioned persistent volumes and the file system is created when the
 volume is mounted for the first time. The default value is `ext4`.

--- a/modules/dynamic-provisioning-ceph-rbd-definition.adoc
+++ b/modules/dynamic-provisioning-ceph-rbd-definition.adoc
@@ -25,18 +25,18 @@ parameters:
   imageFormat: "2" <9>
 ----
 <1> (required) A comma-delimited list of Ceph monitors.
-<2> (optional) Ceph client ID that is capable of creating images in the 
+<2> Optional: Ceph client ID that is capable of creating images in the
 pool. Default is `admin`.
-<3> (required) Secret Name for `adminId`. The provided secret must have 
+<3> (required) Secret Name for `adminId`. The provided secret must have
 type `kubernetes.io/rbd`.
-<4> (optional) The namespace for `adminSecret`. Default is `default`.
-<5> (optional) Ceph RBD pool. Default is `rbd`.
-<6> (optional) Ceph client ID that is used to map the Ceph RBD image. 
+<4> Optional: The namespace for `adminSecret`. Default is `default`.
+<5> Optional: Ceph RBD pool. Default is `rbd`.
+<6> Optional: Ceph client ID that is used to map the Ceph RBD image.
 Default is the same as `adminId`.
-<7> (required) The name of Ceph Secret for `userId` to map Ceph RBD image. 
-It must exist in the same namespace as PVCs. 
-<8> (optional) File system that is created on dynamically provisioned 
-volumes. This value is copied to the `fsType` field of dynamically 
-provisioned persistent volumes and the file system is created when the 
+<7> (required) The name of Ceph Secret for `userId` to map Ceph RBD image.
+It must exist in the same namespace as PVCs.
+<8> Optional: File system that is created on dynamically provisioned
+volumes. This value is copied to the `fsType` field of dynamically
+provisioned persistent volumes and the file system is created when the
 volume is mounted for the first time. The default value is `ext4`.
-<9> (optional) Ceph RBD image format. The default value is `2`.
+<9> Optional: Ceph RBD image format. The default value is `2`.

--- a/modules/ovirt-csi-driver-storage-class.adoc
+++ b/modules/ovirt-csi-driver-storage-class.adoc
@@ -1,30 +1,44 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
+// * post_installation_configuration/storage-configuration.adoc
 
 [id="ovirt-csi-driver-storage-class_{context}"]
-= oVirt CSI driver storage class
+ifeval::["{context}" == "post-install-storage-configuration"]
+= {rh-virtualization-first} object definition
+endif::[]
+ifeval::["{context}" == "persistent-storage-csi-ovirt"]
+= {rh-virtualization-first} CSI driver storage class
+endif::[]
+
 
 {product-title} creates a default object of type `StorageClass` named `ovirt-csi-sc` which is used for creating dynamically provisioned persistent volumes.
 
 To create additional storage classes for different configurations, create and save a file with the `StorageClass` object described by the following sample YAML:
 
+.ovirt-storageclass.yaml
 [source,yaml]
 ----
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: <storage-class-name>  <1>
+  name: <storage_class_name>  <1>
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"  <2>
+    storageclass.kubernetes.io/is-default-class: "<boolean>"  <2>
 provisioner: csi.ovirt.org
+allowVolumeExpansion: <boolean> <3>
+reclaimPolicy: Delete <4>
+volumeBindingMode: Immediate <5>
 parameters:
-  storageDomainName: <rhv-storage-domain-name> <3>
-  thinProvisioning: "true"  <4>
-  csi.storage.k8s.io/fstype: ext4 <5>
+  storageDomainName: <rhv-storage-domain-name> <6>
+  thinProvisioning: "<boolean>"  <7>
+  csi.storage.k8s.io/fstype: <file_system_type> <8>
 ----
 <1> Name of the storage class.
 <2> Set to `false` if the storage class is the default storage class in the cluster. If set to `true`, the existing default storage class must be edited and set to `false`.
-<3> {rh-virtualization} storage domain name to use.
-<4> Disk must be thin provisioned.
-<5> File system type to be created.
+<3> `true` enables dynamic volume expansion, `false` prevents it. `true` is recommended.
+<4> Dynamically provisioned persistent volumes of this storage class are created with this reclaim policy. This default policy is `Delete`.
+<5> Indicates how to provision and bind `PersistentVolumeClaims`. When not set, `VolumeBindingImmediate` is used. This field is only applied by servers that enable the `VolumeScheduling` feature.
+<6> The {rh-virtualization} storage domain name to use.
+<7> If `true`, the disk is thin provisioned. If `false`, the disk is preallocated. Thin provisioning is recommended.
+<8> Optional: File system type to be created. Possible values: `ext4` (default) or `xfs`.

--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -18,10 +18,10 @@ The following table describes the CSI drivers that are installed with {product-t
 
 |AWS EBS (Tech Preview) | ✅ | - | ✅
 |Google Cloud Platform (GCP) persistent disk (PD) (Tech Preview)| ✅ | - | ✅
-|Microsoft Azure Disk (Tech Preview) | ✅ | ✅ | ✅ 
+|Microsoft Azure Disk (Tech Preview) | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅
 |OpenStack Manila | ✅ | ✅ | ✅
-|Red Hat Virtualization (oVirt) | - | - | -
+|Red Hat Virtualization (oVirt) | - | - | ✅
 |VMware vSphere (Tech Preview) | - | - | -
 |===
 

--- a/modules/persistent-storage-rhv.adoc
+++ b/modules/persistent-storage-rhv.adoc
@@ -11,7 +11,7 @@ When you create a `PersistentVolumeClaim` (PVC) object, {product-title} provisio
 
 .Procedure
 
-* If you are using the we console to dynamically create a persistent volume on {rh-virtualization}:
+* If you are using the web console to dynamically create a persistent volume on {rh-virtualization}:
 +
 . In the {product-title} console, click *Storage* -> *Persistent Volume Claims*.
 . In the persistent volume claims overview, click *Create Persistent Volume Claim*.
@@ -45,7 +45,7 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-    storage: <volume size>  <2>
+      storage: <volume size>  <2>
   volumeMode: <volume mode> <3>
 ----
 <1> Name of the required storage class.

--- a/post_installation_configuration/storage-configuration.adoc
+++ b/post_installation_configuration/storage-configuration.adoc
@@ -53,6 +53,8 @@ include::modules/dynamic-provisioning-gce-definition.adoc[leveloffset=+2]
 
 include::modules/dynamic-provisioning-vsphere-definition.adoc[leveloffset=+2]
 
+include::modules/ovirt-csi-driver-storage-class.adoc[leveloffset=+2]
+
 include::modules/dynamic-provisioning-change-default-class.adoc[leveloffset=+1]
 
 [id="post-install-optimizing-storage"]


### PR DESCRIPTION
enterprise_4.9

For versions 4.9+

https://bugzilla.redhat.com/show_bug.cgi?id=1980340

Direct link to doc preview: 
deploy-preview-34475--osdocs.netlify.app/?utm_source=github&utm_campaign=bot_dp

For each item in bug comment 2:

1. CSI drivers supported by OpenShift container platform Table 1:

https://deploy-preview-34475--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

2. and 4. oVirt CSI driver storage class (code example):
https://deploy-preview-34475--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ovirt.html#ovirt-csi-driver-storage-class_persistent-storage-csi-ovirt

3. Creating a persistent volume on RHV > pvc-ovirt.yaml:
https://deploy-preview-34475--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ovirt.html#persistent-storage-rhv_persistent-storage-csi-ovirt

5. Add a section for RHV/oVirt just as there are specifics for other providers. Use code example from previous item.
https://deploy-preview-34475--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/storage-configuration.html#ovirt-csi-driver-storage-class_post-install-storage-configuration