### PR TITLE
Fix formatting break from errant metadata

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -38,7 +38,7 @@ This feature:
 [id="installation-special-config-encryption-threshold_{context}"]
 === Configuring an encryption threshold
 
-In {product-title}, you can specify a requirement for more than one Tang server. You can also configure the TPM v2 and Tang encryption modes simultaneously, so that the boot disk data can be decrypted only if the TPM secure cryptoprocessor is present and the Tang servers can be accessed over a secure network. 
+In {product-title}, you can specify a requirement for more than one Tang server. You can also configure the TPM v2 and Tang encryption modes simultaneously, so that the boot disk data can be decrypted only if the TPM secure cryptoprocessor is present and the Tang servers can be accessed over a secure network.
 
 You can use the `threshold` attribute in your Butane configuration to define the minimum number of TPM v2 and Tang encryption conditions that must be met for decryption to occur. The threshold is met when the stated value is reached through any combination of the declared conditions. For example, the `threshold` value of `2` in the following configuration can be reached by accessing the two Tang servers, or by accessing the TPM secure cryptoprocessor and one of the Tang servers:
 
@@ -53,8 +53,8 @@ metadata:
   labels:
     machineconfiguration.openshift.io/role: worker
 boot_device:
-  layout: x86_64 
-  luks: 
+  layout: x86_64
+  luks:
     tpm2: true <1>
     tang: <2>
       - url: http://tang1.example.com:7500
@@ -82,11 +82,9 @@ If you require both TPM v2 and Tang for decryption, the value of the `threshold`
 [id="installation-special-config-mirrored-disk_{context}"]
 == About disk mirroring
 
-<<<<<<< HEAD
 During {product-title} installation on control plane and worker nodes, you can enable mirroring of the boot and other disks to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
-=======
+
 During {product-title} installation on control plane and compute nodes, you can enable mirroring of the boot disk to two or more redundant storage devices. A node continues to function after storage device failure as long as one device remains available.
->>>>>>> 5782aad73 (GH#33682: Updating the disk encryption and mirroring section)
 
 Mirroring does not support replacement of a failed disk. To restore the mirror to a pristine, non-degraded state, reprovision the node.
 
@@ -314,13 +312,13 @@ $ oc debug node/compute-1
 .Example output
 [source,terminal]
 ----
-Personalities : [raid1] 
+Personalities : [raid1]
 md126 : active raid1 sdb3[1] sda3[0] <1>
 	  393152 blocks super 1.0 [2/2] [UU]
-      
+
 md127 : active raid1 sda4[0] sdb4[1] <2>
 	  51869632 blocks super 1.2 [2/2] [UU]
-      
+
 unused devices: <none>
 ----
 <1> In the example, the `/dev/md126` software RAID mirror device uses the `/dev/sda3` and `/dev/sdb3` disk devices on the cluster node.
@@ -364,7 +362,7 @@ Consistency Policy : resync
        1     252       19        1      active sync   /dev/sdb3 <6>
 ----
 <1> Specifies the RAID level of the device. `raid1` indicates RAID 1 disk mirroring.
-<2> Specifies the state of the RAID device. 
+<2> Specifies the state of the RAID device.
 <3> States the number of underlying disk devices that are active and working.
 <4> States the number of underlying disk devices that are in a failed state.
 <5> The name of the software RAID device.


### PR DESCRIPTION
Fix to https://github.com/openshift/openshift-docs/pull/34317
Fixes formatting issues by removing errant merge conflict metadata (`<<<<<<< HEAD`) introduced only in 4.8+. No QE required.

Preview link ("About disk mirroring"): https://deploy-preview-34997--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-mirrored-disk_installing-customizing