### PR TITLE
RHDEVDOCS-3180 Issue in ClusterLogForwarder custom resource sample

### DIFF
--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -51,14 +51,14 @@ spec:
      - default <10>
      parse: json <11>
      labels:
-       myLabel: myValue <12>
+       myLabel: "myValue" <12>
    - name: infrastructure-audit-logs <13>
      inputRefs:
      - infrastructure
      outputRefs:
      - elasticsearch-insecure
      labels:
-       logs: audit-infra
+       logs: "audit-infra"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -71,12 +71,12 @@ spec:
 <9> Specify the output to use with that pipeline for forwarding the logs.
 <10> Optional: Specify the `default` output to send the logs to the internal Elasticsearch instance.
 <11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<12> Optional: One or more labels to add to the logs.
-<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: String. One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
-** Optional: One or more labels to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 
 . Create the CR object:
 +

--- a/modules/cluster-logging-collector-log-forward-fluentd.adoc
+++ b/modules/cluster-logging-collector-log-forward-fluentd.adoc
@@ -49,14 +49,14 @@ spec:
      - default <10>
      parse: json <11>
      labels:
-       clusterId: C1234 <12>
+       clusterId: "C1234" <12>
    - name: forward-to-fluentd-insecure <13>
      inputRefs:
      - infrastructure
      outputRefs:
      - fluentd-server-insecure
      labels:
-       clusterId: C1234
+       clusterId: "C1234"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -69,12 +69,12 @@ spec:
 <9> Specify the output to use  with that pipeline for forwarding the logs.
 <10> Optional. Specify the `default` output to forward logs to the internal Elasticsearch instance.
 <11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<12> Optional. One or more labels to add to the logs.
-<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: String. One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
-** Optional: One or more labels to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 
 . Create the CR object:
 +

--- a/modules/cluster-logging-collector-log-forward-kafka.adoc
+++ b/modules/cluster-logging-collector-log-forward-kafka.adoc
@@ -43,14 +43,14 @@ spec:
      - app-logs
      parse: json <11>
      labels:
-       logType: application <12>
+       logType: "application" <12>
    - name: infra-topic <13>
      inputRefs:
      - infrastructure
      outputRefs:
      - infra-logs
      labels:
-       logType: infra
+       logType: "infra"
    - name: audit-topic
      inputRefs:
      - audit
@@ -58,7 +58,7 @@ spec:
      - audit-logs
      - default <14>
      labels:
-       logType: audit
+       logType: "audit"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -71,12 +71,12 @@ spec:
 <9> Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 <10> Specify the output to use with that pipeline for forwarding the logs.
 <11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<12> Optional: One or more labels to add to the logs.
-<13> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<12> Optional: String. One or more labels to add to the logs.
+<13> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
-** Optional: One or more labels to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 <14> Optional: Specify `default` to forward logs to the internal Elasticsearch instance.
 
 . Optional: To forward a single output to multiple Kafka brokers, specify an array of Kafka brokers as shown in this example:

--- a/modules/cluster-logging-collector-log-forward-project.adoc
+++ b/modules/cluster-logging-collector-log-forward-project.adoc
@@ -46,8 +46,8 @@ spec:
      outputRefs: <10>
      - fluentd-server-insecure
      parse: json <11>
-     labels: <12>
-       project: my-project
+     labels:
+       project: "my-project" <12>
    - name: forward-to-fluentd-secure <13>
      inputRefs:
      - application
@@ -57,7 +57,7 @@ spec:
      - fluentd-server-secure
      - default
      labels:
-       clusterId: C1234
+       clusterId: "C1234"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -70,13 +70,13 @@ spec:
 <9> The `my-app-logs` input.
 <10> The name of the output to use.
 <11> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<12> Optional: A label to add to the logs.
+<12> Optional: String. One or more labels to add to the logs.
 <13> Configuration for a pipeline to send logs to other log aggregators.
 ** Optional: Specify a name for the pipeline.
 ** Specify which log types should be forwarded using that pipeline: `application,` `infrastructure`, or `audit`.
 ** Specify the output to use with that pipeline for forwarding the logs.
 ** Optional: Specify the `default` output to forward logs to the internal Elasticsearch instance.
