### PR TITLE
[enterprise-4.9] GitHub-32555: Updating location to download the CLI

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -73,9 +73,9 @@ ifdef::openshift-origin[]
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
-. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
-. Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command line interface* section, select *Linux* from the drop-down menu and click *Download command-line tools*.
+. Navigate to the link:https://access.redhat.com/downloads/content/290[{product-title} downloads page] on the Red Hat Customer Portal.
+. Select the appropriate version in the *Version* drop-down menu.
+. Click *Download Now* next to the *OpenShift v{product-version} Linux Client* entry and save the file.
 endif::[]
 . Unpack the archive:
 +
@@ -92,7 +92,7 @@ To check your `PATH`, execute the following command:
 $ echo $PATH
 ----
 
-After you install the CLI, it is available using the `oc` command:
+After you install the OpenShift CLI, it is available using the `oc` command:
 
 [source,terminal]
 ----
@@ -111,9 +111,9 @@ ifdef::openshift-origin[]
 . Download `oc.zip`.
 endif::[]
 ifndef::openshift-origin[]
-. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
-. Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command line interface* section, select *Windows* from the drop-down menu and click *Download command-line tools*.
+. Navigate to the link:https://access.redhat.com/downloads/content/290[{product-title} downloads page] on the Red Hat Customer Portal.
+. Select the appropriate version in the *Version* drop-down menu.
+. Click *Download Now* next to the *OpenShift v{product-version} Windows Client* entry and save the file.
 endif::[]
 . Unzip the archive with a ZIP program.
 . Move the `oc` binary to a directory that is on your `PATH`.
@@ -125,7 +125,7 @@ To check your `PATH`, open the command prompt and execute the following command:
 C:\> path
 ----
 
-After you install the CLI, it is available using the `oc` command:
+After you install the OpenShift CLI, it is available using the `oc` command:
 
 [source,terminal]
 ----
@@ -144,9 +144,9 @@ ifdef::openshift-origin[]
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
-. Navigate to the link:https://cloud.redhat.com/openshift/install[Infrastructure Provider] page on the {cloud-redhat-com} site.
-. Select your infrastructure provider, and, if applicable, your installation type.
-. In the *Command line interface* section, select *MacOS* from the drop-down menu and click *Download command-line tools*.
+. Navigate to the link:https://access.redhat.com/downloads/content/290[{product-title} downloads page] on the Red Hat Customer Portal.
+. Select the appropriate version in the *Version* drop-down menu.
+. Click *Download Now* next to the *OpenShift v{product-version} MacOSX Client* entry and save the file.
 endif::[]
 . Unpack and unzip the archive.
 . Move the `oc` binary to a directory on your PATH.
@@ -158,7 +158,7 @@ To check your `PATH`, open a terminal and execute the following command:
 $ echo $PATH
 ----
 
-After you install the CLI, it is available using the `oc` command:
+After you install the OpenShift CLI, it is available using the `oc` command:
 
 [source,terminal]
 ----


### PR DESCRIPTION
Manual cherry pick of #35143 to 4.9, because cherry pick bot isn't working right now.