### PR TITLE
BZ#1977897 Updated the instance type from m5a.10xlarge to m5a.12xlarge

### DIFF
--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -165,7 +165,7 @@ the CloudFormation template for the security group and roles.
 * `m5a.2xlarge`
 * `m5a.4xlarge`
 * `m5a.8xlarge`
-* `m5a.10xlarge`
+* `m5a.12xlarge`
 * `m5a.16xlarge`
 * `c4.2xlarge`
 * `c4.4xlarge`

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -123,7 +123,7 @@ the CloudFormation template for the security group and roles.
 * `m5a.2xlarge`
 * `m5a.4xlarge`
 * `m5a.8xlarge`
-* `m5a.10xlarge`
+* `m5a.12xlarge`
 * `m5a.16xlarge`
 * `c4.large`
 * `c4.xlarge`

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -119,7 +119,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
-|`m5a.10xlarge`
+|`m5a.12xlarge`
 |
 |x
 |x


### PR DESCRIPTION
This PR updates the value of an AWS instance type from the defunct `m5a.10xlarge` to `m5a.12xlarge`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1977897

Preview: https://deploy-preview-35359--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations