### PR TITLE
OSSMDOC-358:Move statement about inclusion

### DIFF
--- a/modules/ossm-servicemesh-overview.adoc
+++ b/modules/ossm-servicemesh-overview.adoc
@@ -11,7 +11,3 @@ Module included in the following assemblies:
 Microservice architectures split the work of enterprise applications into modular services, which can make scaling and maintenance easier. However, as an enterprise application built on a microservice architecture grows in size and complexity, it becomes difficult to understand and manage. {ProductShortName} can address those architecture problems by capturing or intercepting traffic between services and can modify, redirect, or create new requests to other services.
 
 {ProductShortName}, which is based on the open source link:https://istio.io/[Istio project], provides an easy way to create a network of deployed services that provides discovery, load balancing, service-to-service authentication, failure recovery, metrics, and monitoring. A service mesh also provides more complex operational functionality, including A/B testing, canary releases, rate limiting, access control, and end-to-end authentication.
-
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].

--- a/service_mesh/v1x/servicemesh-release-notes.adoc
+++ b/service_mesh/v1x/servicemesh-release-notes.adoc
@@ -5,6 +5,11 @@ include::modules/ossm-document-attributes-1x.adoc[]
 
 toc::[]
 
+== Making open source more inclusive
+
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
+
+
 // The following include statements pull in the module files that comprise 1.x release notes.
 
 include::modules/ossm-servicemesh-overview.adoc[leveloffset=+1]

--- a/service_mesh/v2x/servicemesh-release-notes.adoc
+++ b/service_mesh/v2x/servicemesh-release-notes.adoc
@@ -5,6 +5,10 @@ include::modules/ossm-document-attributes.adoc[]
 
 toc::[]
 
+== Making open source more inclusive
+
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
+
 // The following include statements pull in the module files that comprise 2.x release notes.
 
 include::modules/ossm-rn-new-features.adoc[leveloffset=+1]


### PR DESCRIPTION
Moved inclusion language out of module/ossm-servicemesh-overview.adoc and into the assembly servicmesh-release-notes (both v1 and v2 versions).

@JStickler I'm assuming this change should be cherry picked to 4.6, 4.7, 4.8, and 4.9. Please let me know if this is not the case. Thanks!