### PR TITLE
Kuryr: Add a 4.5 known issue

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -1807,6 +1807,8 @@ This script removes unauthenticated subjects from the following cluster role bin
 // TODO: This known issue should carry forward to 4.6 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
+* Instances of kuryr-controller might crash if the cluster includes services for which all member pods are not ready. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1980957[*BZ#1980957*])
+
 [id="ocp-4-5-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Bug [1] describes a Kuryr issue manifesting when there are some Services
that are having all the pods in not ready state. This causes crashes of
kuryr-controller. This commit adds that to known issues. The problem is
fixed in 4.6.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=1980957