### PR TITLE
BZ1989549: Fixed keepalived-ipfailover image URL

### DIFF
--- a/modules/nw-ipfailover-configuration.adoc
+++ b/modules/nw-ipfailover-configuration.adoc
@@ -67,7 +67,7 @@ spec:
         node-role.kubernetes.io/worker: ""
       containers:
       - name: openshift-ipfailover
-        image: quay.io/openshift/ose-keepalived-ipfailover:latest
+        image: quay.io/openshift/origin-keepalived-ipfailover
         ports:
         - containerPort: 63000
           hostPort: 63000


### PR DESCRIPTION
Fixed keepalived-ipfailover image URL. The correct image URL is "quay.io/openshift/origin-keepalived-ipfailover".
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1989549
OCP Version: 4.8 and 4.9
Doc Preview: https://deploy-preview-35607--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ipfailover.html#nw-ipfailover-configuration_configuring-ipfailover