### PR TITLE
[BZ1990497]: Removed a redundant URL from the allowlist.

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -123,15 +123,11 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 
 |`api.openshift.com`
 |443, 80
-|Required to check if updates are available for the cluster.
+|Required both for your cluster token and to check if updates are available for the cluster.
 
 |`art-rhcos-ci.s3.amazonaws.com`
 |443, 80
 |Required to download {op-system-first} images.
-
-|`api.openshift.com`
-|443, 80
-|Required for your cluster token.
 
 |`cloud.redhat.com/openshift`
 |443, 80


### PR DESCRIPTION
This PR removes a redundant URL from the Allowlist table. This URL was merged with the other instance.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1990497

Version: 4.6+

Preview: https://deploy-preview-35244--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall?utm_source=github&utm_campaign=bot_dp