### PR TITLE
WIN-C: Updated a description about a VSphere template property.

### DIFF
--- a/modules/windows-machineset-vsphere.adoc
+++ b/modules/windows-machineset-vsphere.adoc
@@ -67,7 +67,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the Windows machine set name. The machine set name cannot be more than 9 characters long, due to the way machine names are generated in vSphere.
 <3> Configure the machine set as a Windows machine.
 <4> Configure the Windows node as a compute machine.
-<5> Specify the vSphere VM network to deploy the machine set to.
+<5> Specify the vSphere VM network to deploy the machine set to. This name must match the network name where other Linux workers are in the cluster.
 <6> Specify the full path of the Windows vSphere VM template to use, such as `/Datacenter/vm/ocp4-llplx/windows-golden-image`. The name must be unique.
 +
 [IMPORTANT]


### PR DESCRIPTION
Updated a description for the Vsphere VM Network name property. It notes that this network name must match wherever the Linux workers reside.

WIN-C Ticket: https://github.com/openshift/windows-machine-config-operator/pull/545

Version: 4.7+

Preview: