### PR TITLE
Added scoped access control docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -123,8 +123,10 @@ Topics:
     File: configure-okta-identity-cloud
   - Name: Configuring Google Workspace as an OIDC identity provider
     File: configure-google-workspace-identity
-  - Name: Managing role-based access control
-    File: manage-role-based-access-control
+  - Name: Managing RBAC in Red Hat Advanced Cluster Security for Kubernetes 3.63.0 and newer
+    File: manage-role-based-access-control-3630
+  - Name: Managing RBAC in Red Hat Advanced Cluster Security for Kubernetes 3.0.62 and older
+    File: manage-role-based-access-control-3062
   - Name: Enabling PKI authentication
     File: enable-pki-authentication
 - Name: Using the system health dashboard

--- a/modules/assign-role-to-user-or-group.adoc
+++ b/modules/assign-role-to-user-or-group.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="assign-role-to-user-or-group_{context}"]
+= Assigning a role to a user or a group
+
+You can use the RHACS portal to assign roles to a user or a group.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access Control*.
+. From the list of authentication providers, select the authentication provider.
+. Click *Edit minimum role and rules*.
+. Under the *Rules* section, click *Add new rule*.
+. For *Key*, select one of the values from `userid`, `name`, `email` or `group`.
+. For *Value*, enter the value of the user ID, name, email address or group based on the key you selected.
+. Click the *Role* drop-down menu and select the role you want to assign.
+. Click *Save*.
+
+You can repeat these instructions for each user or group and assign different roles.

--- a/modules/create-a-custom-access-scope.adoc
+++ b/modules/create-a-custom-access-scope.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="create-a-custom-access-scope_{context}"]
+= Creating a custom access scope
+
+[role="_abstract"]
+You can create new access scopes from the *Access Control* view.
+
+.Prerequisites
+* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select the *Access scope* tab.
+. Click *Add access scope*.
+. Enter a *Name* and *Description* for the new access scope.
+. Under the *Allowed resources* section:
+** Use the *Cluster filter* and *Namespace filter* boxes to filter the list of clusters and namespaces visible in the list.
+** Expand the *<Cluster_name>* to see the list of namespaces in that cluster.
+** Turn on the toggle under the *Manual selection* column for a cluster to allow access to all namespaces in that cluster.
++
+[NOTE]
+====
+Access to a specific cluster provides users with access to the following resources within the scope of the cluster:
+
+* {ocp} or Kubernetes cluster metadata and security information
+* Compliance information for authorized clusters
+* Node metadata and security information
+* Acess to all namespaces in that cluster and their associated security information
+====
+** Turn on the toggle under the *Manual selection* column for a namespace to allow access to that namespace.
++
+[NOTE]
+====
+Access to a specific namespace gives access to the following information within the scope of the namespace:
+
+* Alerts and violations for deployments
+* Vulerability data for images
+* Deployment metadata and security information
+* Role and user information
+* Network graph, policy, and baseline information for deployments
+* Process information and process baseline configuration
+* Prioritized risk information for each deployment
+====
+. If you want to allow access to clusters and namespaces based on labels, click *Add label selector* under the *Label selection rules* section. Then click *Add rules* to specify *Key* and *Value* pairs for the label selector. You can specify labels for clusters and namespaces.
+. Click *Save*.
+

--- a/modules/create-a-custom-permission-set.adoc
+++ b/modules/create-a-custom-permission-set.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="create-a-custom-permission-set_{context}"]
+= Creating a custom permission set
+
+[role="_abstract"]
+You can create new permission sets from the *Access Control* view.
+
+.Prerequisites
+* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete permission sets.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select the *Permission sets* tab.
+. Click *Add permission set*.
+. Enter a *Name* and *Description* for the new permission set.
+. For each resource, under the *Access level* column, select one of the permissions from `No access`, `Read access`, `Read and Write access`.
++
+[WARNING]
+====
+* If you are configuring a permission set for users, you must grant read-only permissions for the following resources:
+** `Alert`
+** `Cluster`
+** `Deployment`
+** `Image`
+** `NetworkPolicy`
+** `NetworkGraph`
+** `Policy`
+** `Secret`
+* These permissions are pre-selected when you create a new permission set.
+* If you do not grant these permissions, users will experience issues with viewing pages in the RHACS portal.
+====
+. Click *Save*.

--- a/modules/create-a-custom-role-3630.adoc
+++ b/modules/create-a-custom-role-3630.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="create-a-custom-role-3630_{context}"]
+= Creating a custom role
+
+[role="_abstract"]
+You can create new roles from the *Access Control* view.
+
+.Prerequisites
+* You must have the *Admin* role, or a role with the permission set with read and write permissions for the `AuthProvider` and `Role` resources to create, modify, and delete custom roles.
+* You must create a permissions set and an access scope for the custom role before creating the role.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select the *Roles* tab.
+. Click *Add role*.
+. Enter a *Name* and *Description* for the new role.
+. Select a *Permission set* for the role.
+. Select an *Access scope* for the role.
+. Click *Save*.

