### PR TITLE
BZ1997024 'excluded resources' list updated (MTC 1.6.0)

### DIFF
--- a/modules/migration-excluding-resources.adoc
+++ b/modules/migration-excluding-resources.adoc
@@ -45,6 +45,7 @@ spec:
   - serviceplans
   - operatorgroups
   - events
+  - events.events.k8s.io
 ----
 <1> Add `disable_image_migration: true` to exclude image streams from the migration. Do not edit the `excluded_resources` parameter. `imagestreams` is added to `excluded_resources` when the `MigrationController` pod restarts.
 <2> Add `disable_pv_migration: true` to exclude PVs from the migration plan. Do not edit the `excluded_resources` parameter. `persistentvolumes` and `persistentvolumeclaims` are added to `excluded_resources` when the `MigrationController` pod restarts. Disabling PV migration also disables PV discovery when you create the migration plan.


### PR DESCRIPTION
For versions 4.5+

hhttps://bugzilla.redhat.com/show_bug.cgi?id=1997024

The 'excluded resources' list updated in migration-excluding-resources.adoc

Direct link to doc preview: https://deploy-preview-35749--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html#migration-excluding-resources_advanced-migration-options-3-4

Approved by peer, to be merged 