### PR TITLE
BZ1855393: Explained a parameter for setting the GCP cluster region.

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -855,6 +855,10 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the existing VPC that you want to deploy your cluster to.
 |String.
 
+|`platform.gcp.region`
+|The name of the GCP region that hosts your cluster.
+|Any valid region name, such as `us-central1`.
+
 |`platform.gcp.type`
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type].
 |The GCP machine type.


### PR DESCRIPTION
Added a row to the configuration parameters table for GCP to explain the `platform.<platform>.region` parameter.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1855393

Version: 4.6+

Preview: https://deploy-preview-34750--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc.html#installation-configuration-parameters-additional-gcp_installing-gcp-vpc