### PR TITLE
#35338: bug fix

### DIFF
--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -65,6 +65,5 @@ autoscaler-hpa-78665569b8-qmlmn    1/1     Running   0          9m26s
 autoscaler-hpa-78665569b8-tqwvw    1/1     Running   0          9m26s
 controller-7fd5655f49-9gxz5        1/1     Running   0          9m32s
 controller-7fd5655f49-pncv5        1/1     Running   0          9m14s
-kn-cli-downloads-8c65d4cbf-mt4t7   1/1     Running   0          9m42s
 webhook-5c7d878c7c-n267j           1/1     Running   0          9m35s
 ----


### PR DESCRIPTION
Fixes #35338
Applies for OCP 4.6+
Direct preview link: https://deploy-preview-35514--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/installing-knative-serving?utm_source=github&utm_campaign=bot_dp#serverless-install-serving-yaml_installing-knative-serving