### PR TITLE
Change to sshAuthorizedKeys path

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco.adoc
@@ -11,11 +11,11 @@ When configuration changes are made by the Machine Config Operator (MCO), {op-sy
 ====
 The following modifications do not trigger a node reboot:
 
-* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node: 
+* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
 
-** Changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config.
+** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
-** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator. 
+** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
 * When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
 ====
@@ -26,4 +26,3 @@ To avoid unwanted disruptions, you can modify the machine config pool (MCP) to p
 ====
 Pausing a machine config pool stops all system reboot processes and all configuration changes from being applied.
 ====
-

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -47,12 +47,11 @@ To prevent the nodes from automatically rebooting after machine configuration ch
 
 The following modifications do not trigger a node reboot:
 
-* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node: 
+* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
 
-** Changes to the SSH key in the `spec.config.ignition.passwd.users.sshAuthorizedKeys` parameter of a machine config.
+** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
 * When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.
 ====
-


### PR DESCRIPTION
Per [#34406 (comment)](https://github.com/openshift/openshift-docs/pull/34406)

Targeted for release 4.8 and 4.9

Preview:
Understanding the MCO - https://deploy-preview-35368--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#understanding-machine-config-operator_control-plane
Disabling the MCO with auto-reboot - https://deploy-preview-35368--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues

@rioliu-rh - Kindly review the change. This is related to the linked PR above where this change was identified by you.