### PR TITLE
Adds 4.7.21 release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2512,7 +2512,7 @@ In an upcoming release of {product-title}, OAuth tokens that do not include a SH
 * Previously, when importing a devfile, the `buildguidanceimage-placeholder` container that provides the configuration for environment variables, ports, and limits was ignored. As a result, new deployments had a second container which could not start because the placeholder image could not be fetched, and the user container was missing additional configurations. This release removes the `buildguidanceimage-placeholder` container from new deployments, and adds environment variables, ports, and limit configurations to the user container so that the devfile is imported correctly.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1956313[*BZ#1956313*])
 
-* Previously, `Keepalived` did not properly clean up virtual IP (VIP) addresses when it was force restarted. As a result, VIP addresses might appear on multiple nodes, which sometimes caused problems connecting to services behind the VIP. With this release, the removal of configured VIP addresses is verified before starting `Keepalived`, and VIP addresses no longer appear on multiple nodes.
+* Previously, Keepalived did not properly clean up virtual IP (VIP) addresses when it was force restarted. As a result, VIP addresses might appear on multiple nodes, which sometimes caused problems connecting to services behind the VIP. With this release, the removal of configured VIP addresses is verified before starting Keepalived, and VIP addresses no longer appear on multiple nodes.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1957015[*BZ#1957015*])
 
 [id="ocp-4-7-11-upgrading"]
@@ -2664,6 +2664,37 @@ link:https://access.redhat.com/solutions/6163712[{product-title} 4.7.19 containe
 * Previously, the authorization header created during image mirroring could exceed the header size limit for some registries. This would cause an error during the mirroring operation. Now, the `--skip-multiple-scopes` option is set to `true` for the `oc adm catalog mirror` command, to help prevent the authorization header from exceeding the header size limits. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976284[*BZ#1976284*])
 
 [id="ocp-4-7-19-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-21"]
+=== RHBA-2021:2762 - {product-title} 4.7.21 bug fix and security update
+
+Issued: 2021-07-26
+
+{product-title} release 4.7.21, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2762[RHBA-2021:2762] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2763[RHSA-2021:2763] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6209792[{product-title} 4.7.21 container image list]
+
+[id="ocp-4-7-21-features"]
+==== Features
+
+[id="ocp-4-7-21-aws-sdk-version-update"]
+===== Amazon Web Services SDK update
+
+With this update, `aws-sdk-go` is bumped to v1.38.35, which supports new Amazon Web Services (AWS) regions. This feature allows for new clusters to be installed in previously unknown regions without the risk of crashing the `image-registry` pod. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1977159[*BZ#1977159*].
+
+[id="ocp-4-7-21-bug-fixes"]
+==== Bug fixes
+
+* Previously, an incorrect Keepalived setting sometimes resulted in the VIP ending up on an incorrect system and unable to move back to the correct system. With this update, the incorrect Keepalived setting is removed so that the VIP ends up on the correct system. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971864[*BZ#1971864*])
+
+* Previously, when a Baremetal IPI was deployed with a proxy configured, the internal `machine-os` image download was directed through the proxy. This corrupted the image and prevented it from being downloaded. This update fixes the Internal image traffic to `no_proxy`, so that the image download no longer uses a proxy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1972291[*BZ#1972291*])
+
+[id="ocp-4-7-21-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-34813--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-21

To be merged 7-26. Will DM reminder. 