### PR TITLE
BZ1989538: Remove trust bundle steps from ShiftStack clouds.yaml definition procedure

### DIFF
--- a/modules/installation-osp-describing-cloud-parameters.adoc
+++ b/modules/installation-osp-describing-cloud-parameters.adoc
@@ -45,20 +45,6 @@ clouds:
 
 . If your {rh-openstack} installation uses self-signed certificate authority (CA) certificates for endpoint authentication:
 .. Copy the certificate authority file to your machine.
-.. Add the machine to the certificate authority trust bundle:
-+
-[source,terminal]
-----
-$ sudo cp ca.crt.pem /etc/pki/ca-trust/source/anchors/
-----
-
-.. Update the trust bundle:
-+
-[source,terminal]
-----
-$ sudo update-ca-trust extract
-----
-
 .. Add the `cacerts` key to the `clouds.yaml` file. The value must be an absolute, non-root-accessible path to the CA certificate:
 +
 [source,yaml]


### PR DESCRIPTION
Context: https://bugzilla.redhat.com/show_bug.cgi?id=1989538

Preview: https://deploy-preview-35150--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-describing-cloud-parameters_installing-openstack-installer-custom