### PR TITLE
OSDOCS-1485: Update supported objects in bundle

### DIFF
--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -50,12 +50,20 @@ etcd
 The following object types can also be optionally included in the `/manifests` directory of a bundle:
 
 .Supported optional object types
-* `Secret`
+* `ClusterRole`
+* `ClusterRoleBinding`
 * `ConfigMap`
-* `Service`
+* `ConsoleYamlSample`
 * `PodDisruptionBudget`
 * `PriorityClass`
-* `VerticalPodAutoScaler`
+* `PrometheusRule`
+* `Role`
+* `RoleBinding`
+* `Secret`
+* `Service`
+* `ServiceAccount`
+* `ServiceMonitor`
+* `VerticalPodAutoscaler`
 
 When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1485

Changes:

- Updated the list of supported optional objects that can be included in a bundle per https://olm.operatorframework.io/docs/tasks/creating-operator-manifests/#packaging-additional-objects-alongside-an-operator, which says this list is "supported as of OLM 0.16.0" (looks like OCP 4.6 was on OLM 0.16.1).
- Rearranged list in alphabetical order.

Preview: 

- Updated "Supported optional object types" list under [Additionally supported objects](https://deploy-preview-35455--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-packaging-format#olm-bundle-format-manifests-optional_olm-packaging-format)

Comparing the different release branches in https://github.com/operator-framework/operator-registry/blob/master/pkg/lib/bundle/supported_resources.go, it looks like `ConsoleYamlSample` should be removed from the list when cherry-picking this to the 4.6 docs.