### PR TITLE
Added notes for release 4.6.39

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3123,3 +3123,26 @@ link:https://access.redhat.com/solutions/6176142[{product-title} 4.6.36 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-39"]
+=== RHBA-2021:2684 - {product-title} 4.6.39 bug fix
+
+Issued: 2021-07-21
+
+{product-title} release 4.6.39 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2684[RHBA-2021:2684] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2685[RHBA-2021:2685] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6196661[{product-title} 4.6.39 container image list]
+
+[id="ocp-4-6-39-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the `oc image extract` command was run as a non-root user, it failed with an `operation not permitted` error. This was the result of insufficient privileges to set extended attributes during decompression. With this update, extended security attributes are only set when the command is run as root, so that the command works for both root and non-root users. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1969929[*BZ#1969929*])
+
+* Previously, when the label changed for making a service cluster local on the Developer Console, users were not able to create a Knative service. This update to the Knative service uses the latest supported label for `cluster-local` in order to enable users to create a Knative service as cluster-local from Developer Console. (https://bugzilla.redhat.com/show_bug.cgi?id=1978159[*BZ1978159*])
+
+[id="ocp-4-6-39-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for OCP 4.6.39

https://issues.redhat.com/browse/OCPPLAN-6824

* Applies only to `enterprise-4.6`
* [Preview link](https://deploy-preview-34737--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#rhba-20212684-openshift-container-platform-4-6-39-bug-fix)
