### PR TITLE
BZ1961004: Clarifying that AWS endpoints are required with a proxy

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -45,10 +45,7 @@ and approving them.
 * IAM roles
 * S3 buckets
 
-If you are working in a disconnected environment, you are unable to reach the
-public IP addresses for EC2 and ELB endpoints. To resolve this, you must create
-a VPC endpoint and attach it to the subnet that the clusters are using. The
-endpoints should be named as follows:
+If you are working in a disconnected environment or use a proxy, you cannot reach the public IP addresses for EC2 and ELB endpoints. To reach these endpoints, you must create a VPC endpoint and attach it to the subnet that the clusters are using. Create the following endpoints:
 
 * `ec2.<region>.amazonaws.com`
 * `elasticloadbalancing.<region>.amazonaws.com`

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -70,6 +70,8 @@ The `Proxy` object `status.noProxy` field is populated with the values of the `n
 
 For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
+* If your cluster is on AWS, you added the `ec2.<region>.amazonaws.com`,  `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+// TODO: xref installation-aws-user-infra-requirements.adoc#installation-aws-user-infra-other-infrastructure_{context} as a relative link
 
 .Procedure
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1961004

4.6+

This change appears in many AWS installation topics, for example: https://deploy-preview-34703--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-other-infrastructure_installing-aws-user-infra