### PR TITLE
OSDOCS-2386: MCO needs to support RHEL 7 and 8 nodes in OCP 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -22,11 +22,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} is supported on {op-system-base-full} 7.9 or later, as well as on {op-system-first} 4.8.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 7.9 or later for compute machines.
-
-[IMPORTANT]
-====
-Because only {op-system-base} 7.9 or later is supported for compute machines, you must not upgrade the {op-system-base} compute machines to {op-system-base} 8.
-====
+//Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
 //{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
@@ -93,6 +89,10 @@ This release adds improvements related to the following components and concepts.
 
 [id="ocp-4-9-machine-api"]
 === Machine API
+
+[id="ocp-4-9-machine-api-rhel8"]
+==== {op-system-base-full} 8 now supported for compute machines
+Starting in {product-title} {product-version}, you can now use {op-system-base-full} 8 for compute machines. Previously, RHEL 8 was not supported for compute machines.
 
 [id="ocp-4-9-nodes"]
 === Nodes


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2386