### PR TITLE
OSDOCS-2412 - Updating AWS firewall prerequisites

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -43,16 +43,43 @@ See link:https://docs.openshift.com/container-platform/4.6/support/remote_health
 |Required
 |===
 
-. For Amazon Web Services (AWS), you must grant access to the URLs that provide the AWS API and DNS:
+. For Amazon Web Services (AWS), you must grant access to the URLs that provide the AWS API and DNS services:
+* You can grant access by allowing the `.amazonaws.com` wildcard:
 +
 [cols="2,4,2",options="header"]
 |===
 |URL | Function | Requirement
 
-|`*.amazonaws.com`
-|Required to access AWS services and resources. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
+|`.amazonaws.com`
+|Required to access AWS services and resources.
 |Required
 |===
++
+* Alternatively, you can grant access by allowing the following regional AWS service endpoints:
++
+[cols="2,4,2",options="header"]
+|===
+|URL | Function | Requirement
+|`ec2.<aws_region>.amazonaws.com`
+|Required for regional access to Amazon EC2 services. EC2 instances are required to deploy the control plane and data plane functions of ROSA. Replace `<aws_region>` with an AWS region code, for example `us-east-1`.
+|Required
+
+|`elasticloadbalancing.<aws_region>.amazonaws.com`
+|Required to access Amazon Elastic Load Balancers (ELBs) for API and application load balancing.
+|Required
+
+|`<cluster_id>-<shard>.<aws_region>.amazonaws.com`
+|Required for access to the registry. Replace `<cluster_id>`, `<shard>`, and `<aws_region>` with your cluster ID, shard name and AWS region code.
+
+|Required
+|===
++
+[NOTE]
+====
+The cluster ID and shard information is generated at installation time. You can grant access to `.<aws_region>.amazonaws.com` when you create a cluster and later refine the firewall configuration by specifying the cluster ID and shard.
+====
++
+Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
 
 . Allowlist the following URLs:
 +


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This pull request relates to https://issues.redhat.com/browse/OSDOCS-2412. The PR updates the AWS PrivateLink firewall prerequisites for API and DNS access. The updated content includes an option to specify regional AWS service endpoints instead of the wider `.amazonaws.com` wildcard.

The preview is [here](https://deploy-preview-35744--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites).