### PR TITLE
OSSMDOC-361: Change heading

### DIFF
--- a/modules/ossm-vs-istio.adoc
+++ b/modules/ossm-vs-istio.adoc
@@ -4,7 +4,7 @@ Module included in the following assemblies:
 ////
 
 [id="ossm-vs-istio_{context}"]
-= Service Mesh features
+= Differences between Istio and {ProductName}
 
 The following features are different in {ProductShortName} and Istio.
 


### PR DESCRIPTION
Revert the heading for modules\ossm-vs-istio.adoc from "Service Mesh features  "  back to "Differences between Istio and Service Mesh"