### PR TITLE
BZ1977184: removing a BZ that is no longer needed from the RNs

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2406,8 +2406,6 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=18786
 
 * Previously, the topology URLs created for deployments using Bitbucket repository in the {product-title} web console did not work if they included a branch name that contained a slash character. This was due to an issue with the Bitbucket API (link:https://jira.atlassian.com/browse/BCLOUD-9969[BCLOUD-9969]). The current release mitigates this issue. If a branch name contains a slash, the topology URLs point to the default branch page for the repository. This issue will be fixed in a future release of {product-title}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1969535[*BZ#1969535*]).
 
-* The AWS Security Token Service is not supported for clusters installed on AWS in a restricted network. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1977184[*BZ#1977184*].
-
 * Installing {product-title} (OCP) version 4.6 on {rh-virtualization-first} requires RHV version 4.4. If you are running an earlier version of OCP on RHV 4.3, do not update it to OCP version 4.6. Red Hat has not tested running OCP version 4.6 on RHV version 4.3 and does not support this combination. For additional information about tested integrations, see link:https://access.redhat.com/articles/4763741[OpenShift Container Platform 4.x Tested Integrations (for x86_x64)].
 
 * The `operator-sdk pkgman-to-bundle` command exits with an error when run with the `--build-cmd` flag. For more information, see (link:https://bugzilla.redhat.com/show_bug.cgi?id=1967369[*BZ#1967369*]).


### PR DESCRIPTION
Update to remove BZ1977184 from the 4.8 RNs as this is not needed per https://bugzilla.redhat.com/show_bug.cgi?id=1977184#c5

Preview: https://deploy-preview-34742--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-known-issues