### PR TITLE
Reorganize Multus related CNI plug-in content

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -931,16 +931,6 @@ Topics:
     File: attaching-pod
   - Name: Removing a pod from an additional network
     File: removing-pod
-  - Name: Configuring a bridge network
-    File: configuring-bridge
-  - Name: Configuring a host-device network
-    File: configuring-host-device
-  - Name: Configuring an ipvlan network
-    File: configuring-ipvlan
-  - Name: Configuring a macvlan network with basic customizations
-    File: configuring-macvlan-basic
-  - Name: Configuring a macvlan network
-    File: configuring-macvlan
   - Name: Editing an additional network
     File: edit-additional-network
   - Name: Removing an additional network

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -921,6 +921,8 @@ Topics:
   Topics:
   - Name: Understanding multiple networks
     File: understanding-multiple-networks
+  - Name: Configuring an additional network
+    File: configuring-additional-network
   - Name: About virtual routing and forwarding
     File: about-virtual-routing-and-forwarding
   - Name: Configuring multi-network policy

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -72,12 +72,9 @@ plug-in:
 
 The following example configures an additional network named `bridge-net`:
 
-[source,yaml]
+[source,json]
 ----
-name: bridge-net
-namespace: work-network
-type: Raw
-rawCNIConfig: '{ <1>
+{
   "cniVersion": "0.3.1",
   "name": "work-network",
   "type": "bridge",
@@ -86,6 +83,5 @@ rawCNIConfig: '{ <1>
   "ipam": {
     "type": "dhcp"
     }
-}'
+}
 ----
-<1> The CNI configuration object is specified as a YAML string.

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -3,104 +3,69 @@
 // * networking/multiple_networks/configuring-bridge.adoc
 
 [id="nw-multus-bridge-object_{context}"]
-= Configuration for bridge
-
-The configuration for an additional network attachment that uses the bridge
-Container Network Interface (CNI) plug-in is provided in two parts:
-
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
-
-The CNO configuration specifies the name for the additional network attachment
-and the namespace to create the attachment in. The plug-in
-is configured by a JSON object specified by the `rawCNIConfig` parameter in
-the CNO configuration.
-
-The following YAML describes the configuration parameters for the CNO:
-
-.Cluster Network Operator YAML configuration
-[source,yaml]
-----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: '{ <3>
-  ...
-}'
-type: Raw
-----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
-
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+= Configuration for a bridge additional network
 
 The following object describes the configuration parameters for the bridge CNI
 plug-in:
 
-.bridge CNI plug-in JSON configuration object
-[source,json]
-----
-{
-  "cniVersion": "0.3.1",
-  "name": "<name>", <1>
-  "type": "bridge",
-  "bridge": "<bridge>", <2>
-  "ipam": { <3>
-    ...
-  },
-  "ipMasq": false, <4>
-  "isGateway": false, <5>
-  "isDefaultGateway": false, <6>
-  "forceAddress": false, <7>
-  "hairpinMode": false, <8>
-  "promiscMode": false, <9>
-  "vlan": <vlan>, <10>
-  "mtu": <mtu> <11>
-}
-----
-<1> Specify the value for the `name` parameter you provided previously for
-the CNO configuration.
+.Bridge CNI plug-in JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
 
-<2> Specify the name of the virtual bridge to use. If the bridge
-interface does not exist on the host, it is created. The default value is
-`cni0`.
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
 
-<3> Specify a configuration object for the ipam CNI plug-in. The plug-in
-manages IP address assignment for the network attachment definition.
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
 
-<4> Set to `true` to enable IP masquerading for traffic that leaves the
-virtual network. The source IP address for all traffic is rewritten to the
-bridge's IP address. If the bridge does not have an IP address, this setting has
-no effect. The default value is `false`.
+|`type`
+|`string`
+|
 
-<5> Set to `true` to assign an IP address to the bridge. The
-default value is `false`.
+|`bridge`
+|`string`
+|Specify the name of the virtual bridge to use. If the bridge interface does not exist on the host, it is created. The default value is `cni0`.
 
-<6> Set to `true` to configure the bridge as the default
-gateway for the virtual network. The default value is `false`. If
-`isDefaultGateway` is set to `true`, then `isGateway` is also set to `true`
-automatically.
+|`ipam`
+|`object`
+|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
 
-<7> Set to `true` to allow assignment of a previously assigned
-IP address to the virtual bridge. When set to `false`, if an IPv4 address or an
-IPv6 address from overlapping subsets is assigned to the virtual bridge, an
-error occurs. The default value is `false`.
+|`ipMasq`
+|`boolean`
+|Set to `true` to enable IP masquerading for traffic that leaves the virtual network. The source IP address for all traffic is rewritten to the bridge's IP address. If the bridge does not have an IP address, this setting has no effect. The default value is `false`.
 
-<8> Set to `true` to allow the virtual bridge to send an ethernet
-frame back through the virtual port it was received on. This mode is also known
-as _reflective relay_. The default value is `false`.
+|`isGateway`
+|`boolean`
+|Set to `true` to assign an IP address to the bridge. The default value is `false`.
 
-<9> Set to `true` to enable promiscuous mode on the bridge. The
-default value is `false`.
+|`isDefaultGateway`
+|`boolean`
+|Set to `true` to configure the bridge as the default gateway for the virtual network. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
 
-<10> Specify a virtual LAN (VLAN) tag as an integer value. By default,
-no VLAN tag is assigned.
+|`forceAddress`
+|`boolean`
+|Set to `true` to allow assignment of a previously assigned IP address to the virtual bridge. When set to `false`, if an IPv4 address or an IPv6 address from overlapping subsets is assigned to the virtual bridge, an error occurs. The default value is `false`.
 
-<11> Set the maximum transmission unit (MTU) to the specified value. The
-default value is automatically set by the kernel.
+|`hairpinMode`
+|`boolean`
+|Set to `true` to allow the virtual bridge to send an ethernet frame back through the virtual port it was received on. This mode is also known as _reflective relay_. The default value is `false`.
+
+|`promiscMode`
+|`boolean`
+|Set to `true` to enable promiscuous mode on the bridge. The default value is `false`.
+
+|`vlan`
+|`string`
+|Specify a virtual LAN (VLAN) tag as an integer value. By default, no VLAN tag is assigned.
+
+|`mtu`
+|`string`
+|Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+|====
 
 [id="nw-multus-bridge-config-example_{context}"]
 == bridge configuration example

--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-bridge.adoc
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 [id="nw-multus-bridge-object_{context}"]
 = Configuration for a bridge additional network

--- a/modules/nw-multus-create-network-apply.adoc
+++ b/modules/nw-multus-create-network-apply.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+
+[id="nw-multus-create-network-apply_{context}"]
+= Creating an additional network attachment by applying a YAML manifest
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a YAML file with your additional network configuration, such as in the following example:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: next-net
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "work-network",
+      "type": "host-device",
+      "device": "eth1",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }
+----
+
+. To create the additional network, enter the following command:
++
+[source,terminal]
+----
+$ oc apply -f <file>.yaml
+----
++
+--
+where:
+
+`<file>`:: Specifies the name of the file contained the YAML manifest.
+--

