### PR TITLE
Fix note formatting for FIPS mode

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -198,10 +198,12 @@ $ eval "$(ssh-agent -s)"
 ----
 Agent pid 31874
 ----
++
 [NOTE]
 ====
 If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate the SSH key. The key must be either RSA or ECDSA.
 ====
+
 . Add your SSH private key to the `ssh-agent`:
 +
 [source,terminal]


### PR DESCRIPTION
No QE necessary; formatting change only.

Original note rendering: https://docs.openshift.com/container-platform/4.8/installing/installing_azure/installing-azure-user-infra.html#ssh-agent-using_installing-azure-user-infra

Change preview: https://deploy-preview-35640--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#ssh-agent-using_installing-azure-user-infra