### PR TITLE
GitHub Issue 34890: Need to fix a link in MAIN and pick to 4.9

### DIFF
--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -60,7 +60,7 @@ Use the following tables to find content to help you learn about and use {VirtPr
 |
 
 |
-| link:https://www.google.com/url?q=https://www.openshift.com/blog/updating-a-boot-source-image&sa=D&source=editors&ust=1626893484915000&usg=AOvVaw0cDIQr63zScl7b-Cn8G0rA[Updating boot source templates]
+| link:https://www.openshift.com/blog/updating-a-boot-source-image[Updating boot source templates]
 | xref:../virt/logging_events_monitoring/virt-monitoring-vm-health.adoc#virt-monitoring-vm-health[Monitoring virtual machine health]
 |
 


### PR DESCRIPTION
For 4.9 only.

Fixing GitHub Issue #34890.

Direct doc preview link: https://deploy-preview-35027--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-learn-more-about-openshift-virtualization.html and click **Updating boot source templates** link.

cc: @bergerhoffer @ctomasko 