### PR TITLE
fixes formatting typo in adding-bare-metal-host-to-cluster-using-yaml.adoc

### DIFF
--- a/modules/adding-bare-metal-host-to-cluster-using-yaml.adoc
+++ b/modules/adding-bare-metal-host-to-cluster-using-yaml.adoc
@@ -34,7 +34,6 @@ spec:
   bootMACAddress: <host_boot_mac_address>
   hardwareProfile: unknown
 ----
-+
 <1> `credentialsName` must reference a valid `Secret` CR. The `baremetal-operator` cannot manage the bare metal host without a valid `Secret` referenced in the `credentialsName`. For more information about secrets and how to create them, see xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets].
 
 . Select *Create* to save the YAML and create the new bare metal host.


### PR DESCRIPTION
This is for enterprise-4.7, enterprise-4.8, and main.

An incorrect `+` before a callout creates a formatting error on https://access.redhat.com/documentation/en-us/openshift_container_platform/4.8/html/scalability_and_performance/managing-bare-metal-hosts#adding-bare-metal-host-to-cluster-using-yaml_managing-bare-metal-hosts