### PR TITLE
GitHub-31646: Fixed secret name and YAML

### DIFF
--- a/modules/gitops-configuring-argo-cd-oidc.adoc
+++ b/modules/gitops-configuring-argo-cd-oidc.adoc
@@ -1,6 +1,6 @@
 // Module is included in the following assemblies:
 //
-// * 
+// * cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
 
 [id="configuring-argo-cd-oidc_{context}"]
 = Configuring Argo CD OIDC
@@ -9,7 +9,7 @@ To configure Argo CD OpenID Connect (OIDC), you must generate your client secret
 
 .Prerequisites
 
-* You have obtained your client secret. 
+* You have obtained your client secret.
 
 .Procedure
 
@@ -25,18 +25,19 @@ $ echo -n '83083958-8ec6-47b0-a411-a8c55381fbd2' | base64
 .. Edit the secret and add the base64 value to an `oidc.keycloak.clientSecret` key:
 +
 [source,terminal]
----- 
-$ oc edit secret openshift-gitops-secret -n <namespace>
+----
+$ oc edit secret argocd-secret -n <namespace>
 ----
 +
 .Example YAML of the secret
 [source,yaml]
 ----
-yaml apiVersion: v1 
-kind: Secret 
-metadata: name: argocd-secret 
+apiVersion: v1
+kind: Secret
+metadata:
+  name: argocd-secret
 data:
-  oidc.keycloak.clientSecret: ODMwODM5NTgtOGVjNi00N2IwLWE0MTEtYThjNTUzODFmYmQy …
+  oidc.keycloak.clientSecret: ODMwODM5NTgtOGVjNi00N2IwLWE0MTEtYThjNTUzODFmYmQy
 ----
 
 . Edit the `argocd` custom resource and add the OIDC configuration to enable the Keycloak authentication:
@@ -74,7 +75,7 @@ spec:
     route:
       enabled: true
 ----
-<1> `issuer` must end with the correct realm name (in this example `myrealm`). 
+<1> `issuer` must end with the correct realm name (in this example `myrealm`).
 <2> `clientID` is the Client ID you configured in your Keycloak account.
-<3> `clientSecret` points to the right key you created in the argocd-secret secret. 
+<3> `clientSecret` points to the right key you created in the argocd-secret secret.
 <4> `requestedScopes` contains the groups claim if you did not add it to the Default scope.


### PR DESCRIPTION
Fixes #31646

Preview: https://deploy-preview-35366--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-on-openshift?utm_source=github&utm_campaign=bot_dp#configuring-argo-cd-oidc_configuring-sso-for-argo-cd-on-openshift