### PR TITLE
BZ1980863: Changed OpenJ9 to Eclipse OpenJ9

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -342,7 +342,7 @@ Note the following restrictions for {product-title} on IBM Power Systems:
 * Worker nodes must run {op-system-first}.
 * Persistent storage must be of the `Filesystem` mode using local volumes, Network File System (NFS), OpenStack Cinder, or Container Storage Interface (CSI).
 * Networking must use either DHCP or static addressing with Red Hat Openshift SDN.
-* AdoptOpenJDK with OpenJ9
+* AdoptOpenJDK with Eclipse OpenJ9
 * Installer-provisioned infrastructure
 * Device Manager for NVIDIA GPUs
 * Special Resources Operator


### PR DESCRIPTION
This PR is to address BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1980863
Change is available in this topic: https://deploy-preview-34815--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-ibm-power
Exact section: IBM Power Systems > Restrictions > AdoptOpenJDK with Eclipse OpenJ9
Label: enterprise-4.6
This is the only instance of OpenJ9 across the docs repo that I could find. There are no instances in master, 4.5, or 4.7 versions. 