### PR TITLE
SRVKE-835: Add section on monitoring Knative Eventing channels

### DIFF
--- a/modules/serverless-admin-monitoring-eventing-channel.adoc
+++ b/modules/serverless-admin-monitoring-eventing-channel.adoc
@@ -1,0 +1,28 @@
+[id="serverless-admin-monitoring-eventing-channel_{context}"]
+= Monitoring Knative Eventing channels
+
+You can use the {product-title} monitoring dashboards to view metrics for channels in your cluster.
+
+.Prerequisites
+
+* You have cluster administrator permissions, and access to the *Administrator* perspective in the {product-title} web console.
+* You installed the {ServerlessOperatorName}, the Knative Eventing component, and the `KnativeKafka` custom resource.
+* The {product-title} monitoring stack is enabled on your cluster. You can enable monitoring for {ServerlessProductName} during installation by checking the box to *Enable operator recommended cluster monitoring on this namespace* when installing the {ServerlessOperatorName}.
+
+.Procedure
+
+. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. Select the *Knative Eventing - Channel* dashboard in the *Dashboard* drop-down list.
+. You can now view the following metrics:
+.. For in-memory channels:
+*** Event Count (avg/sec, over 1m window)
+*** Success Rate (2xx Event, fraction rate, over 1m window)
+*** Event Count by Response Code Class (avg/sec, over 1m window)
+*** Failure Rate (non-2xx Event, fraction rate, over 1m window)
+*** Event Dispatch Latency (ms)
+.. For Kafka channels:
+*** Event Count (avg/sec, over 1m window)
+*** Success Rate (2xx Event, fraction rate, over 1m window)
+*** Event Count by Response Code Class (avg/sec, over 1m window)
+*** Failure Rate (non-2xx Event, fraction rate, over 1m window)
+*** Event Dispatch Latency (ms)

--- a/serverless/admin_guide/serverless-admin-monitoring.adoc
+++ b/serverless/admin_guide/serverless-admin-monitoring.adoc
@@ -18,3 +18,4 @@ include::modules/serverless-admin-monitoring-serving-cpu-memory.adoc[leveloffset
 include::modules/serverless-admin-monitoring-eventing-cpu-memory.adoc[leveloffset=+1]
 include::modules/serverless-admin-monitoring-eventing-sources.adoc[leveloffset=+1]
 include::modules/serverless-admin-monitoring-eventing-broker-trigger.adoc[leveloffset=+1]
+include::modules/serverless-admin-monitoring-eventing-channel.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVKE-835
Docs preview: https://deploy-preview-35611--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-admin-monitoring?utm_source=github&utm_campaign=bot_dp#serverless-admin-monitoring-eventing-channel_serverless-admin-monitoring