### PR TITLE
RNs: Added notes for release 4.8.3

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2452,3 +2452,26 @@ Issued: 2021-07-27
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6164202[{product-title} 4.8.2 container image list]
+
+[id="ocp-4-8-3"]
+=== RHBA-2021:2896 - {product-title} 4.8.3 bug fix update
+
+Issued: 2021-08-02
+
+{product-title} release 4.8.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2157[RHBA-2021:2896] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2158[RHBA-2021:2899] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6221811[{product-title} 4.8.3 container image list]
+
+[id="ocp-4-8-3-bug-fixes"]
+==== Bug fixes
+
+* Previously, a bug in the lock implementation for the `nmstate-handler` pod caused multiple nodes to gain control. This update fixes the lock implementation so that only one node is in control of the lock. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954309[*BZ#1954309*])
+
+* Previously, there was an incorrect toleration setting on the `nmstate-handler` pod, which made network configuration on nodes with the `nmstate` Operator impossible. With this update, the handler pod allows toleration on all nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960446[*BZ#1960446*])
+
+[id="ocp-4-8-3-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.8.3

- Applies only to enterprise-4.8
- [Preview Link](https://deploy-preview-35050--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-3)