### PR TITLE
Updated release date and image addresses for 63

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -33,7 +33,7 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-acs
 Topics:
-- Name: Red Hat Advanced Cluster Security for Kubernetes 3.63.0
+- Name: Red Hat Advanced Cluster Security for Kubernetes 3.63
   File: 363-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.0.62
   File: 3062-release-notes
@@ -125,7 +125,7 @@ Topics:
     File: configure-okta-identity-cloud
   - Name: Configuring Google Workspace as an OIDC identity provider
     File: configure-google-workspace-identity
-  - Name: Managing RBAC in Red Hat Advanced Cluster Security for Kubernetes 3.63.0 and newer
+  - Name: Managing RBAC in Red Hat Advanced Cluster Security for Kubernetes 3.63 and newer
     File: manage-role-based-access-control-3630
   - Name: Managing RBAC in Red Hat Advanced Cluster Security for Kubernetes 3.0.62 and older
     File: manage-role-based-access-control-3062

--- a/installing/install-ocp-operator.adoc
+++ b/installing/install-ocp-operator.adoc
@@ -52,6 +52,10 @@ include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 // Generating init bundle CLI
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the roxctl CLI]
+
 include::modules/create-resource-init-bundle.adoc[leveloffset=+1]
 
 include::modules/install-secured-cluster-operator.adoc[leveloffset=+1]

--- a/installing/installing_helm/install-helm-customization.adoc
+++ b/installing/installing_helm/install-helm-customization.adoc
@@ -51,6 +51,10 @@ You can create an init bundle by using the the roxctl CLI or from the RHACS port
 // Generating init bundle
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the roxctl CLI]
+
 // Generating init bundle
 include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 

--- a/modules/download-images-directly.adoc
+++ b/modules/download-images-directly.adoc
@@ -7,7 +7,7 @@
 
 If you do not want to use an image bundle, you can manually pull, retag, and push {product-title} images to your registry. The images included in the current version of the image bundles are:
 
-* `stackrox.io/main:{rhacs-version}`
-* `stackrox.io/scanner:{scanner-version}`
-* `stackrox.io/scanner-db:{scanner-version}`
-* `collector.stackrox.io/collector:{collector-version}`
+* `registry.redhat.io/rh-acs/main:{rhacs-version}`
+* `registry.redhat.io/rh-acs/scanner:{scanner-version}`
+* `registry.redhat.io/rh-acs/scanner-db:{scanner-version}`
+* `registry.redhat.io/rh-acs/collector:{collector-version}`

--- a/modules/enable-offline-mode-roxctl.adoc
+++ b/modules/enable-offline-mode-roxctl.adoc
@@ -14,17 +14,17 @@ You can enable offline mode when you are installing {product-title} by using the
 +
 [source,terminal,subs=attributes+]
 ----
