### PR TITLE
Removed old upgrade guide

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -185,8 +185,6 @@ Topics:
   Topics:
   - Name: Upgrading from Red Hat Advanced Cluster Security for Kubernetes 3.0.44 or higher
     File: upgrade-from-44
-  - Name: Upgrading from Red Hat Advanced Cluster Security for Kubernetes 3.0.40 through 3.0.43
-    File: upgrade-from-40-43
 ---
 Name: roxctl CLI
 Dir: cli


### PR DESCRIPTION
Removed the page at https://docs.openshift.com/acs/upgrading/upgrading_roxctl/upgrade-from-40-43.html

- This topic is for older versions which no ones uses.