### PR TITLE
Bug 1987333: Operator shows wrong channel

### DIFF
--- a/modules/psap-installing-node-feature-discovery-operator.adoc
+++ b/modules/psap-installing-node-feature-discovery-operator.adoc
@@ -67,13 +67,13 @@ $ oc create -f nfd-operatorgroup.yaml
 +
 [source,terminal]
 ----
-$ oc get packagemanifest openshift-nfd-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
+$ oc get packagemanifest nfd -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
 ----
 +
 .Example output
 [source,terminal]
 ----
-nfd.v4.8.0
+4.8
 ----
 
 .. Create the following `Subscription` CR and save the YAML in the `nfd-sub.yaml` file:
@@ -87,7 +87,7 @@ metadata:
   name: nfd
   namespace: openshift-nfd-operator
 spec:
-  channel: nfd.v4.8.0
+  channel: "4.8"
   installPlanApproval: Automatic
   name: nfd
   source: redhat-operators


### PR DESCRIPTION
Docs are pointing to the community-operator catalog packageName of NFD,
they need to point to the redhat-certified name.

Signed-off-by: Carlos Eduardo Arango Gutierrez <carangog@redhat.com>

https://bugzilla.redhat.com/show_bug.cgi?id=1987333