### PR TITLE
BZ-1994420: Added a link to OCP Update Graph

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -116,6 +116,11 @@ ifdef::openshift-origin[]
 The presence of an update recommendation in the `stable-4` channel at any point is a declaration that the update is supported. While releases will never be removed from the channel, update recommendations that exhibit serious issues will be removed from the channel. Updates initiated after the update recommendation has been removed are still supported.
 endif::openshift-origin[]
 
+[NOTE]
+====
+You can use the link:https://access.redhat.com/labs/ocpupgradegraph/update_channel[Red Hat {product-title} Update Graph] visualizer and update planner to plan an upgrade from one version to another. The {product-title} Update Graph provides channel graphs and verifies if there is an update path between your current and intended cluster version. 
+====
+
 ifndef::openshift-origin[]
 [discrete]
 == Fast and stable channel use and strategies


### PR DESCRIPTION
Applies to 4.6+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1994420
Preview Link: [OpenShift Container Platform upgrade channels and releases](https://deploy-preview-35600--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster.html#understanding-upgrade-channels_updating-cluster). Scroll down to Upgrade version paths, and see the NOTE. 
QE Ack needed.