### PR TITLE
Replaced some stock text and added notes for 4.6.42

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -2421,7 +2421,7 @@ For any {product-title} release, always review the instructions on xref:../updat
 
 Issued: 2020-10-27
 
-{product-title} release 4.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:4196[RHBA-2020:4196] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:4197[RHBA-2020:4197] advisory.
+{product-title} release 4.6 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2020:4196[RHBA-2020:4196] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:4197[RHBA-2020:4197] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2446,7 +2446,7 @@ An update for several images is now available for {product-title} 4.6. Details o
 
 Issued: 2020-11-09
 
-{product-title} release 4.6.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:4339[RHBA-2020:4339] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:4340[RHBA-2020:4340] advisory.
+{product-title} release 4.6.3 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2020:4339[RHBA-2020:4339] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:4340[RHBA-2020:4340] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2467,7 +2467,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2020-11-16
 
-{product-title} release 4.6.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:4987[RHBA-2020:4987] advisory. There are no RPM packages for this release.
+{product-title} release 4.6.4 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2020:4987[RHBA-2020:4987] advisory. There are no RPM packages for this release.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2483,7 +2483,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2020-11-30
 
-{product-title} release 4.6.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2020:5115[RHBA-2020:5115] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:5116[RHBA-2020:5116] advisory.
+{product-title} release 4.6.6 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2020:5115[RHBA-2020:5115] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2020:5116[RHBA-2020:5116] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2515,7 +2515,7 @@ An update for `golang` is now available for {product-title} 4.6. Details of the 
 
 Issued: 2020-12-14
 
-{product-title} release 4.6.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2020:5259[RHSA-2020:5259] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2020:5260[RHSA-2020:5260] advisory.
+{product-title} release 4.6.8 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2020:5259[RHSA-2020:5259] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2020:5260[RHSA-2020:5260] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2545,7 +2545,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 Issued: 2020-12-21
 
 {product-title} release 4.6.9, which includes a security update for `openshift-clients`,
-`openvswitch2.13`, and `python-sushy`, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2020:5614[RHSA-2020:5614] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2020:5615[RHSA-2020:5615] advisory.
+`openvswitch2.13`, and `python-sushy`, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2020:5614[RHSA-2020:5614] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2020:5615[RHSA-2020:5615] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2561,7 +2561,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-01-18
 
-{product-title} release 4.6.12, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0037[RHSA-2021:0037] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0038[RHSA-2021:0038] advisory.
+{product-title} release 4.6.12, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:0037[RHSA-2021:0037] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0038[RHSA-2021:0038] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2590,7 +2590,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-01-25
 
-{product-title} release 4.6.13, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0171[RHSA-2021:0171] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0172[RHSA-2021:0172] advisory.
+{product-title} release 4.6.13, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:0171[RHSA-2021:0171] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0172[RHSA-2021:0172] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2606,7 +2606,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-02-01
 
-{product-title} release 4.6.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0235[RHBA-2021:0235] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0237[RHBA-2021:0237] advisory.
+{product-title} release 4.6.15 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0235[RHBA-2021:0235] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0237[RHBA-2021:0237] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2622,7 +2622,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-02-08
 
-{product-title} release 4.6.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2021:0308[RHSA-2021:0308] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0309[RHBA-2021:0309] advisory.
+{product-title} release 4.6.16, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:0308[RHSA-2021:0308] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0309[RHBA-2021:0309] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2681,7 +2681,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-02-15
 
-{product-title} release 4.6.17, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0424[RHBA-2021:0424] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0423[RHSA-2021:0423] advisory.
+{product-title} release 4.6.17, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0424[RHBA-2021:0424] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0423[RHSA-2021:0423] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2697,7 +2697,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-02-22
 
-{product-title} release 4.6.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0510[RHBA-2021:0510] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0511[RHBA-2021:0511] advisory.
+{product-title} release 4.6.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0510[RHBA-2021:0510] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0511[RHBA-2021:0511] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2726,7 +2726,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-03-01
 
-{product-title} release 4.6.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0634[RHBA-2021:0634] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0633[RHBA-2021:0633] advisory.
+{product-title} release 4.6.19 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0634[RHBA-2021:0634] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0633[RHBA-2021:0633] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2742,7 +2742,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-03-09
 
-{product-title} release 4.6.20 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0674[RHBA-2021:0674] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0673[RHBA-2021:0673] advisory.
+{product-title} release 4.6.20 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0674[RHBA-2021:0674] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0673[RHBA-2021:0673] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2758,7 +2758,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-03-16
 
-{product-title} release 4.6.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0753[RHBA-2021:0753] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0750[RHBA-2021:0750] advisory.
+{product-title} release 4.6.21 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0753[RHBA-2021:0753] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0750[RHBA-2021:0750] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2774,7 +2774,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-03-23
 
-{product-title} release 4.6.22 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0825[RHBA-2021:0825] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0826[RHBA-2021:0826] advisory.
+{product-title} release 4.6.22 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0825[RHBA-2021:0825] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:0826[RHBA-2021:0826] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2805,7 +2805,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-03-30
 
-{product-title} release 4.6.23, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:0952[RHBA-2021:0952] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0956[RHSA-2021:0956] advisory.
+{product-title} release 4.6.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:0952[RHBA-2021:0952] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:0956[RHSA-2021:0956] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2821,7 +2821,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-04-20
 
-{product-title} release 4.6.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1153[RHBA-2021:1153] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1154[RHBA-2021:1154] advisory.
+{product-title} release 4.6.25 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1153[RHBA-2021:1153] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1154[RHBA-2021:1154] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2892,7 +2892,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-04-27
 
