### PR TITLE
Removed extra + to rectify build issues in the customer portal

### DIFF
--- a/modules/odc-using-the-developer-catalog-to-add-services-or-components.adoc
+++ b/modules/odc-using-the-developer-catalog-to-add-services-or-components.adoc
@@ -16,4 +16,3 @@ You use the Developer Catalog to deploy applications and services based on Opera
 +
 .MariaDB in Topology
 image::odc_devcatalog_toplogy.png[]
-+


### PR DESCRIPTION
Removed an extra `+` sign from the `modules/odc-using-the-developer-catalog-to-add-services-or-components.adoc` file as it was giving some build failures/issues in the [customer portal](https://access.redhat.com/).

Target versions: **Openshift 4.8**, **Openshift 4.7**

Preview: https://deploy-preview-35474--osdocs.netlify.app/openshift-enterprise/latest/applications/application_life_cycle_management/odc-creating-applications-using-developer-perspective.html#odc-using-the-developer-catalog-to-add-services-or-components_odc-creating-applications-using-developer-perspective