### PR TITLE
OSDOCS-2304: Add back supported platforms for OVN-Kubernetes migration

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -7,6 +7,17 @@
 
 Migrating to the OVN-Kubernetes Container Network Interface (CNI) cluster network provider is a manual process that includes some downtime during which your cluster is unreachable. Although a rollback procedure is provided, the migration is intended to be a one-way process.
 
+
+A migration to the OVN-Kubernetes cluster network provider is supported on the following platforms:
+
+* Bare metal hardware
+* Amazon Web Services (AWS)
+* Google Cloud Platform (GCP)
+* Microsoft Azure
+* {rh-openstack-first}
+* {rh-virtualization-first}
+* VMware vSphere
+
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
 == Considerations for migrating to the OVN-Kubernetes network provider
 


### PR DESCRIPTION
Somehow this entire section went missing between 4.7 and 4.8.
This adds the section back along with RHV as a platform.
Drops mention that only installer-provisioned is supported.

What's really interesting is part of this happened here: https://github.com/openshift/openshift-docs/pull/33306
And here: https://github.com/openshift/openshift-docs/pull/31089

So where's that content now?

- https://issues.redhat.com/browse/OSDOCS-2304

Preview: https://deploy-preview-35310--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn