### PR TITLE
[RHDEVDOCS - 3045]: Additional tutorial updates for Pipelines 1.5

### DIFF
--- a/modules/op-running-a-pipeline.adoc
+++ b/modules/op-running-a-pipeline.adoc
@@ -18,7 +18,8 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-api \
+    --use-param-defaults
 ----
 +
 The previous command uses a volume claim template, which creates a persistent volume claim for the pipeline execution.
@@ -40,7 +41,8 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui
+    -p IMAGE=image-registry.openshift-image-registry.svc:5000/pipelines-tutorial/pipelines-vote-ui \
+    --use-param-defaults
 ----
 
 . To track the progress of the pipeline run, enter the following command:


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`
- **JIRA issues**: [Tutorial updates 1.5](https://issues.redhat.com/browse/RHDEVDOCS-3045)
- **Preview pages**: [Running a pipeline](https://deploy-preview-34897--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/creating-applications-with-cicd-pipelines?utm_source=github&utm_campaign=bot_dp#running-a-pipeline_creating-applications-with-cicd-pipelines)
- **SME+QE review**: Praveen Thangadacha, Veeresh Acharya
- **Peer-review**: Preeti Chandrashekar
- **Additional info**: 
  - This PR was raised in response to https://github.com/openshift/pipelines-tutorial/pull/145.
  - The main PR for Pipelines 1.5 tutorial is https://github.com/openshift/openshift-docs/pull/34675.