### PR TITLE
OSDOCS-2174: subtask: remove IP failover

### DIFF
--- a/modules/nw-ipfailover-remove.adoc
+++ b/modules/nw-ipfailover-remove.adoc
@@ -1,0 +1,128 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-ipfailover.adoc
+
+[id="nw-ipfailover-remove_{context}"]
+= Removing IP failover
+
+When IP failover is initially configured, the worker nodes in the cluster are modified with an `iptables` rule that explicitly allows multicast packets on `224.0.0.18` for Keepalived. Because of the change to the nodes, removing IP failover requires running a job to remove the `iptables` rule and removing the virtual IP addresses used by Keepalived.
+
+.Procedure
+
+. Optional: Identify and delete any check and notify scripts that are stored as config maps:
+
+.. Identify whether any pods for IP failover use a config map as a volume:
++
+[source,terminal]
+----
+$ oc get pod -l ipfailover \
+  -o jsonpath="\
+{range .items[?(@.spec.volumes[*].configMap)]}
+{'Namespace: '}{.metadata.namespace}
+{'Pod:       '}{.metadata.name}
+{'Volumes that use config maps:'}
+{range .spec.volumes[?(@.configMap)]}  {'volume:    '}{.name}
+  {'configMap: '}{.configMap.name}{'\n'}{end}
+{end}"
+----
++
+.Example output
+----
+Namespace: default
+Pod:       keepalived-worker-59df45db9c-2x9mn
+Volumes that use config maps:
+  volume:    config-volume
+  configMap: mycustomcheck
+----
+
+.. If the preceding step provided the names of config maps that are used as volumes, delete the config maps:
++
+[source,terminal]
+----
+$ oc delete configmap <configmap_name>
+----
+
+. Identify an existing deployment for IP failover:
++
+[source,terminal]
+----
+$ oc get deployment -l ipfailover
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE   NAME         READY   UP-TO-DATE   AVAILABLE   AGE
+default     ipfailover   2/2     2            2           105d
+----
+
+. Delete the deployment:
++
+[source,terminal]
+----
+$ oc delete deployment <ipfailover_deployment_name>
+----
+
+. Remove the `ipfailover` service account:
++
+[source,terminal]
+----
+$ oc delete sa ipfailover
+----
+
+. Run a job that removes the IP tables rule that was added when IP failover was initially configured:
+
+.. Create a file such as `remove-ipfailover-job.yaml` with contents that are similar to the following example:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: batch/v1
+kind: Job
+metadata:
+  generateName: remove-ipfailover-
+  labels:
+    app: remove-ipfailover
+spec:
+  template:
+    metadata:
+      name: remove-ipfailover
+    spec:
+      containers:
+      - name: remove-ipfailover
+        image: quay.io/openshift/origin-keepalived-ipfailover:{product-version}
+        command: ["/var/lib/ipfailover/keepalived/remove-failover.sh"]
+      nodeSelector:
+        kubernetes.io/hostname: <host_name>  <.>
+      restartPolicy: Never
+----
+<.> Run the job for each node in your cluster that was configured for IP failover and replace the host name each time.
+
+.. Run the job:
++
+[source,terminal]
+----
+$ oc create -f remove-ipfailover-job.yaml
+----
++
+.Example output
+----
+job.batch/remove-ipfailover-2h8dm created
+----
+
+.Verification
+
+* Confirm that the job removed the initial configuration for IP failover.
++
+[source,terminal]
+----
+$ oc logs job/remove-ipfailover-2h8dm
+----
++
+.Example output
+[source,terminal]
+----
+remove-failover.sh: OpenShift IP Failover service terminating.
+  - Removing ip_vs module ...
+  - Cleaning up ...
+  - Releasing VIPs  (interface eth0) ...
+----

--- a/networking/configuring-ipfailover.adoc
+++ b/networking/configuring-ipfailover.adoc
@@ -66,6 +66,7 @@ include::modules/nw-ipfailover-configuring-more-than-254.adoc[leveloffset=+1]
 
 include::modules/nw-ipfailover-cluster-ha-ingress.adoc[leveloffset=+1]
 
+include::modules/nw-ipfailover-remove.adoc[leveloffset=+1]
 
 //== Additional resources
 //TCP connection


### PR DESCRIPTION
MetalLB and IP failover (keepalived) are
incompatible.  Technical info for this
commit originated in NE-572.

----
Preview the [Removing IP failover](https://deploy-preview-35436--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html#nw-ipfailover-remove_configuring-ipfailover) topic.