### PR TITLE
Bug 1988311: Fix typo in modules/psap-driver-toolkit-using.adoc

### DIFF
--- a/modules/psap-driver-toolkit-using.adoc
+++ b/modules/psap-driver-toolkit-using.adoc
@@ -130,7 +130,7 @@ $ oc create -f 0000-buildconfig.yaml
 
 . Once the builder pod completes successfully, deploy the driver container image as a `DaemonSet`. 
 
-.. The driver container must run with the privileged security context in order to load the kernel modules on the host. The following YAML file contains the RBAC rules and the `DaemonSet` for running the driver container. Save this YAML as `1000-driver-container.yaml`.
+.. The driver container must run with the privileged security context in order to load the kernel modules on the host. The following YAML file contains the RBAC rules and the `DaemonSet` for running the driver container. Save this YAML as `1000-drivercontainer.yaml`.
 +
 [source,yaml]
 ----


### PR DESCRIPTION
This bug applies to version 4.8 of the docs. 

Signed-off-by: dagrayvid <dagray@redhat.com>