### PR TITLE
BZ1869798: Change in message to show only IPI cluster for 4.6

### DIFF
--- a/installing/install_config/configuring-private-cluster.adoc
+++ b/installing/install_config/configuring-private-cluster.adoc
@@ -7,10 +7,6 @@ toc::[]
 
 After you install an {product-title} version {product-version} cluster, you can set some of its core components to be private.
 
-[IMPORTANT]
-====
-You can configure this change for only clusters that use infrastructure that you provision to a cloud provider.
-====
 
 include::modules/private-clusters-about.adoc[leveloffset=+1]
 

--- a/modules/private-clusters-setting-api-private.adoc
+++ b/modules/private-clusters-setting-api-private.adoc
@@ -22,7 +22,14 @@ After you deploy a cluster to Amazon Web Services (AWS) or Microsoft Azure, you 
 
 .. Delete the `api.$clustername.$yourdomain` DNS entry in the public zone.
 
-. From your terminal, list the cluster machines:
+. Remove the external load balancers:
++
+[IMPORTANT]
+====
+You can run the following steps only for an installer-provisioned infrastructure (IPI) cluster. For a user-provisioned infrastructure (UPI) cluster, you must manually remove or disable the external load balancers.
+====
++
+.. From your terminal, list the cluster machines:
 +
 [source,terminal]
 ----
@@ -43,8 +50,8 @@ lk4pj-worker-us-east-1b-zgpzg   running   m4.xlarge   us-east-1   us-east-1b   1
 +
 You modify the control plane machines, which contain `master` in the name, in the following step.
 
-. Remove the external load balancer from each control plane machine.
-.. Edit a control plane `Machine` object to remove the reference to the external load balancer.
+.. Remove the external load balancer from each control plane machine.
+... Edit a control plane `Machine` object to remove the reference to the external load balancer:
 +
 [source,terminal]
 ----
@@ -52,7 +59,7 @@ $ oc edit machines -n openshift-machine-api <master_name> <1>
 ----
 <1> Specify the name of the control plane, or master, `Machine` object to modify.
 
-.. Remove the lines that describe the external load balancer, which are marked in the following example, and save and exit the object specification:
+... Remove the lines that describe the external load balancer, which are marked in the following example, and save and exit the object specification:
 +
 [source,yaml]
 ----
@@ -69,4 +76,4 @@ spec:
 ----
 <1> Delete this line.
 
-.. Repeat this process for each of the machines that contains `master` in the name.
+... Repeat this process for each of the machines that contains `master` in the name.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1869798

This fix is for 4.6 which is same as PR #35218 for 4.7,4.8 and 4.9

Preview: https://deploy-preview-35219--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-private-cluster.html#private-clusters-setting-api-private_configuring-private-cluster