### PR TITLE
BZ1903383: Is fixed for 4.8 therefore removing the restriction

### DIFF
--- a/modules/installation-full-ibm-z-kvm-user-infra-machines-iso.adoc
+++ b/modules/installation-full-ibm-z-kvm-user-infra-machines-iso.adoc
@@ -54,12 +54,7 @@ $ virt-install \
    --network network={virt_network_parm} \
    --boot hd \
    --location {media_location},kernel={rhcos_kernel},initrd={rhcos_initrd} \
-   --extra-args "rd.neednet=1 dfltcc=off coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url={rhcos_liveos} ip={ip}::{default_gateway}:{subnet_mask_length}:{vn_name}:enc1:none:{MTU} nameserver={dns} coreos.inst.ignition_url={rhcos_ign}" \
+   --extra-args "rd.neednet=1 coreos.inst=yes coreos.inst.install_dev=vda coreos.live.rootfs_url={rhcos_liveos} ip={ip}::{default_gateway}:{subnet_mask_length}:{vn_name}:enc1:none:{MTU} nameserver={dns} coreos.inst.ignition_url={rhcos_ign}" \
    --noautoconsole \
    --wait
 ----
-+
-[NOTE]
-====
-`dfltcc=off` is required for IBM z15 and LinuxONE III.
-====

--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -58,18 +58,13 @@ Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 +
 [source,terminal]
 ----
-rd.neednet=1 dfltcc=off console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
+rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
 cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
 coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
 rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
 !condev rd.dasd=0.0.3490
 ----
-+
-[NOTE]
-====
-`dfltcc=off` is required for IBM z15 and LinuxONE III.
-====
 
 ** For installations on FCP-type disks, complete the following tasks:
 ... Use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. For multipathing repeat this step for each additional path.
@@ -96,7 +91,7 @@ The following is an example parameter file `worker-1.parm` for a worker node wit
 +
 [source,terminal]
 ----
-rd.neednet=1 dfltcc=off console=ttysclp0 coreos.inst.install_dev=sda
+rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=sda
 coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
 coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
@@ -107,11 +102,6 @@ rd.zfcp=0.0.19C7,0x50050763070bc5e3,0x4008400B00000000
 rd.zfcp=0.0.1987,0x50050763071bc5e3,0x4008400B00000000
 rd.zfcp=0.0.19C7,0x50050763071bc5e3,0x4008400B00000000
 ----
-+
-[NOTE]
-====
-`dfltcc=off` is required for IBM z15 and LinuxONE III.
-====
 
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to z/VM, for example with FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-installing-zvm-s390[Installing under Z/VM].
 . Punch the files to the virtual reader of the z/VM guest virtual machine that is to become your bootstrap node.


### PR DESCRIPTION
- OCP version: 4.8 and later (fix for 4.7 will be rebased after 4.8 GA therefore only cherrypick to 4.8) 

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=190338
- Reviewer: Wolfgang Voesch
- Preview pages:
   - [Installing a cluster with z/VM on IBM Z and LinuxONE](https://deploy-preview-34590--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z)
   - [Installing a cluster with z/VM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-34590--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-restricted-networks-ibm-z)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE](https://deploy-preview-34590--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#installation-user-infra-machines-iso-ibm-z-kvm-full_installing-ibm-z-kvm)
   - [Installing a cluster with RHEL KVM on IBM Z and LinuxONE in a restricted network](https://deploy-preview-34590--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.html#installation-user-infra-machines-iso-ibm-z-kvm-full_installing-restricted-networks-ibm-z-kvm)