### PR TITLE
SRVCOM-1409: Serverless 1.17.0 release notes

### DIFF
--- a/modules/serverless-api-versions.adoc
+++ b/modules/serverless-api-versions.adoc
@@ -1,0 +1,8 @@
+[id="serverless-api-versions_{context}"]
+= About API versions
+
+The {ServerlessOperatorName} automatically upgrades older resources that use deprecated versions of APIs to use the latest version.
+
+For example, if you have created resources on your cluster that use older versions of the `ApiServerSource` API, such as `v1beta1`, the {ServerlessOperatorName} automatically updates these resources to use the `v1` version of the API when this is available and the `v1beta1` version is deprecated.
+
+After they have been deprecated, older versions of APIs might be removed in any upcoming release. Using deprecated versions of APIs does not cause resources to fail. However, if you try to use a version of an API that has been removed, it will cause resources to fail. Ensure that your manifests are updated to use the latest version to avoid issues.

--- a/modules/serverless-rn-1-14-0.adoc
+++ b/modules/serverless-rn-1-14-0.adoc
@@ -25,3 +25,8 @@ Only the `v1beta1` version of the APIs for `KafkaChannel` and `KafkaSource` obje
 == Known issues
 
 * Subscriptions for the Kafka channel sometimes fail to become marked as `READY` and remain in the `SubscriptionNotMarkedReadyByChannel` state. You can fix this by restarting the dispatcher for the Kafka channel.
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+// add KB article link when ready

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -1,7 +1,7 @@
 [id="serverless-rn-1-15-0_{context}"]
 = Release Notes for Red Hat {ServerlessProductName} 1.15.0
 
-[id="new-features-1.15.0_{context}"]
+[id="new-features-1-15-0_{context}"]
 == New features
 
 * {ServerlessProductName} now uses Knative Serving 0.21.0.
@@ -15,3 +15,11 @@
 ====
 The `serving.knative.dev/visibility` label, which was previously used to create private services, is now deprecated. You must update existing services to use the `networking.knative.dev/visibility` label instead.
 ====
+
+[id="known-issues-1-15-0_{context}"]
+== Known issues
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+// add KB article link when ready

--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -15,6 +15,8 @@
 [id="known-issues-1-16-0_{context}"]
 == Known issues
 
+* You must upgrade {product-title} to version 4.6.30, 4.7.11, or higher before upgrading to {ServerlessProductName} 1.16.0.
+
 * The AMQ Streams Operator might prevent the installation or upgrade of the {ServerlessOperatorName}. If this happens, the following error is thrown by Operator Lifecycle Manager (OLM):
 +
 [source,terminal]
@@ -120,3 +122,8 @@ spec:
 * If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there is a delay when you create the first new service after the `KnativeServing` custom resource definition (CRD) becomes `Ready`.
 +
 The `3scale-kourier-control` service reconciles all previously existing Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state updates to `Ready`.
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+// add KB article link when ready

