### PR TITLE
[enterprise-4.9] Clarifying that 1.3 isn't supported as the minTLS

### DIFF
--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -40,7 +40,7 @@ You can see the configured TLS security profile in the `APIServer` custom resour
 
 [NOTE]
 ====
-The control plane does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported.
+The control plane does not support TLS `1.3` as the minimum TLS version; the `Modern` profile is not supported because it requires TLS `1.3`.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Manual CP of #34895 to 4.9 because the cherry-pick bot isn't working right now.