### PR TITLE
Refix format issue where indentation is not correct

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -222,12 +222,10 @@ Allocatable:
 $ oc get kubeletconfigs set-max-pods -o yaml
 ----
 +
-
 This should show a status of `True` and `type:Success`, as shown in the following example:
 +
 [source,yaml]
 ----
- ...
 spec:
   kubeletConfig:
     maxPods: 500
@@ -240,5 +238,4 @@ status:
     message: Success
     status: "True"
     type: Success
- ...
 ----


### PR DESCRIPTION
I noticed a `+` rendering in docs.openshift.com, so created https://github.com/openshift/openshift-docs/pull/35250 to fix the indentation. Rendered fine locally and in netlify preview, but when checking live docs after the PR, it is now showing 2 `+` symbols. 

This PR is another attempt to fix this issue, this time by removing the ellipses at the top and bottom of the spec sample.

Preview link:
https://deploy-preview-35270--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_