### PR TITLE
OSDOCS-621 - Adding 'Copy login command' note

### DIFF
--- a/modules/cli-logging-in.adoc
+++ b/modules/cli-logging-in.adoc
@@ -52,4 +52,9 @@ Welcome! See 'oc help' to get started.
 <2> Enter whether to use insecure connections.
 <3> Enter the user's password.
 
+[NOTE]
+====
+If you are logged in to the web console, you can generate an `oc login` command that includes your token and server information. You can use the command to log in to the {product-title} CLI without the interactive prompts. To generate the command, select *Copy login command* from the username drop-down menu at the top right of the web console.
+====
+
 You can now create a project or issue other commands for managing your cluster.


### PR DESCRIPTION
Applies to `main`, `enterprise-4.6`, `enterprise-4.7`, `enterprise-4.8` and `enterprise-4.9`.

This pull request relates to https://issues.redhat.com/browse/OSDOCS-621.

The preview is [here](https://deploy-preview-35385--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in_cli-developer-commands).