--- a/modules/serverless-rn-1-17-0.adoc
+++ b/modules/serverless-rn-1-17-0.adoc
@@ -1,0 +1,52 @@
+[id="serverless-rn-1-17-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.17.0
+
+[id="new-features-1-17-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.23.0.
+* {ServerlessProductName} now uses Knative Eventing 0.23.0.
+* {ServerlessProductName} now uses Kourier 0.23.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.23.0.
+* {ServerlessProductName} now uses Knative Kafka 0.23.0.
+* The `kn func` CLI plug-in now uses `func` 0.17.0.
+* In the upcoming {ServerlessProductName} 1.19.0 release, the URL scheme of external routes will default to HTTPS for enhanced security.
++
+If you do not want this change to apply for your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource definition (CRD):
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      defaultExternalScheme: "http"
+...
+----
+
+* mTLS functionality is now Generally Available (GA).
+
+* TypeScript templates are now available when you create a function using `kn func`.
+
+* Changes to API versions in Knative Eventing 0.23.0:
+
+** The `v1alpha1` version of the `KafkaChannel` API, which was deprecated in {ServerlessProductName} version 1.14.0, has been removed. If the `ChannelTemplateSpec` parameters of your config maps contain references to this older version, you must update this part of the spec to use the correct API version.
+
+[id="fixed-issues-1-17-0_{context}"]
+== Fixed issues
+
+[id="known-issues-1-17-0_{context}"]
+== Known issues
+
+* If you try to use an older version of the Knative `kn` CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
++
+For example, if you use the 1.16.0 release of the `kn` CLI, which uses version 0.22.0, with the 1.17.0 {ServerlessProductName} release, which uses the 0.23.0 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 0.22.0 API versions.
++
+Ensure that you are using the latest `kn` CLI version for your {ServerlessProductName} release to avoid issues.
+
+* Kafka channel metrics are not monitored or shown in the corresponding web console dashboard in this release. This is due to a breaking change in the Kafka dispatcher reconciling process.
+
+* If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
++
+As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+// add KB article link when ready

--- a/serverless/admin_guide/serverless-ossm-setup.adoc
+++ b/serverless/admin_guide/serverless-ossm-setup.adoc
@@ -22,9 +22,6 @@ The {ServerlessOperatorName} provides Kourier as the default ingress for Knative
 
 Integrating {ProductShortName} with {ServerlessProductName} natively, without Kourier, allows you to use additional networking and routing options that are not supported by the default Kourier ingress, such as mTLS functionality.
 
-:FeatureName: mTLS for {ServerlessProductName}
-include::modules/technology-preview.adoc[leveloffset=+2]
-
 The examples in the following procedures use the domain `example.com`. The example certificate for this domain is used as a certificate authority (CA) that signs the subdomain certificate.
 
 To complete and verify these procedures in your deployment, you need either a certificate signed by a widely trusted public CA or a CA provided by your organization. Example commands must be adjusted according to your domain, subdomain, and CA.

--- a/serverless/cli_tools/installing-kn.adoc
+++ b/serverless/cli_tools/installing-kn.adoc
@@ -6,13 +6,19 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-[NOTE]
-====
 The Knative CLI (`kn`) does not have its own login mechanism. To log in to the cluster, you must install the `oc` CLI and use the `oc login` command.
 
 Installation options for the `oc` CLI will vary depending on your operating system.
 
 For more information on installing the `oc` CLI for your operating system and logging in with `oc`, see the xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI getting started] documentation.
+
+[IMPORTANT]
+====
+If you try to use an older version of the Knative `kn` CLI with a newer {ServerlessProductName} release, the API is not found and an error occurs.
+
+For example, if you use the 1.16.0 release of the `kn` CLI, which uses version 0.22.0, with the 1.17.0 {ServerlessProductName} release, which uses the 0.23.0 versions of the Knative Serving and Knative Eventing APIs, the CLI does not work because it continues to look for the outdated 0.22.0 API versions.
+
+Ensure that you are using the latest `kn` CLI version for your {ServerlessProductName} release to avoid issues.
 ====
 
 include::modules/serverless-installing-cli-web-console.adoc[leveloffset=+1]

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -15,11 +15,14 @@ For an overview of {ServerlessProductName} functionality, see xref:../serverless
 For details about the latest Knative component releases, see the link:https://knative.dev/blog/releases[Knative releases blog].
 ====
 
+include::modules/serverless-api-versions.adoc[leveloffset=+1]
+
 // Modules included, most to least recent
+include::modules/serverless-rn-1-17-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-16-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-15-0.adoc[leveloffset=+1]
+// No longer supported
 include::modules/serverless-rn-1-14-0.adoc[leveloffset=+1]
-// delete older relnotes?
 include::modules/serverless-rn-1-13-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-12-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-11-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies for OCP 4.6+

Jira issues:
- https://issues.redhat.com/browse/SRVCOM-1409
- https://issues.redhat.com/browse/SRVKE-830
- https://issues.redhat.com/browse/SRVCOM-1449
- https://issues.redhat.com/browse/SRVKE-907
- https://issues.redhat.com/browse/SRVKS-792 (remove TP note)
- https://issues.redhat.com/browse/SRVCLI-315 (CLI bug)
- https://issues.redhat.com/browse/SRVKS-754

Direct preview link: https://deploy-preview-35500--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html