--- a/modules/nw-multus-create-network.adoc
+++ b/modules/nw-multus-create-network.adoc
@@ -1,39 +1,9 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-macvlan.adoc
-// * networking/multiple_networks/configuring-ipvlan.adoc
-// * networking/multiple_networks/configuring-bridge.adoc
-// * networking/multiple_networks/configuring-host-device.adoc
-
-// Configuring Multus plug-ins using the Cluster Network Operator
-// is nearly identical in each case.
-
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:plugin: macvlan
-:macvlan:
-:yaml:
-endif::[]
-// This is necessary for Whereabouts CNI which is JSON-only
-ifeval::["{context}" == "configuring-macvlan"]
-:plugin: macvlan
-:macvlan:
-:json:
-endif::[]
-ifeval::["{context}" == "configuring-ipvlan"]
-:plugin: ipvlan
-:json:
-endif::[]
-ifeval::["{context}" == "configuring-bridge"]
-:plugin: bridge
-:json:
-endif::[]
-ifeval::["{context}" == "configuring-host-device"]
-:plugin: host-device
-:json:
-endif::[]
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 [id="nw-multus-create-network_{context}"]
-= Creating an additional network attachment with the {plugin} CNI plug-in
+= Creating an additional network attachment with the Cluster Network Operator
 
 The Cluster Network Operator (CNO) manages additional network definitions. When
 you specify an additional network to create, the CNO creates the
@@ -53,9 +23,7 @@ network.
 
 .Procedure
 
-To create an additional network for your cluster, complete the following steps:
-
-. Edit the CNO CR by running the following command:
+. To edit the CNO configuration, enter the following command:
 +
 [source,terminal]
 ----
@@ -65,33 +33,6 @@ $ oc edit networks.operator.openshift.io cluster
 . Modify the CR that you are creating by adding the configuration for the
 additional network you are creating, as in the following example CR.
 +
-ifdef::yaml[]
-The following YAML configures the {plugin} CNI plug-in:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: SimpleMacvlan
-    simpleMacvlanConfig:
-      ipamConfig:
-        type: static
-        staticIPAMConfig:
-          addresses:
-          - address: 10.1.1.7/24
-----
-endif::yaml[]
-ifdef::json[]
-The following YAML configures the {plugin} CNI plug-in:
-endif::json[]
-+
-ifeval::["{plugin}" == "bridge"]
 [source,yaml,subs="attributes+"]
 ----
 apiVersion: operator.openshift.io/v1
@@ -99,120 +40,45 @@ kind: Network
 metadata:
   name: cluster
 spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
+  # ...
+  additionalNetworks:
+  - name: tertiary-net
+    namespace: project2
     type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
+    rawCNIConfig: |-
+      {
+        "cniVersion": "0.3.1",
+        "name": "tertiary-net",
+        "type": "ipvlan",
+        "master": "eth1",
+        "mode": "l2",
+        "ipam": {
+          "type": "static",
+          "addresses": [
+            {
+              "address": "192.168.1.23/24"
+            }
+          ]
+        }
       }
-    }'
 ----
-endif::[]
-ifeval::["{plugin}" == "host-device"]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "device": "eth1",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-ifeval::["{plugin}" == "ipvlan"]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "master": "eth1",
-      "mode": "l2",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-ifdef::macvlan+json[]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "master": "eth1",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-<1> Specify the configuration for the additional network attachment definition.
 
 . Save your changes and quit the text editor to commit your changes.
 
-. Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the object.
+.Verification
+
+* Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. There might be a delay before the CNO creates the object.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions -n <namespace>
 ----
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace for the network attachment that you added to the CNO configuration.
+--
 +
 .Example output
 [source,terminal]
@@ -220,26 +86,3 @@ $ oc get network-attachment-definitions -n <namespace>
 NAME                 AGE
 test-network-1       14m
 ----
-
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:!macvlan:
-:!plugin:
-:!yaml:
-endif::[]
-ifeval::["{context}" == "configuring-macvlan"]
-:!macvlan:
-:!plugin:
-:!json:
-endif::[]
-ifeval::["{context}" == "configuring-ipvlan"]
-:!plugin:
-:!json:
-endif::[]
-ifeval::["{context}" == "configuring-bridge"]
-:!plugin:
-:!json:
-endif::[]
-ifeval::["{context}" == "configuring-host-device"]
-:!plugin:
-:!json:
-endif::[]

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -55,12 +55,9 @@ The following object describes the configuration parameters for the host-device 
 
 The following example configures an additional network named `hostdev-net`:
 
-[source,yaml]
+[source,json]
 ----
-name: hostdev-net
-namespace: work-network
-type: Raw
-rawCNIConfig: '{ <1>
+{
   "cniVersion": "0.3.1",
   "name": "work-network",
   "type": "host-device",
@@ -68,6 +65,5 @@ rawCNIConfig: '{ <1>
   "ipam": {
     "type": "dhcp"
   }
-}'
+}
 ----
-<1> The CNI configuration object is specified as a YAML string.

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -3,77 +3,52 @@
 // * networking/multiple_networks/configuring-host-device.adoc
 
 [id="nw-multus-host-device-object_{context}"]
-= Configuration for host-device
-
-The configuration for an additional network attachment that uses the host-device
-Container Network Interface (CNI) plug-in is provided in two parts:
-
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
-
-The CNO configuration specifies the name for the additional network attachment
-and the namespace to create the attachment in. The plug-in
-is configured by a JSON object specified by the `rawCNIConfig` parameter in
-the CNO configuration.
-
-The following YAML describes the configuration parameters for the CNO:
-
-.Cluster Network Operator YAML configuration
-[source,yaml]
-----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: '{ <3>
-  ...
-}'
-type: Raw
-----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, the `default` namespace is used.
-
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+= Configuration for a host device additional network
 
 IMPORTANT: Specify your network device by setting only one of the
 following parameters: `device`, `hwaddr`, `kernelpath`, or `pciBusID`.
 
-The following object describes the configuration parameters for the host-device CNI
-plug-in:
+The following object describes the configuration parameters for the host-device CNI plug-in:
 
 // containernetworking/plugins/.../host-device.go#L50
-.host-device CNI plug-in JSON configuration object
-[source,json]
-----
-{
-  "cniVersion": "0.3.1",
-  "name": "<name>", <1>
-  "type": "host-device",
-  "device": "<device>", <2>
-  "hwaddr": "<hwaddr>", <3>
-  "kernelpath": "<kernelpath>", <4>
-  "pciBusID": "<pciBusID>", <5>
-  "ipam": { <6>
-    ...
-  }
-}
-----
-<1> Specify the value for the `name` parameter you provided previously for
-the CNO configuration.
+.Host device CNI plug-in JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
 
-<2> Specify the name of the device, such as `eth0`.
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
 
-<3> Specify the device hardware MAC address.
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
 
-<4> Specify the Linux kernel device path, such as
-`/sys/devices/pci0000:00/0000:00:1f.6`.
+|`type`
+|`string`
+|The name of the CNI plug-in to configure: `host-device`.
 
-<5> Specify the PCI address of the network device, such as `0000:00:1f.6`.
+|`device`
+|`string`
+|Optional: The name of the device, such as `eth0`.
 
-<6> Specify a configuration object for the ipam CNI plug-in. The plug-in
-manages IP address assignment for the attachment definition.
+|`hwaddr`
+|`string`
+|Optional: The device hardware MAC address.
+
+|`kernelpath`
+|`string`
+|Optional: The Linux kernel device path, such as `/sys/devices/pci0000:00/0000:00:1f.6`.
+
+|`pciBusID`
+|`string`
+|Optional: The PCI address of the network device, such as `0000:00:1f.6`.
+
+|`ipam`
+|`object`
+|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+
+|====
 
 [id="nw-multus-hostdev-config-example_{context}"]
 == host-device configuration example

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-host-device.adoc
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 [id="nw-multus-host-device-object_{context}"]
 = Configuration for a host device additional network

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -153,7 +153,6 @@ kind: Network
 metadata:
   name: cluster
 spec:
