### PR TITLE
Fixed the upgrade instructions

### DIFF
--- a/modules/update-other-images.adoc
+++ b/modules/update-other-images.adoc
@@ -8,11 +8,6 @@
 [role="_abstract"]
 If you are upgrading {product-title} version between 3.0.44 and 3.0.54, you must update the Sensor and Collector images.
 
-[WARNING]
-====
-Updating images is only required when you are upgrading from {product-title} version between 3.0.44 and 3.0.54. Otherwise, skip the instructions in this section.
-====
-
 .Prerequisites
 
 * You must be using {product-title} version between 3.0.44 and 3.0.54.
@@ -24,12 +19,6 @@ If you are using Kubernetes, use `kubectl` instead of `oc` for the commands list
 
 .Procedure
 
-. Apply the patch for Sensor:
-+
-[source,terminal]
-----
-$ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"volumeMounts":[{"name":"cache","mountPath":"/var/cache/stackrox"}]}],"volumes":[{"name":"cache","emptyDir":{}}]}}}}'
-----
 . Update the Sensor image:
 +
 [source,terminal,subs=attributes+]
@@ -48,7 +37,25 @@ $ oc -n stackrox set image ds/collector compliance=registry.redhat.io/rh-acs/mai
 ----
 $ oc -n stackrox set image ds/collector collector=registry.redhat.io/rh-acs/collector:{collector-version}
 ----
+. Apply the patch for Sensor:
++
+[WARNING]
+====
+Applying the patch for Sensor is only required when you are upgrading from a {product-title} version that is between 3.0.44 and 3.0.54.
+Otherwise, skip this step.
+====
++
+[source,terminal]
+----
+$ oc -n stackrox patch deploy/sensor -p '{"spec":{"template":{"spec":{"containers":[{"name":"sensor","env":[{"name":"POD_NAMESPACE","valueFrom":{"fieldRef":{"fieldPath":"metadata.namespace"}}}],"volumeMounts":[{"name":"cache","mountPath":"/var/cache/stackrox"}]}],"volumes":[{"name":"cache","emptyDir":{}}]}}}}'
+----
 . Apply the following cluster role and cluster role binding:
++
+[WARNING]
+====
+Applying the cluster role and the cluster role binding is only required when you are upgrading from a {product-title} version that is between 3.0.44 and 3.0.54.
+Otherwise, skip this step.
+====
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Fixed the upgrade instructions for `update-other-images` module.

Preview: https://openshift-docs-git-upgrade-command-fix-gnelson.vercel.app/openshift-acs/master/upgrading/upgrading_roxctl/upgrade-from-44.html#update-other-images_upgrade-from-44