### PR TITLE
RHDEVDOCS-3202 Tracker for issue#35108 logging/cluster-logging-deploy…

### DIFF
--- a/modules/cluster-logging-deploy-multitenant.adoc
+++ b/modules/cluster-logging-deploy-multitenant.adoc
@@ -47,8 +47,11 @@ kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-openshift-operators-redhat
+  namespace: openshift-logging
 spec:
   ingress:
+    - from:
+      - podSelector: {}
     - from:
       - namespaceSelector:
           matchLabels:


### PR DESCRIPTION
…ing.adoc

- Purpose: Fix bug to allow traffic between projects when network isolation is enabled
- Aligned team: Dev Tools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3202
- Direct link to doc preview: https://deploy-preview-35429--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-deploying?utm_source=github&utm_campaign=bot_dp#cluster-logging-deploy-multitenant_cluster-logging-deploying
- SME review: @eranra 
- QE review: @anpingli 
- Peer review: @JStickler 
- All reviews complete. Please merge now.