--- a/modules/rbac-access-scopes.adoc
+++ b/modules/rbac-access-scopes.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: CONCEPT
+[id="rbac-access-scopes_{context}"]
+= System access scopes
+
+[role="_abstract"]
+{product-title} includes some default system access scopes that you can apply on roles.
+You can also create custom access scopes as required.
+
+[cols="1,3"]
+|===
+| Acces scope | Description
+
+| *Unrestricted*
+| Provides access to all clusters and namespaces that {product-title} monitors.
+
+| *Deny All*
+| Provides no access to any Kubernetes and {ocp} resources.
+|===

--- a/modules/rbac-permission-sets.adoc
+++ b/modules/rbac-permission-sets.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: CONCEPT
+[id="rbac-permission-sets_{context}"]
+= System permission sets
+
+[role="_abstract"]
+{product-title} includes some default system permission sets that you can apply to roles.
+You can also create custom permission sets as required.
+
+[cols="1,3"]
+|===
+| Permission set | Description
+
+| *Admin*
+| Provides read and write access to all resources.
+
+| *Analyst*
+| Provides read-only access for all resources.
+
+| *Continuous Integration*
+| This permission set is targeted for CI (continuous integration) systems and includes the permissions required to enforce deployment policies.
+
+| *None*
+| No read and write permissions are allowed for any resource.
+
+| *Sensor Creator*
+| Provides permissions for resources that are required to create Sensors in secured clusters.
+|===

--- a/modules/rbac-system-roles-3630.adoc
+++ b/modules/rbac-system-roles-3630.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: CONCEPT
+[id="rbac-system-roles-3630_{context}"]
+= System roles
+
+[role="_abstract"]
+{product-title} includes some default system roles that you can apply to users when you create rules.
+You can also create custom roles as required.
+
+[cols="1,3"]
+|===
+| System role | Description
+
+| *Admin*
+| This role is targeted for administrators. Use it to provide read and write access to all resources.
+
+| *Analyst*
+| This role is targeted for a user who cannot make any changes, but can view everything. Use it to provide read-only access for all resources.
+
+| *Continuous Integration*
+| This role is targeted for CI (continuous integration) systems and includes the permission set required to enforce deployment policies.
+
+| *None*
+| This role has no read and write access to any resource.
+You can set this role as the minimum access role for all users.
+
+| *Sensor Creator*
+| {product-title} uses this role to automate new cluster setups. It includes the permission set to create Sensors in secured clusters.
+|===

--- a/modules/view-system-access-scopes.adoc
+++ b/modules/view-system-access-scopes.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="view-system-access-scopes_{context}"]
+= Viewing the details for a system access scope
+
+You can view the Kubernetes and {ocp} resources that are allowed and not allowed for an access scope in the RHACS portal.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select *Access scopes*.
+. Click on one of the access scopes to view its details. The details page shows a list of clusters and namespaces, and which ones are allowed for the selected access scope.
+
+[NOTE]
+====
+You cannot modify allowed resources for a system access scope.
+====

--- a/modules/view-system-permission-set.adoc
+++ b/modules/view-system-permission-set.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="view-system-permission-set_{context}"]
+= Viewing the permissions for a system permission set
+
+You can view the permissions for a system permission set in the RHACS portal.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select *Permission sets*.
+. Click on one of the permission sets to view its details. The details page shows a list of resources and their permissions for the selected permission set.
+
+[NOTE]
+====
+You cannot modify permissions for a system permission set.
+====

--- a/modules/view-system-roles-permission-scope.adoc
+++ b/modules/view-system-roles-permission-scope.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-role-based-access-control.adoc
+:_module-type: PROCEDURE
+[id="view-system-roles-permission-scope_{context}"]
+= Viewing the permission set and access scope for a system role
+
+You can view the permission set and access scope for the default system roles.
+
+.Procedure
+. On the RHACS portal, navigate to *Platform Configuration* -> *Access control*.
+. Select *Roles*.
+. Click on one of the roles to view its details. The details page shows the permission set and access scope for the slected role.
+
+[NOTE]
+====
+You cannot modify permission set and access scope for the default system roles.
+====

--- a/operating/manage-user-access/manage-role-based-access-control-3062.adoc
+++ b/operating/manage-user-access/manage-role-based-access-control-3062.adoc
@@ -1,15 +1,22 @@
 [id="manage-role-based-access-control"]
-= Managing role-based access control
+= Managing RBAC in {product-title} 3.0.62 and older
 include::modules/common-attributes.adoc[]
 :context: manage-role-based-access-control
 
 toc::[]
 
 [role="_abstract"]
-{product-title} comes with role-based access control (RBAC) that you can use to configure roles and grant various levels of access to {product-title} to different users.
-These roles govern access to {product-title} resources to prevent unwanted access.
+{product-title} (RHACS) comes with role-based access control (RBAC) that you can use to configure roles and grant various levels of access to {product-title} for different users.
 
