### PR TITLE
BZ1966642: updated load balancer source range documentation

### DIFF
--- a/modules/nw-create-load-balancer-service.adoc
+++ b/modules/nw-create-load-balancer-service.adoc
@@ -38,15 +38,24 @@ spec:
   - name: db
     port: 3306 <2>
   loadBalancerIP:
-  type: LoadBalancer <3>
+  loadBalancerSourceRanges: <3>
+  - 10.0.0.0/8
+  - 192.168.0.0/16
+  type: LoadBalancer <4>
   selector:
-    name: mysql <4>
+    name: mysql <5>
 ----
 <1> Enter a descriptive name for the load balancer service.
 <2> Enter the same port that the service you want to expose is listening on.
-<3> Enter `loadbalancer` as the type.
-<4> Enter the name of the service.
-
+<3> Enter a list of specific IP addresses to restrict traffic through the load balancer. This field is ignored if the cloud-provider does not support the feature.
+<4> Enter `Loadbalancer` as the type.
+<5> Enter the name of the service.
++
+[NOTE]
+====
+To restrict traffic through the load balancer to specific IP addresses, it is recommended to use the `service.beta.kubernetes.io/load-balancer-source-ranges` annotation rather than setting the `loadBalancerSourceRanges` field.
+With the annotation, you can more easily migrate to the OpenShift API, which will be implemented in a future release.
+====
 . Save and exit the file.
 
 . Run the following command to create the service:


### PR DESCRIPTION
Applicable for 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1966642

Doc preview link: https://deploy-preview-34517--osdocs.netlify.app/openshift-enterprise/latest/rest_api/network_apis/service-core-v1?utm_source=github&utm_campaign=bot_dp

Requires approval from @Miciah 
Requires QA approval from @lihongan 
