### PR TITLE
Added the missing secured-cluster-service section in quick install

### DIFF
--- a/installing/installing_helm/install-helm-customization.adoc
+++ b/installing/installing_helm/install-helm-customization.adoc
@@ -46,7 +46,7 @@ include::modules/change-config-options-after-deployment-central-service.adoc[lev
 
 To create a secured cluster, you must create an init bundle. The secured cluster uses this bundle to authenticate with Central.
 
-You can create an init bundle by using the the roxctl CLI or from the RHACS portal.
+You can create an init bundle by using the the `roxctl` CLI or from the RHACS portal.
 
 // Generating init bundle
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]

--- a/installing/installing_helm/install-helm-quick.adoc
+++ b/installing/installing_helm/install-helm-quick.adoc
@@ -8,6 +8,13 @@ toc::[]
 [role="_abstract"]
 {product-title} installs a set services on your {ocp} cluster. This topic describes the installation procedure for installing {product-title} on your {ocp} cluster without any customizations.
 
+The following steps represent the high-level installation flow for quickly installing {product-title}:
+
+. Add the {product-title} Helm chart repository.
+. Install the `central-services` Helm chart to install the xref:../../architecture/index.adoc#centralized-components_acs-architecture[centralized components] (Central and Scanner).
+. Generate an init bundle.
+. Install the `secured-cluster-services` Helm chart to install the xref:../../architecture/index.adoc#per-cluster-components_acs-architecture[per-cluster] and xref:../../architecture/index.adoc#per-node-components_acs-architecture[per-node] components (Sensor, Admission Controller, and Collector).
+
 Before you install:
 
 * Understand xref:../../architecture/index.adoc#acs-architecture_acs-architecture[{product-title} architecture].
@@ -16,6 +23,21 @@ Before you install:
 include::modules/adding-helm-repository.adoc[leveloffset=+1]
 
 include::modules/acs-quick-install-using-helm.adoc[leveloffset=+1]
+
+[id="generate-init-bundle"]
+== Generating an init bundle
+
+To create a secured cluster, you must create an init bundle. The secured cluster uses this bundle to authenticate with Central.
+
+// Generating init bundle
+include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the roxctl CLI]
+* xref:../../installing/installing_helm/install-helm-customization.adoc#portal-generate-init-bundle_acs-install-helm-customization[Generating an init bundle by using the RHACS portal]
+
+include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+1]
 
 include::modules/verify-acs-installation.adoc[leveloffset=+1]
 

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_helm/install-helm-quick.adoc
+:_module-type: PROCEDURE
+[id="installing-secured-cluster-services-quickly_{context}"]
+= Installing the secured-cluster-services Helm chart without customization
+
+[role="_abstract"]
+Use the following instructions to install the `secured-cluster-services` Helm chart to deploy the per-cluster and per-node components (Sensor, Admission Controller, and Collector).
+
+[CAUTION]
+====
+To install Collector on systems configured with Unified Extensible Firmware Interface (UEFI) boot, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages.
+====
+
+.Prerequisites
+* You must have the address and the port number that you are exposing the Central service on.
+
+.Procedure
+* Run the following command:
++
+[source,terminal]
+----
+$ helm install -n stackrox --create-namespace \
+    stackrox-secured-cluster-services stackrox/secured-cluster-services \
+    -f <path_to_cluster_init_bundle.yaml> \ <1>
+    --set clusterName=<name_of_the_secured_cluster> \
+    --set centralEndpoint=<endpoint_of_central_service> <2>
+----
+<1> Use the `-f` option to specify the path for the init bundle.
+<2> Specify the address and port number for Central. For example, `central.stackrox:443`.

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -3,13 +3,13 @@
 // * installing/installing_helm/install-helm-quick.adoc
 :_module-type: PROCEDURE
 [id="installing-quickly_{context}"]
-= Installing quickly
+= Installing the central-services Helm chart without customization
 
-Use the following instructions to install {product-title} without any customizations.
+Use the following instructions to install the `central-services` Helm chart to deploy the centralized components (Central and Scanner).
 
 .Procedure
 
-* Run the following command to install {product-title} and expose it using a route:
+* Run the following command to install Central services and expose Central using a route:
 +
 [source,terminal]
 ----
@@ -19,7 +19,7 @@ $ helm install -n stackrox \
   --set central.exposure.route.enabled=true
 ----
 
-* Or, run the following command to install {product-title} and expose it using a load balancer:
+* Or, run the following command to install Central services and expose Central using a load balancer:
 +
 [source,terminal]
 ----
@@ -29,7 +29,7 @@ $ helm install -n stackrox \
   --set central.exposure.loadBalancer.enabled=true
 ----
 
-* Or, run the following command to install {product-title} and expose it using port forward:
+* Or, run the following command to install Central services and expose Central using port forward:
 +
 [source,terminal]
 ----

--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -5,6 +5,8 @@
 [id="portal-generate-init-bundle_{context}"]
 = Generating an init bundle by using the RHACS portal
 
+You can create an init bundle by using the RHACS portal.
+
 .Procedure
 
 . Find the address of the RHACS portal based on your exposure method:

--- a/modules/roxctl-generate-init-bundle.adoc
+++ b/modules/roxctl-generate-init-bundle.adoc
@@ -6,6 +6,8 @@
 [id="roxctl-generate-init-bundle_{context}"]
 = Generating an init bundle by using the roxctl CLI
 
+You can create an init bundle by using the the `roxctl` CLI.
+
 .Prerequisites
 * You have configured the `ROX_API_TOKEN` and the `ROX_CENTRAL_ADDRESS` environment variables.
 


### PR DESCRIPTION
This PR includes a missing section for the Helm quick install topic. 

PREVIEW: https://openshift-docs-git-secure-cluster-helm-gnelson.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-quick.html