### PR TITLE
SRVCOM-1430: Updated 1.16.0 release notes

### DIFF
--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -12,13 +12,19 @@
 * The `kn func` CLI plug-in now uses `func` 0.16.0.
 * The `kn func emit` command has been added to the functions `kn` plug-in. You can use this command to send events to test locally deployed functions.
 
-[id="fixed-issues-1-16-0_{context}"]
-== Fixed issues
-
 [id="known-issues-1-16-0_{context}"]
 == Known issues
 
-// Add a note about the following to the mTLS docs when they're ready to merge
+* The AMQ Streams Operator might prevent the installation or upgrade of the {ServerlessOperatorName}. If this happens, the following error is thrown by Operator Lifecycle Manager (OLM):
++
+[source,terminal]
+----
+WARNING: found multiple channel heads: [amqstreams.v1.7.2 amqstreams.v1.6.2], please check the `replaces`/`skipRange` fields of the operator bundles.
+----
++
+You can fix this issue by uninstalling the AMQ Streams Operator before installing or upgrading the {ServerlessOperatorName}. You can then reinstall the AMQ Streams Operator.
+
+// Added note about the following to admin and dev metrics assemblies - remove these if the issue gets resolved.
 * If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
 +
 If you want to enable Knative Serving metrics for use with Service Mesh and mTLS, you must complete the following steps:

--- a/serverless/admin_guide/serverless-admin-metrics.adoc
+++ b/serverless/admin_guide/serverless-admin-metrics.adoc
@@ -14,6 +14,13 @@ Metrics enable cluster administrators to monitor how {ServerlessProductName} clu
 * See the {product-title} documentation on xref:../../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics] for information about enabling metrics for your cluster.
 * To view metrics for Knative components on {product-title}, you need cluster administrator permissions, and access to the web console *Administrator* perspective.
 
+[WARNING]
+====
+If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
+
+For information about resolving this issue, see the xref:../../serverless/serverless-release-notes.adoc#serverless-rn-1-16-0_serverless-release-notes[Serverless 1.16.0 release notes].
+====
+
 // Common metrics
 include::modules/serverless-controller-metrics.adoc[leveloffset=+1]
 include::modules/serverless-webhook-metrics.adoc[leveloffset=+1]

--- a/serverless/knative_serving/serverless-serving-metrics.adoc
+++ b/serverless/knative_serving/serverless-serving-metrics.adoc
@@ -13,4 +13,11 @@ Metrics enable developers to monitor how Knative services are performing.
 
 * To view metrics for Knative components on {product-title}, you need access to the web console *Developer* perspective.
 
+[WARNING]
+====
+If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
+
+For information about resolving this issue, see the xref:../../serverless/serverless-release-notes.adoc#serverless-rn-1-16-0_serverless-release-notes[Serverless 1.16.0 release notes].
+====
+
 include::modules/serverless-queue-proxy-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies for OCP 4.6+

Jira: https://issues.redhat.com/browse/SRVCOM-1430

Direct preview links:
- release notes: https://deploy-preview-34567--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-16-0_serverless-release-notes
- metrics notes:
  - https://deploy-preview-34567--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-admin-metrics.html#prerequisites_serverless-admin-metrics
  - https://deploy-preview-34567--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-serving-metrics.html#prerequisites_serverless-metrics