### PR TITLE
BZ#1877064: nw latency guideline

### DIFF
--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -113,6 +113,11 @@ You must configure the network connectivity between machines to allow {product-t
 components to communicate. Each machine must be able to resolve the hostnames
 of all other machines in the cluster.
 
+For clusters that run general-purpose workloads such as databases, microservices, and web applications, a network latency up to 10 ms between all nodes provides acceptable performance.
+Specialized workloads could have stringent network latency requirements that are lower.
+Geographic distribution requirements and other constraints can add to network latency and reduce performance.
+For general-purpose clusters, the control plane nodes benefit from low latency that provides stability for etcd, quorum, and reduces etcd leader elections that are disruptive to the cluster.
+
 This section provides details about the ports that are required.
 
 ifndef::restricted,origin[]


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1877064

~~For conventional installations, 2ms is identified in the
foll KCS: https://access.redhat.com/articles/3220991~~

After some mailing list discussion, it seems that 10ms is often acceptable.
I tried to wordsmith that the 10ms is for general-purpose workloads and that
more exotic requirements can affect latency and reduce performance.

----
Preview link is the second para beneath [Network connectivity requirements](https://deploy-preview-35256--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-network-connectivity-user-infra_installing-bare-metal) in the bare-metal UPI documentation.