### PR TITLE
[WIN-C]: Updated the vSphere Template documentation.

### DIFF
--- a/modules/creating-the-vsphere-windows-vm-golden-image.adoc
+++ b/modules/creating-the-vsphere-windows-vm-golden-image.adoc
@@ -62,17 +62,17 @@ This entry ensures the following:
 
 .. The VMTools Windows service is running.
 
-. Pull all of the required Windows container base images needed for your applications. The images you pull
-are dependent on the Windows kernel you are using. See Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images[pulling Windows container base images] for more information.
+. Pull all of the required Windows container base images needed for your applications. The images you pull are dependent on the Windows kernel you are using. See Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/manage-containers/container-base-images[pulling Windows container base images] for more information.
 
-. Run the link:https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[Windows Sysprep tool] on the Windows VM:
+. Clone the Windows VM, and in this cloned VM, run the link:https://docs.microsoft.com/en-us/windows-hardware/manufacture/desktop/sysprep--generalize--a-windows-installation[Windows Sysprep tool] on the Windows VM:
 +
 [source,terminal]
 ----
 C:\> sysprep.exe /generalize /oobe /shutdown /unattend:<path_to_unattend.xml>
 ----
 +
-An example `unattend.xml` is provided, which maintains all the changes needed for the WMCO. For example, the `unattend.xml` file must ensure the Administrator's home directory stays intact with the SSH public key. You must customize the example to fit your needs.
+An example `unattend.xml` is provided, which maintains all the changes needed for the WMCO. For example, the `unattend.xml` file must ensure the Administrator's home directory stays intact with the SSH public key. You must customize the example ensuring that the `WindowsPassword` parameter uses the password for the Administrator user. It is recommended to
+follow the link:https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements[Microsoft best practices for choosing the password].
 +
 .Example `unattend.xml`
 [%collapsible]
@@ -105,7 +105,7 @@ An example `unattend.xml` is provided, which maintains all the changes needed fo
       <component xmlns:wcm="http://schemas.microsoft.com/WMIConfig/2002/State" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="Microsoft-Windows-Shell-Setup" processorArchitecture="amd64" publicKeyToken="31bf3856ad364e35" language="neutral" versionScope="nonSxS">
          <AutoLogon>
             <Password>
-               <Value>MyPassword</Value>
+               <Value>WindowsPassword</Value>
                <PlainText>true</PlainText>
             </Password>
             <Enabled>true</Enabled>
@@ -128,7 +128,7 @@ An example `unattend.xml` is provided, which maintains all the changes needed fo
          <TimeZone>Eastern Standard Time</TimeZone>
          <UserAccounts>
             <AdministratorPassword>
-               <Value>MyPassword</Value>
+               <Value>WindowsPassword</Value>
                <PlainText>true</PlainText>
             </AdministratorPassword>
             <LocalAccounts>
@@ -145,3 +145,17 @@ An example `unattend.xml` is provided, which maintains all the changes needed fo
 </unattend>
 ----
 ====
++
+[NOTE]
+====
+The value of the `ComputerName` property in the `unattend.xml` file must follow the link:https://kubernetes.io/docs/concepts/overview/working-with-objects/names[Kubernetes' names specification]. These specifications also apply to Guest OS customization performed on the resulting template while creating new VMs.
+====
+
+. Once the `Sysprep` tool has completed, the Windows virtual machine will power off.
++
+[IMPORTANT]
+====
+You must not use or power on this virtual machine anymore.
+====
+
+. Convert the Windows VM to link:https://docs.vmware.com/en/VMware-vSphere/6.0/com.vmware.vsphere.hostclient.doc/GUID-846238E4-A1E3-4A28-B230-33BDD1D57454.html[a template in vCenter].

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -130,7 +130,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ifndef::infra[]
 <2> Specify the infrastructure ID and node label.
 <3> Specify the node label to add.
-<4> Specify the vSphere VM network to deploy the machine set to.
+<4> Specify the vSphere VM network to deploy the machine set to. This VM network must be where other Linux works reside in the cluster.
 <5> Specify the vSphere VM clone of the template to use, such as `user-5ddjd-rhcos`.
 +
 [IMPORTANT]
@@ -149,7 +149,7 @@ ifdef::infra[]
 <2> Specify the infrastructure ID and `infra` node label.
 <3> Specify the `infra` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-<5> Specify the vSphere VM network to deploy the machine set to.
+<5> Specify the vSphere VM network to deploy the machine set to. This VM network must be where other Linux works reside in the cluster.
 <6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 <7> Specify the vCenter Datacenter to deploy the machine set on.
 <8> Specify the vCenter Datastore to deploy the machine set on.

--- a/modules/windows-machineset-vsphere.adoc
+++ b/modules/windows-machineset-vsphere.adoc
@@ -67,7 +67,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 <2> Specify the Windows machine set name. The machine set name cannot be more than 9 characters long, due to the way machine names are generated in vSphere.
 <3> Configure the machine set as a Windows machine.
 <4> Configure the Windows node as a compute machine.
-<5> Specify the vSphere VM network to deploy the machine set to.
+<5> Specify the vSphere VM network to deploy the machine set to. This VM network must be where other Linux works reside in the cluster.
 <6> Specify the full path of the Windows vSphere VM template to use, such as `/Datacenter/vm/ocp4-llplx/windows-golden-image`. The name must be unique.
 +
 [IMPORTANT]


### PR DESCRIPTION
This PR addresses two WINC updates to the vSphere template documentation: https://github.com/openshift/windows-machine-config-operator/pull/515 & https://github.com/openshift/windows-machine-config-operator/pull/545.

OCP: 4.7+

Preview:

1. https://deploy-preview-35444--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#creating-the-vsphere-windows-vm-golden-image_creating-windows-machineset-vsphere

2. https://deploy-preview-35444--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#windows-machineset-vsphere_creating-windows-machineset-vsphere