### PR TITLE
BZ:1973274 Added a note on maximum cluster downtime

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -7,6 +7,11 @@
 
 You can shut down your cluster in a graceful manner so that it can be restarted at a later date.
 
+[NOTE]
+====
+You can shut down a cluster until a year from the installation date and expect it to restart gracefully. After a year from the installation date, the cluster certificates expire.
+====
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -18,6 +23,19 @@ It is important to take an etcd backup before performing this procedure so that 
 ====
 
 .Procedure
+
+. If you are shutting the cluster down for an extended period, determine the date on which certificates expire.
++
+[source,terminal]
+----
+$ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer -o jsonpath='{.metadata.annotations.auth\.openshift\.io/certificate-not-after}'
+----
++
+.Example output
+----
+2022-08-05T14:37:50Zuser@user:~ $ <1>
+----
+<1> To ensure that the cluster can restart gracefully, plan to restart it on or before the specified date. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
 
 . Shut down all of the nodes in the cluster. You can do this from your cloud provider's web console, or you can use the below commands:
 


### PR DESCRIPTION
CP to 4.6, 4.7, 4.8, and 4.9

https://bugzilla.redhat.com/show_bug.cgi?id=1973274

Updated Shutting down a cluster gracefully:

- Added a note that states the maximum amount of time that a cluster can remain down and be expected to restart gracefully is 1 year.
- Step 1 specifies how to determine when the cluster certificates will expire.

https://deploy-preview-35099--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown?utm_source=github&utm_campaign=bot_dp

**QE**: In a case where a cluster has been down for 1 year, please also verify that steps 4 and 6 in Restarting the cluster gracefully is all a user would need to do with regard to pending CSRs. I suspect the answer is yes, but wanted to verify.

https://deploy-preview-35099--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-restart.html
