### PR TITLE
Updated 4.8 RNs to reflect Driver Toolkit's Tech Preview status

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1000,9 +1000,9 @@ For more information, see xref:../scalability_and_performance/cnf-create-perform
 The xref:../scalability_and_performance/psap-node-feature-discovery-operator.adoc#node-feature-discovery-operator[Node Feature Discovery (NFD) Operator] is now available. Use it to expose node-level information by orchestrating Node Feature Discovery, a Kubernetes add-on for detecting hardware features and system configuration.
 
 [id="ocp-4-8-driver-toolkit"]
-==== The Driver Toolkit
+==== The Driver Toolkit (Technology Preview)
 
-You can now use xref:../scalability_and_performance/psap-driver-toolkit.adoc#driver-toolkit[the Driver Toolkit] as a base image for driver containers so that you can enable special software and hardware devices on Kubernetes.
+You can now use xref:../scalability_and_performance/psap-driver-toolkit.adoc#driver-toolkit[the Driver Toolkit] as a base image for driver containers so that you can enable special software and hardware devices on Kubernetes. This is currently a Technology Preview feature.
 
 [id="ocp-4-8-backup-and-restore"]
 === Backup and restore
@@ -2224,6 +2224,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 |DEP
+
+|Driver Toolkit
+|-
+|-
+|TP
 
 |====
 


### PR DESCRIPTION
This change is in conjunction with https://github.com/openshift/openshift-docs/pull/35249

The original JIRA https://issues.redhat.com/browse/PSAP-424 never indicated that this feature was Tech Preview, but the 4.9 JIRA does https://issues.redhat.com/browse/PSAP-407. I confirmed with @ashishkamra that this feature should be labeled as Tech Preview for both 4.8 and 4.9.

cc @dagrayvid @vikram-redhat