### PR TITLE
Changed supported NIC device list to table

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -5,16 +5,50 @@
 [id="supported-devices_{context}"]
 = Supported devices
 
-{product-title} supports the following network interface controller (NIC) models:
+{product-title} supports the following network interface controllers:
 
-* Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
-* Intel XL710 40GbE SFP+ with vendor ID `0x8086` and device ID `0x1583`
-* Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
-* Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
-* Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT27800 Family [ConnectX-5] 100GbE with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT27700 Family [ConnectX-4] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1013`
-* Mellanox MT27800 Family [ConnectX-5] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT28880 Family [ConnectX-5 Ex] Ethernet controller, 100Gb/s, dual-port QSPF28 with vendor ID `0x15b3` and device ID `0x1019`
-* Mellanox MT28908 Family [ConnectX-6] VPI adapter card, 100Gb/s (HDR100, EDR IB), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`
-* Mellanox MT28908 Family [ConnectX-6] VPI adapter card, HDR200 IB (200Gb/s), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`
+.Supported network interface controllers
+[cols="1,2,1,1"]
+|===
+|Manufacturer |Model |Vendor ID | Device ID 
+
+|Intel
+|X710
+|8086
+|1572
+
+|Intel
+|XL710
+|8086
+|1583
+
+|Intel
+|XXV710
+|8086
+|158b
+
+|Mellanox
+|MT27700 Family [ConnectX&#8209;4]
+|15b3
+|1013
+
+|Mellanox
+|MT27710 Family [ConnectX&#8209;4{nbsp}Lx]
+|15b3
+|1015
+
+|Mellanox
+|MT27800 Family [ConnectX&#8209;5]
+|15b3
+|1017
+
+|Mellanox
+|MT28880 Family [ConnectX&#8209;5{nbsp}Ex]
+|15b3
+|1019
+
+|Mellanox
+|MT28908 Family [ConnectX&#8209;6]
+|15b3
+|101b
+|===


### PR DESCRIPTION
### [~~OSDOCS-2173~~](https://issues.redhat.com/browse/OSDOCS-2173)

~~This PR adds two new devices to our list of supported network interface controllers: Broadcom models BCM57414 and BCM57508.~~ [pushed to 4.10]

### General improvements 

- Made the device information easier to read by converting the list to a table.
- Removed the first two characters `0x` from the vendor and device IDs.
- Removed unnecessary product language.
- Combined items for NICs that were variants of the same device (that is, for list items that had the same vendor and device IDs)

### Reviews
* SME @zshi-redhat
* FYI @jboxman @mikemckiernan Any suggestions?

### Other
* applies to `main`, `enterprise-4.8`, `enterprise-4.9`
* [direct preview link](https://deploy-preview-35174--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov#supported-devices_about-sriov)