### PR TITLE
Add xref to mpath doc for 4-8 RNs

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -86,7 +86,7 @@ If a cloud administrator has already set a custom `/etc/chrony.conf` configurati
 
 Enabling multipathing during bare metal installation is now supported for nodes provisioned in {product-title} 4.8 or higher. You can enable multipathing by appending kernel arguments to the `coreos-installer install` command so that the installed system itself uses multipath beginning from the first boot. While post-installation support is still available by activating multipathing via the machine config, enabling multipathing during installation is recommended for nodes provisioned starting in {product-title} 4.8.
 
-//For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-enabling-multipath_installing-bare-metal[Enabling multipathing with kernel arguments on RHCOS].
+For more information, see xref:../installing/installing_bare_metal/installing-bare-metal.adoc#rhcos-enabling-multipath_installing-bare-metal[Enabling multipathing with kernel arguments on {op-system}].
 
 [id="ocp-4-8-installation-and-upgrade"]
 === Installation and upgrade


### PR DESCRIPTION
With merge of https://github.com/openshift/openshift-docs/pull/34462, we can now add (uncomment) the xref to the 4.8 Release Notes entry for multipathing.

Preview build link: https://deploy-preview-34853--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-rhcos-multipath-install