### PR TITLE
CNV-12620: updating virt metrics docs for clarity

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -5,35 +5,39 @@
 [id="virt-querying-metrics_{context}"]
 = Virtualization metrics
 
-The following metric descriptions include example Prometheus Query Language (PromQL) queries.
+The following metric descriptions include example Prometheus Query Language (PromQL) queries. These metrics are not an API and might change between versions.
 
 [NOTE]
 ====
-These metrics are not an API and might change between versions.
+The following examples use `topk` queries that specify a time period. If virtual machines are deleted during that time period, they can still appear in the query output.
 ====
 
 [id="virt-promql-vcpu-metrics_{context}"]
 == vCPU metrics
 
-[NOTE]
-====
-The vCPU metric requires the `schedstats=enable` kernel argument applied to the `MachineConfig` object before it can be used. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
-====
+The following query can identify virtual machines that are waiting for Input/Output (I/O):
 
 `kubevirt_vmi_vcpu_wait_seconds`::
 Returns the wait time (in seconds) for a virtual machine's vCPU.
 
-A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with Input/Output.
+A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with I/O.
 
-.Example query
+[NOTE]
+====
+To query the vCPU metric, the `schedstats=enable` kernel argument must first be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler.
+====
+
+.Example vCPU wait time query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_vcpu_wait_seconds[6m]), 0.1))) > 0
+topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_vcpu_wait_seconds[6m]), 0.1))) > 0 <1>
 ----
-The above query returns the top 3 VMs waiting for I/O at every given moment in time over the time period.
+<1> This query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period.
 
 [id="virt-promql-network-metrics_{context}"]
 == Network metrics
+
+The following queries can identify virtual machines that are saturating the network:
 
 `kubevirt_vmi_network_receive_bytes_total`::
 Returns the total amount of traffic received (in bytes) on the virtual machine's network.
@@ -41,17 +45,20 @@ Returns the total amount of traffic received (in bytes) on the virtual machine's
 `kubevirt_vmi_network_transmit_bytes_total`::
 Returns the total amount of traffic transmitted (in bytes) on the virtual machine's network.
 
-These queries can be used to identify virtual machines that are saturating the network.
-
-.Example query
+.Example network traffic query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_network_receive_bytes_total[6m]), 0.1)) + sum by (name, namespace) (round(irate(kubevirt_vmi_network_transmit_bytes_total[6m]) , 0.1))) > 0
+topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_network_receive_bytes_total[6m]), 0.1)) + sum by (name, namespace) (round(irate(kubevirt_vmi_network_transmit_bytes_total[6m]) , 0.1))) > 0 <1>
 ----
-The above query returns the top 3 VMs transmitting the most network traffic at every given moment in time over a six-minute time period.
+<1> This query returns the top 3 VMs transmitting the most network traffic at every given moment over a six-minute time period.
 
 [id="virt-promql-storage-metrics_{context}"]
 == Storage metrics
+
+[id="virt-storage-traffic_{context}"]
+=== Storage-related traffic
+
+The following queries can identify VMs that are writing large amounts of data:
 
 `kubevirt_vmi_storage_read_traffic_bytes_total`::
 Returns the total amount (in bytes) of the virtual machine's storage-related traffic.
@@ -59,15 +66,18 @@ Returns the total amount (in bytes) of the virtual machine's storage-related tra
 `kubevirt_vmi_storage_write_traffic_bytes_total`::
 Returns the total amount of storage writes (in bytes) of the virtual machine's storage-related traffic.
 
-These queries can be used to identify virtual machines that are writing large amounts of data.
-
-.Example query
+.Example storage-related traffic query
 [source,promql]
 ----
 topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_storage_read_traffic_bytes_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]), 0.1))) > 0
++ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]), 0.1))) > 0 <1>
 ----
-The above query returns the top 3 VMs performing the most storage traffic at every given moment in time over a six-minute time period.
+<1> This query returns the top 3 VMs performing the most storage traffic at every given moment over a six-minute time period.
+
+[id="virt-iops_{context}"]
+=== I/O performance
+
+The following queries can determine the I/O performance of storage devices:
 
 `kubevirt_vmi_storage_iops_read_total`::
 Returns the amount of write I/O operations the virtual machine is performing per second.
