### PR TITLE
OSDOCS-2225: Add release note for OVN-Kubernetes egress IP balancing

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -89,6 +89,12 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 [id="ocp-4-9-networking"]
 === Networking
 
+[id="ocp-4-9-ovn-kubernetes-egress-ips-balance"]
+==== OVN-Kubernetes cluster network provider egress IP feature balances across nodes
+
+The egress IP feature of OVN-Kubernetes now balances network traffic approximately equally across nodes for a given namespace, if that namespace is assigned multiple egress IP addresses. Each IP address must reside on a different node.
+For more information, refer to xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring egress IPs for a project] for OVN-Kubernetes.
+
 [id="ocp-4-9-sriov-dpdk-ga"]
 ==== SR-IOV containerized Data Plane Development Kit (DPDK) is GA
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2225

Preview: https://deploy-preview-35307--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-openshift-sdn-egress-ips-balance