### PR TITLE
Update upgrade instructions for SCCs

### DIFF
--- a/modules/update-openshift-security-context-constraints.adoc
+++ b/modules/update-openshift-security-context-constraints.adoc
@@ -17,3 +17,234 @@ If you are upgrading to {product-title} 3.0.57.2 or higher, you must patch {ocp}
 ----
 $ oc patch --type merge scc scanner -p '{"priority":0}'
 ----
+
+[role="_abstract"]
+{product-title} 3.64.0 renames the security context constraints.
+
+If you are upgrading to {product-title} 3.64.0 or higher, you must delete and reapply the {ocp} security context constraints.
+
+* Run the following commands to update Central:
++
+[source,terminal]
+----
+oc apply -f - <<EOF
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: stackrox-central
+  labels:
+    app.kubernetes.io/name: stackrox
+  annotations:
+    kubernetes.io/description: stackrox-central is the security constraint for the central server
+    email: support@stackrox.com
+    owner: stackrox
+allowHostDirVolumePlugin: false
+allowedCapabilities: []
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+defaultAddCapabilities: []
+fsGroup:
+  type: MustRunAs
+  ranges:
+    - max: 4000
+      min: 4000
+priority: 0
+readOnlyRootFilesystem: true
+requiredDropCapabilities: []
+runAsUser:
+  type: MustRunAs
+  uid: 4000
+seLinuxContext:
+  type: MustRunAs
+seccompProfiles:
+  - '*'
+users:
+  - system:serviceaccount:stackrox:central
+volumes:
+  - '*'
+EOF
+oc delete scc central
+----
+
+* Run the following commands to update Scanner:
++
+[source,terminal]
+----
+oc apply -f - <<EOF
+kind: SecurityContextConstraints
+apiVersion: security.openshift.io/v1
+metadata:
+  name: stackrox-scanner
+  labels:
+    app.kubernetes.io/name: stackrox
+  annotations:
+    email: support@stackrox.com
+    owner: stackrox
+    kubernetes.io/description: stackrox-scanner is the security constraint for the Scanner container
+priority: 0
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+users:
+  - system:serviceaccount:stackrox:scanner
+volumes:
+  - '*'
+allowHostDirVolumePlugin: false
+allowedCapabilities: []
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+defaultAddCapabilities: []
+fsGroup:
+  type: RunAsAny
+readOnlyRootFilesystem: false
+requiredDropCapabilities: []
+EOF
+oc delete scc scanner
+----
+
+* Run the following command to update Secured Cluster:
++
+[source,terminal]
+----
+oc apply -f - <<EOF
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: stackrox-admission-control
+  labels:
+    app.kubernetes.io/name: stackrox
+    auto-upgrade.stackrox.io/component: "sensor"
+  annotations:
+    email: support@stackrox.com
+    owner: stackrox
+    kubernetes.io/description: stackrox-admission-control is the security constraint for the admission controller
+users:
+  - system:serviceaccount:stackrox:admission-control
+priority: 0
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+groups: []
+readOnlyRootFilesystem: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: false
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - secret
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: stackrox-collector
+  labels:
+    app.kubernetes.io/name: stackrox
+    auto-upgrade.stackrox.io/component: "sensor"
+  annotations:
+    email: support@stackrox.com
+    owner: stackrox
+    kubernetes.io/description: This SCC is based on privileged, hostaccess, and hostmount-anyuid
+users:
+  - system:serviceaccount:stackrox:collector
+allowHostDirVolumePlugin: true
+allowPrivilegedContainer: true
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: 0
+readOnlyRootFilesystem: true
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - hostPath
+  - secret
+---
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  name: stackrox-sensor
+  labels:
+    app.kubernetes.io/name: stackrox
+    auto-upgrade.stackrox.io/component: "sensor"
+  annotations:
+    email: support@stackrox.com
+    owner: stackrox
+    kubernetes.io/description: stackrox-sensor is the security constraint for the sensor
+users:
+  - system:serviceaccount:stackrox:sensor
+  - system:serviceaccount:stackrox:sensor-upgrader
+priority: 0
+runAsUser:
+  type: RunAsAny
+seLinuxContext:
+  type: RunAsAny
+seccompProfiles:
+  - '*'
+supplementalGroups:
+  type: RunAsAny
+fsGroup:
+  type: RunAsAny
+groups: []
+readOnlyRootFilesystem: true
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: []
+defaultAddCapabilities: []
+requiredDropCapabilities: []
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - secret
+EOF
+oc delete scc admission-control collector sensor
+----


### PR DESCRIPTION
This PR updates upgrade instructions for 3.64.0. We've renamed our SCCs to avoid naming conflicts.