### PR TITLE
BZ1856380: Added About section for GCP restricted network - 4.7

### DIFF
--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -31,6 +31,8 @@ Because the installation media is on the mirror host, you can use that computer 
 * If you use a firewall, you must xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configure it to allow the sites] that your cluster requires access to. While you might need to grant access to more sites, you must grant access to `*.googleapis.com` and `accounts.google.com`.
 * If you do not allow the system to manage identity and access management (IAM), then a cluster administrator can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials]. Manual mode can also be used in environments where the cloud IAM APIs are not reachable.
 
+include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
+
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 [id="installation-restricted-networks-gcp-user-infra-config-project"]

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -7,8 +7,8 @@
 // * installing/installing_vmc/installing-restricted-networks-vmc.adoc
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc 
-// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc 
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing-rhv-restricted-network.adoc


### PR DESCRIPTION
Changes for 4.7 version from PR #35548
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1856380

Preview link: https://deploy-preview-35598--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp?utm_source=github&utm_campaign=bot_dp#installation-about-restricted-networks_installing-restricted-networks-gcp

@codyhoag - Kindly review. This can be merged if looks good.