### PR TITLE
Telcodocs 85 revise: Updating yaml and placement of note in two files

### DIFF
--- a/modules/cnf-programming-the-sriov-operator.adoc
+++ b/modules/cnf-programming-the-sriov-operator.adoc
@@ -138,44 +138,44 @@ kind: SriovFecClusterConfig
 metadata:
     name: config
     namespace: vran-acceleration-operators
-    spec:
-      nodes:
-        - nodeName: node1 <1>
-          physicalFunctions:
-            - pciAddress: 0000.1d.00.0 <2>
-              pfDriver: pci-pf-stub
-              vfDriver: vfio-pci
-              vfAmount: 2 <3>
-              bbDevConfig:
-                n3000:
-                  # Network Type: either "FPGA_5GNR" or "FPGA_LTE"
-                  networkType: "FPGA_5GNR"
-                  pfMode: false
-                  flrTimeout: 610
-                  downlink:
-                    bandwidth: 3
-                    loadBalance: 128
-                    queues: <4>
-                      vf0: 16
-                      vf1: 16
-                      vf2: 0
-                      vf3: 0
-                      vf4: 0
-                      vf5: 0
-                      vf6: 0
-                      vf7: 0
-                  uplink:
-                    bandwidth: 3
-                    loadBalance: 128
-                    queues: <5>
-                      vf0: 16
-                      vf1: 16
-                      vf2: 0
-                      vf3: 0
-                      vf4: 0
-                      vf5: 0
-                      vf6: 0
-                      vf7: 0
+spec:
+  nodes:
+    - nodeName: node1 <1>
+      physicalFunctions:
+        - pciAddress: 0000:1d:00.0 <2>
+          pfDriver: pci-pf-stub
+          vfDriver: vfio-pci
+          vfAmount: 2 <3>
+          bbDevConfig:
+            n3000:
+              # Network Type: either "FPGA_5GNR" or "FPGA_LTE"
+              networkType: "FPGA_5GNR"
+              pfMode: false
+              flrTimeout: 610
+              downlink:
+                bandwidth: 3
+                loadBalance: 128
+                queues: <4>
+                  vf0: 16
+                  vf1: 16
+                  vf2: 0
+                  vf3: 0
+                  vf4: 0
+                  vf5: 0
+                  vf6: 0
+                  vf7: 0
+              uplink:
+                bandwidth: 3
+                loadBalance: 128
+                queues: <5>
+                  vf0: 16
+                  vf1: 16
+                  vf2: 0
+                  vf3: 0
+                  vf4: 0
+                  vf5: 0
+                  vf6: 0
+                  vf7: 0
 ----
 <1> Specify the node name.
 <2> Specify the PCI Address of the card on which the SR-IOV-FEC Operator will be installed.

--- a/modules/cnf-verify-sriov-operator-n3000.adoc
+++ b/modules/cnf-verify-sriov-operator-n3000.adoc
@@ -206,7 +206,7 @@ EAL: No legacy callbacks, legacy socket not created
 ===========================================================
 Starting Test Suite : BBdev Validation Tests
 Test vector file = ldpc_dec_v7813.data
-Device 0 queue 16 setup failed <1>
+Device 0 queue 16 setup failed
 Allocated all queues (id=16) at prio0 on dev0
 Device 0 queue 32 setup failed
 Allocated all queues (id=32) at prio1 on dev0
@@ -228,7 +228,7 @@ TestCase [ 0] : validation_tc passed
  + Test Suite Summary : BBdev Validation Tests
  + Tests Total :        1
  + Tests Skipped :      0
- + Tests Passed :       1
+ + Tests Passed :       1 <1>
  + Tests Failed :       0
  + Tests Lasted :       177.67 ms
  + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ +


### PR DESCRIPTION
Following up guidance from https://github.com/openshift/openshift-docs/pull/34666 and integrating here with another small change. 
I made the change here https://deploy-preview-34678--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-optimize-data-performance-n3000.html#cnf-verify-sriov-operator-n3000_cnf-n3000