### PR TITLE
Updating 4.8 rel notes to accommodate new GA date and version

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -15,7 +15,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
 {product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.21] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-//Red Hat did not publicly release {product-title} 4.8.0 as the GA version and, instead, is releasing {product-title} 4.8.z as the GA version.
+Red Hat did not publicly release {product-title} 4.8.0 as the GA version and, instead, is releasing {product-title} 4.8.1 as the GA version.
 
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
@@ -1965,7 +1965,7 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19300
 
 *Web console (Developer perspective)*
 
-* Previously, when the label changed for making a service cluster local on the Developer Console, users were not able to create a Knative service. This update to the Knative service uses the latest supported label for `cluster-local` in order to enable users to create a Knative service as cluster-local from Developer Console. 
+* Previously, when the label changed for making a service cluster local on the Developer Console, users were not able to create a Knative service. This update to the Knative service uses the latest supported label for `cluster-local` in order to enable users to create a Knative service as cluster-local from Developer Console.
 (https://bugzilla.redhat.com/show_bug.cgi?id=1969951[*1969951*])
 
 * Previously, the colors for the *Low* and *Medium* severity issues of the Image Manifest Vulnerabilities (IMVs) did not match the color representation shown in the (link:https://quay.io/[Quay.io]) interface. As a result, when the user changed the severity order of vulnerabilities to *High*, the IMVs ordered the issues incorrectly. This created confusion when reviewing the IMVs. The current release fixes this issue. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942716[*BZ#1942716*])
@@ -2442,13 +2442,13 @@ This section will continue to be updated over time to provide notes on enhanceme
 For any {product-title} release, always review the instructions on xref:../updating/updating-cluster.adoc#updating-cluster[updating your cluster] properly.
 ====
 
-[id="ocp-4-8-0-ga"]
-=== RHSA-2021:2438 - {product-title} 4.8.0 image release, bug fix, and security update advisory
+[id="ocp-4-8-1-ga"]
+=== RHSA-2021:2438 - {product-title} 4.8.1 image release, bug fix, and security update advisory
 
-Issued: 2021-07-12
+Issued: 2021-07-27
 
-{product-title} release 4.8.0, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2437[RHSA-2021:2437] advisory.
+{product-title} release 4.8.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2437[RHSA-2021:2437] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
-link:https://access.redhat.com/solutions/6164202[{product-title} 4.8.0 container image list]
+link:https://access.redhat.com/solutions/6164202[{product-title} 4.8.1 container image list]


### PR DESCRIPTION
To-do:
- ~confirm version~
- ~confirm date~
- ~update advisory links when avail~ (reusing existing ones)
- ~update KCS with list when avail~

Preview: https://deploy-preview-34639--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html