### PR TITLE
BZ1988324: Add note that egress firewall blocks API endpoints

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -37,6 +37,37 @@ ifdef::ovn[]
 - A protocol that is one of the following protocols: TCP, UDP, and SCTP
 endif::ovn[]
 
+[IMPORTANT]
+====
+If your egress firewall includes a deny rule for `0.0.0.0/0`, access to your {product-title} API servers is blocked.
+To ensure that pods can continue to access the {product-title} API servers, you must include the IP address range that the API servers listen on in your egress firewall rules, as in the following example:
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressFirewall
+metadata:
+  name: default
+  namespace: <namespace> <1>
+spec:
+  egress:
+  - to:
+      cidrSelector: <api_server_address_range> <2>
+    type: Allow
+# ...
+  - deny:
+      cidrSelector: 0.0.0.0/0 <3>
+    type: Deny
+----
+<1> The namespace for the egress firewall.
+<2> The IP address range that includes your {product-title} API servers.
+<3> A global deny rule prevents access to the {product-title} API servers.
+
+To find the IP address for your API servers, run `oc get ep kubernetes -n default`.
+
+For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1988324[BZ#1988324].
+====
+
 ifdef::openshift-sdn[]
 [IMPORTANT]
 ====
@@ -58,6 +89,9 @@ An egress firewall has the following limitations:
 
 * No project can have more than one {kind} object.
 
+ifdef::ovn[]
+* A maximum of one {kind} object with a maximum of 8,000 rules can be defined per project.
+endif::ovn[]
 ifdef::openshift-sdn[]
 * A maximum of one {kind} object with a maximum of 1,000 rules can be defined per project.
 


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1988324

This PR warns users about blocking the API server and offers a solution.

Preview: https://deploy-preview-35311--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html