### PR TITLE
RHDEVDOCS-2882 Tracker for Bug 1942908 - mention syslog prerequisite

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -18,6 +18,10 @@ endif::openshift-origin[]
 
 To send logs using the Fluentd *forward* protocol, create a configuration file called `secure-forward.conf`, that points to an external log aggregator. Then, use that file to create a config map called called `secure-forward` in the `openshift-logging` project, which {product-title} uses when forwarding the logs.
 
+.Prerequisites
+
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
+
 .Sample Fluentd configuration file
 
 [source,yaml]

--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-syslog_{context}"]
 = Forwarding logs using the legacy syslog method
 
-You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator, such as a syslog server, to receive log data from {product-title}.
+You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator, such as a syslog server, to receive the logs from {product-title}.
 
 [IMPORTANT]
 ====
@@ -18,6 +18,11 @@ There are two versions of the *syslog* protocol:
 * *out_syslog_buffered*: The buffered implementation, which communicates through TCP and link:https://docs.fluentd.org/buffer[buffers data into chunks].
 
 To send logs using the *syslog* protocol, create a configuration file called `syslog.conf`, with the information needed to forward the logs. Then, use that file to create a config map called `syslog` in the `openshift-logging` project, which {product-title} uses when forwarding the logs.
+
+.Prerequisites
+
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
+
 
 .Sample syslog configuration file
 [source,yaml]

--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -16,6 +16,10 @@ To forward logs to both an external and the internal Elasticsearch instance, cre
 If you want to forward logs to *only* the internal {product-title} Elasticsearch instance, you do not need to create a `ClusterLogForwarder` CR.
 ====
 
+.Prerequisites
+
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
+
 .Procedure
 
 . Create a `ClusterLogForwarder` CR YAML file similar to the following:

--- a/modules/cluster-logging-collector-log-forward-fluentd.adoc
+++ b/modules/cluster-logging-collector-log-forward-fluentd.adoc
@@ -14,6 +14,10 @@ To configure log forwarding using the *forward* protocol, create a `ClusterLogFo
 Alternately, you can use a config map to forward logs using the *forward* protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
 
+.Prerequisites
+
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
+
 .Procedure
 
 . Create a `ClusterLogForwarder` CR YAML file similar to the following:

--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -11,7 +11,7 @@ To configure forwarding application logs from a project, create a `ClusterLogFor
 
 .Prerequisites
 
-*  An external log aggregator that is configured to receive log data from {product-title} using the specified protocol.
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
 
 .Procedure
 

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-syslog_{context}"]
 = Forwarding logs using the syslog protocol
 
-You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator, such as a syslog server, to receive the logs from {product-title}.
 
 To configure log forwarding using the *syslog* protocol, create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
 
@@ -13,6 +13,10 @@ To configure log forwarding using the *syslog* protocol, create a `ClusterLogFor
 ====
 Alternately, you can use a config map to forward logs using the *syslog* RFC3164 protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
+
+.Prerequisites
+
+* You must have a logging server that is configured to receive the logging data using the specified protocol or format.
 
 .Procedure
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.5+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-2882
- Direct link to doc preview: https://deploy-preview-34584--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp and ctrl+f for "You must have a logging server that is" and also "such as a syslog server"
- SME review: @btaani  
- QE review: @kabirbhartiRH 
- Peer review: @missmesss
- All reviews complete. Please merge now.