### PR TITLE
BZ1982729: 1.5.0 RN - PV resize on OCP 3.7, 3.9

### DIFF
--- a/migration-toolkit-for-containers/mtc-release-notes.adoc
+++ b/migration-toolkit-for-containers/mtc-release-notes.adoc
@@ -12,3 +12,4 @@ You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.
 
 include::modules/migration-mtc-release-notes-1-5.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-4.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-4.adoc
+++ b/modules/migration-mtc-release-notes-1-4.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * migration-toolkit-for-containers/mtc-release-notes.adoc
+
+[id="migration-mtc-release-notes-1-4_{context}"]
+= {mtc-full} 1.4 release notes
+
+The release notes for {mtc-full} ({mtc-short}) version 1.4 describe new features, enhancements, and known issues.
+
+[id="known-issues-1-4_{context}"]
+== Known issues
+
+* MTC 1.4.6 cannot be deployed on {product-title} 3.9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981794[*BZ#1981794*]) or 3.10 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981537[*BZ#1981537*]).

--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -34,6 +34,27 @@ This release has the following new features and enhancements:
 
 This release has the following known issues:
 
-* PV resizing does not work as expected for AWS gp2 storage unless the `pv_resizing_threshold` is 42% or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973148[*BZ#1973148*])
-* If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 * Microsoft Azure storage is unavailable if you create more than 400 migration plans. The `MigStorage` custom resource displays the following message: `The request is being throttled as the limit has been reached for operation type`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977226[*BZ#1977226*])
+* If a migration fails, the migration plan does not retain custom persistent volume (PV) settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
+* PV resizing does not work as expected for AWS gp2 storage unless the `pv_resizing_threshold` is 42% or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973148[*BZ#1973148*])
+* PV resizing does not work with {product-title} 3.7 and 3.9 source clusters in the following scenarios:
+
+** The application was installed after MTC was installed.
+** An application pod was rescheduled on a different node after MTC was installed.
++
+{product-title} 3.7 and 3.9 do not support the Mount Propagation feature that enables Velero to mount PVs automatically in the `Restic` pod. The `MigAnalytic` custom resource (CR) fails to collect PV data from the `Restic` pod and reports the resources as `0`. The `MigPlan` CR displays a status similar to the following:
++
+.Example output
+[source,yaml]
+----
+status:
+  conditions:
+  - category: Warn
+    lastTransitionTime: 2021-07-15T04:11:44Z
+    message: Failed gathering extended PV usage information for PVs [nginx-logs nginx-html], please see MigAnalytic openshift-migration/ocp-24706-basicvolmig-migplan-1626319591-szwd6 for details
+    reason: FailedRunningDf
+    status: "True"
+    type: ExtendedPVAnalysisFailed
+----
++
+To enable PV resizing, you can manually restart the Restic daemonset on the source cluster or restart the `Restic` pods on the same nodes as the application. If you do not restart Restic, you can run the direct volume migration without PV resizing. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1982729[*BZ#1982729*])


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1982729

1.5.0 RN: PV resize does not work on OCP 3.7, 3.9

4.8

Preview: https://deploy-preview-34725--osdocs.netlify.app/openshift-enterprise/latest/migration-toolkit-for-containers/mtc-release-notes.html#known-issues-1-5_mtc-release-notes

QE approved. peer review required