### PR TITLE
BZ1858166 Clarify maxUnhealthy in machine health check

### DIFF
--- a/modules/machine-health-checks-resource.adoc
+++ b/modules/machine-health-checks-resource.adoc
@@ -60,6 +60,8 @@ Remediation is not performed if the number of unhealthy machines exceeds the `ma
 If `maxUnhealthy` is not set, the value defaults to `100%` and the machines are remediated regardless of the state of the cluster.
 ====
 
+The appropriate `maxUnhealthy` value depends on the scale of the cluster you deploy and how many machines the `MachineHealthCheck` covers. For example, you can use the `maxUnhealthy` value to cover multiple machine sets across multiple availability zones so that if you lose an entire zone, your `maxUnhealthy` setting prevents further remediation within the cluster.
+
 The `maxUnhealthy` field can be set as either an integer or percentage.
 There are different remediation implementations depending on the `maxUnhealthy` value.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1858166

This was reported in 4.5, which is now EOL. But the requested fix applies to all currently supported OCP versions. However, since the creation of this BZ, extensive doc additions have been made that seem to thoroughly address the reporter's concerns about vague descriptions. 

In this PR, I've added a couple of sentences to further clarify based on the reporter's request. It may or may not be necessary/helpful to add this info.

Preview link: https://deploy-preview-35060--osdocs.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks.html#machine-health-checks-short-circuiting_deploying-machine-health-checks