### PR TITLE
Support Multiple Logins to the Same Registry

### DIFF
--- a/modules/builds-docker-credentials-private-registries.adoc
+++ b/modules/builds-docker-credentials-private-registries.adoc
@@ -7,6 +7,8 @@
 
 You can supply builds with a .`docker/config.json` file with valid credentials for private container registries. This allows you to push the output image into a private container image registry or pull a builder image from the private container image registry that requires authentication.
 
+You can supply credentials for multiple repositories within the same registry, each with credentials specific to that registry path.
+
 [NOTE]
 ====
 For the {product-title} container image registry, this is not required because secrets are generated automatically for you by {product-title}.
@@ -21,12 +23,20 @@ auths:
   https://index.docker.io/v1/: <1>
     auth: "YWRfbGzhcGU6R2labnRib21ifTE=" <2>
     email: "user@example.com" <3>
+  https://docker.io/my-namespace/my-user/my-image: <4>
+      auth: "GzhYWRGU6R2fbclabnRgbkSp=""
+      email: "user@example.com"
+  https://docker.io/my-namespace: <5>
+      auth: "GzhYWRGU6R2deesfrRgbkSp=""
+      email: "user@example.com"
 ----
 <1> URL of the registry.
 <2> Encrypted password.
 <3> Email address for the login.
+<4> URL and credentials for a specific image in a namespace.
+<5> URL and credentials for a registry namespace.
 
-You can define multiple container image registry entries in this file. Alternatively, you can also add authentication entries to this file by running the `docker login` command. The file will be created if it does not exist.
+You can define multiple container image registries or define multiple repositories in the same registry. Alternatively, you can also add authentication entries to this file by running the `docker login` command. The file will be created if it does not exist.
 
 Kubernetes provides `Secret` objects, which can be used to store configuration and passwords.
 

--- a/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
+++ b/modules/images-allow-pods-to-reference-images-from-secure-registries.adoc
@@ -10,6 +10,45 @@ The `.dockercfg` `$HOME/.docker/config.json` file for Docker clients is a Docker
 
 To pull a secured container image that is not from {product-title}'s internal registry, you must create a pull secret from your Docker credentials and add it to your service account.
 
+The Docker credentials file and the associated pull secret can contain multiple references to the same registry, each with its own set of credentials.
+
+.Example `config.json` file
+[source,json]
+----
+{
+   "auths":{
+      "cloud.openshift.com":{
+         "auth":"b3Blb=",
+         "email":"you@example.com"
+      },
+      "quay.io":{
+         "auth":"b3Blb=",
+         "email":"you@example.com"
+      },
+      "quay.io/repository-main":{
+         "auth":"b3Blb=",
+         "email":"you@example.com"
+      }
+   }
+}
+----
+
+.Example pull secret
+[source,yaml]
+----
+apiVersion: v1
+data:
+  .dockerconfigjson: ewogICAiYXV0aHMiOnsKICAgICAgIm0iOnsKICAgICAgIsKICAgICAgICAgImF1dGgiOiJiM0JsYj0iLAogICAgICAgICAiZW1haWwiOiJ5b3VAZXhhbXBsZS5jb20iCiAgICAgIH0KICAgfQp9Cg==
+kind: Secret
+metadata:
+  creationTimestamp: "2021-09-09T19:10:11Z"
+  name: pull-secret
+  namespace: default
+  resourceVersion: "37676"
+  uid: e2851531-01bc-48ba-878c-de96cfe31020
+type: Opaque
+----
+
 .Procedure
 
 * If you already have a `.dockercfg` file for the secured registry, you can create a secret from that file by running:

--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -47,7 +47,7 @@ $ oc registry login --registry="<registry>" \ <1>
 --auth-basic="<username>:<password>" \ <2>
 --to=<pull_secret_location> <3>
 ----
-<1> Provide the new registry.
+<1> Provide the new registry. You can include multiple repositories within the same registry, for example: `--registry="<registry/my-namespace/my-repository>"`. 
 <2> Provide the credentials of the new registry.
 <3> Provide the path to the pull secret file.
 +

--- a/modules/olm-accessing-images-private-registries.adoc
+++ b/modules/olm-accessing-images-private-registries.adoc
@@ -44,9 +44,9 @@ The file path of your registry credentials can be different depending on the con
 
 .. It is recommended to include credentials for only one registry per secret, and manage credentials for multiple registries in separate secrets. Multiple secrets can be included in a `CatalogSource` object in later steps, and {product-title} will merge the secrets into a single virtual credentials file for use during an image pull.
 +
-A registry credentials file can, by default, store details for more than one registry. Verify the current contents of your file. For example:
+A registry credentials file can, by default, store details for more than one registry or for multiple repositories in one registry. Verify the current contents of your file. For example:
 +
-.File storing credentials for two registries
+.File storing credentials for multiple registries
 [source,json]
 ----
 {
@@ -55,7 +55,19 @@ A registry credentials file can, by default, store details for more than one reg
                         "auth": "FrNHNydQXdzclNqdg=="
                 },
                 "quay.io": {
-                        "auth": "Xd2lhdsbnRib21iMQ=="
+                        "auth": "fegdsRib21iMQ=="
+                }
+                },
+                "https://quay.io/my-namespace/my-user/my-image": {
+                        "auth": "eWfjwsDdfsa221=="
+                }
+                },
+                "https://quay.io/my-namespace/my-user": {
+                        "auth": "feFweDdscw34rR=="
+                }
+                },
+                "https://quay.io/my-namespace": {
+                        "auth": "frwEews4fescyq=="
                 }
         }
 }

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -13,23 +13,6 @@ You can obtain the image pull secret, `pullSecret`, from the link:https://cloud.
 
 You use this pull secret to authenticate with the services that are provided by the included authorities, including link:quay.io[Quay.io] and link:registry.redhat.io[registry.redhat.io], which serve the container images for {product-title} components.
 
-.Example `config.json` file
-[source,json]
-----
-{
-   "auths":{
-      "cloud.openshift.com":{
-         "auth":"b3Blb=",
-         "email":"you@example.com"
-      },
-      "quay.io":{
-         "auth":"b3Blb=",
-         "email":"you@example.com"
-      }
-   }
-}
-----
-
 include::modules/images-allow-pods-to-reference-images-across-projects.adoc[leveloffset=+1]
 
 include::modules/images-allow-pods-to-reference-images-from-secure-registries.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2384
https://issues.redhat.com/browse/OCPNODE-596

Previews:
[Using docker credentials for private registries](https://deploy-preview-35639--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs)
[Allowing pods to reference images from other secured registries](https://deploy-preview-35639--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets)
[Updating the global cluster pull secret](https://deploy-preview-35639--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets)
[Accessing images for Operators from private registries](https://deploy-preview-35639--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-accessing-images-private-registries_olm-managing-custom-catalogs)
[Using image pull secrets](https://deploy-preview-35639--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html)


