### PR TITLE
BZ1840935: Adding config APIs for control plane - Backporting from 4.7 to 4.6

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -665,6 +665,8 @@ Topics:
   File: audit-log-view
 - Name: Configuring the audit log policy
   File: audit-log-policy-config
+- Name: Configuring TLS security profiles
+  File: tls-security-profiles
 - Name: Allowing JavaScript-based access to the API server from additional hosts
   File: allowing-javascript-access-api-server
   Distros: openshift-enterprise,openshift-webscale,openshift-origin
@@ -2372,7 +2374,7 @@ Topics:
   - Name: SMCP configuration reference
     File: ossm-reference-smcp
   - Name: Jaeger configuration reference
-    File: ossm-reference-jaeger 
+    File: ossm-reference-jaeger
   - Name: Uninstalling Service Mesh
     File: removing-ossm
 - Name: Service Mesh 1.x

--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -1,0 +1,106 @@
+// Module included in the following assemblies:
+//
+// * security/tls-profiles.adoc
+
+[id="tls-profiles-ingress-configuring_{context}"]
+= Configuring the TLS security profile for the Ingress Controller
+
+To configure a TLS security profile for an Ingress Controller, edit the `IngressController` custom resource (CR) to specify a predefined or custom TLS security profile. If a TLS security profile is not configured, the default value is based on the TLS security profile set for the API server.
+
+.Sample `IngressController` CR that configures the `Old` TLS security profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  tlsSecurityProfile:
+    old: {}
+    type: Old
+ ...
+----
+
+The TLS security profile defines the minimum TLS version and the TLS ciphers for TLS connections for Ingress Controllers.
+
+You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `IngressController` custom resource (CR) under `Status.Tls Profile` and the configured TLS security profile under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed under both parameters.
+
+[IMPORTANT]
+====
+The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the `IngressController` CR in the `openshift-ingress-operator` project to configure the TLS security profile:
++
+[source,terminal]
+----
+$ oc edit IngressController default -n openshift-ingress-operator
+----
+
+. Add the `spec.tlsSecurityProfile` field:
++
+.Sample `IngressController` CR for a `Custom` profile
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+ ...
+spec:
+  tlsSecurityProfile:
+    type: Custom <1>
+    custom: <2>
+      ciphers: <3>
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS11
+ ...
+----
+<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+<2> Specify the appropriate field for the selected type:
+* `old: {}`
+* `intermediate: {}`
+* `custom:`
+<2> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+
+. Save the file to apply the changes.
+
+.Verification
+
+* Verify that the profile is set in the `IngressController` CR:
++
+[source,terminal]
+----
+$ oc describe IngressController default -n openshift-ingress-operator
+----
++
+.Example output
+[source,terminal]
+----
+Name:         default
+Namespace:    openshift-ingress-operator
+Labels:       <none>
+Annotations:  <none>
+API Version:  operator.openshift.io/v1
+Kind:         IngressController
+ ...
+Spec:
+ ...
+  Tls Security Profile:
+    Custom:
+      Ciphers:
+        ECDHE-ECDSA-CHACHA20-POLY1305
+        ECDHE-RSA-CHACHA20-POLY1305
+        ECDHE-RSA-AES128-GCM-SHA256
+        ECDHE-ECDSA-AES128-GCM-SHA256
+      Min TLS Version:  VersionTLS11
+    Type:               Custom
+ ...
+----

