### PR TITLE
OSDOCS-1981: Add ICSP note to OLM mirror proc

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -187,7 +187,7 @@ If you used the `--manifests-only` flag during the mirroring process and want to
 ====
 --
 
-. On a host with access to the disconnected cluster, create the `ImageContentSourcePolicy` object by running the following command to specify the `imageContentSourcePolicy.yaml` file in your manifests directory:
+. On a host with access to the disconnected cluster, create the `ImageContentSourcePolicy` (ICSP) object by running the following command to specify the `imageContentSourcePolicy.yaml` file in your manifests directory:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -195,7 +195,11 @@ $ oc create -f <path/to/manifests/dir>/imageContentSourcePolicy.yaml
 ----
 +
 where `<path/to/manifests/dir>` is the path to the manifests directory for your mirrored content.
-
++
+[NOTE]
+====
+Applying the ICSP causes all worker nodes in the cluster to restart. You must wait for this reboot process to finish cycling through each of your worker nodes before proceeding.
+====
 
 You can now create a `CatalogSource` object to reference your mirrored index image and Operator content.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1981

Add note about ICSP creation causing node reboots.

Preview:

* Added NOTE admonition to step 4 of ["Mirroring an Operator catalog"](https://deploy-preview-35425--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks#olm-mirror-catalog_olm-restricted-networks)