### PR TITLE
CNV-12358: Bumping HCO version to 2.6.6

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.5
+:HCOVersion: 2.6.6
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
[CNV-12358](https://issues.redhat.com/browse/CNV-12358)

[Example](https://deploy-preview-35327--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-collecting-virt-data.html#gathering-data-specific-features_virt-collecting-virt-data) (must-gather command)

No CP