-Enter main image to use (default: "stackrox.io/main:{rhacs-version}"): <your_registry>/stackrox/main:{rhacs-version}
+Enter main image to use (default: "registry.redhat.io/rh-acs/main:{rhacs-version}"): <your_registry>/stackrox/main:{rhacs-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-Enter Scanner DB image to use (default: "stackrox.io/scanner-db:{scanner-version}"): <your_registry>/stackrox/scanner-db:{scanner-version}
+Enter Scanner DB image to use (default: "registry.redhat.io/rh-acs/scanner-db:{scanner-version}"): <your_registry>/stackrox/scanner-db:{scanner-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-Enter Scanner image to use (default: "stackrox.io/scanner:{scanner-version}"): <your_registry>/stackrox/scanner:{scanner-version}
+Enter Scanner image to use (default: "registry.redhat.io/rh-acs/scanner:{scanner-version}"): <your_registry>/stackrox/scanner:{scanner-version}
 ----
 . To enable the offline mode, enter `true` when answering the `Enter whether to run StackRox in offline mode` prompt:
 +

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -29,7 +29,7 @@ You must install {product-title} `SecuredCluster` resource in its own project an
 . Enter the new project name as *stackrox* or some other name, and click *Create*.
 . Under the *Provided APIs* section, select *Create instance* on the *Secured Cluster* API.
 . Enter a name for your `SecuredCluster` custom resource.
-. For *Central Endpoint*, enter the address and port number of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `\central.example.com:443`. The default value of `central.stackrox:443` only works if you are installing secured cluster services in the same cluster that Central is installed in.
+. For *Central Endpoint*, enter the address and port number of your Central instance. For example, if Central is available at `\https://central.example.com`, then specify the central endpoint as `central.example.com:443`. The default value of `central.stackrox:443` only works if you are installing secured cluster services in the same cluster that Central is installed in.
 . Accept the default values or configure custom values for the avilable options.
 //Add a link for customization options
 . Click *Create*.

--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -27,7 +27,7 @@ $ oc get service central-loadbalancer -n stackrox
 ----
 $ oc port-forward svc/central 18443:443 -n stackrox
 ----
-... Navigate to `https://localhost:18443/`.
+... Navigate to `\https://localhost:18443/`.
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Authentication Tokens* section, click on *Cluster Init Bundle*.
 . Click *Generate Bundle* (*`add`* icon) on the top right.

--- a/modules/retag-images.adoc
+++ b/modules/retag-images.adoc
@@ -12,12 +12,12 @@ You can download and retag images using the Docker command-line interface.
 When you retag an image, you must maintain the name of the image and the tag. For example, use:
 [source,terminal,subs=attributes+]
 ----
-$ docker tag stackrox.io/main:{rhacs-version} <your_registry>/main:{rhacs-version}
+$ docker tag registry.redhat.io/rh-acs/main:{rhacs-version} <your_registry>/main:{rhacs-version}
 ----
 and do not retag like the following example:
 [source,terminal,subs=attributes+]
 ----
-$ docker tag stackrox.io/main:{rhacs-version} <your_registry>/other-name:latest
+$ docker tag registry.redhat.io/rh-acs/main:{rhacs-version} <your_registry>/other-name:latest
 ----
 ====
 

--- a/modules/rollback-central-forced.adoc
+++ b/modules/rollback-central-forced.adoc
@@ -54,6 +54,6 @@ data:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set image deploy/central central=stackrox.io/main:<x.x.x.x> <1>
+$ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:<x.x.x.x> <1>
 ----
 <1> Specify the version that you want to roll back to. It should be the same version that you sepecified for the `maintenance.forceRollbackVersion` key in the `central-config` config map.

--- a/modules/roxctl-generate-init-bundle.adoc
+++ b/modules/roxctl-generate-init-bundle.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_helm/install-helm-customization.adoc
+// * installing/install-ocp-operator.adoc
 :_module-type: PROCEDURE
 [id="roxctl-generate-init-bundle_{context}"]
 = Generating an init bundle by using the roxctl CLI
@@ -24,7 +25,3 @@ $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
 Make sure that you store this bundle securely because it contains secrets.
 You can use the same bundle to set up multiple secured clusters.
 ====
-
-[role="_additional-resources"]
-.Additional resources
-* xref:../../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the roxctl CLI]

--- a/modules/update-other-images-40.adoc
+++ b/modules/update-other-images-40.adoc
@@ -61,19 +61,19 @@ $ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"container
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/sensor sensor=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 . Update the Compliance image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector compliance=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 . Update the Collector image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=collector.stackrox.io/collector:{collector-version}
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version}
 ----
 . Apply the following cluster role and cluster role binding:
 +

--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -34,19 +34,19 @@ $ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"container
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/sensor sensor=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image deploy/sensor sensor=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 . Update the Compliance image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector compliance=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 . Update the Collector image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image ds/collector collector=collector.stackrox.io/collector:{collector-version}
+$ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version}
 ----
 . Apply the following cluster role and cluster role binding:
 +

--- a/modules/upgrade-central-40.adoc
+++ b/modules/upgrade-central-40.adoc
@@ -11,9 +11,9 @@ You can update Central to the latest version by downloading and deploying the up
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\stackrox.io/main-rhel`
-** For Scanner, use `\stackrox.io/scanner-rhel` and `\stackrox.io/scanner-db-rhel`
-** For Collector, use `\collector.stackrox.io/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
+** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
+** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 
 .Procedure
 
@@ -31,7 +31,7 @@ $ oc -n stackrox patch scc central -p '{"priority": 0}'
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/central central=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 . Optional: If you have installed Istio in your cluster, run the following additional command:
 +

