### PR TITLE
[Enterprise-4.8]: Fixed two typos in the Enterprise 4.8 documentation.

### DIFF
--- a/modules/installation-osp-provider-network-preparation.adoc
+++ b/modules/installation-osp-provider-network-preparation.adoc
@@ -46,7 +46,7 @@ Provider networks must be owned by the {rh-openstack} project that is used to cr
 
 * Verify that the provider network can reach the {rh-openstack} metadata service IP address, which is `169.254.169.254` by default.
 +
-Depending on your {rh-openstack} SDN and networking service configuration, you might need to create provide the route when you create the subnet. For example:
+Depending on your {rh-openstack} SDN and networking service configuration, you might need to provide the route when you create the subnet. For example:
 +
 [source,terminal]
 ----

--- a/modules/nw-gcp-installing-global-access-configuration.adoc
+++ b/modules/nw-gcp-installing-global-access-configuration.adoc
@@ -5,7 +5,7 @@
 
 [id="nw-gcp-global-access-configuration_{context}"]
 = Create an Ingress Controller with global access on GCP
-You can create an Ingress Controller with global access on a new GCP cluster when your. Global access is only available to Ingress Controllers using internal load balancers.
+You can create an Ingress Controller that has global access to a Google Cloud Platform (GCP) cluster. Global access is only available to Ingress Controllers using internal load balancers.
 
 .Prerequisites
 


### PR DESCRIPTION
Fixes #34536. This PR fixes two typos in the 4.8 documentation.

Version: 4.8

Previews: 

1. https://deploy-preview-34741--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-user.html#installation-osp-provider-network-preparation_installing-openstack-user
2. https://deploy-preview-34741--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#nw-gcp-global-access-configuration_installing-restricted-networks-gcp-installer-provisioned