### PR TITLE
BZ1856380: GCP restricted network - Adding About contents

### DIFF
--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -19,6 +19,7 @@ The steps for performing a user-provided infrastructure install are outlined her
 The steps for performing a user-provisioned infrastructure installation are provided as an example only. Installing a cluster with infrastructure you provide requires knowledge of the cloud provider and the installation process of {product-title}. Several Deployment Manager templates are provided to assist in completing these steps or to help model your own. You are also free to create the required resources through other methods; the templates are just an example.
 ====
 
+
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -31,6 +32,8 @@ Because the installation media is on the mirror host, you can use that computer 
 ====
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
+
+include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Fix for bug: https://bugzilla.redhat.com/show_bug.cgi?id=1856380

This fix targeted for 4.8 and 4.9 releases.

Preview link: https://deploy-preview-35548--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp.html#installation-about-restricted-networks_installing-restricted-networks-gcp

@tsze-redhat - Kindly review the changes. The changes are done maintaining the consistency of modular doc structure.