--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * security/tls-profiles.adoc
+
+[id="tls-profiles-kubernetes-configuring_{context}"]
+= Configuring the TLS security profile for the control plane
+
+To configure a TLS security profile for the control plane, edit the `APIServer` custom resource (CR) to specify a predefined or custom TLS security profile. Setting the TLS security profile in the `APIServer` CR propagates the setting to the following control plane components:
+
+* Kubernetes API server
+* OpenShift API server
+* OpenShift OAuth API server
+* OpenShift OAuth server
+
+If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
+
+[NOTE]
+====
+The default TLS security profile for the Ingress Controller is based on the TLS security profile set for the API server.
+====
+
+.Sample `APIServer` CR that configures the `Old` TLS security profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: APIServer
+ ...
+spec:
+  tlsSecurityProfile:
+    old: {}
+    type: Old
+ ...
+----
+
+The TLS security profile defines the minimum TLS version and the TLS ciphers required to communicate with the control plane components.
+
+You can see the configured TLS security profile in the `APIServer` custom resource (CR) under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed.
+
+[NOTE]
+====
+The control plane does not support TLS `1.3` as the minimum TLS version; the `Modern` profile is not supported because it requires TLS `1.3`.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the default `APIServer` CR to configure the TLS security profile:
++
+[source,terminal]
+----
+$ oc edit APIServer cluster
+----
+
+. Add the `spec.tlsSecurityProfile` field:
++
+.Sample `APIServer` CR for a `Custom` profile
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: APIServer
+metadata:
+  name: cluster
+spec:
+  tlsSecurityProfile:
+    type: Custom <1>
+    custom: <2>
+      ciphers: <3>
+      - ECDHE-ECDSA-CHACHA20-POLY1305
+      - ECDHE-RSA-CHACHA20-POLY1305
+      - ECDHE-RSA-AES128-GCM-SHA256
+      - ECDHE-ECDSA-AES128-GCM-SHA256
+      minTLSVersion: VersionTLS11
+----
+<1> Specify the TLS security profile type (`Old`, `Intermediate`, or `Custom`). The default is `Intermediate`.
+<2> Specify the appropriate field for the selected type:
+* `old: {}`
+* `intermediate: {}`
+* `custom:`
+<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+
+. Save the file to apply the changes.
+
+.Verification
+
+* Verify that the TLS security profile is set in the `APIServer` CR:
++
+[source,terminal]
+----
+$ oc describe apiserver cluster
+----
++
+.Example output
+[source,terminal]
+----
+Name:         cluster
+Namespace:
+ ...
+API Version:  config.openshift.io/v1
+Kind:         APIServer
+ ...
+Spec:
+  Audit:
+    Profile:  Default
+  Tls Security Profile:
+    Custom:
+      Ciphers:
+        ECDHE-ECDSA-CHACHA20-POLY1305
+        ECDHE-RSA-CHACHA20-POLY1305
+        ECDHE-RSA-AES128-GCM-SHA256
+        ECDHE-ECDSA-AES128-GCM-SHA256
+      Min TLS Version:  VersionTLS11
+    Type:               Custom
+ ...
+----

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * security/tls-security-profiles.adoc
+
+[id="tls-profiles-understanding_{context}"]
+= Understanding TLS security profiles
+
+You can use a TLS (Transport Layer Security) security profile to define which TLS ciphers are required by various {product-title} components. The {product-title} TLS security profiles are based on link:https://wiki.mozilla.org/Security/Server_Side_TLS[Mozilla recommended configurations].
+
+You can specify one of the following TLS security profiles for each component:
+
+.TLS security profiles
+[cols="1,2a",options="header"]
+|===
+|Profile
+|Description
+
+|`Old`
+|This profile is intended for use with legacy clients or libraries. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility[Old backward compatibility] recommended configuration.
+
+The `Old` profile requires a minimum TLS version of 1.0.
+
+[NOTE]
+====
+For the Ingress Controller, the minimum TLS version is converted from 1.0 to 1.1.
+====
+
+|`Intermediate`
+|This profile is the recommended configuration for the majority of clients. It is the  default TLS security profile for the Ingress Controller and control plane. The profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29[Intermediate compatibility] recommended configuration.
+
+The `Intermediate` profile requires a minimum TLS version of 1.2.
+
+|`Modern`
+|This profile is intended for use with modern clients that have no need for backwards compatibility. This profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility[Modern compatibility] recommended configuration.
+
+The `Modern` profile requires a minimum TLS version of 1.3.
+
+[IMPORTANT]
+====
+The `Modern` profile is currently not supported.
+====
+
+|`Custom`
+|This profile allows you to define the TLS version and ciphers to use.
+
+[WARNING]
+====
+Use caution when using a `Custom` profile, because invalid configurations can cause problems.
+====
+
+|===
+
+[NOTE]
+====
+When using one of the predefined profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the Intermediate profile deployed on release X.Y.Z, an upgrade to release X.Y.Z+1 might cause a new profile configuration to be applied, resulting in a rollout.
+====

