### PR TITLE
RHDEVDOCS-2381 Document prunning of PipelineRun and TaskRun

### DIFF
--- a/modules/op-tkn-pipeline-management.adoc
+++ b/modules/op-tkn-pipeline-management.adoc
@@ -6,7 +6,7 @@
 = Pipelines management commands
 
 == pipeline
-Manage Pipelines.
+Manage pipelines.
 
 .Example: Display help
 [source,terminal]
@@ -16,45 +16,45 @@ $ tkn pipeline --help
 
 == pipeline delete
 
-Delete a Pipeline.
+Delete a pipeline.
 
-.Example: Delete the `mypipeline` Pipeline from a namespace
+.Example: Delete the `mypipeline` pipeline from a namespace
 [source,terminal]
 ----
 $ tkn pipeline delete mypipeline -n myspace
 ----
 
 == pipeline describe
-Describe a Pipeline.
+Describe a pipeline.
 
-.Example: Describe `mypipeline` Pipeline
+.Example: Describe the `mypipeline` pipeline
 [source,terminal]
 ----
 $ tkn pipeline describe mypipeline
 ----
 
 == pipeline list
-List Pipelines.
+Display a list of pipelines.
 
-.Example: Display a list of Pipelines
+.Example: Display a list of pipelines
 [source,terminal]
 -----
 $ tkn pipeline list
 -----
 
 == pipeline logs
-Display Pipeline logs for a specific Pipeline.
+Display the logs for a specific pipeline.
 
-.Example: Stream live logs for the `mypipeline` Pipeline
+.Example: Stream the live logs for the `mypipeline` pipeline
 [source,terminal]
 ----
 $ tkn pipeline logs -f mypipeline
 ----
 
 == pipeline start
-Start a Pipeline.
+Start a pipeline.
 
-.Example: Start `mypipeline` Pipeline
+.Example: Start the `mypipeline` pipeline
 [source,terminal]
 ----
 $ tkn pipeline start mypipeline

--- a/modules/op-tkn-pipeline-run.adoc
+++ b/modules/op-tkn-pipeline-run.adoc
@@ -3,11 +3,11 @@
 // * cli_reference/tkn_cli/op-tkn-references.adoc
 
 [id="op-tkn-pipeline-run_{context}"]
-= PipelineRun commands
+= Pipeline run commands
 
 
 == pipelinerun
-Manage PipelineRuns.
+Manage pipeline runs.
 
 .Example: Display help
 [source,terminal]
@@ -16,45 +16,52 @@ $ tkn pipelinerun -h
 ----
 
 == pipelinerun cancel
-Cancel a PipelineRun.
+Cancel a pipeline run.
 
-.Example: Cancel the `mypipelinerun` PipelineRun from a namespace
+.Example: Cancel the `mypipelinerun` pipeline run from a namespace
 [source,terminal]
 ----
 $ tkn pipelinerun cancel mypipelinerun -n myspace
 ----
 
 == pipelinerun delete
-Delete a PipelineRun.
+Delete a pipeline run.
 
-.Example: Delete PipelineRuns from a namespace
+.Example: Delete pipeline runs from a namespace
 [source,terminal]
 ----
 $ tkn pipelinerun delete mypipelinerun1 mypipelinerun2 -n myspace
 ----
 
-== pipelinerun describe
-Describe a PipelineRun.
+.Example: Delete all pipeline runs from a namespace, except the five most recently executed pipeline runs
+[source,terminal]
+----
+$ tkn pipelinerun delete -n myspace --keep 5 <1>
+----
+<1> Replace `5` with the number of most recently executed pipeline runs you want to retain.
 
-.Example: Describe the `mypipelinerun` PipelineRun in a namespace
+== pipelinerun describe
+Describe a pipeline run.
+
+.Example: Describe the `mypipelinerun` pipeline run in a namespace
 [source,terminal]
 ----
 $ tkn pipelinerun describe mypipelinerun -n myspace
 ----
 
 == pipelinerun list
-List PipelineRuns.
+List pipeline runs.
 
-.Example: Display a list of PipelineRuns in a namespace
+.Example: Display a list of pipeline runs in a namespace
 [source,terminal]
 ----
 $ tkn pipelinerun list -n myspace
 ----
 
 == pipelinerun logs
-Display the logs of a PipelineRun.
+Display the logs of a pipeline run.
 
-.Example: Display the logs of the `mypipelinerun` PipelineRun with all tasks and steps in a namespace
+.Example: Display the logs of the `mypipelinerun` pipeline run with all tasks and steps in a namespace
 [source,terminal]
 ----
 $ tkn pipelinerun logs mypipelinerun -a -n myspace

--- a/modules/op-tkn-task-management.adoc
+++ b/modules/op-tkn-task-management.adoc
@@ -6,7 +6,7 @@
 = Task management commands
 
 == task