-  ...
   additionalNetworks:
   - name: dhcp-shim
     namespace: default
@@ -167,6 +166,7 @@ spec:
           "type": "dhcp"
         }
       }
+  # ...
 ----
 ====
 

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -12,96 +12,125 @@
 // for the Macvlan CNI plug-in only. In the future other Multus plug-ins
 // might be managed the same way by the CNO.
 
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:yaml:
-endif::[]
-ifeval::["{context}" != "configuring-macvlan-basic"]
-:json:
-endif::[]
 ifeval::["{context}" == "configuring-sriov-net-attach"]
 :sr-iov:
 endif::[]
 
 [id="nw-multus-ipam-object_{context}"]
-= Configuration for ipam CNI plug-in
+= Configuration of IP address assignment for an additional network
 
-The ipam Container Network Interface (CNI) plug-in provides IP address management (IPAM) for other CNI plug-ins.
+The IP address management (IPAM) Container Network Interface (CNI) plug-in provides IP addresses for other CNI plug-ins.
 
-ifdef::json[]
-You can use the following methods for IP address assignment:
+You can use the following IP address assignment types:
 
 - Static assignment.
 - Dynamic assignment through a DHCP server. The DHCP server you specify must be reachable from the additional network.
 - Dynamic assignment through the Whereabouts IPAM CNI plug-in.
-endif::json[]
-
-ifdef::yaml[]
-The following YAML configuration describes the parameters that you can set.
-endif::yaml[]
 
 ////
 IMPORTANT: If you set the `type` parameter to the `DHCP` value, you cannot set
 any other parameters.
 ////
 
-ifdef::json[]
 [id="nw-multus-static_{context}"]
 == Static IP address assignment configuration
 
-The following JSON describes the configuration for static IP address assignment:
+The following table describes the configuration for static IP address assignment:
 
-.Static assignment configuration
+.`ipam` static configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`type`
+|`string`
+|The IPAM address type. The value `static` is required.
+
+|`addresses`
+|`array`
+|An array of objects specifying IP addresses to assign to the virtual interface. Both IPv4 and IPv6 IP addresses are supported.
+
+|`routes`
+|`array`
+|An array of objects specifying routes to configure inside the pod.
+
+|`dns`
+|`array`
+|Optional: An array of objects specifying the DNS configuration.
+
+|====
+
+The `adddresses` array requires objects with the following fields:
+
+.`ipam.addresses[]` array
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`address`
+|`string`
+|An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the additional network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
+
+|`gateway`
+|`string`
+|The default gateway to route egress network traffic to.
+
+|====
+
+.`ipam.routes[]` array
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`dst`
+|`string`
+|The IP address range in CIDR format, such as `192.168.17.0/24` or `0.0.0.0/0` for the default route.
+
+|`gw`
+|`string`
+|The gateway where network traffic is routed.
+
+|====
+
+.`ipam.dns` object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`nameservers`
+|`array`
+|An of array of one or more IP addresses for to send DNS queries to.
+
+|`domain`
+|`array`
+|The default domain to append to a host name. For example, if the
+domain is set to `example.com`, a DNS lookup query for `example-host` is
+rewritten as `example-host.example.com`.
+
+|`search`
+|`array`
+|An array of domain names to append to an unqualified host name,
+such as `example-host`, during a DNS lookup query.
+
+|====
+
+.Static IP address assignment configuration example
 [source,json]
 ----
 {
   "ipam": {
     "type": "static",
-    "addresses": [ <1>
-      {
-        "address": "<address>", <2>
-        "gateway": "<gateway>" <3>
-      }
-    ],
-    "routes": [ <4>
-      {
-        "dst": "<dst>", <5>
-        "gw": "<gw>" <6>
-      }
-    ],
-    "dns": { <7>
-      "nameservers": ["<nameserver>"], <8>
-      "domain": "<domain>", <9>
-      "search": ["<search_domain>"] <10>
-    }
+      "addresses": [
+        {
+          "address": "191.168.1.7"
+        }
+      ]
   }
 }
 ----
-<1> An array describing IP addresses to assign to the virtual interface. Both
-IPv4 and IPv6 IP addresses are supported.
-
-<2> An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the additional network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
-
-<3> The default gateway to route egress network traffic to.
-
-<4> An array describing routes to configure inside the pod.
-
-<5> The IP address range in CIDR format, such as `192.168.17.0/24`, or `0.0.0.0/0` for the default route.
-
-<6> The gateway where network traffic is routed.
-
-<7> Optional: DNS configuration.
-
-<8> An of array of one or more IP addresses for to send DNS queries to.
-
-<9> The default domain to append to a host name. For example, if the
-domain is set to `example.com`, a DNS lookup query for `example-host` is
-rewritten as `example-host.example.com`.
-
-<10> An array of domain names to append to an unqualified host name,
-such as `example-host`, during a DNS lookup query.
 
 [id="nw-multus-dhcp_{context}"]
-== Dynamic IP address assignment configuration
+== Dynamic IP address (DHCP) assignment configuration
 
 The following JSON describes the configuration for dynamic IP address address assignment with DHCP.
 
@@ -141,7 +170,18 @@ spec:
 ----
 ====
 
-.DHCP assignment configuration
+.`ipam` DHCP configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`type`
+|`string`
+|The IPAM address type. The value `dhcp` is required.
+
+|====
+
+.Dynamic IP address (DHCP) assignment configuration example
 [source,json]
 ----
 {
@@ -156,21 +196,26 @@ spec:
 
 The Whereabouts CNI plug-in allows the dynamic assignment of an IP address to an additional network without the use of a DHCP server.
 
-The following JSON describes the configuration for dynamic IP address assignment with Whereabouts:
+The following table describes the configuration for dynamic IP address assignment with Whereabouts:
 
-.Whereabouts assignment configuration
-[source,json]
-----
-{
-  "ipam": {
-    "type": "whereabouts",
-    "range": "<range>", <1>
-    "exclude": ["<exclude_part>, ..."], <2>
-  }
-}
-----
-<1> Specify an IP address and range in CIDR notation. IP addresses are assigned from within this range of addresses.
-<2> Optional: Specify a list of IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
+.`ipam` whereabouts configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`type`
+|`string`
+|The IPAM address type. The value `whereabouts` is required.
+
+|`range`
+|`string`
+|An IP address and range in CIDR notation. IP addresses are assigned from within this range of addresses.
+
+|`exclude`
+|`array`
+|Optional: A list of zero ore more IP addresses and ranges in CIDR notation. IP addresses within an excluded address range are not assigned.
+
+|====
 
 ////
 [NOTE]
@@ -179,44 +224,7 @@ Whereabouts can be used for both IPv4 and IPv6 addresses.
 =====
 ////
 
-[id="nw-multus-static-example_{context}"]
-== Static IP address assignment configuration example
-
-You can configure ipam for static IP address assignment:
-
-[source,json]
-----
-{
-  "ipam": {
-    "type": "static",
-      "addresses": [
-        {
-          "address": "191.168.1.7"
-        }
-      ]
-  }
-}
-----
-
-[id="nw-multus-dhcp-example_{context}"]
-== Dynamic IP address assignment configuration example using DHCP
-
-You can configure ipam for DHCP:
-
-[source,json]
-----
-{
-  "ipam": {
-    "type": "dhcp"
-  }
-}
-----
-
-[id="nw-multus-whereabouts-example_{context}"]
-== Dynamic IP address assignment configuration example using Whereabouts
-
-You can configure ipam to use Whereabouts:
-
+.Dynamic IP address assignment configuration example using Whereabouts
 [source,json]
 ----
 {
@@ -230,130 +238,7 @@ You can configure ipam to use Whereabouts:
   }
 }
 ----
