### PR TITLE
RHDEVDOCS-3181: Instructions for updating to OpenShift Logging 5.1

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,6 +1,6 @@
 [id="cluster-logging-release-notes"]
 = Release notes for Red Hat OpenShift Logging
-include::modules/cluster-logging-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
 toc::[]
@@ -8,7 +8,7 @@ toc::[]
 [id="openshift-logging-about-this-release"]
 == About this release
 
-The following advisories are available for {ProductName}:
+The following advisories are available for Red Hat OpenShift Logging:
 
 * link:https://access.redhat.com/errata/RHBA-2021:2112[RHBA-2021:2112 - Bug Fix Advisory. OpenShift Logging Bug Fix Release 5.1.0]
 //* link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -5,18 +5,19 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+{product-title} versions 4.7 and 4.8 both support OpenShift Logging versions 5.0 and 5.1.
 
+To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
 
-After updating the {product-title} cluster from 4.6 to 4.7, you can update the OpenShift Elasticsearch Operator and Cluster Logging Operator from 4.6 to 5.0.
+* From Elasticsearch Operator 4.x to OpenShift Elasticsearch Operator 5.x
+* From Cluster Logging Operator 4.x to Red Hat OpenShift Logging Operator 5.x
 
-[NOTE]
-====
-In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator.
-====
+To upgrade from a previous version of OpenShift Logging to the current version, you update OpenShift Elasticsearch Operator and Red Hat OpenShift Logging Operator to their current versions.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/cluster-logging-updating-logging.adoc[leveloffset=+1]
+include::modules/cluster-logging-updating-logging-to-5-0.adoc[leveloffset=+1]
+include::modules/cluster-logging-updating-logging-to-5-1.adoc[leveloffset=+1]

--- a/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.adoc
+++ b/logging/troubleshooting/cluster-logging-troubleshooting-for-critical-alerts.adoc
@@ -19,7 +19,7 @@ At least one primary shard and its replicas are not allocated to a node.
 +
 [source,terminal]
 ----
-oc exec -n openshift-logging -c elasticsearch <elasticsearch_pod_name> -- es_cluster_health
+oc exec -n openshift-logging -c elasticsearch <elasticsearch_pod_name> -- health
 ----
 
 . List the nodes that have joined the cluster.
@@ -72,7 +72,7 @@ If there is no command output, the recovery process might be delayed or stalled 
 +
 [source,terminal]
 ----
-oc exec -n openshift-logging -c elasticsearch <elasticsearch_pod_name> -- es_cluster_health |grep  number_of_pending_tasks
+oc exec -n openshift-logging -c elasticsearch <elasticsearch_pod_name> -- health |grep  number_of_pending_tasks
 ----
 
 . If there are pending tasks, monitor their status.

--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -139,14 +139,14 @@ metadata:
   name: "elasticsearch-operator"
   namespace: "openshift-operators-redhat" <1>
 spec:
-  channel: "5.0" <2>
+  channel: "stable-5.1" <2>
   installPlanApproval: "Automatic"
   source: "redhat-operators" <3>
   sourceNamespace: "openshift-marketplace"
   name: "elasticsearch-operator"
 ----
 <1> You must specify the `openshift-operators-redhat` Namespace.
-<2> Specify `5.0` or `stable` as the channel. `stable` is the latest 5.x released code.
+<2> Specify `5.0` or `stable-5.<x>` as the channel. `stable-5.<x>` is the latest released code for the version number you specify with `x`.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster,
 specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
 
@@ -177,14 +177,14 @@ $ oc get csv --all-namespaces
 [source,terminal]
 ----
 NAMESPACE                                               NAME                                            DISPLAY                  VERSION               REPLACES   PHASE
-default                                                 elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-kube-node-lease                                         elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-kube-public                                             elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-kube-system                                             elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-openshift-apiserver-operator                            elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-openshift-apiserver                                     elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-openshift-authentication-operator                       elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
-openshift-authentication                                elasticsearch-operator.5.0.0-202007012112.p0    OpenShift Elasticsearch Operator   5.0.0-202007012112.p0               Succeeded
+default                                                 elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+kube-node-lease                                         elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+kube-public                                             elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+kube-system                                             elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+openshift-apiserver-operator                            elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+openshift-apiserver                                     elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+openshift-authentication-operator                       elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
+openshift-authentication                                elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.1.0-202007012112.p0               Succeeded
 ...
 ----
 +
