### PR TITLE
CCXDEV-5371 Cloud migration link fixes

### DIFF
--- a/modules/displaying-potential-issues-with-your-cluster.adoc
+++ b/modules/displaying-potential-issues-with-your-cluster.adoc
@@ -5,15 +5,15 @@
 [id="displaying-potential-issues-with-your-cluster_{context}"]
 = Displaying potential issues with your cluster
 
-This section describes how to display the Insights report in the {cloud-redhat-com}.
+This section describes how to display the {insights-title} report in the {link-ocm-title}.
 
-Note that Insights repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
+Note that {insights-title} repeatedly analyzes your cluster and shows the latest results. These results can change, for example, if you fix an issue or a new issue has been detected.
 
 .Prerequisites
 
-* Your cluster is registered in the {cloud-redhat-com}.
+* Your cluster is registered in the {link-ocm-title}.
 * Remote health reporting is enabled, which is the default.
-* You are logged in to the link:https://cloud.redhat.com/openshift[{cloud-redhat-com}].
+* You are logged in to the {link-ocm-title}.
 
 .Procedure
 
@@ -21,15 +21,15 @@ Note that Insights repeatedly analyzes your cluster and shows the latest results
 
 . Click the cluster's name to display the details of the cluster.
 
-. Open the *Insights* tab of the cluster.
+. Open the *{insights-title}* tab of the cluster.
 +
 Depending on the result, the tab displays one of the following:
 +
-* *Your cluster passed all health checks*, if Insights did not identify any issues.
+* *Your cluster passed all health checks*, if {insights-title} did not identify any issues.
 
-* A list of issues Insights has detected, prioritized by risk (low, moderate, important, and critical).
+* A list of issues {insights-title} has detected, prioritized by risk (low, moderate, important, and critical).
 
-* *No health checks to display*, if Insights has not yet analyzed the cluster. The analysis starts shortly after the cluster has been installed and connected to the internet.
+* *No health checks to display*, if {insights-title} has not yet analyzed the cluster. The analysis starts shortly after the cluster has been installed and connected to the internet.
 
 . If any issues are displayed on the tab, click the *>* icon in front of the entry for further details.
 +

--- a/modules/insights-operator-about.adoc
+++ b/modules/insights-operator-about.adoc
@@ -7,12 +7,12 @@
 
 The Insights Operator periodically gathers configuration and component failure status and, by default, reports that data every two hours to Red Hat. This information enables Red Hat to assess configuration and deeper failure data than is reported through Telemetry.
 
-Users of {product-title} can display the report of each cluster in {cloud-redhat-com}. If any issues have been identified, Insights provides further details and, if available, steps on how to solve a problem.
+Users of {product-title} can display the report of each cluster in {link-ocm-title}. If any issues have been identified, {insights-title} provides further details and, if available, steps on how to solve a problem.
 
-The Insights Operator does not collect identifying information, such as user names, passwords, or certificates. See link:https://cloud.redhat.com/security/insights[Red Hat Insights Data & Application Security] for information about Red Hat Insights data collection and controls.
+The Insights Operator does not collect identifying information, such as user names, passwords, or certificates. See {link-insights-security} for information about Red Hat Insights data collection and controls.
 
 Red Hat uses all connected cluster information to:
 
-* Proactively identify potential cluster issues and provide a solution and preventive actions in {cloud-redhat-com}
+* Proactively identify potential cluster issues and provide a solution and preventive actions in {link-ocm-title}
 * Improve {product-title} by providing aggregated and critical information to product and support teams
 * Make {product-title} more intuitive

--- a/modules/insights-operator-document-attributes.adoc
+++ b/modules/insights-operator-document-attributes.adoc
@@ -1,0 +1,10 @@
+////
+This is a custom set of attributes for the Insights Operator related documentation. 
+////
+
+:insights-title: Insights Advisor
+
+:link-cloud-redhat-com: link:https://cloud.redhat.com/[cloud.redhat.com]
+:link-ocm: link:https://console.redhat.com/openshift[https://console.redhat.com/openshift] 
+:link-ocm-title: link:https://console.redhat.com/openshift[Red Hat Openshift Cluster Manager]
+:link-insights-security: link:https://cloud.redhat.com/security/insights[Red Hat Insights Data & Application Security] 

--- a/modules/insights-operator-enable-obfuscation.adoc
+++ b/modules/insights-operator-enable-obfuscation.adoc
@@ -7,14 +7,14 @@
 [id="insights-operator-enable-obfuscation_{context}"]
 = Enabling Insights Operator data obfuscation
 
-You can enable obfuscation to mask sensitive and identifiable IPv4 addresses and cluster base domains that the Insights Operator sends to link:https://cloud.redhat.com[cloud.redhat.com].
+You can enable obfuscation to mask sensitive and identifiable IPv4 addresses and cluster base domains that the Insights Operator sends to {link-cloud-redhat-com}.
 
 [WARNING]
 ====
 Although this feature is available, Red Hat recommends keeping obfuscation disabled for a more effective support experience.
 ====
 
