### PR TITLE
CNV 12576: Updating text about EFI mode and Secure Boot

### DIFF
--- a/modules/virt-about-efi-mode-for-vms.adoc
+++ b/modules/virt-about-efi-mode-for-vms.adoc
@@ -8,9 +8,3 @@
 Extensible Firmware Interface (EFI), like legacy BIOS, initializes hardware components and operating system image files when a computer starts. EFI supports more modern features and customization options than BIOS, enabling faster boot times.
 
 It stores all the information about initialization and startup in a file with a `.efi` extension, which is stored on a special partition called EFI System Partition (ESP). The ESP also contains the boot loader programs for the operating system that is installed on the computer.
-
-
-[NOTE]
-====
-{VirtProductName} only supports a virtual machine (VM) with Secure Boot when using EFI mode. If Secure Boot is not enabled, the VM crashes repeatedly. However, the VM might not support Secure Boot. Before you boot a VM, verify that it supports Secure Boot by checking the VM settings.
-====

--- a/modules/virt-booting-efi-mode.adoc
+++ b/modules/virt-booting-efi-mode.adoc
@@ -42,7 +42,7 @@ You can configure a virtual machine to boot in EFI mode by editing the VM or VMI
 ...
 ----
 <1> {VirtProductName} requires System Management Mode (`SMM`) to be enabled for Secure Boot in EFI mode to occur.
-<2> {VirtProductName} only supports a virtual machine (VM) with Secure Boot when using EFI mode. If Secure Boot is not enabled, the VM crashes repeatedly. However, the VM might not support Secure Boot. Before you boot a VM, verify that it supports Secure Boot by checking the VM settings.
+<2> {VirtProductName} supports a VM with or without Secure Boot when using EFI mode. If Secure Boot is enabled, then EFI mode is required. However, EFI mode can be enabled without using Secure Boot.
 
 . Apply the manifest to your cluster by running the following command:
 +


### PR DESCRIPTION
This PR addresses JIRA story [CNV-12576](https://issues.redhat.com/browse/CNV-12576) ( https://issues.redhat.com/browse/CNV-12576 ).

The story asks that the text in Advanced VM Management about Booting a VM in EFI Mode be changed to say that Secure Boot is no longer required to use EFI mode.

CP: 4.9

Preview: https://deploy-preview-35513--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms?utm_source=github&utm_campaign=bot_dp#virt-about-efi-mode-for-vms_virt-efi-mode-for-vms