### PR TITLE
OSDOCS-2106: Updated namespace info for CodeReady Workspaces, and moves the AWS in…

### DIFF
--- a/adding_service_cluster/adding-service.adoc
+++ b/adding_service_cluster/adding-service.adoc
@@ -1,13 +1,21 @@
 include::modules/attributes-openshift-dedicated.adoc[]
 [id="adding-service"]
-= Adding services to a {product-title} cluster
+= Adding services to a cluster using the OCM console
 :context: adding-service
 
 toc::[]
 
-You can add services to your existing {product-title} cluster.
+ifdef::openshift-rosa[]
+== Prerequisites
+* For the Amazon CloudWatch service, you must first install the `cluster-logging-operator` using the `rosa` CLI.
+endif::[]
 
 include::modules/adding-service-existing.adoc[leveloffset=+1]
 include::modules/access-service.adoc[leveloffset=+1]
 include::modules/deleting-service.adoc[leveloffset=+1]
 include::modules/deleting-service-cli.adoc[leveloffset=+1]
+
+ifdef::openshift-rosa[]
+== Additional resources
+* For information about the `cluster-logging-operator` and the AWS CloudWatch log forwarding service, see xref:../logging/rosa-install-logging.adoc#rosa-install-logging[Install the logging add-on service]
+endif::[]

--- a/adding_service_cluster/available-services.adoc
+++ b/adding_service_cluster/available-services.adoc
@@ -5,7 +5,7 @@ include::modules/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Learn more about available services that can be added on to your {product-title} cluster.
+You can add services to your existing {product-title} cluster using the xref:../adding_service_cluster/adding-service.adoc#adding-service[OpenShift Cluster Manager console].
 
 include::modules/osd-rhoam.adoc[leveloffset=+1]
 include::modules/codeready-workspaces.adoc[leveloffset=+1]

--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -4,14 +4,11 @@ include::modules/attributes-openshift-dedicated.adoc[]
 :context: rosa-available-services
 
 
-Learn more about available services you can add on to your {product-title} (ROSA) cluster.
+You can add services to your existing {product-title} ROSA cluster using the xref:../adding_service_cluster/adding-service.adoc#adding-service[OpenShift Cluster Manager console].
 
-include::modules/osd-rhoam.adoc[leveloffset=+1]
+These services can also be installed xref:../rosa_cli/rosa-manage-objects-cli.adoc#rosa-managing-objects-cli[using the `rosa` CLI].
+
+
+include::modules/aws-cloudwatch.adoc[leveloffset=+1]
 include::modules/codeready-workspaces.adoc[leveloffset=+1]
-
-[NOTE]
-====
-You must first install the ROSA `cluster-logging-operator` using the `rosa` CLI before installing the AWS CloudWatch service through the OpenShift Cluster Manager (OCM) console.
-
-For more information, see xref:../logging/rosa-install-logging.adoc#rosa-install-logging[Install the logging add-on service] for information about the AWS CloudWatch log forwarding service.
-====
+include::modules/osd-rhoam.adoc[leveloffset=+1]

--- a/modules/aws-cloudwatch.adoc
+++ b/modules/aws-cloudwatch.adoc
@@ -1,0 +1,10 @@
+
+[id="aws-cloudwatch_{context}"]
+= AWS CloudWatch
+
+The AWS CloudWatch service is available as an add-on to your {product-title} cluster. AWS CloudWatch is a log forwarding solution that lets you view {product-title} logs in the AWS console.
+
+You must first install the `cluster-logging-operator` using the `rosa` CLI before installing the AWS CloudWatch service. The AWS CloudWatch add-on can be installed using either the `rosa` CLI or the OpenShift Cluster Manager (OCM). For more information, see link:https://docs.openshift.com/rosa/logging/rosa-install-logging.html#rosa-install-logging[Installing logging add-on services].
+
+.Additional resources
+* link:https://docs.aws.amazon.com/cloudwatch/?id=docs_gateway[Amazon CloudWatch] documentation

--- a/modules/codeready-workspaces.adoc
+++ b/modules/codeready-workspaces.adoc
@@ -4,6 +4,10 @@
 
 The Red Hat CodeReady Workspaces service is available as an add-on to your {product-title} cluster. CodeReady Workspaces is a developer tool that makes cloud-native development practical for teams, using Kubernetes and containers to provide any member of the development or IT team with a consistent, preconfigured development environment. Developers can create code, build, and test in containers running on Red Hat OpenShift.
 
-.Additional resources
+[NOTE]
+====
+When using this service with {product-title}, CodeReady Workspace can be deployed to any namespace except `openshift-workspaces`.
+====
 
-* For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/1.1/[Red Hat CodeReady Workspaces] documentation.
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.10/html/installation_guide/installing-codeready-workspaces_crw#creating-a-project-in-openshift-web-console_crw[Red Hat CodeReady Workspaces Operator] documentation

--- a/modules/osd-rhoam.adoc
+++ b/modules/osd-rhoam.adoc
@@ -8,5 +8,4 @@ The Red Hat OpenShift API Management service is available as an add-on to your {
 Red Hat OpenShift API Management includes an implementation of the Red Hat Single Sign-On to secure and protect your API and for API Management and not as a company-wide SSO solution.
 
 .Additional resources
-
-* For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management[Red Hat OpenShift API Management] documentation.
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management[Red Hat OpenShift API Management] documentation

--- a/modules/rosa-install-uninstall-addon.adoc
+++ b/modules/rosa-install-uninstall-addon.adoc
@@ -49,13 +49,18 @@ $ rosa install addon --cluster=<cluster_name> | <cluster_id> [arguments]
 |Automatically answers `yes` to confirm the operation.
 |===
 
-.Examples
+.Example
 Add the `codeready-workspaces` add-on installation to a cluster named `mycluster`.
 
 [source,terminal]
 ----
 $ rosa install addon --cluster=mycluster codeready-workspaces
 ----
+
+[NOTE]
+====
+After installing Red Hat CodeReady Workspace, it can be deployed to any namespace except `openshift-workspaces`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_codeready_workspaces/2.10/html/installation_guide/installing-codeready-workspaces_crw#creating-a-project-in-openshift-web-console_crw[Installing the Red Hat CodeReady Workspaces Operator].
+====
 
 [id="rosa-uninstall-addon_{context}"]
 == uninstall addon
@@ -98,7 +103,7 @@ $ rosa uninstall addon --cluster=<cluster_name> | <cluster_id> [arguments]
 |Automatically answers `yes` to confirm the operation.
 |===
 
-.Examples
+.Example
 Remove the `codeready-workspaces` add-on installation from a cluster named `mycluster`.
 
 [source,terminal]


### PR DESCRIPTION
…fo from the ROSA assembly to a module that can be shared by OSD later.

https://issues.redhat.com/browse/OSDOCS-2106

**Previews:**

- https://deploy-preview-35284--osdocs.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli?utm_source=github&utm_campaign=bot_dp#rosa-install-addon_rosa-managing-objects-cli

- https://deploy-preview-35284--osdocs.netlify.app/openshift-rosa/latest/adding_service_cluster/adding-service.html

- https://deploy-preview-35284--osdocs.netlify.app/openshift-rosa/latest/adding_service_cluster/rosa-available-services.html

- https://deploy-preview-35284--osdocs.netlify.app/openshift-dedicated/latest/adding_service_cluster/available-services.html


Merge to `dedicated-4` branch. No CP and no milestones.