### PR TITLE
BZ1855793: Updated the output of HPA example

### DIFF
--- a/modules/nodes-pods-autoscaling-status-about.adoc
+++ b/modules/nodes-pods-autoscaling-status-about.adoc
@@ -82,7 +82,7 @@ Conditions:
   Type                  Status    Reason                    Message
   ----                  ------    ------                    -------
   AbleToScale           True     SucceededGetScale          the HPA controller was able to get the target's current scale
-  ScalingActive         False    FailedGetResourceMetric    the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from heapster
+  ScalingActive         False    FailedGetResourceMetric    the HPA was unable to compute the replica count: failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API
 ----
 
 The following is an example of a pod where the requested autoscaling was less than the required minimums:


### PR DESCRIPTION
**This PR is to address BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1855793
**Preview topic**: https://deploy-preview-35447--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling?utm_source=github&utm_campaign=bot_dp#nodes-pods-autoscaling-status-about_nodes-pods-autoscaling
**Exact section to be reviewed**: Understanding horizontal pod autoscaler status conditions by using the CLI > Example output for "The following is an example of a pod that could not obtain the needed metrics for scaling:" > Output "  _ScalingActive         False    FailedGetResourceMetric    the HPA was unable to compute the replica count: unable to get metrics for resource cpu: no metrics returned from heapster_" is changed to remove 'heapster' but also includes the latest output "_ScalingActive         False    FailedGetResourceMetric    the HPA was unable to compute the replica count: failed to get cpu utilization: unable to get metrics for resource cpu: no metrics returned from resource metrics API_"
**Labels**: enterprise-4.6, enterprise-4.7, enterprise-4.8, enterprise-4.9