### PR TITLE
OSDOCS-2285: Added AWS PrivateLink info to configure DNS forwarding.

### DIFF
--- a/modules/osd-aws-privatelink-about.adoc
+++ b/modules/osd-aws-privatelink-about.adoc
@@ -1,7 +1,6 @@
 [id="osd-aws-privatelink-about.adoc_{context}"]
-= Understanding PrivateLink
+= Understanding AWS PrivateLink
 
-A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink (PrivateLink) to manage and monitor a cluster in order to avoid all public ingress network traffic.
+A {product-title} cluster can be created without any requirements on public subnets, internet gateways, or network address translation (NAT) gateways. In this configuration, Red Hat uses AWS PrivateLink to manage and monitor a cluster in order to avoid all public ingress network traffic.
 
 For more information, see link:https://aws.amazon.com/privatelink/[AWS PrivateLink] on the AWS website.
-

--- a/modules/osd-aws-privatelink-architecture.adoc
+++ b/modules/osd-aws-privatelink-architecture.adoc
@@ -1,7 +1,7 @@
 [id="osd-aws-privatelink-architecture.adoc_{context}"]
-= PrivateLink architecture
+= AWS PrivateLink architecture
 
-The Red Hat managed infrastructure that creates AWS PrivateLink clusters is hosted on private subnets. The connection between Red Hat and the customer-provided infrastructure is created through PrivateLink VPC endpoints.
+The Red Hat managed infrastructure that creates AWS PrivateLink clusters is hosted on private subnets. The connection between Red Hat and the customer-provided infrastructure is created through AWS PrivateLink VPC endpoints.
 
 [NOTE]
 ====
@@ -10,13 +10,13 @@ AWS PrivateLink is supported on existing VPCs only.
 
 The following diagram shows a multiple availability zone (Multi-AZ) PrivateLink cluster deployed on private subnets.
 
-.Multi-AZ PrivateLink cluster deployed on private subnets
+.Multi-AZ AWS PrivateLink cluster deployed on private subnets
 
-image::156_OpenShift_ROSA_Arch_0621_privatelink.svg[Multi-AZ PrivateLink cluster deployed on private subnets]
+image::156_OpenShift_ROSA_Arch_0621_privatelink.svg[Multi-AZ AWS PrivateLink cluster deployed on private subnets]
 
 = AWS reference architectures
 
-AWS provides multiple reference architectures that can be useful to customers when planning how to set up a configuration that uses PrivateLink. Here are three examples:
+AWS provides multiple reference architectures that can be useful to customers when planning how to set up a configuration that uses AWS PrivateLink. Here are three examples:
 
 * VPC with a private subnet and AWS Site-to-Site VPN access.
 +

--- a/modules/osd-aws-privatelink-config-dns-forwarding.adoc
+++ b/modules/osd-aws-privatelink-config-dns-forwarding.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc
+
+[id="osd-aws-privatelink-config-dns-forwarding_{context}"]
+= Configuring AWS PrivateLink DNS forwarding
+
+With PrivateLink clusters, only a private hosted zone is created in Route53. With private-hosted zones, records within this zone are only resolvable from within the VPC it is assigned.
+For more information about private hosted zone, read here: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html
+
+.Prerequisites
+
+* your corporate network or other VPC has connectivity and has ports UDP/53 TCP/53 enabled across networks to allow for DNS queries
+
+.Procedure
+
+. In order to allow for records such as api.<cluster-domain>, and *.apps.<cluster-domain> to resolve outside the VPC, a Route53 Resolver Inbound Endpoint must be configured. To configure an inbound endpoint, refer to AWS documentation here: https://aws.amazon.com/premiumsupport/knowledge-center/route53-resolve-with-inbound-endpoint/
+
+. When configuring the inbound endpoint, select the VPC and private subnet(s) used during cluster installation.
+
+. Once the endpoints are operational and associated, use those IP addresses to configure your corporate network to forward DNS queries to these IP addresses for the top-level cluster-domain (eg. drow-pl-01.htno.p1.openshiftapps.com).
+
+. If forwarding DNS queries from one VPC to another, refer to the AWS documentation to configure forwarding rules: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-rules-managing.html
+If configuring your remote network DNS server, please refer to your specific documentation to configure selective DNS forwarding for the installed cluster domain.

--- a/modules/osd-aws-privatelink-config-dns-forwarding.adoc
+++ b/modules/osd-aws-privatelink-config-dns-forwarding.adoc
@@ -5,20 +5,23 @@
 [id="osd-aws-privatelink-config-dns-forwarding_{context}"]
 = Configuring AWS PrivateLink DNS forwarding
 
-With PrivateLink clusters, only a private hosted zone is created in Route53. With private-hosted zones, records within this zone are only resolvable from within the VPC it is assigned.
-For more information about private hosted zone, read here: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html
+With AWS PrivateLink clusters, only a private hosted zone is created in Route 53. With a private hosted zone, records within the zone are resolvable only from within the VPC to which it is assigned.
+For more information about private hosted zones, see link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/hosted-zones-private.html[AWS private hosted zones documentation].
 
 .Prerequisites
 
-* your corporate network or other VPC has connectivity and has ports UDP/53 TCP/53 enabled across networks to allow for DNS queries
+* Your corporate network or other VPC has connectivity
+* UDP port 53 and TCP port 53 ARE enabled across your networks to allow for DNS queries
+* You have created an AWS PrivateLink cluster using {product-title}
 
 .Procedure
 