--- a/modules/upgrade-central.adoc
+++ b/modules/upgrade-central.adoc
@@ -11,9 +11,9 @@ You can update Central to the latest version by downloading and deploying the up
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\stackrox.io/main-rhel`
-** For Scanner, use `\stackrox.io/scanner-rhel` and `\stackrox.io/scanner-db-rhel`
-** For Collector, use `\collector.stackrox.io/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
+** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
+** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 
 .Procedure
 
@@ -26,7 +26,7 @@ $ oc -n stackrox patch deploy/central -p '{"spec":{"template":{"spec":{"containe
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/central central=stackrox.io/main:{rhacs-version}
+$ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
 
 .Verification

--- a/modules/upgrade-scanner-40.adoc
+++ b/modules/upgrade-scanner-40.adoc
@@ -11,9 +11,9 @@ You can update Scanner to the latest version by using the `roxctl` CLI.
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\stackrox.io/main-rhel`
-** For Scanner, use `\stackrox.io/scanner-rhel` and `\stackrox.io/scanner-db-rhel`
-** For Collector, use `\collector.stackrox.io/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
+** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
+** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 
 .Procedure
 
@@ -56,18 +56,18 @@ $ oc -n stackrox patch hpa/scanner -p '{"spec":{"minReplicas":2}}'
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner scanner=stackrox.io/scanner:{scanner-version}
+$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/rh-acs/scanner:{scanner-version}
 ----
 . Update the Scanner database image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db db=stackrox.io/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db init-db=stackrox.io/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
 ----
 . Optional: If you have installed Istio in your cluster, run the following additional command:
 +

--- a/modules/upgrade-scanner.adoc
+++ b/modules/upgrade-scanner.adoc
@@ -11,9 +11,9 @@ You can update Scanner to the latest version by using the `roxctl` CLI.
 
 * If you deploy images from a private image registry, first push the new image into your private registry, and then replace your image registry for the commands in this section.
 * If you used Red Hat UBI-based images when you installed {product-title}, replace the image names for the commands in this section with the following UBI-based image names:
-** For Central, Sensor, and Compliance, use `\stackrox.io/main-rhel`
-** For Scanner, use `\stackrox.io/scanner-rhel` and `\stackrox.io/scanner-db-rhel`
-** For Collector, use `\collector.stackrox.io/collector-rhel`
+** For Central, Sensor, and Compliance, use `\registry.redhat.io/rh-acs/main-rhel`
+** For Scanner, use `\registry.redhat.io/rh-acs/scanner-rhel` and `\registry.redhat.io/rh-acs/scanner-db-rhel`
+** For Collector, use `\registry.redhat.io/rh-acs/collector-rhel`
 * If you have created custom scanner configurations, you must apply those changes before updating the scanner configuration file:
 +
 [source,terminal]
@@ -43,18 +43,18 @@ $ oc -n stackrox patch hpa/scanner -p '{"spec":{"minReplicas":2}}'
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner scanner=stackrox.io/scanner:{scanner-version}
+$ oc -n stackrox set image deploy/scanner scanner=registry.redhat.io/rh-acs/scanner:{scanner-version}
 ----
 . Update the Scanner database image:
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db db=stackrox.io/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
 ----
 +
 [source,terminal,subs=attributes+]
 ----
-$ oc -n stackrox set image deploy/scanner-db init-db=stackrox.io/scanner-db:{scanner-version}
+$ oc -n stackrox set image deploy/scanner-db init-db=registry.redhat.io/rh-acs/scanner-db:{scanner-version}
 ----
 
 .Verification

--- a/modules/verify-acs-installation.adoc
+++ b/modules/verify-acs-installation.adoc
@@ -32,7 +32,7 @@ $ oc get service central-loadbalancer -n stackrox
 ----
 $ oc port-forward svc/central 18443:443 -n stackrox
 ----
-... Navigate to `https://localhost:18443/`.
+... Navigate to `\https://localhost:18443/`.
 . Create a new project:
 +
 [source,terminal]

--- a/operating/manage-user-access/manage-role-based-access-control-3062.adoc
+++ b/operating/manage-user-access/manage-role-based-access-control-3062.adoc
@@ -10,8 +10,8 @@ toc::[]
 
 [IMPORTANT]
 ====
