### PR TITLE
OSDOCS-2225: Multiple egressIPs are load balanced with OVN-Kubernetes

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -65,7 +65,9 @@ When creating an `EgressIP` object, the following conditions apply to nodes that
 
 - An egress IP address is never assigned to more than one node at a time.
 - An egress IP address is equally balanced between available nodes that can host the egress IP address.
-- If the `spec.EgressIPs` array in an `EgressIP` object specifies more than one IP address, no node will ever host more than one of the specified addresses.
+- If the `spec.EgressIPs` array in an `EgressIP` object specifies more than one IP address, the following conditions apply:
+* No node will ever host more than one of the specified IP addresses.
+* Traffic is balanced roughly equally between the specified IP addresses for a given namespace.
 - If a node becomes unavailable, any egress IP addresses assigned to it are automatically reassigned, subject to the previously described conditions.
 
 When a pod matches the selector for multiple `EgressIP` objects, there is no guarantee which of the egress IP addresses that are specified in the `EgressIP` objects is assigned as the egress IP address for the pod.
@@ -80,7 +82,7 @@ image::nw-egress-ips-diagram.svg[Architectural diagram for the egress IP feature
 
 Both Node 1 and Node 3 are labeled with `k8s.ovn.org/egress-assignable: ""` and thus available for the assignment of egress IP addresses.
 
-The dashed lines in the diagram depict the traffic flow from pod1, pod2, and pod3 traveling through the pod network to egress the cluster from Node 1 and Node 3. When an external service receives traffic from any of the pods selected by the example `EgressIP` object, the source IP address is either `192.168.126.10` or `192.168.126.102`.
+The dashed lines in the diagram depict the traffic flow from pod1, pod2, and pod3 traveling through the pod network to egress the cluster from Node 1 and Node 3. When an external service receives traffic from any of the pods selected by the example `EgressIP` object, the source IP address is either `192.168.126.10` or `192.168.126.102`. The traffic is balanced roughly equally between these two nodes.
 
 The following resources from the diagram are illustrated in detail:
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2225

This highlights that traffic is now evenly balanced between IPs.

Preview: https://deploy-preview-35287--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-node-assignment_configuring-egress-ips-ovn