### PR TITLE
RHDEVDOCS-3168: Document warning about escalated pipelines SCC privileges in Pipelines TP versions

### DIFF
--- a/modules/op-about-tasks.adoc
+++ b/modules/op-about-tasks.adoc
@@ -46,3 +46,10 @@ spec: <4>
 This Task starts the pod and runs a container inside that pod using the `maven:3.6.0-jdk-8-slim` image to run the specified commands. It receives an input directory called `workspace-git` that contains the source code of the application.
 
 The Task only declares the placeholder for the Git repository, it does not specify which Git repository to use. This allows Tasks to be reusable for multiple Pipelines and purposes.
+
+[WARNING]
+====
+{pipelines-title} 1.3 and earlier versions in Technology Preview (TP) allowed users to create a task without verifying their xref:../authentication/managing-security-context-constraints.adoc[Security Context Constraints] (SCC). Thus, any authenticated user could create a task using a container running with a privileged SCC.
+
+To avoid such security issues in the production scenario, do not use {pipelines-shortname} versions that are in TP. Instead, consider upgrading the Operator to generally available versions such as {pipelines-shortname} 1.4 or later.
+====


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.6`
- **JIRA issues**: [Document warning about escalated pipelines SCC privileges in Pipelines TP versions](https://issues.redhat.com/browse/RHDEVDOCS-3168)
- **BugZilla**: https://bugzilla.redhat.com/show_bug.cgi?id=1977641
- **Preview pages**: See the warning at the bottom of the section [Understanding OpenShift Pipelines > Tasks](https://deploy-preview-35748--osdocs.netlify.app/openshift-enterprise/latest/pipelines/understanding-openshift-pipelines.html#about-tasks_understanding-openshift-pipelines)
- **SME review**: @vdemeester 
- **Peer-review**: @Preeticp 