### PR TITLE
RHDEVDOCS-2882-2: Tracker for Bug 1942908 - Include prerequisites sect…

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-fluentd_{context}"]
 = Forwarding logs using the legacy Fluentd method
 
-You can use the Fluentd *forward* protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the Fluentd *forward* protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive log data from {product-title}.
 
 [IMPORTANT]
 ====

--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-legacy-syslog_{context}"]
 = Forwarding logs using the legacy syslog method
 
-You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the *syslog* RFC3164 protocol to send logs to destinations outside of your {product-title} cluster by creating a configuration file and config map. You are responsible for configuring the external log aggregator, such as a syslog server, to receive log data from {product-title}.
 
 [IMPORTANT]
 ====

--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-es_{context}"]
 = Forwarding logs to an external Elasticsearch instance
 
-You can optionally forward logs to an external Elasticsearch instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can optionally forward logs to an external Elasticsearch instance in addition to, or instead of, the internal {product-title} Elasticsearch instance. You are responsible for configuring the external log aggregator to receive log data from {product-title}.
 
 To configure log forwarding to an external Elasticsearch instance, create a `ClusterLogForwarder` custom resource (CR) with an output to that instance and a pipeline that uses the output. The external Elasticsearch output can use the HTTP (insecure) or HTTPS (secure HTTP) connection.
 
@@ -66,7 +66,7 @@ spec:
 <9> Specify the output to use with that pipeline for forwarding the logs.
 <10> Optional: Specify the `default` output to send the logs to the internal Elasticsearch instance.
 <11> Optional: One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
@@ -79,8 +79,7 @@ spec:
 $ oc create -f <file-name>.yaml
 ----
 
-The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. If the pods do not redeploy, you can delete the Fluentd
-pods to force them to redeploy.
+The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. If the pods do not redeploy, you can delete the Fluentd pods to force them to redeploy.
 
 [source,terminal]
 ----

--- a/modules/cluster-logging-collector-log-forward-fluentd.adoc
+++ b/modules/cluster-logging-collector-log-forward-fluentd.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-fluentd_{context}"]
 = Forwarding logs using the Fluentd forward protocol
 
-You can use the Fluentd *forward* protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the Fluentd *forward* protocol to send a copy of your logs to an external log aggregator that you have configured to accept the protocol. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator to receive log data from {product-title}.
 
 To configure log forwarding using the *forward* protocol, create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the Fluentd servers and pipelines that use those outputs. The Fluentd output can use a TCP (insecure) or TLS (secure TCP) connection.
 
@@ -13,6 +13,10 @@ To configure log forwarding using the *forward* protocol, create a `ClusterLogFo
 ====
 Alternately, you can use a config map to forward logs using the *forward* protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
+
+.Prerequisites
+
+*  An external log aggregator that is configured to receive log data from {product-title} using the Fluentd *forward* protocol.
 
 .Procedure
 
@@ -64,7 +68,7 @@ spec:
 <9> Specify the output to use  with that pipeline for forwarding the logs.
 <10> Optional. Specify the `default` output to forward logs to the internal Elasticsearch instance.
 <11> Optional. One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.

--- a/modules/cluster-logging-collector-log-forward-kafka.adoc
+++ b/modules/cluster-logging-collector-log-forward-kafka.adoc
@@ -70,7 +70,7 @@ spec:
 <9> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <10> Specify the output to use with that pipeline for forwarding the logs.
 <11> Optional: One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.

--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -5,9 +5,13 @@
 [id="cluster-logging-collector-log-forward-project_{context}"]
 = Forwarding application logs from specific projects
 
-You can use the Cluster Log Forwarder to send a copy of the application logs from specific projects to an external log aggregator instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+You can use the Cluster Log Forwarder to send a copy of the application logs from specific projects to an external log aggregator. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator to receive log data from {product-title}.
 
 To configure forwarding application logs from a project, create a `ClusterLogForwarder` custom resource (CR) with at least one input from a project, optional outputs for other log aggregators, and pipelines that use those inputs and outputs.
+
+.Prerequisites
+
+*  An external log aggregator that is configured to receive log data from {product-title} using the specified protocol.
 
 .Procedure
 

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -5,14 +5,16 @@
 [id="cluster-logging-collector-log-forward-syslog_{context}"]
 = Forwarding logs using the syslog protocol
 
-You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
-
-To configure log forwarding using the *syslog* protocol, create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
+You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator that you have configured to accept the protocol. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator, such as a syslog server, to receive log data from {product-title}.
 
 [NOTE]
 ====
 Alternately, you can use a config map to forward logs using the *syslog* RFC3164 protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
+
+.Prerequisites
+
+*  An external log aggregator, such as a syslog server, that is configured to receive log data from {product-title} using the RFC3164 or RFC5424 protocol.
 
 .Procedure
 
@@ -79,7 +81,7 @@ spec:
 <10> Specify the output to use  with that pipeline for forwarding the logs.
 <11> Optional: Specify the `default` output to forward logs to the internal Elasticsearch instance.
 <12> Optional: One or more labels to add to the logs.
-<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -127,10 +127,10 @@ spec:
 ** Specify the URL and port of the Kafka broker as a valid absolute URL, including the prefix.
 <6> Configuration for an input to filter application logs from the `my-namespace` project.
 <7> Configuration for a pipeline to send audit logs to the secure external Elasticsearch instance:
-** Optional. A name to describe the pipeline.
-** The `inputRefs` is the log type, in this example `audit`.
-** The `outputRefs` is the name of the output to use, in this example `elasticsearch-secure` to forward to the secure Elasticsearch instance and `default` to forward to the internal Elasticsearch instance.
-** Optional: Labels to add to the logs.
+** Optional: For `name`, you can give a name that describes the pipeline.
+** For `inputRefs`, name one or more log types as the inputs for this pipeline.
+** For `outputRefs`, provide the name of one or more outputs to use. For example, `elasticsearch-secure` forwards the audit log data to a secure Elasticsearch instance and `default` forwards the data to the internal Elasticsearch instance.
+** Optional: For `labels` you can specify labels to add to the logs.
 <8> Configuration for a pipeline to send infrastructure logs to  the insecure external Elasticsearch instance:
 <9> Configuration for a pipeline to send logs from the `my-project` project to the internal Elasticsearch instance.
 ** Optional. A name to describe the pipeline.


### PR DESCRIPTION
…ion when using clusterlogforwarder for syslog

Purpose: Suggest using a syslog server to receive syslog outputs from the cluster log forwarder. I did this by adding the phrase, "such as a syslog server," to various syslog topics. Also fix some typos and minor style issues.
 
- Aligned team: Dev Tools
- For branches: 4.5+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-2882
- Direct link to doc preview: https://deploy-preview-34587--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-log-forward-syslog_cluster-logging-external
- SME review: not needed, wording change.
- QE reviewed by @anpingli 
- Peer review by @Srivaralakshmi 
- All reviews complete. Please merge now.