### PR TITLE
[enterprise-4.7] Refix format issue where indentation is not correct

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -228,14 +228,11 @@ Allocatable:
 ----
 $ oc get kubeletconfigs set-max-pods -o yaml
 ----
-
-This should show a `status: "True"` and `type:Success`:
 +
-
+This should show a `status: "True"` and `type:Success`:
 +
 [source,yaml]
 ----
- ...
 spec:
   kubeletConfig:
     maxPods: 500
@@ -248,5 +245,4 @@ status:
     message: Success
     status: "True"
     type: Success
- ...
 ----


### PR DESCRIPTION
Cherrypick of 2897b4525323d7d24eb72af3254be4cadea99176 | xref: https://github.com/openshift/openshift-docs/pull/35270