### PR TITLE
BZ1896880: Correctly describe behavior for policy=null

### DIFF
--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -115,8 +115,7 @@ The policy object has the following shape:
 
 When configuring policy restrictions, the following rules apply:
 
-- If `policy={}` is set, then creating a `Service` object with `spec.ExternalIPs[]` set will fail. This is the default for {product-title}.
-- If `policy=null` is set, then creating a `Service` object with `spec.ExternalIPs[]` set to any IP address is allowed.
+- If `policy={}` is set, then creating a `Service` object with `spec.ExternalIPs[]` set will fail. This is the default for {product-title}. The behavior when `policy=null` is set is identical.
 - If `policy` is set and either `policy.allowedCIDRs[]` or `policy.rejectedCIDRs[]` is set, the following rules apply:
 
 * If `allowedCIDRs[]` and `rejectedCIDRs[]` are both set, then `rejectedCIDRs[]` has precedence over `allowedCIDRs[]`.


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1896880

Preview: https://deploy-preview-34806--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip?utm_source=github&utm_campaign=bot_dp#restrictions-on-ip-assignment_configuring-externalip