### PR TITLE
modules: Replace some 4.6 references with {product-version}

### DIFF
--- a/modules/getting-cluster-version-status-and-update-details.adoc
+++ b/modules/getting-cluster-version-status-and-update-details.adoc
@@ -24,10 +24,10 @@ $ oc get clusterversion
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME      VERSION   AVAILABLE   PROGRESSING   SINCE   STATUS
-version   4.6.4     True        False         6m25s   Cluster version is 4.6.4
+version   {product-version}.0     True        False         6m25s   Cluster version is {product-version}.0
 ----
 +
 The example output indicates that the cluster has been installed successfully.
@@ -54,9 +54,9 @@ $ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-{"channel":"stable-4.6","clusterID":"245539c1-72a3-41aa-9cec-72ed8cf25c5c"}
+{"channel":"stable-{product-version}","clusterID":"245539c1-72a3-41aa-9cec-72ed8cf25c5c"}
 ----
 
 . Review the available cluster updates:
@@ -67,12 +67,12 @@ $ oc adm upgrade
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-Cluster version is 4.6.4
+Cluster version is {product-version}.0
 
 Updates:
 
 VERSION IMAGE
-4.6.6   quay.io/openshift-release-dev/ocp-release@sha256:c7e8f18e8116356701bd23ae3a23fb9892dd5ea66c8300662ef30563d7104f39
+{product-version}.2   quay.io/openshift-release-dev/ocp-release@sha256:...
 ----

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -44,7 +44,7 @@ $ OCP_RELEASE=<release_version>
 ----
 +
 For `<release_version>`, specify the tag that corresponds to the version of {product-title} to
-install, such as `4.6.4`.
+install, such as `{product-version}.0`.
 
 .. Export the local registry name and host port:
 +


### PR DESCRIPTION
To help folks running on more recent releases feel more comfortable that these docs apply to them (they do) without needing to worry that important parts are stale.