### PR TITLE
Clarify syntax admonition for modules in contrib guide

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -229,7 +229,9 @@ link:https://redhat-documentation.github.io/modular-docs/#forming-assemblies[Red
 
 [NOTE]
 ====
-When using "Prerequisites", "Next steps", and "Additional resources" headings in an assembly, use `==` formatting, such as `== Prerequisites` and `== Additional resources`. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly. Only use `.` syntax (`.Additional resources`) to follow the module as a trailing include at the assembly level, which indicates that the resources apply specifically to the module.
+When using the "Prerequisites", "Next steps", or "Additional resources" headings in an assembly, use `==` formatting, such as `== Prerequisites` or `== Additional resources`. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly.
+
+Only use `.` formatting (`.Additional resources`) to follow a module in an assembly. Because you cannot use the xrefs in modules, this functions as a _trailing include_ at the assembly level, where the `.` formatting of the `include` statement indicates that the resource applies specifically to the module and not to the assembly.
 ====
 
 == Writing concepts
@@ -254,7 +256,7 @@ link:https://redhat-documentation.github.io/modular-docs/#creating-procedure-mod
 
 [NOTE]
 ====
-When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syntax to suppress TOC formatting within a module. Do not use `==` headings or xrefs in modules.
+When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syntax to suppress TOC formatting within a module. Do not use `==` syntax for these headings in modules. Because you cannot use the xrefs in modules, if you need to include a link under one of these headings, place the entire subsection in the assembly instead.
 ====
 
 [id="using-conscious-language"]


### PR DESCRIPTION
Thank you @kalexand-rh for pointing out the muddiness in this note. I've attempted to clarify that `==` should not be used only with these specific procedure headings in modules. Using the syntax for subheads in modules elsewhere besides procedures is fine. See https://redhat-documentation.github.io/modular-docs/#creating-concept-modules.

Clarifies https://github.com/openshift/openshift-docs/pull/25072
No preview link available because this is for `main` only.