### PR TITLE
Fixing the required machine table header

### DIFF
--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -15,9 +15,9 @@ One or more KVM host machines based on {op-system-base} 8.3 or later. Each {op-s
 [id="machine-requirements_{context}"]
 == Required machines
 
-The smallest {product-title} clusters require the following nodes:
+The smallest {product-title} clusters require the following hosts:
 
-.Default monitoring stack components
+.Minimum required hosts
 [options="header"]
 |===
 |Hosts |Description

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -62,7 +62,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 The smallest {product-title} clusters require the following hosts:
 
-.Default monitoring stack components
+.Minimum required hosts
 [options="header"]
 |===
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.8` and `enterprise-4.9`.

This relates to [this comment in PR 32618](https://github.com/openshift/openshift-docs/commit/e3a2d5205fea95389eb2fec526c8e911ed7465e6#r55092000).

Preview examples are [here](https://deploy-preview-35606--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#machine-requirements_installing-bare-metal) and [here](https://deploy-preview-35606--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#machine-requirements_installing-ibm-z-kvm).