### PR TITLE
RHDEVDOCS-3057: Securing Webhooks with Event Listeners

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1429,6 +1429,8 @@ Topics:
     File: reducing-pipelines-resource-consumption
   - Name: Using pods in a privileged security context
     File: using-pods-in-a-privileged-security-context
+  - Name: Securing webhooks with event listeners
+    File: securing-webhooks-with-event-listeners
 - Name: GitOps
   Dir: gitops
   Distros: openshift-enterprise

--- a/cicd/pipelines/securing-webhooks-with-event-listeners.adoc
+++ b/cicd/pipelines/securing-webhooks-with-event-listeners.adoc
@@ -1,0 +1,25 @@
+[id="securing-webhooks-with-event-listeners"]
+= Securing webhooks with event listeners
+include::modules/common-attributes.adoc[]
+include::modules/pipelines-document-attributes.adoc[]
+
+:context: securing-webhooks-with-event-listeners
+
+toc::[]
+
+As an administrator, you can secure webhooks with event listeners. After creating a namespace, you enable HTTPS for the `Eventlistener` resource by adding the `operator.tekton.dev/enable-annotation=enabled` label to the namespace. Then, you create a `Trigger` resource and a secured route using the re-encrypted TLS termination.
+
+Triggers in {pipelines-title} support insecure HTTP and secure HTTPS connections to the `Eventlistener` resource. HTTPS secures connections within and outside the cluster.
+
+{pipelines-title} runs a `tekton-operator-proxy-webhook` pod that watches for the labels in the namespace. When you add the label to the namespace, the webhook sets the `service.beta.openshift.io/serving-cert-secret-name=<secret_name>` annotation on the `EventListener` object. This, in turn, creates secrets and the required certificates.
+
+[source,terminal,subs="atrributes+"]
+----
+service.beta.openshift.io/serving-cert-secret-name=<secret_name>
+----
+
+In addition, you can mount the created secret into the `Eventlistener` pod to secure the request.
+
+include::modules/op-providing-secure-connection.adoc[leveloffset=+1]
+
+include::modules/op-sample-eventlistener-resource.adoc[leveloffset=+1]

--- a/modules/op-about-triggers.adoc
+++ b/modules/op-about-triggers.adoc
@@ -141,5 +141,3 @@ spec:
 <4> Service account name to be used.
 <5> Name of the `Trigger` resource referenced by the `EventListener` resource.
 --
-
-Triggers in {pipelines-title} support both HTTP (insecure) and HTTPS (secure HTTP) connections to the `Eventlistener` resource. With the secure HTTPS connection, you get end-to-end secure connection within and outside the cluster. After you create a namespace, you can enable this secure HTTPS connection for the `Eventlistener` resource by adding the `operator.tekton.dev/enable-annotation=enabled` label to the namespace, and then creating a `Trigger` resource and a secured route using re-encrypt TLS termination.

--- a/modules/op-providing-secure-connection.adoc
+++ b/modules/op-providing-secure-connection.adoc
@@ -1,0 +1,41 @@
+[id='op-providing-secure-connection_{context}']
+= Providing secure connection with OpenShift routes
+
+To create a route with the re-encrypted TLS termination, run:
+
+[source,terminal,subs="atrributes+"]
+----
+oc create route reencrypt --service=<svc-name> --cert=tls.crt --key=tls.key --ca-cert=ca.crt --hostname=<hostname>
+----
+
+Alternatively, you can create a re-encrypted TLS termination YAML file to create a secure route.
+
+.Example re-encrypt TLS termination YAML to create a secure route
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  name: route-passthrough-secured  <1>
+spec:
+  host: <hostname>
+  to:
+    kind: Service
+    name: frontend <1>
+  tls:
+    termination: reencrypt <2>
+    key: [as in edge termination]
+    certificate: [as in edge termination]
+    caCertificate: [as in edge termination]
+    destinationCACertificate: |- <3>
+      -----BEGIN CERTIFICATE-----
+      [...]
+      -----END CERTIFICATE-----
+----
+<1> The name of the object, which is limited to only 63 characters.
+<2> The termination field is set to `reencrypt`. This is the only required TLS field.
+<3> This is required for re-encryption. The `destinationCACertificate` field specifies a CA certificate to validate the endpoint certificate, thus securing the connection from the router to the destination pods. You can omit this field in either of the following scenarios:
+* The service uses a service signing certificate.
+* The administrator specifies a default CA certificate for the router, and the service has a certificate signed by that CA.
+
+You can run the `oc create route reencrypt --help` command to display more options.

--- a/modules/op-sample-eventlistener-resource.adoc
+++ b/modules/op-sample-eventlistener-resource.adoc
@@ -1,0 +1,49 @@
+[id='op-sample-eventlistener-resource_{context}']
+= Creating a sample EventListener resource using a secure HTTPS connection
+
+This section uses the link:https://github.com/openshift/pipelines-tutorial[pipelines-tutorial] example to demonstrate creation of a sample EventListener resource using a secure HTTPS connection.
+
+.Procedure
+
+. Create the `TriggerBinding` resource from the YAML file available in the pipelines-tutorial repository:
++
+[source,terminal,subs="atrributes+"]
+----
+oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/master/03_triggers/01_binding.yaml
+----
+
+. Create the `TriggerTemplate` resource from the YAML file available in the pipelines-tutorial repository:
++
+[source,terminal,subs="atrributes+"]
+----
+oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/master/03_triggers/02_template.yaml
+----
+
+. Create the `Trigger` resource directly from the pipelines-tutorial repository:
++
+[source,terminal,subs="atrributes+"]
+----
+oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/master/03_triggers/03_trigger.yaml
+----
+
+. Create an `EventListener` resource using a secure HTTPS connection:
+.. Add a label to enable the secure HTTPS connection to the `Eventlistener` resource:
++
+[source,terminal,subs="atrributes+"]
+----
+oc label namespace <ns-name> operator.tekton.dev/enable-annotation=enabled
+----
+
+.. Create the `EventListener` resource from the YAML file available in the pipelines-tutorial repository:
++
+[source,terminal,subs="atrributes+"]
+----
+oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/master/03_triggers/04_event_listener.yaml
+----
+
+.. Create a route with the re-encrypted TLS termination:
++
+[source,terminal,subs="atrributes+"]
+----
+oc create route reencrypt --service=<svc-name> --cert=tls.crt --key=tls.key --ca-cert=ca.crt --hostname=<hostname>
+----


### PR DESCRIPTION
- JIRA ID: [RHDEVDOCS-3057](https://issues.redhat.com/browse/RHDEVDOCS-3057)
- Aligned Team: Devtools
- SME+QE review: savita ashture
- Peer-Review: @sounix000 and @Preeticp 
- Docs Preview: [Securing webhooks with event listeners](https://deploy-preview-34882--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/securing-webhooks-with-event-listeners.html)

This PR is for the Pipelines 1.5 release.

