### PR TITLE
modules: Drop 'upstream' from ClusterVersion examples

### DIFF
--- a/_unused_topics/upgrade-cluster-version-definition.adoc
+++ b/_unused_topics/upgrade-cluster-version-definition.adoc
@@ -24,7 +24,6 @@ spec:
   channel: stable-4.3 <1>
   overrides: "" <2>
   clusterID: 0b1cf91f-c3fb-4f9e-aa02-e0d70c71f6e6
-  upstream: https://api.openshift.com/api/upgrades_info/v1/graph
   status: <3>
     availableUpdates: null <4>
     conditions: <5>

--- a/modules/getting-cluster-version-status-and-update-details.adoc
+++ b/modules/getting-cluster-version-status-and-update-details.adoc
@@ -56,7 +56,7 @@ $ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'
 .Example output
 [source,terminal]
 ----
-{"channel":"stable-4.6","clusterID":"245539c1-72a3-41aa-9cec-72ed8cf25c5c","upstream":"https://api.openshift.com/api/upgrades_info/v1/graph"}
+{"channel":"stable-4.6","clusterID":"245539c1-72a3-41aa-9cec-72ed8cf25c5c"}
 ----
 
 . Review the available cluster updates:

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -49,7 +49,7 @@ $ oc get clusterversion -o json|jq ".items[0].spec"
 ----
 {
   "channel": "stable-4.9",
-  "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff",
+  "clusterID": "990f7ab8-109b-4c95-8480-2bd1deec55ff"
 }
 ----
 +
@@ -111,6 +111,7 @@ $ oc get clusterversion -o json|jq ".items[0].spec"
     "force": false,
     "image": "quay.io/openshift-release-dev/ocp-release@sha256:9c5f0df8b192a0d7b46cd5f6a4da2289c155fd5302dec7954f8f06c878160b8b",
     "version": "4.9.0" <1>
+  }
 }
 ----
 <1> If the `version` number in the `desiredUpdate` stanza matches the value that


### PR DESCRIPTION
In 4.1, the installer used to explicitly set upstream to our default URI.  But in openshift/installer#c9095b34518a0 (openshift/installer#4112), which landed in 4.7 and was not backported, I'd stopped doing that.  In clusters born in 4.7 and later, the installer will leave upstream unset, and the cluster-version operator will default to making a reasonable choice.

We still need to talk about explicit upstreams in the case where folks are pointing their cluster at a local OpenShift Update Service, but this commit drops the properties where we were incidentally pointing at the default, Red-Hat-hosted location, because explicitly setting that value is an anti-pattern that makes it harder for clusters to adapt if we try to move our default location elsewhere in the future.