### PR TITLE
BZ1903933: Removed note referring to performance addon operator not in developer preview anymore

### DIFF
--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -3,12 +3,6 @@
 // Epic CNF-422 (4.5)
 // scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
 
-[IMPORTANT]
-====
-The feature described in this document is for *Developer Preview* purposes and is *not supported* by Red Hat at this time.
-This feature could cause nodes to reboot and not be available.
-====
-
 [id="cnf-tuning-nodes-for-low-latency-via-performanceprofile_{context}"]
 = Tuning nodes for low latency with the performance profile
 


### PR DESCRIPTION
Removed a developer preview disclaimer at the indicated place. This is no longer valid.

https://bugzilla.redhat.com/show_bug.cgi?id=1903933

Affected version: 4.6.

Browse the preview: https://deploy-preview-35583--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes

From SME: Looked in to the changes specified in the https://github.com/openshift/openshift-docs/pull/35583. 
The changes look good to me. (Full details in BZ).
