### PR TITLE
CNV-8578: Documenting CNV integration with Service Mesh

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2858,6 +2858,8 @@ Topics:
       File: virt-configuring-sriov-device-for-vms
     - Name: Configuring certificate rotation
       File: virt-configuring-certificate-rotation
+    - Name: Connecting virtual machines to a service mesh
+      File: virt-connecting-vm-to-service-mesh
     - Name: Defining an SR-IOV network
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network

--- a/modules/virt-adding-vm-to-service-mesh.adoc
+++ b/modules/virt-adding-vm-to-service-mesh.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.adoc
+
+[id="virt-adding-vm-to-service-mesh_{context}"]
+= Configuring a virtual machine for the service mesh
+
+To add a virtual machine (VM) workload to a service mesh, enable automatic sidecar injection in the VM configuration file by setting the `sidecar.istio.io/inject` annotation to `true`. Then expose your VM as a service to view your application in the mesh.
+
+
+.Procedure
+
+. Edit the VM configuration file to add the `sidecar.istio.io/inject: "true"` annotation.
++
+.Example configuration file
+[source,yaml]
+----
+  apiVersion: kubevirt.io/v1
+  kind: VirtualMachine
+  metadata:
+    labels:
+      kubevirt.io/vm: vm-istio
+    name: vm-istio
+  spec:
+    runStrategy: Always
+    template:
+      metadata:
+        labels:
+          kubevirt.io/vm: vm-istio
+          app: vm-istio <1>
+        annotations:
+          sidecar.istio.io/inject: "true" <2>
+      spec:
+        domain:
+          devices:
+            interfaces:
+            - name: default
+              masquerade: {} <3>
+            disks:
+            - disk:
+                bus: virtio
+              name: containerdisk
+            - disk:
+                bus: virtio
+              name: cloudinitdisk
+          resources:
+            requests:
+              memory: 1024M
+        networks:
+        - name: default
+          pod: {}
+        terminationGracePeriodSeconds: 0
+        volumes:
+        - containerDisk:
+            image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
+          name: containerdisk
+----
+<1> The key/value pair (label) that must be matched to the service selector attribute.
+<2> The annotation to enable automatic sidecar injection.
+<3> The binding method (masquerade mode) for use with the default pod network.
++
+[NOTE]
+====
+To avoid port conflicts with sidecars, do not use ports used by Istio proxy for user workloads.
+====
+
+. Apply the VM configuration:
++
+[source,terminal]
+----
+$ oc apply -f <vm_name>.yaml <1>
+----
+<1> The name of the virtual machine YAML file.
+
+
+. Create a `Service` object to expose your VM to the service mesh.
++
+[source,yaml]
+----
+  apiVersion: v1
+  kind: Service
+  metadata:
+    name: vm-istio
+  spec:
+    selector:
+      app: vm-istio <1>
+    ports:
+      - port: 8080
+        name: http
+        protocol: TCP
+----
+<1> The service selector that determines the set of pods targeted by a service. This attribute corresponds to the `spec.metadata.labels` field in the VM configuration file. In the above example, the `Service` object named `vm-istio` targets TCP port 8080 on any pod with the label `app=vm-istio`.
+
+. Create the service:
++
+[source,terminal]
+----
+$ oc create -f <service_name>.yaml <1>
+----
+<1> The name of the service YAML file.

--- a/virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.adoc
+++ b/virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.adoc
@@ -1,0 +1,19 @@
+[id="virt-connecting-vm-to-service-mesh"]
+= Connecting virtual machines to a service mesh
+include::modules/virt-document-attributes.adoc[]
+:context: virt-connecting-vm-to-service-mesh
+
+toc::[]
+
+{VirtProductName} is now integrated with OpenShift Service Mesh. You can monitor, visualize, and control traffic between pods that run virtual machine workloads on the default pod network with IPv4.
+
+== Prerequisites
+
+* You must have xref:../../../service_mesh/v2x/installing-ossm.adoc#installing-ossm[installed the Service Mesh Operator] and xref:../../../service_mesh/v2x/ossm-create-smcp.adoc#ossm-create-smcp[deployed the service mesh control plane].
+
+* You must have added the namespace where the virtual machine is created to the xref:../../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-create-mesh[service mesh member roll].
+
+* You must use the `masquerade` binding method for the default pod network.
+
+
+include::modules/virt-adding-vm-to-service-mesh.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses [CNV-8578](https://issues.redhat.com/browse/CNV-8578)

Created new assembly with a procedure module to describe the process of adding VMs to a service mesh.

Applies to 4.9

Preview build: https://deploy-preview-35153--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.html

Requesting SME review from @phoracek @rhrazdil 