### PR TITLE
OSDOCS-2022: Added support for wildcard domains in Image CR

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -17,7 +17,7 @@ The `image.config.openshift.io/cluster` resource holds cluster-wide information 
 
 Every element of this list contains a location of the registry specified by the registry domain name.
 
-`domainName`: Specifies a domain name for the registry. In case the registry uses a non-standard `80` or `443` port, the port should be included in the domain name as well.
+`domainName`: Specifies a domain name for the registry. If the registry uses a non-standard `80` or `443` port, the port should be included in the domain name as well.
 
 `insecure`: Insecure indicates whether the registry is secure or insecure. By default, if not otherwise specified, the registry is assumed to be secure.
 
@@ -33,11 +33,11 @@ The namespace for this config map is `openshift-config`. The format of the confi
 |Contains configuration that determines how the container runtime should treat individual registries when accessing images for builds and
 pods. For instance, whether or not to allow insecure access. It does not contain configuration for the internal cluster registry.
 
-`insecureRegistries`: Registries which do not have a valid TLS certificate or only support HTTP connections. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`.
+`insecureRegistries`: Registries which do not have a valid TLS certificate or only support HTTP connections. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name. For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`.
 
-`blockedRegistries`: Registries for which image pull and push actions are denied. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are allowed.
+`blockedRegistries`: Registries for which image pull and push actions are denied. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name. For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are allowed. 
 
-`allowedRegistries`: Registries for which image pull and push actions are allowed. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are blocked.
+`allowedRegistries`: Registries for which image pull and push actions are allowed. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are blocked.
 
 `containerRuntimeSearchRegistries`: Registries for which image pull and push actions are allowed using image short names. All other registries are blocked.
 


### PR DESCRIPTION
This PR documents #RUN-1142, which adds support for wildcard entries in the Image CR.

* applies to `main` and `enterprise-4.9` 
* [direct preview link](https://deploy-preview-35288--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html)