### PR TITLE
RHDEVDOCS-3185 Update release notes OpenShift Logging 5.1.1 (RHBA-2021:2885-02)

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,5 +1,5 @@
 [id="cluster-logging-release-notes"]
-= Release notes for Red Hat OpenShift Logging
+= Release notes for Red Hat OpenShift Logging 5.1
 include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
@@ -8,22 +8,14 @@ toc::[]
 [id="openshift-logging-about-this-release"]
 == About this release
 
-The following advisories are available for Red Hat OpenShift Logging:
+The following advisories are available for OpenShift Logging 5.1.x:
 
+* link:https://access.redhat.com/errata/RHBA-2021:2885[RHBA-2021:2885 - Bug Fix Advisory. Openshift Logging Bug Fix Release 5.1.1]
 * link:https://access.redhat.com/errata/RHBA-2021:2112[RHBA-2021:2112 - Bug Fix Advisory. OpenShift Logging Bug Fix Release 5.1.0]
-* link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.7)]
-* link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]
-* link:https://access.redhat.com/errata/RHSA-2021:2374[RHSA-2021:2374 - Security Advisory. Moderate: Openshift Logging Bug Fix Release (5.0.5)]
-* link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 - Security Advisory. Moderate: Openshift Logging security and bugs update (5.0.4)]
-* link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 - Security Advisory. Important OpenShift Logging Bug Fix Release (5.0.3)]
-* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.2)]
-* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)]
-* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0]
 
 [id="openshift-logging-supported-versions"]
 == Supported versions
 
-* OpenShift Logging version 5.0 runs on {product-title} versions 4.7 and 4.8.
 * OpenShift Logging version 5.1 runs on {product-title} versions 4.7 and 4.8.
 
 [id="openshift-logging-inclusive-language"]
@@ -33,11 +25,3 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 
 // Release Notes by version
 include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.7.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.6.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.5.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.4.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]


### PR DESCRIPTION
Purposes:
- Update release notes OpenShift Logging 5.1.1 (RHBA-2021:2885-02).
- Remove 5.0 release notes from OpenShift 4.8 docs.
- Remove release notes that duplicate advisory contents because advisories now include links to Jira issues.

PR information:
- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3185
- Direct link to doc preview: https://deploy-preview-34843--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-about-this-release
- SME review: NA
- QE review: @anpingli 
- Peer review: @ tbd
- 5.1.1 is LIVE.
- All reviews complete. Please merge now.