-endif::json[]
 
-// YAML configuration is only relevant to `simpleMacvlanConfig`
-// This is limited by the fields that the CNO accepts
-
-ifdef::yaml[]
-.ipam CNI plug-in YAML configuration object
-[source,yaml]
-----
-ipamConfig:
-  type: <type> <1>
-  ... <2>
-----
-<1> Specify `static` to configure the plug-in to manage IP address assignment.
-Specify `DHCP` to allow a DHCP server to manage IP address assignment. You
-cannot specify any additional parameters if you specify a value of `DHCP`.
-
-<2> If you set the `type` parameter to `static`, then provide the
-`staticIPAMConfig` parameter.
-
-[id="nw-multus-static-config_{context}"]
-== Static ipam configuration YAML
-
-The following YAML describes a configuration for static IP address assignment:
-
-.Static ipam configuration YAML
-[source,yaml]
-----
-ipamConfig:
-  type: static
-  staticIPAMConfig:
-    addresses: <1>
-    - address: <address> <2>
-      gateway: <gateway> <3>
-    routes: <4>
-    - destination: <destination> <5>
-      gateway: <gateway> <6>
-    dns: <7>
-      nameservers: <8>
-      - <nameserver>
-      domain: <domain> <9>
-      search: <10>
-      - <search_domain>
-----
-<1> A collection of mappings that define IP addresses to assign to the virtual
-interface. Both IPv4 and IPv6 IP addresses are supported.
-
-<2> An IP address and network prefix that you specify. For example, if you specify `10.10.21.10/24`, then the additional network is assigned an IP address of `10.10.21.10` and the netmask is `255.255.255.0`.
-
-<3> The default gateway to route egress network traffic to.
-
-<4> A collection of mappings describing routes to configure inside the pod.
-
-<5> The IP address range in CIDR format, such as `192.168.17.0/24`, or `0.0.0.0/0` for the default route.
-
-<6> The gateway where network traffic is routed.
-
-<7> Optional: The DNS configuration.
-
-<8> A collection of one or more IP addresses for to send DNS queries to.
-
-<9> The default domain to append to a host name. For example, if the
-domain is set to `example.com`, a DNS lookup query for `example-host` is
-rewritten as `example-host.example.com`.
-
-<10> An array of domain names to append to an unqualified host name,
-such as `example-host`, during a DNS lookup query.
-
-[id="nw-multus-dynamic-config_{context}"]
-== Dynamic ipam configuration YAML
-
-The following YAML describes a configuration for static IP address assignment:
-
-.Dynamic ipam configuration YAML
-[source,yaml]
-----
-ipamConfig:
-  type: DHCP
-----
-
-[id="nw-multus-static-example-yaml_{context}"]
-== Static IP address assignment configuration example
-
-The following example shows an ipam configuration for static IP addresses:
-
-[source,yaml]
-----
-ipamConfig:
-  type: static
-  staticIPAMConfig:
-    addresses:
-    - address: 198.51.100.11/24
-      gateway: 198.51.100.10
-    routes:
-    - destination: 0.0.0.0/0
-      gateway: 198.51.100.1
-    dns:
-      nameservers:
-      - 198.51.100.1
-      - 198.51.100.2
-      domain: testDNS.example
-      search:
-      - testdomain1.example
-      - testdomain2.example
-----
-
-[id="nw-multus-dynamic-example-yaml_{context}"]
-== Dynamic IP address assignment configuration example
-
-The following example shows an ipam configuration for DHCP:
-
-[source,yaml]
-----
-ipamConfig:
-  type: DHCP
-----
-endif::yaml[]
-
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:!yaml:
-endif::[]
-ifeval::["{context}" != "configuring-macvlan-basic"]
-:!json:
-endif::[]
-ifeval::["{context}" == "configuring-sriov-net-attach"]
+ifdef::sr-iov[]
 :!sr-iov:
 endif::[]

--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -1,9 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-macvlan.adoc
-// * networking/multiple_networks/configuring-ipvlan.adoc
-// * networking/multiple_networks/configuring-bridge.adoc
-// * networking/multiple_networks/configuring-host-device.adoc
+// * networking/multiple_networks/configuring-additional-network.adoc
 // * networking/hardware_networks/configuring-sriov-net-attach.adoc
 // * virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc
 

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -51,21 +51,16 @@ plug-in:
 
 The following example configures an additional network named `ipvlan-net`:
 
-[source,yaml]
+[source,json]
 ----
-name: ipvlan-net
-namespace: work-network
-type: Raw
-rawCNIConfig: |- <1>
-  {
-    "cniVersion": "0.3.1",
-    "name": "work-network",
-    "type": "ipvlan",
-    "master": "eth1",
-    "mode": "l3",
-    "ipam": {
-      "type": "dhcp"
-      }
-  }
+{
+  "cniVersion": "0.3.1",
+  "name": "work-network",
+  "type": "ipvlan",
+  "master": "eth1",
+  "mode": "l3",
+  "ipam": {
+    "type": "dhcp"
+    }
+}
 ----
-<1> The CNI configuration object is specified as a YAML string.

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -2,45 +2,16 @@
 //
 // * networking/multiple_networks/configuring-ipvlan.adoc
 
+//37.1. IPVLAN overview
+// https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-ipvlan_configuring-and-managing-networking#ipvlan-overview_getting-started-with-ipvlan
+
 [id="nw-multus-ipvlan-object_{context}"]
-= Configuration for ipvlan
+= Configuration for an IPVLAN additional network
 
-The configuration for an additional network attachment that uses the ipvlan
-Container Network Interface (CNI) plug-in is provided in two parts:
-
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
-
-The CNO configuration specifies the name for the additional network attachment
-and the namespace to create the attachment in. The plug-in
-is configured by a JSON object specified by the `rawCNIConfig` parameter in
-the CNO configuration.
-
-The following YAML describes the configuration parameters for the CNO:
-
-.Cluster Network Operator YAML configuration
-[source,yaml]
-----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: '{ <3>
-  ...
-}'
-type: Raw
-----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
-
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
-
-The following object describes the configuration parameters for the ipvlan CNI
+The following object describes the configuration parameters for the IPVLAN CNI
 plug-in:
 
-.ipvlan CNI plug-in JSON configuration object
+.IPVLAN CNI plug-in JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
 |====
 |Field|Type|Description

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -41,35 +41,39 @@ The following object describes the configuration parameters for the ipvlan CNI
 plug-in:
 
 .ipvlan CNI plug-in JSON configuration object
-[source,json]
-----
-{
-  "cniVersion": "0.3.1",
-  "name": "<name>", <1>
-  "type": "ipvlan",
-  "mode": "<mode>", <2>
-  "master": "<master>", <3>
-  "mtu": <mtu>, <4>
-  "ipam": { <5>
-    ...
-  }
-}
-----
-<1> Specify the value for the `name` parameter you provided previously for
-the CNO configuration.
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
 
-<2> Specify the operating mode for the virtual network. The value must
-be `l2`, `l3`, or `l3s`. The default value is `l2`.
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
 
-<3> Specify the ethernet interface to associate with the network
-attachment. If a `master` is not specified, the interface for the default
-network route is used.
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
 
-<4> Set the maximum transmission unit (MTU) to the specified value. The
-default value is automatically set by the kernel.
+|`type`
+|`string`
+|
 
