### PR TITLE
BZ1939165: Steps to update global pull secret

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -9,7 +9,7 @@
 [id="images-update-global-pull-secret_{context}"]
 = Updating the global cluster pull secret
 
-You can update the global pull secret for your cluster.
+You can update the global pull secret for your cluster by either replacing the current pull secret or appending a new pull secret.
 
 [WARNING]
 ====
@@ -25,16 +25,39 @@ As of {product-title} 4.7, changes to the global pull secret no longer trigger a
 
 .Prerequisites
 
-* You have a new or modified pull secret file to upload.
 * You have access to the cluster as a user with the `cluster-admin` role.
 
-.Procedure
 
-* Enter the following command to update the global pull secret for your cluster:
+.Procedure
+. Optional: To append a new pull secret to the existing pull secret, complete the following steps:
+
+.. Enter the following command to download the pull secret:
 +
 [source,terminal]
 ----
-$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=<pull-secret-location> <1>
+$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' ><pull_secret_location> <1>
+----
+<1> Provide the path to the pull secret file.
+
+.. Enter the following command to add the new pull secret:
++
+[source,terminal]
+----
+$ oc registry login --registry="<registry>" \ <1>
+--auth-basic="<username>:<password>" \ <2>
+--to=<pull_secret_location> <3>
+----
+<1> Provide the new registry.
+<2> Provide the credentials of the new registry.
+<3> Provide the path to the pull secret file.
++
+Alternatively, you can perform a manual update to the pull secret file.
+
+. Enter the following command to update the global pull secret for your cluster:
++
+[source,terminal]
+----
+$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=<pull_secret_location> <1>
 ----
 <1> Provide the path to the new pull secret file.
 


### PR DESCRIPTION
Fix for bug [BZ1939165](https://bugzilla.redhat.com/show_bug.cgi?id=1939165)
Targeted for releases 4.7 and 4.8

PR for 4.6: https://github.com/openshift/openshift-docs/pull/34628

Here's the [preview link](https://deploy-preview-34539--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets)

@dmage - Kindly help with SME review
@wzheng1 - Kindly help with QE review