### PR TITLE
OSDOCS-2174: MetalLB glossary entry

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -299,7 +299,7 @@ load balancing and proxy layer via a public DNS entry. The Ingress resource may
 further specify TLS options and a certificate, or specify a public CNAME that
 the OpenShift Ingress Controller should also accept for HTTP and HTTPS traffic.
 An administrator typically configures their Ingress Controller to be visible
-outside the cluster firewall, and may also add additional security, caching, or
+outside the cluster firewall, and might also add additional security, caching, or
 traffic controls on the service content.
 
 ''''
@@ -351,6 +351,15 @@ Usage: Kubernetes API server
 == L
 
 == M
+
+''''
+=== MetalLB
+
+Usage: MetalLB, MetalLB Operator, MetalLB project
+
+MetalLB is an open source project that provides a way to add services of type `LoadBalancer` to clusters that are not installed on infrastructure from a cloud provider. MetalLB primarily targets on-premise, bare-metal clusters, but any infrastructure that does not include a native load-balancing capability is a candidate.
+
+"MetalLB" always has the first letter and last two letters capitalized in general text. Do not use "Metallb."
 
 ''''
 === minion
@@ -547,10 +556,10 @@ Usage: route(s)
 
 OpenShift-specific API object that allows developers to expose services through
 an HTTP(S) aware load balancing and proxy layer via a public DNS entry. The
-route may further specify TLS options and a certificate, or specify a public
+route might further specify TLS options and a certificate, or specify a public
 CNAME that the OpenShift Ingress Controller should also accept for HTTP and
 HTTPS traffic. An administrator typically configures their Ingress Controller to
-be visible outside the cluster firewall, and may also add additional security,
+be visible outside the cluster firewall, and might also add additional security,
 caching, or traffic controls on the service content.
 
 == S


### PR DESCRIPTION
* Add a glossary entry for MetalLB and state
  the accepted usage.

* s/may/might/ and s/their/an/ in two spots
  because it was flagged by textlint.