### PR TITLE
[WIP] BZ1906375: Update oc adm policy add-scc-to-user for RBAC

### DIFF
--- a/modules/cli-administrator-security-policy.adoc
+++ b/modules/cli-administrator-security-policy.adoc
@@ -49,6 +49,7 @@ $ oc adm pod-network isolate-projects project1 project2
 
 Manage roles and policies on the cluster.
 
+
 .Example: Add the `edit` role to `user1` for all projects
 [source,terminal]
 ----
@@ -60,3 +61,8 @@ $ oc adm policy add-cluster-role-to-user edit user1
 ----
 $ oc adm policy add-scc-to-user privileged -z myserviceaccount
 ----
+
+[NOTE]
+====
+As of {product-title} 4.5, role-based access control (RBAC) objects are the preferred way to manage security context constraints (SCC). In the past, `oc adm policy add-scc-to-user` modified SCC fields directly. Now, the command creates role bindings to update the SCC to a service account.  For more information, see xref:../../authentication/managing-security-context-constraints.adoc#role-based-access-to-ssc_configuring-internal-oauth[role-based access to security context constraints].
+====


### PR DESCRIPTION
**Version:** 4.7 

**Issue:** https://bugzilla.redhat.com/show_bug.cgi?id=1906375

**Docs preview:** https://deploy-preview-35421--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/administrator-cli-commands?utm_source=github&utm_campaign=bot_dp#policy

**Summary**
- 4.6 bug fix: see # 
- 4.8+ bug fix: CLI command are automatically generated for 4.8+. For these versions, the `oc` command will have updated doctext
- This bug relates to [BZ1833558](https://bugzilla.redhat.com/show_bug.cgi?id=1833558).
- Customers were notified of this change in [RHNA-2020:2409](https://access.redhat.com/errata/RHBA-2020:2409), but the docs were not updated. RHNA-2020:2409 was included in the [OCP 4.5 release notes](https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-asynchronous-errata-updates)

**Review checklist**
- [ ] SME review
- [ ] Peer review
- [ ] QE review