### PR TITLE
BZ1892557: Changed Advanced Metrics to Monitoring Metrics

### DIFF
--- a/modules/monitoring-accessing-the-metrics-of-your-service-as-a-developer.adoc
+++ b/modules/monitoring-accessing-the-metrics-of-your-service-as-a-developer.adoc
@@ -21,7 +21,7 @@ The Grafana instance shipped within {product-title} Monitoring is read-only and 
 
 .Procedure
 
-. Go to the {product-title} web console, switch to the Developer Perspective, then click *Advanced* -> *Metrics*. Select the project you want to see the metrics for.
+. Go to the {product-title} web console, switch to the Developer Perspective, then click *Monitoring* -> *Metrics*. Select the project you want to see the metrics for.
 +
 [NOTE]
 ====


### PR DESCRIPTION
This PR is to address BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1892557
Change is available in this topic: https://deploy-preview-34817--osdocs.netlify.app/openshift-enterprise/latest/monitoring/monitoring-your-own-services.html#accessing-the-metrics-of-your-service-as-a-developer_monitoring-your-own-services
Label: enterprise-4.5
This is the only instance of Advanced -> Metrics across the docs repo that I could find. There are no instances in master, 4.6, or 4.7 versions. Request the PR to be cherry picked to enterprise-4.5 repo. 