### PR TITLE
Notes for 4.7.24 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2757,3 +2757,28 @@ link:https://access.redhat.com/solutions/6246671[{product-title} 4.7.23 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-24"]
+=== RHBA-2021:3032 - {product-title} 4.7.24 bug fix update
+
+Issued: 2021-08-17
+
+{product-title} release 4.7.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3032[RHBA-2021:3032] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3033[RHSA-2021:3033] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6258591[{product-title} 4.7.24 container image list]
+
+[id="ocp-4-7-24-bug-fixes"]
+==== Bug fixes
+
+*  Previously, the installation program created out of order `noProxy` values due to allowing for spaces in the input for `noProxy`. With this update, spaces in the input were removed to sort the values. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954595[*BZ#1954595*])
+
+*  Previously, OVN-Kubernetes handled some NetworkPolicies with multiple `ipBlocks` unable to reach all IP addresses. With this update, generating Open Virtual Network (OVN) ACLs from Kubernetes NetworkPolicies with multiple `ipBlocks` work correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1967132[*BZ#1967132*])
+
+*  Previously, custom tolerations from `spec.tolerations` were only applied when `spec.nodeSelector` was set. With this update, the Operator will use custom tolerations if `spec.tolerations` is set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1988388[*BZ#1988388*])
+
+[id="ocp-4-7-24-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.7.24 release

- Applies to `enterprise-4.7`
- [Preview Link](https://deploy-preview-35475--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-24)
