### PR TITLE
Update master/worker subnet CIDR examples

### DIFF
--- a/modules/installation-creating-gcp-vpc.adoc
+++ b/modules/installation-creating-gcp-vpc.adoc
@@ -105,8 +105,8 @@ ifdef::shared-vpc[]
 <1> `infra_id` is the prefix of the network name.
 endif::shared-vpc[]
 <2> `region` is the region to deploy the cluster into, for example `us-central1`.
-<3> `master_subnet_cidr` is the CIDR for the master subnet, for example `10.0.0.0/19`.
-<4> `worker_subnet_cidr` is the CIDR for the worker subnet, for example `10.0.32.0/19`.
+<3> `master_subnet_cidr` is the CIDR for the master subnet, for example `10.0.0.0/17`.
+<4> `worker_subnet_cidr` is the CIDR for the worker subnet, for example `10.0.128.0/17`.
 
 . Create the deployment by using the `gcloud` CLI:
 +


### PR DESCRIPTION
Followup to #32061; the examples for GCP were missed, so updating them here.

Preview: https://deploy-preview-35462--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-vpc_installing-gcp-user-infra-vpc