-In {product-title} 3.63.0, a scoped access control feature has been added.
-If you are using {product-title} 3.63.0 or newer, see xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#manage-rbac-3630[Managing access control in {product-title} 3.63.0 and newer].
+In {product-title} 3.63, a scoped access control feature has been added.
+If you are using {product-title} 3.63 or newer, see xref:../../operating/manage-user-access/manage-role-based-access-control-3630.adoc#manage-rbac-3630[Managing access control in {product-title} 3.63 and newer].
 ====
 
 In {product-title} 3.0.62 and older, different roles govern access to {product-title} resources to prevent unwanted access.

--- a/operating/manage-user-access/manage-role-based-access-control-3630.adoc
+++ b/operating/manage-user-access/manage-role-based-access-control-3630.adoc
@@ -1,5 +1,5 @@
 [id="manage-role-based-access-control"]
-= Managing RBAC in {product-title} 3.63.0 and newer
+= Managing RBAC in {product-title} 3.63 and newer
 include::modules/common-attributes.adoc[]
 :context: manage-role-based-access-control
 
@@ -13,7 +13,7 @@ toc::[]
 If you are using {product-title} 3.0.62 or older, see xref:../../operating/manage-user-access/manage-role-based-access-control-3062.adoc#manage-rbac-3062[Managing access control in {product-title} 3.0.62 and older].
 ====
 
-{product-title} 3.63.0 includes a scoped access control feature that enables you to configure fine-grained and specific sets of permissions that define how a given {product-title} user or a group of users can interact with {product-title}, which resources they can access, and which actions they can perform.
+{product-title} 3.63 includes a scoped access control feature that enables you to configure fine-grained and specific sets of permissions that define how a given {product-title} user or a group of users can interact with {product-title}, which resources they can access, and which actions they can perform.
 
 * _Roles_ are a collection of permission sets and access scopes. You can assign roles to users and groups by specifying rules. You can configure these rules when you configure an authentication provider.
 There are two types of roles in {product-title}:

--- a/release_notes/3060-release-notes.adoc
+++ b/release_notes/3060-release-notes.adoc
@@ -49,17 +49,17 @@ Release date: May 26, 2021
 | Main
 | It includes Central, Sensor, Admission Controller, and Compliance.
 It also includes `roxctl` for use in  CI (continuous integration) systems.
-| stackrox.io/main:3.0.60.1
+| registry.redhat.io/rh-acs/main:3.0.60.1
 
 | Scanner
 | Scans images and nodes.
-| stackrox.io/scanner:2.14.1
+| registry.redhat.io/rh-acs/scanner:2.14.1
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| stackrox.io/scanner-db:2.14.1
+| registry.redhat.io/rh-acs/scanner-db:2.14.1
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| collector.stackrox.io/collector:3.1.22-latest
+| registry.redhat.io/rh-acs/collector:3.1.22-latest
 |===

--- a/release_notes/3061-release-notes.adoc
+++ b/release_notes/3061-release-notes.adoc
@@ -52,17 +52,17 @@ Doing this provides a more accurate reflection of an image's risk.
 | Main
 | It includes Central, Sensor, Admission Controller, and Compliance.
 It also includes `roxctl` for use in  CI (continuous integration) systems.
-| stackrox.io/main:3.0.61.1
+| registry.redhat.io/rh-acs/main:3.0.61.1
 
 | Scanner
 | Scans images and nodes.
-| stackrox.io/scanner:2.15.2
+| registry.redhat.io/rh-acs/scanner:2.15.2
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| stackrox.io/scanner-db:2.15.2
+| registry.redhat.io/rh-acs/scanner-db:2.15.2
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| collector.stackrox.io/collector:3.1.25-latest
+| registry.redhat.io/rh-acs/collector:3.1.25-latest
 |===

--- a/release_notes/3062-release-notes.adoc
+++ b/release_notes/3062-release-notes.adoc
@@ -43,7 +43,7 @@ It addresses some currently active crypto-mining campaigns.
 
 The next release and the subsequent releases of {product-title} will use the updated version number convention as `major-release.minor-release.patch-release`.
 
