### PR TITLE
OSDOCS-1837: Remove admonition that TLS 1.3 and  config are not supported in Ingress

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -92,18 +92,18 @@ If not set, the default value is based on the `apiservers.config.openshift.io/cl
 
 When using the `Old`, `Intermediate`, and `Modern` profile types, the effective profile configuration is subject to change between releases. For example, given a specification to use the `Intermediate` profile deployed on release `X.Y.Z`, an upgrade to release `X.Y.Z+1` may cause a new profile configuration to be applied to the Ingress Controller, resulting in a rollout.
 
-The minimum TLS version for Ingress Controllers is `1.1`, and the maximum TLS version is `1.2`.
-
-[IMPORTANT]
-====
-The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
-
-The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
-====
+The minimum TLS version for Ingress Controllers is `1.1`, and the maximum TLS version is `1.3`.
 
 [NOTE]
 ====
 Ciphers and the minimum TLS version of the configured security profile are reflected in the `TLSProfile` status.
+====
+
+[IMPORTANT]
+====
+The Ingress Controller supports using TLS `1.3` and the `Modern` profile in HAProxy.
+
+The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`.
 ====
 
 |`routeAdmission`

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -35,11 +35,6 @@ The `Intermediate` profile requires a minimum TLS version of 1.2.
 
 The `Modern` profile requires a minimum TLS version of 1.3.
 
-[IMPORTANT]
-====
-The `Modern` profile is currently not supported.
-====
-
 |`Custom`
 |This profile allows you to define the TLS version and ciphers to use.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/NE-472

TLS 1.3 is now supported in Ingress, so I have removed the admonition stating that it is not supported.

For 4.9

Preview: https://deploy-preview-35361--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#configuring-ingress-controller-tls

@miheer 