### PR TITLE
TELCODOCS-249 - Memory manager release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -173,6 +173,15 @@ The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled 
 [id="ocp-4-9-scale"]
 === Scale
 
+[id="ocp-4-9-scale-memory-manager-in-beta-version"]
+==== Memory Manager feature (Technology Preview)
+The Memory Manager feature is now enabled by default for all pods running on the node that is configured with one of the following Topology Manager policies:
+
+* `single-numa-node`
+* `restricted`
+
+For more information, see xref:../scalability_and_performance/using-topology-manager.adoc#topology_manager_policies_using-topology-manager[Topology Manager policies].
+
 [id="ocp-4-9-backup-and-restore"]
 === Backup and restore
 
@@ -575,6 +584,11 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 |GA
+
+|Memory Manager feature
+|
+|
+|TP
 
 |====
 


### PR DESCRIPTION
Added a release note for the Memory manager feature.

https://issues.redhat.com/browse/TELCODOCS-249

https://deploy-preview-35743--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-scale-memory-manager-in-beta-version