### PR TITLE
RHDEVDOCS-3182: Update the "Supported log data output types" for 5.1

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -29,7 +29,8 @@ You cannot use the config map methods and the Cluster Log Forwarder in the same 
 // assemblies.
 
 include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset=+1]
-include::modules/cluster-logging-collector-log-forwarding-supported-plugins.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-log-forwarding-supported-plugins-5-0.adoc[leveloffset=+1]
+include::modules/cluster-logging-collector-log-forwarding-supported-plugins-5-1.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-es.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-fluentd.adoc[leveloffset=+1]
 include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+1]

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-0.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-0.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// logging/cluster-logging-external.adoc
+
+[id="cluster-logging-collector-log-forwarding-supported-plugins-5-0_{context}"]
+
+= Supported log data output types in OpenShift Logging 5.0
+
+Red Hat OpenShift Logging version 5.0 provides the following output types and protocols for sending log data to target log collectors.
+
+Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
+
+[options="header"]
+|====
+| Output types   | Protocols          | Tested with
+
+| fluentdForward
+| fluentd forward v1
+a| fluentd 1.7.4
+
+logstash 7.10.1
+
+| elasticsearch
+| elasticsearch
+a| Elasticsearch 6.8.1
+
+Elasticsearch 7.10.1
+
+| syslog
+| RFC-3164, RFC-5424
+| rsyslog 8.37.0-9.el7
+
+| kafka
+| kafka 0.11
+| kafka 2.4.1
+
+|====
+
+// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
+// This file is the authoritative source of information about which items and versions Red Hat tests and supports.
+// According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
+
+[NOTE]
+====
+Previously, the syslog output supported only RFC-3164. The current syslog output adds support for RFC-5424.
+====

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-1.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-1.adoc
@@ -2,11 +2,11 @@
 //
 // logging/cluster-logging-external.adoc
 
-[id="cluster-logging-collector-log-forwarding-supported-plugins_{context}"]
+[id="cluster-logging-collector-log-forwarding-supported-plugins-5-1_{context}"]
 
-= Supported log data output types
+= Supported log data output types in OpenShift Logging 5.1
 
-Red Hat OpenShift Logging version 5.0 provides the following output types and protocols for sending log data to target log collectors.
+Red Hat OpenShift Logging versions 5.1 provides the following output types and protocols for sending log data to target log collectors.
 
 Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
 
@@ -24,21 +24,26 @@ logstash 7.10.1
 | elasticsearch
 a| Elasticsearch 6.8.1
 
-Elasticsearch 7.10.1
+Elasticsearch 6.8.4
+
+Elasticsearch 7.12.2
 
 | syslog
 | RFC-3164, RFC-5424
-| rsyslog 8.37.0-9.el7
+| rsyslog-8.39.0
 
 | kafka
 | kafka 0.11
-| kafka 2.4.1
+a| kafka 2.4.1
+
+kafka 2.7.0
 
 |====
 
 // Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
 // This file is the authoritative source of information about which items and versions Red Hat tests and supports.
 // According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
+// Logstash support is according to https://github.com/openshift/cluster-logging-operator/blob/master/test/functional/outputs/forward_to_logstash_test.go#L37
 
 [NOTE]
 ====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.7+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3182
- Direct link to doc preview: https://deploy-preview-34820--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-log-forwarding-supported-plugins_cluster-logging-external
- Reviewed by @jcantrill, who indicated that the supported log data output types and versions haven't changed from 5.0 to 5.1.
- SME reviewed and approved by @vimalk78 
- QE reviewed and approved by @anpingli
- Peer reviewed and approved by @jc-berger 
- All reviews complete. Please merge now.