### PR TITLE
BZ#1886450: Added information for Keepalived router id check for RHV/VMware IPI

### DIFF
--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -56,6 +56,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+include::modules/keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installing-rhv-example-install-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -54,6 +54,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
+include::modules/keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 [IMPORTANT]

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -45,6 +45,8 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -37,6 +37,8 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -40,6 +40,8 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -38,6 +38,8 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::keepalived-limitation-for-ipi.adoc[leveloffset=+2]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -30,7 +30,6 @@ See the xref:../../architecture/architecture-installation.html#installation-proc
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the vSphere platform and the installation process of {product-title}. Use the user-provisioned infrastructure installation instructions as a guide; you are free to create the required resources through other methods.
 ====
 
-
 === Installer-provisioned infrastructure installation of {product-title} on vSphere
 
 Installer-provisioned infrastructure allows the installation program to pre-configure and automate the provisioning of resources required by {product-title}.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1249,6 +1249,11 @@ Additional {rh-virtualization} configuration parameters are described in the fol
 |Integer. Example: `3`
 |====
 
+[NOTE]
+====
+To avoid virtual router ID conflicts, see "Identifying virtual router conflicts".
+====
+
 [id="installation-configuration-parameters-additional-machine_{context}"]
 == Additional {rh-virtualization} parameters for machine pools
 

--- a/modules/keepalived-limitation-for-ipi.adoc
+++ b/modules/keepalived-limitation-for-ipi.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_rhv/installing-rhv-customizations.adoc
+// * installing/installing_rhv/installing-rhv-default.adoc
+[id="keepalived-limitation-for-ipi_{context}"]
+= Identifying virtual router conflicts
+
+The Openshift cluster Virtual IPs are managed using multicast (VRRPv2 or VRRPv3), and there is a limitation of 255 unique virtual routers per multicast domain. Each VIP has a virtual router-id associated with it based on the cluster name. Duplication of these ids can result in a conflict, preventing the Virtual IPs from being assigned to the node. Therefore, if you have multiple clusters using the same network, check to see which VIPs the installation will choose to avoid conflicts.
+
+[NOTE]
+====
+This procedure is only required if you have multiple clusters using the same network.
+====
+
+To discover the VIPs that will be chosen, you can use the `runtimecfg` utility.
+
+.Procedure
+
+. Identify the release being used by the installer:
++
+[source, terminal]
+----
+$ ./openshift-install version|grep 'release image'
+----
++
+.Example output
+[source, terminal]
+----
+release image registry.ci.openshift.org/ocp/release@sha256:9aa0dce0b119d1d3f284df2cd30394a23e2d97f4b3e3853503a655caf90219a5
+----
++
+. Display information about the release:
++
+[source, terminal]
+----
+$ oc adm release info --registry-config pull-secret.txt registry.ci.openshift.org/ocp/release@sha256:9aa0dce0b119d1d3f284df2cd30394a23e2d97f4b3e3853503a655caf90219a5 -o json | jq -r '.references.spec.tags[] | select(.name == "baremetal-runtimecfg") | .from.name'
+----
++
+.Example output
+[source, terminal]
+----
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b717191f780ebc5a9cce440993f51e0a2b6ef3eab3c450185996b4c79189506b
+----
++
++
+. Run the runtimecfg utility with the cluster name, in this example `cnf10`:
++
+[source, terminal]
+----
+$ podman run --authfile /<path>/<to>/<pull-secret> quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b717191f780ebc5a9cce440993f51e0a2b6ef3eab3c450185996b4c79189506b vr-ids cnf10
+----
++
+.Example output
+[source, terminal]
+----
+APIVirtualRouterID: 147
+DNSVirtualRouterID: 158
+IngressVirtualRouterID: 2
+----
++
+. Run the utility again using a different cluster name, in this example `cnf11`:
++
+[source, terminal]
+----
+$ podman run --authfile /<path>/<to>/<pull-secret> quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b717191f780ebc5a9cce440993f51e0a2b6ef3eab3c450185996b4c79189506b vr-ids cnf11
+----
++
+.Example output
+[source, terminal]
+----
+APIVirtualRouterID: 228
+DNSVirtualRouterID: 239
+IngressVirtualRouterID: 147
+----
+In the prevous example output, you can see that installing two clusters in the same multicast domain with names `cnf10` and `cnf11` will lead to a conflict with the `APIVirtualRouterID` and the `IngressVirtrualRouterID` IDs. To resolve this conflict, rename one of the clusters and repeat this procedure until the conflict is eliminated.
++
+[NOTE]
+====
+Be sure that none of the IDs are assigned to other independent Virtual Router Redundancy Protocol (VRRP) virtual routers running in the same broadcast domain.
+====


### PR DESCRIPTION
For ~4.6~ 4.8 to 4.10

https://bugzilla.redhat.com/show_bug.cgi?id=1886450

Direct links to preview changes:
https://deploy-preview-35316--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/preparing-to-install-on-rhv.html#keepalived-limitation-for-ipi_preparing-to-install-on-rhv

https://deploy-preview-35316--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html#keepalived-limitation-for-ipi_preparing-to-install-on-vsphere