### PR TITLE
Bz1964896 add bpg performance metrics to mtc troubleshooting

### DIFF
--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -18,6 +18,8 @@ This section describes logs and debugging tools that you can use for troubleshoo
 include::modules/migration-viewing-migration-plan-resources.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-plan-log.adoc[leveloffset=+2]
 include::modules/migration-using-mig-log-reader.adoc[leveloffset=+2]
+include::modules/migration-performance-metrics.adoc[leveloffset=+2]
+include::modules/migration-accessing-performance-metrics-in-ocp-web-console.adoc[leveloffset=+2]
 include::modules/migration-using-must-gather.adoc[leveloffset=+2]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -18,6 +18,7 @@ This section describes logs and debugging tools that you can use for troubleshoo
 include::modules/migration-viewing-migration-plan-resources.adoc[leveloffset=+2]
 include::modules/migration-viewing-migration-plan-log.adoc[leveloffset=+2]
 include::modules/migration-using-mig-log-reader.adoc[leveloffset=+2]
+include::modules/migration-performance-metrics.adoc[leveloffset=+2]
 include::modules/migration-using-must-gather.adoc[leveloffset=+2]
 include::modules/migration-debugging-velero-resources.adoc[leveloffset=+2]
 include::modules/migration-partial-failure-velero.adoc[leveloffset=+2]

--- a/modules/migration-accessing-performance-metrics-in-ocp-web-console.adoc
+++ b/modules/migration-accessing-performance-metrics-in-ocp-web-console.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+// * migration-toolkit-for-containers/troubleshooting-mtc.adoc
+
+[id="migration-accessing-performance-metrics-in-ocp-web-console_{context}"]
+= Accessing performance metrics in the {product-title} web console
+
+You can access performance metrics and run queries using the {product-title} web console.
+
+.Procedure
+. In the {product-title} 4 web console, click *Monitoring* -> *Metrics*.
+
+. Enter PromQL queries, select a time window to display, and click *Run Queries*.
++
+If your web browser does not display all the results, use the Prometheus console.

--- a/modules/migration-performance-metrics.adoc
+++ b/modules/migration-performance-metrics.adoc
@@ -1,0 +1,118 @@
+// Module included in the following assemblies:
+//
+// * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+// * migration-toolkit-for-containers/troubleshooting-mtc.adoc
+
+[id="migration-performance-metrics_{context}"]
+= Performance metrics
+
+The `MigrationController` custom resource (CR) records a set of metrics and pulls it into on-cluster monitoring storage. You can query the metrics by using Prometheus Query Language (PromQL) to diagnose migration performance issues. All metrics are reset when the Migration Controller pod restarts.
+
+[id="provided-metrics_{context}"]
+== Provided metrics
+
+[id="cam_app_workload_migrations-metric_{context}"]
+=== cam_app_workload_migrations
+
+This metric is a count of `MigMigration` CRs over time. It is useful for viewing alongside the `mtc_client_request_count` and `mtc_client_request_elapsed` metrics to collate API request information with migration status changes. This metric is included in Telemetry.
+
+.cam_app_workload_migrations metric
+[%header,cols="3,3,3"]
+|===
+|Queryable label name |Sample label values |Label description
+
+|status
+|`running`, `idle`, `failed`, `completed`
+|Status of the `MigMigration` CR
+
+|type
+|stage, final
+|Type of the `MigMigration` CR
+|===
+
+[id="mtc_client_request_count-metric_{context}"]
+=== mtc_client_request_count
+
+This metric is a cumulative count of Kubernetes API requests that `MigrationController` issued. It is not included in Telemetry.
+
+.mtc_client_request_count metric
+[%header,cols="3,3,3"]
+|===
+|Queryable label name |Sample label values |Label description
+
+|cluster
+|`\https://migcluster-url:443`
+|Cluster that the request was issued against
+
+|component
+|`MigPlan`, `MigCluster`
+|Sub-controller API that issued request
+
+|function
+|`(*ReconcileMigPlan).Reconcile`
+|Function that the request was issued from
+
+|kind
+|`SecretList`, `Deployment`
+|Kubernetes kind the request was issued for
+|===
+
+[id="mtc_client_request_elapsed-metric_{context}"]
+=== mtc_client_request_elapsed
+
+This metric is a cumulative latency, in milliseconds, of Kubernetes API requests that `MigrationController` issued. It is not included in Telemetry.
+
+.mtc_client_request_elapsed metric
+[%header,cols="3,3,3"]
+|===
+|Queryable label name |Sample label values |Label description
+
+|cluster
+|`\https://cluster-url.com:443`
+|Cluster that the request was issued against
+
+|component
+|`migplan`, `migcluster`
+|Sub-controller API that issued request
+
+|function
+|`(*ReconcileMigPlan).Reconcile`
+|Function that the request was issued from
+
+|kind
+|`SecretList`, `Deployment`
+|Kubernetes resource that the request was issued for
+|===
+
+[id="useful-queries_{context}"]
+== Useful queries
+
+The table lists some helpful queries that can be used for monitoring performance.
+
+.Useful queries
+
+[%header,cols="3,3"]
+|===
+|Query |Description
+
+|`mtc_client_request_count`
+|Number of API requests issued, sorted by request type
+
+|`sum(mtc_client_request_count)`
+|Total number of API requests issued
+
+|`mtc_client_request_elapsed`
+|API request latency, sorted by request type
+
+|`sum(mtc_client_request_elapsed)`
+|Total latency of API requests
+
+|`sum(mtc_client_request_elapsed) / sum(mtc_client_request_count)`
+|Average latency of API requests
+
+|`mtc_client_request_elapsed / mtc_client_request_count`
+|Average latency of API requests, sorted by request type
+
+|`cam_app_workload_migrations{status="running"} * 100`
+|Count of running migrations, multiplied by 100 for easier viewing alongside request counts
+|===


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1964896

Added BPG performance metrics and queries to MTC documentation (migration-performance-metrics.adoc)

For versions 4.6+

Preview: https://deploy-preview-35690--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html#migration-performance-metrics_troubleshooting-3-4