### PR TITLE
RHDEVDOCS-3221 Make the Builds API topics visible in the "Builds" are…

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1409,6 +1409,15 @@ Topics:
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
     Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  - Name: REST APIs
+    Dir: workloads_apis
+    Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+    Topics:
+    - Name: 'BuildConfig [build.openshift.io/v1]'
+      File: buildconfig-build-openshift-io-v1
+    - Name: 'Build [build.openshift.io/v1]'
+      File: build-build-openshift-io-v1
+
 - Name: Migrating from Jenkins to Tekton
   Dir: jenkins-tekton
   Distros: openshift-enterprise

--- a/cicd/builds/objects
+++ b/cicd/builds/objects
@@ -1,0 +1,1 @@
+../../rest_api/objects/

--- a/cicd/builds/workloads_apis
+++ b/cicd/builds/workloads_apis
@@ -1,0 +1,1 @@
+../../rest_api/workloads_apis/


### PR DESCRIPTION
…a of the TOC

- Purpose: Make Build APIs visible in the Build TOC.
- Aligned team: Dev Tools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3221
- Direct link to doc preview: tbd
- SME review: @adambkaplan 
- QE review: @ tbd
- Peer review: @ 	tbd
- <All reviews complete. Please merge now>