### PR TITLE
BZ1983669: MTC 1.4.6 RN

### DIFF
--- a/migration-toolkit-for-containers/mtc-release-notes.adoc
+++ b/migration-toolkit-for-containers/mtc-release-notes.adoc
@@ -11,4 +11,4 @@ You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to
 
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.
 
-include::modules/migration-mtc-release-notes-1-5.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-4.adoc[leveloffset=+1]

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -39,5 +39,5 @@ endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
-:mtc-version: 1.5
-:mtc-version-z: 1.5.0
+:mtc-version: 1.4
+:mtc-version-z: 1.4.6

--- a/modules/migration-mtc-release-notes-1-4.adoc
+++ b/modules/migration-mtc-release-notes-1-4.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * migration-toolkit-for-containers/mtc-release-notes.adoc
+
+[id="migration-mtc-release-notes-1-4_{context}"]
+= {mtc-full} 1.4 release notes
+
+The release notes for {mtc-full} ({mtc-short}) version 1.4 describe new features, enhancements, and known issues.
+
+[id="known-issues-1-4_{context}"]
+== Known issues
+
+* MTC 1.4.6 cannot be deployed on {product-title} 3.9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981794[*BZ#1981794*]) or 3.10 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981537[*BZ#1981537*]).


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1983669

MTC 1.4.6 RN (GA is July 21)

4.5, 4.6, 4.7

Prevew build: https://deploy-preview-34684--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/mtc-release-notes.html

No QE needed. Peer review required.