-Obfuscation assigns non-identifying values to cluster IPv4 addresses, and uses a translation table that is retained in memory to change IP addresses to their obfuscated versions throughout the Insights Operator archive before uploading the data to link:https://cloud.redhat.com[cloud.redhat.com].
+Obfuscation assigns non-identifying values to cluster IPv4 addresses, and uses a translation table that is retained in memory to change IP addresses to their obfuscated versions throughout the Insights Operator archive before uploading the data to {link-cloud-redhat-com}.
 
 For cluster base domains, obfuscation changes the base domain to a hardcoded substring. For example, `cluster-api.openshift.example.com` becomes `cluster-api.<CLUSTER_BASE_DOMAIN>`.
 

--- a/modules/insights-operator-manual-upload.adoc
+++ b/modules/insights-operator-manual-upload.adoc
@@ -7,7 +7,7 @@
 [id="insights-operator-manual-upload_{context}"]
 = Uploading an Insights Operator archive
 
-You can manually upload an Insights Operator archive to link:https://cloud.redhat.com[cloud.redhat.com] to diagnose potential issues.
+You can manually upload an Insights Operator archive to {link-cloud-redhat-com} to diagnose potential issues.
 
 .Prerequisites
 
@@ -37,7 +37,7 @@ $ oc extract secret/pull-secret -n openshift-config --to=.
 ----
 
 
-. Upload the archive to link:https://cloud.redhat.com[cloud.redhat.com]:
+. Upload the archive to {link-cloud-redhat-com}:
 +
 [source,terminal,subs="+quotes"]
 ----
