### PR TITLE
Create dummy Release Notes for 4.9 on main

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1,0 +1,11 @@
+[id="ocp-4-9-release-notes"]
+= {product-title} {product-version} release notes
+include::modules/common-attributes.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.


### PR DESCRIPTION
We need a dummy Release Notes doc on main to prevent build failures.

Actual 4.9 release notes stub is submitted in #34907