--- a/modules/tls-profiles-view-details.adoc
+++ b/modules/tls-profiles-view-details.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * security/tls-security-profiles.adoc
+
+[id="tls-profiles-view-details_{context}"]
+= Viewing TLS security profile details
+
+You can view the minimum TLS version and ciphers for the predefined TLS security profiles for each of the following components: Ingress Controller and control plane.
+
+[IMPORTANT]
+====
+The effective configuration of minimum TLS version and list of ciphers for a profile might differ between components.
+====
+
+.Procedure
+
+* View details for a specific TLS security profile:
++
+[source,terminal]
+----
+$ oc explain <component>.spec.tlsSecurityProfile.<profile> <1>
+----
+<1> For `<component>`, specify `ingresscontroller` or `apiserver`. For `<profile>`, specify `old`, `intermediate`, or `custom`.
++
+For example, to check the ciphers included for the `intermediate` profile for the control plane:
++
+[source,terminal]
+----
+$ oc explain apiserver.spec.tlsSecurityProfile.intermediate
+----
++
+.Example output
+[source,terminal]
+----
+KIND:     APIServer
+VERSION:  config.openshift.io/v1
+
+DESCRIPTION:
+    intermediate is a TLS security profile based on:
+    https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+    and looks like this (yaml):
+    ciphers: - TLS_AES_128_GCM_SHA256 - TLS_AES_256_GCM_SHA384 -
+    TLS_CHACHA20_POLY1305_SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 -
+    ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES256-GCM-SHA384 -
+    ECDHE-RSA-AES256-GCM-SHA384 - ECDHE-ECDSA-CHACHA20-POLY1305 -
+    ECDHE-RSA-CHACHA20-POLY1305 - DHE-RSA-AES128-GCM-SHA256 -
+    DHE-RSA-AES256-GCM-SHA384 minTLSVersion: TLSv1.2
+----
+
+* View all details for the `tlsSecurityProfile` field of a component:
++
+[source,terminal]
+----
+$ oc explain <component>.spec.tlsSecurityProfile <1>
+----
+<1> For `<component>`, specify `ingresscontroller` or `apiserver`.
++
+For example, to check all details for the `tlsSecurityProfile` field for the Ingress Controller:
++
+[source,terminal]
+----
+$ oc explain ingresscontroller.spec.tlsSecurityProfile
+----
++
+.Example output
+[source,terminal]
+----
+KIND:     IngressController
+VERSION:  operator.openshift.io/v1
+
+RESOURCE: tlsSecurityProfile <Object>
+
+DESCRIPTION:
+     ...
+
+FIELDS:
+   custom	<>
+     custom is a user-defined TLS security profile. Be extremely careful using a
+     custom profile as invalid configurations can be catastrophic. An example
+     custom profile looks like this:
+     ciphers: - ECDHE-ECDSA-CHACHA20-POLY1305 - ECDHE-RSA-CHACHA20-POLY1305 -
+     ECDHE-RSA-AES128-GCM-SHA256 - ECDHE-ECDSA-AES128-GCM-SHA256 minTLSVersion:
+     TLSv1.1
+
+   intermediate	<>
+     intermediate is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Intermediate_compatibility_.28recommended.29
+     and looks like this (yaml):
+     ... <1>
+
+   modern	<>
+     modern is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility and
+     looks like this (yaml):
+     ... <2>
+     NOTE: Currently unsupported.
+
+   old	<>
+     old is a TLS security profile based on:
+     https://wiki.mozilla.org/Security/Server_Side_TLS#Old_backward_compatibility
+     and looks like this (yaml):
+     ... <3>
+
+   type	<string>
+     ...
+----
+<1> Lists ciphers and minimum version for the `intermediate` profile here.
+<2> Lists ciphers and minimum version for the `modern` profile here.
+<3> Lists ciphers and minimum version for the `old` profile here.

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -17,7 +17,16 @@ include::modules/nw-installation-ingress-config-asset.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-controller-configuration-parameters.adoc[leveloffset=+1]
 
-include::modules/nw-ingress-controller-tls-profiles.adoc[leveloffset=+2]
+[id="configuring-ingress-controller-tls"]
+=== Ingress Controller TLS security profiles
+
+TLS security profiles provide a way for servers to regulate which ciphers a connecting client can use when connecting to the server.
+
+// Understanding TLS security profiles
+include::modules/tls-profiles-understanding.adoc[leveloffset=+3]
+
+// Configuring the TLS profile for the Ingress Controller
+include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+3]
 
 include::modules/nw-ingress-controller-endpoint-publishing-strategies.adoc[leveloffset=+2]
 

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -1,0 +1,29 @@
+[id="tls-security-profiles"]
+= Configuring TLS security profiles
+include::modules/common-attributes.adoc[]
+:context: tls-security-profiles
+
+toc::[]
+
+TLS security profiles provide a way for servers to regulate which ciphers a client can use when connecting to the server. This ensures that {product-title} components use cryptographic libraries that do not allow known insecure protocols, ciphers, or algorithms.
+
+Cluster administrators can choose which TLS security profile to use for each of the following components:
+
+* the Ingress Controller
+* the control plane
++
+This includes the Kubernetes API server, OpenShift API server, OpenShift OAuth API server, and OpenShift OAuth server.
++
+// NOTE: etcd and OpenShift controller manager are not included
+
+// Understanding TLS security profiles
+include::modules/tls-profiles-understanding.adoc[leveloffset=+1]
+
+// Viewing TLS security profile details
+include::modules/tls-profiles-view-details.adoc[leveloffset=+1]
+
+// Configuring for ingress
+include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+1]
+
+// Configuring for the control plane
+include::modules/tls-profiles-kubernetes-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
Bug https://bugzilla.redhat.com/show_bug.cgi?id=1840935
Backporting of  4.7 content to 4.6

@bergerhoffer - Kindly review these changes and provide your comments, if any. Can be merged if looks good.

Preview link: https://deploy-preview-35107--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html