### PR TITLE
Bug 1867186: correct router.openshift.io/cookie-same-site variable name

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -38,7 +38,7 @@ The maximum number of IP addresses and CIDR ranges allowed in a whitelist is 61.
 |`haproxy.router.openshift.io/hsts_header` | Sets a Strict-Transport-Security header for the edge terminated or re-encrypt route. |
 |`haproxy.router.openshift.io/log-send-hostname` | Sets the `hostname` field in the Syslog header. Uses the host name of the system. `log-send-hostname` is enabled by default if any Ingress API logging method, such as sidecar or Syslog facility, is enabled for the router. |
 |`haproxy.router.openshift.io/rewrite-target` | Sets the rewrite path of the request on the backend. |
-|`haproxy.router.openshift.io/cookie-same-site` | Sets a value to restrict cookies. The values are:
+|`router.openshift.io/cookie-same-site` | Sets a value to restrict cookies. The values are:
 
 `Lax`: cookies are transferred between the visited site and third-party sites.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1867186

Preview: https://deploy-preview-34610--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration?utm_source=github&utm_campaign=bot_dp#nw-route-specific-annotations_route-configuration