### PR TITLE
Small changes noticed while reading "Machine management" book

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -5,6 +5,8 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
 You can create a machine set to host only infrastructure components. You apply specific Kubernetes labels to these machines and then update the infrastructure components to run on only those machines. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment.
 
 [IMPORTANT]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -3,9 +3,11 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-aws
 
+toc::[]
+
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-toc::[]
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -3,9 +3,11 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-azure
 
+toc::[]
+
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-toc::[]
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -3,9 +3,11 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-gcp
 
+toc::[]
+
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Google Cloud Platform (GCP). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-toc::[]
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-osp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-osp.adoc
@@ -3,9 +3,11 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-osp
 
+toc::[]
+
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on {rh-openstack-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-toc::[]
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-rhv.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-rhv.adoc
@@ -3,9 +3,11 @@
 include::modules/common-attributes.adoc[]
 :context: creating-machineset-rhv
 
+toc::[]
+
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on {rh-virtualization-first}. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
-toc::[]
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -7,6 +7,8 @@ toc::[]
 
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on VMware vSphere. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]

--- a/modules/machine-api-overview.adoc
+++ b/modules/machine-api-overview.adoc
@@ -18,7 +18,7 @@ For {product-title} {product-version} clusters, the Machine API performs all nod
 
 The two primary resources are:
 
-Machines:: A fundamental unit that describes the host for a Node. A machine has a `providerSpec` specification, which describes the types of compute nodes that are offered for different cloud platforms. For example, a machine type for a worker node on Amazon Web Services (AWS) might define a specific machine type and required metadata.
+Machines:: A fundamental unit that describes the host for a node. A machine has a `providerSpec` specification, which describes the types of compute nodes that are offered for different cloud platforms. For example, a machine type for a worker node on Amazon Web Services (AWS) might define a specific machine type and required metadata.
 
 Machine sets:: `MachineSet` resources are groups of machines. Machine sets are to machines as replica sets are to pods. If you need more machines or must scale them down, you change the *replicas* field on the machine set to meet your compute need.
 

--- a/modules/machine-user-provisioned-limitations.adoc
+++ b/modules/machine-user-provisioned-limitations.adoc
@@ -1,13 +1,17 @@
 // Module included in the following assemblies:
 //
-// * machine_management/applying_autoscaling.adoc
 // * machine_management/creating-infrastructure-machinesets.adoc
-// * machine_management/creating-machinesets.adoc
+// * machine_management/creating_machinesets/creating-machineset-aws.adoc
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+// * machine_management/creating_machinesets/creating-machineset-osp.adoc
+// * machine_management/creating_machinesets/creating-machineset-rhv.adoc
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
 // * machine_management/deploying-machine-health-checks.adoc
 // * machine_management/manually-scaling-machinesets.adoc
 // * post_installation_configuration/node-tasks.adoc
 
 [IMPORTANT]
 ====
-This process is not applicable to clusters where you manually provisioned the machines yourself. You can use the advanced machine management and scaling capabilities only in clusters where the machine API is operational.
+This process is not applicable for clusters with manually provisioned machines. You can use the advanced machine management and scaling capabilities only in clusters where the Machine API is operational.
 ====

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -46,7 +46,7 @@ endif::vsphere[]
 +
 Ensure that you set the `<clusterID>` and `<role>` parameter values.
 
-.. If you are not sure about which value to set for a specific field, you can check an existing machine set from your cluster.
+.. If you are not sure which value to set for a specific field, you can check an existing machine set from your cluster:
 +
 [source,terminal]
 ----

--- a/modules/machineset-customer-managed-encryption-azure.adoc
+++ b/modules/machineset-customer-managed-encryption-azure.adoc
@@ -17,7 +17,7 @@ An Azure Key Vault, a disk encryption set, and an encryption key are required to
 
 .Procedure
 
-. Configure the disk encryption set under the `providerSpec` field in your machine set YAML file. For example:
+* Configure the disk encryption set under the `providerSpec` field in your machine set YAML file. For example:
 +
 [source,yaml]
 ----

--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -7,9 +7,9 @@
 [id="machineset-manually-scaling_{context}"]
 = Scaling a machine set manually
 
-If you must add or remove an instance of a machine in a machine set, you can manually scale the machine set.
+To add or remove an instance of a machine in a machine set, you can manually scale the machine set.
 
-This guidance is relevant to fully automated, installer-provisioned infrastructure installations. Customized, user-provisioned infrastructure installations does not have machine sets.
+This guidance is relevant to fully automated, installer-provisioned infrastructure installations. Customized, user-provisioned infrastructure installations do not have machine sets.
 
 .Prerequisites
 

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -75,7 +75,7 @@ ifndef::infra[]
           node-role.kubernetes.io/<role>: "" <2>
 endif::infra[]
 ifdef::infra[]
-          node-role.kubernetes.io/infra: "" <2>      
+          node-role.kubernetes.io/infra: "" <2>
       taints: <4>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
@@ -148,13 +148,13 @@ $  oc -n openshift-machine-api \
 ifndef::infra[]
 <2> Specify the node label to add.
 <3> Specify the infrastructure ID, node label, and region.
-<4> Specify the zone within your region to place Machines on. Be sure that your region supports the zone that you specify.
+<4> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 endif::infra[]
 ifdef::infra[]
 <2> Specify the `<infra>` node label.
 <3> Specify the infrastructure ID, `<infra>` node label, and region.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
-<5> Specify the zone within your region to place Machines on. Be sure that your region supports the zone that you specify.
+<5> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]


### PR DESCRIPTION
Applies to branches 4.6+ (with exceptions for any platforms that aren't supported in prior releases - will handle via cherrypick as appropriate).

- Fixed a few typos and other style issues.
- Fixed some assemblies that had the TOC in the wrong place.
- The list of assemblies in the `machine-user-provisioned-limitations.adoc` module was mostly incorrect. Removed a couple outdated lines, replaced one generic "Creating machine sets" reference with provider-specific refs and added the module to those assemblies.
- It appears Atom has also removed some extraneous spaces from the files I touched. 

Previews:
* [Creating a machine set on AWS (**IMPORTANT** note)](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html) - AWS as example, reused in other providers
* [Machine API overview](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machine-api-overview_creating-machineset-aws) - AWS as example, reused in other providers
* [Creating a machine set](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html#machineset-creating_creating-machineset-aws) - AWS as example, reused in other providers
* [Manually scaling a machine set](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/manually-scaling-machineset.html)
* [Creating infrastructure machine sets](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html)
* [Sample YAML for a machine set custom resource on Azure](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)
* [Enabling customer-managed encryption keys for a machine set](https://deploy-preview-35685--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-enabling-customer-managed-encryption-azure_creating-machineset-azure)