### PR TITLE
BZ#1972578 - Added warning to sample.yaml file platform=none

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -234,7 +234,15 @@ ifdef::ibm-z,ibm-z-kvm[IBM Z infrastructure.]
 ifdef::ibm-power[IBM Power Systems infrastructure.]
 ifdef::rhv[RHV infrastructure.]
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[WARNING]
+====
+If you set the platform to None, OpenShift will identify each node as a bare-metal node and the cluster will be a bare-metal cluster. This is the same as  xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[installing a cluster on any platform], and has the following limitations:
+
+. There will be no cluster provider so you must manually add each machine and there will be no node scaling capabilities.
+. The oVirt CSI driver will not be installed and there will be no CSI capabilities.
+====
+<11> Whether to  enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 endif::openshift-origin[]
 ifndef::restricted[]
 ifdef::ibm-z,ibm-z-kvm[]


### PR DESCRIPTION
For Version 4.7 and 4.8

Turns out this is needed in the 4.9 release as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1972578

Direct link to doc preview: https://deploy-preview-35166--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-restricted-network.html#installation-bare-metal-config-yaml_installing-rhv-restricted-network