### PR TITLE
OSDOCS-2142: Release note for Azure subnet space usage in the machine…

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -58,6 +58,10 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-9-installation-and-upgrade"]
 === Installation and upgrade
 
+[id=ocp-4.9-azure-cidr]
+==== Increased size of Azure subnets within the machine CIDR
+The {product-title} installation program for Microsoft Azure now creates subnets as large as possible within the machine CIDR. This lets the cluster use a machine CIDR that is appropriately sized to accommodate the number of nodes in the cluster.
+
 [id="ocp-4-9-web-console"]
 === Web console
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2142

Updated `Installation and upgrade` to include `Increased size of Azure subnets within the machine CIDR`

https://deploy-preview-35568--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4.9-azure-cidr