### PR TITLE
OSDOCS-1788: Adding release notes for scheduler profiles GA

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -97,6 +97,19 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-9-nodes"]
 === Nodes
 
+[id="ocp-4-9-nodes-scheduler-profiles"]
+==== Scheduler profiles GA
+
+Scheduling pods using a scheduler profile is now generally available. This is a replacement for configuring a scheduler policy. The following scheduler profiles are available:
+
+* `LowNodeUtilization`: This profile attempts to spread pods evenly across nodes to get low resource usage per node.
+
+* `HighNodeUtilization`: This profile attempts to place as many pods as possible onto as few nodes as possible, to minimize node count with high usage per node.
+
+* `NoScoring`: This is a low-latency profile that strives for the quickest scheduling cycle by disabling all score plug-ins. This might sacrifice better scheduling decisions for faster ones.
+
+For more information, see xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[Scheduling pods using a scheduler profile].
+
 [id="ocp-4-9-logging"]
 === Red Hat OpenShift Logging
 
@@ -461,7 +474,7 @@ In the table below, features are marked with the following statuses:
 |Scheduler profiles
 |TP
 |TP
-|
+|GA
 
 |Non-preempting priority classes
 |TP


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1788

Preview: https://deploy-preview-35449--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-nodes-scheduler-profiles