### PR TITLE
OSDOCS-2229: Added `list instance-types` command to ROSA CLI documentation.

### DIFF
--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -5,7 +5,6 @@
 [id="rosa-list-objects_{context}"]
 = List and describe objects
 
-
 This section describes the `list` and `describe` commands for clusters and resources.
 
 [id="rosa-list-oaddon_{context}"]
@@ -174,6 +173,42 @@ List all API and ingress endpoints for a cluster named `mycluster`:
 [source,terminal]
 ----
 $ rosa list ingresses --cluster=mycluster
+----
+
+== list instance-types
+
+List all of the available instance types for use with {product-title}. Availability is based on the account's AWS quota.
+
+.Syntax
+[source,terminal]
+----
+$ rosa list instance-types [arguments]
+----
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--output
+|The output format. Allowed formats are `json` or `yaml`.
+
+|--profile
+|Specifies an AWS profile (string) from your credentials file.
+|===
+
+.Example
+List all instance types:
+
+[source,terminal]
+----
+$ rosa list instance-types
 ----
 
 [id="rosa-list-machinepools_{context}"]

--- a/modules/rosa-upgrade-cluster-cli.adoc
+++ b/modules/rosa-upgrade-cluster-cli.adoc
@@ -68,7 +68,7 @@ Schedule a cluster upgrade within the hour on a cluster named `mycluster`:
 $ rosa upgrade cluster --cluster=mycluster --version 4.5.20
 ----
 
- [id="rosa-delete-upgrade-cluster_{context}"]
+[id="rosa-delete-upgrade-cluster_{context}"]
 == delete upgrade
 
 Cancel a scheduled cluster upgrade:


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2229

Preview: https://deploy-preview-34943--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli?utm_source=github&utm_campaign=bot_dp#list-instance-types


Peer reviewer: Please merge to `dedicated-4` branch. No milestones and no CP needed. Thanks.


