### PR TITLE
BZ1955422: Cluster and service networks cannot overlap existing nets

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -238,16 +238,13 @@ If you are installing a three-node cluster, do not deploy any compute machines w
 the cluster uses these values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
 <6> The cluster name that you specified in your DNS records.
-<7> A block of IP addresses from which pod IP addresses are allocated. This block must
-not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
+<7> A block of IP addresses from which pod IP addresses are allocated. This block must not overlap with existing physical networks. These IP addresses are used for the pod network. If you need to access the pods from an external network, you must configure load balancers and routers to manage the traffic.
 <8> The subnet prefix length to assign to each individual node. For example, if
 `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of
 the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If
 you are required to provide access to nodes from an external network, configure
 load balancers and routers to manage the traffic.
-<9> The IP address pool to use for service IP addresses. You can enter only
-one IP address pool. If you need to access the services from an external network,
-configure load balancers and routers to manage the traffic.
+<9> The IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
 <10> You must set the platform to `none`. You cannot provide additional platform
 configuration variables for
 ifndef::ibm-z,ibm-z-kvm,ibm-power,rhv[your platform.]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1955422

Preview: https://deploy-preview-34807--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal