### PR TITLE
Bump Contour v1.18.0

### DIFF
--- a/modules/nw-install-config-gateway-api.adoc
+++ b/modules/nw-install-config-gateway-api.adoc
@@ -24,7 +24,7 @@ The following guide provides instructions for using link:https://gateway-api.sig
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.16.0/examples/gateway/gateway.yaml
+$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.18.0/examples/gateway/gateway.yaml
 ----
 +
 [NOTE]
@@ -60,7 +60,7 @@ The number of Envoy pods depends on how many worker nodes are in your cluster.
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.16.0/examples/gateway/kuard/kuard.yaml
+$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.18.0/examples/gateway/kuard/kuard.yaml
 ----
 +
 .Verification

--- a/modules/nw-install-contour-operator.adoc
+++ b/modules/nw-install-contour-operator.adoc
@@ -23,7 +23,7 @@ Install the Contour Operator on {product-title} to use link:https://gateway-api.
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.16.0/examples/operator/operator.yaml
+$ oc apply -f https://raw.githubusercontent.com/projectcontour/contour-operator/v1.18.0/examples/operator/operator.yaml
 ----
 +
 [NOTE]


### PR DESCRIPTION
A new version of Contour was released 6 days ago and it still works with the instructions we have. Let's keep the documentation up to date.

Tested on OpenShift 4.8.2:
```bash
$ oc version
Client Version: 4.7.11
Server Version: 4.8.2
Kubernetes Version: v1.21.1+051ac4f

$ oc -n projectcontour get pod envoy-cz2zc --template='{{range .spec.containers}}{{.image}}{{"\n"}}{{end}}'
docker.io/projectcontour/contour:v1.18.0
docker.io/envoyproxy/envoy:v1.19.0

$ oc -n projectcontour get pod contour-65b455dccf-wgr4k --template='{{range .spec.containers}}{{.image}}{{"\n"}}{{end}}'
docker.io/projectcontour/contour:v1.18.0

$ export GATEWAY=$(oc -n projectcontour get svc/envoy -o jsonpath='{.status.loadBalancer.ingress[0].ip}')

$ echo $GATEWAY
34.67.219.58

$ oc -n projectcontour get httproute
NAME    HOSTNAMES                     AGE
kuard   ["local.projectcontour.io"]   9m16s

$ curl -H "Host: local.projectcontour.io" -s -o /dev/null -w "%{http_code}" "http://$GATEWAY/" && echo
200

$ oc logs ds/envoy -c envoy -n projectcontour | grep curl
Found 3 pods, using pod/envoy-v9rww
[2021-08-03T15:17:40.988Z] "GET / HTTP/1.1" 200 - 0 1701 2 2 "92.XXX.XXX.XXX" "curl/7.61.1" "d8f88bf5-c66c-4986-88e1-694cfd132632" "local.projectcontour.io" "10.131.0.38:8080"
[2021-08-03T15:19:06.771Z] "GET / HTTP/1.1" 200 - 0 1701 5 5 "92.XXX.XXX.XXX" "curl/7.61.1" "286f69e9-d29a-4e9f-8db9-620216497206" "local.projectcontour.io" "10.128.2.42:8080"
```