### PR TITLE
[RHACS] Updates for the policy crietria section

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -13,15 +13,17 @@ You can configure the policy based on the attributes listed in the following tab
 In this table:
 
 * The *Regular expressions*, *AND, OR*, and *NOT* columns indicate whether you can use regular expressions and other logical operators along with the specific attribute.
-`!` in the *Regular expressions* column indicates that you can only use regular expressions for the listed fields.
-* You cannot use logical combination operators (`AND`, `OR`) for attributes that have:
-** Boolean values (`true` and `false`)
+** `!` in the *Regular expressions* column indicates that you can only use regular expressions for the listed fields.
+** `!` in the *AND, OR* column indicates that you can only use the mentioned logical operator for the attribute.
+* The *RHACS version* column indicates the version of {product-title} that you must have to use the attribute.
+* You cannot use logical combination operators `AND` and `OR` for attributes that have:
+** Boolean values `true` and `false`
 ** Minimum-value semantics, for example:
 *** *Minimum RBAC permissions*
 *** *Days since image was created*
 * You cannot use the `NOT` logical operator for attributes that have:
-** Boolean values (`true` and `false`)
-** Numeric values that already use comparison (`<`, `>`, `+<=+`, `>=`) operators.
+** Boolean values `true` and `false`
+** Numeric values that already use comparison, such as the `<`, `>`, `+<=+`, `>=` operators.
 ** Compound criteria that can have multiple values, for example:
 *** *Dockerfile Line*, which includes both instructions and arguments.
 *** *Environment Variable*, which consists of both name and value.
@@ -29,17 +31,17 @@ In this table:
 
 [NOTE]
 ====
-To use logical operators (`AND`, `OR`, and `NOT`) for creating security policies, you need {product-title} version 3.0.45 or newer.
+To use logical operators `AND`, `OR`, and `NOT` for creating security policies, you need {product-title} version 3.0.45 or newer.
 However, on earlier versions you can still use regular expressions for the fields listed in the *Regular expressions* column.
 ====
 
-[cols="<,<,^,^,^,<"]
+[cols="<,<,<,^,^,^,<"]
 |===
-| *Attribute* | *Description* | *Regular expressions* | *NOT* | *AND, OR* | *Phase*
+| *Attribute* | *Description* | *RHACS version* | *Regular expressions* | *NOT* | *AND, OR* | *Phase*
 
 | Namespace
 | The name of the namespace.
-The `Namespace` policy criteria only works when you are using {product-title} version 3.0.51 or newer.
+| 3.0.51 and newer
 | ✓
 | ✓
 | ✓
@@ -47,6 +49,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Image Registry
 | The name of the image registry.
+| All
 | ✓
 | ✓
 | ✓
@@ -54,6 +57,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Image Remote
 | The full name of the image in registry, for example `library/nginx`.
+| All
 | ✓
 | ✓
 | ✓
@@ -61,6 +65,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Image Tag
 | Identifier for an image.
+| All
 | ✓
 | ✓
 | ✓
@@ -68,6 +73,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Days since image was created
 | The number of days from image creation date.
+| All
 | ✕
 | ✕
 | ✕
@@ -75,6 +81,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Days since image was last scanned
 | The number of days since the last image scan.
+| All
 | ✕
 | ✕
 | ✕
@@ -82,20 +89,23 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Dockerfile Line
 | A specific line in the Dockerfile, including both instructions and arguments.
-| ! (for values)
+| All
+| ! only for values
 | ✕
 | ✓
 | Build
 
 | Image is NOT Scanned
 | No scan data is available for the image.
+| All
 | ✕
 | ✕
 | ✕
 | Build
 
 | CVSS
-| Common Vulnerability Scoring System, use it to match images with vulnerabilities whose scores are greater than (>), less than (<), or equal to (=) the specified CVSS.
+| Common Vulnerability Scoring System, use it to match images with vulnerabilities whose scores are greater than `>`, less than `<`, or equal to `=` the specified CVSS.
+| All
 | ✕
 | ✕
 | ✓
@@ -103,6 +113,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Fixed By
 | The version string of a package that fixes a flagged vulnerability in an image.
+| All
 | ✓
 | ✓
 | ✓
@@ -110,6 +121,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | CVE
 | Common Vulnerabilities and Exposures, use it with specific CVE numbers.
+| All
 | ✓
 | ✓
 | ✓
@@ -117,6 +129,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Image Component
 | Name and version number of a specific software component present in an image.
+| All
 | ✓
 | ✕
 | ✓
@@ -124,7 +137,7 @@ The `Namespace` policy criteria only works when you are using {product-title} ve
 
 | Image OS
 | Name and version number of the base operating system of the image.
-The `Image OS` policy criteria only works when you are using {product-title} version 3.0.47 or newer.
+| 3.0.47 and newer
 | ✓
 | ✓
 | ✓
