### PR TITLE
GitHub-35357: Fixing instances of OCP showing in OKD docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -620,7 +620,7 @@ Topics:
   Dir: helm_cli
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Getting started with Helm on OpenShift Container Platform
+  - Name: Getting started with Helm
     File: getting-started-with-helm-on-openshift-container-platform
   - Name: Configuring custom Helm chart repositories
     File: configuring-custom-helm-chart-repositories
@@ -1182,7 +1182,10 @@ Topics:
   File: architecture-component-imageregistry
 - Name: Image Registry Operator in OpenShift Container Platform
   File: configuring-registry-operator
-  Distros: openshift-enterprise,openshift-origin
+  Distros: openshift-enterprise
+- Name: Image Registry Operator in OKD
+  File: configuring-registry-operator
+  Distros: openshift-origin
 - Name: Setting up and configuring the registry
   Dir: configuring_registry_storage
   Distros: openshift-enterprise,openshift-origin
@@ -2054,14 +2057,22 @@ Topics:
   - Name: Recovering from expired control plane certificates
     File: scenario-3-expired-certs
 ---
-Name: Migrating from OpenShift Container Platform 3 to 4
+Name: Migrating from version 3 to 4
 Dir: migrating_from_ocp_3_to_4
 Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: About migrating from OpenShift Container Platform 3 to 4
   File: about-migrating-from-3-to-4
+  Distros: openshift-enterprise
+- Name: About migrating from OKD 3 to 4
+  File: about-migrating-from-3-to-4
+  Distros: openshift-origin
 - Name: Differences between OpenShift Container Platform 3 and 4
   File: planning-migration-3-4
+  Distros: openshift-enterprise
+- Name: Differences between OKD 3 and 4
+  File: planning-migration-3-4
+  Distros: openshift-origin
 # - Name: Planning considerations
 #   File: planning-considerations-3-4
 - Name: About MTC

--- a/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.adoc
+++ b/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.adoc
@@ -1,6 +1,6 @@
 [id="getting-started-with-helm-on-openshift"]
 
-= Getting started with Helm 3 on {product-title}
+= Getting started with Helm 3
 include::modules/common-attributes.adoc[]
 :context: getting-started-with-helm-on-openshift
 
@@ -13,4 +13,3 @@ include::modules/helm-installing-helm.adoc[leveloffset=+1]
 include::modules/helm-installing-a-helm-chart-on-an-openshift-cluster.adoc[leveloffset=+1]
 
 include::modules/helm-creating-a-custom-helm-chart-on-openshift.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Fixes #35357

Previews:

**MTC**
* OKD: http://file.rdu.redhat.com/~ahoffer/2021/github-35357/github-35357/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.html
* OCP: https://deploy-preview-35512--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.html

**Image registry**
* OKD: http://file.rdu.redhat.com/~ahoffer/2021/github-35357/github-35357/registry/configuring-registry-operator.html
* OCP: https://deploy-preview-35512--osdocs.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html

**Helm CLI**
* OKD: http://file.rdu.redhat.com/~ahoffer/2021/github-35357/github-35357/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.html
* OCP: https://deploy-preview-35512--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/helm_cli/getting-started-with-helm-on-openshift-container-platform.html