-* _Roles_ are a collection of rules, which are a group of `read` and `write` permissions that user can perform on a set of resources.
+[IMPORTANT]
+====
+In {product-title} 3.63.0, a scoped access control feature has been added.
+If you are using {product-title} 3.63.0 or newer, see xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#manage-rbac-3630[Managing access control in {product-title} 3.63.0 and newer].
+====
+
+In {product-title} 3.0.62 and older, different roles govern access to {product-title} resources to prevent unwanted access.
+
+* _Roles_ are a collection of rules, which are a group of `read` and `write` permissions that a user can perform on a set of resources.
 * _Resources_ are the functionalities of {product-title} for which you can set view (`read`) and modify (`write`) permissions.
 See the Resource definitions section to understand the access level that each permission grants.
 //TODO: Add link to Resource definitions

--- a/operating/manage-user-access/manage-role-based-access-control-3630.adoc
+++ b/operating/manage-user-access/manage-role-based-access-control-3630.adoc
@@ -1,0 +1,62 @@
+[id="manage-role-based-access-control"]
+= Managing RBAC in {product-title} 3.63.0 and newer
+include::modules/common-attributes.adoc[]
+:context: manage-role-based-access-control
+
+toc::[]
+
+[role="_abstract"]
+{product-title} (RHACS) comes with role-based access control (RBAC) that you can use to configure roles and grant various levels of access to {product-title} for different users.
+
+[IMPORTANT]
+====
+If you are using {product-title} 3.0.62 or older, see xref:../../operating/manage-user-access/manage-role-based-access-control-3062.adoc#manage-rbac-3062[Managing access control in {product-title} 3.0.62 and older].
+====
+
+{product-title} 3.63.0 includes a scoped access control feature that enables you to configure fine-grained and specific sets of permissions that define how a given {product-title} user or a group of users can interact with {product-title}, which resources they can access, and which actions they can perform.
+
+* _Roles_ are a collection of permission sets and access scopes. You can assign roles to users and groups by specifying rules. You can configure these rules when you configure an authentication provider.
+There are two types of roles in {product-title}:
+** System roles that are created by Red Hat and cannot be changed.
+** Custom roles, which {product-title} administrators can create and change at any time.
++
+[NOTE]
+====
+* If you assign multiple roles for a user, they get access to the combined permissions of the assigned roles.
+* If you have users assigned to a custom role, and you delete that role, all associated users transfer to the minimum access role that you have configured.
+====
+
+* _Permission sets_ are a set of permissions that define what actions a role can perform on a given resource. _Resources_ are the functionalities of {product-title} for which you can set view (`read`) and modify (`write`) permissions. There are two types of permission sets in {product-title}:
+** System permission sets, which are created by Red Hat and cannot be changed.
+** Custom permission sets, which {product-title} administrators can create and change at any time.
+
+* _Access scopes_ are a set of Kubernetes and {ocp} resources that users can access. For example, you can define an access scope that only allows users to access information about pods in a given project. There are two types of access scopes in {product-title}:
+** System access scopes, which are created by Red Hat and cannot be changed.
+** Custom access scopes, which {product-title} administrators can create and change at any time.
+
+include::modules/rbac-system-roles-3630.adoc[leveloffset=+1]
+
+include::modules/view-system-roles-permission-scope.adoc[leveloffset=+2]
+
+include::modules/create-a-custom-role-3630.adoc[leveloffset=+2]
+
+[role="additional-resources"]
+.Additional resources
+* xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#create-a-custom-permission-set_manage-role-based-access-control[Creating a custom permission set]
+* xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#create-a-custom-access-scope_manage-role-based-access-control[Creating a custom access scope]
+
+include::modules/assign-role-to-user-or-group.adoc[leveloffset=+2]
+
+include::modules/rbac-permission-sets.adoc[leveloffset=+1]
+
+include::modules/view-system-permission-set.adoc[leveloffset=+2]
+
+include::modules/create-a-custom-permission-set.adoc[leveloffset=+2]
+
+include::modules/rbac-access-scopes.adoc[leveloffset=+1]
+
+include::modules/view-system-access-scopes.adoc[leveloffset=+2]
+
+include::modules/create-a-custom-access-scope.adoc[leveloffset=+2]
+
+include::modules/rbac-resource-definitions.adoc[leveloffset=+1]


### PR DESCRIPTION
New content for Scoped access control feature in the upcoming release.

Preview: https://openshift-docs-git-scoped-access-gnelson.vercel.app/openshift-acs/master/operating/manage-user-access/manage-role-based-access-control-3630.html

Note: 
- I've renamed an existing page to accommodate the changes in the new version. (We still don't have versioning for our docs)
- The previous version of RHACS was `3.0.62.0` but from this release we are changing are versioning format so the next version is called as `3.63.0`.