### PR TITLE
BZ1986952: Modifying proxy support requirement description when preparing a cluster for virt

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -37,7 +37,7 @@ Without an external monitoring system or a qualified human monitoring node healt
 
 * To deploy {VirtProductName} in a disconnected environment, you must xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[configure Operator Lifecycle Manager on restricted networks].
 
-* To use proxy with {VirtProductName}, you must xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager].
+* When using a disconnected cluster on a restricted network, you must xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager] to access the Red Hat-provided OperatorHub. Using a proxy allows the cluster to fetch the {VirtProductName} Operator.
 
 * If your cluster uses worker nodes from multiple CPU vendors, live migration failures can occur. For example, a virtual machine with an AMD CPU might attempt to live-migrate to a node with an Intel CPU and likely fail migration. To avoid this, label nodes with a vendor-specific label, such as `Vendor=Intel` or `Vendor=AMD`, and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
 


### PR DESCRIPTION
This PR addresses Bug 1986952 ( https://bugzilla.redhat.com/show_bug.cgi?id=1986952 ).

The bug is about updating the description of a requirement where a user needs to configure proxy support when preparing a cluster to use OpenShift Virtualization.

CP: 4.9

Preview: 6th solid bullet starting with "When using a disconnected cluster" in https://deploy-preview-35406--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt 