### PR TITLE
[WMCO-2.x]: Added a note to the WMCO 2.x release note set

### DIFF
--- a/windows_containers/windows-containers-release-notes-2-x.adoc
+++ b/windows_containers/windows-containers-release-notes-2-x.adoc
@@ -26,6 +26,11 @@ Issued:2021-07-08
 
 The WMCO 2.0.2 is now available with bug fixes. The components of the WMCO were released in link:https://access.redhat.com/errata/RHBA-2021:2671[RHBA-2021:2671].
 
+[IMPORTANT]
+====
+Users who are running a version of WMCO prior to 2.0.3 should first upgrade to WMCO 2.0.3 prior to upgrading to WMCO 3.0.0. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1983153[**BZ#1983153**])
+====
+
 [id="wmco-2-0-2-bug-fixes"]
 === Bug fixes
 * {product-title} 4.8 enables the `BoundServiceAccountTokenVolume` option by default. This option attaches the projected volumes to all of the pods. In addition, {product-title} 4.8 xref:../rest_api/objects/index.adoc#podsecuritycontext-core-v1[the `RunAsUser` option of the `SecurityContext`]. This combination results in Windows pods being stuck in the `ContainerCreating` status. To work around this issue, you should upgrade to WMCO 2.0.2 before upgrading your cluster to {product-title} 4.8. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975553[**BZ#1975553**])


### PR DESCRIPTION
This PR adds an important note to the 2.x release notes that users should upgrade to 2.0.3 prior to upgrading to WMCO 3.0.

OCP Version: 4.7

Preview: https://deploy-preview-35179--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-2-x.html#getting-support