### PR TITLE
routes must conform with DNS 1123 in 4.6+

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2386,6 +2386,8 @@ This caused image pulls to fail against the inaccessible private registry, norma
 
 * Currently, a Kubernetes port collision issue can cause a breakdown in pod-to-pod communication, even after pods are redeployed. For detailed information and a workaround, see the Red Hat Knowledge Base solution link:https://access.redhat.com/solutions/5940711[Port collisions between pod and cluster IPs on OpenShift 4 with OVN-Kubernetes]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939676[*BZ#1939676*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1939045[*BZ#1939045*])
 
+* Route names that do not conform to DNS 1123 naming conventions (should be a domain with at least two segments separated by dots) are now rejected. If applications exist with invalid DNS names, these will be unreachable until a valid spec.host is utilized. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957584[*BZ#1957584*])
+
 [id="ocp-4-6-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
In 4.6+, short routes are no longer allowed. Routes must conform to DNS 1123 naming conventions. Existing routes which are invalid will not work following an upgrade to 4.6+

@openshift/team-documentation