### PR TITLE
RNs 4.6.40: Added notes for 4.6.40 release

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3146,3 +3146,19 @@ link:https://access.redhat.com/solutions/6196661[{product-title} 4.6.39 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-40"]
+=== RHBA-2021:2767 - {product-title} 4.6.40 bug fix
+
+Issued: 2021-07-28
+
+{product-title} release 4.6.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2767[RHBA-2021:2767] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2768[RHBA-2021:2768] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6214081[{product-title} 4.6.40 container image list]
+
+[id="ocp-4-6-40-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release Notes for 4.6.40

- Applies only to enterprise-4.6
- [Preview Link](https://deploy-preview-34844--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-40)