### PR TITLE
CNV-13251:  Correct typo in Creating data volumes

### DIFF
--- a/modules/virt-creating-data-volumes-using-pvc-api.adoc
+++ b/modules/virt-creating-data-volumes-using-pvc-api.adoc
@@ -8,7 +8,7 @@
 
 When you create a data volume using the PVC API, the Containerized Data Interface (CDI) creates the data volume based on what you specify for the following fields:
 
-* `accessModes` (`ReadWriteOnce`, `ReadWrtieMany`, or `ReadOnlyMany`)
+* `accessModes` (`ReadWriteOnce`, `ReadWriteMany`, or `ReadOnlyMany`)
 * `volumeMode` (`Filesystem` or `Block`)
 * `capacity` of `storage` (`5Gi`, for example)
 


### PR DESCRIPTION
RE: [CNV-13251](https://issues.redhat.com/browse/CNV-13251)
For 4.8 and later

Preview: https://deploy-preview-34987--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.html#virt-creating-data-volumes-using-pvc-api_virt-creating-data-volumes