### PR TITLE
WMCO-2.0.3: Added a new bug fix for the WMCO 2.0.3 release note set.

### DIFF
--- a/windows_containers/windows-containers-release-notes-2-x.adoc
+++ b/windows_containers/windows-containers-release-notes-2-x.adoc
@@ -19,10 +19,22 @@ You must have a subscription to receive support for the Red Hat WMCO. Deploying 
 
 include::modules/wmco-prerequisites.adoc[leveloffset=+1]
 
+[id="wmco-2-0-3"]
+== Release notes for Red Hat Windows Machine Config Operator 2.0.3
+
+Issued: 2021-07-28
+
+The WMCO 2.0.3 is now available with bug fixes. The components of the WMCO were released in link:https://access.redhat.com/errata/RHBA-2021:2926[RHBA-2021:2926].
+
+[id="wmco-2-0-3-bug-fixes"]
+=== Bug fixes
+
+* This WMCO release fixes a bug that prevented users from upgrading to WMCO 3.0.0. Users should upgrade to WMCO 2.0.3 before upgrading to {product-title} 4.8, which only supports WMCO 3.0.0. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985349[**BZ#1985349**])
+
 [id="wmco-2-0-2"]
 == Release notes for Red Hat Windows Machine Config Operator 2.0.2
 
-Issued:2021-07-08
+Issued: 2021-07-08
 
 The WMCO 2.0.2 is now available with bug fixes. The components of the WMCO were released in link:https://access.redhat.com/errata/RHBA-2021:2671[RHBA-2021:2671].
 
@@ -33,12 +45,12 @@ Users who are running a version of WMCO prior to 2.0.3 should first upgrade to W
 
 [id="wmco-2-0-2-bug-fixes"]
 === Bug fixes
-* {product-title} 4.8 enables the `BoundServiceAccountTokenVolume` option by default. This option attaches the projected volumes to all of the pods. In addition, {product-title} 4.8 xref:../rest_api/objects/index.adoc#podsecuritycontext-core-v1[the `RunAsUser` option of the `SecurityContext`]. This combination results in Windows pods being stuck in the `ContainerCreating` status. To work around this issue, you should upgrade to WMCO 2.0.2 before upgrading your cluster to {product-title} 4.8. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975553[**BZ#1975553**])
+* {product-title} 4.8 enables the `BoundServiceAccountTokenVolume` option by default. This option attaches the projected volumes to all of the pods. In addition, {product-title} 4.8 adds xref:../rest_api/objects/index.adoc#podsecuritycontext-core-v1[the `RunAsUser` option to the `SecurityContext`]. This combination results in Windows pods being stuck in the `ContainerCreating` status. To work around this issue, you should upgrade to WMCO 2.0.2 before upgrading your cluster to {product-title} 4.8. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975553[**BZ#1975553**])
 
 [id="wmco-2-0-1"]
 == Release notes for Red Hat Windows Machine Config Operator 2.0.1
 
-Issued:2021-06-23
+Issued: 2021-06-23
 
 The WMCO 2.0.1 is now available with bug fixes. The components of the WMCO were released in link:https://access.redhat.com/errata/RHSA-2021:2130[RHSA-2021:2130].
 


### PR DESCRIPTION
This PR corrects a typo to the WMCO 2.x release notes. It also adds the disclosure around a bug fix in WMCO 2.0.3 that enables users to upgrade to WMCO 3.0/OCP 4.8.

OCP Version: 4.7

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1985349

Preview: https://deploy-preview-34899--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-2-x.html#wmco-2-0-3