### PR TITLE
[enterprise-4.8] Remove support for Intel E810

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -10,9 +10,6 @@
 * Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
 * Intel XL710 40GbE SFP+ with vendor ID `0x8086` and device ID `0x1583`
 * Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
-* Intel E810-CQDA2 100GbE dual-port QSPF28 and E810-2CQDA2 100GbE dual-port QSPF28 with vendor ID `0x8086` and device ID `0x1592`
-* Intel E810-XXVDA2 25GbE dual-port SPF28 with vendor ID `0x8086` and device ID `0x159b`
-* Intel E810-XXVDA4 25GbE quad-port SPF28 with vendor ID `0x8086` and device ID `0x1593`
 * Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
 * Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`
 * Mellanox MT27800 Family [ConnectX-5] 100GbE with vendor ID `0x15b3` and device ID `0x1017`

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -438,7 +438,6 @@ For more information, see xref:../networking/multiple_networks/configuring-multi
 {product-title} {product-version} adds support for additional Intel and Mellanox hardware.
 
 * Intel X710 and XL710 controllers
-* Four Intel E810 family controllers: E810-CQDA2, E810-2CQDA2, E810-XXVDA2, E810-XXVDA4
 * Mellanox ConnectX-5 Ex
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].


### PR DESCRIPTION
Intel E810 series NICs are not fully supported in RHEL-8.4

Signed-off-by: Zenghui Shi <zshi@redhat.com>