### PR TITLE
Fix kubelet typo again

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -213,7 +213,7 @@ Allocatable:
   pods:                       500 <1>
  ...
 ----
-<1> In this example, the `pods` parameter should report the value you set in the `KubletConfig` object.
+<1> In this example, the `pods` parameter should report the value you set in the `KubeletConfig` object.
 
 . Verify the change in the `KubeletConfig` object:
 +


### PR DESCRIPTION
While trying to fix a format rendering issue in this file and resolving merge conflicts, I must have inadvertently reverted a typo fix that @bergerhoffer made. This PR repairs that in 4.7+, where necessary (it might only exist on main, however).

Preview link (step 4b): https://deploy-preview-35277--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-machine-configuration-tasks