### PR TITLE
[BZ1969849]: cluster logging external add type requirement

### DIFF
--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -65,7 +65,7 @@ spec:
 <3> Specify a name for the output.
 <4> Specify the `elasticsearch` type.
 <5> Specify the URL and port of the external Elasticsearch instance as a valid absolute URL. You can use the `http` (insecure) or `https` (secure HTTP) protocol. If the cluster-wide proxy using the CIDR annotation is enabled, the output must be a server name or FQDN, not an IP Address.
-<6> If using an `https` prefix, you must specify the name of the secret required by the endpoint for TLS communication. The secret must exist in the `openshift-logging` project and must have keys of: *tls.crt*, *tls.key*, and *ca-bundle.crt* that point to the respective certificates that they represent.
+<6> If using an `https` prefix and the external Elasticsearch server is using a private CA or you enabled mutual Transport Layer Security (mTLS) to Fluentd, you must specify the name of the secret required by the endpoint for TLS communication. To trust the Elasticsearch private CA, you must specify the key *ca-bundle.crt*. To enable mTLS, you must specify keys: *ca-bundle.crt*, *tls.crt*, and *tls.key*. The secret must exist in the `openshift-logging` project and must be of type `opaque` or `generic`.
 <7> Optional: Specify a name for the pipeline.
 <8> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <9> Specify the output to use with that pipeline for forwarding the logs.


### PR DESCRIPTION
OCP versions: 4.7 and later
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1969849

Preview pages: [Forwarding logs to an external Elasticsearch instance](https://deploy-preview-35372--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-log-forward-es_cluster-logging-external)

@anpingli Can you QE review please? 

@rolfedh 
