### PR TITLE
Bugfix: Fix xrefs and prepend link: to external links

### DIFF
--- a/serverless/functions/serverless-functions-yaml.adoc
+++ b/serverless/functions/serverless-functions-yaml.adoc
@@ -20,7 +20,7 @@ include::modules/serverless-functions-func-yaml-environment-variables.adoc[level
 
 .Additional resources
 
-* For information on overriding values in the `func.yaml` file, see xref:serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].
-* For more information on accessing data in secrets and config maps, see xref:serverless-functions-accessing-secrets-configmaps.adoc#serverless-functions-accessing-secrets-configmaps[Accessing secrets and config maps from Serverless functions].
+* For information on overriding values in the `func.yaml` file, see xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-functions-getting-started[Getting started with functions].
+* For more information on accessing data in secrets and config maps, see xref:../../serverless/functions/serverless-functions-accessing-secrets-configmaps.adoc#serverless-functions-accessing-secrets-configmaps[Accessing secrets and config maps from Serverless functions].
 * For more information on the `scale` set of options, see the link:https://knative.dev/docs/serving/autoscaling/[Knative documentation on Autoscaling].
-* For more information on the `resources` set of options, see the https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers] and the https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency].
+* For more information on the `resources` set of options, see the link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/[Kubernetes documentation on managing resources for containers] and the link:https://knative.dev/docs/serving/autoscaling/concurrency/[Knative documentation on configuring concurrency].


### PR DESCRIPTION
For versions 4.6+
No Jira
Docs preview: https://deploy-preview-34630--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-yaml.html