### PR TITLE
Configure the provisioner node with a IPv4 address

### DIFF
--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -134,7 +134,7 @@ $ sudo nohup bash -c "
     nmcli con delete \"$PROV_CONN\"
     nmcli connection add ifname provisioning type bridge con-name provisioning
     nmcli con add type bridge-slave ifname \"$PROV_CONN\" master provisioning
-    nmcli connection modify provisioning ipv6.addresses fd00:1101::1/64 ipv6.method manual
+    nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 ipv4.method manual ipv6.addresses fd00:1101::1/64 ipv6.method manual
     nmcli con down provisioning
     nmcli con up provisioning
 "

--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -134,7 +134,8 @@ $ sudo nohup bash -c "
     nmcli con delete \"$PROV_CONN\"
     nmcli connection add ifname provisioning type bridge con-name provisioning
     nmcli con add type bridge-slave ifname \"$PROV_CONN\" master provisioning
-    nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 ipv4.method manual ipv6.addresses fd00:1101::1/64 ipv6.method manual
+    nmcli connection modify provisioning ipv4.addresses 172.22.0.1/24 \
+      ipv4.method manual ipv6.addresses fd00:1101::1/64 ipv6.method manual
     nmcli con down provisioning
     nmcli con up provisioning
 "


### PR DESCRIPTION
The default provisioningNetworkCIDR is 172.22.0.0/24. Configure the
first IP address in the provisioner node so it can communicate with the
bootstrap node.