### PR TITLE
BZ1984781: Add SCC step to Helm OSDK guides

### DIFF
--- a/modules/osdk-create-cr.adoc
+++ b/modules/osdk-create-cr.adoc
@@ -60,6 +60,16 @@ ifndef::helm[]
 endif::[]
 ----
 
+ifdef::helm[]
+. The {app-proper} service account requires privileged access to run in {product-title}. Add the following security context constraint (SCC) to the service account for the `{app}-sample` pod:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc adm policy add-scc-to-user \
+    anyuid system:serviceaccount:{app}-operator-system:{app}-sample
+----
+endif::[]
+
 . Create the CR:
 +
 [source,terminal,subs="attributes+"]

--- a/modules/osdk-quickstart.adoc
+++ b/modules/osdk-quickstart.adoc
@@ -35,7 +35,7 @@ You can build and deploy a simple {type}-based Operator for {app-proper} by usin
 
 . *Create a project.*
 
-.. Create your project:
+.. Create your project directory:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -142,6 +142,18 @@ $ make install
 ----
 $ make deploy IMG=<registry>/<user>/<image_name>:<tag>
 ----
+
+ifdef::helm[]
+. *Add a security context constraint (SCC).*
++
+The {app-proper} service account requires privileged access to run in {product-title}. Add the following SCC to the service account for the `{app}-sample` pod:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc adm policy add-scc-to-user \
+    anyuid system:serviceaccount:{app}-operator-system:{app}-sample
+----
+endif::[]
 
 . *Create a sample custom resource (CR).*
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1984781

Add SCC step to Helm OSDK guides to avoid "Permission denied" errors when applying the sample CR.

* Getting started (step 5): https://deploy-preview-35034--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-quickstart.html#osdk-quickstart_osdk-helm-quickstart
* Tutorial (step 3): https://deploy-preview-35034--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-create-cr_osdk-helm-tutorial