### PR TITLE
[RHACS] Added supported operating system images version

### DIFF
--- a/modules/scanning-images.adoc
+++ b/modules/scanning-images.adoc
@@ -61,26 +61,39 @@ Scanner identifies vulnerabilities in images that contain the following Linux di
 | Distribution | Version
 
 | link:https://www.alpinelinux.org/[Alpine Linux]
-| 3.2 to 3.12
+| `alpine:v3.2`, `alpine:v3.3`, `alpine:v3.4`, `alpine:v3.5`, `alpine:v3.6`, `alpine:v3.7`, `alpine:v3.8`, `alpine:v3.9`, `alpine:v3.10`, `alpine:v3.11`, `alpine:v3.12`, `alpine:v3.13`, `alpine:v3.14`, `alpine:edge`
 
 | link:https://aws.amazon.com/amazon-linux-ami[Amazon Linux]
-| 2018.03, 2
+| `amzn:2018.03`, `amzn:2`
 
-| link:https://wiki.centos.org/Manuals/ReleaseNotes[CentOS] and https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/[{op-system-base-full}]
-| 5, 6, 7, 8
+| link:https://wiki.centos.org/Manuals/ReleaseNotes[CentOS]
+| `centos:6`, `centos:7`, `centos:8`
 
 | link:https://www.debian.org/releases/[Debian]
-| 9 and newer
+| `debian:9`, `debian:10`, `debian:11`, `debian:unstable`
 
-| link:https://www.oracle.com/linux/[Oracle Linux]
-| 5 and newer
+| link:https://www.redhat.com/en/technologies/linux-platforms/enterprise-linux[{op-system-base-full}]
+| `rhel:6`, `rhel:7`, `rhel:8`
 
 | link:http://releases.ubuntu.com/[Ubuntu]
-| 12.04 to 20.04, including LTS and ESM releases
+| `ubuntu:12.04`, `ubuntu:14.04`, `ubuntu:16.04`, `ubuntu:18.04`, `ubuntu:20.04`, `ubuntu:20.10`, `ubuntu:21.04`
 |===
 
 [NOTE]
 ====
-Scanner does not support the Fedora operating system because Fedora does not maintain a vulnerability database.
+* Scanner does not support the Fedora operating system because Fedora does not maintain a vulnerability database.
 However, Scanner still detects language-specific vulnerabilities in Fedora-based images.
+* Scanner also identifies vulnerabilities in the following images.
+However, the vulnerability sources are not updated anymore by their vendor:
++
+|===
+| Distribution | Version
+
+| link:https://www.debian.org/releases/[Debian]
+| `debian:8`
+
+| link:http://releases.ubuntu.com/[Ubuntu]
+| `ubuntu:12.10`, `ubuntu:13.04`, `ubuntu:14.10`, `ubuntu:15.04`, `ubuntu::15.10`, `ubuntu::16.10`, `ubuntu:17.04`, `ubuntu:17.10`, `ubuntu:18.10`, `ubuntu:19.04`, `ubuntu:19.10`
+
+|===
 ====


### PR DESCRIPTION
> ... will help in identifying the latest version of Linux distribution that scanner supports

The supported operating system images that Scanner supports was missing complete versions. 
- Added all supported versions.
- Separated out CentOS and RHEL

Preview: https://openshift-docs-2968i0rzg-gnelson.vercel.app/openshift-acs/master/operating/examine-images-for-vulnerabilities.html#scanning-images_examine-images-for-vulnerabilities

NOTES:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones