### PR TITLE
RHDEVDOCS-2677 Document "Allow storing and querying of structured log…

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1872,6 +1872,8 @@ Topics:
 - Name: Forwarding logs to third party systems
   File: cluster-logging-external
   Distros: openshift-enterprise,openshift-origin
+- Name: Enabling JSON logging
+  File: cluster-logging-enabling-json-logging
 - Name: Collecting and storing Kubernetes events
   File: cluster-logging-eventrouter
   Distros: openshift-enterprise,openshift-origin
@@ -2674,7 +2676,7 @@ Topics:
   - Name: SMCP configuration reference
     File: ossm-reference-smcp
   - Name: Jaeger configuration reference
-    File: ossm-reference-jaeger 
+    File: ossm-reference-jaeger
   - Name: Uninstalling Service Mesh
     File: removing-ossm
 - Name: Service Mesh 1.x

--- a/logging/cluster-logging-enabling-json-logging.adoc
+++ b/logging/cluster-logging-enabling-json-logging.adoc
@@ -1,0 +1,16 @@
+:context: cluster-logging-enabling-json-logging
+[id="cluster-logging-enabling-json-logging"]
+= Enabling JSON logging
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+You can configure the Log Forwarding API to parse JSON strings into a structured object.
+
+include::modules/cluster-logging-json-log-forwarding.adoc[leveloffset=+1]
+include::modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc[leveloffset=+1]
+include::modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third-party systems]

--- a/logging/cluster-logging-exported-fields.adoc
+++ b/logging/cluster-logging-exported-fields.adoc
@@ -5,11 +5,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The following fields can be present in log records exported by OpenShift Logging system. Although log records are typically formatted as JSON objects, the same data model can be applied to other encodings.
+The following fields can be present in log records exported by OpenShift Logging. Although log records are typically formatted as JSON objects, the same data model can be applied to other encodings.
 
 To search these fields from Elasticsearch and Kibana, use the full dotted field name when searching. For example, with an Elasticsearch */_search URL*, to look for a Kubernetes pod name, use `/_search/q=kubernetes.pod_name:name-of-my-pod`.
 
-// The logging system can forward JSON-formatted log entries to external systems. These log entries are formatted as a fluentd message with extra fields such as `kubernetes`. The fields exported by the logging system and available for searching from Elasticsearch and Kibana are documented at the end of this document.
+// The logging system can parse JSON-formatted log entries to external systems. These log entries are formatted as a fluentd message with extra fields such as `kubernetes`. The fields exported by the logging system and available for searching from Elasticsearch and Kibana are documented at the end of this document.
 
 include::modules/cluster-logging-exported-fields-top-level-fields.adoc[leveloffset=0]
 include::modules/cluster-logging-exported-fields-kubernetes.adoc[leveloffset=0]
+// add modules/cluster-logging-exported-fields-openshift when available

--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -1,13 +1,13 @@
 :context: cluster-logging-external
 [id="cluster-logging-external"]
-= Forwarding logs to third party systems
+= Forwarding logs to third-party systems
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
 By default, OpenShift Logging sends container and infrastructure logs to the default internal Elasticsearch log store defined in the `ClusterLogging` custom resource. However, it does not send audit logs to the internal store because it does not provide secure storage. If this default configuration meets your needs, you do not need to configure the Cluster Log Forwarder.
 
-To send logs to other log aggregators, you use the {product-title} Cluster Log Forwarder. This API enables you to send container, infrastructure, and audit logs to specific endpoints within or outside your cluster. In addition, you can send different types of logs to various systems so that various individuals can access each type. You can also enable TLS support to send logs securely, as required by your organization.
+To send logs to other log aggregators, you use the {product-title} Cluster Log Forwarder. This API enables you to send container, infrastructure, and audit logs to specific endpoints within or outside your cluster. In addition, you can send different types of logs to various systems so that various individuals can access each type. You can also enable Transport Layer Security (TLS) support to send logs securely, as required by your organization.
 
 [NOTE]
 ====

--- a/logging/cluster-logging.adoc
+++ b/logging/cluster-logging.adoc
@@ -68,4 +68,4 @@ For information, see xref:../logging/cluster-logging-eventrouter.adoc#cluster-lo
 
 include::modules/cluster-logging-forwarding-about.adoc[leveloffset=+2]
 
-For information, see xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third party systems].
+For information, see xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third-party systems].

--- a/logging/config/cluster-logging-collector.adoc
+++ b/logging/config/cluster-logging-collector.adoc
@@ -26,4 +26,4 @@ include::modules/cluster-logging-removing-unused-components-if-no-elasticsearch.
 
 .Additional resources
 
-* xref:../../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third party systems]
+* xref:../../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third-party systems]

--- a/modules/cluster-logging-collector-legacy-syslog.adoc
+++ b/modules/cluster-logging-collector-legacy-syslog.adoc
@@ -57,7 +57,7 @@ You can configure the following `syslog` parameters. For more information, see t
 ** `15` or `solaris-cron` for the scheduling daemon
 ** `16`–`23` or `local0` – `local7` for locally used facilities
 * payloadKey: The record field to use as payload for the syslog message.
