### PR TITLE
ROSA STS: Fix role creation script

### DIFF
--- a/modules/rosa-sts-creating-cluster.adoc
+++ b/modules/rosa-sts-creating-cluster.adoc
@@ -188,12 +188,12 @@ $ ccoctl aws create-iam-roles \
   --region ${region} \
   --dry-run
 
-$ for role in `find . -name "*-role.json"` 
-do 
+$ for role in `find . -name "*-role.json"`
+do
   policy=$(sed -e 's/05-/06-/' -e 's/role/policy/' <<< ${role})
-  role_name=$(grep RoleName ${policy} | awk '{print $2}' | awk -F '"' '{print $2}')
+  role_name=$(grep --color=never -o "RoleName\":\"(\w|-)*" ${policy} | sed "s/RoleName\":\"//")
   aws iam create-role --cli-input-json file://${role}
-  sed -i.bak '/RoleName/d' ${policy}
+  sed -i.bak 's/,"RoleName":".*"//' ${policy}
   policy_arn=$(aws iam create-policy --output json --cli-input-json file://$policy | grep Arn | awk '{print $2}' | awk -F '"' '{print $2}')
   aws iam attach-role-policy --role-name $role_name --policy-arn $policy_arn
   rm ${policy}


### PR DESCRIPTION
Since the latest version of ccoctl, the script to create roles and
policies does not match the output of the generated JSON files.

https://issues.redhat.com/browse/OSDOCS-2324