### PR TITLE
BZ1945837: Revised second application example

### DIFF
--- a/modules/deployments-ab-testing-lb.adoc
+++ b/modules/deployments-ab-testing-lb.adoc
@@ -37,7 +37,7 @@ $ oc new-app openshift/deployment-example --name=ab-example-a
 +
 [source,terminal]
 ----
-$ oc new-app openshift/deployment-example --name=ab-example-b
+$ oc new-app openshift/deployment-example:v2 --name=ab-example-b
 ----
 +
 Both applications are deployed and services are created.


### PR DESCRIPTION
This change is for Enterprise-4.6, 4.7, and 4.8.![image](https://user-images.githubusercontent.com/83772007/127350166-75e58423-fc5e-4863-b058-eb2ff200ab80.png)
This pull request is tied to [Bug 1945837](https://bugzilla.redhat.com/show_bug.cgi?id=1945837).

Revised [the load balancing example for a second application](https://deploy-preview-34934--osdocs.netlify.app/openshift-enterprise/latest/applications/deployments/route-based-deployment-strategies?utm_source=github&utm_campaign=bot_dp#deployments-ab-testing-lb_route-based-deployment-strategies), changing "example" to "example2" in Step 1B.

August 3: Replaced "example2" with "example:V2." 

Ready for QE: @zhouying7780 
Ready for peer review