### PR TITLE
OSDOCS-1488: Add more info to InstallPlan section

### DIFF
--- a/modules/olm-installplan.adoc
+++ b/modules/olm-installplan.adoc
@@ -5,4 +5,98 @@
 [id="olm-installplan_{context}"]
 = Install plan
 
-An _install plan_, defined by an `InstallPlan` object, describes a set of resources to be created to install or upgrade to a specific version of an Operator, as defined by a cluster service version (CSV).
+An _install plan_, defined by an `InstallPlan` object, describes a set of resources that Operator Lifecycle Manager (OLM) creates to install or upgrade to a specific version of an Operator. The version is defined by a cluster service version (CSV).
+
+To install an Operator, a cluster administrator, or a user who has been granted Operator installation permissions, must first create a `Subscription` object. A subscription represents the intent to subscribe to a stream of available versions of an Operator from a catalog source. The subscription then creates an `InstallPlan` object to facilitate the installation of the resources for the Operator.
+
+The install plan must then be approved according to one of the following approval strategies:
+
+* If the subscription's `spec.installPlanApproval` field is set to `Automatic`, the install plan is approved automatically.
+* If the subscription's `spec.installPlanApproval` field is set to `Manual`, the install plan must be manually approved by a cluster administrator or user with proper permissions.
+
+After the install plan is approved, OLM creates the specified resources and installs the Operator in the namespace that is specified by the subscription.
+
+.Example `InstallPlan` object
+[%collapsible]
+====
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: InstallPlan
+metadata:
+  name: install-abcde
+  namespace: operators
+spec:
+  approval: Automatic
+  approved: true
+  clusterServiceVersionNames:
+    - my-operator.v1.0.1
+  generation: 1
+status:
+  ...
+  catalogSources: []
+  conditions:
+    - lastTransitionTime: '2021-01-01T20:17:27Z'
+      lastUpdateTime: '2021-01-01T20:17:27Z'
+      status: 'True'
+      type: Installed
+  phase: Complete
+  plan:
+    - resolving: my-operator.v1.0.1
+      resource:
+        group: operators.coreos.com
+        kind: ClusterServiceVersion
+        manifest: >-
+        ...
+        name: my-operator.v1.0.1
+        sourceName: redhat-operators
+        sourceNamespace: openshift-marketplace
+        version: v1alpha1
+      status: Created
+    - resolving: my-operator.v1.0.1
+      resource:
+        group: apiextensions.k8s.io
+        kind: CustomResourceDefinition
+        manifest: >-
+        ...
+        name: webservers.web.servers.org
+        sourceName: redhat-operators
+        sourceNamespace: openshift-marketplace
+        version: v1beta1
+      status: Created
+    - resolving: my-operator.v1.0.1
+      resource:
+        group: ''
+        kind: ServiceAccount
+        manifest: >-
+        ...
+        name: my-operator
+        sourceName: redhat-operators
+        sourceNamespace: openshift-marketplace
+        version: v1
+      status: Created
+    - resolving: my-operator.v1.0.1
+      resource:
+        group: rbac.authorization.k8s.io
+        kind: Role
+        manifest: >-
+        ...
+        name: my-operator.v1.0.1-my-operator-6d7cbc6f57
+        sourceName: redhat-operators
+        sourceNamespace: openshift-marketplace
+        version: v1
+      status: Created
+    - resolving: my-operator.v1.0.1
+      resource:
+        group: rbac.authorization.k8s.io
+        kind: RoleBinding
+        manifest: >-
+        ...
+        name: my-operator.v1.0.1-my-operator-6d7cbc6f57
+        sourceName: redhat-operators
+        sourceNamespace: openshift-marketplace
+        version: v1
+      status: Created
+      ...
+----
+====

--- a/operators/admin/olm-status.adoc
+++ b/operators/admin/olm-status.adoc
@@ -8,4 +8,8 @@ toc::[]
 Understanding the state of the system in Operator Lifecycle Manager (OLM) is important for making decisions about and debugging problems with installed Operators. OLM provides insight into subscriptions and related catalog sources regarding their state and actions performed. This helps users better understand the healthiness of their Operators.
 
 include::modules/olm-status-conditions.adoc[leveloffset=+1]
+.Additional resources
+
+* xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-refresh-subs_olm-deleting-operators-from-a-cluster[Refreshing failing subscriptions]
+
 include::modules/olm-status-viewing-cli.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-understanding-olm.adoc
+++ b/operators/understanding/olm/olm-understanding-olm.adoc
@@ -13,10 +13,18 @@ include::modules/olm-csv.adoc[leveloffset=+2]
 include::modules/olm-catalogsource.adoc[leveloffset=+2]
 include::modules/olm-subscription.adoc[leveloffset=+2]
 include::modules/olm-installplan.adoc[leveloffset=+2]
+.Additional resources
+
+* xref:../../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
+
 include::modules/olm-operatorgroups-about.adoc[leveloffset=+2]
 
-For more information, see xref:../../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-understanding-operatorgroups[Operator groups].
+.Additional resources
+
+* xref:../../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-understanding-operatorgroups[Operator groups].
 
 include::modules/olm-operatorconditions-about.adoc[leveloffset=+2]
 
-For more information, see xref:../../../operators/understanding/olm/olm-operatorconditions.adoc#olm-operatorconditions[Operator conditions].
+.Additional resources
+
+* xref:../../../operators/understanding/olm/olm-operatorconditions.adoc#olm-operatorconditions[Operator conditions].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1488

* The "OLM concepts" section on install plans has been pretty sparse. Add more information about how it works and provide an example YAML definition.
  * Preview: https://deploy-preview-35480--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-olm#olm-installplan_olm-understanding-olm
* Add link to "Refreshing failing subscriptions" from "Operator subscription condition types".
  * Preview: https://deploy-preview-35480--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-status.html#olm-status-conditions_olm-status