### PR TITLE
BZ#1928021: Restricting container registries in Configuring image settings

### DIFF
--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -4,7 +4,7 @@
 // * post_installation_configuration/preparing-for-users.adoc
 
 [id="images-configuration-file_{context}"]
-= Configuring image settings
+= Configuring image registry settings
 
 You can configure image registry settings by editing the `image.config.openshift.io/cluster` custom resource (CR). The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to the registries and reboots the nodes when it detects changes.
 
@@ -44,6 +44,7 @@ spec:
     - quay.io
     - registry.redhat.io
     - image-registry.openshift-image-registry.svc:5000
+    - reg1.io/myrepo/myapp:latest
     insecureRegistries:
     - insecure.com
 status:
@@ -52,11 +53,15 @@ status:
 <1> `Image`: Holds cluster-wide information about how to handle images. The canonical, and only valid name is `cluster`.
 <2> `allowedRegistriesForImport`: Limits the container image registries from which normal users may import images. Set this list to the registries that you trust to contain valid images, and that you want applications to be able to import from. Users with permission to create images or `ImageStreamMappings` from the API are not affected by this policy. Typically only cluster administrators have the appropriate permissions.
 <3> `additionalTrustedCA`: A reference to a config map containing additional certificate authorities (CA) that are trusted during image stream import, pod image pull, `openshift-image-registry` pullthrough, and builds. The namespace for this config map is `openshift-config`. The format of the config map is to use the registry hostname as the key, and the PEM certificate as the value, for each additional registry CA to trust.
-<4> `registrySources`: Contains configuration that determines how the container runtime should treat individual registries when accessing images for builds and pods. For instance, whether or not to allow insecure access. It does not contain configuration for the internal cluster registry. This example lists `allowedRegistries`, which defines the registries that are allowed to be used. One of the registries listed is insecure.
+<4> `registrySources`: Contains configuration that determines whether the container runtime allows or blocks individual registries when accessing images for builds and pods.  Either the `allowedRegistries` parameter or the `blockedRegistries` parameter can be set, but not both. You can also define whether or not to allow access to insecure registries or registries that allow registries that use image short names. This example uses the `allowedRegistries` parameter, which defines the registries that are allowed to be used. The insecure registry `insecure.com` is also allowed. The `registrySources` paramter does not contain configuration for the internal cluster registry. 
 +
 [NOTE]
 ====
+When the `allowedRegistries` parameter is defined, all registries, including the registry.redhat.io and quay.io registries and the default internal image registry, are blocked unless explicitly listed. If you use the parameter, to prevent pod failure, you must add the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. Do not add the `registry.redhat.io` and `quay.io` registries to the `blockedRegistries` list.
+
 When using the `allowedRegistries`, `blockedRegistries`, or `insecureRegistries` parameter, you can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`.
+
+Insecure external registries should be avoided to reduce possible security risks.
 ====
 
 . To check that the changes are applied, list your nodes:

--- a/post_installation_configuration/preparing-for-users.adoc
+++ b/post_installation_configuration/preparing-for-users.adoc
@@ -118,18 +118,16 @@ include::modules/authentication-kubeadmin.adoc[leveloffset=+1]
 include::modules/authentication-remove-kubeadmin.adoc[leveloffset=+2]
 
 [id="post-install-image-configuration-resources"]
-== Image configuration resources
+== Image configuration
 Understand and configure image registry settings.
 
 include::modules/images-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/images-configuration-file.adoc[leveloffset=+2]
 
+For more information on the allowed, blocked, and insecure registry parameters, see xref:../openshift_images/image-configuration.adoc#images-configuration-file_image-configuration[Configuring image registry settings].
+
 include::modules/images-configuration-cas.adoc[leveloffset=+3]
-
-include::modules/images-configuration-insecure.adoc[leveloffset=+3]
-
-include::modules/images-configuration-shortname.adoc[leveloffset=+3]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+3]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1928021

When I updated and improved the topics on allowed, blocked, and insecure registries recently in the _[Image configuration resources](https://docs.openshift.com/container-platform/4.7/openshift_images/image-configuration.html#images-configuration-file_image-configuration)_ assembly,I didn't bring the changes to the post-install _[Preparing for users](https://docs.openshift.com/container-platform/4.6/post_installation_configuration/preparing-for-users.html#images-configuration-file_post-install-preparing-for-users)_ module well enough.

With this PR I added some of the new information that I had added to _Image configuration_ to _Preparing for users_ and put a link to _Image configuration resources_.  

Direct preview link: https://deploy-preview-34585--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html#images-configuration-file_post-install-preparing-for-users