### PR TITLE
[enterprise-4.7]RHDEVDOCS-3126 Show which versions of OpenShift Logging run on which versions of OpenShift Container Platform.

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,41 +1,41 @@
 [id="cluster-logging-release-notes"]
-= Release notes for Red Hat OpenShift Logging 5.0
+= Release notes for Red Hat OpenShift Logging
 include::modules/cluster-logging-document-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
 toc::[]
 
-[id="openshift-logging-5-0-about-this-release"]
+[id="openshift-logging-about-this-release"]
 == About this release
 
-The following advisories are available for {ProductName} 5.0:
+The following advisories are available for {ProductName}:
 
-* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Bug Fix Advisory for OpenShift Logging 5.0.0]
-* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.1)]
-* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.2)]
-* link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)]
-* link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 Moderate: Openshift Logging security and bugs update (5.0.4)]
+* link:https://access.redhat.com/errata/RHBA-2021:2112[RHBA-2021:2112 - Bug Fix Advisory. OpenShift Logging Bug Fix Release 5.1.0]
+//* link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]
+* link:https://access.redhat.com/errata/RHSA-2021:2374[RHSA-2021:2374 - Security Advisory. Moderate: Openshift Logging Bug Fix Release (5.0.5)]
+* link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 - Security Advisory. Moderate: Openshift Logging security and bugs update (5.0.4)]
+* link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 - Security Advisory. Important OpenShift Logging Bug Fix Release (5.0.3)]
+* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.2)]
+* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)]
+* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0]
 
-[id="openshift-logging-5-0-inclusive-language"]
+[id="openshift-logging-supported-versions"]
+== Supported versions
+
+* OpenShift Logging version 5.0 runs on {product-title} versions 4.7 and 4.8.
+* OpenShift Logging version 5.1 runs on {product-title} versions 4.7 and 4.8.
+
+[id="openshift-logging-inclusive-language"]
 == Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
 
-[id="openshift-logging-5-0-deprecated-removed-features"]
-== Deprecated and removed features
-
-Some features available in previous releases have been deprecated or removed.
-
-Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
-
-[id="openshift-logging-5-0-elasticsearch-curator"]
-=== Elasticsearch Curator
-
-The Elasticsearch Curator is deprecated in OpenShift Logging 5.0 and will be removed in OpenShift Logging 5.1. Elasticsearch Curator helps you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator,  xref:../logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store[configure the log retention time].
-
 // Release Notes by version
-include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+1]
+// include::modules/cluster-logging-release-notes-5.0.6.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.5.adoc[leveloffset=+1]
 include::modules/cluster-logging-release-notes-5.0.4.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]

--- a/modules/cluster-logging-release-notes-5.0.0.adoc
+++ b/modules/cluster-logging-release-notes-5.0.0.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-0"]
 = OpenShift Logging 5.0.0
 
-This release includes link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 Bug Fix Advisory for OpenShift Logging 5.0.0].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0].
 
 
 [id="openshift-logging-5-0-new-features-and-enhancements"]

--- a/modules/cluster-logging-release-notes-5.0.1.adoc
+++ b/modules/cluster-logging-release-notes-5.0.1.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-1"]
 = OpenShift Logging 5.0.1
 
-This release includes link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.1)].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)].
 
 [id="openshift-logging-5-0-1-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.0.2.adoc
+++ b/modules/cluster-logging-release-notes-5.0.2.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-2"]
 = OpenShift Logging 5.0.2
 
-This release includes link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 Bug Fix Advisory for OpenShift Logging Bug Fix Release (5.0.2)].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.2)].
 
 [id="openshift-logging-5-0-2-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.0.3.adoc
+++ b/modules/cluster-logging-release-notes-5.0.3.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-3"]
 = OpenShift Logging 5.0.3
 
-This release includes link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 Security Advisory for Important OpenShift Logging Bug Fix Release (5.0.3)].
+This release includes link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 - Security Advisory. Important OpenShift Logging Bug Fix Release (5.0.3)].
 
 
 [id="openshift-logging-5-0-3-security-fixes"]

