### PR TITLE
BZ:1877387: Incorrect command for deleting a baremetal node in the docs

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -24,7 +24,7 @@ xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installin
 In {VirtProductName} clusters installed using installer-provisioned infrastructure and with MachineHealthCheck properly configured, if a node fails the MachineHealthCheck and becomes unavailable to the cluster, it is recycled. What happens next with VMs that ran on the failed node depends on a series of conditions. See xref:../../virt/virtual_machines/virt-create-vms.adoc#virt-about-runstrategies-vms_virt-create-vms[About RunStrategies for virtual machines] for more detailed information about the potential outcomes and how RunStrategies affect those outcomes.
 ====
 
-** If you are not using installer-provisioned infrastructure, use either a monitoring system or a qualified human to monitor node availability. When a node is lost, shut it down and run `oc adm delete node <lost_node>`.
+** If you are not using installer-provisioned infrastructure, use either a monitoring system or a qualified human to monitor node availability. When a node is lost, shut it down and run `oc delete node <lost_node>`.
 +
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1877387

This change is for 4.8 only. The text was added to 4.8 only in https://github.com/openshift/openshift-docs/pull/30696.