@@ -232,13 +232,13 @@ metadata:
   name: cluster-logging
   namespace: openshift-logging <1>
 spec:
-  channel: "5.0" <2>
+  channel: "stable-5.1" <2>
   name: cluster-logging
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace
 ----
 <1> You must specify the `openshift-logging` Namespace.
-<2> Specify `5.0` or `stable` as the channel. `stable` is the latest 5.x released code.
+<2> Specify `5.0` or `stable-5.<x>` as the channel. `stable-5.<x>` is the latest released code for the version number you specify with `x`.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object you created when you configured the Operator Lifecycle Manager (OLM).
 +
 [source,terminal]
@@ -269,7 +269,7 @@ $ oc get csv -n openshift-logging
 ----
 NAMESPACE                                               NAME                                         DISPLAY                  VERSION               REPLACES   PHASE
 ...
-openshift-logging                                       clusterlogging.5.0.0-202007012112.p0         OpenShift Logging          5.0.0-202007012112.p0              Succeeded
+openshift-logging                                       clusterlogging.5.1.0-202007012112.p0         OpenShift Logging          5.1.0-202007012112.p0              Succeeded
 ...
 ----
 

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -50,7 +50,7 @@ This option sets the `openshift.io/cluster-monitoring: "true"` label in the Name
 You must select this option to ensure that cluster monitoring
 scrapes the `openshift-operators-redhat` namespace.
 
-.. Select *5.0* as the *Update Channel*.
+.. Select *stable-5.x* as the *Update Channel*.
 
 .. Select an *Approval Strategy*.
 +
@@ -80,7 +80,7 @@ This option sets the `openshift.io/cluster-monitoring: "true"` label in the Name
 You must select this option to ensure that cluster monitoring
 scrapes the `openshift-logging` namespace.
 
-.. Select *5.0* as the *Update Channel*.
+.. Select *stable-5.x* as the *Update Channel*.
 
 .. Select an *Approval Strategy*.
 +

--- a/modules/cluster-logging-updating-logging-to-5-0.adoc
+++ b/modules/cluster-logging-updating-logging-to-5-0.adoc
@@ -1,41 +1,33 @@
-// Module included in the following assemblies:
-//
-// * logging/cluster-logging-upgrading.adoc
+[id="cluster-logging-updating-logging-to-5-0_{context}"]
+= Updating from cluster logging in {product-title} 4.6 or earlier to OpenShift Logging 5.x
 
-[id="cluster-logging-updating-logging_{context}"]
-= Updating OpenShift Logging
+{product-title} 4.7 made the following name changes:
 
-After updating the {product-title} cluster, you can update from cluster logging 4.6 to Red Hat OpenShift Logging 5.0 by changing the subscription for the OpenShift Elasticsearch Operator and the Cluster Logging Operator.
+* The _cluster logging_ feature became the _Red Hat OpenShift Logging_ 5.x product.
+* The _Cluster Logging_ Operator became the _Red Hat OpenShift Logging_ Operator.
+* The _Elasticsearch_ Operator became _OpenShift Elasticsearch_ Operator.
 
-[NOTE]
-====
-In OpenShift Logging 5.0 and later, the Cluster Logging Operator is called Red Hat OpenShift Logging Operator.
-====
+To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
 
-When you update:
-
-* You must update the OpenShift Elasticsearch Operator before updating the Cluster Logging Operator.
-* You must update both the OpenShift Elasticsearch Operator and the Cluster Logging Operator.
-+
-Kibana is unusable when the OpenShift Elasticsearch Operator has been updated but the Cluster Logging Operator has not been updated.
-+
-If you update the Cluster Logging Operator before the OpenShift Elasticsearch Operator, Kibana does not update and the Kibana custom resource (CR) is not created. To work around this problem, delete the Cluster Logging Operator pod. When the Cluster Logging Operator pod redeploys, the Kibana CR is created.
+* From Elasticsearch Operator 4.x to OpenShift Elasticsearch Operator 5.x
+* From Cluster Logging Operator 4.x to Red Hat OpenShift Logging Operator 5.x
 
 [IMPORTANT]
 ====
