### PR TITLE
CNV-11114: OpenShift Virtualization 4.8 release notes

### DIFF
--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -19,6 +19,7 @@ Learn more about xref:../virt/about-virt.adoc#about-virt[what you can do with {V
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
 [id="virt-guest-os"]
+//CNV-8167  Supported guest operating systems
 === Supported guest operating systems
 {VirtProductName} guests can use the following operating systems:
 
@@ -27,8 +28,6 @@ include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 * Microsoft Windows 10.
 
 Other operating system templates shipped with {VirtProductName} are not supported.
-
-//CNV-8167  Supported guest operating systems
 
 [id="virt-4-8-inclusive-language"]
 == Making open source more inclusive
@@ -46,6 +45,9 @@ The SVVP Certification applies to:
 ** Intel and AMD CPUs.
 * The Containerized Data Importer (CDI) now uses the {product-title} xref:../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide proxy configuration].
 
+//CNV-9518 Release Note for calico
+* {VirtProductName} now supports third-party Container Network Interface (CNI) plug-ins that are link:https://access.redhat.com/articles/5436171[certified by Red Hat] for use with {product-title}.
+
 //CNV-12323 OpenShift Virtualization is exposing additional metrics
 * {VirtProductName} now provides metrics for monitoring how infrastructure resources are consumed in the cluster. You can use the {product-title} monitoring dashboard to xref:../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-prometheus-queries[query metrics] for the following resources:
 +
@@ -54,18 +56,14 @@ The SVVP Certification applies to:
 ** Storage
 ** Guest memory swapping
 
+//CNV-12326 Openshift Virtualization is providing an unified API to configure cert rotation on different components.
+* {VirtProductName} now provides a unified API to xref:../virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc#virt-configuring-certificate-rotation[configure certificate rotation].
+
 //CNV-12346 Windows VMs will now only be scheduled to hyper-v capable nodes
 * If a Windows virtual machine is created from a template or has predefined Hyper-V capabilities, it can now only be scheduled to Hyper-V capable nodes.
 
 //CNV-12348 Add `--proxy-only` option to `virtctl vnc` for only proxying a VNC connection to allow manual connections
 * The `--proxy-only` option for the `virtctl vnc` command allows you to xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[manually connect to a virtual machine instance] through a Virtual Network Client (VNC) connection by using any VNC viewer.
-
-//CNV-12326 Openshift Virtualization is providing an unified API to configure cert rotation on different components.
-* {VirtProductName} now provides a unified API to xref:../virt/virtual_machines/vm_networking/virt-configuring-certificate-rotation.adoc#virt-configuring-certificate-rotation[configure certificate rotation].
-
-//CNV-9518 Release Note for calico
-
-* {VirtProductName} now supports third-party Container Network Interface (CNI) plug-ins that are link:https://access.redhat.com/articles/5436171[certified by Red Hat] for use with {product-title}.
 
 [id="virt-4-8-quick-starts"]
 === Quick starts
@@ -99,11 +97,10 @@ The SVVP Certification applies to:
 * You can now xref:../virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume#virt-cloning-vm-disk-into-new-datavolume[clone virtual machine disks between different data volume modes] if they have the content type `kubevirt`. For example, you can clone a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem.`
 
 //CNV-12273 CDI now follows the OpenShift cluster-wide proxy configuration when importing virtual machine disk images.
-
 * You can xref:../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-a-custom-disk-image-boot-source-web_virt-creating-and-using-boot-sources[create a custom disk image as a boot source] for any template that has a defined source by running a wizard in the {VirtProductName} console.
 
-[id="virt-4-8-web-new"]
-=== Web console
+//[id="virt-4-8-web-new"]
+//=== Web console
 
 [id="virt-4-8-deprecated-removed"]
 == Deprecated and removed features
@@ -121,6 +118,11 @@ Deprecated features are included in the current release and supported. However, 
 
 [id="virt-4-8-changes"]
 == Notable technical changes
+//CNV-9052 OpenShift Virtualization now automatically configures IPv6 IP when running on dual-stack clusters.
+* {VirtProductName} now configures IPv6 addresses when running on clusters that have dual-stack networking enabled. You can xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt[create a service] that uses IPv4, IPv6, or both IP address families, if dual-stack networking is enabled for the underlying {product-title} cluster.
+
+//CNV-9054 MAC address pool is now enabled on all namespaces by default.
+* KubeMacPool is now enabled by default when you install {VirtProductName}. You can xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[disable a MAC address pool] for a namespace by adding the `mutatevirtualmachines.kubemacpool.io=ignore` label to the namespace. Re-enable KubeMacPool for the namespace by removing the label.
 
 //CNV-12325 All product configuration options are expressed from the HCO CR
 * The `HyperConverged` custom resource (CR) is now the central point of configuration for {VirtProductName}. By editing the `HyperConverged` CR, you can:
@@ -130,12 +132,6 @@ Deprecated features are included in the current release and supported. However, 
 ** xref:../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms[Disable TLS for container registries]
 ** xref:../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass_virt-preparing-cdi-scratch-space[Configure a storage class for scratch space]
 ** xref:../virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota.adoc#virt-overriding-cpu-and-memory-defaults_virt-configuring-cdi-for-namespace-resourcequota[Configure resource requirements for storage workloads]
-
-//CNV-9052 OpenShift Virtualization now automatically configures IPv6 IP when running on dual-stack clusters.
-* {VirtProductName} now configures IPv6 addresses when running on clusters that have dual-stack networking enabled. You can xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-creating-a-service-from-a-virtual-machine_virt-using-the-default-pod-network-with-virt[create a service] that uses IPv4, IPv6, or both IP address families, if dual-stack networking is enabled for the underlying {product-title} cluster.
-
-//CNV-9054 MAC address pool is now enabled on all namespaces by default.
-* KubeMacPool is now enabled by default when you install {VirtProductName}. You can xref:../virt/virtual_machines/vm_networking/virt-using-mac-address-pool-for-vms.adoc#virt-using-mac-address-pool-for-vms[disable a MAC address pool] for a namespace by adding the `mutatevirtualmachines.kubemacpool.io=ignore` label to the namespace. Re-enable KubeMacPool for the namespace by removing the label.
 
 [id="virt-4-8-technology-preview"]
 == Technology Preview features


### PR DESCRIPTION
[CNV-11114](https://issues.redhat.com/browse/CNV-11114)

This PR is available to capture feedback from PM and QE leads for the 4.8 release notes.

Preview build: https://deploy-preview-34818--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-8-release-notes

Please note that the OpenShift version variable renders as "Branch Build" in the supported cluster version section and the 'what you can do with OpenShift Virtualization' link routes to placeholder content. Both of these issues will be resolved when the docs are live.