### PR TITLE
OSDOCS-2428: Adding CVO conditions

### DIFF
--- a/modules/update-cvo-conditions.adoc
+++ b/modules/update-cvo-conditions.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * updating/understanding-update-service.adoc
+
+[id="update-cvo-conditions_{context}"]
+= Understanding CVO conditions
+
+The `ClusterVersion` object sets the conditions that describe the state of the cluster-version operator (CVO).
+
+Failing:: When `Failing` is set to True, the CVO fails to reconcile the cluster with the desired release image. In all cases, the impact on the cluster is that the dependent nodes in the manifest graph may not be reconciled. The graph may be flattened, in which case there are no dependent nodes.
++
+Most reconciliation errors result in `Failing=True`, even though `ClusterOperatorNotAvaliable` has special handling.
+
+NoDesiredImage:: The CVO has not been given a release image to reconcile. When NoDesiredImage is True, it is a CVO coding error. The `desiredUpdate` field returns you to the current CVO's release image.
+
+ClusterOperatorNotAvailable:: `ClusterOperatorNotAvailable` is set when the CVO fails to retrieve the ClusterOperator from the cluster or when the retrieved ClusterOperator does not satisfy the reconciliation conditions.
++
+Unlike most manifest-reconciliation failures, this error does not immediately result in `Failing=True`. Under some conditions during installs and updates, the CVO will treat this condition as a `Progressing=True` condition and give the operator up to forty minutes to level before reporting `Failing=True`.
+
+RetrievedUpdates:: When `RetrievedUpdates` is set to True, the CVO successfully retrieves updates. When the `RetrievedUpdates` is set to False, the cluster is not able to retrieve recommended updates. When a CVO is unable to retrieve recommended updates the `CannotRetrieveUpdates` alert displays the reason for not retrieving recommended updates.
+
+// When `RetrievedUpdates` is False, reason will be set to explain why, as discussed in the following subsections.
+// In all cases, the impact is that the cluster will not be able to retrieve recommended updates, so cluster admins will need to monitor for available updates on their own or risk falling behind on security or other bugfixes.
+// When CVO is unable to retrieve recommended updates the CannotRetrieveUpdates alert will fire containing the reason.
+// This alert will not fire when the reason updates cannot be retrieved is NoChannel.
+
+NoUpstream:: No upstream server has been set to retrieve updates.
++
+Set `spec.upstream` in `ClusterVersion` to point to a link:https://github.com/openshift/cincinnati/blob/master/docs/design/openshift.md[Cincinnati server] to receive updates.
+
+InvalidURI:: The configured upstream URI is not valid.
++
+Configure the upstream URI by setting `spec.upstream` in `ClusterVersion` to point to a valid link:https://github.com/openshift/cincinnati/blob/master/docs/design/openshift.md[Cincinnati URI].
+
+InvalidID:: The configured clusterID is not a valid UUID.
++
+To configure the clusterID, set `spec.clusterID` to a valid UUID. The UUID should be unique for each cluster. The default value is used report Telemetry and Insights. It may also be used by the CVO when making Cincinnati requests, so that Cincinnati can return update recommendations tailored to the specific cluster.
+
+NoArchitecture:: The set of architectures has not been configured. This is a result of a CVO coding error. There is no mitigation except to upgrade to a new release image with a fixed CVO.
+
+Impact:: The cluster is unable to retrieve recommended updates. This is a result of a CVO coding error. There is no mitigation except to upgrade to a new release image with a fixed CVO.
+
+NoCurrentVersion:: The cluster version does not have a semantic version assigned and is unable to calculate valid upgrades. This is the result of a release-image creation error. There is no mitigation except to upgrade to a new release image with a fixed CVO.
+
+NoChannel:: The update channel is not configured.
++
+To fix, set the channel to a valid value. For example, stable-4.8.
+
+InvalidCurrentVersion:: The cluster version does not have a semantic version assigned and is unable to calculate valid upgrades. This is the result of a release-image creation error. There is no mitigation except to upgrade to a new release image with a fixed CVO.
+
+InvalidRequest:: The CVO is unable to construct a valid Cincinnati request. This is a result of a CVO coding error. There is no mitigation except to upgrade to a new release image with a fixed CVO.
+
+RemoteFailed:: The CVO is unable to connect to the configured upstream. This may be caused by a misconfigured upstream URI. This may also be caused by networking or connectivity issue between the CVO and Cincinnati server. It may also be caused by a crashed or broken Cincinnati server.
+
+ResponseFailed:: The Cincinnati server has returned a non-200 response or the connection failed before the CVO read the full response body. This may be caused by the CVO failing to construct a valid request. It may also be caused by networking or connectivity issues. It may also be an overloaded or failing Cincinnati server.
+
+ResponseInvalid:: The Cincinnati server has returned a response that is not valid JSON or is otherwise corrupted. This may be caused by an unstable Cincinnati server. It may be caused by response corruption.
+
+VersionNotFound:: The reconciling cluster version is not found on the configured channel. This usually means that the configured channel is known to Cincinnati, but the version the cluster is currently applying is not found in that channel's graph.
++
+To fix, set the channel to a valid value. For example, stable-4.8.
++
+If this error occurs due to a forced update to a release that is not on any channel, you can fix by updating back to a release that occurs in a channel.
+
+Unknown:: This is a result of a CVO coding error. There is no mitigation except to upgrade to a new release image with a fixed CVO.

--- a/updating/understanding-the-update-service.adoc
+++ b/updating/understanding-the-update-service.adoc
@@ -14,4 +14,6 @@ If you are on a restricted network where disconnected clusters cannot access the
 
 include::modules/update-service-overview.adoc[leveloffset=+1]
 
+include::modules/update-cvo-conditions.adoc[leveloffset=+2]
+
 include::modules/unmanaged-operators.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to 4.7+
QE ack required.
SME ack required.
Preview Link: [Understanding CVO conditions](https://deploy-preview-35453--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-the-update-service?utm_source=github&utm_campaign=bot_dp#update-cvo-conditions_understanding-the-update-service)
JIRA Link: https://issues.redhat.com/browse/OSDOCS-2428