### PR TITLE
OSDOCS-2419: Updated the privileged access controls

### DIFF
--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -27,7 +27,7 @@ Red Hat SRE adheres to the principle of least privilege when accessing {product-
 
 * OpenShift elevation, which is a manual elevation using Red Hat SSO. It is limited to 2 hours, is fully audited, and requires management approval.
 
-* Cloud provider access/elevation, which is a manual elevation for cloud provider console access. It is limited to 60 minutes, is fully audited, and requires management approval.
+* Cloud provider access or elevation, which is a manual elevation for cloud provider console or CLI access. Access is limited to 60 minutes and is fully audited.
 
 Each of these access types has different levels of access to components:
 


### PR DESCRIPTION
This PR updates the language for a privileged access category to note CLI access and remove the requirement for management approval.

JIRA: https://issues.redhat.com/browse/OSDOCS-2419

Preview: https://deploy-preview-35603--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/policy-process-security?utm_source=github&utm_campaign=bot_dp#privileged-access_policy-process-security