### PR TITLE
Update version number and RN for MTC 1.5.0

### DIFF
--- a/migration_toolkit_for_containers/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -11,4 +11,5 @@ You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to
 
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.
 
+include::modules/migration-mtc-release-notes-1-5.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-4.adoc[leveloffset=+1]

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -39,5 +39,5 @@ endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
-:mtc-version: 1.4
-:mtc-version-z: 1.4.6
+:mtc-version: 1.5
+:mtc-version-z: 1.5.0


### PR DESCRIPTION
No Jira or BZ number

Changes: Update MTC version and RN

4.8+

Preview: https://deploy-preview-34921--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes.html

No QE required. Peer review required