@@ -132,13 +145,15 @@ The `Image OS` policy criteria only works when you are using {product-title} ver
 
 | Environment Variable
 | Check environment variables by name or value.
-| ! (for key and value)
+| All
+| ! only for key and value
 | ✕
 | ✓
 | Deploy
 
 | Disallowed Annotation
 | An annotation which is not allowed to be present on Kubernetes resources in a specified environment.
+| All
 | ✓
 | ✕
 | ✓
@@ -147,8 +162,9 @@ The `Image OS` policy criteria only works when you are using {product-title} ver
 | Disallowed Image Label
 | Check for the presence of a Docker image label that should not be in use.
 The policy triggers if any image in the deployment has the specified label.
-You can use regular expressions (for both `key` and `value` fields) to match labels.
-The `Disallowed Image Label` policy criteria only works when you are using {product-title} version 3.0.40 or newer and integrate with a Docker registry.
+You can use regular expressions for both `key` and `value` fields to match labels.
+The `Disallowed Image Label` policy criteria only works when you integrate with a Docker registry.
+| 3.0.40 and newer
 | ✓
 | ✕
 | ✓
@@ -157,8 +173,9 @@ The `Disallowed Image Label` policy criteria only works when you are using {prod
 | Required Image Label
 | Check for the presence of a required Docker image label.
 The policy triggers if any image in the deployment does not have the specified label.
-You can use regular expressions (for both `key` and `value` fields) to match labels.
-The `Required Image Label` policy criteria only works when you are using {product-title} version 3.0.40 or newer and integrate with a Docker registry.
+You can use regular expressions for both `key` and `value` fields to match labels.
+The `Required Image Label` policy criteria only works when you integrate with a Docker registry.
+| 3.0.40 and newer
 | ✓
 | ✕
 | ✓
@@ -166,6 +183,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Required Label
 | Check for the presence of a required label in Kubernetes.
+| All
 | ✓
 | ✕
 | ✓
@@ -173,6 +191,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Required Annotation
 | Check for the presence of a required annotation in Kubernetes.
+| All
 | ✓
 | ✕
 | ✓
@@ -180,13 +199,15 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Volume Name
 | Name of the storage.
+| All
 | ✓
 | ✓
 | ✓
 | Deploy
 
 | Volume Source
-| Indicates the form in which the volume is provisioned (for example, `persistentVolumeClaim` or `hostPath`).
+| Indicates the form in which the volume is provisioned. For example, `persistentVolumeClaim` or `hostPath`.
+| All
 | ✓
 | ✓
 | ✓
@@ -194,6 +215,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Volume Destination
 | The path where the volume is mounted.
+| All
 | ✓
 | ✓
 | ✓
@@ -201,6 +223,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Volume Type
 | The type of volume.
+| All
 | ✓
 | ✓
 | ✓
@@ -208,13 +231,15 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Writable Volume
 | Volumes that are mounted as writable.
+| All
 | ✕
 | ✕
 | ✕
 | Deploy
 
 | Protocol
-| Protocol (such as TCP or UDP) used by exposed port.
+| Protocol, such as, TCP or UDP, that is used by the exposed port.
+| All
 | ✓
 | ✓
 | ✓
@@ -222,6 +247,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Port
 | Port numbers exposed by a deployment.
+| All
 | ✕
 | ✓
 | ✓
@@ -229,6 +255,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Privileged
 | Privileged running deployments.
+| All
 | ✕
 | ✕
 | ✕
@@ -236,6 +263,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 
 | Read-Only Root Filesystem
 | Containers running with the root file system configured as read only.
+| All
 | ✕
 | ✕
 | ✕
@@ -244,6 +272,7 @@ The `Required Image Label` policy criteria only works when you are using {produc
 | Drop Capabilities
 | Linux capabilities that must be dropped from the container.
 For example `CAP_SETUID` or `CAP_NET_RAW`.
+| All
 | ✕
 | ✕
 | ✓
@@ -251,6 +280,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Add Capabilities
 | Linux capabilities that must not be added to the container, for instance the ability to send raw packets or override file permissions.
+| All
 | ✕
 | ✕
 | ✓
@@ -258,6 +288,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Process Name
 | Name of the process executed in a deployment.
+| All
 | ✓
 | ✓
 | ✓
@@ -265,6 +296,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Process Ancestor
 | Name of any parent process for a process executed in a deployment.
+| All
 | ✓
 | ✓
 | ✓
@@ -272,6 +304,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Process Arguments
 | Command arguments for a process executed in a deployment.
+| All
 | ✓
 | ✓
 | ✓
@@ -279,6 +312,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Process UID
 | Unix user ID for a process executed in a deployment.
+| All
 | ✕
 | ✓
 | ✓
@@ -286,6 +320,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Port Exposure
 | Exposure method of the service, for example, LoadBalancer or NodePort.
+| All
 | ✕
 | ✓
 | ✓
@@ -293,6 +328,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Service Account
 | The name of the service account.
+| All
 | ✓
 | ✓
 | ✓
@@ -300,6 +336,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Writable Host Mount
 | Resource has mounted a path on the host with write permissions.
+| All
 | ✕
 | ✕
 | ✕
@@ -307,13 +344,15 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Unexpected Process Executed
 | Check deployments for which process executions are not listed in the deployment's locked process baseline.
+| All
 | ✕
 | ✕
 | ✕
 | Runtime
 
 | Minimum RBAC Permissions
-| Match if the deployment's Kubernetes service account has Kubernetes RBAC permission level equal to (=) or greater than (>) the specified level.
+| Match if the deployment's Kubernetes service account has Kubernetes RBAC permission level equal to `=` or greater than `>` the specified level.
+| All
 | ✕
 | ✓
 | ✕
@@ -321,7 +360,7 @@ For example `CAP_SETUID` or `CAP_NET_RAW`.
 
 | Container Name
 | The name of the container.
-The `Container Name` policy criteria only works when you are using {product-title} version 3.0.52 or newer.
+| 3.0.52 and newer
 | ✓
 | ✓
 | ✓
@@ -329,6 +368,7 @@ The `Container Name` policy criteria only works when you are using {product-titl
 
 | Container CPU Request
 | Check for the number of cores reserved for a given resource.
+| All
 | ✕
 | ✕
 | ✓
@@ -336,6 +376,7 @@ The `Container Name` policy criteria only works when you are using {product-titl
 
 | Container CPU Limit
 | Check for the maximum number of cores a resource is allowed to use.
+| All
 | ✕
 | ✕
 | ✓
@@ -343,6 +384,7 @@ The `Container Name` policy criteria only works when you are using {product-titl
 
 | Container Memory Request
 | Check for the amount of memory reserved for a given resource.
+| All
 | ✕
 | ✕
 | ✓
@@ -350,6 +392,7 @@ The `Container Name` policy criteria only works when you are using {product-titl
 
 | Container Memory Limit
 | Check for the maximum amount of memory a resource is allowed to use.
+| All
 | ✕
 | ✕
 | ✓
@@ -357,11 +400,77 @@ The `Container Name` policy criteria only works when you are using {product-titl
 
 | Kubernetes Action
 | The name of the Kubernetes action, such as `Pod Exec`.
-The `Kubernetes Action` policy criteria only works when you are using {product-title} version 3.0.55 or newer.
+| 3.0.55 and newer
 | ✕
-| ✓ (`OR` only)
+| ✕
+| ! `OR` only
+| Runtime
+
+| Kubernetes Resource
+| The name of the accessed Kubernetes resource, such as `configmaps` or `secrets`.
+| 3.63 and newer
+| ✕
+| ✕
+| ! `OR` only
+| Runtime
+
+| Kubernetes Resource Name
+| The name of the accessed Kubernetes resource.
+| 3.63 and newer
+| ✓
+| ✓
+| ! `OR` only
+| Runtime
+
+| Kubernetes API Verb
+| The Kubernetes API verb that is used to access the resource, such as `GET` or `POST`.
+| 3.63 and newer
+| ✕
+| ✕
+| ! `OR` only
+| Runtime
+
+| Kubernetes User Name
+| The name of the user who accessed the resource.
+| 3.63 and newer
+| ✓
+| ✓
+| ! `OR` only
+| Runtime
+
+| Kubernetes User Group
+| The name of the group to which the user who accessed the resource belongs to.
+| 3.63 and newer
+| ✓
+| ✕
+| ! `OR` only
+| Runtime
+
+| User Agent
+| The user agent that the user used to access the resource.
+For example `oc`, or `kubectl`.
+| 3.63 and newer
+| ✓
+| ✓
+| ! `OR` only
+| Runtime
+
+| Source IP Address
+| The IP address from which the user accessed the resource.
+| 3.63 and newer
+| ✓
+| ✓
+| ! `OR` only
+| Runtime
+
+| Is Impersonated User
+| Check if the request was made by a user that is impersonated by a service account or some other account.
+| 3.63 and newer
+| ✕
+| ✕
 | ✕
 | Runtime
+
 |===
 
 [NOTE]


### PR DESCRIPTION
There were some attributes missing which were part of the recent release 3.63
- I've added another column to the existing tables called `RHACS version`.
- Added the version required to use various attributes.

NOTE:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones

Preview: https://openshift-docs-git-policy-criteria-updates-gnelson.vercel.app/openshift-acs/master/operating/manage-security-policies.html#policy-criteria_manage-security-policies