### PR TITLE
CNV-13244: Incorrect code snippet

### DIFF
--- a/modules/virt-defining-a-watchdog.adoc
+++ b/modules/virt-defining-a-watchdog.adoc
@@ -81,12 +81,12 @@ $ lspci | grep watchdog -i
 +
 [source,terminal]
 ----
-$ echo c > /proc/sysrq-trigger
+# echo c > /proc/sysrq-trigger
 ----
 
 * Terminate the watchdog service:
 +
 [source,terminal]
 ----
-$ kill -9 pgrep watchdog
+# pkill -9 watchdog
 ----


### PR DESCRIPTION
Re: [CNV-13244](https://issues.redhat.com/browse/CNV-13244)
For 4.8 and later

Preview: https://deploy-preview-35049--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-a-watchdog?utm_source=github&utm_campaign=bot_dp
