### PR TITLE
BZ1664914: descheduler documentation lack of the introduction of 'nodeaffinity' strategy

### DIFF
--- a/admin_guide/scheduling/descheduler.adoc
+++ b/admin_guide/scheduling/descheduler.adoc
@@ -138,8 +138,7 @@ For example:
 [[admin-guide-descheduler-policies]]
 == Creating Descheduler Policies
 
-You can configure the descheduler to remove pods from nodes that violate rules defined by _strategies_ in a YAML policy file. Include a path to the
-policy file in the xref:admin-guide-descheduler-job[job specification] to apply the specific descheduling strategy.
+You can configure the descheduler to remove pods from nodes that violate rules defined by _strategies_ in a YAML policy file. You then create a xref:admin-guide-descheduler-policy[configuration map] that includes a path to the policy file and a xref:admin-guide-descheduler-job[job specification] using that configuration map to apply the specific descheduling strategy.
 
 .Sample descheduler policy file
 [source,yaml]
@@ -164,13 +163,19 @@ strategies:
          numberOfNodes: 3
   "RemovePodsViolatingInterPodAntiAffinity":
      enabled: true
+  "RemovePodsViolatingNodeAffinity":
+    enabled: true
+    params:
+      nodeAffinityType:
+      - "requiredDuringSchedulingIgnoredDuringExecution"
 ----
 
 There are three default strategies that can be used with the descheduler:
 
-* Remove duplicate pods (`RemoveDuplicates`)
-* Move pods to underutilized nodes (`LowNodeUtilization`)
-* Remove pods that violate anti-affinity rules (`RemovePodsViolatingInterPodAntiAffinity`).
+* xref:admin-guide-descheduler-policies-remove[Remove duplicate pods (`RemoveDuplicates`)]
+* xref:admin-guide-descheduler-policies-low[Move pods to underutilized nodes (`LowNodeUtilization`)]
+* xref:admin-guide-descheduler-policies-anti[Remove pods that violate anti-affinity rules (`RemovePodsViolatingInterPodAntiAffinity`)]
+* xref:admin-guide-descheduler-policies-node[Remove Pods Violating Node Affinity (RemovePodsViolatingNodeAffinity)]
 
 You can configure and disable parameters associated with strategies as needed.
 
@@ -252,6 +257,28 @@ strategies:
 
 <1> Set this value to `enabled: true` to use this policy. Set to `false` to disable this policy.
 
+[[admin-guide-descheduler-policies-node]]
+=== Remove Pods Violating Node Affinity
+
+The `RemovePodsViolatingNodeAffinity` strategy ensures that all pods violating node affinity are removed from nodes. This situation could occur if a node no longer satisfies a pod’s affinity rule. If another node is available that satisfies the affinity rule, the pod is evicted.
+
+For example, *podA* is scheduled on *nodeA*, because the node satisfies the `requiredDuringSchedulingIgnoredDuringExecution` node affinity rule at the time of scheduling.If *nodeA* stops satisfying the rule, and if there is another node available that satisfies the node affinity rule, the strategy evicts *podA* from *nodeA* and moves it to the other node.
+
+[source,yaml]
+----
+apiVersion: "descheduler/v1alpha1"
+kind: "DeschedulerPolicy"
+strategies:
+  "RemovePodsViolatingNodeAffinity": <1>
+    enabled: true
+    params:
+      nodeAffinityType:
+      - "requiredDuringSchedulingIgnoredDuringExecution" <2>
+----
+
+<1> Set this value to `enabled: true` to use this policy. Set to `false` to disable this policy.
+<2> Specify the `requiredDuringSchedulingIgnoredDuringExecution` node affinity type.
+
 [[admin-guide-descheduler-policy]]
 == Create a Configuration Map for the Descheduler Policy
 
@@ -287,7 +314,7 @@ spec:
     spec:
         containers:
         - name: descheduler
-          image: descheduler
+          image: registry.access.redhat.com/openshift3/ose-descheduler
           volumeMounts: <3>
           - mountPath: /policy-dir
             name: policy-volume


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1664914

Preview: https://deploy-preview-34906--osdocs.netlify.app/openshift-enterprise/latest/admin_guide/scheduling/descheduler?utm_source=github&utm_campaign=bot_dp#admin-guide-descheduler-policies-node