### PR TITLE
CNF-1500 - remove incorrect xref and update ACM version

### DIFF
--- a/modules/ztp-acm-installing-disconnected-rhacm.adoc
+++ b/modules/ztp-acm-installing-disconnected-rhacm.adoc
@@ -18,8 +18,6 @@ You use {rh-rhacm-first} on a hub cluster in the disconnected environment to man
 If you want to deploy Operators to the spoke clusters, you must also add them to this registry.
 ====
 
-* Enable the disconnected Operator Lifecycle Manager (OLM). {rh-rhacm} is included in the OLM Red Hat Operator catalog. Follow the steps in xref:../operators/admin/olm-restricted-networks.adoc[Using Operator Lifecycle Manager on restricted networks].
-
 .Procedure
 
-* Install {rh-rhacm} on the hub cluster in the disconnected environment. See link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.2/html/install/installing#installing-in-a-disconnected-environment[Installing {rh-rhacm} in a disconnected environment].
+* Install {rh-rhacm} on the hub cluster in the disconnected environment. See link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.3/html/install/installing#install-on-disconnected-networks[Installing {rh-rhacm} in a disconnected environment].


### PR DESCRIPTION
Removes an erroneous xref for [CNF-1500](https://issues.redhat.com/browse/CNF-1500) post release clean up work, tracked in https://issues.redhat.com/browse/TELCODOCS-302. The xref is not required and additionally causes a 404 on the openshift-webscale distro. 

This xref content is linked in the ACM install content that follows, and the ACM link will be updated for OCP 4.8 when ACM GA's later this month.

This PR is for enterprise-main, enterprise-4.8, enterprise-4.9 streams.