### PR TITLE
Clarifying that 1.3 isn't supported as the minTLS

### DIFF
--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -40,7 +40,7 @@ You can see the configured TLS security profile in the `APIServer` custom resour
 
 [NOTE]
 ====
-The control plane does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported.
+The control plane does not support TLS `1.3` as the minimum TLS version; the `Modern` profile is not supported because it requires TLS `1.3`.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Per https://github.com/openshift/openshift-docs/pull/34810#discussion_r677316405

Preview: https://deploy-preview-34895--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles?utm_source=github&utm_campaign=bot_dp#tls-profiles-kubernetes-configuring_tls-security-profiles

FYI @snarayan-redhat 