### PR TITLE
vsphere: move nsx-t lower in table; mark optional

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -28,14 +28,13 @@ You must install the {product-title} cluster on a VMware vSphere version 6 or 7 
 |vSphere 6.5 and later with HW version 13
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
-|Networking (NSX-T)
-|vSphere 6.5U3 or vSphere 6.7U2 and later
-|vSphere 6.5U3 or vSphere 6.7U2+ are required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
-
-
 |Storage with in-tree drivers
 |vSphere 6.5 and later
 |This plug-in creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
+
+|Optional: Networking (NSX-T)
+|vSphere 6.5U3 or vSphere 6.7U2 and later
+|vSphere 6.5U3 or vSphere 6.7U2+ are required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
 
 |===
 


### PR DESCRIPTION
This is PR is in response to a question internally
by customer support regarding the requirement
of NSX-T for OCP installation. NSX-T is not
required, moving lower in the table and marking as
optional