-<5> Specify a configuration object for the ipam CNI plug-in. The plug-in
-manages IP address assignment for the attachment definition.
+|`mode`
+|`string`
+|The operating mode for the virtual network. The value must be `l2`, `l3`, or `l3s`. The default value is `l2`.
+
+|`master`
+|`string`
+|Specify the ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
+
+|`mtu`
+|`integer`
+|Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+|`ipam`
+|`object`
+|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+
+|====
 
 [id="nw-multus-ipvlan-config-example_{context}"]
 == ipvlan configuration example
@@ -81,15 +85,16 @@ The following example configures an additional network named `ipvlan-net`:
 name: ipvlan-net
 namespace: work-network
 type: Raw
-rawCNIConfig: '{ <1>
-  "cniVersion": "0.3.1",
-  "name": "work-network",
-  "type": "ipvlan",
-  "master": "eth1",
-  "mode": "l3",
-  "ipam": {
-    "type": "dhcp"
-    }
-}'
+rawCNIConfig: |- <1>
+  {
+    "cniVersion": "0.3.1",
+    "name": "work-network",
+    "type": "ipvlan",
+    "master": "eth1",
+    "mode": "l3",
+    "ipam": {
+      "type": "dhcp"
+      }
+  }
 ----
 <1> The CNI configuration object is specified as a YAML string.

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-ipvlan.adoc
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 //37.1. IPVLAN overview
 // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-ipvlan_configuring-and-managing-networking#ipvlan-overview_getting-started-with-ipvlan

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -2,138 +2,52 @@
 //
 // * networking/multiple_networks/configuring-macvlan.adoc
 
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:yaml:
-endif::[]
-// This is necessary for Whereabouts CNI which is JSON-only
-ifeval::["{context}" == "configuring-macvlan"]
-:json:
-endif::[]
-
-// Content duplicated because the callouts are identical
-// and must be changed simultaneously if edited. The numbers
-// do not easily line up, so the content is duplicated in each section.
-
 [id="nw-multus-macvlan-object_{context}"]
-= Configuration for macvlan CNI plug-in
-
-ifdef::json[]
-The configuration for an additional network attachment that uses the macvlan
-Container Network Interface (CNI) plug-in is provided in two parts:
-
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
-
-The CNO configuration specifies the name for the additional network attachment
-and the namespace to create the attachment in. The plug-in
-is configured by a JSON object specified by the `rawCNIConfig` parameter in
-the CNO configuration.
-
-The following YAML describes the configuration parameters for the CNO:
-
-.Cluster Network Operator YAML configuration
-[source,yaml]
-----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: '{ <3>
-  ...
-}'
-type: Raw
-----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
-
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
-
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+= Configuration for a MACVLAN additional network
 
 The following object describes the configuration parameters for the macvlan CNI
 plug-in:
 
-.macvlan CNI plug-in JSON configuration object
-[source,json]
-----
-{
-  "cniVersion": "0.3.1",
-  "name": "<name>", <1>
-  "type": "macvlan",
-  "mode": "<mode>", <2>
-  "master": "<master>", <3>
-  "mtu": <mtu>, <4>
-  "ipam": { <5>
-    ...
-  }
-}
-----
-<1> Specify a name for the additional network attachment that you are creating. The name must be unique within the specified `namespace`.
+.MACVLAN CNI plug-in JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
 
-<2> Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
 
-<3> The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
 
-<4> Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+|`type`
+|`string`
+|The name of the CNI plug-in to configure: `macvlan`.
 
-<5> Specify a configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
-endif::json[]
+|`mode`
+|`string`
+|Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
 
-ifdef::yaml[]
-The following YAML describes the configuration parameters for the macvlan
-Container Network Interface (CNI) plug-in:
+|`master`
+|`string`
+|The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
 
-.macvlan YAML configuration
-[source,yaml]
-----
-name: <name> <1>
-namespace: <namespace> <2>
-type: SimpleMacvlan
-simpleMacvlanConfig:
-  master: <master> <3>
-  mode: <mode> <4>
-  mtu: <mtu> <5>
-  ipamConfig: <6>
-    ...
-----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
+|`mtu`
+|`string`
+|Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
-<2> Specify the namespace to create the network attachment in. If
-a value is not specified, the `default` namespace is used.
+|`ipam`
+|`object`
+|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
 
-<3> The ethernet interface to associate with the virtual interface. If
-a value for `master` is not specified, then the host system's primary ethernet
-interface is used.
-
-<4> Configures traffic visibility on the virtual network. Must be either
-`bridge`, `passthru`, `private`, or `vepa`. If a value for `mode` is not
-provided, the default value is `bridge`.
-
-<5> Set the maximum transmission unit (MTU) to the specified value. The
-default value is automatically set by the kernel.
-
-<6> Specify a configuration object for the ipam CNI plug-in. The
-plug-in manages IP address assignment for the attachment definition.
-endif::yaml[]
+|====
 
 [id="nw-multus-macvlan-config-example_{context}"]
 == macvlan configuration example
 
 The following example configures an additional network named `macvlan-net`:
 
-ifdef::yaml[]
-[source,yaml]
-----
-name: macvlan-net
-namespace: work-network
-type: SimpleMacvlan
-simpleMacvlanConfig:
-  ipamConfig:
-    type: DHCP
-----
-endif::yaml[]
-ifdef::json[]
 [source,yaml]
 ----
 name: macvlan-net
@@ -151,11 +65,3 @@ rawCNIConfig: |-
       }
   }
 ----
-endif::json[]
-
-ifeval::["{context}" == "configuring-macvlan-basic"]
-:!yaml:
-endif::[]
-ifeval::["{context}" == "configuring-macvlan"]
-:!json:
-endif::[]

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -48,20 +48,16 @@ plug-in:
 
 The following example configures an additional network named `macvlan-net`:
 
-[source,yaml]
+[source,json]
 ----
-name: macvlan-net
-namespace: work-network
-type: Raw
-rawCNIConfig: |-
-  {
-    "cniVersion": "0.3.1",
-    "name": "macvlan-net",
-    "type": "macvlan",
-    "master": "eth1",
-    "mode": "bridge",
-    "ipam": {
-      "type": "dhcp"
-      }
-  }
+{
+  "cniVersion": "0.3.1",
+  "name": "macvlan-net",
+  "type": "macvlan",
+  "master": "eth1",
+  "mode": "bridge",
+  "ipam": {
+    "type": "dhcp"
+    }
+}
 ----

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-macvlan.adoc
+// * networking/multiple_networks/configuring-additional-network.adoc
 
 [id="nw-multus-macvlan-object_{context}"]
 = Configuration for a MACVLAN additional network

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -22,6 +22,42 @@ The CNO automatically creates and manages the `NetworkAttachmentDefinition` obje
 Applying a YAML manifest::
 You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object.
 
+=== Configure an additional network through the Cluster Network Operator
+
+The configuration for an additional network attachment that uses the ipvlan
+Container Network Interface (CNI) plug-in is provided in two parts:
+
+* Cluster Network Operator (CNO) configuration
+* CNI plug-in configuration
+
+The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in. The plug-in is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
+
+The following YAML describes the configuration parameters for the CNO:
+
+.Cluster Network Operator configuration
+[source,yaml]
+----
+name: <name> <1>
+namespace: <namespace> <2>
+rawCNIConfig: |- <3>
+  {
+    ...
+  }
+type: Raw
+----
+<1> Specify a name for the additional network attachment that you are
+creating. The name must be unique within the specified `namespace`.
+
+<2> Specify the namespace to create the network attachment in. If
+you do not specify a value, then the `default` namespace is used.
+
+<3> Specify the CNI plug-in configuration in JSON format, which
+is based on the following template.
+
+=== Configure an additional network from a YAML manifest
+
+This works as you'd expect. `oc create`.
+
 == IP address assignment
 
 == Configuration for additional network types