@@ -57,16 +57,16 @@ If the operation is successful, the command returns a `"request_id"` and `"accou
 
 .Verification steps
 
-. Log in to link:https://cloud.redhat.com/openshift[].
+. Log in to {link-ocm}
 
 . Click the *Clusters* menu in the left pane.
 
 . To display the details of the cluster, click the cluster name.
 
-. Open the *Insights Advisor* tab of the cluster.
+. Open the *{insights-title}* tab of the cluster.
 +
 If the upload was successful, the tab displays one of the following:
 +
-* *Your cluster passed all recommendations*, if Insights Advisor did not identify any issues.
+* *Your cluster passed all recommendations*, if {insights-title} did not identify any issues.
 
-* A list of issues that Insights Advisor has detected, prioritized by risk (low, moderate, important, and critical).
+* A list of issues that {insights-title} has detected, prioritized by risk (low, moderate, important, and critical).

--- a/modules/telemetry-consequences-of-disabling-telemetry.adoc
+++ b/modules/telemetry-consequences-of-disabling-telemetry.adoc
@@ -5,7 +5,7 @@
 [id="telemetry-consequences-of-disabling-telemetry_{context}"]
 = Consequences of disabling remote health reporting
 
-In {product-title}, customers can opt out of reporting usage information. However, connected clusters allow Red Hat to react more quickly to problems and better support our customers, as well as better understand how product upgrades impact clusters. Connected clusters also help to simplify the subscription and entitlement process and enable the {cloud-redhat-com} service to provide an overview of your clusters and their subscription status.
+In {product-title}, customers can opt out of reporting usage information. However, connected clusters allow Red Hat to react more quickly to problems and better support our customers, as well as better understand how product upgrades impact clusters. Connected clusters also help to simplify the subscription and entitlement process and enable the {link-ocm-title} service to provide an overview of your clusters and their subscription status.
 
 Red Hat strongly recommends leaving health and usage reporting enabled for pre-production and test clusters even if it is necessary to opt out for production clusters. This allows Red Hat to be a participant in qualifying {product-title} in your environments and react more rapidly to product issues.
 
@@ -13,9 +13,9 @@ Some of the consequences of opting out of having a connected cluster are:
 
 * Red Hat will not be able to monitor the success of product upgrades or the health of your clusters without a support case being opened.
 * Red Hat will not be able to use configuration data to better triage customer support cases and identify which configurations our customers find important.
-* The {cloud-redhat-com} will not show data about your clusters including health and usage information.
+* The {link-ocm-title} will not show data about your clusters including health and usage information.
 ifndef::openshift-origin[]
-* Your subscription entitlement information must be manually entered via cloud.redhat.com without the benefit of automatic usage reporting.
+* Your subscription entitlement information must be manually entered via {link-cloud-redhat-com} without the benefit of automatic usage reporting.
 endif::[]
 
 In restricted networks, Telemetry and Insights data can still be reported through appropriate configuration of your proxy.

--- a/modules/understanding-telemetry-and-insights-operator-data-flow.adoc
+++ b/modules/understanding-telemetry-and-insights-operator-data-flow.adoc
@@ -7,7 +7,7 @@
 
 The Telemeter Client collects selected time series data from the Prometheus API. The time series data is uploaded to api.openshift.com every four minutes and thirty seconds for processing.
 
-The Insights Operator gathers selected data from the Kubernetes API and the Prometheus API into an archive. The archive is uploaded to link:https://cloud.redhat.com[cloud.redhat.com] every two hours for processing. The Insights Operator also downloads the latest Insights analysis from link:https://cloud.redhat.com[cloud.redhat.com]. This is used to populate the *Insights status* pop-up that is included in the *Overview* page in the {product-title} web console.
+The Insights Operator gathers selected data from the Kubernetes API and the Prometheus API into an archive. The archive is uploaded to {link-cloud-redhat-com} every two hours for processing. The Insights Operator also downloads the latest Insights analysis from {link-cloud-redhat-com}. This is used to populate the *Insights status* pop-up that is included in the *Overview* page in the {product-title} web console.
 
 All of the communication with Red Hat occurs over encrypted channels by using Transport Layer Security (TLS) and mutual certificate authentication. All of the data is encrypted in transit and at rest.
 

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -1,6 +1,7 @@
 [id="about-remote-health-monitoring"]
 = About remote health monitoring
 include::modules/common-attributes.adoc[]
+include::modules/insights-operator-document-attributes.adoc[]
 :context: about-remote-health-monitoring
 
 toc::[]
@@ -11,7 +12,7 @@ A cluster that reports data to Red Hat through Telemetry and the Insights Operat
 
 *Telemetry* is the term that Red Hat uses to describe the information being sent to Red Hat by the {product-title} Telemeter Client. Lightweight attributes are sent from connected clusters to Red Hat to enable subscription management automation, monitor the health of clusters, assist with support, and improve customer experience.
 
-The *Insights Operator* gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on link:https://cloud.redhat.com/openshift[cloud.redhat.com/openshift].
+The *Insights Operator* gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on {link-ocm}.
 
 More information is provided in this document about these two processes. 
 
@@ -27,10 +28,10 @@ Telemetry and the Insights Operator enable the following benefits for end-users:
 
 * *A streamlined support experience*. You can provide a cluster ID for a connected cluster when creating a support ticket on the link:https://access.redhat.com/support/[Red Hat Customer Portal]. This enables Red Hat to deliver a streamlined support experience that is specific to your cluster, by using the connected information. This document provides more information about that enhanced support experience.
 
-* *Predictive analytics*. The insights displayed for your cluster on link:https://cloud.redhat.com/openshift/[cloud.redhat.com/openshift] are enabled by the information collected from connected clusters. Red Hat is investing in applying deep learning, machine learning, and artificial intelligence automation to help identify issues that {product-title} clusters are exposed to.
+* *Predictive analytics*. The insights displayed for your cluster on {link-ocm} are enabled by the information collected from connected clusters. Red Hat is investing in applying deep learning, machine learning, and artificial intelligence automation to help identify issues that {product-title} clusters are exposed to.
 
 ifdef::openshift-origin[]
-{product-title} may be installed without a pull secret received at cloud.redhat.com. In this case default imagestreams will not be imported and telemetry data will not be sent.
+{product-title} may be installed without a pull secret received at {link-cloud-redhat-com}. In this case default imagestreams will not be imported and telemetry data will not be sent.
 endif::[]
 
 include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]

--- a/support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
+++ b/support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
@@ -1,6 +1,7 @@
 [id="opting-out-remote-health-reporting"]
 = Opting out of remote health reporting
 include::modules/common-attributes.adoc[]
+include::modules/insights-operator-document-attributes.adoc[]
 :context: opting-out-remote-health-reporting
 
 toc::[]

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -1,6 +1,7 @@
 [id="remote-health-reporting-from-restricted-network"]
 = Using remote health reporting in a restricted network
 include::modules/common-attributes.adoc[]
+include::modules/insights-operator-document-attributes.adoc[]
 :context: remote-health-reporting-from-restricted-network
 
 toc::[]
@@ -10,7 +11,7 @@ You can manually gather and upload Insights Operator archives to diagnose issues
 To use the Insights Operator in a restricted network, you must:
 
 * Create a copy of your Insights Operator archive.
-* Upload the Insights Operator archive to link:https://cloud.redhat.com[cloud.redhat.com].
+* Upload the Insights Operator archive to {link-cloud-redhat-com}.
 
 Additionally, you can choose to xref:../../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network[obfuscate] the Insights Operator data before upload. 
 

--- a/support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc
@@ -1,6 +1,7 @@
 [id="showing-data-collected-by-remote-health-monitoring"]
 = Showing data collected by remote health monitoring
 include::modules/common-attributes.adoc[]
+include::modules/insights-operator-document-attributes.adoc[]
 :context: showing-data-collected-by-remote-health-monitoring
 
 toc::[]

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -1,6 +1,7 @@
 [id="using-insights-to-identify-issues-with-your-cluster"]
 = Using Insights to identify issues with your cluster
 include::modules/common-attributes.adoc[]
+include::modules/insights-operator-document-attributes.adoc[]
 :context: using-insights-to-identify-issues-with-your-cluster
 
 toc::[]


### PR DESCRIPTION
Versions:  4.6+

This PR replaces the clouddot links in the Insights Operator Docs with custom attributes for the migration from cloud.redhat.com to ->  console.redhat.com. 

https://issues.redhat.com/browse/CCXDEV-5371 

This PR should only be merged after the official clouddot migration. 


Preview: https://deploy-preview-34748--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/about-remote-health-monitoring.html 