-Upgrade your cluster logging version to 4.6 before updating to Red Hat OpenShift Logging 5.0.
+You must update the OpenShift Elasticsearch Operator _before_ you update the Red Hat OpenShift Logging Operator. You must also update _both_ Operators to the same version.
 ====
+
+If you update the operators in the wrong order, Kibana does not update and the Kibana custom resource (CR) is not created. To work around this problem, you delete the Red Hat OpenShift Logging Operator pod. When the Red Hat OpenShift Logging Operator pod redeploys, it creates the Kibana CR and Kibana becomes available again.
 
 .Prerequisites
 
-* Update the {product-title} cluster from 4.6 to 4.7.
+* The {product-title} version is 4.7 or later.
 
-* Make sure the OpenShift Logging status is healthy:
-+
+* The OpenShift Logging status is healthy:
 ** All pods are `ready`.
 ** The Elasticsearch cluster is healthy.
 
-* Back up your Elasticsearch and Kibana data.
+* Your Elasticsearch and Kibana data is backed up.
 
 .Procedure
 
@@ -49,11 +41,11 @@ Upgrade your cluster logging version to 4.6 before updating to Red Hat OpenShift
 
 .. Click *Subscription* -> *Channel*.
 
-.. In the *Change Subscription Update Channel* window, select *5.0* and click *Save*.
+.. In the *Change Subscription Update Channel* window, select *5.0* or *stable-5.1* and click *Save*.
 
 .. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
 +
-Verify that the OpenShift Elasticsearch Operator version is 5.0.x.
+Verify that the OpenShift Elasticsearch Operator version is 5.x.x.
 +
 Wait for the *Status* field to report *Succeeded*.
 
@@ -67,11 +59,11 @@ Wait for the *Status* field to report *Succeeded*.
 
 .. Click *Subscription* -> *Channel*.
 
-.. In the *Change Subscription Update Channel* window, select *5.0* and click *Save*.
+.. In the *Change Subscription Update Channel* window, select *5.0* or *stable-5.1* and click *Save*.
 
 .. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
 +
-Verify that the Red Hat OpenShift Logging Operator version is 5.0.x.
+Verify that the Red Hat OpenShift Logging Operator version is 5.0.x or 5.1.x.
 +
 Wait for the *Status* field to report *Succeeded*.
 
@@ -97,7 +89,7 @@ elasticsearch-cdm-1pbrl44l-3-88df5d47-m45jc     2/2     Running   0          29m
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b7546f4c-mshhk -- es_cluster_health
+$ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b7546f4c-mshhk -- health
 ----
 +
 [source,json]
@@ -106,7 +98,6 @@ $ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b
   "cluster_name" : "elasticsearch",
   "status" : "green",
 }
-...
 ----
 
 .. Ensure that the Elasticsearch cron jobs are created:
@@ -124,13 +115,12 @@ $ oc get cronjob
 [source,terminal]
 ----
 NAME                     SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
-curator                  30 3,9,15,21 * * * False 0        <none>          20s
 elasticsearch-im-app     */15 * * * *   False     0        <none>          56s
 elasticsearch-im-audit   */15 * * * *   False     0        <none>          56s
 elasticsearch-im-infra   */15 * * * *   False     0        <none>          56s
 ----
 
-.. Verify that the log store is updated to 5.0 and the indices are `green`:
+.. Verify that the log store is updated to 5.0 or 5.1 and the indices are `green`:
 +
 [source,terminal]
 ----
@@ -172,7 +162,7 @@ green  open   audit-000001                                                      
 ----
 ====
 
-.. Verify that the log collector is updated to 5.0:
+.. Verify that the log collector is updated to 5.0 or 5.1:
 +
 [source,terminal]
 ----
@@ -186,7 +176,7 @@ Verify that the output includes a `fluentd-init` container:
 "containerName": "fluentd-init"
 ----
 
-.. Verify that the log visualizer is updated to 5.0 using the Kibana CRD:
+.. Verify that the log visualizer is updated to 5.0 or 5.1 using the Kibana CRD:
 +
 [source,terminal]
 ----