--- a/modules/cluster-logging-release-notes-5.0.4.adoc
+++ b/modules/cluster-logging-release-notes-5.0.4.adoc
@@ -1,8 +1,7 @@
 [id="cluster-logging-release-notes-5-0-4"]
 = OpenShift Logging 5.0.4
 
-This release includes link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 Moderate: Openshift Logging security and bugs update (5.0.4)].
-
+This release includes link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 - Security Advisory. Moderate: Openshift Logging security and bugs update (5.0.4)].
 
 [id="openshift-logging-5-0-4-security-fixes"]
 == Security fixes

--- a/modules/cluster-logging-release-notes-5.0.5.adoc
+++ b/modules/cluster-logging-release-notes-5.0.5.adoc
@@ -1,0 +1,18 @@
+[id="cluster-logging-release-notes-5-0-5"]
+= OpenShift Logging 5.0.5
+
+This release includes link:https://access.redhat.com/errata/RHSA-2021:2374[RHSA-2021:2374 - Security Advisory. Moderate: Openshift Logging Bug Fix Release (5.0.5)].
+
+[id="openshift-logging-5-0-5-security-fixes"]
+== Security fixes
+
+* gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index
+validation. (link:https://access.redhat.com/security/cve/CVE-2021-3121[*CVE-2021-3121*])
+* glib: integer overflow in g_bytes_new function on 64-bit platforms due to an implicit cast from 64 bits to 32 bits(link:https://access.redhat.com/security/cve/cve-2021-27219[*CVE-2021-27219*])
+
+The following issues relate to the above CVEs:
+
+* BZ#1921650 gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation(link:https://bugzilla.redhat.com/show_bug.cgi?id=1921650[*BZ#1921650*])
+* LOG-1361 CVE-2021-3121 elasticsearch-operator-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1361*])
+* LOG-1362 CVE-2021-3121 elasticsearch-proxy-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1362*])
+* LOG-1363 CVE-2021-3121 logging-eventrouter-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1363*])

