### PR TITLE
Adding information about stopping MHC before updating a cluster

### DIFF
--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -29,6 +29,9 @@ Consider the timeouts carefully, accounting for workloads and requirements.
 
 To stop the check, remove the resource.
 
+For example, you should stop the check during the upgrade process because the nodes in the cluster might become temporarily unavailable. The `MachineHealthCheck` might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, remove any `MachineHealthCheck` resource that you have deployed before updating the cluster.
+However, a `MachineHealthCheck` resource that is deployed by default (such as `machine-api-termination-handler`) cannot be removed and will be recreated.
+
 [id="machine-health-checks-limitations_{context}"]
 == Limitations when deploying machine health checks
 

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -39,8 +39,14 @@ Only upgrading to a newer version is supported. Reverting or rolling back your c
 
 During the upgrade process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. The MCO then applies the new configuration and reboots the machine.
 
-If you use {op-system-base-full} machines as workers, the MCO does not update the kubelet because you must update the OpenShift API on the machines first. 
+If you use {op-system-base-full} machines as workers, the MCO does not update the kubelet because you must update the OpenShift API on the machines first.
 
 With the specification for the new version applied to the old kubelet, the {op-system-base} machine cannot return to the `Ready` state. You cannot complete the update until the machines are available. However, the maximum number of unavailable nodes is set to ensure that normal cluster operations can continue with that number of machines out of service.
 
 The OpenShift Update Service is composed of an Operator and one or more application instances.
+
+[NOTE]
+====
+During the upgrade process, nodes in the cluster might become temporarily unavailable. The `MachineHealthCheck` might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, remove any `MachineHealthCheck` resource that you have deployed before updating the cluster.
+However, a MachineHealthCheck resource that is deployed by default (such as `machine-api-termination-handler`) cannot be removed and will be recreated.
+====


### PR DESCRIPTION
[TELCODOCS-290](https://issues.redhat.com/browse/TELCODOCS-290): Added a information about stopping MachineHealthCheck before updating a cluster.

Applies to OpenShift version 4.8+

Preview links: 
- https://deploy-preview-35373--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-the-update-service.html#update-service-overview_understanding-the-update-service (added a note at the end of the topic)
- https://deploy-preview-35373--osdocs.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks.html#machine-health-checks-about_deploying-machine-health-checks (added the same content towards the end of the topic)