### PR TITLE
[enterprise-4.6] Network policy Ingress Controller host network support

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -47,11 +47,6 @@ spec:
 +
 To make a project allow only connections from the {product-title} Ingress Controller, add the following `NetworkPolicy` object.
 +
-[IMPORTANT]
-====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
-====
-+
 [source,yaml]
 ----
 apiVersion: networking.k8s.io/v1
@@ -68,11 +63,6 @@ spec:
   policyTypes:
   - Ingress
 ----
-+
-If the Ingress Controller is configured with `endpointPublishingStrategy: HostNetwork`, then the Ingress Controller pod runs on the host network.
-When running on the host network, the traffic from the Ingress Controller is assigned the `netid:0` Virtual Network ID (VNID).
-The `netid` for the namespace that is associated with the Ingress Operator is different, so the `matchLabel` in the `allow-from-openshift-ingress` network policy does not match traffic from the `default` Ingress Controller.
-With OpenShift SDN, the `default` namespace is assigned the `netid:0` VNID and you can allow traffic from the `default` Ingress Controller by labeling your `default` namespace with `network.openshift.io/policy-group: ingress`.
 
 * Only accept connections from pods within a project:
 +

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -31,11 +31,6 @@ This mode is the default for OpenShift SDN.
 . Create the following `NetworkPolicy` objects:
 .. A policy named `allow-from-openshift-ingress`.
 +
-[IMPORTANT]
-====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
-====
-+
 [source,terminal]
 ----
 $ cat << EOF| oc create -f -
@@ -93,56 +88,44 @@ spec:
 EOF
 ----
 
-. If the `default` Ingress Controller configuration has the `spec.endpointPublishingStrategy: HostNetwork` value set, you must apply a label to the `default` {product-title} namespace to allow network traffic between the Ingress Controller and the project:
-
-.. Determine if your `default` Ingress Controller uses the `HostNetwork` endpoint publishing strategy:
+. Optional: To confirm that the network policies exist in your current project, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get --namespace openshift-ingress-operator ingresscontrollers/default \
-  --output jsonpath='{.status.endpointPublishingStrategy.type}'
-----
-
-.. If the previous command reports the endpoint publishing strategy as `HostNetwork`, set a label on the `default` namespace:
-+
-[source,terminal]
-----
-$ oc label namespace default 'network.openshift.io/policy-group=ingress'
-----
-
-. Confirm that the `NetworkPolicy` object exists in your current project
-by running the following command:
-+
-[source,terminal]
-----
-$ oc get networkpolicy <policy-name> -o yaml
-----
-+
-In the following example, the `allow-from-openshift-ingress` `NetworkPolicy`
-object is displayed:
-+
-[source,terminal]
-----
-$ oc get -n project1 networkpolicy allow-from-openshift-ingress -o yaml
+$ oc describe networkpolicy
 ----
 +
 .Example output
-[source,terminal]
+[source,text]
 ----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-from-openshift-ingress
-  namespace: project1
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          network.openshift.io/policy-group: ingress
-  podSelector: {}
-  policyTypes:
-  - Ingress
+Name:         allow-from-openshift-ingress
+Namespace:    example1
+Created on:   2020-06-09 00:28:17 -0400 EDT
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
+  Allowing ingress traffic:
+    To Port: <any> (traffic allowed to all ports)
+    From:
+      NamespaceSelector: network.openshift.io/policy-group: ingress
+  Not affecting egress traffic
+  Policy Types: Ingress
+
+
+Name:         allow-from-openshift-monitoring
+Namespace:    example1
+Created on:   2020-06-09 00:29:57 -0400 EDT
+Labels:       <none>
+Annotations:  <none>
+Spec:
+  PodSelector:     <none> (Allowing the specific traffic to all pods in this namespace)
+  Allowing ingress traffic:
+    To Port: <any> (traffic allowed to all ports)
+    From:
+      NamespaceSelector: network.openshift.io/policy-group: monitoring
+  Not affecting egress traffic
+  Policy Types: Ingress
 ----
 
 ifdef::ovn[]

--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -743,6 +743,24 @@ Configuring an Ingress Controller to inject an HTTP header with a uniquely defin
 
 For more information, see the xref:../rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc#specification[`IngressController` specification].
 
+[id="ocp-4-6-network-policy-host-network-ingress-controllers"]
+==== Network policy supports selecting host network Ingress Controllers
+
+When using the OVN-Kubernetes cluster network provider, you can select traffic from Ingress Controllers in a network policy rule regardless of whether an Ingress Controller runs on the cluster network or the host network.
+In a network policy rule, the `policy-group.network.openshift.io/ingress=""` namespace selector label matches traffic from an Ingress Controller.
+You can continue to use the `network.openshift.io/policy-group: ingress` namespace selector label, but this is a legacy label that can be removed in a future release of {product-title}.
+
+In earlier releases of {product-title}, the following limitations existed:
+
+- A cluster that uses the OVN-Kubernetes cluster network provider could not select traffic from an Ingress Controller on the host network.
+
+For more information, refer to xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
+
+[id="ocp-4-6-network-policy-host-network-policy-group"]
+==== Network policy supports selecting host network traffic
+
+When using the OVN-Kubernetes cluster network provider, you can use the `policy-group.network.openshift.io/host-network: ""` namespace selector to select host network traffic in a network policy rule.
+
 [id="ocp-4-6-storage"]
 === Storage
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-1811

Refs https://github.com/openshift/openshift-docs/pull/34404.

Preview: https://deploy-preview-35531--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-network-policy-host-network-ingress-controllers