### PR TITLE
BZ1981717: Cannot deploy MTC on 3.10

### DIFF
--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -36,3 +36,4 @@ This release has the following known issues:
 * PV resizing does not work as expected for AWS gp2 storage unless the `pv_resizing_threshold` is 42% or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973148[*BZ#1973148*])
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 * Microsoft Azure storage is unavailable if you create more than 400 migration plans. The `MigStorage` custom resource displays the following message: `The request is being throttled as the limit has been reached for operation type`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977226[*BZ#1977226*])
+* The current release cannot be deployed on {product-title} 3.10.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1981717

Add known issue to MTC 1.5 RN.

4.8

No QE required.