### PR TITLE
[Enterprise-4.7+]: Azure Installation Note Cleanup

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -363,6 +363,7 @@ endif::[]
 ifndef::restricted[]
 . Modify the `install-config.yaml` file. You can find more information about
 the available parameters in the "Installation configuration parameters" section.
+ifdef::rhv[]
 +
 [NOTE]
 ====
@@ -393,6 +394,7 @@ If you have any intermediate CA certificates on the engine, verify that the cert
      -----END CERTIFICATE-----
 ----
 ====
+endif::rhv[]
 endif::restricted[]
 
 ifdef::osp+restricted[]


### PR DESCRIPTION
This pull request fixes a conditional in the Azure installation that accidentally published the wrong note.

Version: 4.7+

Preview: 
Azure: 
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-initializing_installing-azure-user-infra
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-vnet.html#installation-initializing_installing-azure-vnet
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-network-customizations.html#installation-initializing_installing-azure-network-customizations

GCP: 
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-initializing_installing-gcp-customizations
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc.html#installation-initializing_installing-gcp-vpc
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations.html#installation-initializing_installing-gcp-network-customizations

AWS: 
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-initializing_installing-aws-network-customizations
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-initializing_installing-aws-customizations
- https://deploy-preview-35106--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-vpc.html#installation-initializing_installing-aws-vpc