### PR TITLE
BZ1986619: Changing description of vCPU metrics related to kernel arguments

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -12,14 +12,18 @@ The following metric descriptions include example Prometheus Query Language (Pro
 These metrics are not an API and might change between versions.
 ====
 
-
 [id="virt-promql-vcpu-metrics_{context}"]
 == vCPU metrics
+
+[NOTE]
+====
+The vCPU metric requires the `schedstats=enable` kernel argument applied to the `MachineConfig` object before it can be used. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
+====
 
 `kubevirt_vmi_vcpu_wait_seconds`::
 Returns the wait time (in seconds) for a virtual machine's vCPU.
 
-A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This indicates that there is an issue with Input/Output.
+A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with Input/Output.
 
 .Example query
 [source,promql]
@@ -50,7 +54,7 @@ The above query returns the top 3 VMs transmitting the most network traffic at e
 == Storage metrics
 
 `kubevirt_vmi_storage_read_traffic_bytes_total`::
-Returns the total amount (in bytes) of the virtual machine's storage-related traffic. 
+Returns the total amount (in bytes) of the virtual machine's storage-related traffic.
 
 `kubevirt_vmi_storage_write_traffic_bytes_total`::
 Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic.
@@ -79,7 +83,7 @@ These queries can be used to determine the I/O performance of storage devices.
 topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_read_total[6m]), 0.1))
 + sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_write_total[6m]) , 0.1))) > 0
 ----
-The above query returns the top 3 VMs performing the most I/O operations per second at every given moment in time over a six-minute time period. 
+The above query returns the top 3 VMs performing the most I/O operations per second at every given moment in time over a six-minute time period.
 
 [id="virt-promql-guest-memory-metrics_{context}"]
 == Guest memory swapping metrics
@@ -87,9 +91,9 @@ The above query returns the top 3 VMs performing the most I/O operations per sec
 Returns the total amount (in bytes) of memory the virtual guest is swapping in.
 
 `kubevirt_vmi_memory_swap_out_traffic_bytes_total`::
-Returns the total amount (in bytes) of memory the virtual guest is swapping out. 
+Returns the total amount (in bytes) of memory the virtual guest is swapping out.
 
-Memory swapping indicates that the virtual machine is under memory pressure. Increasing the memory allocation of the virtual machine can mitigate this issue. 
+Memory swapping indicates that the virtual machine is under memory pressure. Increasing the memory allocation of the virtual machine can mitigate this issue.
 
 [NOTE]
 ====
@@ -102,5 +106,4 @@ These queries only return data for virtual guests that have memory swapping enab
 topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[6m]), 0.1))
 + sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]), 0.1))) > 0
 ----
-The above query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment in time over a six-minute time period. 
-
+The above query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment in time over a six-minute time period.

--- a/virt/logging_events_monitoring/virt-prometheus-queries.adoc
+++ b/virt/logging_events_monitoring/virt-prometheus-queries.adoc
@@ -14,7 +14,6 @@ toc::[]
 Use the {product-title} monitoring dashboard to query virtualization metrics.
 
 .Prerequisite
-
 * The vCPU metric requires the `schedstats=enable` kernel argument applied to the `MachineConfig` object before it can be used. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. See the xref:../../post_installation_configuration/machine-configuration-tasks.adoc#nodes-nodes-kernel-arguments_post-install-machine-configuration-tasks[{product-title} machine configuration tasks] documentation for more information on applying a kernel argument.
 
 include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses Bug 1986619 ( https://bugzilla.redhat.com/show_bug.cgi?id=1986619 ).

The bug is about updating the description of vCPU metrics to mention that vCPU metrics requires a kernel argument to be applied.

CP: 4.9

Preview: https://deploy-preview-35055--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-prometheus-queries?utm_source=github&utm_campaign=bot_dp#virt-promql-vcpu-metrics_virt-prometheus-queries