### PR TITLE
TELCODOCS-189 - 4.7 release notes updates

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -706,6 +706,15 @@ The machine health resource example described in xref:../machine_management/depl
 
 Starting with {product-title} 4.7, during power-based remediation if the power operations do not complete successfully, the bare-metal machine controller triggers the reprovisioning of the unhealthy node. The exception to this is if the node is a master node or a node that was provisioned externally.
 
+[id="cp-4-7-ipi-install-diagnosing-duplicate-mac-address"]
+==== Diagnosing a duplicate MAC address when provisioning a new host in the cluster
+
+When provisioning a new node in the cluster, if the MAC address of an existing bare-metal node in the cluster matches the MAC address of a bare-metal host you are attempting to add to the cluster, the installation fails and a registration error is displayed for the failed bare-metal host.
+
+You can diagnose a duplicate MAC address by examining the bare-metal hosts that are running in the `openshift-machine-api` namespace.
+
+For more information, see xref:../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc#ipi-install-diagnosing-duplicate-mac-address_ipi-install-expanding[Diagnosing a duplicate MAC address when provisioning a new host in the cluster].
+
 [id="ocp-4-7-nodes"]
 === Nodes
 


### PR DESCRIPTION
4.7 release note for for https://issues.redhat.com/browse/TELCODOCS-189 documenting KNIDEPLOY-2111. 

This should be merged to enterprise-4.7 branch.

Preview is here: https://deploy-preview-34924--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes#cp-4-7-ipi-install-diagnosing-duplicate-mac-address