### PR TITLE
[enterprise-4.8] Adjust release note for network policy

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -406,11 +406,11 @@ For more information, refer to xref:../networking/openshift_sdn/assigning-egress
 ==== Network policy supports selecting host network Ingress Controllers
 
 When using the OpenShift SDN or OVN-Kubernetes cluster network providers, you can select traffic from Ingress Controllers in a network policy rule regardless of whether an Ingress Controller runs on the cluster network or the host network.
-In a network policy rule, the `network.openshift.io/policy-group: ingress` namespace selector matches traffic from an Ingress Controller.
+In a network policy rule, the `policy-group.network.openshift.io/ingress=""` namespace selector label matches traffic from an Ingress Controller. You can continue to use the `network.openshift.io/policy-group: ingress` namespace selector label, but this is a legacy label that can be removed in a future release of {product-title}.
 
-In earlier releases of {product-title} the following limitations existed:
+In earlier releases of {product-title}, the following limitations existed:
 
-- A cluster that uses the OpenShift SDN cluster network provider could select traffic from an Ingress Controller on the host network only by applying the `network.openshift.io/policy-group: ingress` label to the `default` namespace.
+- A cluster that uses the OpenShift SDN cluster network provider could select traffic from an Ingress Controller on the host network only by applying the `network.openshift.io/policy-group="ingress"` label to the `default` namespace.
 - A cluster that uses the OVN-Kubernetes cluster network provider could not select traffic from an Ingress Controller on the host network.
 
 For more information, refer to xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].


### PR DESCRIPTION
@abhat, is this any better for 4.8 and 4.7? Thanks!

Refs https://github.com/openshift/openshift-docs/pull/35531.

Preview: https://deploy-preview-35738--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-network-policy-host-network-ingress-controllers