--- a/modules/cluster-logging-updating-logging-to-5-1.adoc
+++ b/modules/cluster-logging-updating-logging-to-5-1.adoc
@@ -1,0 +1,217 @@
+[id="cluster-logging-updating-logging-to-5-1_{context}"]
+= Updating OpenShift Logging to the current version
+
+To update OpenShift Logging from 5.x to the current version, you change the subscriptions for the OpenShift Elasticsearch Operator and Red Hat OpenShift Logging Operator.
+
+[IMPORTANT]
+====
+You must update the OpenShift Elasticsearch Operator _before_ you update the Red Hat OpenShift Logging Operator. You must also update _both_ Operators to the same version.
+====
+
+
+If you update the operators in the wrong order, Kibana does not update and the Kibana custom resource (CR) is not created. To work around this problem, you delete the Red Hat OpenShift Logging Operator pod. When the Red Hat OpenShift Logging Operator pod redeploys, it creates the Kibana CR and Kibana becomes available again.
+
+.Prerequisites
+
+* The {product-title} version is 4.7 or later.
+
+* The OpenShift Logging status is healthy:
++
+** All pods are `ready`.
+** The Elasticsearch cluster is healthy.
+
+* Your Elasticsearch and Kibana data is backed up.
+
+.Procedure
+
+. Update the OpenShift Elasticsearch Operator:
+
+.. From the web console, click *Operators* -> *Installed Operators*.
+
+.. Select the `openshift-operators-redhat` project.
+
+.. Click the *OpenShift Elasticsearch Operator*.
+
+.. Click *Subscription* -> *Channel*.
+
+.. In the *Change Subscription Update Channel* window, select *stable-5.x* and click *Save*.
+
+.. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
++
+Verify that the OpenShift Elasticsearch Operator version is 5.x.x.
++
+Wait for the *Status* field to report *Succeeded*.
+
+. Update the Red Hat OpenShift Logging Operator:
+
+.. From the web console, click *Operators* -> *Installed Operators*.
+
+.. Select the `openshift-logging` project.
+
+.. Click the *Red Hat OpenShift Logging Operator*.
+
+.. Click *Subscription* -> *Channel*.
+
+.. In the *Change Subscription Update Channel* window, select *stable-5.x* and click *Save*.
+
+.. Wait for a few seconds, then click *Operators* -> *Installed Operators*.
++
+Verify that the Red Hat OpenShift Logging Operator version is 5.x.x.
++
+Wait for the *Status* field to report *Succeeded*.
+
+. Check the logging components:
+
+.. Ensure that all Elasticsearch pods are in the *Ready* status:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-logging --selector component=elasticsearch
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                            READY   STATUS    RESTARTS   AGE
+elasticsearch-cdm-1pbrl44l-1-55b7546f4c-mshhk   2/2     Running   0          31m
+elasticsearch-cdm-1pbrl44l-2-5c6d87589f-gx5hk   2/2     Running   0          30m
+elasticsearch-cdm-1pbrl44l-3-88df5d47-m45jc     2/2     Running   0          29m
+----
++
+.. Ensure that the Elasticsearch cluster is healthy:
++
+[source,terminal]
+----
+$ oc exec -n openshift-logging -c elasticsearch elasticsearch-cdm-1pbrl44l-1-55b7546f4c-mshhk -- health
+----
++
+[source,json]
+----
+{
+  "cluster_name" : "elasticsearch",
+  "status" : "green",
+}
+----
+
+.. Ensure that the Elasticsearch cron jobs are created:
++
+[source,terminal]
+----
+$ oc project openshift-logging
+----
++
+[source,terminal]
+----
+$ oc get cronjob
+----
++
+[source,terminal]
+----
+NAME                     SCHEDULE       SUSPEND   ACTIVE   LAST SCHEDULE   AGE
+elasticsearch-im-app     */15 * * * *   False     0        <none>          56s
+elasticsearch-im-audit   */15 * * * *   False     0        <none>          56s
+elasticsearch-im-infra   */15 * * * *   False     0        <none>          56s
+----
+
+.. Verify that the log store is updated to 5.x and the indices are `green`:
++
+[source,terminal]
+----
+$ oc exec -c elasticsearch <any_es_pod_in_the_cluster> -- indices
+----
++
+Verify that the output includes the `app-00000x`, `infra-00000x`, `audit-00000x`, `.security` indices.
++
+.Sample output with indices in a green status
+[%collapsible]
+====
+[source,terminal]
+----
+Tue Jun 30 14:30:54 UTC 2020
+health status index                                                                 uuid                   pri rep docs.count docs.deleted store.size pri.store.size
+green  open   infra-000008                                                          bnBvUFEXTWi92z3zWAzieQ   3 1       222195            0        289            144
+green  open   infra-000004                                                          rtDSzoqsSl6saisSK7Au1Q   3 1       226717            0        297            148
+green  open   infra-000012                                                          RSf_kUwDSR2xEuKRZMPqZQ   3 1       227623            0        295            147
+green  open   .kibana_7                                                             1SJdCqlZTPWlIAaOUd78yg   1 1            4            0          0              0
+green  open   infra-000010                                                          iXwL3bnqTuGEABbUDa6OVw   3 1       248368            0        317            158
+green  open   infra-000009                                                          YN9EsULWSNaxWeeNvOs0RA   3 1       258799            0        337            168
+green  open   infra-000014                                                          YP0U6R7FQ_GVQVQZ6Yh9Ig   3 1       223788            0        292            146
+green  open   infra-000015                                                          JRBbAbEmSMqK5X40df9HbQ   3 1       224371            0        291            145
+green  open   .orphaned.2020.06.30                                                  n_xQC2dWQzConkvQqei3YA   3 1            9            0          0              0
+green  open   infra-000007                                                          llkkAVSzSOmosWTSAJM_hg   3 1       228584            0        296            148
+green  open   infra-000005                                                          d9BoGQdiQASsS3BBFm2iRA   3 1       227987            0        297            148
+green  open   infra-000003                                                          1-goREK1QUKlQPAIVkWVaQ   3 1       226719            0        295            147
+green  open   .security                                                             zeT65uOuRTKZMjg_bbUc1g   1 1            5            0          0              0
+green  open   .kibana-377444158_kubeadmin                                           wvMhDwJkR-mRZQO84K0gUQ   3 1            1            0          0              0
+green  open   infra-000006                                                          5H-KBSXGQKiO7hdapDE23g   3 1       226676            0        295            147
+green  open   infra-000001                                                          eH53BQ-bSxSWR5xYZB6lVg   3 1       341800            0        443            220
+green  open   .kibana-6                                                             RVp7TemSSemGJcsSUmuf3A   1 1            4            0          0              0
+green  open   infra-000011                                                          J7XWBauWSTe0jnzX02fU6A   3 1       226100            0        293            146
+green  open   app-000001                                                            axSAFfONQDmKwatkjPXdtw   3 1       103186            0        126             57
+green  open   infra-000016                                                          m9c1iRLtStWSF1GopaRyCg   3 1        13685            0         19              9
+green  open   infra-000002                                                          Hz6WvINtTvKcQzw-ewmbYg   3 1       228994            0        296            148
+green  open   infra-000013                                                          KR9mMFUpQl-jraYtanyIGw   3 1       228166            0        298            148
+green  open   audit-000001                                                          eERqLdLmQOiQDFES1LBATQ   3 1            0            0          0              0
+----
+====
+
+.. Verify that the log collector is updated to 5.x:
++
+[source,terminal]
+----
+$ oc get ds fluentd -o json | grep fluentd-init
+----
++
+Verify that the output includes a `fluentd-init` container:
++
+[source,terminal]
+----
+"containerName": "fluentd-init"
+----
+
+.. Verify that the log visualizer is updated to 5.x using the Kibana CRD:
++
+[source,terminal]
+----
+$ oc get kibana kibana -o json
+----
++
+Verify that the output includes a Kibana pod with the `ready` status:
++
+.Sample output with a ready Kibana pod
+[%collapsible]
+====
+[source,json]
+----
+[
+{
+"clusterCondition": {
+"kibana-5fdd766ffd-nb2jj": [
+{
+"lastTransitionTime": "2020-06-30T14:11:07Z",
+"reason": "ContainerCreating",
+"status": "True",
+"type": ""
+},
+{
+"lastTransitionTime": "2020-06-30T14:11:07Z",
+"reason": "ContainerCreating",
+"status": "True",
+"type": ""
+}
+]
+},
+"deployment": "kibana",
+"pods": {
+"failed": [],
+"notReady": []
+"ready": []
+},
+"replicaSets": [
+"kibana-5fdd766ffd"
+],
+"replicas": 1
+}
+]
+----
+====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.7+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3181
- Direct link to doc preview: https://deploy-preview-34821--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-upgrading.html
- SME review approved by @jcantrill 
- QE review: @anpingli
- Peer review: @ tbd
- <All reviews complete. Please merge now>