### PR TITLE
OSDOCS-2363: Updating link for Kubernetes 1.22 RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://kubernetes.io/docs/setup/release/notes/[Kubernetes 1.21] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md[Kubernetes 1.22] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.9.0 as the GA version and, instead, is releasing {product-title} 4.9.TBD as the GA version.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2363

Preview: https://deploy-preview-35414--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-about-this-release