### PR TITLE
OSDOCS-2302: Added backup and restore content to OpenShift Online Pro 3.11 documentation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -238,6 +238,13 @@ Topics:
   - Name: AWS Service Broker
     File: aws_broker
 ---
+Name: Backup and Restore
+Dir: admin_guide
+Distros: openshift-online
+Topics:
+- Name: Backing up and restoring applicatons and projects
+  File: assembly_backing-up-restoring-project-application
+---
 Name: Container Security Guide
 Dir: security
 Distros: openshift-enterprise,openshift-origin

--- a/admin_guide/assembly_backing-up-restoring-project-application.adoc
+++ b/admin_guide/assembly_backing-up-restoring-project-application.adoc
@@ -1,5 +1,5 @@
 [[assembly_backup-restore-project-application]]
-= Backing up and restoring projects and applications
+= Backing up and restoring applications and projects
 {product-author}
 {product-version}
 :data-uri:
@@ -12,7 +12,7 @@
 
 toc::[]
 
-You can manually back up and restore data for your projects and applications.
+You can manually back up and restore data for your applications and projects.
 
 [IMPORTANT]
 ====

--- a/day_two_guide/topics/proc_backing-up-project.adoc
+++ b/day_two_guide/topics/proc_backing-up-project.adoc
@@ -102,4 +102,3 @@ $ oc get dc ruby-ex -o jsonpath="{.spec.template.spec.containers[].image}"
 +
 If importing the `deploymentconfig` as it is exported with `oc get --export` it fails
 if the image does not exist.
-+


### PR DESCRIPTION
For OpenShift Online Pro 3.11

[Jira [OSDOCS-2302](https://issues.redhat.com/browse/OSDOCS-2302)](https://issues.redhat.com/browse/OSDOCS-2302): Add back up and restore topics to OpenShift Online Pro 3.11 documentation

For QE: @yasun1 and @xueli181114.
SME: @wgordon17 

Review the backup and restore content in Openshift Online Pro documentation here:
http://file.rdu.redhat.com/nalhadef/072121/osdocs-2302/admin_guide/assembly_backing-up-restoring-project-application.html (disregard the Netlify link)