### PR TITLE
[RHDEVDOCS-2386]: Jenkins to Tekton Migration Guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1409,6 +1409,12 @@ Topics:
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
     Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+- Name: Migrating from Jenkins to Tekton
+  Dir: jenkins-tekton
+  Distros: openshift-enterprise
+  Topics:
+  - Name: Migrating from Jenkins to Tekton
+    File: migrating-from-jenkins-to-tekton
 - Name: Pipelines
   Dir: pipelines
   Distros: openshift-enterprise

--- a/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+++ b/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
@@ -1,0 +1,22 @@
+//Jenkins-Tekton-Migration
+include::modules/common-attributes.adoc[]
+include::modules/pipelines-document-attributes.adoc[]
+[id="migrating-from-jenkins-to-tekton_{context}"]
+= Migrating from Jenkins to Tekton
+:context: migrating-from-jenkins-to-tekton
+//include::modules/common-attributes.adoc[]
+
+toc::[]
+
+
+Jenkins and Tekton are extensively used to automate the process of building, testing, and deploying applications and projects. However, Tekton is a cloud-native CI/CD solution that works seamlessly with Kubernetes and {product-title}. This document helps you migrate your Jenkins CI/CD workflows to Tekton.
+
+include::modules/jt-comparison-of-jenkins-and-tekton-concepts.adoc[leveloffset=+1]
+
+include::modules/jt-migrating-a-sample-pipeline-from-jenkins-to-tekton.adoc[leveloffset=+1]
+
+include::modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc[leveloffset=+1]
+
+include::modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc[leveloffset=+1]
+
+include::modules/jt-comparison-of-jenkins-tekton-execution-models.adoc[leveloffset=+1]

--- a/modules/jt-comparison-of-jenkins-and-tekton-concepts.adoc
+++ b/modules/jt-comparison-of-jenkins-and-tekton-concepts.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-comparison-of-jenkins-and-tekton-concepts_{context}"]
+= Comparison of Jenkins and Tekton concepts
+
+toc::[]
+
+
+This section summarizes the basic terms used in Jenkins and Tekton, and compares the equivalent terms.
+
+== Jenkins terminology
+Jenkins offers declarative and scripted pipelines that are extensible using shared libraries and plugins. Some basic terms in Jenkins are as follows:
+
+* *Pipeline*: Automates the entire process of building, testing, and deploying applications, using the link:https://groovy-lang.org/[Groovy] syntax.
+* *Node*: A machine capable of either orchestrating or executing a scripted pipeline.
+* *Stage*: A conceptually distinct subset of tasks performed in a pipeline. Plugins or user interfaces often use this block to display status or progress of tasks.
+* **Step**: A single task that specifies the exact action to be taken, either by using a command or a script.
+
+== Tekton terminology
+Tekton uses the link:https://yaml.org/[YAML] syntax for declarative pipelines and consists of tasks. Some basic terms in Tekton are as follows:
+
+* **Pipeline**: A set of tasks in a series, in parallel, or both.
+* **Task**: A sequence of steps as commands, binaries, or scripts.
+* **PipelineRun**: Execution of a pipeline with one or more tasks.
+* **TaskRun**: Execution of a task with one or more steps.
++
+[NOTE]
+====
+You can initiate a PipelineRun or a TaskRun with a set of inputs such as parameters and workspaces, and the execution results in a set of outputs and artifacts.
+====
+* **Workspace**: In Tekton, workspaces are conceptual blocks that serve the following purposes:
+
+** Storage of inputs, outputs, and build artifacts.
+
+** Common space to share data among tasks.
+
+** Mount points for credentials held in secrets, configurations held in config maps, and common tools shared by an organization.
+
++
+[NOTE]
+====
+In Jenkins, there is no direct equivalent of Tekton workspaces. You can think of the control node as a workspace, as it stores the cloned code repository, build history, and artifacts. In situations where a job is assigned to a different node, the cloned code and the generated artifacts are stored in that node, but the build history is maintained by the control node.
+====
+
+== Mapping of concepts
+The building blocks of Jenkins and Tekton are not equivalent, and a comparison does not provide a technically accurate mapping. The following terms and concepts in Jenkins and Tekton correlate in general:
+
+.Jenkins and Tekton - basic comparison
+[cols="1,1",options="header"]
+|===
+|Jenkins|Tekton
+|Pipeline|Pipeline and PipelineRun
+|Stage|Task
+|Step|A step in a task
+|===

