### PR TITLE
BZ1964901: Manually rolling back migration, uninstalling

### DIFF
--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -2,6 +2,7 @@
 = Troubleshooting
 include::modules/common-attributes.adoc[]
 :context: troubleshooting-3-4
+:troubleshooting-3-4:
 
 toc::[]
 
@@ -22,8 +23,8 @@ include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
 include::modules/migration-using-mtc-crs-for-troubleshooting.adoc[leveloffset=+2]
 
-[discrete]
 [id="additional-resources-for-debugging-tools_{context}"]
+[discrete]
 === Additional resources for debugging tools
 
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
@@ -44,5 +45,18 @@ include::modules/migration-known-issues.adoc[leveloffset=+2]
 
 You can roll back a migration by using the {mtc-short} web console or the CLI.
 
+You can also xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-rolling-back-migration-manually_troubleshooting-3-4[roll back a migration manually].
+
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
+include::modules/migration-rolling-back-migration-manually.adoc[leveloffset=+2]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
+
+[id="additional-resources-uninstalling_{context}"]
+[discrete]
+=== Additional resources for uninstalling {mtc-short}
+
+* xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-cluster[Deleting Operators from a cluster using the web console]
+
+:troubleshooting-3-4!:

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -2,6 +2,7 @@
 = Troubleshooting
 include::modules/common-attributes.adoc[]
 :context: troubleshooting-mtc
+:troubleshooting-mtc:
 
 toc::[]
 
@@ -22,8 +23,8 @@ include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]
 include::modules/migration-using-mtc-crs-for-troubleshooting.adoc[leveloffset=+2]
 
-[discrete]
 [id="additional-resources-for-debugging-tools_{context}"]
+[discrete]
 === Additional resources for debugging tools
 
 * xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
@@ -42,5 +43,18 @@ include::modules/migration-error-messages.adoc[leveloffset=+2]
 
 You can roll back a migration by using the {mtc-short} web console or the CLI.
 
+You can also xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-rolling-back-migration-manually_troubleshooting-mtc[roll back a migration manually].
+
 include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
+include::modules/migration-rolling-back-migration-manually.adoc[leveloffset=+2]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
+
+[id="additional-resources-uninstalling_{context}"]
+[discrete]
+=== Additional resources for uninstalling {mtc-short}
+
+* xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-cluster[Deleting Operators from a cluster using the web console]
+
+:troubleshooting-mtc!:

--- a/modules/migration-rolling-back-migration-cli.adoc
+++ b/modules/migration-rolling-back-migration-cli.adoc
@@ -10,15 +10,13 @@ You can roll back a migration by creating a `MigMigration` custom resource (CR) 
 
 [NOTE]
 ====
-If you roll back a failed direct volume migration, the following resources are preserved in the namespaces specified in the `MigPlan` custom resource (CR) to help you debug the failed migration:
+The following resources remain in the migrated namespaces for debugging after a failed direct volume migration (DVM):
 
 * Config maps (source and destination clusters)
 * `Secret` CRs (source and destination clusters)
 * `Rsync` CRs (source cluster)
-* `Service` CRs (destination cluster)
-* `Route` CRs (destination cluster)
 
-These resources must be deleted manually.
+These resources do not affect rollback. You can delete them manually.
 
 If you later run the same migration plan successfully, the resources from the failed migration are deleted automatically.
 ====

--- a/modules/migration-rolling-back-migration-manually.adoc
+++ b/modules/migration-rolling-back-migration-manually.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+// * migration_toolkit_for_containers/troubleshooting-mtc
+
+[id="migration-rolling-back-migration-manually_{context}"]
+= Rolling back a migration manually
+
+You can roll back a failed migration manually by deleting the `stage` pods and unquiescing the application.
+
+If you run the same migration plan successfully, the resources from the failed migration are deleted automatically.
+
+[NOTE]
+====
+The following resources remain in the migrated namespaces after a failed direct volume migration (DVM):
+
+* Config maps (source and destination clusters)
+* `Secret` CRs (source and destination clusters)
+* `Rsync` CRs (source cluster)
+
+These resources do not affect rollback. You can delete them manually.
+====
+
+.Procedure
+
+. Delete the `stage` pods on all clusters:
++
+[source,terminal]
+----
+$ oc delete $(oc get pods -l migration.openshift.io/is-stage-pod -n <namespace>) <1>
+----
+<1> Namespaces specified in the `MigPlan` CR.
+
+. Unquiesce the application on the source cluster by scaling the replicas to their premigration number:
++
+[source,terminal]
+----
+$ oc scale deployment <deployment> --replicas=<premigration_replicas>
+----
++
+The `migration.openshift.io/preQuiesceReplicas` annotation in the `Deployment` CR displays the premigration number of replicas:
++
+[source,yaml]
+----
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  annotations:
+    deployment.kubernetes.io/revision: "1"
+    migration.openshift.io/preQuiesceReplicas: "1"
+----
+
+. Verify that the application pods are running on the source cluster:
++
+[source,terminal]
+----
+$ oc get pod -n <namespace>
+----