-** Optional: One or more labels to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 
 . Create the CR object:
 +

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -61,8 +61,8 @@ spec:
      - default <11>
      parse: json <12>
      labels:
-       syslog: east <13>
-       secure: true
+       secure: "true" <13>
+       syslog: "east"
    - name: syslog-west <14>
      inputRefs:
      - infrastructure
@@ -70,7 +70,7 @@ spec:
      - rsyslog-west
      - default
      labels:
-       syslog: west
+       syslog: "west"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -84,12 +84,12 @@ spec:
 <10> Specify the output to use  with that pipeline for forwarding the logs.
 <11> Optional: Specify the `default` output to forward logs to the internal Elasticsearch instance.
 <12> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<13> Optional: One or more labels to add to the logs.
-<14> Optional: Configure multiple outputs to forward logs to other external log aggregtors of any supported type:
+<13> Optional: String. One or more labels to add to the logs. Quote values like "true" so they are recognized as string values, not as a boolean.
+<14> Optional: Configure multiple outputs to forward logs to other external log aggregators of any supported type:
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is the log type to forward using that pipeline: `application,` `infrastructure`, or `audit`.
 ** The `outputRefs` is the name of the output to use.
-** Optional: One or more labels to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 
 . Create the CR object:
 +

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -90,26 +90,26 @@ spec:
       - default
      parse: json <8>
      labels:
-       datacenter: east
-       secure: true
-   - name: infrastructure-logs <9>
+       secure: "true" <9>
+       datacenter: "east"
+   - name: infrastructure-logs <10>
      inputRefs:
       - infrastructure
      outputRefs:
       - elasticsearch-insecure
      labels:
-       datacenter: west
-   - name: my-app <10>
+       datacenter: "west"
+   - name: my-app <11>
      inputRefs:
       - my-app-logs
      outputRefs:
       - default
-   - inputRefs: <11>
+   - inputRefs: <12>
       - application
      outputRefs:
       - kafka-app
      labels:
-       datacenter: south
+       datacenter: "south"
 ----
 <1> The name of the `ClusterLogForwarder` CR must be `instance`.
 <2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
@@ -133,16 +133,17 @@ spec:
 ** The `outputRefs` is the name of the output to use, in this example `elasticsearch-secure` to forward to the secure Elasticsearch instance and `default` to forward to the internal Elasticsearch instance.
 ** Optional: Labels to add to the logs.
 <8> Optional: Forward structured JSON log entries as JSON objects in the `structured` field. The log entry must contain valid structured JSON; otherwise, OpenShift Logging removes the `structured` field and instead sends the log entry to the default index, `app-00000x`.
-<9> Configuration for a pipeline to send infrastructure logs to the insecure external Elasticsearch instance.
-<10> Configuration for a pipeline to send logs from the `my-project` project to the internal Elasticsearch instance.
+<9> Optional: String. One or more labels to add to the logs. Quote values like "true" so they are recognized as string values, not as a boolean.
+<10> Configuration for a pipeline to send infrastructure logs to the insecure external Elasticsearch instance.
+<11> Configuration for a pipeline to send logs from the `my-project` project to the internal Elasticsearch instance.
 ** Optional. A name to describe the pipeline.
 ** The `inputRefs` is a specific input: `my-app-logs`.
 ** The `outputRefs` is `default`.
-** Optional: A label to add to the logs.
-<11> Configuration for a pipeline to send logs to the Kafka broker, with no pipeline name:
+** Optional: String. One or more labels to add to the logs.
+<12> Configuration for a pipeline to send logs to the Kafka broker, with no pipeline name:
 ** The `inputRefs` is the log type, in this example `application`.
 ** The `outputRefs` is the name of the output to use.
-** Optional: A label to add to the logs.
+** Optional: String. One or more labels to add to the logs.
 
 [discrete]
 [id="cluster-logging-external-fluentd"]

--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -29,9 +29,9 @@ endif::[]
 
 To install the OpenShift Elasticsearch Operator and Red Hat OpenShift Logging Operator using the CLI:
 
