### PR TITLE
OSDOCS-2395: Add release note for DPDK GA

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -69,6 +69,11 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-9-networking"]
 === Networking
 
+[id="ocp-4-9-sriov-dpdk-ga"]
+==== SR-IOV containerized Data Plane Development Kit (DPDK) is GA
+
+The containerized Data Plane Development Kit (DPDK) is now GA in {product-title} {product-version}. For more information, see xref:../networking/hardware_networks/using-dpdk-and-rdma.adoc#using-dpdk-and-rdma[Using virtual functions (VFs) with DPDK and RDMA modes].
+
 [id="ocp-4-9-storage"]
 === Storage
 
@@ -510,6 +515,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 |
+
+|Data Plane Development Kit (DPDK) support
+|TP
+|TP
+|GA
 
 |====
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2395

This adds a RN for DPDK GA and updates the TP table.

Previews:
- https://deploy-preview-35643--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-sriov-dpdk-ga
- https://deploy-preview-35643--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-technology-preview