### PR TITLE
SRVKS-657: Add module for custom route labels and annotations

### DIFF
--- a/modules/serverless-customize-labels-annotations-routes.adoc
+++ b/modules/serverless-customize-labels-annotations-routes.adoc
@@ -1,0 +1,52 @@
+[id="serverless-customize-labels-annotations-routes_{context}"]
+= Customizing labels and annotations for {product-title} routes
+
+{product-title} routes support the use of custom labels and annotations, which you can configure by modifying the `metadata` spec of a Knative service. Custom labels and annotations are propagated from the service to the Knative route, then to the Knative ingress, and finally to the {product-title} route.
+
+.Prerequisites
+
+* You must have the {ServerlessOperatorName} and Knative Serving installed on your {product-title} cluster.
+
+.Procedure
+
+. Create a Knative service that contains the label or annotation that you want to propagate to the {product-title} route:
+** To create a service by using YAML:
++
+.Example service created by using YAML
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: <service_name>
+  labels:
+    <label_name>: <label_value>
+  annotations:
+    <annotation_name>: <annotation_value>
+...
+----
+** To create a service by using the `kn` CLI, enter:
++
+.Example service created by using a `kn` command
+[source,terminal]
+----
+$ kn service create <service_name> \
+  --image=<image> \
+  --annotation <annotation_name>=<annotation_value> \
+  --label <label_value>=<label_value>
+----
+
+. Verify that the {product-title} route has been created with the annotation or label that you added by inspecting the output from the following command:
++
+.Example command for verification
+[source,terminal]
+----
+$ oc get routes.route.openshift.io \
+     -l serving.knative.openshift.io/ingressName=<service_name> \ <1>
+     -l serving.knative.openshift.io/ingressNamespace=<service_namespace> \ <2>
+     -n knative-serving-ingress -o yaml \
+         | grep -e "<label_name>: \"<label_value>\""  -e "<annotation_name>: <annotation_value>" <3>
+----
+<1> Use the name of your service.
+<2> Use the namespace where your service was created.
+<3> Use your values for the label and annotation names and values.

--- a/serverless/knative_serving/serverless-configuring-routes.adoc
+++ b/serverless/knative_serving/serverless-configuring-routes.adoc
@@ -12,5 +12,11 @@ You can disable Operator control of {product-title} routing so that you can conf
 
 Knative routes can also be used alongside the {product-title} route to provide additional fine-grained routing capabilities, such as traffic splitting.
 
+include::modules/serverless-customize-labels-annotations-routes.adoc[leveloffset=+1]
 include::modules/serverless-openshift-routes.adoc[leveloffset=+1]
 include::modules/knative-service-cluster-local.adoc[leveloffset=+1]
+
+[id="additional-resources_serverless-configuring-routes"]
+== Additional resources
+
+* For more information about supported {product-title} route annotations, see xref:../..//networking/routes/route-configuration.adoc#nw-route-specific-annotations_route-configuration[Route-specific annotations].


### PR DESCRIPTION
Applies for OCP 4.6+

Jira: https://issues.redhat.com/browse/SRVKS-657

Direct preview links:

- https://deploy-preview-34553--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-configuring-routes.html#serverless-customize-labels-annotations-routes_serverless-configuring-routes
- https://deploy-preview-34553--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-configuring-routes.html#additional-resources_serverless-configuring-routes