### PR TITLE
BZ-1982575: Adding a note about worker node verification

### DIFF
--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -62,6 +62,12 @@ and click *Save*.
 +
 The Input channel
 *Update status* changes to *Update to <product-version> in progress*, and you can review the progress of the cluster update by watching the progress bars for the Operators and nodes.
++
+[NOTE]
+====
+If you are upgrading your cluster to the next minor version, like version 4.y to 4.(y+1), it is recommended to confirm your nodes are upgraded before deploying workloads that rely on a new feature. Any pools with worker nodes that are not yet updated are displayed on the *Cluster Settings* page.
+====
+
 
 ifdef::between[]
 . After the update completes and the Cluster Version Operator refreshes the available updates, check if more updates are available in your current channel.


### PR DESCRIPTION
Applies to 4.6+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1982575
QE ack required.
Preview Link: [Updating a cluster by using the web console](https://deploy-preview-35589--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster.html#update-upgrading-web_updating-cluster) Step number 3 and the note below it.