### PR TITLE
[enterprise-4.6] Add OVN-Kubernetes egress firewall 8,000 rule limit

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -61,7 +61,7 @@ An egress firewall has the following limitations:
 * No project can have more than one {kind} object.
 
 ifdef::ovn[]
-* A maximum of one {kind} object with a maximum of 50 rules can be defined per project.
+* A maximum of one {kind} object with a maximum of 8,000 rules can be defined per project.
 endif::ovn[]
 
 ifdef::openshift-sdn[]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2306

Preview: https://deploy-preview-34537--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn#limitations-of-an-egress-firewall_configuring-egress-firewall-ovn