### PR TITLE
Fix an indentation issue

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -213,7 +213,7 @@ Allocatable:
   pods:                       500 <1>
  ...
 ----
-<1> In this example, the `pods` parameter should report the value you set in the `KubeletConfig` object.
+<1> In this example, the `pods` parameter should report the value you set in the `KubletConfig` object.
 
 . Verify the change in the `KubeletConfig` object:
 +
@@ -222,7 +222,8 @@ Allocatable:
 $ oc get kubeletconfigs set-max-pods -o yaml
 ----
 +
-This should show a status of `True` and `type:Success`:
+
+This should show a status of `True` and `type:Success`, as shown in the following example:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Page was displaying a `+`, trying to fix the formatting/indentation issue in this module:
![image](https://user-images.githubusercontent.com/47002677/128389737-5ef8e71b-1dc4-4318-95c6-167dc62e16cc.png)

Applies to 4.7+
Not sure why adding a couple of line breaks seems to fix the problem but it does.

Here's the preview (scroll to the last step of the procedure to see impacted content):
https://deploy-preview-35250--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_