### PR TITLE
adds instructions and guidance for user to change channels using patch

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -132,5 +132,21 @@ ifndef::openshift-origin[]
 [discrete]
 == Switching between channels
 
-Your cluster is still supported if you change from the `stable-{product-version}` channel to the `fast-{product-version}` channel. Although you can switch to the `candidate-{product-version}` channel at any time, some releases in that channel might be unsupported release candidates. You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release. You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel, although if the current release was recently promoted to `fast-{product-version}` there can be a delay of up to a day for the release to be promoted to `stable-{product-version}`. If you change to a channel that does not include your current release, an alert displays and no updates can be recommended, but you can safely change back to your original channel at any point.
+A channel can be switched from the web console or through the `patch` command:
+
+----
+$ oc patch clusterversion version --type json -p '[{"op": "add", "path": "/spec/channel", "value": "<channel>”}]'
+----
+
+If you change to a channel that does not include your current release, an alert will display and no updates can be recommended, but you can safely change back to your original channel at any point.
+
+Changing your channel might impact the supportability of your cluster. The following conditions might apply:
+
+* Your cluster is still supported if you change from the `stable-{product-version}` channel to the `fast-{product-version}` channel.
+
+* You can switch to the `candidate-{product-version}` channel but, some releases for this channel might be unsupported.
+
+* You can switch from the `candidate-{product-version}` channel to the `fast-{product-version}` channel if your current release is a general availability release.
+
+* You can always switch from the `fast-{product-version}` channel to the `stable-{product-version}` channel. There is a  possible delay of up to a day for the release to be promoted to `stable-{product-version}` if the current release was recently promoted.
 endif::openshift-origin[]


### PR DESCRIPTION
[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=1860503)

- Applies to `enterprise-4.6` only
- [Preview link](https://deploy-preview-35410--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-between-minor.html#understanding-upgrade-channels_updating-cluster-between-minor)
- Switching between channels section