### PR TITLE
CNV12495: Adding learn more about OpenShift Virtualization page

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2722,6 +2722,8 @@ Distros: openshift-enterprise
 Topics:
 - Name: About OpenShift Virtualization
   File: about-virt
+- Name: Learn more about deploying and managing virtual machines in your OpenShift cluster
+  File: virt-learn-more-about-openshift-virtualization
 - Name: OpenShift Virtualization release notes
   File: virt-4-8-release-notes
 - Name: Installing OpenShift Virtualization

--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -1,0 +1,108 @@
+[id="virt-learn-more-about-openshift-virtualization"]
+= Learn more about deploying and managing virtual machines in your {product-title} cluster
+include::modules/virt-document-attributes.adoc[]
+:context: virt-learn-more-about-openshift-virtualization
+
+toc::[]
+
+Use the following tables to find content to help you learn about and use {VirtProductName}.
+
+[id="virt-learn-more-cluster-administrator"]
+== Cluster administrator
+
+[options="header",cols="4*"]
+|===
+|Learn |Plan |Deploy |Additional resources
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| xref:../virt/install/preparing-cluster-for-virt.adoc#preparing-cluster-for-virt[Configuring your cluster for {VirtProductName}]
+| xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-updating-node-network-config[Updating your node network configuration]
+| xref:../virt/logging_events_monitoring/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Getting Support]
+
+| xref:../welcome/learn_more_about_openshift.adoc#learn_more_about_openshift[Learn more about {product-title}]
+| xref:../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Plan storage for virtual machine disks]
+| xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
+|
+
+| xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Learn about virtual machine live migration]
+|
+| Installing {VirtProductName} using the xref:../virt/install/installing-virt-web.adoc#installing-virt-web[{VirtProductName} console] or xref:../virt/install/installing-virt-cli.adoc#installing-virt-cli[CLI]
+|
+
+| xref:../virt/node_maintenance/virt-about-node-maintenance.adoc#virt-about-node-maintenance[Learn about node maintenance]
+|
+|
+|
+
+|
+|===
+
+[id="virt-learn-more-virtualization-administrator"]
+== Virtualization administrator
+
+[options="header",cols="4*"]
+|===
+|Learn |Deploy |Manage |Use
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| Connecting virtual machines to the xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-using-the-default-pod-network-with-virt[default pod network for virtual machines] and xref:../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[multiple networks]
+| xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Installing the `virtctl` client]
+| xref:../migration-toolkit-for-containers/about-mtc.adoc#about-mtc[Importing virtual machines with the Migration Toolkit for containers]
+
+| xref:../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Learn about storage features for virtual machine disks]
+| xref:../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Configuring data volume defaults]
+| xref:../virt/virt-using-the-cli-tools.adoc#virt-using-the-cli-tools[Using  the CLI tools]
+| xref:../virt/live_migration/virt-live-migration.adoc#virt-live-migration[Using live migration]
+
+|
+| xref:../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-and-using-boot-sources[Creating boot sources and attaching them to templates]
+| Viewing xref:../virt/logging_events_monitoring/virt-logs.adoc#virt-logs[logs] and xref:../virt/logging_events_monitoring/virt-events.adoc#virt-events[events]
+|
+
+|
+| link:https://www.google.com/url?q=https://www.openshift.com/blog/updating-a-boot-source-image&sa=D&source=editors&ust=1626893484915000&usg=AOvVaw0cDIQr63zScl7b-Cn8G0rA[Updating boot source templates]
+| xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
+|
+
+|
+|===
+
+[id="virt-learn-more-developer"]
+== Virtual machine administrator / developer
+
+[options="header",cols="4*"]
+|===
+|Learn |Use |Manage |Additional resources
+
+| xref:../virt/about-virt.adoc#about-virt[Learn about {VirtProductName}]
+| xref:../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Installing the `virtctl` client]
+| Viewing xref:../virt/logging_events_monitoring/virt-logs.adoc#virt-logs[logs] and xref:../virt/logging_events_monitoring/virt-events.adoc#virt-events[events]
+| xref:../virt/logging_events_monitoring/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Getting Support]
+
+|
+| xref:../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[Creating virtual machines]
+| xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
+|
+
+|
+| xref:../virt/virtual_machines/virt-manage-vmis.adoc#virt-manage-vmis[Managing virtual machines instances]
+| xref:../virt/virtual_machines/virtual_disks/virt-managing-offline-vm-snapshots.adoc#virt-managing-offline-vm-snapshots[Creating and managing virtual machine snapshots]
+|
+
+|
+| xref:../virt/virtual_machines/virt-controlling-vm-states.adoc#virt-controlling-vm-states[Controlling virtual machine states]
+|
+|
+
+|
+| xref:../virt/virtual_machines/virt-accessing-vm-consoles.adoc#virt-accessing-vm-consoles[Accessing the virtual machine consoles]
+|
+|
+
+|
+| xref:../virt/virtual_machines/virt-managing-configmaps-secrets-service-accounts.adoc#virt-managing-configmaps-secrets-service-accounts[Pass configuration data to virtual machines using secrets, configuration maps, and service accounts]
+|
+|
+
+|
+|===


### PR DESCRIPTION
For 4.8 only.

Jira: https://issues.redhat.com/browse/CNV-12495

Tagging @peterclauterbach @dankenigsberg for code review
Tagging Oded Ramraz per Peter Lauterbach to assign a QE resource to review this new page.

Direct doc preview link: https://deploy-preview-34775--osdocs.netlify.app/openshift-enterprise/latest/virt/learn_more_about_openshift_virtualization.html

This PR replaced: https://github.com/openshift/openshift-docs/pull/34713