### PR TITLE
OSDOCS-2395: Graduate DPDK to GA

### DIFF
--- a/modules/nw-sriov-dpdk-example-intel.adoc
+++ b/modules/nw-sriov-dpdk-example-intel.adoc
@@ -66,17 +66,20 @@ metadata:
   namespace: openshift-sriov-network-operator
 spec:
   networkNamespace: <target_namespace>
-  ipam: "{}" <1>
+  ipam: |-
+# ... <1>
   vlan: <vlan>
   resourceName: intelnics
 ----
-<1> Specify an empty object `"{}"` for the ipam CNI plug-in. DPDK works in userspace mode and does not require an IP address.
+<1> Specify a configuration object for the ipam CNI plug-in as a YAML block scalar. The plug-in manages IP address assignment for the attachment definition.
 +
 [NOTE]
 =====
 See the `Configuring SR-IOV additional network` section for a detailed explanation on each option in `SriovNetwork`.
 =====
 +
+An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
+
 . Create the `SriovNetwork` object by running the following command:
 +
 [source,terminal]

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -70,7 +70,7 @@ metadata:
 spec:
   networkNamespace: <target_namespace>
   ipam: |- <1>
-    ...
+# ...
   vlan: <vlan>
   resourceName: mlxnics
 ----
@@ -80,6 +80,8 @@ spec:
 =====
 See the `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
 =====
++
+An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
 
 . Create the `SriovNetworkNodePolicy` object by running the following command:
 +

--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -4,7 +4,8 @@
 
 [id="example-vf-use-in-rdma-mode-mellanox_{context}"]
 = Using a virtual function in RDMA mode with a Mellanox NIC
-
+// Extract content for TP notice
+// tag::content[]
 RDMA over Converged Ethernet (RoCE) is the only supported mode when using RDMA
 on {product-title}.
 
@@ -73,7 +74,7 @@ metadata:
 spec:
   networkNamespace: <target_namespace>
   ipam: |- <1>
-    ...
+# ...
   vlan: <vlan>
   resourceName: mlxnics
 ----
@@ -83,6 +84,8 @@ spec:
 =====
 See the `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
 =====
++
+An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
 
 . Create the `SriovNetworkNodePolicy` object by running the following command:
 +
@@ -140,3 +143,4 @@ spec:
 ----
 $ oc create -f mlx-rdma-pod.yaml
 ----
+// end::content[]

--- a/networking/hardware_networks/using-dpdk-and-rdma.adoc
+++ b/networking/hardware_networks/using-dpdk-and-rdma.adoc
@@ -1,19 +1,32 @@
 [id="using-dpdk-and-rdma"]
-= Using virtual functions (VFs) with DPDK and RDMA modes
+= Using DPDK and RDMA
 include::modules/common-attributes.adoc[]
 :context: using-dpdk-and-rdma
 
 toc::[]
 
-You can use Single Root I/O Virtualization (SR-IOV) network hardware with the Data Plane Development Kit (DPDK) and with remote direct memory access (RDMA).
 
-:FeatureName: The Data Plane Development Kit (DPDK)
-include::modules/technology-preview.adoc[leveloffset=+0]
+The containerized Data Plane Development Kit (DPDK) application is supported on {product-title}. You can use Single Root I/O Virtualization (SR-IOV) network hardware with the Data Plane Development Kit (DPDK) and with remote direct memory access (RDMA).
+
+For information on supported devices, refer to xref:../../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
 include::modules/nw-sriov-dpdk-example-intel.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-dpdk-example-mellanox.adoc[leveloffset=+1]
 
-include::modules/nw-sriov-rdma-example-mellanox.adoc[leveloffset=+1]
+[id="example-vf-use-in-rdma-mode-mellanox_{context}"]
+== Using a virtual function in RDMA mode with a Mellanox NIC
+
+:FeatureName: RDMA over Converged Ethernet (RoCE)
+include::modules/technology-preview.adoc[leveloffset=+0]
+
+// Use a tag to skip header and include content only
+include::modules/nw-sriov-rdma-example-mellanox.adoc[tag=content]
+
+[id="{context}_additional_resources"]
+== Additional resources
+
+* xref:../../networking/hardware_networks/configuring-sriov-net-attach.adoc#configuring-sriov-net-attach[Configuring an SR-IOV Ethernet network attachment].
+* The xref:../../networking/hardware_networks/about-sriov.adoc#nw-sriov-app-netutil_about-sriov[app-netutil library], provides several API methods for gathering network information about a container's parent pod.
 
 :!FeatureName:


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2395

This PR reshuffles the TP notice so it only applies to RDMA and updates some callout descriptions.

Preview: https://deploy-preview-35276--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-dpdk-and-rdma