### PR TITLE
OSDOCS-2375 Update auto-included UPI template versions

### DIFF
--- a/modules/installation-arm-bootstrap.adoc
+++ b/modules/installation-arm-bootstrap.adoc
@@ -13,6 +13,6 @@ bootstrap machine that you need for your {product-title} cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/04_bootstrap.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/04_bootstrap.json[]
 ----
 ====

--- a/modules/installation-arm-control-plane.adoc
+++ b/modules/installation-arm-control-plane.adoc
@@ -13,6 +13,6 @@ control plane machines that you need for your {product-title} cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/05_masters.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/05_masters.json[]
 ----
 ====

--- a/modules/installation-arm-dns.adoc
+++ b/modules/installation-arm-dns.adoc
@@ -14,6 +14,6 @@ cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/03_infra.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/03_infra.json[]
 ----
 ====

--- a/modules/installation-arm-image-storage.adoc
+++ b/modules/installation-arm-image-storage.adoc
@@ -13,6 +13,6 @@ stored {op-system-first} image that you need for your {product-title} cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/02_storage.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/02_storage.json[]
 ----
 ====

--- a/modules/installation-arm-vnet.adoc
+++ b/modules/installation-arm-vnet.adoc
@@ -13,6 +13,6 @@ VNet that you need for your {product-title} cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/01_vnet.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/01_vnet.json[]
 ----
 ====

--- a/modules/installation-arm-worker.adoc
+++ b/modules/installation-arm-worker.adoc
@@ -13,6 +13,6 @@ worker machines that you need for your {product-title} cluster:
 ====
 [source,json]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/azure/06_workers.json[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/azure/06_workers.json[]
 ----
 ====

--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -47,7 +47,7 @@ environment variable:
 +
 [source,terminal]
 ----
-$ export VHD_URL=`curl -s https://raw.githubusercontent.com/openshift/installer/release-4.8/data/data/rhcos.json | jq -r .azure.url`
+$ export VHD_URL=`curl -s https://raw.githubusercontent.com/openshift/installer/release-4.9/data/data/rhcos.json | jq -r .azure.url`
 ----
 +
 [IMPORTANT]

--- a/modules/installation-cloudformation-bootstrap.adoc
+++ b/modules/installation-cloudformation-bootstrap.adoc
@@ -14,6 +14,6 @@ machine that you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/04_cluster_bootstrap.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/04_cluster_bootstrap.yaml[]
 ----
 ====

--- a/modules/installation-cloudformation-control-plane.adoc
+++ b/modules/installation-cloudformation-control-plane.adoc
@@ -14,6 +14,6 @@ machines that you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/05_cluster_master_nodes.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/05_cluster_master_nodes.yaml[]
 ----
 ====

--- a/modules/installation-cloudformation-dns.adoc
+++ b/modules/installation-cloudformation-dns.adoc
@@ -14,7 +14,7 @@ objects and load balancers that you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/02_cluster_infra.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/02_cluster_infra.yaml[]
 ----
 ====
 

--- a/modules/installation-cloudformation-security.adoc
+++ b/modules/installation-cloudformation-security.adoc
@@ -14,6 +14,6 @@ that you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/03_cluster_security.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/03_cluster_security.yaml[]
 ----
 ====

--- a/modules/installation-cloudformation-vpc.adoc
+++ b/modules/installation-cloudformation-vpc.adoc
@@ -14,6 +14,6 @@ you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/01_vpc.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/01_vpc.yaml[]
 ----
 ====

--- a/modules/installation-cloudformation-worker.adoc
+++ b/modules/installation-cloudformation-worker.adoc
@@ -14,6 +14,6 @@ that you need for your {product-title} cluster.
 ====
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/aws/cloudformation/06_cluster_worker_node.yaml[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/aws/cloudformation/06_cluster_worker_node.yaml[]
 ----
 ====

--- a/modules/installation-deployment-manager-bootstrap.adoc
+++ b/modules/installation-deployment-manager-bootstrap.adoc
@@ -14,6 +14,6 @@ machine that you need for your {product-title} cluster:
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/04_bootstrap.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/04_bootstrap.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-control-plane.adoc
+++ b/modules/installation-deployment-manager-control-plane.adoc
@@ -14,6 +14,6 @@ plane machines that you need for your {product-title} cluster:
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/05_control_plane.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/05_control_plane.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-ext-lb.adoc
+++ b/modules/installation-deployment-manager-ext-lb.adoc
@@ -12,6 +12,6 @@ You can use the following Deployment Manager template to deploy the external loa
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/02_lb_ext.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/02_lb_ext.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-firewall-rules.adoc
+++ b/modules/installation-deployment-manager-firewall-rules.adoc
@@ -12,6 +12,6 @@ You can use the following Deployment Manager template to deploy the firewall rue
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/03_firewall.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/03_firewall.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-iam-shared-vpc.adoc
+++ b/modules/installation-deployment-manager-iam-shared-vpc.adoc
@@ -12,6 +12,6 @@ You can use the following Deployment Manager template to deploy the IAM roles th
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/03_iam.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/03_iam.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-int-lb.adoc
+++ b/modules/installation-deployment-manager-int-lb.adoc
@@ -12,7 +12,7 @@ You can use the following Deployment Manager template to deploy the internal loa
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/02_lb_int.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/02_lb_int.py[]
 ----
 ====
 

--- a/modules/installation-deployment-manager-private-dns.adoc
+++ b/modules/installation-deployment-manager-private-dns.adoc
@@ -12,6 +12,6 @@ You can use the following Deployment Manager template to deploy the private DNS 
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/02_dns.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/02_dns.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-vpc.adoc
+++ b/modules/installation-deployment-manager-vpc.adoc
@@ -14,6 +14,6 @@ you need for your {product-title} cluster:
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/01_vpc.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/01_vpc.py[]
 ----
 ====

--- a/modules/installation-deployment-manager-worker.adoc
+++ b/modules/installation-deployment-manager-worker.adoc
@@ -14,6 +14,6 @@ that you need for your {product-title} cluster:
 ====
 [source,python]
 ----
-include::https://raw.githubusercontent.com/openshift/installer/release-4.8/upi/gcp/06_worker.py[]
+include::https://raw.githubusercontent.com/openshift/installer/release-4.9/upi/gcp/06_worker.py[]
 ----
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2375

This PR updates the auto-included templates to display the latest 4.9 UPI templates.

Updates are for the AWS, Azure, and GCP UPI assemblies:

AWS: https://deploy-preview-35634--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html
Azure: https://deploy-preview-35634--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html
GCP: https://deploy-preview-35634--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html