### PR TITLE
TELCODOCS-111: KNIDEPLOY-3655, Support Fujitsu nodes in OCP Metal

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -25,7 +25,7 @@ include::modules/ipi-install-bmc-addressing-for-dell-idrac.adoc[leveloffset=+1]
 include::modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc[leveloffset=+1]
 
 ifeval::[{product-version} > 4.7]
-include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+2]
+include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+1]
 endif::[]
 
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]


### PR DESCRIPTION
Changed level offset in the assembly from +2 to +1. +2 displays in the upstream TOC, but does not display in the downstream TOC. Changing it to +1 in the downstream makes the module appear in the TOC properly. NOTE: It still will not appear in the preview, because it uses conditional text. Note that the module does appear in the live 4.8 docs. So the conditional text is working properly.

Fixes: [TELCODOCS-111](https://issues.redhat.com/browse/TELCODOCS-111)

See https://issues.redhat.com/browse/TELCODOCS-111 for additional details.

Preview URL:

For release(s): 4.8
Signed-off-by: John Wilkins <jowilkin@redhat.com>
