### PR TITLE
add warning about what disaster recovery does to a running cluster

### DIFF
--- a/backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
+++ b/backup_and_restore/disaster_recovery/about-disaster-recovery.adoc
@@ -23,6 +23,25 @@ This also includes situations where you have lost the majority of your control p
 +
 If applicable, you might also need to xref:../../backup_and_restore/disaster_recovery/scenario-3-expired-certs.adoc#dr-recovering-expired-certs[recover from expired control plane certificates].
 +
+[IMPORTANT]
+====
+You should only restore to an old etcd state when your etcd is not functioning and your kube-apiserver is inaccessible because etcd is down.
+If you can reach the kube-apiserver and get etcd content back, doing an etcd restore will almost certainly make your situation worse, not better.
+
+Disaster recovery will take your cluster back in time and all clients will experience a conflicting, parallel history.
+This is an extremely destructive and destablizing action to take on a running cluster.
+In the vast majority of cases, taking a running cluster and restoring an etcd backup will make your situation worse, not better.
+Restoring etcd effectively takes a cluster back in time and causes the etcd state to mismatch against the actual state of the cluster.
+Etcd contains an ordered list of changes.
+By restoring backup, you not only move back in time, but every component watching etcd will start to experience a parallel history of changes.
+This can impact the behavior of watching components like kubelets, kube-controller-managers, SDN controllers, persistent volume controllers.
+In extreme cases, the cluster can lose track of persistent volumes, delete critical workloads that no longer exist, re-image machines,
+and re-write CA bundles with expired certificates.
+In less extreme cases, it can cause operator churn as the content in etcd does not match the actual content on disk, causing operators like
+the kube-apiserver, kube-controller-manager, kube-scheduler, and etcd to get "stuck" when files on disk conflict with content in etcd, forcing
+manual action to unstick the cluster.
+====
++
 [NOTE]
 ====
 If you have a majority of your masters still available and have an etcd quorum, then follow the procedure to xref:../../backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[replace a single unhealthy etcd member].


### PR DESCRIPTION
Occasionally developers, administrators, and support people think that running etcd disaster recovery will improve the state of their cluster.  This is usually not the case.  This PR describes the hazards.

/assign @hexfusion @sttts 

for technical review