--- a/modules/jt-comparison-of-jenkins-tekton-execution-models.adoc
+++ b/modules/jt-comparison-of-jenkins-tekton-execution-models.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-comparison-of-jenkins-tekton-execution-models_{context}"]
+= Comparison of Jenkins and Tekton execution models
+
+Jenkins and Tekton offer similar functions but are different in architecture and execution. This section outlines a brief comparison of the two execution models.
+
+.Comparison of execution models in Jenkins and Tekton
+[cols="1,1",options="header"]
+|===
+|Jenkins|Tekton
+|Jenkins has a control node. Jenkins executes pipelines and steps centrally, or orchestrates jobs running in other nodes.|Tekton is serverless and distributed, and there is no central dependency for execution.
+|The containers are launched by the control node through the pipeline.|Tekton adopts a 'container-first' approach, where every step is executed as a container running in a pod (equivalent to nodes in Jenkins).
+|Extensibility is achieved using plugins.|Extensibility is achieved using tasks in Tekton Hub, or by creating custom tasks and scripts.
+|===

--- a/modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc
+++ b/modules/jt-extending-tekton-capabilities-using-custom-tasks-and-scripts.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-extending-tekton-capabilities-using-custom-tasks-and-scripts_{context}"]
+= Extending Tekton capabilities using custom tasks and scripts
+
+toc::[]
+
+
+In Tekton, if you do not find the right task in Tekton Hub, or need greater control over tasks, you can create custom tasks and scripts to extend Tekton's capabilities.
+
+.Example: Custom task for running the `maven test` command
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: maven-test
+spec:
+  workspaces:
+  - name: source
+  steps:
+  - image: my-maven-image
+    command: ["mvn test"]
+    workingDir: $(workspaces.source.path)
+----
+
+.Example: Execute a custom shell script by providing its path
+[source,yaml,subs="attributes+"]
+----
+...
+steps:
+  image: ubuntu
+  script: |
+      #!/usr/bin/env bash
+      /workspace/my-script.sh
+...
+----
+
+.Example: Execute a custom Python script by writing it in the YAML file
+[source,yaml,subs="attributes+"]
+----
+...
+steps:
+  image: python
+  script: |
+      #!/usr/bin/env python3
+      print(“hello from python!”)
+...
+----

--- a/modules/jt-migrating-a-sample-pipeline-from-jenkins-to-tekton.adoc
+++ b/modules/jt-migrating-a-sample-pipeline-from-jenkins-to-tekton.adoc
@@ -1,0 +1,127 @@
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-migrating-a-sample-pipeline-from-jenkins-to-tekton_{context}"]
+= Migrating a sample pipeline from Jenkins to Tekton
+
+toc::[]
+
+
+This section provides equivalent examples of pipelines in Jenkins and Tekton and helps you to migrate your build, test, and deploy pipelines from Jenkins to Tekton.
+
+== Jenkins pipeline
+Consider a Jenkins pipeline written in Groovy for building, testing, and deploying:
+[source,groovy,subs="attributes+"]
+----
+pipeline {
+   agent any
+   stages {
+       stage('Build') {
+           steps {
+               sh 'make'
+           }
+       }
+       stage('Test'){
+           steps {
+               sh 'make check'
+               junit 'reports/**/*.xml'
+           }
+       }
+       stage('Deploy') {
+           steps {
+               sh 'make publish'
+           }
+       }
+   }
+}
+----
+
+== Tekton pipeline
+In Tekton, the equivalent example of the Jenkins pipeline comprises of three tasks, each of which can be written declaratively using the YAML syntax:
+
+.Example `build` task
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: myproject-build
+spec:
+  workspaces:
+  - name: source
+  steps:
+  - image: my-ci-image
+    command: ["make"]
+    workingDir: $(workspaces.source.path)
+----
+
+.Example `test` task:
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: myproject-test
+spec:
+  workspaces:
+  - name: source
+  steps:
+  - image: my-ci-image
+    command: ["make check"]
+    workingDir: $(workspaces.source.path)
+  - image: junit-report-image
+    script: |
+      #!/usr/bin/env bash
+      junit-report reports/**/*.xml
+    workingDir: $(workspaces.source.path)
+----
+
+.Example `deploy` task:
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: myprojectd-deploy
+spec:
+  workspaces:
+  - name: source
+  steps:
+  - image: my-deploy-image
+    command: ["make deploy"]
+    workingDir: $(workspaces.source.path)
+----
+
+You can combine the three tasks sequentially to form a Tekton pipeline:
+
+.Example: Tekton pipeline for building, testing, and deployment
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  name: myproject-pipeline
+spec:
+  workspaces:
+  - name: shared-dir
+  tasks:
+  - name: build
+    taskRef:
+      name: myproject-build
+    workspaces:
+    - name: source
+      workspace: shared-dir
+  - name: test
+    taskRef:
+      name: myproject-test
+    workspaces:
+    - name: source
+      workspace: shared-dir
+  - name: deploy
+    taskRef:
+      name: myproject-deploy
+    workspaces:
+    - name: source
+      workspace: shared-dir
+----

