### PR TITLE
MON-1756: Document excluding projects from user-workload monitoring

### DIFF
--- a/modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc
+++ b/modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * monitoring/enabling-monitoring-for-user-defined-projects.adoc
+
+[id="excluding-a-user-defined-project-from-monitoring_{context}"]
+= Excluding a user-defined project from monitoring
+
+Individual user-defined projects can be excluded from user workload monitoring. To do so, simply add the `openshift.io/user-monitoring` label to the project's namespace with a value of `false`.
+
+.Procedure
+
+. Add the label to the project namespace:
++
+[source,terminal]
+----
+$ oc label namespace my-project 'openshift.io/user-monitoring=false'
+----
++
+. To re-enable monitoring, remove the label from the namespace:
++
+[source,terminal]
+----
+$ oc label namespace my-project 'openshift.io/user-monitoring-'
+----
++
+[NOTE]
+====
+If there were any active monitoring targets for the project, it may take a few minutes for Prometheus to stop scraping them after adding the label.
+====

--- a/monitoring/enabling-monitoring-for-user-defined-projects.adoc
+++ b/monitoring/enabling-monitoring-for-user-defined-projects.adoc
@@ -32,6 +32,9 @@ include::modules/monitoring-granting-users-permission-to-configure-monitoring-fo
 // Accessing metrics from outside the cluster for custom applications
 include::modules/accessing-metrics-outside-cluster.adoc[leveloffset=+1]
 
+// Excluding a user-defined project from monitoring
+include::modules/monitoring-excluding-a-user-defined-project-from-monitoring.adoc[leveloffset=+1]
+
 // Disabling monitoring for user-defined projects
 include::modules/monitoring-disabling-monitoring-for-user-defined-projects.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Adds docs for [MON-1756](https://issues.redhat.com/browse/MON-1756) (https://github.com/openshift/cluster-monitoring-operator/pull/1312), which adds the ability to exclude namespaces from user-workload monitoring by adding a `openshift.io/user-monitoring` label with a value of `false` to the namespace.

Link the section in the preview: https://deploy-preview-35289--osdocs.netlify.app/openshift-enterprise/latest/monitoring/enabling-monitoring-for-user-defined-projects.html#excluding-a-user-defined-project-from-monitoring_enabling-monitoring-for-user-defined-projects

JIRA issues for docs: https://issues.redhat.com/browse/MON-1800

This is applies to OpenShift 4.9 and above.