-. Create a Namespace for the OpenShift Elasticsearch Operator.
+. Create a namespace for the OpenShift Elasticsearch Operator.
 
-.. Create a Namespace object YAML file (for example, `eo-namespace.yaml`) for the OpenShift Elasticsearch Operator:
+.. Create a namespace object YAML file (for example, `eo-namespace.yaml`) for the OpenShift Elasticsearch Operator:
 +
 [source,yaml]
 ----
@@ -44,17 +44,10 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true" <2>
 ----
-<1> You must specify the `openshift-operators-redhat` Namespace. To prevent
-possible conflicts with metrics, you should configure the Prometheus Cluster
-Monitoring stack to scrape metrics from the `openshift-operators-redhat`
-Namespace and not the `openshift-operators` Namespace. The `openshift-operators`
-Namespace might contain Community Operators, which are untrusted and could publish
-a metric with the same name as an {product-title} metric, which would cause
-conflicts.
-<2> You must specify this label as shown to ensure that cluster monitoring
-scrapes the `openshift-operators-redhat` Namespace.
+<1> You must specify the `openshift-operators-redhat` namespace. To prevent possible conflicts with metrics, you should configure the Prometheus Cluster Monitoring stack to scrape metrics from the `openshift-operators-redhat` namespace and not the `openshift-operators` namespace. The `openshift-operators` namespace might contain community Operators, which are untrusted and could publish a metric with the same name as an {product-title} metric, which would cause conflicts.
+<2> String. You must specify this label as shown to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
 
-.. Create the Namespace:
+.. Create the namespace:
 +
 [source,terminal]
 ----
@@ -68,9 +61,9 @@ For example:
 $ oc create -f eo-namespace.yaml
 ----
 
-. Create a Namespace for the Red Hat OpenShift Logging Operator:
+. Create a namespace for the Red Hat OpenShift Logging Operator:
 
-.. Create a Namespace object YAML file (for example, `olo-namespace.yaml`) for the Red Hat OpenShift Logging Operator:
+.. Create a namespace object YAML file (for example, `olo-namespace.yaml`) for the Red Hat OpenShift Logging Operator:
 +
 [source,yaml]
 ----
@@ -84,7 +77,7 @@ metadata:
     openshift.io/cluster-monitoring: "true"
 ----
 
-.. Create the Namespace:
+.. Create the namespace:
 +
 [source,terminal]
 ----
@@ -111,7 +104,7 @@ metadata:
   namespace: openshift-operators-redhat <1>
 spec: {}
 ----
-<1> You must specify the `openshift-operators-redhat` Namespace.
+<1> You must specify the `openshift-operators-redhat` namespace.
 
 .. Create an Operator Group object:
 +
@@ -128,7 +121,7 @@ $ oc create -f eo-og.yaml
 ----
 
 .. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
-subscribe a Namespace to the OpenShift Elasticsearch Operator.
+subscribe a namespace to the OpenShift Elasticsearch Operator.
 +
 .Example Subscription
 [source,yaml]
@@ -145,7 +138,7 @@ spec:
   sourceNamespace: "openshift-marketplace"
   name: "elasticsearch-operator"
 ----
-<1> You must specify the `openshift-operators-redhat` Namespace.
+<1> You must specify the `openshift-operators-redhat` namespace.
 <2> Specify `5.0`, `stable`, or `stable-5.<x>` as the channel. See the following note.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster,
 specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
@@ -172,7 +165,7 @@ For example:
 $ oc create -f eo-sub.yaml
 ----
 +
-The OpenShift Elasticsearch Operator is installed to the `openshift-operators-redhat` Namespace and copied to each project in the cluster.
+The OpenShift Elasticsearch Operator is installed to the `openshift-operators-redhat` namespace and copied to each project in the cluster.
 
 .. Verify the Operator installation:
 +
@@ -196,7 +189,7 @@ openshift-authentication                                elasticsearch-operator.5
 ...
 ----
 +
-There should be an OpenShift Elasticsearch Operator in each Namespace. The version number might be different than shown.
+There should be an OpenShift Elasticsearch Operator in each namespace. The version number might be different than shown.
 
 . Install the Red Hat OpenShift Logging Operator by creating the following objects:
 
