### PR TITLE
BZ1973326: Add 4-8 RN for multipath

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -81,6 +81,13 @@ For more information, see xref:../installing/install_config/installing-customizi
 
 If a cloud administrator has already set a custom `/etc/chrony.conf` configuration, {op-system} no longer sets the `PEERNTP=no` option by default on cloud platforms. Otherwise, the `PEERNTP=no` option is still set by default. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1924869[BZ#1924869] for more information.
 
+[id="ocp-4-8-rhcos-multipath-install"]
+==== Enabling multipathing at bare metal installation time
+
+Enabling multipathing during bare metal installation is now supported for nodes provisioned in {product-title} 4.8 or higher. You can enable multipathing by appending kernel arguments to the `coreos-installer install` command so that the installed system itself uses multipath beginning from the first boot. While post-installation support is still available by activating multipathing via the machine config, enabling multipathing during installation is recommended for nodes provisioned starting in {product-title} 4.8.
+
+//For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-enabling-multipath_installing-bare-metal[Enabling multipathing with kernel arguments on RHCOS].
+
 [id="ocp-4-8-installation-and-upgrade"]
 === Installation and upgrade
 


### PR DESCRIPTION
Adds 4.8 Release Note for enabling multipathing at installation.

Relates to https://github.com/openshift/openshift-docs/pull/34462, which will be merged post-GA.

https://bugzilla.redhat.com/show_bug.cgi?id=1973326
Relates to content added as part of https://github.com/openshift/openshift-docs/pull/34462

Preview: https://deploy-preview-34798--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-rhcos-