--- a/modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc
+++ b/modules/jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assembly:
+//
+// jenkins-tekton/migrating-from-jenkins-to-tekton.adoc
+
+[id="jt-migrating-from-jenkins-plugins-to-tekton-hub-tasks_{context}"]
+= Migrating from Jenkins plugins to Tekton Hub tasks
+
+toc::[]
+
+
+You can exend the capability of Jenkins by using link:https://plugins.jenkinsci.org[plugins]. To achieve similar extensibility in Tekton, use any of the available tasks from link:https://hub.tekton.dev[Tekton Hub].
+
+As an example, consider the link:https://hub.tekton.dev/tekton/task/git-clone[git-clone] task available in the Tekton Hub, that corresponds to the link:https://plugins.jenkins.io/git/[git plugin] for Jenkins.
+
+.Example: `git-clone` task from Tekton Hub
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+ name: demo-pipeline
+spec:
+ params:
+   - name: repo_url
+   - name: revision
+ workspaces:
+   - name: source
+ tasks:
+   - name: fetch-from-git
+     taskRef:
+       name: git-clone
+     params:
+       - name: url
+         value: $(params.repo_url)
+       - name: revision
+         value: $(params.revision)
+     workspaces:
+     - name: output
+       workspace: source
+----


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `4.8`, `4.9`
- **JIRA issues**: 
  - [Epic: Document Jenkins to Tekton migration guide](https://issues.redhat.com/browse/RHDEVDOCS-2386)
    - [Brief introduction on creating Tasks for Jenkins plugins that don't exist](https://issues.redhat.com/browse/RHDEVDOCS-2801)
    - [Document how to find Tekton tasks as opposed to Jenkins plugins](https://issues.redhat.com/browse/RHDEVDOCS-2800)
    - [Mapping of Jenkins concepts and Tekton concepts](https://issues.redhat.com/browse/RHDEVDOCS-2797)
    - [Compare the Tekton execution model with that of Jenkins](https://issues.redhat.com/browse/RHDEVDOCS-2798)
    
    NOTE: Content for the following JIRA issues are not included in this PR, and will be added afterwards:
        - [Document basic common use-cases](https://issues.redhat.com/browse/RHDEVDOCS-2875)
        - [Dealing with Jenkins shared library in Tekton](https://issues.redhat.com/browse/RHDEVDOCS-2802)
        - [Mapping Pipeline CRD structure to Jenkinsfile structure](https://issues.redhat.com/browse/RHDEVDOCS-2799)
    
- **Preview pages**: [Migrating from Jenkins to Tekton](https://deploy-preview-34792--osdocs.netlify.app/openshift-enterprise/latest/cicd/jenkins-tekton/migrating-from-jenkins-to-tekton.html)
- **Reviewer**: Rupali Behera
- **Peer Review**: Preeti Chandrasekhar