### PR TITLE
added notes for 3.11.501 release

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -4715,6 +4715,7 @@ Issued: 2021-06-30
 [[ocp-3-11-462-images]]
 ==== Images
 
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
 ----
 openshift3/ose-ansible:v3.11.462-1.git.53e69e6
 openshift3/ose-cluster-autoscaler:v3.11.462-1.git.99b2acf
@@ -4810,6 +4811,7 @@ Issued: 2021-07-07
 [[ocp-3-11-465-images]]
 ==== Images
 
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
 ----
 openshift3/ose-ansible:v3.11.465-1.git.58ac570
 openshift3/ose-cluster-autoscaler:v3.11.465-1.git.99b2acf
@@ -4910,6 +4912,7 @@ Issued: 2021-08-04
 [[ocp-3-11-487-images]]
 ==== Images
 
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
 ----
 openshift3/ose-ansible:v3.11.487-1.git.f146c20
 openshift3/ose-cluster-autoscaler:v3.11.487-1.git.99b2acf
@@ -4991,6 +4994,104 @@ openshift3/ose-template-service-broker:v3.11.487-1.git.0b26065
 ----
 
 [[ocp-3-11-487-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
+
+[[ocp-3-11-501]]
+
+=== RHBA-2021:3192 - {product-title} 3.11.501 bug fix and security update
+
+Issued: 2021-08-25
+
+{product-title} release 3.11.501 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2021:3193[RHSA-2021:3193] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3192[RHBA-2021:3192] advisory.
+
+[[ocp-3-11-501-images]]
+
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
+----
+openshift3/ose-ansible:v3.11.501-1.git.5ea39b1
+openshift3/ose-cluster-autoscaler:v3.11.501-1.git.99b2acf
+openshift3/ose-descheduler:v3.11.501-1.git.d435537
+openshift3/ose-metrics-server:v3.11.501-1.git.f8bf728
+openshift3/ose-node-problem-detector:v3.11.501-1.git.c8f26da
+openshift3/automation-broker-apb:v3.11.501-1
+openshift3/ose-cluster-monitoring-operator:v3.11.501-1.git.a9fd527
+openshift3/ose-configmap-reloader:v3.11.501-1.git.bb85bd3
+openshift3/csi-attacher:v3.11.501-1
+openshift3/csi-driver-registrar:v3.11.501-1
+openshift3/csi-livenessprobe:v3.11.501-1
+openshift3/csi-provisioner:v3.11.501-1
+openshift3/ose-efs-provisioner:v3.11.501-1.git.04aa20d
+openshift3/oauth-proxy:v3.11.501-1.git.edebe84
+openshift3/prometheus-alertmanager:v3.11.501-1.git.13de638
+openshift3/prometheus-node-exporter:v3.11.501-1.git.609cd20
+openshift3/prometheus:v3.11.501-1.git.99aae51
+openshift3/grafana:v3.11.501-1.git.2ea5517
+openshift3/image-inspector:v3.11.501-1
+openshift3/jenkins-agent-maven-35-rhel7:v3.11.501-1.git.10eb612
+openshift3/jenkins-agent-maven-36-rhel7:v3.11.501-1.git.10eb612
+openshift3/jenkins-agent-nodejs-10-rhel7:v3.11.501-1.git.10eb612
+openshift3/jenkins-agent-nodejs-12-rhel7:v3.11.501-1.git.10eb612
+openshift3/jenkins-slave-base-rhel7:v3.11.501-1.git.10eb612
+openshift3/ose-kube-rbac-proxy:v3.11.501-1.git.31106c3
+openshift3/ose-kube-state-metrics:v3.11.501-1.git.b7c6d38
+openshift3/kuryr-cni:v3.11.501-1.git.c33a657
+openshift3/ose-logging-curator5:v3.11.501-1.git.99f978e
+openshift3/ose-logging-elasticsearch5:v3.11.501-1.git.99f978e
+openshift3/ose-logging-eventrouter:v3.11.501-1
+openshift3/logging-fluentd:v3.11.501-1.git.99f978e
+openshift3/ose-logging-kibana5:v3.11.501-1.git.99f978e
+openshift3/metrics-cassandra:v3.11.501-1
+openshift3/metrics-hawkular-metrics:v3.11.501-1
+openshift3/metrics-hawkular-openshift-agent:v3.11.501-1
+openshift3/metrics-heapster:v3.11.501-1
+openshift3/metrics-schema-installer:v3.11.501-1
+openshift3/apb-base:v3.11.501-1.git.1177b41
+openshift3/apb-tools:v3.11.501-1
+openshift3/ose-ansible-service-broker:v3.11.501-1
+openshift3/ose-docker-builder:v3.11.501-1.git.f8c4746
+openshift3/ose-cli:v3.11.501-1.git.f8c4746
+openshift3/ose-cluster-capacity:v3.11.501-1.git.22be164
+openshift3/ose-console:v3.11.501-1.git.34f65c8
+openshift3/ose:v3.11.501-1.git.f8c4746
+openshift3/ose-deployer:v3.11.501-1.git.f8c4746
+openshift3/ose-egress-dns-proxy:v3.11.501-1.git.f8c4746
+openshift3/ose-egress-router:v3.11.501-1.git.f8c4746
+openshift3/ose-haproxy-router:v3.11.501-1.git.f8c4746
+openshift3/ose-hyperkube:v3.11.501-1.git.f8c4746
+openshift3/ose-hypershift:v3.11.501-1.git.f8c4746
+openshift3/ose-keepalived-ipfailover:v3.11.501-1.git.f8c4746
+openshift3/mariadb-apb:v3.11.501-1
+openshift3/mediawiki-apb:v3.11.501-1
+openshift3/mediawiki:v3.11.501-1
+openshift3/mysql-apb:v3.11.501-1
+openshift3/node:v3.11.501-1.git.f8c4746
+openshift3/ose-pod:v3.11.501-1.git.f8c4746
+openshift3/postgresql-apb:v3.11.501-1
+openshift3/ose-recycler:v3.11.501-1.git.f8c4746
+openshift3/ose-docker-registry:v3.11.501-1.git.3571208
+openshift3/ose-service-catalog:v3.11.501-1.git.2e6be86
+openshift3/ose-tests:v3.11.501-1.git.f8c4746
+openshift3/jenkins-2-rhel7:v3.11.501-1.git.10eb612
+openshift3/local-storage-provisioner:v3.11.501-1
+openshift3/manila-provisioner:v3.11.501-1
+openshift3/ose-operator-lifecycle-manager:v3.11.501-1.git.1054881
+openshift3/ose-web-console:v3.11.501-1.git.fc3b323
+openshift3/ose-egress-http-proxy:v3.11.501-1.git.f8c4746
+openshift3/kuryr-controller:v3.11.501-1.git.c33a657
+openshift3/ose-ovn-kubernetes:v3.11.501-1.git.21370b4
+openshift3/ose-prometheus-config-reloader:v3.11.501-1.git.d4bae2d
+openshift3/ose-prometheus-operator:v3.11.501-1.git.d4bae2d
+openshift3/registry-console:v3.11.501-1
+openshift3/snapshot-controller:v3.11.501-1
+openshift3/snapshot-provisioner:v3.11.501-1
+openshift3/ose-template-service-broker:v3.11.501-1.git.f8c4746
+----
+
+[[ocp-3-11-501-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.


### PR DESCRIPTION
Release notes for 3.11.501

- Applies to `enterprise-3.11`
- [Preview link](https://deploy-preview-35670--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes?utm_source=github&utm_campaign=bot_dp#ocp-3-11-501)