### PR TITLE
BZ1888541: Include bonded and VLAN interfaces for Multus macvlan

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -72,7 +72,7 @@ plug-in:
 
 <2> Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
 
-<3> The ethernet interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
+<3> The ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
 
 <4> Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
@@ -102,9 +102,7 @@ creating. The name must be unique within the specified `namespace`.
 <2> Specify the namespace to create the network attachment in. If
 a value is not specified, the `default` namespace is used.
 
-<3> The ethernet interface to associate with the virtual interface. If
-a value for `master` is not specified, then the host system's primary ethernet
-interface is used.
+<3> The ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value for `master` is not specified, then the host system's primary ethernet interface is used.
 
 <4> Configures traffic visibility on the virtual network. Must be either
 `bridge`, `passthru`, `private`, or `vepa`. If a value for `mode` is not


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1888541

Preview: https://deploy-preview-34808--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-macvlan.html#nw-multus-macvlan-object_configuring-macvlan