@@ -35,35 +71,192 @@ include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
 // IP address assignment
 
-include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+1]
+include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 
-== Configuring an additional network through the Cluster Network Operator
+= Creating an additional network attachment
 
-The configuration for an additional network attachment that uses the ipvlan
-Container Network Interface (CNI) plug-in is provided in two parts:
+The Cluster Network Operator (CNO) manages additional network definitions. When
+you specify an additional network to create, the CNO creates the
+`NetworkAttachmentDefinition` object automatically.
 
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
+[IMPORTANT]
+====
+Do not edit the `NetworkAttachmentDefinition` objects that the Cluster Network
+Operator manages. Doing so might disrupt network traffic on your additional
+network.
+====
 
-The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in. The plug-in is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
+.Prerequisites
 
-The following YAML describes the configuration parameters for the CNO:
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
 
-.Cluster Network Operator YAML configuration
+.Procedure
+
+To create an additional network for your cluster, complete the following steps:
+
+. To edit the CNO configuration, enter the following command:
++
+[source,terminal]
+----
+$ oc edit networks.operator.openshift.io cluster
+----
+
+. Modify the CR that you are creating by adding the configuration for the
+additional network you are creating, as in the following example CR.
++
+ifdef::yaml[]
+The following YAML configures the {plugin} CNI plug-in:
++
 [source,yaml]
 ----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: '{ <3>
-  ...
-}'
-type: Raw
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: SimpleMacvlan
+    simpleMacvlanConfig:
+      ipamConfig:
+        type: static
+        staticIPAMConfig:
+          addresses:
+          - address: 10.1.1.7/24
 ----
-<1> Specify a name for the additional network attachment that you are
-creating. The name must be unique within the specified `namespace`.
+endif::yaml[]
+ifdef::json[]
+The following YAML configures the {plugin} CNI plug-in:
+endif::json[]
++
+ifeval::["{plugin}" == "bridge"]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "test-network-1",
+      "type": "{plugin}",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "192.168.1.23/24"
+          }
+        ]
+      }
+    }'
+----
+endif::[]
+ifeval::["{plugin}" == "host-device"]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "test-network-1",
+      "type": "{plugin}",
+      "device": "eth1",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "192.168.1.23/24"
+          }
+        ]
+      }
+    }'
+----
+endif::[]
+ifeval::["{plugin}" == "ipvlan"]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "test-network-1",
+      "type": "{plugin}",
+      "master": "eth1",
+      "mode": "l2",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "192.168.1.23/24"
+          }
+        ]
+      }
+    }'
+----
+endif::[]
+ifdef::macvlan+json[]
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: '{
+      "cniVersion": "0.3.1",
+      "name": "test-network-1",
+      "type": "{plugin}",
+      "master": "eth1",
+      "ipam": {
+        "type": "static",
+        "addresses": [
+          {
+            "address": "192.168.1.23/24"
+          }
+        ]
+      }
+    }'
+----
+endif::[]
+<1> Specify the configuration for the additional network attachment definition.
 
-<2> Specify the namespace to create the network attachment in. If
-you do not specify a value, then the `default` namespace is used.
+. Save your changes and quit the text editor to commit your changes.
 
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+. Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the object.
++
+[source,terminal]
+----
+$ oc get network-attachment-definitions -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                 AGE
+test-network-1       14m
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -14,24 +14,45 @@ As a cluster administrator, you can configure an additional network for your clu
 
 == Approaches to managing an additional network
 
-You can manage the life cycle of an additional network by two mutually exclusively approaches:
+You can manage the life cycle of an additional network by two mutually exclusively approaches. For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you configure.
 
 Modify the Cluster Network Operator (CNO) configuration::
-The CNO automatically creates and manages the `NetworkAttachmentDefinition` object.
++
+--
+The CNO automatically creates and manages the `NetworkAttachmentDefinition` object. In addition to managing the object lifecycle the CNO ensures a DHCP is available for an additional network that uses a DHCP assigned IP address.
+--
 
 Applying a YAML manifest::
-You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object.
+You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object. This approach allows for the chaining of CNI plug-ins.
 
-For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you can configure.
+== Configuration for an additional network attachment
+
+An additional network is configured through the `NetworkAttachmentDefinition` API in the `k8s.cni.cncf.io` API group. The configuration for the API is described in the following table:
+
+.`NetworkAttachmentDefinition` API fields
+[cols=".^3,.^2,.^5",options="header"]
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|The name for the additional network.
+
+|`metadata.namespace`
+|`string`
+|The namespace that the object is associated with.
+
+|`spec.config`
+|`string`
+|The CNI plug-in configuration in JSON format.
+
+|====
 
 === Configure an additional network through the Cluster Network Operator
 
 The configuration for an additional network attachment is specified as part of the Cluster Network Operator (CNO) configuration.
 
-* The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in.
-* The additional network is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
-
-The following YAML describes the configuration parameters for the CNO:
+The following YAML describes the configuration parameters for managing an additional network with the CNO:
 
 .Cluster Network Operator configuration
 [source,yaml]
@@ -58,13 +79,11 @@ creating. The name must be unique within the specified `namespace`.
 <3> The namespace to create the network attachment in. If
 you do not specify a value, then the `default` namespace is used.
 
-<4> The CNI plug-in configuration in JSON format.
+<4> A CNI plug-in configuration in JSON format.
 
 === Configure an additional network from a YAML manifest
 
 This works as you'd expect. `oc create`.
-
-== IP address assignment
 
 == Configuration for additional network types
 
@@ -75,11 +94,11 @@ include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
-// IP address assignment
+== IP address assignment
 
-include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
+include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-= Creating an additional network attachment
+= Creating an additional network attachment with the Cluster Network Operator
 
 The Cluster Network Operator (CNO) manages additional network definitions. When
 you specify an additional network to create, the CNO creates the
@@ -99,8 +118,6 @@ network.
 
 .Procedure
 
-To create an additional network for your cluster, complete the following steps:
-
 . To edit the CNO configuration, enter the following command:
 +
 [source,terminal]
@@ -110,15 +127,54 @@ $ oc edit networks.operator.openshift.io cluster
 
 . Modify the CR that you are creating by adding the configuration for the
 additional network you are creating, as in the following example CR.
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: test-network-1
+    namespace: test-1
+    type: Raw
+    rawCNIConfig: |-
+      {
+        "cniVersion": "0.3.1",
+        "name": "test-network-1",
+        "type": "ipvlan",
+        "master": "eth1",
+        "mode": "l2",
+        "ipam": {
+          "type": "static",
+          "addresses": [
+            {
+              "address": "192.168.1.23/24"
+            }
+          ]
+        }
+      }
+  # ...
+----
+<1> A comment.
 
 . Save your changes and quit the text editor to commit your changes.
 
-. Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the object.
+.Verification
+
+* Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. There might be a delay before the CNO creates the object.
 +
 [source,terminal]
 ----
 $ oc get network-attachment-definitions -n <namespace>
 ----
++
+--
+where:
+
+`<namespace>`:: Specifies the namespace for the network attachment.
+--
 +
 .Example output
 [source,terminal]
@@ -127,146 +183,20 @@ NAME                 AGE
 test-network-1       14m
 ----
 
-////
+= Creating an additional network attachment by applying a YAML manifest
 
