### PR TITLE
Fixed broken links and changed title for release 4.5.35

### DIFF
--- a/release_notes/ocp-4-5-release-notes.adoc
+++ b/release_notes/ocp-4-5-release-notes.adoc
@@ -2578,11 +2578,11 @@ link:https://access.redhat.com/solutions/5866491[{product-title} 4.5.34 containe
 To upgrade an existing {product-title} 4.5 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI for instructions.]
 
 [id="ocp-4-5-35"]
-=== RHSA-2021:0785 - {product-title} 4.5.35 bug fix and security update
+=== RHBA-2021:0785 - {product-title} 4.5.35 bug fix update
 
 Issued: 2021-03-17
 
-{product-title} release 4.5.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0785[RHSA-2021:0785] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0786[RHSA-2021:0786] advisory.
+{product-title} release 4.5.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0785[RHBA-2021:0785] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0786[RHBA-2021:0786] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
Fixed a couple broken links.

* applies only to `enterprise-4.5`
* [direct preview link](https://deploy-preview-35120--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-5-release-notes.html#ocp-4-5-35)