### PR TITLE
BZ1973254: Added requested additional RBAC rules to Mirroring to the cluster internal registry

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -313,6 +313,26 @@ $ oc policy add-role-to-user system:image-puller system:serviceaccount:dpdk-test
 ----
 $ oc policy add-role-to-user system:image-puller system:serviceaccount:sriov-conformance-testing:default --namespace=cnftests
 ----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:xt-u32-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:vrf-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:gatekeeper-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:ovs-qos-testing:default --namespace=cnftests
+----
 
 . Retrieve the docker secret name and auth token:
 +


### PR DESCRIPTION
For 4.8+

https://bugzilla.redhat.com/show_bug.cgi?id=1973254

Preview: https://deploy-preview-35198--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes?utm_source=github&utm_campaign=bot_dp#cnf-performing-end-to-end-tests-disconnected-mode_cnf-master
>Mirroring to the cluster internal registry>#4 (last 4 code blocks)

Ready for QA: @xiuwang 