-Manage Tasks.
+Manage tasks.
 
 .Example: Display help
 [source,terminal]
@@ -15,45 +15,45 @@ $ tkn task -h
 ----
 
 == task delete
-Delete a Task.
+Delete a task.
 
-.Example: Delete `mytask1` and `mytask2` Tasks from a namespace
+.Example: Delete `mytask1` and `mytask2` tasks from a namespace
 [source,terminal]
 ----
 $ tkn task delete mytask1 mytask2 -n myspace
 ----
 
 == task describe
-Describe a Task.
+Describe a task.
 
-.Example: Describe the `mytask` Task in a namespace
+.Example: Describe the `mytask` task in a namespace
 [source,terminal]
 ----
 $ tkn task describe mytask -n myspace
 ----
 
 == task list
-List Tasks.
+List tasks.
 
-.Example: List all the Tasks in a namespace
+.Example: List all the tasks in a namespace
 [source,terminal]
 ----
 $ tkn task list -n myspace
 ----
 
 == task logs
-Display Task logs.
+Display task logs.
 
-.Example: Display logs for the `mytaskrun` TaskRun of the `mytask` Task
+.Example: Display logs for the `mytaskrun` task run of the `mytask` task
 [source,terminal]
 ----
 $ tkn task logs mytask mytaskrun -n myspace
 ----
 
 == task start
-Start a Task.
+Start a task.
 
-.Example: Start the `mytask` Task in a namespace
+.Example: Start the `mytask` task in a namespace
 [source,terminal]
 ----
 $ tkn task start mytask -s <ServiceAccountName> -n myspace

--- a/modules/op-tkn-task-run.adoc
+++ b/modules/op-tkn-task-run.adoc
@@ -3,10 +3,10 @@
 // *  cli_reference/tkn_cli/op-tkn-reference.adoc
 
 [id="op-tkn-task-run_{context}"]
-= TaskRun commands
+= Task run commands
 
 == taskrun
-Manage TaskRuns.
+Manage task runs.
 
 .Example: Display help
 [source,terminal]
@@ -15,9 +15,9 @@ $ tkn taskrun -h
 ----
 
 == taskrun cancel
-Cancel a TaskRun.
+Cancel a task run.
 
-.Example: Cancel the `mytaskrun` TaskRun from a namespace
+.Example: Cancel the `mytaskrun` task run from a namespace
 [source,terminal]
 ----
 $ tkn taskrun cancel mytaskrun -n myspace
@@ -26,25 +26,32 @@ $ tkn taskrun cancel mytaskrun -n myspace
 == taskrun delete
 Delete a TaskRun.
 
-.Example: Delete `mytaskrun1` and `mytaskrun2` TaskRuns from a namespace
+.Example: Delete the `mytaskrun1` and `mytaskrun2` task runs from a namespace
 [source,terminal]
 ----
 $ tkn taskrun delete mytaskrun1 mytaskrun2 -n myspace
 ----
 
-== taskrun describe
-Describe a TaskRun.
+.Example: Delete all but the five most recently executed task runs from a namespace
+[source,terminal]
+----
+$ tkn taskrun delete -n myspace --keep 5 <1>
+----
+<1> Replace `5` with the number of most recently executed task runs you want to retain.
 
-.Example: Describe the `mytaskrun` TaskRun in a namespace
+== taskrun describe
+Describe a task run.
+
+.Example: Describe the `mytaskrun` task run in a namespace
 [source,terminal]
 ----
 $ tkn taskrun describe mytaskrun -n myspace
 ----
 
 == taskrun list
-List TaskRuns.
+List task runs.
 
-.Example: List all TaskRuns in a namespace
+.Example: List all the task runs in a namespace
 [source,terminal]
 ----
 $ tkn taskrun list -n myspace
@@ -52,9 +59,9 @@ $ tkn taskrun list -n myspace
 
 
 == taskrun logs
-Display TaskRun logs.
+Display task run logs.
 
-.Example: Display live logs for the `mytaskrun` TaskRun in a namespace
+.Example: Display live logs for the `mytaskrun` task run in a namespace
 
 [source,terminal]
 ----


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [Document prunning of PipelineRun and TaskRun](https://issues.redhat.com/browse/RHDEVDOCS-2381)
- **Preview pages**: See the second example in the following sections:
  - [pipelinerun delete](https://deploy-preview-35460--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/op-tkn-reference?utm_source=github&utm_campaign=bot_dp#pipelinerun-delete)
  - [taskrun delete](https://deploy-preview-35460--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/op-tkn-reference?utm_source=github&utm_campaign=bot_dp#taskrun-delete)
- **SME+QE review**: @VeereshAradhya 
- **Peer-review**: @rolfedh 