### PR TITLE
OSDOCS-2443: Release note for AWS support for China regions

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -68,6 +68,12 @@ You can incorporate example Azure Resource Manager (ARM) templates provided by R
 ==== Increased size of Azure subnets within the machine CIDR
 The {product-title} installation program for Microsoft Azure now creates subnets as large as possible within the machine CIDR. This lets the cluster use a machine CIDR that is appropriately sized to accommodate the number of nodes in the cluster.
 
+[id="ocp-4-9-aws-china-regions"]
+==== Support for AWS regions in China
+{product-title} {product-version} introduces support for AWS regions in China. You can now install and update {product-title} clusters in the `cn-north-1` (Beijing) and `cn-northwest-1`(Ningxia) regions.
+
+//For more information, ../installing/installing_aws/installing-aws-china.adoc[Installing a cluster on AWS into a China region].
+
 [id="ocp-4-9-web-console"]
 === Web console
 


### PR DESCRIPTION
4.9 release note.

https://issues.redhat.com/browse/OSDOCS-2443

Updated `Installation and upgrade` to include `Support for AWS regions in China`

https://deploy-preview-35553--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-aws-china-regions