### PR TITLE
RHEL bump from 8.3 --> 8.4 in RNs (4.8 version)

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -56,9 +56,9 @@ This release adds improvements related to the following components and concepts.
 === {op-system-first}
 
 [id="ocp-4-8-rhcos-rhel-8-4-packages"]
-==== {op-system} now supports RHEL 8.4
+==== {op-system} now uses {op-system-base} 8.4
 
-{op-system} is now using {op-system-base-full} 8.4 packages. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates. {product-title} 4.7 is currently using {op-system-base} 8.3 packages and will upgrade to {op-system-base} 8.4 in a future update. {product-title} 4.6 is an Extended Update Support (EUS) release that will continue to use {op-system-base} 8.2 EUS packages for the entirety of its lifecycle.
+{op-system} now uses {op-system-base-full} 8.4 packages in {product-title} 4.8, as well as in {product-title} 4.7.24 and above. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates. {product-title} 4.6 is an Extended Update Support (EUS) release that will continue to use {op-system-base} 8.2 EUS packages for the entirety of its lifecycle.
 
 [id="ocp-4-8-stream-metadata"]
 ==== Using stream metadata for improved boot image automation


### PR DESCRIPTION
RHCOS got a bump from using RHEL 8.3 to RHEL 8.4. Currently, the OCP 4.8 RNs state that 4.8 is using RHEL 8.3. 
xref: http://mailman-int.corp.redhat.com/archives/coreos-devel/2021-August/msg00000.html

This PR updates this, and change management is also required.

Preview link:
https://deploy-preview-35265--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-rhcos-rhel-8-4-packages

Relates to https://github.com/openshift/openshift-docs/pull/35261
Change management email sent Aug. 5