### PR TITLE
OSDOCS-2267: Added note that PrivateLink is only supported on existing VPCs

### DIFF
--- a/modules/osd-aws-privatelink-architecture.adoc
+++ b/modules/osd-aws-privatelink-architecture.adoc
@@ -3,6 +3,11 @@
 
 The Red Hat managed infrastructure that creates AWS PrivateLink clusters is hosted on private subnets. The connection between Red Hat and the customer-provided infrastructure is created through PrivateLink VPC endpoints.
 
+[NOTE]
+====
+AWS PrivateLink is supported on existing VPCs only.
+====
+
 The following diagram shows a multiple availability zone (Multi-AZ) PrivateLink cluster deployed on private subnets.
 
 .Multi-AZ PrivateLink cluster deployed on private subnets

--- a/modules/rosa-aws-privatelink-create-cluster.adoc
+++ b/modules/rosa-aws-privatelink-create-cluster.adoc
@@ -2,6 +2,11 @@
 = Creating an AWS PrivateLink cluster
 
 You can create an AWS PrivateLink cluster using the `rosa` CLI.
++
+[NOTE]
+====
+AWS PrivateLink is supported on existing VPCs only.
+====
 
 .Prerequisites
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2267

Preview: https://deploy-preview-35225--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-architecture-models.html#osd-aws-privatelink-architecture.adoc_rosa-architecture-models

Needs merge to `dedicated-4` branch. No CP and no milestones.