### PR TITLE
BZ1833574: Added a new section having an example insecure route

### DIFF
--- a/modules/nw-creating-a-route.adoc
+++ b/modules/nw-creating-a-route.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * networking/routes/route-configuration.adoc
+
+[id="nw-creating-a-route_{context}"]
+= Creating an HTTP-based route
+
+A route allows you to host your application at a public URL. It can either be secure or unsecured, depending on the network security configuration of your application. An HTTP-based route is an unsecured route that uses the basic HTTP routing protocol and exposes a service on an unsecured application port.
+
+The following procedure describes how to create a simple HTTP-based route to a web application, using the `hello-openshift` application as an example.
+//link:https://github.com/openshift/origin/tree/master/examples/hello-openshift[hello-openshift]
+
+.Prerequisites
+
+
+* You installed the OpenShift CLI (`oc`).
+* You are logged in as an administrator.
+* You have a web application that exposes a port and a TCP endpoint listening for traffic on the port.
+
+.Procedure
+
+. Create a project called `hello-openshift` by running the following command:
++
+[source,terminal]
+----
+$ oc new-project hello-openshift
+----
+
+. Create a pod in the project by running the following command:
++
+[source,terminal]
+----
+$ oc create -f https://raw.githubusercontent.com/openshift/origin/master/examples/hello-openshift/hello-pod.json
+----
+
+. Create a service called `hello-openshift` by running the following command:
++
+[source,terminal]
+----
+$ oc expose pod/hello-openshift
+----
+
+. Create an unsecured route to the `hello-openshift` application by running the following command:
++
+[source,terminal]
+----
+$ oc expose svc hello-openshift
+----
++
+If you examine the resulting `Route` resource, it should look similar to the following:
++
+.YAML definition of the created unsecured route:
+[source,yaml]
+----
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
+  name: hello-openshift
+spec:
+  host: hello-openshift-hello-openshift.<Ingress_Domain> <1>
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-openshift
+----
+<1> `<Ingress_Domain>` is the default ingress domain name.
++
+[NOTE]
+====
+To display your default ingress domain, run the following command:
+[source,terminal]
+----
+$ oc get ingresses.config/cluster -o jsonpath={.spec.domain}
+----
+====

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -7,6 +7,10 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+
+//Creating an insecure route
+include::modules/nw-creating-a-route.adoc[leveloffset=+1]
+//
 //Creating route timeouts
 include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Applicable for 4.5+

https://bugzilla.redhat.com/show_bug.cgi?id=1833574

Doc preview link: https://deploy-preview-34812--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html

Requires QA approval from @quarterpin 
Requires dev approval from @Miciah 