### PR TITLE
[enterprise-4.6] MHC: Improve explanation of maxUnhealthy

### DIFF
--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -41,7 +41,7 @@ spec:
 <3> Specify a label for the machine pool that you want to check.
 <4> Specify the machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
 <5> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
-<6> Specify the amount of unhealthy machines allowed in the targeted pool. This can be set as a percentage or an integer.
+<6> Specify the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
 <7> Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
 
 [NOTE]
@@ -77,7 +77,7 @@ spec:
 <2> Specify a label for the machine pool that you want to check.
 <3> Specify the machine set to track in `<cluster_name>-<label>-<zone>` format. For example, `prod-node-us-east-1a`.
 <4> Specify the timeout duration for a node condition. If a condition is met for the duration of the timeout, the machine will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy machine.
-<5> Specify the amount of unhealthy machines allowed in the targeted pool. This can be set as a percentage or an integer.
+<5> Specify the amount of machines allowed to be concurrently remediated in the targeted pool. This can be set as a percentage or an integer. If the number of unhealthy machines exceeds the limit set by `maxUnhealthy`, remediation is not performed.
 <6> Specify the timeout duration that a machine health check must wait for a node to join the cluster before a machine is determined to be unhealthy.
 
 [NOTE]


### PR DESCRIPTION
Cherry Picked from 882f758b7e65b114d7a486054570c3de8322148b xref: #33739

A value in a custom resource cannot control how many nodes are healthy.
The health of node depends on physcial reality. maxUnhealthy limits only
the amount of nodes that are to be remediating concurrently.

Signed-off-by: Dan Kenigsberg <danken@redhat.com>