### PR TITLE
BZ1917336: add UEFI instructions when using PXE 4.6

### DIFF
--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -58,8 +58,9 @@ ifdef::openshift-origin[]
 link:https://getfedora.org/en/coreos/download?tab=metal_virtualized&stream=stable[{op-system} Downloads] page
 endif::openshift-origin[]
 
-. Upload the `rootfs`, `kernel`, and `initramfs` files
-to your HTTP server.
+. Upload the additional files that are required for your booting method:
+* For traditional PXE, upload the `kernel` and `initramfs` files to your TFTP server and the `rootfs` file to your HTTP server.
+* For iPXE, upload the `kernel`, `initramfs`, and `rootfs` files to your HTTP server.
 +
 [IMPORTANT]
 ====
@@ -123,6 +124,81 @@ For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
 [NOTE]
 ====
 This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `kernel` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
+====
++
+. If you use PXE UEFI, perform the following actions:
+.. Provide the `shimx64.efi` and `grubx64.efi` EFI binaries and the `grub.cfg` file that are required for booting the system.
+
+** Extract the necessary EFI binaries by mounting the {op-system} ISO to your host and then mounting the `images/efiboot.img` file to your host:
++
+[source,terminal]
+----
+$ mkdir -p /mnt/iso
+----
++
+[source,terminal]
+----
+$ mkdir -p /mnt/efiboot
+----
++
+[source,terminal]
+----
+$ mount -o loop rhcos-installer.x86_64.iso /mnt/iso
+----
++
+[source,terminal]
+----
+$ mount -o loop,ro /mnt/iso/images/efiboot.img /mnt/efiboot
+----
+
+** From the `efiboot.img` mount point, copy the `EFI/redhat/shimx64.efi` and
+`EFI/redhat/grubx64.efi` files to your TFTP server:
++
+[source,terminal]
+----
+$ cp /mnt/efiboot/EFI/redhat/shimx64.efi .
+----
++
+[source,terminal]
+----
+$ cp /mnt/efiboot/EFI/redhat/grubx64.efi .
+----
++
+[source,terminal]
+----
+$ umount /mnt/efiboot
+----
++
+[source,terminal]
+----
+$ umount /mnt/iso
+----
+
+** Copy the `EFI/redhat/grub.cfg` file that is included in the {op-system} ISO to your TFTP server.
+
+.. Edit the `grub.cfg` file to include arguments similar to the following:
++
+----
+menuentry 'Install Red Hat Enterprise Linux CoreOS' --class fedora --class gnu-linux --class gnu --class os {
+	linuxefi rhcos-<version>-live-kernel-<architecture> coreos.inst.install_dev=/dev/sda coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign
+	initrdefi rhcos-<version>-live-initramfs.<architecture>.img
+}
+----
++
+--
+where:
+
+`rhcos-<version>-live-kernel-<architecture>`:: Specifies the `kernel` file that you uploaded to your TFTP server. 
+`\http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img`:: Specifies the location of the live rootfs image that you uploaded
+to your HTTP server. 
+`\http://<HTTP_server>/bootstrap.ign`:: Specifies the location of the bootstrap Ignition config file that you uploaded to your HTTP server.
+`rhcos-<version>-live-initramfs.<architecture>.img`:: Specifies the location of the `initramfs` file that you uploaded to your TFTP
+server.
+--
++
+[NOTE]
+====
+For more information on how to configure a PXE server for UEFI boot, see the Red Hat Knowledgebase article: link:https://access.redhat.com/solutions/353313[How to configure/setup a PXE server for UEFI boot for Red Hat Enterprise Linux?].
 ====
 +
 . Continue to create the machines for your cluster.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1917336

Following up on https://github.com/openshift/openshift-docs/pull/33051. Pulling separate PRs for each branch due to changes to the installation files. At least one for 4.6 and 4.7 and another for 4.8 and master. Significant changes were made for 4.8+.

Preview of the module in baremetal with network customizations (added Step 6): https://deploy-preview-34732--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-user-infra-machines-pxe_installing-bare-metal-network-customizations