### PR TITLE
Fix URLs typo in the logging release notes

### DIFF
--- a/modules/cluster-logging-release-notes-5.0.4.adoc
+++ b/modules/cluster-logging-release-notes-5.0.4.adoc
@@ -19,4 +19,4 @@ The following Jira issues contain the above CVEs:
 
 This release also includes the following bug fixes:
 
-* LOG-1328 Port fix to 5.0.z for BZ-1945168. (link:https://issues.redhat.com/browse/LOG-1364[*LOG-1364*])
+* LOG-1328 Port fix to 5.0.z for BZ-1945168. (link:https://issues.redhat.com/browse/LOG-1328[*LOG-1328*])

--- a/modules/cluster-logging-release-notes-5.0.5.adoc
+++ b/modules/cluster-logging-release-notes-5.0.5.adoc
@@ -13,6 +13,6 @@ validation. (link:https://access.redhat.com/security/cve/CVE-2021-3121[*CVE-2021
 The following issues relate to the above CVEs:
 
 * BZ#1921650 gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation(link:https://bugzilla.redhat.com/show_bug.cgi?id=1921650[*BZ#1921650*])
-* LOG-1361 CVE-2021-3121 elasticsearch-operator-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1361*])
-* LOG-1362 CVE-2021-3121 elasticsearch-proxy-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1362*])
-* LOG-1363 CVE-2021-3121 logging-eventrouter-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1364[*LOG-1363*])
+* LOG-1361 CVE-2021-3121 elasticsearch-operator-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1361[*LOG-1361*])
+* LOG-1362 CVE-2021-3121 elasticsearch-proxy-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1362[*LOG-1362*])
+* LOG-1363 CVE-2021-3121 logging-eventrouter-container: gogo/protobuf: plugin/unmarshal/unmarshal.go lacks certain index validation [openshift-logging-5](link:https://issues.redhat.com/browse/LOG-1363[*LOG-1363*])


### PR DESCRIPTION
@vikram-redhat There are some URL typo in the logging release notes, minimum version that the change applies to should be 4.7 in my opinion, could you arrange someone to review it? Thanks.