-ifdef::yaml[]
-The following YAML configures the {plugin} CNI plug-in:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: SimpleMacvlan
-    simpleMacvlanConfig:
-      ipamConfig:
-        type: static
-        staticIPAMConfig:
-          addresses:
-          - address: 10.1.1.7/24
-----
-endif::yaml[]
-ifdef::json[]
-The following YAML configures the {plugin} CNI plug-in:
-endif::json[]
-+
-ifeval::["{plugin}" == "bridge"]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-ifeval::["{plugin}" == "host-device"]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "device": "eth1",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-ifeval::["{plugin}" == "ipvlan"]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "master": "eth1",
-      "mode": "l2",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-ifdef::macvlan+json[]
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: '{
-      "cniVersion": "0.3.1",
-      "name": "test-network-1",
-      "type": "{plugin}",
-      "master": "eth1",
-      "ipam": {
-        "type": "static",
-        "addresses": [
-          {
-            "address": "192.168.1.23/24"
-          }
-        ]
-      }
-    }'
-----
-endif::[]
-<1> Specify the configuration for the additional network attachment definition.
+.Prerequisites
 
-////
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a YAML file with your additional network configuration.
+
+. To create the additional network, enter the following command:
++
+[source,terminal]
+----
+$ oc apply -f <file_name>.yaml
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -1,0 +1,69 @@
+[id="configuring-additional-network"]
+= Configuring an additional network
+include::modules/common-attributes.adoc[]
+:context: configuring-additional-network
+
+toc::[]
+
+As a cluster administrator, you can configure an additional network for your cluster. The following additional network types are supported:
+
+* macvlan
+* ipvlan
+* bridge
+* host-device
+
+== Approaches to managing an additional network
+
+You can manage the life cycle of an additional network by two mutually exclusively approaches:
+
+Modify the Cluster Network Operator (CNO) configuration::
+The CNO automatically creates and manages the `NetworkAttachmentDefinition` object.
+
+Applying a YAML manifest::
+You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object.
+
+== IP address assignment
+
+== Configuration for additional network types
+
+The specific configuration fields for additional networks is described in the following sections.
+
+include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
+include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
+include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
+
+// IP address assignment
+
+include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+1]
+
+== Configuring an additional network through the Cluster Network Operator
+
+The configuration for an additional network attachment that uses the ipvlan
+Container Network Interface (CNI) plug-in is provided in two parts:
+
+* Cluster Network Operator (CNO) configuration
+* CNI plug-in configuration
+
+The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in. The plug-in is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
+
+The following YAML describes the configuration parameters for the CNO:
+
+.Cluster Network Operator YAML configuration
+[source,yaml]
+----
+name: <name> <1>
+namespace: <namespace> <2>
+rawCNIConfig: '{ <3>
+  ...
+}'
+type: Raw
+----
+<1> Specify a name for the additional network attachment that you are
+creating. The name must be unique within the specified `namespace`.
+
+<2> Specify the namespace to create the network attachment in. If
+you do not specify a value, then the `default` namespace is used.
+
+<3> Specify the CNI plug-in configuration in JSON format, which
+is based on the following template.

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -22,37 +22,43 @@ The CNO automatically creates and manages the `NetworkAttachmentDefinition` obje
 Applying a YAML manifest::
 You can manage the additional network directly by creating an `NetworkAttachmentDefinition` object.
 
+For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you can configure.
+
 === Configure an additional network through the Cluster Network Operator
 
-The configuration for an additional network attachment that uses the ipvlan
-Container Network Interface (CNI) plug-in is provided in two parts:
+The configuration for an additional network attachment is specified as part of the Cluster Network Operator (CNO) configuration.
 
-* Cluster Network Operator (CNO) configuration
-* CNI plug-in configuration
-
-The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in. The plug-in is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
+* The CNO configuration specifies the name for the additional network attachment and the namespace to create the attachment in.
+* The additional network is configured by a JSON object specified by the `rawCNIConfig` parameter in the CNO configuration.
 
 The following YAML describes the configuration parameters for the CNO:
 
 .Cluster Network Operator configuration
 [source,yaml]
 ----
-name: <name> <1>
-namespace: <namespace> <2>
-rawCNIConfig: |- <3>
-  {
-    ...
-  }
-type: Raw
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks: <1>
+  - name: <name> <2>
+    namespace: <namespace> <3>
+    rawCNIConfig: |- <4>
+      {
+        ...
+      }
+    type: Raw
 ----
-<1> Specify a name for the additional network attachment that you are
+<1> An array of one or more additional network configurations.
+
+<2> The name for the additional network attachment that you are
 creating. The name must be unique within the specified `namespace`.
 
-<2> Specify the namespace to create the network attachment in. If
+<3> The namespace to create the network attachment in. If
 you do not specify a value, then the `default` namespace is used.
 
-<3> Specify the CNI plug-in configuration in JSON format, which
-is based on the following template.
+<4> The CNI plug-in configuration in JSON format.
 
 === Configure an additional network from a YAML manifest
 
@@ -104,7 +110,25 @@ $ oc edit networks.operator.openshift.io cluster
 
 . Modify the CR that you are creating by adding the configuration for the
 additional network you are creating, as in the following example CR.
+
+. Save your changes and quit the text editor to commit your changes.
+
+. Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the object.
 +
+[source,terminal]
+----
+$ oc get network-attachment-definitions -n <namespace>
+----
++
+.Example output
+[source,terminal]
+----
+NAME                 AGE
+test-network-1       14m
+----
+
+////
+
 ifdef::yaml[]
 The following YAML configures the {plugin} CNI plug-in:
 +
@@ -245,18 +269,4 @@ spec:
 endif::[]
 <1> Specify the configuration for the additional network attachment definition.
 
-. Save your changes and quit the text editor to commit your changes.
-
-. Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. Replace `<namespace>` with the namespace that you specified when configuring the network attachment. There might be a delay before the CNO creates the object.
-+
-[source,terminal]
-----
-$ oc get network-attachment-definitions -n <namespace>
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                 AGE
-test-network-1       14m
-----
+////

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -7,14 +7,14 @@ toc::[]
 
 As a cluster administrator, you can configure an additional network for your cluster. The following additional network types are supported:
 
-* macvlan
-* ipvlan
-* bridge
-* host-device
+* Bridge
+* Host device
+* IPVLAN
+* MACVLAN
 
 == Approaches to managing an additional network
 
-You can manage the life cycle of an additional network by two mutually exclusively approaches. For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you configure.
+You can manage the life cycle of an additional network by two approaches. Each approach is mutually exclusive and you can only use one approach for managing an additional network at a time. For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you configure.
 
 Modify the Cluster Network Operator (CNO) configuration::
 +
@@ -62,6 +62,7 @@ kind: Network
 metadata:
   name: cluster
 spec:
+  # ...
   additionalNetworks: <1>
   - name: <name> <2>
     namespace: <namespace> <3>
@@ -83,7 +84,23 @@ you do not specify a value, then the `default` namespace is used.
 
 === Configure an additional network from a YAML manifest
 
-This works as you'd expect. `oc create`.
+The configuration for an additional network is specified from a YAML configuration file, such as in the following example:
+
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: <name> <1>
+spec:
+  config: |- <2>
+    {
+      ...
+    }
+----
+<1> The name for the additional network attachment that you are
+creating.
+<2> A CNI plug-in configuration in JSON format.
 
 == Configuration for additional network types
 
@@ -96,92 +113,11 @@ include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
 == IP address assignment
 
+Some text about this.
+
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
 
