### PR TITLE
CNV-12495: Fixing broken link in Learn more about page

### DIFF
--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -60,7 +60,7 @@ Use the following tables to find content to help you learn about and use {VirtPr
 |
 
 |
-| link:https://www.google.com/url?q=https://www.openshift.com/blog/updating-a-boot-source-image&sa=D&source=editors&ust=1626893484915000&usg=AOvVaw0cDIQr63zScl7b-Cn8G0rA[Updating boot source templates]
+| link:https://www.openshift.com/blog/updating-a-boot-source-image[Updating boot source templates]
 | xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
 |
 


### PR DESCRIPTION
For 4.8 only.

Fixing a blog link with a Google redirect in it post-merge of https://github.com/openshift/openshift-docs/pull/34775

Jira: https://issues.redhat.com/browse/CNV-12495

Doc preview link: https://deploy-preview-34889--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-learn-more-about-openshift-virtualization.html

Opened GitHub issue https://github.com/openshift/openshift-docs/issues/34890 to track needed fix for main/4.9
