### PR TITLE
Replace example kernel argument in Butane introduction

### DIFF
--- a/modules/installation-special-config-butane-create.adoc
+++ b/modules/installation-special-config-butane-create.adoc
@@ -13,19 +13,19 @@ You can use Butane to produce a `MachineConfig` object so that you can configure
 
 .Procedure
 
-. Create a Butane config file. The following example creates a file named `99-worker-console.bu` that configures the system console to use the second serial port and specifies custom settings for the chrony time service:
+. Create a Butane config file. The following example creates a file named `99-worker-custom.bu` that configures the system console to show kernel debug messages and specifies custom settings for the chrony time service:
 +
 [source,yaml]
 ----
 variant: openshift
 version: 4.8.0
 metadata:
-  name: 99-worker-console
+  name: 99-worker-custom
   labels:
     machineconfiguration.openshift.io/role: worker
 openshift:
   kernel_arguments:
-    - console=ttyS1,115200
+    - loglevel=7
 storage:
   files:
     - path: /etc/chrony.conf
@@ -42,14 +42,14 @@ storage:
 +
 [NOTE]
 ====
-The `99-worker-console.bu` file is set to create a machine config for worker nodes. To deploy on control plane nodes, change the role from `worker` to `master`. To do both, you could repeat the whole procedure using different file names for the two types of deployments.
+The `99-worker-custom.bu` file is set to create a machine config for worker nodes. To deploy on control plane nodes, change the role from `worker` to `master`. To do both, you could repeat the whole procedure using different file names for the two types of deployments.
 ====
 
 . Create a `MachineConfig` object by giving Butane the file that you created in the previous step:
 +
 [source,terminal]
 ----
-$ butane 99-worker-console.bu -o ./99-worker-console.yaml
+$ butane 99-worker-custom.bu -o ./99-worker-custom.yaml
 ----
 +
 A `MachineConfig` object YAML file is created for you to finish configuring your machines.
@@ -58,5 +58,5 @@ A `MachineConfig` object YAML file is created for you to finish configuring your
 +
 [source,terminal]
 ----
-$ oc create -f 99-worker-console.yaml
+$ oc create -f 99-worker-custom.yaml
 ----


### PR DESCRIPTION
As pointed out in https://github.com/openshift/openshift-docs/pull/34317#issuecomment-880767451, `console=ttyS1,115200` has no effect because the first console of each type wins, and RHCOS configures `console=ttyS0,115200` by default.