### PR TITLE
virt: node placement: there are two nodePlacement fields

### DIFF
--- a/modules/virt-about-node-placement-virtualization-components.adoc
+++ b/modules/virt-about-node-placement-virtualization-components.adoc
@@ -68,10 +68,12 @@ metadata:
 spec:
   infra:
     nodePlacement: <1>
+    ...
   workloads:
     nodePlacement:
+    ...
 ----
-<1> The `nodePlacement` field supports `nodeSelector`, `affinity`, and `tolerations` fields.
+<1> The `nodePlacement` fields support `nodeSelector`, `affinity`, and `tolerations` fields.
 
 [id="node-placement-hpp_{context}"]
 == Node placement in the HostPathProvisioner object


### PR DESCRIPTION
The text refered to a single field, while there are two optional ones.
I also add ellipses to signify that the example yaml is missing an actual content for these fields. 

Signed-off-by: Dan Kenigsberg <danken@redhat.com>