### PR TITLE
RHDEVDOCS-3090 1494416 - The logging_mux_memory_limit is different wi…

### DIFF
--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -1873,7 +1873,7 @@ TLS server cert subject.
 |500M
 
 | `openshift_logging_mux_memory_limit`
-|1Gi
+|2Gi
 
 | `openshift_logging_mux_default_namespaces`
 |The default is `mux-undefined`. The first value in the list is the namespace to


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-3.11 ONLY
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3090
- Direct link to doc preview: https://deploy-preview-35360--osdocs.netlify.app/openshift-enterprise/latest/install_config/aggregate_logging?utm_source=github&utm_campaign=bot_dp
- SME review: @jcantrill (approved)
- QE review: @anpingli (approved)
- Peer review: @rolfedh (approved)
- All reviews complete. Please merge now