### PR TITLE
MON-1801: Document disabling Grafana in monitoring stack

### DIFF
--- a/modules/monitoring-disabling-grafana.adoc
+++ b/modules/monitoring-disabling-grafana.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+[id="disabling_grafana_{context}"]
+= Disabling the default Grafana deployment
+
+By default, a read-only Grafana instance is deployed with a collection of dashboards displaying cluster metrics. The Grafana instance is not user-configurable.
+
+You can disable the Grafana deployment, causing the associated resources to be deleted from the cluster. You might do this if you do not need these dashboards and want to conserve resources in your cluster. You will still be able to view metrics and dashboards included in the web console. Grafana can be safely enabled again at any time.
+
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+. Add `enabled: false` for the `grafana` component under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    grafana:
+      enabled: false
+----
+
+. Save the file to apply the changes. The resources will begin to be removed automatically when you apply the change.
++
+[WARNING]
+====
+This change results in some components, including Prometheus and the Thanos Querier, being restarted. This might lead to previously collected metrics being lost if you have not yet followed the steps in the "Configuring persistent storage" section.
+====
+
+. Check that the Grafana pod is no longer running. The following example lists the status of pods in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring get pods
+----
++
+[NOTE]
+====
+It may take a few minutes after applying the change for these pods to terminate.
+====

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -133,6 +133,13 @@ include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[le
 * See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]
 
+// Disabling the default Grafana deployment
+include::modules/monitoring-disabling-grafana.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
+
 == Next steps
 
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]


### PR DESCRIPTION
[MON-1675](https://issues.redhat.com/browse/MON-1675) (https://github.com/openshift/cluster-monitoring-operator/pull/1241) added the ability for users to disable the default Grafana deployment included in the monitoring stack. This documents the process.