### PR TITLE
TELCODOCS-250: D/S Docs & RN: KNIDEPLOY-4551, Worker deployment via virtualmedia on either provisioning/controlplane network

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -12,6 +12,8 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
-include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+2]
+include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
+
+include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+1]
 
 include::modules/ipi-install-provisioning-the-bare-metal-node.adoc[leveloffset=+1]

--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -1,0 +1,119 @@
+// This is included in the following assemblies:
+//
+// installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+
+[id="preparing-to-deploy-with-virtual-media-on-the-baremetal-network_{context}"]
+= Preparing to deploy with Virtual Media on the baremetal network
+
+If the `provisioning` network is enabled and you want to expand the cluster using Virtual Media on the `baremetal` network, use the following procedure.
+
+.Procedure
+
+. Edit the `provisioning` custom resource (CR) to enable deploying with Virtual Media on the `baremetal` network:
++
+[source,terminmal]
+----
+oc edit provisioning
+----
++
+[source,yaml]
+----
+  apiVersion: metal3.io/v1alpha1
+  kind: Provisioning
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:50Z"
+    finalizers:
+    - provisioning.metal3.io
+    generation: 8
+    name: provisioning-configuration
+    resourceVersion: "551591"
+    uid: f76e956f-24c6-4361-aa5b-feaf72c5b526
+  spec:
+    preProvisioningOSDownloadURLs: {}
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
+    provisioningIP: 172.22.0.3
+    provisioningInterface: enp1s0
+    provisioningNetwork: Managed
+    provisioningNetworkCIDR: 172.22.0.0/24
+    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.gz?sha256=c7dde5f96826c33c97b5a4ad34110212281916128ae11100956f400db3d5299e
+    virtualMediaViaExternalNetwork: true <1>
+  status:
+    generations:
+    - group: apps
+      hash: ""
+      lastGeneration: 7
+      name: metal3
+      namespace: openshift-machine-api
+      resource: deployments
+    - group: apps
+      hash: ""
+      lastGeneration: 1
+      name: metal3-image-cache
+      namespace: openshift-machine-api
+      resource: daemonsets
+    observedGeneration: 8
+    readyReplicas: 0
+----
++
+<1> Add `virtualMediaViaExternalNetwork: true` to the `provisioning` CR.
+
+
+. Edit the machineset to use the API VIP address:
++
+[source,terminal]
+----
+oc edit machineset
+----
++
+[source,yaml]
+----
+  apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:52Z"
+    generation: 11
+    labels:
+      machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+      machine.openshift.io/cluster-api-machine-role: worker
+      machine.openshift.io/cluster-api-machine-type: worker
+    name: ostest-hwmdt-worker-0
+    namespace: openshift-machine-api
+    resourceVersion: "551513"
+    uid: fad1c6e0-b9da-4d4a-8d73-286f78788931
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+        machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+          machine.openshift.io/cluster-api-machine-role: worker
+          machine.openshift.io/cluster-api-machine-type: worker
+          machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+      spec:
+        metadata: {}
+        providerSpec:
+          value:
+            apiVersion: baremetal.cluster.k8s.io/v1alpha1
+            hostSelector: {}
+            image:
+              checksum: http:/172.22.0.3:6181/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2/cached-rhcos-49.84.202107010027-0-openstack.x86_64.qcow2.md5sum <1>
+              url: http://172.22.0.3:6181/images/rhcos-49.84.202107010027-0-openstack.x86_64.qcow2/cached-rhcos-49.84.202107010027-0-openstack.x86_64.qcow2 <2>
+            kind: BareMetalMachineProviderSpec
+            metadata:
+              creationTimestamp: null
+            userData:
+              name: worker-user-data
+  status:
+    availableReplicas: 2
+    fullyLabeledReplicas: 2
+    observedGeneration: 11
+    readyReplicas: 2
+    replicas: 2
+----
++
+<1> Edit the `checksum` URL to use the API VIP address.
+<2> Edit the `url` URL to use the API VIP address.

--- a/modules/olm-operatorconditions-about.adoc
+++ b/modules/olm-operatorconditions-about.adoc
@@ -13,4 +13,4 @@ endif::[]
 
 As part of its role in managing the lifecycle of an Operator, Operator Lifecycle Manager (OLM) infers the state of an Operator from the state of Kubernetes resources that define the Operator. While this approach provides some level of assurance that an Operator is in a given state, there are many instances where an Operator might need to communicate information to OLM that could not be inferred otherwise. This information can then be used by OLM to better manage the lifecycle of the Operator.
 
-OLM provides a custom resource definition (CRD) called `OperatorCondition` that allows Operators to communicate conditions to OLM. There are a set of supported conditions that influence management of the Operator by OLM when present in the `Status.Conditions` array of an `OperatorCondition` resource.
+OLM provides a custom resource definition (CRD) called `OperatorCondition` that allows Operators to communicate conditions to OLM. There are a set of supported conditions that influence management of the Operator by OLM when present in the `Spec.Conditions` array of an `OperatorCondition` resource.

--- a/modules/olm-overriding-operatorconditions.adoc
+++ b/modules/olm-overriding-operatorconditions.adoc
@@ -5,7 +5,7 @@
 [id="olm-supported-operatorconditions_{context}"]
 = Overriding Operator conditions
 
-As a cluster administrator, you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Status.Conditions` array, allowing cluster administrators to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
+As a cluster administrator, you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Spec.Conditions` array, allowing cluster administrators to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
 
 For example, consider a known version of an Operator that always communicates that it is not upgradeable. In this instance, you might want to upgrade the Operator despite the Operator communicating that it is not upgradeable. This could be accomplished by overriding the Operator condition by adding the condition `type` and `status` to the `Spec.Overrides` array in the `OperatorCondition` resource.
 
@@ -38,7 +38,6 @@ spec:
     status: "True"
     reason: "upgradeIsSafe"
     message: "This is a known issue with the Operator where it always reports that it cannot be upgraded."
-status:
   conditions:
   - type: Upgradeable
     status: "False"

--- a/modules/olm-supported-operatorconditions.adoc
+++ b/modules/olm-supported-operatorconditions.adoc
@@ -23,7 +23,7 @@ kind: OperatorCondition
 metadata:
   name: my-operator
   namespace: operators
-status:
+spec:
   conditions:
   - type: Upgradeable <1>
     status: "False" <2>


### PR DESCRIPTION
Adds a procedure for expanding the cluster using Virtual Media on the baremetal network.

Fixes: [TELCODOCS-250](https://issues.redhat.com/browse/TELCODOCS-250)

See https://issues.redhat.com/browse/TELCODOCS-250 for additional details.

Preview URL: https://deploy-preview-35304--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
