### PR TITLE
[GH#33838]: Correct typo in security-compliance-operator module

### DIFF
--- a/modules/compliance-filtering-failed-results.adoc
+++ b/modules/compliance-filtering-failed-results.adoc
@@ -27,7 +27,7 @@ List all failing checks that can be remediated automatically:
 
 [source,terminal]
 ----
-$ oc get compliancecheckresults -l 'compliance.openshift.io/check-status=FAIL,compliance.openshift.io/automated-remmediation'
+$ oc get compliancecheckresults -l 'compliance.openshift.io/check-status=FAIL,compliance.openshift.io/automated-remediation'
 ----
 
 List all failing checks that must be remediated manually:


### PR DESCRIPTION
Preview link: https://deploy-preview-35529--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation
Fix applies to 4.6 and later versions. 
Fixes #33738.