### PR TITLE
Added notes for release 4.6.41

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3135,7 +3135,7 @@ link:https://access.redhat.com/solutions/6176142[{product-title} 4.6.36 containe
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-6-39"]
-=== RHBA-2021:2684 - {product-title} 4.6.39 bug fix
+=== RHBA-2021:2684 - {product-title} 4.6.39 bug fix update
 
 Issued: 2021-07-21
 
@@ -3158,7 +3158,7 @@ link:https://access.redhat.com/solutions/6196661[{product-title} 4.6.39 containe
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-6-40"]
-=== RHBA-2021:2767 - {product-title} 4.6.40 bug fix
+=== RHBA-2021:2767 - {product-title} 4.6.40 bug fix update
 
 Issued: 2021-07-28
 
@@ -3169,6 +3169,35 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6214081[{product-title} 4.6.40 container image list]
 
 [id="ocp-4-6-40-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-41"]
+=== RHBA-2021:2886 - {product-title} 4.6.41 bug fix update
+
+Issued: 2021-08-04
+
+{product-title} release 4.6.41 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2886[RHBA-2021:2886] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2888[RHBA-2021:2888] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6227651[{product-title} 4.6.41 container image list]
+
+[id="ocp-4-6-41-features"]
+==== Features
+
+[id="ocp-4-6-41-new-telemetry-metric"]
+===== New Telemetry metric for number of builds by strategy
+
+Telemetry includes a new `openshift:build_by_strategy:sum` gauge metric, which sends the number of builds by strategy type to the Telemeter Client. This metric gives site reliability engineers (SREs) and product managers visibility into the kinds of builds that run on OpenShift Container Platform clusters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1969964[*BZ#1969964*])
+
+[id="ocp-4-6-41-bug-fixes"]
+==== Bug fixes
+
+* Previously, when starting a single-stack IPv6 cluster on nodes with IPv4 address, the kubelet might have used the IPv4 IP instead of the IPv6 IP for the node IP. Consequently, host network pods would have IPv4 IPs rather than IPv6 IPs, which made them unreachable from IPv6-only pods. This update fixes the node-IP-picking code, which results in the kubelet using the IPv6 IPs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942506[*BZ#1942506*])
+
+[id="ocp-4-6-41-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the asynchronous release notes for version 4.6.41.

* PR includes small title changes to earlier releases
* feature and bug already peer reviewed as part of the [4.8 RN](https://docs.openshift.com/container-platform/4.8/release_notes/ocp-4-8-release-notes.html)
* applies only to `enterprise-4.6`
* [direct preview link](https://deploy-preview-35046--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes.html#ocp-4-6-41)