### PR TITLE
MIG-779: Compatibility guidelines (MTC 1.6.0)

### DIFF
--- a/migrating_from_ocp_3_to_4/installing-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-3-4.adoc
@@ -17,6 +17,7 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-3.adoc[leveloffset=+1]
 

--- a/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
@@ -19,6 +19,7 @@ You can configure the `Migration Controller` custom resource manifest to run the
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-3.adoc[leveloffset=+1]
 

--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -19,6 +19,7 @@ You can configure the `Migration Controller` custom resource manifest to run the
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 
 [id="configuring-replication-repository_{context}"]

--- a/migration_toolkit_for_containers/installing-mtc.adoc
+++ b/migration_toolkit_for_containers/installing-mtc.adoc
@@ -17,6 +17,7 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 
 [id="configuring-replication-repository_{context}"]

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/installing-3-4.adoc
+// * migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+// * migration_toolkit_for_containers/installing-mtc.adoc
+// * migration_toolkit_for_containers/installing-mtc-restricted.adoc
+
+[id="migration-compatibility-guidelines_{context}"]
+= Compatibility guidelines
+
+You must install the {mtc-full} ({mtc-short}) version that is compatible with your {product-title} version.
+
+[cols="1,1", options="header"]
+.{product-title} and {mtc-short} compatibility
+|===
+|{product-title} version |{mtc-short} version^[1]^
+|3.7 to 4.5 |1.5.x
+|4.6 or later |1.6.x
+|===
+1. Install the latest z-stream version.
+
+You can migrate workloads from a source cluster with {mtc-short} 1.5.x installed to a target cluster with {mtc-short} 1.6.x installed as long as the `MigrationController` custom resource and the {mtc-short} web console are running on the target cluster.
+
+You cannot install {mtc-short} 1.6.x on a cluster with {product-title} 3.7 to 4.5 installed because the custom resource definition API versions are incompatible.


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-779

Compatibility guidelines module added to installation assemblies.

4.6+

Preview: https://deploy-preview-35689--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-compatibility-guidelines_installing-3-4

QE approved. Peer review needed.