### PR TITLE
BZ1994458: Update OSDK mirror site URL for 4.8+

### DIFF
--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: latest
+:ocp_ver: 4.8.4
 :osdk_ver: v1.8.0
 
 [id="osdk-installing-cli-linux-macos_{context}"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1994458

Doesn't look like the `latest/` linkage on the mirror site has been updated for 4.8 yet, so fixing this on `main` and 4.8+ branches to just specify the most recent 4.8.x folder for now. Will update the 4.9 branch with the relevant folder when we know more about that later.

Preview: [Installing the Operator SDK CLI](https://deploy-preview-35715--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html#osdk-installing-cli-linux-macos_osdk-installing-cli)

Separate PR for 4.7: https://github.com/openshift/openshift-docs/pull/35716