### PR TITLE
BZ1911761: Fixed minor grammatical error

### DIFF
--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -170,7 +170,7 @@ NAME                          STATUS   ROLES    AGE   VERSION
 ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.18.3+002a51f
 ----
 
-. Add the matching node selector a pod:
+. Add the matching node selector to a pod:
 +
 * To add a node selector to existing and future pods, add a node selector to the controlling object for the pods:
 +


### PR DESCRIPTION
This PR is to address BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1911761
Topic: https://deploy-preview-35089--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-pod_nodes-scheduler-node-selectors
Exact section: Using node selectors to control pod placement > Procedure > Step 2 "Add the matching node selector a pod" is changed to "Add the matching node selector **to** a pod"
Labels: enterprise-4.6, enterprise-4.7, enterprise-4.8, enterprise-4.9