--- a/modules/migration-rolling-back-migration-web-console.adoc
+++ b/modules/migration-rolling-back-migration-web-console.adoc
@@ -10,15 +10,13 @@ You can roll back a migration by using the {mtc-full} ({mtc-short}) web console.
 
 [NOTE]
 ====
-If you roll back a failed direct volume migration, the following resources are preserved in the namespaces specified in the migration plan to help you debug the failed migration:
+The following resources remain in the migrated namespaces for debugging after a failed direct volume migration (DVM):
 
-* Config maps (source and target clusters)
-* `Secret` CRs (source and target clusters)
+* Config maps (source and destination clusters)
+* `Secret` CRs (source and destination clusters)
 * `Rsync` CRs (source cluster)
-* `Service` CRs (target cluster)
-* `Route` CRs (target cluster)
 
-These resources must be deleted manually.
+These resources do not affect rollback. You can delete them manually.
 
 If you later run the same migration plan successfully, the resources from the failed migration are deleted automatically.
 ====

--- a/modules/migration-uninstalling-mtc-clean-up.adoc
+++ b/modules/migration-uninstalling-mtc-clean-up.adoc
@@ -1,0 +1,95 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+// * migration_toolkit_for_containers/troubleshooting-mtc
+
+[id="migration-uninstalling-mtc-clean-up_{context}"]
+= Uninstalling {mtc-short} and deleting resources
+
+You can uninstall the {mtc-full} ({mtc-short}) and delete its resources to clean up the cluster.
+
+[NOTE]
+====
+Deleting the `velero` CRDs removes Velero from the cluster.
+====
+
+.Prerequisites
+
+* You must be logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Delete the `MigrationController` custom resource (CR) on all clusters:
++
+[source,terminal]
+----
+$ oc delete migrationcontroller <migration_controller>
+----
+
+. Uninstall the {mtc-short} Operator on {product-title} 4 by using the {product-title} web console.
+ifdef::troubleshooting-3-4[]
+. Uninstall the {mtc-short} Operator on {product-title} 3 by deleting the `operator` CR manifest:
++
+[source,terminal]
+----
+$ oc delete -f operator.yml
+----
+endif::[]
+
+. Delete cluster-scoped resources on all clusters by running the following commands:
+
+* `migration` custom resource definitions (CRDs):
++
+[source,terminal]
+----
+$ oc delete $(oc get crds -o name | grep 'migration.openshift.io')
+----
+
+* `velero` CRDs:
++
+[source,terminal]
+----
+$ oc delete $(oc get crds -o name | grep 'velero')
+----
+
+* `migration` cluster roles:
++
+[source,terminal]
+----
+$ oc delete $(oc get clusterroles -o name | grep 'migration.openshift.io')
+----
+
+* `migration-operator` cluster role:
++
+[source,terminal]
+----
+$ oc delete clusterrole migration-operator
+----
+
+* `velero` cluster roles:
++
+[source,terminal]
+----
+$ oc delete $(oc get clusterroles -o name | grep 'velero')
+----
+
+* `migration` cluster role bindings:
++
+[source,terminal]
+----
+$ oc delete $(oc get clusterrolebindings -o name | grep 'migration.openshift.io')
+----
+
+* `migration-operator` cluster role bindings:
++
+[source,terminal]
+----
+$ oc delete clusterrolebindings migration-operator
+----
+
+* `velero` cluster role bindings:
++
+[source,terminal]
+----
+$ oc delete $(oc get clusterrolebindings -o name | grep 'velero')
+----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1964901

Procedures for manually rolling back a failed migration and for uninstalling MTC and deleting resources.

4.6+

Previews:
https://deploy-preview-34931--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-rolling-back-migration-manually_troubleshooting-mtc

https://deploy-preview-34931--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-uninstalling-mtc-clean-up_troubleshooting-mtc

QE approved. Requires peer review.