--- a/modules/cluster-logging-release-notes-5.0.6.adoc
+++ b/modules/cluster-logging-release-notes-5.0.6.adoc
@@ -1,0 +1,30 @@
+[id="cluster-logging-release-notes-5-0-6"]
+= OpenShift Logging 5.0.6
+
+This release includes link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.6)].
+
+[id="openshift-logging-5-0-6-bug-fixes"]
+== Bug fixes
+
+This release also includes the following bug fixes:
+
+* LOG-1451 [1927249] fieldmanager.go:186] [SHOULD NOT HAPPEN] failed to update managedFields...duplicate entries for key [name="POLICY_MAPPING"] (link:https://issues.redhat.com/browse/LOG-1451[*LOG-1451*])
+* LOG-1537 Full Cluster Cert Redeploy is broken when the ES clusters includes non-data nodes(link:https://issues.redhat.com/browse/LOG-1537[*LOG-1537*])
+* LOG-1430 eventrouter raising "Observed a panic: &runtime.TypeAssertionError" (link:https://issues.redhat.com/browse/LOG-1430[*LOG-1430*])
+
+[id="openshift-logging-5-0-6-references"]
+== References
+
+* https://access.redhat.com/security/cve/CVE-2018-25011
+* https://access.redhat.com/security/cve/CVE-2020-26541
+* https://access.redhat.com/security/cve/CVE-2020-36328
+* https://access.redhat.com/security/cve/CVE-2020-36329
+* https://access.redhat.com/security/cve/CVE-2021-3516
+* https://access.redhat.com/security/cve/CVE-2021-3517
+* https://access.redhat.com/security/cve/CVE-2021-3518
+* https://access.redhat.com/security/cve/CVE-2021-3520
+* https://access.redhat.com/security/cve/CVE-2021-3537
+* https://access.redhat.com/security/cve/CVE-2021-3541
+* https://access.redhat.com/security/cve/CVE-2021-20271
+* https://access.redhat.com/security/cve/CVE-2021-27219
+* https://access.redhat.com/security/cve/CVE-2021-33034

--- a/modules/cluster-logging-release-notes-5.1.0.adoc
+++ b/modules/cluster-logging-release-notes-5.1.0.adoc
@@ -1,0 +1,84 @@
+[id="cluster-logging-release-notes-5-1-0"]
+= OpenShift Logging 5.1.0
+
+This release includes link:https://access.redhat.com/errata/RHSA-2021:2112[RHSA-2021:2112 OpenShift Logging Bug Fix Release 5.1.0].
+
+[id="openshift-logging-5-1-0-new-features-and-enhancements"]
+== New features and enhancements
+
+OpenShift Logging 5.1 now supports {product-title} 4.7 and later running on:
+
+* IBM Power Systems
+* IBM Z and LinuxONE
+
+This release adds improvements related to the following components and concepts.
+
+* As a cluster administrator, you can use Kubernetes pod labels to gather log data from an application and send it to a specific log store. You can gather log data by configuring the `inputs[].application.selector.matchLabels` element in the `ClusterLogForwarder` custom resource (CR) YAML file. You can also filter the gathered log data by namespace.
+(link:https://issues.redhat.com/browse/LOG-883[*LOG-883*])
+
+* This release adds the following new `ElasticsearchNodeDiskWatermarkReached` warnings to the OpenShift Elasticsearch Operator (EO):
+ - Elasticsearch Node Disk Low Watermark Reached
+ - Elasticsearch Node Disk High Watermark Reached
+ - Elasticsearch Node Disk Flood Watermark Reached
+
++
+The alert applies the past several warnings when it predicts that an Elasticsearch node will reach the `Disk Low Watermark`, `Disk High Watermark`, or `Disk Flood Stage Watermark` thresholds in the next 6 hours. This warning period gives you time to respond before the node reaches the disk watermark thresholds. The warning messages also provide links to the troubleshooting steps, which you can follow to help mitigate the issue. The EO applies the past several hours of disk space data to a linear model to generate these warnings.
+(link:https://issues.redhat.com/browse/LOG-1100[*LOG-1100*])
+
+* JSON logs can now be forwarded as JSON objects, rather than quoted strings, to either Red Hat's managed Elasticsearch cluster or any of the other supported third-party systems. Additionally, you can now query individual fields from a JSON log message inside Kibana which increases the discoverability of specific logs.
+(link:https://issues.redhat.com/browse/LOG-785[*LOG-785*], https://issues.redhat.com/browse/LOG-1148[*LOG-1148*])
+
+[id="openshift-logging-5-1-0-deprecated-removed-features"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+[id="openshift-logging-5-1-0-elasticsearch-curator"]
+=== Elasticsearch Curator has been removed
+
+With this update, the Elasticsearch Curator has been removed and is no longer supported. Elasticsearch Curator helped you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator, configure the log retention time.
+
+[id="openshift-logging-5-1-0-bug-fixes"]
+== Bug fixes
+
+* Before this update, the `ClusterLogForwarder` CR did not show the `input[].selector` element after it had been created. With this update, when you specify a `selector` in the `ClusterLogForwarder` CR, it remains. Fixing this bug was necessary for link:https://issues.redhat.com/browse/LOG-883[LOG-883], which enables using pod label selectors to forward application log data.
+(link:https://issues.redhat.com/browse/LOG-1338[*LOG-1338*])
+
+* Before this update, an update in the cluster service version (CSV) accidentally introduced resources and limits for the OpenShift Elasticsearch Operator container. Under specific conditions, this caused an out-of-memory condition that terminated the Elasticsearch Operator pod. This update fixes the issue by removing the CSV resources and limits for the Operator container. The Operator gets scheduled without issues.
+(link:https://issues.redhat.com/browse/LOG-1254[*LOG-1254*])
+
+* Before this update, forwarding logs to Kafka using chained certificates failed with the following error message:
++
+`state=error: certificate verify failed (unable to get local issuer certificate)`
++
+Logs could not be forwarded to a Kafka broker with a certificate signed by an intermediate CA. This happened because the Fluentd Kafka plug-in could only handle a single CA certificate supplied in the `ca-bundle.crt` entry of the corresponding secret. This update fixes the issue by enabling the Fluentd Kafka plug-in to handle multiple CA certificates supplied in the `ca-bundle.crt` entry of the corresponding secret. Now, logs can be forwarded to a Kafka broker with a certificate signed by an intermediate CA.
+(link:https://issues.redhat.com/browse/LOG-1218[*LOG-1218*], link:https://issues.redhat.com/browse/LOG-1216[*LOG-1216*])
+
+* Before this update, while under load, Elasticsearch responded to some requests with an HTTP 500 error, even though there was nothing wrong with the cluster. Retrying the request was successful. This update fixes the issue by updating the index management cron jobs to be more resilient when they encounter temporary HTTP 500 errors. The updated index management cron jobs will first retry a request multiple times before failing.
+(link:https://issues.redhat.com/browse/LOG-1215[*LOG-1215*])
+
+* Before this update, if you did not set the `.proxy` value in the cluster installation configuration, and then configured a global proxy on the installed cluster, a bug prevented Fluentd from forwarding logs to Elasticsearch. To work around this issue, in the proxy or cluster configuration, set the `no_proxy` value to `.svc.cluster.local` so it skips internal traffic. This update fixes the proxy configuration issue. If you configure the global proxy after installing an {product-title} cluster, Fluentd forwards logs to Elasticsearch.
+(link:https://issues.redhat.com/browse/LOG-1187[*LOG-1187*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1915448[*BZ#1915448*])
+
+* Before this update, the logging collector created more socket connections than necessary. With this update, the logging collector reuses the existing socket connection to send logs.
+(link:https://issues.redhat.com/browse/LOG-1186[*LOG-1186*])
+
+* Before this update, if a cluster administrator tried to add or remove storage from an Elasticsearch cluster, the OpenShift Elasticsearch Operator (EO) incorrectly tried to upgrade the Elasticsearch cluster, displaying `scheduledUpgrade: "True"`, `shardAllocationEnabled: primaries`, and change the volumes. With this update, the EO does not try to upgrade the Elasticsearch cluster.
++
+The EO status displays the following new status information to indicate when you have tried to make an unsupported change to the Elasticsearch storage that it has ignored:
++
+ - `StorageStructureChangeIgnored` when you try to change between using ephemeral and persistent storage structures.
+ - `StorageClassNameChangeIgnored` when you try to change the storage class name.
+ - `StorageSizeChangeIgnored` when you try to change the storage size.
++
+[NOTE]
+====
+If you configure the `ClusterLogging` custom resource (CR) to switch from ephemeral to persistent storage, the EO creates a persistent volume claim (PVC) but does not create a persistent volume (PV).  To clear the `StorageStructureChangeIgnored` status, you must revert the change to the `ClusterLogging` CR and delete the persistent volume claim (PVC).
+====
++
+(link:https://issues.redhat.com/browse/LOG-1351[*LOG-1351*])
+
+Before this update, if you redeployed a full Elasticsearch cluster, it got stuck in an unhealthy state, with one non-data node running and all other data nodes shut down. This happened because new certificates prevented the Elasticsearch Operator from scaling down the non-data nodes of the Elasticsearch cluster. With this update, Elasticsearch Operator can scale all the data and non-data nodes down and then back up again, so they load the new certificates. The Elasticsearch Operator can reach the new nodes after they load the new certificates.
+(link:https://issues.redhat.com/browse/LOG-1536[*LOG-1536*])


### PR DESCRIPTION
Manually CP https://github.com/openshift/openshift-docs/pull/34067 to 4.7

Cherry Picked from 00ae72cbf25db6cc0e3dfe81e77f9bb5c487d9a7 xref: #34067
