### PR TITLE
CNV-12495: Adding Learn more about OV page

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2718,6 +2718,8 @@ Distros: openshift-enterprise
 Topics:
 - Name: About OpenShift Virtualization
   File: about-virt
+- Name: Learn more OpenShift Virtualization
+  File: learn_more_about_ov
 - Name: OpenShift Virtualization release notes
   File: virt-4-8-release-notes
 - Name: Installing OpenShift Virtualization

--- a/virt/learn_more_about_ov.adoc
+++ b/virt/learn_more_about_ov.adoc
@@ -1,0 +1,108 @@
+include::modules/virt-document-attributes.adoc[]
+[id="learn_more_about_ov"]
+= Learn more about {VirtProductName}
+:context: learn_more_about_ov
+
+toc::[]
+
+Use the following sections to find content to help you learn about and use {VirtProductName}.
+
+[id="cluster-administrator"]
+== Cluster Administrator (Maintenance)
+
+[options="header",cols="4*"]
+|===
+|Learn about {VirtProductName} |Plan for {VirtProductName} deployment |Deploy {VirtProductName}|Additional resources
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| xref:../virt/install/preparing-cluster-for-virt.adoc#preparing-cluster-for-virt[Configuring your cluster for {VirtProductName}]
+| xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-updating-node-network-config[Updating your node network configuration]
+| xref:../virt/logging_events_monitoring/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Getting Support]
+
+| xref:../welcome/learn_more_about_openshift.adoc#learn_more_about_openshift[Learn more about {product-title}]
+| xref:../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Plan storage for virtual machine disks]
+| xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
+|
+
+| xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Learn about virtual machine live migration]
+|
+| Installing {VirtProductName} using the xref:../virt/install/installing-virt-web.adoc#installing-virt-web[{VirtProductName} console] or xref:../virt/install/installing-virt-cli.adoc#installing-virt-cli[CLI]
+|
+
+| xref:../virt/node_maintenance/virt-about-node-maintenance.adoc#virt-about-node-maintenance[Learn about node maintenance]
+|
+|
+|
+
+|
+|===
+
+[id="virtualizaion-administrator"]
+== Virtualization Administrator (Deployment)
+
+[options="header",cols="4*"]
+|===
+|Learn about {VirtProductName} |Deploy {VirtProductName} |Manage {VirtProductName}|Use {VirtProductName}
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| Connecting virtual machines to the xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-using-the-default-pod-network-with-virt[default pod network for virtual machines]
+| xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Installing the virtctl client]
+| xref:../migration-toolkit-for-containers/about-mtc.adoc#about-mtc[Importing virtual machines with the Migration Toolkit for containers]
+
+| xref:../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Learn about storage features for virtual machine disks]
+| xref:../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Configuring data volume defaults]
+| xref:../virt/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[Using  the CLI tools]
+| xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Using live migration]
+
+|
+| xref:../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-and-using-boot-sources[Creating boot sources and attaching them to templates]
+| Viewing xref:../virt/logging_events_monitoring/virt-logs.adoc#virt-logs[logs] and xref:../virt/logging_events_monitoring/virt-events.adoc#virt-events[events]
+|
+
+|
+|
+| xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
+|
+
+|
+|===
+
+[id="Developer"]
+== Virtual Machine Administrator / Developer (Virtual Machine Consumer)
+
+[options="header",cols="4*"]
+|===
+|Learn about {VirtProductName} |Use {VirtProductName} |Manage {VirtProductName}|Additional resources
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Installing the virtctl client]
+| Viewing xref:../virt/logging_events_monitoring/virt-logs.adoc#virt-logs[logs] and xref:../virt/logging_events_monitoring/virt-events.adoc#virt-events[events]
+| xref:../virt/logging_events_monitoring/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Getting Support]
+
+|
+| xref../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[Creating virtual machines]
+| xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
+|
+
+|
+| xref:../virt/virtual_machines/virt-manage-vmis.adoc#virt-manage-vmis[Managing virtual machines instances]
+| xref:../virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc#virt-managing-offline-vm-snapshots[Creating and managing virtual machine snapshots]
+|
+
+|
+| xref:../virt/virtual_machines/virt-controlling-vm-states.adoc#virt-controlling-vm-states[Controlling virtual machine states]
+|
+|
+
+|
+| xref:../virt/virtual_machines/virt-accessing-vm-consoles.adoc#virt-accessing-vm-consoles[Accessing the virtual machine consoles]
+|
+|
+
+|
+| xref:../virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.adoc#virt-managing-configmaps-secrets-service-accounts[Pass configuration data to virtual machines using secrets, configuration maps, and service accounts]
+|
+|
+
+|
+|===


### PR DESCRIPTION
For 4.8 only.

Jira: https://issues.redhat.com/browse/CNV-12495

Tagging @peterclauterbach @dankenigsberg for code review

There are two problems I have yet to fix: (Tagging @adellape to investigate/help fix)
- The "Create VMs" link is not rendering properly in its table cell. No idea why.
- I need to add this xref:  _xref:../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-attaching-vm-multiple-networks[multiple networks]_ for the cell reading: **Connecting virtual machines to the default pod network for virtual machines**. It should read: **Connecting virtual machines to the default pod network for virtual machines and multiple networks** with the xref inserted for multiple networks. However when I attempt this I get from Travis: **Unknown ID or title "virt-attaching-vm-multiple-networks", used as an internal cross reference** I cannot see any difference in this xref in format or path from the other xrefs.....

Direct doc preview link: https://deploy-preview-34713--osdocs.netlify.app/openshift-enterprise/latest/virt/learn_more_about_ov.html