-Therefore the version for the next release of {product-title} will be 3.63.0.
+Therefore the version for the next release of {product-title} will be 3.63.
 
 [id="image-versions"]
 == Image versions
@@ -54,17 +54,17 @@ Therefore the version for the next release of {product-title} will be 3.63.0.
 | Main
 | It includes Central, Sensor, Admission Controller, and Compliance.
 It also includes `roxctl` for use in  CI (continuous integration) systems.
-| stackrox.io/main:3.0.62.0
+| registry.redhat.io/rh-acs/main:3.0.62.0
 
 | Scanner
 | Scans images and nodes.
-| stackrox.io/scanner:2.16.0
+| registry.redhat.io/rh-acs/scanner:2.16.0
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| stackrox.io/scanner-db:2.16.0
+| registry.redhat.io/rh-acs/scanner-db:2.16.0
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| collector.stackrox.io/collector:3.1.27-latest
+| registry.redhat.io/rh-acs/collector:3.1.27-latest
 |===

--- a/release_notes/363-release-notes.adoc
+++ b/release_notes/363-release-notes.adoc
@@ -1,15 +1,15 @@
 [id="363-release-notes"]
-= Red Hat Advanced Cluster Security for Kubernetes 3.63.0
+= Red Hat Advanced Cluster Security for Kubernetes 3.63
 include::modules/common-attributes.adoc[]
 :context: 363-release-notes
 
 toc::[]
 
-{product-title} 3.63.0 includes feature enhancements, bug fixes, scale improvements, and other changes.
+{product-title} 3.63 includes feature enhancements, bug fixes, scale improvements, and other changes.
 
 //To upgrade to this release from a previous version, see the link:/docs/upgrade-stackrox/[Upgrade]section.
 
-*Release date:* July 21, 2021
+*Release date:* July 26, 2021
 
 [id="release-tag-version-change"]
 == Release tag version change
@@ -26,7 +26,7 @@ You can now install {product-title} on {ocp} by using an Operator. The {product-
 [discrete]
 === Scoped access control
 The way that {product-title} handles access control has been updated. You can now define scopes for Kubernetes resources, such as namespaces and clusters, and assign those scopes to roles.
-See xref:../operating/manage-user-access/manage-role-based-access-control-3630.adoc#manage-role-based-access-control-3630[Managing RBAC in {product-title} 3.63.0 and newer] for more information.
+See xref:../operating/manage-user-access/manage-role-based-access-control-3630.adoc#manage-role-based-access-control-3630[Managing RBAC in {product-title} 3.63 and newer] for more information.
 
 [discrete]
 === Improved alert functionality for {ocp}
@@ -36,7 +36,7 @@ You can now set alerts for detections against the {ocp} API server for secrets a
 == Important system changes
 
 * {product-title} includes new default policies to monitor access to the `kubeadmin` secret, the `Central Admin` secret, and impersonated access to secrets.
-* {product-title} 3.63.0 replaced a default policy, which provides alerts on images that have vulnerabilities with a CVSS score of 7 or higher, with a new default policy that searches for critical severity issues.
+* {product-title} 3.63 replaced a default policy, which provides alerts on images that have vulnerabilities with a CVSS score of 7 or higher, with a new default policy that searches for critical severity issues.
 This new policy is enabled by default.
 This change only impacts new installations of {product-title}.
 
@@ -49,17 +49,17 @@ This change only impacts new installations of {product-title}.
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in  CI (continuous integration) systems.
-| stackrox.io/main:3.63.0
+| registry.redhat.io/rh-acs/main:3.63.0
 
 | Scanner
 | Scans images and nodes.
-| stackrox.io/scanner:2.17.0
+| registry.redhat.io/rh-acs/scanner:2.17.0
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| stackrox.io/scanner-db:2.17.0
+| registry.redhat.io/rh-acs/scanner-db:2.17.0
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| collector.stackrox.io/collector:3.1.28-latest
+| registry.redhat.io/rh-acs/collector:3.1.28-latest
 |===


### PR DESCRIPTION
- Updated the release date to 26 July. 
- Updated the registry address from `stackrox.io/` and `collector.stackrox.io` to `registry.redhat.io/rh-acs/`.
- Few link fixes