### PR TITLE
NTO: TuneD OpenShift profiles are shipped by TuneD

### DIFF
--- a/modules/cluster-node-tuning-operator-default-profiles-set.adoc
+++ b/modules/cluster-node-tuning-operator-default-profiles-set.adoc
@@ -16,69 +16,6 @@ metadata:
   name: default
   namespace: openshift-cluster-node-tuning-operator
 spec:
-  profile:
-  - name: "openshift"
-    data: |
-      [main]
-      summary=Optimize systems running OpenShift (parent profile)
-      include=${f:virt_check:virtual-guest:throughput-performance}
-
-      [selinux]
-      avc_cache_threshold=8192
-
-      [net]
-      nf_conntrack_hashsize=131072
-
-      [sysctl]
-      net.ipv4.ip_forward=1
-      kernel.pid_max=>4194304
-      net.netfilter.nf_conntrack_max=1048576
-      net.ipv4.conf.all.arp_announce=2
-      net.ipv4.neigh.default.gc_thresh1=8192
-      net.ipv4.neigh.default.gc_thresh2=32768
-      net.ipv4.neigh.default.gc_thresh3=65536
-      net.ipv6.neigh.default.gc_thresh1=8192
-      net.ipv6.neigh.default.gc_thresh2=32768
-      net.ipv6.neigh.default.gc_thresh3=65536
-      vm.max_map_count=262144
-
-      [sysfs]
-      /sys/module/nvme_core/parameters/io_timeout=4294967295
-      /sys/module/nvme_core/parameters/max_retries=10
-
-  - name: "openshift-control-plane"
-    data: |
-      [main]
-      summary=Optimize systems running OpenShift control plane
-      include=openshift
-
-      [sysctl]
-      # ktune sysctl settings, maximizing i/o throughput
-      #
-      # Minimal preemption granularity for CPU-bound tasks:
-      # (default: 1 msec#  (1 + ilog(ncpus)), units: nanoseconds)
-      kernel.sched_min_granularity_ns=10000000
-      # The total time the scheduler will consider a migrated process
-      # "cache hot" and thus less likely to be re-migrated
-      # (system default is 500000, i.e. 0.5 ms)
-      kernel.sched_migration_cost_ns=5000000
-      # SCHED_OTHER wake-up granularity.
-      #
-      # Preemption granularity when tasks wake up.  Lower the value to
-      # improve wake-up latency and throughput for latency critical tasks.
-      kernel.sched_wakeup_granularity_ns=4000000
-
-  - name: "openshift-node"
-    data: |
-      [main]
-      summary=Optimize systems running OpenShift nodes
-      include=openshift
-
-      [sysctl]
-      net.ipv4.tcp_fastopen=3
-      fs.inotify.max_user_watches=65536
-      fs.inotify.max_user_instances=8192
-
   recommend:
   - profile: "openshift-control-plane"
     priority: 30
@@ -88,4 +25,12 @@ spec:
 
   - profile: "openshift-node"
     priority: 40
+----
+
+Starting with {product-title} 4.9, all OpenShift TuneD profiles are shipped with
+the TuneD package. You can use the `oc exec` command to view the contents of these profiles:
+
+[source,terminal]
+----
+$ oc exec $tuned_pod -n openshift-cluster-node-tuning-operator -- find /usr/lib/tuned/openshift{,-control-plane,-node} -name tuned.conf -exec grep -H ^ {} \;
 ----


### PR DESCRIPTION
As of https://github.com/redhat-performance/tuned/pull/376 TuneD OpenShift profiles are shipped by TuneD and not NTO. Document this.