### PR TITLE
[installer][aws] adjusting description of new default instance type for control planes

### DIFF
--- a/modules/installation-aws-limits.adoc
+++ b/modules/installation-aws-limits.adoc
@@ -34,10 +34,8 @@ more worker nodes, enable autoscaling, deploy large workloads, or use a
 different instance type, review your account limits to ensure that your cluster
 can deploy the machines that you need.
 
-In most regions, the bootstrap and worker machines uses an `m4.large` machines
-and the control plane machines use `m4.xlarge` instances. In some regions, including
-all regions that do not support these instance types, `m5.large` and `m5.xlarge`
-instances are used instead.
+In most regions, the bootstrap and worker machines uses an `m5.large` machines
+and the control plane machines use `m5.xlarge` instances.
 
 |Elastic IPs (EIPs)
 |0 to 1


### PR DESCRIPTION
### Which section(s) is the issue in?

-  [Installing / Installing on AWS / Configuring an AWS account / AWS account limits](https://docs.openshift.com/container-platform/4.8/installing/installing_aws/installing-aws-account.html#installation-aws-limits_installing-aws-account)

### What needs fixing?

The default instanceType in most of regions is `m5`. And also the PR to leave the default as `m5` is in progress [here (not a blocking for this PR)](https://github.com/openshift/installer/pull/5162).

/cc  @jstuever @patrickdillon 