### PR TITLE
OSDOCS-2354: adding information about ASH CCO support for CCO-22

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -39,8 +39,8 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 
 
 |Microsoft Azure
-|X
-|X
+|X ^[1]^
+|X ^[1]^
 |X
 
 |Google Cloud Platform (GCP)
@@ -64,6 +64,10 @@ Mint mode is the default and recommended best practice setting for the CCO to us
 |
 
 |====
+[.small]
+--
+1. Manual mode is the only supported CCO configuration for Microsoft Azure Stack Hub.
+--
 
 [id="about-cloud-credential-operator-default"]
 == Default behavior

--- a/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
@@ -13,6 +13,11 @@ If the credential is not removed after installation, it is stored and used by th
 
 If the requirement that mint mode stores the administrator-level credential in the cluster `kube-system` namespace does not suit the security requirements of your organization, see _Alternatives to storing administrator-level secrets in the kube-system project_ for xref:../../installing/installing_aws/manually-creating-iam.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-aws[AWS], xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-azure[Azure], or xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp[GCP].
 
+[NOTE]
+====
+xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual mode] is the only supported CCO configuration for Microsoft Azure Stack Hub.
+====
+
 [id="mint-mode-permissions"]
 == Mint mode permissions requirements
 When using the CCO in mint mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials are not sufficient for mint mode, the CCO cannot create an IAM user.

--- a/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.adoc
@@ -9,6 +9,11 @@ Passthrough mode is supported for Amazon Web Services (AWS), Microsoft Azure, Go
 
 In passthrough mode, the Cloud Credential Operator (CCO) passes the provided cloud credential to the components that request cloud credentials. The credential must have permissions to perform the installation and complete the operations that are required by components in the cluster, but does not need to be able to create new credentials. The CCO does not attempt to create additional limited-scoped credentials in passthrough mode.
 
+[NOTE]
+====
+xref:../../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc#cco-mode-manual[Manual mode] is the only supported CCO configuration for Microsoft Azure Stack Hub.
+====
+
 [id="passthrough-mode-permissions"]
 == Passthrough mode permissions requirements
 When using the CCO in passthrough mode, ensure that the credential you provide meets the requirements of the cloud on which you are running or installing {product-title}. If the provided credentials the CCO passes to a component that creates a `CredentialsRequest` CR are not sufficient, that component will report an error when it tries to call an API that it does not have permissions for.


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2354

Previews:
- [CCO mode support matrix](https://deploy-preview-34822--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html#about-cloud-credential-operator-modes)
- [Using mint mode](https://deploy-preview-34822--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint.html#cco-mode-mint)
- [Using passthrough mode](https://deploy-preview-34822--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-passthrough.html#cco-mode-passthrough)

I was not sure whether an explicit mention is needed here or in [Manually creating IAM for Azure](https://deploy-preview-34822--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/manually-creating-iam-azure.html). Probably depends on if ASH is covered under Azure more generally, or if it will have its own section.