### PR TITLE
[RHACS] Added the option for generating init bundle for operator

### DIFF
--- a/installing/install-ocp-operator.adoc
+++ b/installing/install-ocp-operator.adoc
@@ -2,6 +2,7 @@
 = Installing by using an Operator
 include::modules/common-attributes.adoc[]
 :context: install-ocp-operator
+:topic-operator:
 
 toc::[]
 

--- a/installing/installing_helm/install-helm-customization.adoc
+++ b/installing/installing_helm/install-helm-customization.adoc
@@ -2,6 +2,7 @@
 = Installing with customizations using Helm charts
 include::modules/common-attributes.adoc[]
 :context: acs-install-helm-customization
+:topic-helm:
 
 toc::[]
 

--- a/modules/roxctl-generate-init-bundle.adoc
+++ b/modules/roxctl-generate-init-bundle.adoc
@@ -2,6 +2,8 @@
 //
 // * installing/installing_helm/install-helm-customization.adoc
 // * installing/install-ocp-operator.adoc
+//
+// You must declare the `topic-helm` or `topic-operator` attribute when using this module.
 :_module-type: PROCEDURE
 [id="roxctl-generate-init-bundle_{context}"]
 = Generating an init bundle by using the roxctl CLI
@@ -15,12 +17,23 @@ You can create an init bundle by using the the `roxctl` CLI.
 
 * Run the following command to generate a cluster init bundle:
 +
+ifdef::topic-helm[]
 [source,terminal]
 ----
 $ roxctl -e "$ROX_CENTRAL_ADDRESS" \
   central init-bundles generate <cluster_init_bundle_name> \
   --output cluster_init_bundle.yaml
 ----
+endif::[]
+
+ifdef::topic-operator[]
+[source,terminal]
+----
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" \
+  central init-bundles generate <cluster_init_bundle_name> \
+  --output-secrets cluster_init_bundle.yaml
+----
+endif::[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/35628#discussion_r692236950

~~QUESTION for the reviewer:~~
~~I have a procedure module that is being used in two assemblies. Now I need to modify one command in that procedure that is different for each assembly. I've added a callout for the option but do you reckon if there's a better way? or should I duplicate the content with the modified option in another module ?~~

EDIT:
- I've added attributes in the assemblies and added `ifdef` directive in the module. Thanks @mikemckiernan 

Preview:
- https://openshift-docs-l8z3vm2sr-gnelson.vercel.app/openshift-acs/master/installing/install-ocp-operator.html#roxctl-generate-init-bundle_install-ocp-operator
- https://openshift-docs-l8z3vm2sr-gnelson.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-customization.html#roxctl-generate-init-bundle_acs-install-helm-customization

NOTES:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
