### PR TITLE
typo fix

### DIFF
--- a/modules/migration-mtc-workflow.adoc
+++ b/modules/migration-mtc-workflow.adoc
@@ -6,7 +6,7 @@
 [id="migration-mtc-workflow_{context}"]
 = {mtc-full} workflow
 
-You use the {mtc-full} ({mtc-short}) to migrate Kubernetes resources, persistent volume data, and internal container images from to {product-title} {product-version} by using the {mtc-short} web console or the Kubernetes API.
+You can migrate Kubernetes resources, persistent volume data, and internal container images to {product-title} {product-version} by using the {mtc-full} ({mtc-short}) web console or the Kubernetes API.
 
 {mtc-short} migrates the following resources:
 


### PR DESCRIPTION
Fixed typo in a module

4.5+

No QE required.

Preview: https://deploy-preview-34797--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/about-mtc-3-4.html#migration-mtc-workflow_about-mtc-3-4