### PR TITLE
virt: probe examples: replace registryDisk

### DIFF
--- a/modules/virt-define-http-liveness-probe.adoc
+++ b/modules/virt-define-http-liveness-probe.adoc
@@ -55,7 +55,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - name: containerdisk
-    registryDisk:
+    containerDisk:
       image: kubevirt/fedora-cloud-registry-disk-demo
   - cloudInitNoCloud:
       userData: |-

--- a/modules/virt-define-readiness-probe.adoc
+++ b/modules/virt-define-readiness-probe.adoc
@@ -61,7 +61,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - name: containerdisk
-    registryDisk:
+    containerDisk:
       image: kubevirt/fedora-cloud-registry-disk-demo
   - cloudInitNoCloud:
       userData: |-

--- a/modules/virt-define-tcp-liveness-probe.adoc
+++ b/modules/virt-define-tcp-liveness-probe.adoc
@@ -55,7 +55,7 @@ spec:
   terminationGracePeriodSeconds: 0
   volumes:
   - name: containerdisk
-    registryDisk:
+    containerDisk:
       image: kubevirt/fedora-cloud-registry-disk-demo
   - cloudInitNoCloud:
       userData: |-


### PR DESCRIPTION
KubeVirt calls a disk that boots from data stored in a container
registry a `containerDisk`. Without this fix, the examples fail with

    The request is invalid: spec.volumes[0]: spec.volumes[0] must have exactly one source type set

Signed-off-by: Dan Kenigsberg <danken@redhat.com>

/cc @bgaydosrh please review