### PR TITLE
Add documentation for BIOS feature

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -39,3 +39,7 @@ endif::[]
 ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+1]
 endif::[]
+
+ifeval::[{product-version} > 4.8]
+include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+1]
+endif::[]

--- a/modules/ipi-install-configuring-bios-for-worker-node.adoc
+++ b/modules/ipi-install-configuring-bios-for-worker-node.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+[id="configuring-bios-for-worker-node_{context}"]
+= Configuring BIOS for worker node
+
+The following procedure configures BIOS for the worker node during the installation process.
+
+.Procedure
+. Create manifests.
+. Modify the BMH file corresponding to the worker:
++
+----
+$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-3.yaml
+----
+. Add the BIOS configuration to the `spec` section of the BMH file:
++
+----
+spec:
+  firmware:
+    simultaneousMultithreadingEnabled: true
+    sriovEnabled: true
+    virtualizationEnabled: true
+----
++
+[NOTE]
+====
+. Red Hat supports three BIOS configurations. See the link:https://github.com/openshift/baremetal-operator/blob/master/docs/api.md#firmware[BMH documentation] for details. Only servers with bmc type `irmc` are supported. Other types of servers are currently not supported.
+====
+. Create cluster.


### PR DESCRIPTION
In OCP4.9, the feature of configuring the BIOS of the worker node in the process of IPI has been added.
Add corresponding documents for detailed description.

Fixes: [MPHARDWARE-6](https://issues.redhat.com/browse/MPHARDWARE-6) 

See https://issues.redhat.com/browse/MPHARDWARE-6 for additional details

For release(s): 4.9

Preview: this code is branch-specific so can't be previewed with regular tools due to known ascii_binder bug causing any branch-specific content not to be rendered.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>