### PR TITLE
ROSA STS: Fix grep in role creation script

### DIFF
--- a/modules/rosa-sts-creating-cluster.adoc
+++ b/modules/rosa-sts-creating-cluster.adoc
@@ -191,7 +191,7 @@ $ ccoctl aws create-iam-roles \
 $ for role in `find . -name "*-role.json"`
 do
   policy=$(sed -e 's/05-/06-/' -e 's/role/policy/' <<< ${role})
-  role_name=$(grep --color=never -o "RoleName\":\"(\w|-)*" ${policy} | sed "s/RoleName\":\"//")
+  role_name=$(grep --color=never -o RoleName.* ${policy} | sed "s/RoleName\":\"//" | sed "s/\"}//")
   aws iam create-role --cli-input-json file://${role}
   sed -i.bak 's/,"RoleName":".*"//' ${policy}
   policy_arn=$(aws iam create-policy --output json --cli-input-json file://$policy | grep Arn | awk '{print $2}' | awk -F '"' '{print $2}')


### PR DESCRIPTION
Since parts of grep configuration are environment-dependent, we simplify
the regular expression and rely on more basic sed operations.