-. In order to allow for records such as api.<cluster-domain>, and *.apps.<cluster-domain> to resolve outside the VPC, a Route53 Resolver Inbound Endpoint must be configured. To configure an inbound endpoint, refer to AWS documentation here: https://aws.amazon.com/premiumsupport/knowledge-center/route53-resolve-with-inbound-endpoint/
+. To allow for records such as `api.<cluster_domain>`` and ``*.apps.<cluster_domain>`` to resolve outside of the VPC, link:https://aws.amazon.com/premiumsupport/knowledge-center/route53-resolve-with-inbound-endpoint/[configure a Route 53 Resolver Inbound Endpoint].
 
-. When configuring the inbound endpoint, select the VPC and private subnet(s) used during cluster installation.
+. When you configure the inbound endpoint, select the VPC and private subnets that were used when you created the cluster.
 
-. Once the endpoints are operational and associated, use those IP addresses to configure your corporate network to forward DNS queries to these IP addresses for the top-level cluster-domain (eg. drow-pl-01.htno.p1.openshiftapps.com).
+. After the endpoints are operational and associated, configure your corporate network to forward DNS queries to those IP addresses for the top-level cluster domain, such as `drow-pl-01.htno.p1.openshiftapps.com`.
 
-. If forwarding DNS queries from one VPC to another, refer to the AWS documentation to configure forwarding rules: https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-rules-managing.html
-If configuring your remote network DNS server, please refer to your specific documentation to configure selective DNS forwarding for the installed cluster domain.
+. If you are forwarding DNS queries from one VPC to another VPC, link:https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resolver-rules-managing.html[configure forwarding rules].
+
+. If you are configuring your remote network DNS server, see your specific DNS server documentation to configure selective DNS forwarding for the installed cluster domain.

--- a/modules/osd-aws-privatelink-required-resources.adoc
+++ b/modules/osd-aws-privatelink-required-resources.adoc
@@ -1,7 +1,7 @@
 [id="osd-aws-privatelink-required-resources.adoc_{context}"]
-= Requirements for using PrivateLink clusters
+= Requirements for using AWS PrivateLink clusters
 
-For PrivateLink clusters, internet gateways, NAT gateways and public subnets are not required, but the private subnets must have internet connectivity provided in order to install required components. At least one single private subnet is required for Single-AZ clusters and at least 3 private subnets are required for Multi-AZ clusters. The following table shows the AWS resources that are required for a successful installation:
+For AWS PrivateLink clusters, internet gateways, NAT gateways and public subnets are not required, but the private subnets must have internet connectivity provided to install required components. At least one single private subnet is required for Single-AZ clusters and at least 3 private subnets are required for Multi-AZ clusters. The following table shows the AWS resources that are required for a successful installation:
 
 .Required AWS resources
 [cols="1a,2a,3a",options="header"]
@@ -14,12 +14,12 @@ For PrivateLink clusters, internet gateways, NAT gateways and public subnets are
 | Network access control
 |* AWS::EC2::NetworkAcl
 * AWS::EC2::NetworkAclEntry
-| 
+|
 
 You must allow access to the following ports:
 [cols="35%,65%",options="header"]
-!=== 
-!Port !Reason 
+!===
+!Port !Reason
 ! 80
 ! Inbound HTTP traffic
 ! 443
@@ -35,6 +35,6 @@ You must allow access to the following ports:
 |* AWS::EC2::Subnet
 * AWS::EC2::RouteTable
 * AWS::EC2::SubnetRouteTableAssociation
-| Your VPC must have private subnets in 1 availability zone for Single-AZ deployments or 3 availability zones for Multi-AZ deployments. 
+| Your VPC must have private subnets in 1 availability zone for Single-AZ deployments or 3 availability zones for Multi-AZ deployments.
 You must provide appropriate routes and route tables.
 |===

--- a/modules/rosa-aws-privatelink-create-cluster.adoc
+++ b/modules/rosa-aws-privatelink-create-cluster.adoc
@@ -2,7 +2,7 @@
 = Creating an AWS PrivateLink cluster
 
 You can create an AWS PrivateLink cluster using the `rosa` CLI.
-+
+
 [NOTE]
 ====
 AWS PrivateLink is supported on existing VPCs only.

--- a/rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc
+++ b/rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc
@@ -9,6 +9,7 @@ This document describes how to create a ROSA cluster using AWS PrivateLink. Alte
 
 include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-config-dns-forwarding.adoc[leveloffset=+1]
 include::modules/rosa-aws-privatelink-create-cluster.adoc[leveloffset=+1]
 
 == Next steps

--- a/rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc
+++ b/rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc
@@ -9,8 +9,8 @@ This document describes how to create a ROSA cluster using AWS PrivateLink. Alte
 
 include::modules/osd-aws-privatelink-about.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-required-resources.adoc[leveloffset=+1]
-include::modules/osd-aws-privatelink-config-dns-forwarding.adoc[leveloffset=+1]
 include::modules/rosa-aws-privatelink-create-cluster.adoc[leveloffset=+1]
+include::modules/osd-aws-privatelink-config-dns-forwarding.adoc[leveloffset=+1]
 
 == Next steps
 xref:../rosa_getting_started/rosa-config-identity-providers.adoc#rosa-config-identity-providers[Configure identity providers]


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/OSDOCS-2285

Previews: 

https://deploy-preview-35314--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-privatelink-creating-cluster?utm_source=github&utm_campaign=bot_dp#rosa-aws-privatelink-create-cluster.adoc_rosa-getting-started

https://deploy-preview-35314--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-architecture-models.html#osd-aws-privatelink-architecture.adoc_rosa-architecture-models

Merge to `dedicated-4` branch. No milestones and no CP needed.

