### PR TITLE
Fix an OL formatting error in contributor guide

### DIFF
--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -82,7 +82,7 @@ The following instructions describe how to install all the required tools to do
 live content editing on a Fedora Linux system.
 
 1. Install the _RubyGems_ package with `yum install rubygems`
-
++
 [NOTE]
 ====
 On certain systems, `yum` installs an older version of RubyGems that can cause issues. As an alternative, you can install RubyGems by using RVM. The following example is referenced from the link:https://rvm.io/rvm/install[RVM site]:


### PR DESCRIPTION
This PR adds a `+` between a list item and a note so that the OL numbering is correct.

FYI @vikram-redhat 