### PR TITLE
RHEL bump from 8.3 --> 8.4 in RNs (4.7 version)

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -66,9 +66,9 @@ On new clusters, LUKS configuration must use the native Ignition mechanism, as p
 With `bootupd`, {op-system} users now have access to a cross-distribution, system-agnostic OS update tool that manages firmware and boot updates in UEFI and legacy BIOS boot modes that run on modern architectures.
 
 [id="ocp-4-7-rhcos-rhel-8-3-packages"]
-==== {op-system} now supports RHEL 8.3
+==== {op-system} now uses {op-system-base} 8.4
 
-{op-system} is now using Red Hat Enterprise Linux (RHEL) 8.3 packages. {product-title} 4.6 and below will stay with RHEL 8.2 packages. This enables you to have the latest fixes, features, and enhancements, such as NetworkManager features, as well as the latest hardware support and driver updates.
+{op-system} now uses {op-system-base-full} 8.4 packages in {product-title} 4.7.24 and above. This enables you to have the latest fixes, features, and enhancements, such as NetworkManager features, as well as the latest hardware support and driver updates. {product-title} 4.6 is an Extended Update Support (EUS) release that will continue to use {op-system-base} 8.2 EUS packages for the entirety of its lifecycle.
 
 [id="ocp-4-7-rhcos-kdump"]
 ==== {op-system} now supports kdump service (Technology Preview)


### PR DESCRIPTION
RHCOS got a bump from using RHEL 8.3 to RHEL 8.4. Currently, the OCP 4.7 RNs only point to 8.3. xref: http://mailman-int.corp.redhat.com/archives/coreos-devel/2021-August/msg00000.html

This PR updates this, and change management is also required.

Preview link:
https://deploy-preview-35261--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-rhcos-rhel-8-3-packages

Relates to https://github.com/openshift/openshift-docs/pull/35265
Change management email sent Aug. 5