### PR TITLE
search: add OSD version labels

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -191,13 +191,19 @@
 
   var distros = {
     'openshift-origin': ['docs_origin', version],
-    'openshift-dedicated': ['docs_dedicated', version],
+    // specific labels are used for OSD instead of the URL filter, due to its unusual URL structure; assume v4
+    'openshift-dedicated': ['docs_dedicated_v4'],
     'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version],
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
     'openshift-acs' : ['docs_acs']
   };
+
+  // only OSD v3 docs have the version variable specified
+  if (dk == "openshift-dedicated" && version == "3") {
+      distros['openshift-dedicated'] = ['docs_dedicated_v3']
+    }
 
   distros[dk] ? hcSearchCategory.apply(null, distros[dk]) : hcSearchCategory("docs");
   </script>


### PR DESCRIPTION
Hi @vikram-redhat, this PR will fix searching in OSD docs. As the OSD v4 docs no longer have the version number in the URL, it cannot be used as search filter for the results (similarly as for other versioned products). Instead, there are now specific product labels for searching OSD v4 and v3 that are already configured on the search server. Please cherry pick as suitable.