@@ -213,7 +206,7 @@ spec:
   targetNamespaces:
   - openshift-logging <1>
 ----
-<1> You must specify the `openshift-logging` Namespace.
+<1> You must specify the `openshift-logging` namespace.
 
 .. Create an Operator Group object:
 +
@@ -230,7 +223,7 @@ $ oc create -f olo-og.yaml
 ----
 
 .. Create a Subscription object YAML file (for example, `olo-sub.yaml`) to
-subscribe a Namespace to the Red Hat OpenShift Logging Operator.
+subscribe a namespace to the Red Hat OpenShift Logging Operator.
 +
 [source,yaml]
 ----
@@ -245,7 +238,7 @@ spec:
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace
 ----
-<1> You must specify the `openshift-logging` Namespace.
+<1> You must specify the `openshift-logging` namespace.
 <2> Specify `5.0`, `stable`, or `stable-5.<x>` as the channel.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object you created when you configured the Operator Lifecycle Manager (OLM).
 +
@@ -261,11 +254,11 @@ For example:
 $ oc create -f olo-sub.yaml
 ----
 +
-The Red Hat OpenShift Logging Operator is installed to the `openshift-logging` Namespace.
+The Red Hat OpenShift Logging Operator is installed to the `openshift-logging` namespace.
 
 .. Verify the Operator installation.
 +
-There should be a Red Hat OpenShift Logging Operator in the `openshift-logging` Namespace. The Version number might be different than shown.
+There should be a Red Hat OpenShift Logging Operator in the `openshift-logging` namespace. The Version number might be different than shown.
 +
 [source,terminal]
 ----

--- a/modules/cluster-logging-deploy-multitenant.adoc
+++ b/modules/cluster-logging-deploy-multitenant.adoc
@@ -52,5 +52,5 @@ spec:
     - from:
       - namespaceSelector:
           matchLabels:
-            project: openshift-operators-redhat
+            project: "openshift-operators-redhat"
 ----

--- a/modules/cluster-logging-eventrouter-deploy.adoc
+++ b/modules/cluster-logging-eventrouter-deploy.adoc
@@ -69,22 +69,22 @@ objects:
       name: eventrouter
       namespace: ${NAMESPACE}
       labels:
-        component: eventrouter
-        logging-infra: eventrouter
-        provider: openshift
+        component: "eventrouter"
+        logging-infra: "eventrouter"
+        provider: "openshift"
     spec:
       selector:
         matchLabels:
-          component: eventrouter
-          logging-infra: eventrouter
-          provider: openshift
+          component: "eventrouter"
+          logging-infra: "eventrouter"
+          provider: "openshift"
       replicas: 1
       template:
         metadata:
           labels:
-            component: eventrouter
-            logging-infra: eventrouter
-            provider: openshift
+            component: "eventrouter"
+            logging-infra: "eventrouter"
+            provider: "openshift"
           name: eventrouter
         spec:
           serviceAccount: eventrouter

--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -31,7 +31,7 @@ version: 4.8.0
 metadata:
   name: 40-worker-custom-journald
   labels:
-    machineconfiguration.openshift.io/role: worker
+    machineconfiguration.openshift.io/role: "worker"
 storage:
   files:
   - path: /etc/systemd/journald.conf


### PR DESCRIPTION
The main purpose of this PR is to clearly show that `true` in `secure: "true"` must be quoted to ensure that OpenShift interprets it as a string. Otherwise, OpenShift treats an unquoted `true` as a boolean keyword, which causes errors. Non-keyword values do not need to be quoted because OpenShift treats them as a string anyway. But to encourage safe practices and consistency, I have updated all the logging topics to show quoted values and added notes that the values are of the String datatype.  


- Aligned team: Dev Tools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3180
- Direct link to doc preview: https://deploy-preview-35411--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forwarding-about_cluster-logging-external
- SME review: @jcantrill  
- QE review: @anpingli 
- Peer review: @JStickler 
- All reviews complete. Please merge now.