### PR TITLE
BZ1949965 - Added Networking Requirements module to RHV UPI

### DIFF
--- a/installing/installing_rhv/installing-rhv-user-infra.adoc
+++ b/installing/installing_rhv/installing-rhv-user-infra.adoc
@@ -26,7 +26,9 @@ include::modules/installing-rhv-requirements.adoc[leveloffset=+1]
 
 include::modules/installing-rhv-verifying-rhv-environment.adoc[leveloffset=+1]
 
-include::modules/installing-rhv-network-infrastructure-configuration-upi.adoc[leveloffset=+1]
+//include::modules/installing-rhv-network-infrastructure-configuration-upi.adoc[leveloffset=+1]
+
+include::modules/installation-network-user-infra.adoc[leveloffset=+1]
 
 include::modules/installing-rhv-setting-up-installation-machine.adoc[leveloffset=+1]
 

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -20,6 +20,7 @@
 // * installing/installing_ibm_z/installing-ibm-power.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-power.adoc
 // * installing/installing-rhv-restricted-network.adoc
+// * installing/installing-rhv-user-infra.adoc
 
 ifeval::["{context}" == "installing-vsphere"]
 :vsphere:
@@ -64,6 +65,12 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 :gcp:
 :restricted:
 endif::[]
+ifeval::["{context}" == "installing-rhv-user-infra"]
+:rhv:
+endif::[]
+ifeval::["{context}" == "installing-rhv-restricted-network"]
+:rhv:
+endif::[]
 
 
 [id="installation-network-user-infra_{context}"]
@@ -97,6 +104,41 @@ node names. Another supported approach is to always refer to hosts by their
 fully-qualified domain names in both the node objects and all DNS requests.
 endif::azure,gcp[]
 
+ifdef::rhv[]
+.Firewall
+
+Configure your firewall so your cluster has access to required sites.
+
+See also:
+
+ifndef::openshift-origin[]
+* link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/planning_and_prerequisites_guide/index#RHV-manager-firewall-requirements_RHV_planning[Red Hat Virtualization Manager firewall requirements]
+* link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/planning_and_prerequisites_guide#host-firewall-requirements_RHV_planning[Host firewall requirements]
+endif::[]
+ifdef::openshift-origin[]
+* link:https://ovirt.org/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#RHV-manager-firewall-requirements_SHE_cli_deploy[oVirt Engine firewall requirements]
+* link:https://ovirt.org/documentation/installing_ovirt_as_a_self-hosted_engine_using_the_command_line/index.html#host-firewall-requirements_SHE_cli_deploy[Host firewall requirements]
+endif::[]
+
+ifeval::["{context}" == "installing-rhv-user-infra"]
+.Load balancers
+
+Configure one or preferably two layer-4 load balancers:
+
+* Provide load balancing for ports `6443` and `22623` on the control plane and bootstrap machines. Port `6443` provides access to the Kubernetes API server and must be reachable both internally and externally. Port `22623` must be accessible to nodes within the cluster.
+
+* Provide load balancing for port `443` and `80` for machines that run the Ingress router, which are usually compute nodes in the default configuration. Both ports must be accessible from within and outside the cluster.
+endif::[]
+
+.DNS
+
+Configure infrastructure-provided DNS to allow the correct resolution of the main components and services. If you use only one load balancer, these DNS records can point to the same IP address.
+
+* Create DNS records for `api.<cluster_name>.<base_domain>` (internal and external resolution) and `api-int.<cluster_name>.<base_domain>` (internal resolution) that point to the load balancer for the control plane machines.
+
+* Create a DNS record for `*.apps.<cluster_name>.<base_domain>` that points to the load balancer for the Ingress router. For example, ports `443` and `80` of the compute machines.
+endif::rhv[]
+
 ifndef::ibm-z[]
 [id="installation-host-names-dhcp-user-infra_{context}"]
 == Setting the cluster node hostnames through DHCP
@@ -121,6 +163,12 @@ ifndef::restricted,origin[]
 In connected {product-title} environments, all nodes are required to have internet access to pull images
 for platform containers and provide telemetry data to Red Hat.
 ====
+ifeval::["{context}" == "installing-rhv-restricted-network"]
+:!rhv:
+endif::[]
+ifeval::["{context}" == "installing-rhv-user-infra"]
+:!rhv:
+endif::[]
 endif::restricted,origin[]
 
 ifdef::ibm-z-kvm[]


### PR DESCRIPTION
enterprise_4.9
enterprise_4.8
enterprise_4.7
enterprise_4.6

For versions 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1949965

This PR adds the module "Networking Requirements" to the RHV UPI installation section.
- Added modules/installation-network-user-infra.adoc to RHV UPI installation section.
- Removed modules/installing-rhv-network-infrastructure-configuration-upi.adoc and added that info
  to modules/installation-network-user-infra.adoc.

Direct link to doc preview:
