### PR TITLE
BZ1980479: Removing problematic language

### DIFF
--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -131,7 +131,7 @@ documentation for details on how and when you can create additional resource ins
 [id="informational-resources_{context}"]
 === Informational Resources
 
-You use these resources to retrieve information about the cluster. Do not edit these resources directly.
+You use these resources to retrieve information about the cluster. Some configurations might require you to edit these resources directly.
 
 [cols="2a,2a,8a",options="header"]
 |===


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1980479

The statement below was removed because it seems to be an inaccurate statement.  There are multiple provided examples where we show you that you have an option to edit attributes of these files. 
>>> You use these resources to retrieve information about the cluster. Do not edit these resources directly.

for 4.7+

Preview: https://deploy-preview-35188--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks?utm_source=github&utm_campaign=bot_dp#informational-resources_post-install-cluster-tasks

Ready for QA: @zhaozhanqi 