-{product-title} release 4.6.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1232[RHBA-2021:1232] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1229[RHBA-2021:1229] advisory.
+{product-title} release 4.6.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1232[RHBA-2021:1232] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1229[RHBA-2021:1229] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2916,7 +2916,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-05-04
 
-{product-title} release 4.6.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1427[RHBA-2021:1427] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1428[RHBA-2021:1428] advisory.
+{product-title} release 4.6.27 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1427[RHBA-2021:1427] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1428[RHBA-2021:1428] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2932,7 +2932,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-05-12
 
-{product-title} release 4.6.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1487[RHBA-2021:1487] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1488[RHBA-2021:1488] advisory.
+{product-title} release 4.6.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1487[RHBA-2021:1487] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1488[RHBA-2021:1488] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2957,7 +2957,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-05-20
 
-{product-title} release 4.6.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1521[RHBA-2021:1521] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1522[RHBA-2021:1522] advisory.
+{product-title} release 4.6.29 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1521[RHBA-2021:1521] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:1522[RHBA-2021:1522] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2973,7 +2973,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-05-25
 
-{product-title} release 4.6.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:1565[RHBA-2021:1565] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1566[RHSA-2021:1566] advisory.
+{product-title} release 4.6.30, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:1565[RHBA-2021:1565] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:1566[RHSA-2021:1566] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2989,7 +2989,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-06-01
 
-{product-title} release 4.6.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2100[RHBA-2021:2100] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2101[RHBA-2021:2101] advisory.
+{product-title} release 4.6.31 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2100[RHBA-2021:2100] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2101[RHBA-2021:2101] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3005,7 +3005,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-06-08
 
-{product-title} release 4.6.32 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2157[RHBA-2021:2157] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2158[RHBA-2021:2158] advisory.
+{product-title} release 4.6.32 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2157[RHBA-2021:2157] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2158[RHBA-2021:2158] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3032,7 +3032,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-06-14
 
-{product-title} release 4.6.34 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2267[RHBA-2021:2267] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2268[RHBA-2021:2268] advisory.
+{product-title} release 4.6.34 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2267[RHBA-2021:2267] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2268[RHBA-2021:2268] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3056,7 +3056,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-06-22
 
-{product-title} release 4.6.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2410[RHBA-2021:2410] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2407[RHBA-2021:2407] advisory.
+{product-title} release 4.6.35 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2410[RHBA-2021:2410] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2407[RHBA-2021:2407] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3091,7 +3091,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-06-29
 
-{product-title} release 4.6.36 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2498[RHBA-2021:2498] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2499[RHSA-2021:2499] advisory.
+{product-title} release 4.6.36 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2498[RHBA-2021:2498] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:2499[RHSA-2021:2499] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3107,7 +3107,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-07-13
 
-{product-title} release 4.6.38 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2641[RHBA-2021:2641] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2642[RHBA-2021:2642] advisory.
+{product-title} release 4.6.38 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2641[RHBA-2021:2641] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2642[RHBA-2021:2642] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3140,7 +3140,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-07-21
 
-{product-title} release 4.6.39 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2684[RHBA-2021:2684] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2685[RHBA-2021:2685] advisory.
+{product-title} release 4.6.39 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2684[RHBA-2021:2684] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2685[RHBA-2021:2685] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3163,7 +3163,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-07-28
 
-{product-title} release 4.6.40 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2767[RHBA-2021:2767] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2768[RHBA-2021:2768] advisory.
+{product-title} release 4.6.40 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2767[RHBA-2021:2767] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2768[RHBA-2021:2768] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3179,7 +3179,7 @@ To upgrade an existing {product-title} 4.6 cluster to this latest release, see x
 
 Issued: 2021-08-04
 
-{product-title} release 4.6.41 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2021:2886[RHBA-2021:2886] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2888[RHBA-2021:2888] advisory.
+{product-title} release 4.6.41 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:2886[RHBA-2021:2886] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2888[RHBA-2021:2888] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -3199,6 +3199,27 @@ Telemetry includes a new `openshift:build_by_strategy:sum` gauge metric, which s
 * Previously, when starting a single-stack IPv6 cluster on nodes with IPv4 address, the kubelet might have used the IPv4 IP instead of the IPv6 IP for the node IP. Consequently, host network pods would have IPv4 IPs rather than IPv6 IPs, which made them unreachable from IPv6-only pods. This update fixes the node-IP-picking code, which results in the kubelet using the IPv6 IPs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942506[*BZ#1942506*])
 
 [id="ocp-4-6-41-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-6-42"]
+=== RHBA-2021:3008 - {product-title} 4.6.42 bug fix and security update
+
+Issued: 2021-08-11
+
+{product-title} release 4.6.42 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3008[RHBA-2021:3008] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3009[RHSA-2021:3009] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6249631[{product-title} 4.6.42 container image list]
+
+[id="ocp-4-6-42-bug-fixes"]
+==== Bug fixes
+
+* Previously, host network pods had IPv4 IPs making them unreachable from IPv6-only pods. This update fixes the `node-IP-picking code` so that nodes have IPv6 IPs. As a result, the host network pods are now reachable. (https://bugzilla.redhat.com/show_bug.cgi?id=1942506[*BZ1942506*])
+
+[id="ocp-4-6-42-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.6.42

- Applies to `enterprise-4.6`
- [Preview Link](https://deploy-preview-35343--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-42)