-* rfc: The RFC to be used for sending log using syslog.
+* rfc: The RFC to be used for sending logs using syslog.
 * severity: The link:https://tools.ietf.org/html/rfc3164#section-4.1.1[syslog severity] to set on outgoing syslog records. The value can be a decimal integer or a case-insensitive keyword:
 ** `0` or `Emergency` for messages indicating the system is unusable
 ** `1` or `Alert` for messages indicating action must be taken immediately
@@ -67,7 +67,7 @@ You can configure the following `syslog` parameters. For more information, see t
 ** `5` or `Notice` for messages indicating normal but significant conditions
 ** `6` or `Informational` for messages indicating informational messages
 ** `7` or `Debug` for messages indicating debug-level messages, the default
-* tag: The record field to use as tag on the syslog message.
+* tag: The record field to use as a tag on the syslog message.
 * trimPrefix: The prefix to remove from the tag.
 
 .Procedure

--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -45,9 +45,10 @@ spec:
      outputRefs:
      - elasticsearch-secure <9>
      - default <10>
+     parse: json <11>
      labels:
-       logs: application <11>
-   - name: infrastructure-audit-logs <12>
+       myLabel: myValue <12>
+   - name: infrastructure-audit-logs <13>
      inputRefs:
      - infrastructure
      outputRefs:
@@ -65,8 +66,9 @@ spec:
 <8> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <9> Specify the output to use with that pipeline for forwarding the logs.
 <10> Optional: Specify the `default` output to send the logs to the internal Elasticsearch instance.
-<11> Optional: One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
+<11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<12> Optional: One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.

--- a/modules/cluster-logging-collector-log-forward-fluentd.adoc
+++ b/modules/cluster-logging-collector-log-forward-fluentd.adoc
@@ -5,7 +5,7 @@
 [id="cluster-logging-collector-log-forward-fluentd_{context}"]
 = Forwarding logs using the Fluentd forward protocol
 
-You can use the Fluentd *forward* protocol to send a copy of your logs to an external log aggregator that you have configured to accept the protocol. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator to receive log data from {product-title}.
+You can use the Fluentd *forward* protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
 
 To configure log forwarding using the *forward* protocol, create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the Fluentd servers and pipelines that use those outputs. The Fluentd output can use a TCP (insecure) or TLS (secure TCP) connection.
 
