### PR TITLE
BZ1989922 - Corrected the values of minimum resource requirements for Compute

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -156,8 +156,6 @@ ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
 ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.9]
-ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system} or RHEL 7.9]
 |2
 |8 GB
 |120 GB


### PR DESCRIPTION
This PR is to address BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1989922
Change is available in this topic: https://deploy-preview-35679--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#minimum-resource-requirements_installing-bare-metal-network-customizations
Exact section: Machine requirements for a cluster with user-provisioned infrastructure > Minimum Resource Requirements > 'Compute' row
Label: enterprise-4.6
This change is applicable for enterprise-4.6 only. The values are correct in enterprise-4.7 and enterprise-4.8 repos. 