### PR TITLE
CNV 12997: Adding Known Issues for OCP upgrade errors on CNV 2.6.5

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -214,3 +214,43 @@ No model registered for VirtualMachines
 ----
 +
 You can ignore this message. It does not affect VM import. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1974812[*BZ#1974812*])
+
+* If you run {VirtProductName} 2.6.5 with {product-title} 4.8, various issues occur. You can avoid these issues by upgrading {VirtProductName} to version 4.8.
++
+** In the web console, if you navigate to the *Virtualization* page and select *Create* -> *With YAML* the following error message is displayed:
++
+[source,text]
+----
+The server doesn't have a resource type "kind: VirtualMachine, apiVersion: kubevirt.io/v1"
+----
++
+*** As a workaround, edit the `VirtualMachine` manifest so the `apiVersion` is `kubevirt.io/v1alpha3`. For example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  annotations:
+...
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1979114[*BZ#1979114*])
++
+** If you use the *Customize* wizard to create a VM, the following error message is displayed:
++
+[source,text]
+----
+Error creating virtual machine
+----
++
+*** As a workaround, copy the manifest and xref:../virt/virtual_machines/virt-create-vms.adoc#virt-creating-vm_virt-create-vms[create the virtual machine from the CLI].
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1979116[*BZ#1979116*])
++
+// fix targeted for 4.8.1
+** When connecting to the VNC console by using the {VirtProductName} web console, the VNC console always fails to respond.
++
+*** As a workaround, create the virtual machine from the CLI or upgrade to {VirtProductName} 4.8.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1977037[*BZ#1977037*])


### PR DESCRIPTION
This PR addresses JIRA story [CNV-12997](https://issues.redhat.com/browse/CNV-12997) ( https://issues.redhat.com/browse/CNV-12997 ) which covers 3 Known Issue bugs:

https://bugzilla.redhat.com/show_bug.cgi?id=1979114
https://bugzilla.redhat.com/show_bug.cgi?id=1979116
https://bugzilla.redhat.com/show_bug.cgi?id=1977037

This story and these bugs pertain to various errors received when upgrading to OCP 4.8 when running CNV 2.6.5

CP: 4.8

Preview: At the very end of https://deploy-preview-34736--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-8-known-issues. 