-= Creating an additional network attachment with the Cluster Network Operator
-
-The Cluster Network Operator (CNO) manages additional network definitions. When
-you specify an additional network to create, the CNO creates the
-`NetworkAttachmentDefinition` object automatically.
-
-[IMPORTANT]
-====
-Do not edit the `NetworkAttachmentDefinition` objects that the Cluster Network
-Operator manages. Doing so might disrupt network traffic on your additional
-network.
-====
-
-.Prerequisites
-
-* Install the OpenShift CLI (`oc`).
-* Log in as a user with `cluster-admin` privileges.
-
-.Procedure
-
-. To edit the CNO configuration, enter the following command:
-+
-[source,terminal]
-----
-$ oc edit networks.operator.openshift.io cluster
-----
-
-. Modify the CR that you are creating by adding the configuration for the
-additional network you are creating, as in the following example CR.
-+
-[source,yaml,subs="attributes+"]
-----
-apiVersion: operator.openshift.io/v1
-kind: Network
-metadata:
-  name: cluster
-spec:
-  additionalNetworks: <1>
-  - name: test-network-1
-    namespace: test-1
-    type: Raw
-    rawCNIConfig: |-
-      {
-        "cniVersion": "0.3.1",
-        "name": "test-network-1",
-        "type": "ipvlan",
-        "master": "eth1",
-        "mode": "l2",
-        "ipam": {
-          "type": "static",
-          "addresses": [
-            {
-              "address": "192.168.1.23/24"
-            }
-          ]
-        }
-      }
-  # ...
-----
-<1> A comment.
-
-. Save your changes and quit the text editor to commit your changes.
-
-.Verification
-
-* Confirm that the CNO created the NetworkAttachmentDefinition object by running the following command. There might be a delay before the CNO creates the object.
-+
-[source,terminal]
-----
-$ oc get network-attachment-definitions -n <namespace>
-----
-+
---
-where:
-
-`<namespace>`:: Specifies the namespace for the network attachment.
---
-+
-.Example output
-[source,terminal]
-----
-NAME                 AGE
-test-network-1       14m
-----
+include::modules/nw-multus-create-network.adoc[leveloffset=+2]
 
 = Creating an additional network attachment by applying a YAML manifest
 
@@ -192,11 +128,36 @@ test-network-1       14m
 
 .Procedure
 
-. Create a YAML file with your additional network configuration.
+. Create a YAML file with your additional network configuration, such as in the following example:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: next-net
+spec:
+  config: |-
+    {
+      "cniVersion": "0.3.1",
+      "name": "work-network",
+      "type": "host-device",
+      "device": "eth1",
+      "ipam": {
+        "type": "dhcp"
+      }
+    }
+----
 
 . To create the additional network, enter the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <file_name>.yaml
+$ oc apply -f <file>.yaml
 ----
++
+--
+where:
+
+`<file>`:: Specifies the name of the file contained the YAML manifest.
+--

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -5,16 +5,18 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure an additional network for your cluster. The following additional network types are supported:
+As a cluster administrator, you can configure an additional network for your cluster. The following network types are supported:
 
-* Bridge
-* Host device
-* IPVLAN
-* MACVLAN
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Bridge]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
 
 == Approaches to managing an additional network
 
 You can manage the life cycle of an additional network by two approaches. Each approach is mutually exclusive and you can only use one approach for managing an additional network at a time. For either approach, the additional network is managed by a Container Network Interface (CNI) plug-in that you configure.
+
+For an additional network, IP addresses are provisioned through an IPAM CNI plug-in that you configure as part of the additional network. The IPAM plug-in supports a variety of IP address assignment approaches including DHCP and static assignment.
 
 Modify the Cluster Network Operator (CNO) configuration::
 +
@@ -111,53 +113,8 @@ include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 
-== IP address assignment
+include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 
-Some text about this.
+include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 
-include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
-
-include::modules/nw-multus-create-network.adoc[leveloffset=+2]
-
-= Creating an additional network attachment by applying a YAML manifest
-
-.Prerequisites
-
-* Install the OpenShift CLI (`oc`).
-* Log in as a user with `cluster-admin` privileges.
-
-.Procedure
-
-. Create a YAML file with your additional network configuration, such as in the following example:
-+
-[source,yaml]
-----
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: next-net
-spec:
-  config: |-
-    {
-      "cniVersion": "0.3.1",
-      "name": "work-network",
-      "type": "host-device",
-      "device": "eth1",
-      "ipam": {
-        "type": "dhcp"
-      }
-    }
-----
-
-. To create the additional network, enter the following command:
-+
-[source,terminal]
-----
-$ oc apply -f <file>.yaml
-----
-+
---
-where:
-
-`<file>`:: Specifies the name of the file contained the YAML manifest.
---
+include::modules/nw-multus-create-network-apply.adoc[leveloffset=+1]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -39,18 +39,19 @@ add additional network interfaces that use Multus CNI, they are named `net1`,
 
 To attach additional network interfaces to a pod, you must create configurations that define how the interfaces are attached. You specify each interface by using a `NetworkAttachmentDefinition` custom resource (CR). A CNI configuration inside each of these CRs defines how that interface is created.
 
+////
 [id="additional-networks-provided"]
 == Additional networks in {product-title}
 
 {product-title} provides the following CNI plug-ins for creating additional
 networks in your cluster:
 
- * *bridge*: xref:../../networking/multiple_networks/configuring-bridge.adoc#configuring-bridge[Creating a bridge-based additional network]
+ * *bridge*: xref::../../networking/multiple_networks/configuring-bridge.adoc#configuring-bridge[Creating a bridge-based additional network]
  allows pods on the same host to communicate with each other and the host.
 
-* *host-device*: xref:../../networking/multiple_networks/configuring-host-device.adoc#configuring-host-device[Configuring a host-device additional network] allows pods access to a physical Ethernet network device on the host system.
+* *host-device*: xref::../../networking/multiple_networks/configuring-host-device.adoc#configuring-host-device[Configuring a host-device additional network] allows pods access to a physical Ethernet network device on the host system.
 
- * *ipvlan*: xref:../../networking/multiple_networks/configuring-ipvlan.adoc#configuring-ipvlan[Configuring an ipvlan-based additional network]
+ * *ipvlan*: xref::../../networking/multiple_networks/configuring-ipvlan.adoc#configuring-ipvlan[Configuring an ipvlan-based additional network]
  allows pods on a host to communicate with other hosts and pods on those hosts,
  similar to a macvlan-based additional network. Unlike a macvlan-based
  additional network, each pod shares the same MAC address as the parent physical
@@ -60,7 +61,8 @@ networks in your cluster:
 +
 A macvlan additional network can be configured in two ways:
 
- - xref:../../networking/multiple_networks/configuring-macvlan-basic.adoc#configuring-macvlan-basic[Configuring a macvlan-based additional network with basic customizations]
- - xref:../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Configuring a macvlan-based additional network]
+ - xref::../../networking/multiple_networks/configuring-macvlan-basic.adoc#configuring-macvlan-basic[Configuring a macvlan-based additional network with basic customizations]
+ - xref::../../networking/multiple_networks/configuring-macvlan.adoc#configuring-macvlan[Configuring a macvlan-based additional network]
 
- * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configuring an SR-IOV based additional network] allows pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+ * *SR-IOV*: xref::../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configuring an SR-IOV based additional network] allows pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.
+////


### PR DESCRIPTION
This applies to all versions. The goal is to reorganize the content in a manner that is easier to understand.

The legacy content is over duplicated. The procedure for creating a `NetworkAttachmentDefintion` is always the same, with the CNO or with `oc apply`. This approach gathers the object definitions into a single place. How IP addresses are managed is complex, and might be resistant to simplification.

So thinking about this, there's an entire discussion regarding `capabilities`, plug-in chaining, and namespaces that eventually needs to be included. That might not be for this, though.

Preview: https://deploy-preview-34799--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html