### PR TITLE
OSDOCS-2409: Update name of role for SRE access to AWS

### DIFF
--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -46,7 +46,7 @@ Each of these access types has different levels of access to components:
 == SRE access to cloud infrastructure accounts
 Red Hat personnel do not access cloud infrastructure accounts in the course of routine {product-title} operations. For emergency troubleshooting purposes, Red Hat SRE have well-defined and auditable procedures to access cloud infrastructure accounts.
 
-In AWS, SREs generate a short-lived AWS access token for the `osdManagedAdminSRE` user using the AWS Security Token Service (STS). Access to the STS token is audit logged and traceable back to individual users. The `osdManagedAdminSRE` has the `AdministratorAccess` IAM policy attached.
+In AWS, SREs generate a short-lived AWS access token for the `BYOCAdminAccess` user using the AWS Security Token Service (STS). Access to the STS token is audit logged and traceable back to individual users. The `BYOCAdminAccess` has the `AdministratorAccess` IAM policy attached.
 
 In Google Cloud, SREs access resources after being authenticated against a Red Hat SAML identity provider (IDP). The IDP authorizes tokens that have time-to-live expirations. The issuance of the token is auditable by corporate Red Hat IT and linked back to an individual user.
 

--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -43,7 +43,7 @@ Each of these access types have different levels of access to components:
 == SRE access to AWS accounts
 Red Hat personnel do not access AWS accounts in the course of routine {product-title} operations. For emergency troubleshooting purposes, the SREs have well-defined and auditable procedures to access cloud infrastructure accounts.
 
-SREs generate a short-lived AWS access token for the `osdManagedAdminSRE` user using the AWS Security Token Service (STS). Access to the STS token is audit-logged and traceable back to individual users. The `osdManagedAdminSRE` user has the AdministratorAccess IAM policy attached.
+SREs generate a short-lived AWS access token for the `BYOCAdminAccess` user using the AWS Security Token Service (STS). Access to the STS token is audit-logged and traceable back to individual users. The `BYOCAdminAccess` user has the AdministratorAccess IAM policy attached.
 
 [id="rosa-policy-rh-access_{context}"]
 == Red Hat support access


### PR DESCRIPTION
For dedicated-4 branch. 

https://issues.redhat.com/browse/OSDOCS-2409

No QE/peer review required as this falls under the exception for Service Delivery policy docs.