### PR TITLE
SRVOCF-346: Add a section on fine-tuning log levels in Node.js functions

### DIFF
--- a/modules/serverless-nodejs-context-object-reference.adoc
+++ b/modules/serverless-nodejs-context-object-reference.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies
-//
-// * /serverless/functions/serverless-functions-reference-guide.adoc
-
 [id="serverless-nodejs-context-object-reference_{context}"]
 = Node.js context object reference
 
@@ -33,6 +29,8 @@ $ curl http://example.com
 ----
 {"level":30,"time":1604511655265,"pid":3430203,"hostname":"localhost.localdomain","reqId":1,"msg":"Processing customer"}
 ----
+
+You can change the log level to one of `fatal`, `error`, `warn`, `info`, `debug`, `trace`, or `silent`. To do that, change the value of `logLevel` by assigning one of these values to the environment variable `FUNC_LOG_LEVEL` using the `config` command.
 
 [id="serverless-nodejs-context-object-reference-query_{context}"]
 == query


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVOCF-346
Docs preview: https://deploy-preview-35588--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-reference-guide.html#serverless-nodejs-context-object-reference-log_serverless-functions-reference-guide