### PR TITLE
Bug 1983655: Add procedure to assign IPs for externalIP

### DIFF
--- a/modules/nw-assign-ip.adoc
+++ b/modules/nw-assign-ip.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+
+[id="nw-assign-ip_{context}"]
+= Assigning IP addresses
+
+To use IP address blocks defined by `autoAssignCIDRs` in {product-title}, you must configure the necessary IP address assignment and routing for your host network.
+
+.Prerequisites
+
+* You installed a cluster on bare metal infrastructure.
+* You installed the OpenShift CLI (`oc`).
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Edit the `network.config.openshift.io` YAML file:
++
+[source,terminal]
+----
+oc edit network.config.openshift.io cluster -o yaml
+----
++
+. Assign IP addresses to `externalIP`:
++
+.Example `network.config.openshift.io` YAML
++
+[source,yaml]
+----
+spec:
+  externalIP:
+    autoAssignCIDRs:
+    - 192.0.2.0/24
+    policy:
+      allowedCIDRs:
+      - 192.0.2.0/24
+----

--- a/modules/nw-example-configs-for-externalip.adoc
+++ b/modules/nw-example-configs-for-externalip.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+
+[id="nw-example-configs-for-externalip_{context}"]
+= Example configurations for External IP
+
+//Condense the example configs here?

--- a/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-externalip.adoc
@@ -15,9 +15,13 @@ This functionality is generally most useful for clusters installed on bare-metal
 
 include::modules/nw-externalip-about.adoc[leveloffset=+1]
 
+include::modules/nw-assign-ip.adoc[leveloffset=+1]
+
 include::modules/nw-externalip-object.adoc[leveloffset=+1]
 
 include::modules/nw-externalip-configuring.adoc[leveloffset=+1]
+
+//include::modules/nw-example-configs-for-externalip.adoc[leveloffset=+1]
 
 [id="configuring-externalip-next-steps"]
 == Next steps


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1983655

Adding labels for 4.7 - 4.9, may need to cherry pick back further. 

Build preview: https://deploy-preview-35454--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip?utm_source=github&utm_campaign=bot_dp#nw-assign-ip_configuring-externalip