### PR TITLE
sysctls: mention NTO as a way to set node-level sysctls.

### DIFF
--- a/modules/nodes-containers-sysctls-about.adoc
+++ b/modules/nodes-containers-sysctls-about.adoc
@@ -44,7 +44,9 @@ version and distributor.
 Sysctls that are not namespaced are called _node-level_ and must be set
 manually by the cluster administrator, either by means of the underlying Linux
 distribution of the nodes, such as by modifying the *_/etc/sysctls.conf_* file,
-or by using a daemon set with privileged containers.
+or by using a daemon set with privileged containers. You can use
+the Node Tuning Operator to set _node-level_ sysctls.
+
 
 [NOTE]
 ====

--- a/nodes/containers/nodes-containers-sysctls.adoc
+++ b/nodes/containers/nodes-containers-sysctls.adoc
@@ -11,7 +11,8 @@ toc::[]
 Sysctl settings are exposed via Kubernetes, allowing users to modify certain
 kernel parameters at runtime for namespaces within a container. Only sysctls
 that are namespaced can be set independently on pods. If a sysctl is not
-namespaced, called _node-level_, it cannot be set within {product-title}.
+namespaced, called _node-level_, you must use another method of setting the sysctl, such as the
+xref:../../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Node Tuning Operator].
 Moreover, only those sysctls considered _safe_ are whitelisted by default; you
 can manually enable other _unsafe_ sysctls on the node to be available to the
 user.


### PR DESCRIPTION
OpenShift documentation wrongly states that _node-level_ sysctls cannot be set on the OpenShift platform.  Fix this and also mention NTO elsewhere as a way to set node-level sysctls.