### PR TITLE
BZ1994458: Update OSDK mirror site URL for 4.7

### DIFF
--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: latest
+:ocp_ver: 4.7.23
 :osdk_ver: v1.3.0
 
 [id="osdk-installing-cli-linux-macos_{context}"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1994458

4.7 equivalent of https://github.com/openshift/openshift-docs/pull/35715.

Preview: [Installing the Operator SDK CLI](https://deploy-preview-35716--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-installing-cli.html#osdk-installing-cli-linux-macos_osdk-installing-cli)