### PR TITLE
adding MCO content back to the 4.8 rel notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -757,7 +757,6 @@ Previously, creating machine sets required users to manually configure their CPU
 
 Providing a `hugepages` property into the `MachineSet` resource is now possible. This enhancement creates the `MachineSet` resource's nodes with a custom property in oVirt and instructs those nodes to use the `hugepages` of the hypervisor. For more information, see  link:https://bugzilla.redhat.com/show_bug.cgi?id=1948963[*BZ#1948963*].
 
-////
 [id="ocp-4-8-machine-config-operator-image-content-source-object-enhancement"]
 ==== Machine Config Operator ImageContentSourcePolicy object enhancement
 
@@ -768,7 +767,6 @@ Providing a `hugepages` property into the `MachineSet` resource is now possible.
 * Appending items in `unqualified-search-registries` list
 
 For any other changes in `/etc/containers/registries.conf` files, the Machine Config Operator will default to draining nodes to apply changes. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1943315[*BZ#1943315*].
-////
 
 [id="ocp-4-8-nodes"]
 === Nodes
@@ -1354,9 +1352,6 @@ The `authentication` and `openshift-apiserver` Operators now ignore the `oauth-a
 
 [id="ocp-4-8-bug-fixes"]
 == Bug fixes
-*api-server-auth*
-
-
 
 *assisted-installer*
 
@@ -1617,7 +1612,6 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 
 * Previously, Google Cloud Platform (GCP) load balancer health checkers left stale conntrack entries on the host, which caused network interruptions to the API server traffic that used the GCP load balancers. The health check traffic no longer loops through the host, so there is no longer network disruption against the API server. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1925698[*BZ#1925698*])
 
-////
 *Machine Config Operator*
 
 * Previously,  the `drain timeout` and pool degrading period was too short and would cause alerts prematurely on a normal cluster that needed more time. With this update, the time needed before a timeout reports a failure is extended. This provides the Cluster Operator with more realistic and useful alerts without prematurely degrading performance of a normal cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1968019[*BZ#1968019*])
@@ -1636,7 +1630,6 @@ FATAL failed to fetch Metadata: failed to load asset "Install Config": platform.
 * Previously, rpm-ostree related operations were not handled properly on non-CoreOS nodes such as {op-system-first}. As a result, {op-system-base} nodes were degraded when an operation, such as kernel switching, was applied in the pool that contained {op-system-base} nodes. With this update, the Machine Config Daemon logs a message whenever a non-supported operation is performed on non-CoreOS nodes. After logging the message, it returns nil instead of an error. {op-system-base} nodes in the pool now proceed as expected when an unsupported operation is performed by the Machine Config Daemon. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952368[*BZ#1952368*])
 
 * Previously, empty static pod files were being written to the `/etc/kubernetes/manifests` directory. As a result, the kubelet log was reporting errors that could cause confusion with some users. Empty manifests are now moved to a different location when they are not needed. As a result, the errors do not appear in the kubelet log. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1927042[*BZ#1927042*])
-////
 
 *Metering Operator*
 
@@ -1994,13 +1987,13 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=19300
 
 * Previously, the load balancer service became unstable when users would scale additional Windows nodes. With this update, the load balancer service is stabilized, which allows users to add multiple Windows nodes without erratic performance. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905950[*BZ#1905950*])
 
-* Previously, when users provided an invalid private key, the Windows Machine Config Operator (WMCO) would fail. With this update, the WMCO produces an error alerting the user of an invalid key. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929579[*BZ#1929579*])
+// * Previously, when users provided an invalid private key, the Windows Machine Config Operator (WMCO) would fail. With this update, the WMCO produces an error alerting the user of an invalid key. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1929579[*BZ#1929579*])
 
 * Previously, the `kube-proxy` service crashed unexpectedly after the load balancer was created if it was created after the Windows pods were running. With this update, the kube-proxy service does not crash when recreating the load balancer service. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939968[*BZ#1939968*])
 
 * Previously, empty IP address values in the load balancer's Ingress broke the data path. As a result, the Windows service was unreachable. With this update, the Windows service is reachable even if the IP address value is empty. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1952914)[*BZ#1952914*])
 
-* Previously, when the Windows Machine Config Operator configured Windows instances, the node might report itself as `Ready` if the hybrid-overlay or kube-proxy components failed. With this update, the error is detected and the node reports itself as `NotReady`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953692[*BZ#1953692*])
+// * Previously, when the Windows Machine Config Operator configured Windows instances, the node might report itself as `Ready` if the hybrid-overlay or kube-proxy components failed. With this update, the error is detected and the node reports itself as `NotReady`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1953692[*BZ#1953692*])
 
 * Previously, when users created a Windows pod with a projected volume, the pod would remain stuck in the `ContainerCreating` phase. With this update, the Windows pod creation successfully proceeds to the `Running` phase. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973580[*BZ#1973580*])
 


### PR DESCRIPTION
#34433 was meant to hide WMCO content, but hides MCO content. This PR is to revert that change.

Previews:
- MCO feature reinstated https://deploy-preview-34803--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-machine-config-operator-image-content-source-object-enhancement
- MCO bugfixes reinstated (scroll down) https://deploy-preview-34803--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-bug-fixes
- Hid two WMCO BZs (scroll up from here) https://deploy-preview-34803--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-technology-preview

Cc: @vikram-redhat @EricPonvelle @mburke5678 @stevsmit 