### PR TITLE
RHDEVDOCS-2623: Improve the steps for not having pending operations to…

### DIFF
--- a/modules/cluster-logging-manual-rollout-rolling.adoc
+++ b/modules/cluster-logging-manual-rollout-rolling.adoc
@@ -5,11 +5,9 @@
 [id="cluster-logging-manual-rollout-rolling_{context}"]
 = Performing an Elasticsearch rolling cluster restart
 
-Perform a rolling restart when you change the `elasticsearch` config map
-or any of the `elasticsearch-*` deployment configurations.
+Perform a rolling restart when you change the `elasticsearch` config map or any of the `elasticsearch-*` deployment configurations.
 
-Also, a rolling restart is recommended if the nodes on which an Elasticsearch pod
-runs requires a reboot.
+Also, a rolling restart is recommended if the nodes on which an Elasticsearch pod runs requires a reboot.
 
 .Prerequisites
 
@@ -32,6 +30,13 @@ $ oc project openshift-logging
 +
 ----
 $ oc get pods | grep elasticsearch-
+----
+
+. Scale down the Fluentd pods so they stop sending new logs to Elasticsearch:
++
+[source,terminal]
+----
+$ oc -n openshift-logging patch daemonset/logging-fluentd -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-infra-fluentd": "false"}}}}}'
 ----
 
 . Perform a shard synced flush using the {product-title} link:https://github.com/openshift/origin-aggregated-logging/tree/master/elasticsearch#es_util[*es_util*] tool to ensure there are no pending operations waiting to be written to disk prior to shutting down:
@@ -207,4 +212,11 @@ $ oc exec elasticsearch-cdm-5ceex6ts-1-dcd6c4c7c-jpw6 -c elasticsearch -- es_uti
     }
   }
 }
+----
+
+. Scale up the Fluentd pods so they send new logs to Elasticsearch.
++
+[source,terminal]
+----
+$ oc -n openshift-logging patch daemonset/logging-fluentd -p '{"spec":{"template":{"spec":{"nodeSelector":{"logging-infra-fluentd": "true"}}}}}'
 ----


### PR DESCRIPTION
… be written to disk in ES rollout

- Aligned team: Dev Tools
- For branches:  4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-2623
- Direct link to doc preview: https://deploy-preview-35399--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-log-store?utm_source=github&utm_campaign=bot_dp#cluster-logging-manual-rollout-rolling_cluster-logging-store
- Reporter review: @r2d2rnd 
- SME review: @periklis 
- QE review: @kabirbhartiRH 
- Peer review: @jc-berger 
- All reviews complete. Please merge now.