### PR TITLE
GitHub-34018: Updating audit log location to /var/log/origin

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1185,7 +1185,7 @@ Defaults to 100MB.
 [IMPORTANT]
 ====
 Because the {product-title} master API now runs as static pod, you must define
-the `auditFilePath` location in the *_/var/log/audit/_*, *_/var/lib/origin/_* or *_/etc/origin/master/_* directory.
+the `auditFilePath` location in the *_/var/log/audit/_*, *_/var/log/origin/_* or *_/etc/origin/master/_* directory.
 ====
 
 .Example Audit Configuration
@@ -1211,7 +1211,7 @@ To enable the advanced audit feature, you create an audit policy file and specif
 `openshift_master_audit_config` and `openshift_master_audit_policyfile` parameters:
 
 ----
-openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/lib/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5, "policyFile": "/etc/origin/master/adv-audit.yaml", "logFormat":"json"}
+openshift_master_audit_config={"enabled": true, "auditFilePath": "/var/log/origin/audit-ocp.log", "maximumFileRetentionDays": 14, "maximumFileSizeMegabytes": 500, "maximumRetainedFiles": 5, "policyFile": "/etc/origin/master/adv-audit.yaml", "logFormat":"json"}
 openshift_master_audit_policyfile="/<path>/adv-audit.yaml"
 ----
 

--- a/security/monitoring.adoc
+++ b/security/monitoring.adoc
@@ -104,8 +104,8 @@ ifdef::openshift-enterprise[]
 - atomic-openshift-node (use `journalctl -u atomic-openshift-node.service`)
 endif::[]
 
-These logs are intended more for debugging purposes than for security auditing. You can retrieve logs for 
-each service with the `master-logs api api`, `master-logs controllers controllers`, or `master-logs etcd etcd` commands. 
+These logs are intended more for debugging purposes than for security auditing. You can retrieve logs for
+each service with the `master-logs api api`, `master-logs controllers controllers`, or `master-logs etcd etcd` commands.
 If your cluster runs an aggregated logging stack, like an xref:../install_config/aggregate_logging.adoc#aggregated-ops[Ops cluster], cluster administrators can retrieve logs from the logging _.operations_ indexes.
 
 [NOTE]
@@ -135,7 +135,7 @@ of nodes:
 It might be useful to poll the log periodically for the number of recent requests per response code, as shown in the following example:
 
 ----
-$ tail -5000 /var/lib/origin/audit-ocp.log \
+$ tail -5000 /var/log/origin/audit-ocp.log \
   | grep -Po 'response="..."' \
   | sort | uniq -c | sort -rn
 
@@ -165,7 +165,7 @@ It can be useful to look for unusual numbers of requests by a particular user or
 The following example lists the top 10 users by number of requests in the last 5000 lines of the audit log:
 
 ----
-$ tail -5000 /var/lib/origin/audit-ocp.log \
+$ tail -5000 /var/log/origin/audit-ocp.log \
   | grep -Po ' user="(.*?)(?<!\\)"' \
   | sort | uniq -c | sort -rn | head -10
 


### PR DESCRIPTION
Fixes #34018.

Previews:

* https://deploy-preview-35532--osdocs.netlify.app/openshift-enterprise/latest/install_config/master_node_configuration.html#master-node-config-audit-config
* https://deploy-preview-35532--osdocs.netlify.app/openshift-enterprise/latest/security/monitoring.html#security-monitoring-audit-log