@@ -75,35 +85,34 @@ Returns the amount of write I/O operations the virtual machine is performing per
 `kubevirt_vmi_storage_iops_write_total`::
 Returns the amount of read I/O operations the virtual machine is performing per second.
 
-These queries can be used to determine the I/O performance of storage devices.
-
-.Example query
+.Example I/O performance query
 [source,promql]
 ----
 topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_read_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_write_total[6m]) , 0.1))) > 0
++ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_write_total[6m]) , 0.1))) > 0 <1>
 ----
-The above query returns the top 3 VMs performing the most I/O operations per second at every given moment in time over a six-minute time period.
+<1> This query returns the top 3 VMs performing the most I/O operations per second at every given moment over a six-minute time period.
 
 [id="virt-promql-guest-memory-metrics_{context}"]
 == Guest memory swapping metrics
+
+The following queries can identify which swap-enabled guests are performing the most memory swapping:
+
 `kubevirt_vmi_memory_swap_in_traffic_bytes_total`::
 Returns the total amount (in bytes) of memory the virtual guest is swapping in.
 
 `kubevirt_vmi_memory_swap_out_traffic_bytes_total`::
 Returns the total amount (in bytes) of memory the virtual guest is swapping out.
 
-Memory swapping indicates that the virtual machine is under memory pressure. Increasing the memory allocation of the virtual machine can mitigate this issue.
-
-[NOTE]
-====
-These queries only return data for virtual guests that have memory swapping enabled.
-====
-
-.Example query
+.Example memory swapping query
 [source,promql]
 ----
 topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]), 0.1))) > 0
++ sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]), 0.1))) > 0 <1>
 ----
-The above query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment in time over a six-minute time period.
+<1> This query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period.
+
+[NOTE]
+====
+Memory swapping indicates that the virtual machine is under memory pressure. Increasing the memory allocation of the virtual machine can mitigate this issue.
+====

--- a/virt/logging_events_monitoring/virt-prometheus-queries.adoc
+++ b/virt/logging_events_monitoring/virt-prometheus-queries.adoc
@@ -2,6 +2,7 @@
 = Prometheus queries for virtual resources
 include::modules/virt-document-attributes.adoc[]
 :context: virt-prometheus-queries
+
 toc::[]
 
 {VirtProductName} provides metrics for monitoring how infrastructure resources are consumed in the cluster. The metrics cover the following resources:
@@ -13,16 +14,22 @@ toc::[]
 
 Use the {product-title} monitoring dashboard to query virtualization metrics.
 
-.Prerequisite
-* The vCPU metric requires the `schedstats=enable` kernel argument applied to the `MachineConfig` object before it can be used. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. See the xref:../../post_installation_configuration/machine-configuration-tasks.adoc#nodes-nodes-kernel-arguments_post-install-machine-configuration-tasks[{product-title} machine configuration tasks] documentation for more information on applying a kernel argument.
+[id="prerequisites_{context}"]
+== Prerequisites
+
+* To use the vCPU metric, the `schedstats=enable` kernel argument must be applied to the `MachineConfig` object. This kernel argument enables scheduler statistics used for debugging and performance tuning and adds a minor additional load to the scheduler. See the xref:../../post_installation_configuration/machine-configuration-tasks.adoc#nodes-nodes-kernel-arguments_post-install-machine-configuration-tasks[{product-title} machine configuration tasks] documentation for more information on applying a kernel argument.
+
+* For guest memory swapping queries to return data, memory swapping must be enabled on the virtual guests.
 
 include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]
+
 include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
+
 include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc[leveloffset=+2]
 
 include::modules/virt-querying-metrics.adoc[leveloffset=+1]
 
-[id="{context}-additional-resources"]
+[id="additional-resources_virt-prometheus-queries"]
 == Additional resources
 
 * xref:../../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Understanding the {product-title} monitoring stack]


### PR DESCRIPTION
- [CNV-12620](https://issues.redhat.com/browse/CNV-12620)
- cherrypick to 4.8 and 4.9
- This PR addresses the bugs identified in [CNV-12620](https://issues.redhat.com/browse/CNV-12620), fixes a couple of minor issues that I noticed along the way, and includes a few more changes intended to improve clarity/structure.
- [Preview build](https://deploy-preview-35732--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-prometheus-queries?utm_source=github&utm_campaign=bot_dp)