### PR TITLE
[enterprise-4.6] OSDOCS-1485: Update supported objects in bundle

### DIFF
--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -50,12 +50,19 @@ etcd
 The following object types can also be optionally included in the `/manifests` directory of a bundle:
 
 .Supported optional object types
-* `Secret`
+* `ClusterRole`
+* `ClusterRoleBinding`
 * `ConfigMap`
-* `Service`
 * `PodDisruptionBudget`
 * `PriorityClass`
-* `VerticalPodAutoScaler`
+* `PrometheusRule`
+* `Role`
+* `RoleBinding`
+* `Secret`
+* `Service`
+* `ServiceAccount`
+* `ServiceMonitor`
+* `VerticalPodAutoscaler`
 
 When these optional objects are included in a bundle, Operator Lifecycle Manager (OLM) can create them from the bundle and manage their lifecycle along with the CSV:
 


### PR DESCRIPTION
Manual cp of https://github.com/openshift/openshift-docs/pull/35455 to omit inclusion of `ConsoleYamlSample` for 4.6 only.