### PR TITLE
RFE-1839: Including GCP Global Access  module in assembly where it is missing

### DIFF
--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -34,6 +34,9 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
+include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=+2]
+
+
 == Additional resources
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set]


### PR DESCRIPTION
Including GCP Global Access  module in assembly where it is missing. For 4.8+

Related to #33611 where this module should've been included but was missed. 

Preview: https://deploy-preview-35149--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-private.html#nw-gcp-global-access-configuration_installing-gcp-private 

@makentenza ready for review.