@@ -13,10 +13,6 @@ To configure log forwarding using the *forward* protocol, create a `ClusterLogFo
 ====
 Alternately, you can use a config map to forward logs using the *forward* protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
-
-.Prerequisites
-
-*  An external log aggregator that is configured to receive log data from {product-title} using the Fluentd *forward* protocol.
 
 .Procedure
 
@@ -47,9 +43,10 @@ spec:
      outputRefs:
      - fluentd-server-secure <9>
      - default <10>
+     parse: json <11>
      labels:
-       clusterId: C1234 <11>
-   - name: forward-to-fluentd-insecure <12>
+       clusterId: C1234 <12>
+   - name: forward-to-fluentd-insecure <13>
      inputRefs:
      - infrastructure
      outputRefs:
@@ -67,8 +64,9 @@ spec:
 <8> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <9> Specify the output to use  with that pipeline for forwarding the logs.
 <10> Optional. Specify the `default` output to forward logs to the internal Elasticsearch instance.
-<11> Optional. One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
+<11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<12> Optional. One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.

--- a/modules/cluster-logging-collector-log-forward-kafka.adoc
+++ b/modules/cluster-logging-collector-log-forward-kafka.adoc
@@ -41,9 +41,10 @@ spec:
      - application
      outputRefs: <10>
      - app-logs
+     parse: json <11>
      labels:
-       logType: application <11>
-   - name: infra-topic <12>
+       logType: application <12>
+   - name: infra-topic <13>
      inputRefs:
      - infrastructure
      outputRefs:
@@ -55,7 +56,7 @@ spec:
      - audit
      outputRefs:
      - audit-logs
-     - default <13>
+     - default <14>
      labels:
        logType: audit
 ----
@@ -69,15 +70,16 @@ spec:
 <8> Optional: Specify a name for the pipeline.
 <9> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <10> Specify the output to use with that pipeline for forwarding the logs.
-<11> Optional: One or more labels to add to the logs.
-<12> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
+<11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<12> Optional: One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
 ** Optional: One or more labels to add to the logs.
-<13> Optional: Specify `default` to forward logs to the internal Elasticsearch instance.
+<14> Optional: Specify `default` to forward logs to the internal Elasticsearch instance.
 
-. Optional: To forward a single output to multiple kafka brokers, specify an array of kafka brokers as shown in this example:
+. Optional: To forward a single output to multiple Kafka brokers, specify an array of Kafka brokers as shown in this example:
 +
 [source,yaml]
 ----

--- a/modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc
+++ b/modules/cluster-logging-collector-log-forward-logs-from-application-pods.adoc
@@ -25,17 +25,18 @@ spec:
   pipelines:
     - inputRefs: [ myAppLogData ] <3>
       outputRefs: [ default ] <4>
-  inputs: <5>
+      parse: json <5>
+  inputs: <6>
     - name: myAppLogData
       application:
         selector:
-          matchLabels: <6>
+          matchLabels: <7>
             environment: production
             app: nginx
-        namespaces: <7>
+        namespaces: <8>
         - app1
         - app2
-  outputs: <8>
+  outputs: <9>
     - default
     ...
 ----
@@ -43,10 +44,11 @@ spec:
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
 <3> Specify one or more comma-separated values from `inputs[].name`.
 <4> Specify one or more comma-separated values from `outputs[]`.
-<5> Define a unique `inputs[].name` for each application that has a unique set of pod labels.
-<6> Specify the key-value pairs of pod labels whose log data you want to gather. You must specify both a key and value, not just a key. To be selected, the pods must match all the key-value pairs.
-<7> Optional: Specify one or more namespaces.
-<8> Specify one or more outputs to forward your log data to. The optional `default` output shown here sends log data to the internal Elasticsearch instance.
+<5> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<6> Define a unique `inputs[].name` for each application that has a unique set of pod labels.
+<7> Specify the key-value pairs of pod labels whose log data you want to gather. You must specify both a key and value, not just a key. To be selected, the pods must match all the key-value pairs.
+<8> Optional: Specify one or more namespaces.
+<9> Specify one or more outputs to forward your log data to. The optional `default` output shown here sends log data to the internal Elasticsearch instance.
 
 . Optional: To restrict the gathering of log data to specific namespaces, use `inputs[].name.application.namespaces`, as shown in the preceding example.
 

--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -45,9 +45,10 @@ spec:
      - my-app-logs
      outputRefs: <10>
      - fluentd-server-insecure
-     labels: <11>
+     parse: json <11>
+     labels: <12>
        project: my-project
-   - name: forward-to-fluentd-secure <12>
+   - name: forward-to-fluentd-secure <13>
      inputRefs:
      - application
      - audit
@@ -68,8 +69,9 @@ spec:
 <8> Configuration for a pipeline to use the input to send project application logs to an external Fluentd instance.
 <9> The `my-app-logs` input.
 <10> The name of the output to use.
-<11> Optional: A label to add to the logs.
-<12> Configuration for a pipeline to send logs to other log aggregators.
+<11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<12> Optional: A label to add to the logs.
+<13> Configuration for a pipeline to send logs to other log aggregators.
 ** Optional: Specify a name for the pipeline.
 ** Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 ** Specify the output to use with that pipeline for forwarding the logs.

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -5,16 +5,14 @@
 [id="cluster-logging-collector-log-forward-syslog_{context}"]
 = Forwarding logs using the syslog protocol
 
-You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator that you have configured to accept the protocol. You can do this in addition to, or instead of, using the default Elasticsearch log store. You must also configure the external log aggregator, such as a syslog server, to receive log data from {product-title}.
+You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or link:https://tools.ietf.org/html/rfc5424[RFC5424] protocol to send a copy of your logs to an external log aggregator configured to accept the protocol instead of, or in addition to, the default Elasticsearch log store. You are responsible for configuring the external log aggregator to receive the logs from {product-title}.
+
+To configure log forwarding using the *syslog* protocol, create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
 
 [NOTE]
 ====
 Alternately, you can use a config map to forward logs using the *syslog* RFC3164 protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
 ====
-
-.Prerequisites
-
-*  An external log aggregator, such as a syslog server, that is configured to receive log data from {product-title} using the RFC3164 or RFC5424 protocol.
 
 .Procedure
 
@@ -57,10 +55,11 @@ spec:
      outputRefs: <10>
      - rsyslog-east
      - default <11>
+     parse: json <12>
      labels:
-       syslog: east <12>
+       syslog: east <13>
        secure: true
-   - name: syslog-west <13>
+   - name: syslog-west <14>
      inputRefs:
      - infrastructure
      outputRefs:
@@ -80,8 +79,9 @@ spec:
 <9> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <10> Specify the output to use  with that pipeline for forwarding the logs.
 <11> Optional: Specify the `default` output to forward logs to the internal Elasticsearch instance.
-<12> Optional: One or more labels to add to the logs.
-<13> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
+<12> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<13> Optional: One or more labels to add to the logs.
+<14> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
@@ -114,7 +114,7 @@ You can configure the following for the `syslog` outputs. For more information, 
 ** `3` or `daemon` for system daemons
 ** `4` or `auth` for security/authentication messages
 ** `5` or `syslog` for messages generated internally by syslogd
-** `6` or `lpr` for line printer subsystem
+** `6` or `lpr` for the line printer subsystem
 ** `7` or `news` for the network news subsystem
 ** `8` or `uucp` for the UUCP subsystem
 ** `9` or `cron` for the clock daemon
@@ -132,7 +132,7 @@ You can configure the following for the `syslog` outputs. For more information, 
 Configuring the `payloadKey` parameter prevents other parameters from being forwarded to the syslog.
 ====
 +
-* rfc: The RFC to be used for sending log using syslog. The default is RFC5424.
+* rfc: The RFC to be used for sending logs using syslog. The default is RFC5424.
 * severity: The link:https://tools.ietf.org/html/rfc5424#section-6.2.1[syslog severity] to set on outgoing syslog records. The value can be a decimal integer or a case-insensitive keyword:
 ** `0` or `Emergency` for messages indicating the system is unusable
 ** `1` or `Alert` for messages indicating action must be taken immediately
@@ -142,7 +142,7 @@ Configuring the `payloadKey` parameter prevents other parameters from being forw
 ** `5` or `Notice` for messages indicating normal but significant conditions
 ** `6` or `Informational` for messages indicating informational messages
 ** `7` or `Debug` for messages indicating debug-level messages, the default
-* tag: Tag specifies a record field to use as tag on the syslog message.
+* tag: Tag specifies a record field to use as a tag on the syslog message.
 * trimPrefix: Remove the specified prefix from the tag.
 
 [id=cluster-logging-collector-log-forward-examples-syslog-5424]
@@ -152,4 +152,4 @@ The following parameters apply to RFC5424:
 
 * appName: The APP-NAME is a free-text string that identifies the application that sent the log. Must be specified for `RFC5424`.
 * msgID: The MSGID is a free-text string that identifies the type of message. Must be specified for `RFC5424`.
-* procID: The PROCID is a free-text string. A a change in the value indicates a discontinuity in syslog reporting. Must be specified for `RFC5424`.
+* procID: The PROCID is a free-text string. A change in the value indicates a discontinuity in syslog reporting. Must be specified for `RFC5424`.

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -41,7 +41,7 @@ In the pipeline, you define which log types to forward using an `inputRef` param
 
 Note the following:
 
-* If a `ClusterLogForwarder` object exists, logs are not forwarded to the default Elasticsearch instance, unless there is a pipeline with the `default` output.
+* If a `ClusterLogForwarder` CR object exists, logs are not forwarded to the default Elasticsearch instance, unless there is a pipeline with the `default` output.
 
 * By default, OpenShift Logging sends container and infrastructure logs to the default internal Elasticsearch log store defined in the `ClusterLogging` custom resource. However, it does not send audit logs to the internal store because it does not provide secure storage. If this default configuration meets your needs, do not configure the Log Forwarding API.
 
@@ -88,22 +88,23 @@ spec:
      outputRefs:
       - elasticsearch-secure
       - default
+     parse: json <8>
      labels:
        datacenter: east
        secure: true
-   - name: infrastructure-logs <8>
+   - name: infrastructure-logs <9>
      inputRefs:
       - infrastructure
      outputRefs:
       - elasticsearch-insecure
      labels:
        datacenter: west
-   - name: my-app <9>
+   - name: my-app <10>
      inputRefs:
       - my-app-logs
      outputRefs:
       - default
-   - inputRefs: <10>
+   - inputRefs: <11>
       - application
      outputRefs:
       - kafka-app
@@ -127,17 +128,18 @@ spec:
 ** Specify the URL and port of the Kafka broker as a valid absolute URL, including the prefix.
 <6> Configuration for an input to filter application logs from the `my-namespace` project.
 <7> Configuration for a pipeline to send audit logs to the secure external Elasticsearch instance:
-** Optional: For `name`, you can give a name that describes the pipeline.
-** For `inputRefs`, name one or more log types as the inputs for this pipeline.
-** For `outputRefs`, provide the name of one or more outputs to use. For example, `elasticsearch-secure` forwards the audit log data to a secure Elasticsearch instance and `default` forwards the data to the internal Elasticsearch instance.
-** Optional: For `labels` you can specify labels to add to the logs.
-<8> Configuration for a pipeline to send infrastructure logs to  the insecure external Elasticsearch instance:
-<9> Configuration for a pipeline to send logs from the `my-project` project to the internal Elasticsearch instance.
+** Optional. A name to describe the pipeline.
+** The `inputRefs` is the log type, in this example `audit`.
+** The `outputRefs` is the name of the output to use, in this example `elasticsearch-secure` to forward to the secure Elasticsearch instance and `default` to forward to the internal Elasticsearch instance.
+** Optional: Labels to add to the logs.
+<8> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
+<9> Configuration for a pipeline to send infrastructure logs to the insecure external Elasticsearch instance.
+<10> Configuration for a pipeline to send logs from the `my-project` project to the internal Elasticsearch instance.
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is a specific input: `my-app-logs`.
 ** The `outputRefs` is `default`.
 ** Optional: A label to add to the logs.
-<10> Configuration for a pipeline to send logs to the Kafka broker, with no pipeline name:
+<11> Configuration for a pipeline to send logs to the Kafka broker, with no pipeline name:
 ** The `inputRefs` is the log type, in this example `application`.
 ** The `outputRefs` is the name of the output to use.
 ** Optional: A label to add to the logs.

--- a/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
+++ b/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
@@ -1,0 +1,111 @@
+[id="cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_{context}"]
+= Configuring JSON log data for Elasticsearch
+
+When forwarding JSON logs to an Elasticsearch log store, you must create an index for each format if the JSON log entries _have different formats_.
+
+[IMPORTANT]
+====
+You must create a separate index for each different JSON log format. Otherwise, forwarding different formats to the same index can cause type conflicts and cardinality problems.
+====
+
+To provide a different index for each format, you configure the `ClusterLogForwarder` custom resource (CR). You use a structure type from which to construct the index name.
+
+.Structure types
+
+You can use the following structure types in the `ClusterLogForwarder` CR to construct index names for the Elasticsearch log store:
+
+* `structuredTypeKey` (string, optional) is the name of a message field. The value of that field, if present, is used to construct the index name.
+** `kubernetes.labels.<key>` is the Kubernetes Pod label whose value is used to construct the index name.
+** `openshift.labels.<key>` is the `pipeline.label.<key>` element in the `ClusterLogForwarder` CR whose value is used to construct the index name.
+** `kubernetes.container_name` uses the container name to construct the index name.
+* `structuredTypeName`: (string, optional) If `structuredTypeKey` is not set or its key is not present, OpenShift Logging uses the value of `structuredTypeName` as the structured type. When you use both `structuredTypeKey` and `structuredTypeName` together,  `structuredTypeName` provides a fallback index name if the key in `structuredTypeKey` is missing from the JSON log data.
+
+[NOTE]
+====
+Although you can set the value of `structuredTypeKey` to any field shown in the "Log Record Fields" topic, the most useful fields are shown in the preceding list of structure types.
+====
+
+.A structuredTypeKey: kubernetes.labels.<key> example
+
+Suppose the following:
+
+* Your cluster is running application pods that produce JSON logs in two different formats, "apache" and "google".
+* The user labels these application pods with `logFormat=apache` and `logFormat=google`.
+* You use the following snippet in your `ClusterLogForwarder` CR YAML file.
+
+[source,yaml]
+----
+outputDefaults:
+- elasticsearch:
+    structuredTypeKey: kubernetes.labels.logFormat <1>
+    structuredTypeName: nologformat
+pipelines:
+- inputRefs: <application>
+  outputRefs: default
+  parse: json <2>
+----
+<1> Uses the value of the key-value pair that is formed by the Kubernetes `logFormat` label.
+<2> Enables parsing JSON logs.
+
+In that case, the following structured log record goes to the `app-apache-write` index:
+
+[source]
+----
+{
+  "structured":{"name":"fred","home":"bedrock"},
+  "kubernetes":{"labels":{"logFormat": "apache", ...}}
+}
+----
+
+And the following structured log record goes to the `app-google-write` index:
+
+[source]
+----
+{
+  "structured":{"name":"wilma","home":"bedrock"},
+  "kubernetes":{"labels":{"logFormat": "google", ...}}
+}
+----
+
+.A structuredTypeKey: openshift.labels.<key> example
+
+Suppose that you use the following snippet in your `ClusterLogForwarder` CR YAML file.
+
+[source,yaml]
+----
+outputDefaults:
+- elasticsearch:
+    structuredTypeKey: openshift.labels.myLabel <1>
+    structuredTypeName: nologformat
+pipelines:
+ - name: application-logs
+   inputRefs:
+   - application
+   - audit
+   outputRefs:
+   - elasticsearch-secure
+   - default
+   parse: json
+   labels:
+     myLabel: myValue <2>
+----
+<1> Uses the value of the key-value pair that is formed by the OpenShift `myLabel` label.
+<2> The `myLabel` element gives its string value, `myValue`, to the structured log record.
+
+In that case, the following structured log record goes to the `app-myValue-write` index:
+
+[source]
+----
+{
+  "structured":{"name":"fred","home":"bedrock"},
+  "openshift":{"labels":{"myLabel": "myValue", ...}}
+}
+----
+
+.Additional considerations
+
+* The Elasticsearch _index_ for structured records is formed by prepending "app-" to the structured type and appending "-write".
+* Unstructured records are not sent to the structured index. They are indexed as usual in the application, infrastructure, or audit indices.
+* If there is no non-empty structured type, forward an _unstructured_ record with no `structured` field.
+
+It is important not to overload Elasticsearch with too many indices. Only use distinct structured types for distinct log _formats_, *not* for each application or namespace. For example, most Apache applications use the same JSON log format and structured type, such as `LogApache`.

--- a/modules/cluster-logging-exported-fields-kubernetes.adoc
+++ b/modules/cluster-logging-exported-fields-kubernetes.adoc
@@ -1,15 +1,18 @@
 [id="cluster-logging-exported-fields-kubernetes_{context}"]
-== Kubernetes
 
-// Normally, the preceding title would be an H1 prefixed with an `=`. However, because the following content is auto-generated at https://github.com/ViaQ/documentation/blob/main/src/data_model/public/kubernetes.part.adoc and pasted here, it is more efficient to use it as-is with no modifications. Therefore, to "realign" the content, I am going to prefix the title with `==` and use `include::modules/cluster-logging-exported-fields-kubernetes.adoc[leveloffset=0]` in the assembly file.
+// Normally, the following title would be an H1 prefixed with an `=`. However, because the following content is auto-generated at https://github.com/ViaQ/documentation/blob/main/src/data_model/public/kubernetes.part.adoc and pasted here, it is more efficient to use it as-is with no modifications. Therefore, to "realign" the content, I am going to prefix the title with `==` and use `include::modules/cluster-logging-exported-fields-kubernetes.adoc[leveloffset=0]` in the assembly file.
 
 // DO NOT MODIFY THE FOLLOWING CONTENT. Instead, update https://github.com/ViaQ/documentation/blob/main/src/data_model/model/kubernetes.yaml and run `make` as instructed here: https://github.com/ViaQ/documentation
 
 
-The namespace for Kubernetes-specific metadata.
+== kubernetes
+
+The namespace for Kubernetes-specific metadata
+
+[horizontal]
+Data type:: group
 
 === kubernetes.pod_name
-
 
 The name of the pod
 
@@ -19,7 +22,6 @@ Data type:: keyword
 
 === kubernetes.pod_id
 
-
 The Kubernetes ID of the pod
 
 [horizontal]
@@ -27,7 +29,6 @@ Data type:: keyword
 
 
 === kubernetes.namespace_name
-
 
 The name of the namespace in Kubernetes
 
@@ -37,7 +38,6 @@ Data type:: keyword
 
 === kubernetes.namespace_id
 
-
 The ID of the namespace in Kubernetes
 
 [horizontal]
@@ -46,15 +46,14 @@ Data type:: keyword
 
 === kubernetes.host
 
-
 The Kubernetes node name
 
 [horizontal]
 Data type:: keyword
 
 
-=== kubernetes.container_name
 
+=== kubernetes.container_name
 
 The name of the container in Kubernetes
 
@@ -62,8 +61,8 @@ The name of the container in Kubernetes
 Data type:: keyword
 
 
-=== kubernetes.annotations
 
+=== kubernetes.annotations
 
 Annotations associated with the Kubernetes object
 
@@ -73,222 +72,201 @@ Data type:: group
 
 === kubernetes.labels
 
-
 Labels present on the original Kubernetes Pod
 
 [horizontal]
 Data type:: group
 
 
-=== kubernetes.event
 
+
+
+
+=== kubernetes.event
 
 The Kubernetes event obtained from the Kubernetes master API. This event description loosely follows `type Event` in link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#event-v1-core[Event v1 core].
 
 [horizontal]
 Data type:: group
 
-
 ==== kubernetes.event.verb
-
 
 The type of event, `ADDED`, `MODIFIED`, or `DELETED`
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `ADDED`
 
 
 ==== kubernetes.event.metadata
-
 
 Information related to the location and time of the event creation
 
 [horizontal]
 Data type:: group
 
-
 ===== kubernetes.event.metadata.name
-
 
 The name of the object that triggered the event creation
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `java-mainclass-1.14d888a4cfc24890`
 
 
 ===== kubernetes.event.metadata.namespace
 
-
 The name of the namespace where the event originally occurred. Note that it differs from `kubernetes.namespace_name`, which is the namespace where the `eventrouter` application is deployed.
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `default`
 
 
 ===== kubernetes.event.metadata.selfLink
 
-
 A link to the event
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `/api/v1/namespaces/javaj/events/java-mainclass-1.14d888a4cfc24890`
 
 
 ===== kubernetes.event.metadata.uid
 
-
 The unique ID of the event
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `d828ac69-7b58-11e7-9cf5-5254002f560c`
 
 
 ===== kubernetes.event.metadata.resourceVersion
 
-
 A string that identifies the server's internal version of the event. Clients can use this string to determine when objects have changed.
 
 [horizontal]
 Data type:: integer
-
 Example value:: `311987`
 
 
-==== kubernetes.event.involvedObject
 
+==== kubernetes.event.involvedObject
 
 The object that the event is about.
 
 [horizontal]
 Data type:: group
 
-
 ===== kubernetes.event.involvedObject.kind
-
 
 The type of object
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `ReplicationController`
 
 
 ===== kubernetes.event.involvedObject.namespace
 
-
 The namespace name of the involved object. Note that it may differ from `kubernetes.namespace_name`, which is the namespace where the `eventrouter` application is deployed.
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `default`
 
 
 ===== kubernetes.event.involvedObject.name
 
-
 The name of the object that triggered the event
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `java-mainclass-1`
 
 
 ===== kubernetes.event.involvedObject.uid
 
-
 The unique ID of the object
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `e6bff941-76a8-11e7-8193-5254002f560c`
 
 
 ===== kubernetes.event.involvedObject.apiVersion
 
-
 The version of kubernetes master API
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `v1`
 
 
 ===== kubernetes.event.involvedObject.resourceVersion
 
-
 A string that identifies the server's internal version of the pod that triggered the event. Clients can use this string to determine when objects have changed.
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `308882`
 
 
-==== kubernetes.event.reason
 
+==== kubernetes.event.reason
 
 A short machine-understandable string that gives the reason for generating this event
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `SuccessfulCreate`
 
 
 ==== kubernetes.event.source_component
 
-
 The component that reported this event
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `replication-controller`
 
 
 ==== kubernetes.event.firstTimestamp
 
-
 The time at which the event was first recorded
 
 [horizontal]
 Data type:: date
-
 Example value:: `2017-08-07 10:11:57.000000000 Z`
 
 
 ==== kubernetes.event.count
 
-
 The number of times this event has occurred
 
 [horizontal]
 Data type:: integer
-
 Example value:: `1`
 
 
 ==== kubernetes.event.type
 
-
 The type of event, `Normal` or `Warning`. New types could be added in the future.
 
 [horizontal]
 Data type:: keyword
-
 Example value:: `Normal`
+
+== OpenShift
+
+The namespace for openshift-logging specific metadata
+
+[horizontal]
+Data type:: group
+
+=== openshift.labels
+
+Labels added by the Cluster Log Forwarder configuration
+
+[horizontal]
+Data type:: group

--- a/modules/cluster-logging-exported-fields-top-level-fields.adoc
+++ b/modules/cluster-logging-exported-fields-top-level-fields.adoc
@@ -1,7 +1,6 @@
 [id="cluster-logging-exported-fields-top-level-fields_{context}"]
-== Top-level fields
 
-// Normally, the preceding title would be an H1 prefixed with an `=`. However, because the following content is auto-generated at https://github.com/ViaQ/documentation/blob/main/src/data_model/public/top-level.part.adoc and pasted here, it is more efficient to use it as-is with no modifications. Therefore, to "realign" the content, I am going to prefix the title with `==` and use `include::modules/cluster-logging-exported-fields-top-level-fields.adoc[leveloffset=0]` in the assembly file.
+// Normally, the following title would be an H1 prefixed with an `=`. However, because the following content is auto-generated at https://github.com/ViaQ/documentation/blob/main/src/data_model/public/top-level.part.adoc and pasted here, it is more efficient to use it as-is with no modifications. Therefore, to "realign" the content, I am going to prefix the title with `==` and use `include::modules/cluster-logging-exported-fields-top-level-fields.adoc[leveloffset=0]` in the assembly file.
 
 // DO NOT MODIFY THE FOLLOWING CONTENT. Instead, update https://github.com/ViaQ/documentation/blob/main/src/data_model/model/top-level.yaml and run `make` as instructed here: https://github.com/ViaQ/documentation
 
@@ -10,40 +9,54 @@
 
 The top level fields may be present in every record.
 
-=== message
+== message
 
+The original log entry text, UTF-8 encoded. This field may be absent or empty if a non-empty `structured` field is present. See the description of `structured` for more.
 
-Original log entry text, UTF-8 encoded This field may be absent or empty if a non-empty `structured` field is present. See the description of `structured` for more.
+[horizontal]
+Data type:: text
+Example value:: `HAPPY`
 
-=== structured
+== structured
 
+Original log entry as a structured object. This field may be present if the forwarder was configured to parse structured JSON logs. If the original log entry was a valid structured log, this field will contain an equivalent JSON structure. Otherwise this field will be empty or absent, and the `message` field will contain the original log message. The `structured` field can have any subfields that are included in the log message, there are no restrictions defined here.
 
-Original log entry as a structured object. This field may be present if the forwarder was configured to parse structured JSON logs. If the original log entry was a valid structured log, this field will contain an equivalent JSON structure. Otherwise this field will be empty or absent, and the `message` field will contain the original log message. The `structured` field has whatever sub-fields are included in the log message, there are no restrictions defined here.
+[horizontal]
+Data type:: group
+Example value:: map[message:starting fluentd worker pid=21631 ppid=21618 worker=0 pid:21631 ppid:21618 worker:0]
 
-=== @timestamp
-
+== @timestamp
 
 A UTC value that marks when the log payload was created or, if the creation time is not known, when the log payload was first collected. The “@” prefix denotes a field that is reserved for a particular use. By default, most tools look for “@timestamp” with ElasticSearch.
 
-=== hostname
+[horizontal]
+Data type:: date
+Example value:: `2015-01-24 14:06:05.071000000 Z`
 
+== hostname
 
 The name of the host where this log message originated. In a Kubernetes cluster, this is the same as `kubernetes.host`.
 
-=== ipaddr4
+[horizontal]
+Data type:: keyword
 
+== ipaddr4
 
 The IPv4 address of the source server. Can be an array.
 
-=== ipaddr6
+[horizontal]
+Data type:: ip
 
+== ipaddr6
 
 The IPv6 address of the source server, if available. Can be an array.
 
-=== level
+[horizontal]
+Data type:: ip
 
+== level
 
-The logging level from various sources, including `rsyslog(severitytext property)`, python's logging module, and others.
+The logging level from various sources, including `rsyslog(severitytext property)`, a Python logging module, and others.
 
 The following values come from link:http://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/syslog.h;h=ee01478c4b19a954426a96448577c5a76e6647c0;hb=HEAD#l74[`syslog.h`], and are preceded by their http://sourceware.org/git/?p=glibc.git;a=blob;f=misc/sys/syslog.h;h=ee01478c4b19a954426a96448577c5a76e6647c0;hb=HEAD#l51[numeric equivalents]:
 
@@ -63,27 +76,41 @@ The two following values are not part of `syslog.h` but are widely used:
 
 Map the log levels or priorities of other logging systems to their nearest match in the preceding list. For example, from link:https://docs.python.org/2.7/library/logging.html#logging-levels[python logging], you can match `CRITICAL` with `crit`, `ERROR` with `err`, and so on.
 
-=== pid
+[horizontal]
+Data type:: keyword
+Example value:: `info`
 
+== pid
 
 The process ID of the logging entity, if available.
 
-=== service
+[horizontal]
+Data type:: keyword
 
+== service
 
 The name of the service associated with the logging entity, if available. For example, syslog's `APP-NAME` and rsyslog's `programname` properties are mapped to the service field.
 
-=== tags
+[horizontal]
+Data type:: keyword
 
+== tags
 
 Optional. An operator-defined list of tags placed on each log by the collector or normalizer. The payload can be a string with whitespace-delimited string tokens or a JSON list of string tokens.
 
-=== file
+[horizontal]
+Data type:: text
 
+== file
 
-The path to the log file from which the collector read this log entry. Normally, this is a path in the `/var/log` file system of a cluster node.
+The path to the log file from which the collector reads this log entry. Normally, this is a path in the `/var/log` file system of a cluster node.
 
-=== offset
+[horizontal]
+Data type:: text
 
+== offset
 
 The offset value. Can represent bytes to the start of the log line in the file (zero- or one-based), or log line numbers (zero- or one-based), so long as the values are strictly monotonically increasing in the context of a single log file. The values are allowed to wrap, representing a new version of the log file (rotation).
+
+[horizontal]
+Data type:: long

--- a/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
+++ b/modules/cluster-logging-forwarding-json-logs-to-the-default-elasticsearch.adoc
@@ -1,0 +1,48 @@
+[id="cluster-logging-forwarding-json-logs-to-the-default-elasticsearch_{context}"]
+= Forwarding JSON logs to the Elasticsearch log store
+
+For the Elasticsearch log store that OpenShift Logging manages, you must create a different index for each format in advance if your JSON log entries _have different formats_. Otherwise, forwarding different formats to the same index can cause type conflicts and cardinality problems.
+
+.Procedure
+
+. Add the following snippet to your `ClusterLogForwarder` CR YAML file.
++
+[source,yaml]
+----
+outputDefaults:
+- elasticsearch:
+    structuredTypeKey: <log record field>
+    structuredTypeName: <name>
+pipelines:
+- inputRefs:
+  - application
+  outputRefs: default
+  parse: json
+----
+
+. Optional: Use `structuredTypeKey` to specify one of the log record fields, as described in the preceding topic, xref:../logging/cluster-logging-enabling-json-logging.adoc#cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_cluster-logging-enabling-json-logging[Configuring JSON log data for Elasticsearch]. Otherwise, remove this line.
+
+. Optional: Use `structuredTypeName` to specify a `<name>`, as described in the preceding topic, xref:../logging/cluster-logging-enabling-json-logging.adoc#cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_cluster-logging-enabling-json-logging[Configuring JSON log data for Elasticsearch]. Otherwise, remove this line.
++
+[IMPORTANT]
+====
+To parse JSON logs, you must set either `structuredTypeKey` or `structuredTypeName`, or both  `structuredTypeKey` and `structuredTypeName`.
+====
++
+. For `inputRefs`, specify which log types should be forwarded using that pipeline, such as `application,` `infrastructure`, or `audit`.
+
+. Add the `parse: json` element to pipelines.
+
+. Create the CR object:
++
+[source,terminal]
+----
+$ oc create -f <file-name>.yaml
+----
++
+The Red Hat OpenShift Logging Operator redeploys the Fluentd pods. However, if they do not redeploy, delete the Fluentd pods to force them to redeploy.
++
+[source,terminal]
+----
+$ oc delete pod --selector logging-infra=fluentd
+----

--- a/modules/cluster-logging-json-log-forwarding.adoc
+++ b/modules/cluster-logging-json-log-forwarding.adoc
@@ -1,0 +1,48 @@
+[id="cluster-logging-json-log-forwarding_{context}"]
+= Parsing JSON logs
+
+Logs including JSON logs are usually represented as a string inside the `message` field. That makes it hard for users to query specific fields inside a JSON document. OpenShift Logging's Log Forwarding API enables you to parse JSON logs into a structured object and forward them to either Red Hat's managed Elasticsearch or any other third-party system supported by the Log Forwarding API.
+
+To illustrate how this works, suppose that you have the following structured JSON log entry.
+
+.Example structured JSON log entry
+[source,yaml]
+----
+{"level":"info","name":"fred","home":"bedrock"}
+----
+
+Normally, the `ClusterLogForwarder` custom resource (CR) forwards that log entry in the `message` field. The `message` field contains the JSON-quoted string equivalent of the JSON log entry, as shown in the following example.
+
+.Example `message` field
+[source,yaml]
+----
+{"message":"{\"level\":\"info\",\"name\":\"fred\",\"home\":\"bedrock\"",
+ "more fields..."}
+----
+
+To enable parsing JSON log, you add `parse: json` to a pipeline in the `ClusterLogForwarder` CR, as shown in the following example.
+
+.Example snippet showing `parse: json`
+[source,yaml]
+----
+pipelines:
+- inputRefs: [ application ]
+  outputRefs: myFluentd
+  parse: json
+----
+
+When you enable parsing JSON logs by using `parse: json`, the CR copies the JSON-structured log entry in a `structured` field, as shown in the following example. This does not modify the original `message` field.
+
+.Example `structured` output containing the structured JSON log entry
+[source,yaml]
+----
+{"structured": { "level": "info", "name": "fred", "home": "bedrock" },
+ "more fields..."}
+----
+
+[IMPORTANT]
+====
+If the log entry does not contain valid structured JSON, the `structured` field will be absent.
+====
+
+To enable parsing JSON logs for specific logging platforms, see xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third-party systems].


### PR DESCRIPTION
…s (JSON)"

Previews:
- [Enabling JSON logging](https://deploy-preview-34891--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-enabling-json-logging.html)  - Explains forwarding of JSON-based structured log data in general. This topic includes
-- Configuration of JSON log data for default Elasticsearch
-- Forwarding JSON logs to the default Elasticsearch log store
- [Forwarding logs to third party systems](https://deploy-preview-34891--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-enabling-json-based-structured-log-data_cluster-logging-external)
- [Log Record Fields](https://deploy-preview-34891--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-exported-fields.html)

PR information:
- Aligned team: Dev Tools
- For branches: 4.7+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-2677  
- FYI PM: @vhc-smwilber
- SME review: @alanconway 
- QE review: @anpingli 
- Peer review: @JStickler
