### PR TITLE
OSDOCS-2272 - Enhancing the ROSA STS documentation

### DIFF
--- a/modules/rosa-deleting-aws-resources-aws-console.adoc
+++ b/modules/rosa-deleting-aws-resources-aws-console.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
+
+[id="rosa-deleting-aws-resources-aws-console_{context}"]
+= Deleting the AWS resources by using the AWS IAM Console
+
+After deleting a {product-title} (ROSA) cluster, you can delete the AWS Security Token Service (STS) resources by using the AWS Identity and Access Management (IAM) Console.
+
+[IMPORTANT]
+====
+Account-wide IAM roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
+====
+
+.Prerequisites
+
+* You have deleted your ROSA cluster. For more information, see the _Deleting a cluster_ section.
++
+[IMPORTANT]
+====
+You must delete the cluster before you remove the IAM roles and policies. The account-wide roles are required to delete the resources created by the installer. The cluster-specific Operator roles are required to clean-up the resources created by the OpenShift Operators.
+====
+
+.Procedure
+
+. Log in to the link:https://console.aws.amazon.com/iamv2/home#/home[AWS IAM Console].
+
+. Delete the OpenID Connect (OIDC) provider that you created for Operator authentication in your cluster:
+.. Navigate to *Access management* -> *Identity providers* and click on the OIDC resource that you created to authenticate the cluster Operators.
+.. In the dialog page for the resource, select *Delete* to delete the OIDC provider.
+
+. Delete the cluster-specific Operator IAM roles:
++
+[TIP]
+====
+The IAM role and policy names include the role prefix that is specified when the STS resources are created. The default prefix is `ManagedOpenShift`.
+====
++
+.. Navigate to *Access management* -> *Roles* and click on one of the cluster-specific Operator roles that you created for your cluster.
+.. In the dialog page for the resource, select *Delete role* to delete the role. Select *Yes, delete* to confirm the role deletion.
+.. Repeat this step to delete each of the cluster-specific Operator roles for the cluster.
+
+. Delete the account-wide Operator policies that you created for ROSA deployments that use STS:
+.. Navigate to *Access management* -> *Policies* and click on one of the Operator policies.
+.. In the dialog page for the resource, select *Delete policy* to delete the policy. Select *Delete* to confirm the policy deletion.
+.. Repeat this step to delete each of the Operator policies.
+
+. Delete the account-wide IAM roles and inline policies that you created for ROSA deployments that use STS:
+.. Navigate to *Access management* -> *Roles* and click on one of the account-wide roles.
+.. In the dialog page for the resource, select *Delete role* to delete the role. Select *Yes, delete* to confirm the role deletion.
+.. Repeat this step to delete each of the account-wide roles for the cluster.

--- a/modules/rosa-deleting-aws-resources-cli.adoc
+++ b/modules/rosa-deleting-aws-resources-cli.adoc
@@ -1,0 +1,100 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
+
+[id="rosa-deleting-aws-resources-cli_{context}"]
+= Deleting the AWS resources by using the CLI
+
+After deleting a {product-title} (ROSA) cluster, you can delete the AWS Security Token Service (STS) resources by using the CLI.
+
+[IMPORTANT]
+====
+Account-wide Identity Access Management (IAM) roles and policies might be used by other ROSA clusters in the same AWS account. You must only remove the resources if they are not required by other clusters.
+====
+
+.Prerequisites
+
+* You have installed and configured the latest AWS CLI on your installation host.
+* You have deleted your ROSA cluster. For more information, see the _Deleting a cluster_ section.
++
+[IMPORTANT]
+====
+You must delete the cluster before you remove the IAM roles and policies. The account-wide roles and policies are required to delete the resources created by the installer. The Operator roles and policies are required to clean-up the resources created by the OpenShift Operators.
+====
+
+.Procedure
+
+. Delete the OpenID Connect (OIDC) provider that you created for Operator authentication in your cluster:
++
+[source,terminal]
+----
+$ aws iam delete-open-id-connect-provider --open-id-connect-provider-arn <oidc_provider_arn> <1>
+----
+<1> Replace `<oidc_provider_arn>` with the Amazon Resource Name (ARN) of the OpenID Connect (OIDC) resource that you created to authenticate the cluster Operators. You can run `$ aws iam list-open-id-connect-providers` to list the OIDC providers in your account.
+
+. Delete the cluster-specific Operator IAM roles:
+.. List the account-wide Operator policy that is attached to one of the cluster-specific IAM roles:
++
+[source,terminal]
+----
+$ aws iam list-attached-role-policies --role-name <operator_role_name> <1>
+----
+<1> Replace `<operator_role_name>` with the name of a cluster-specific Operator role that you created for the cluster. Specify the role name and not the full ARN. You can run `$ aws iam list-roles` to list the roles in your account.
++
+[TIP]
+====
+The IAM role and policy names include the role prefix that is specified when the STS resources are created. The default prefix is `ManagedOpenShift`.
+====
++
+.. Detach the policy from role:
++
+[source,terminal]
+----
+$ aws iam detach-role-policy --role-name <operator_role_name> --policy-arn <operator_policy_arn> <1>
+----
+<1> Replace `<operator_policy_arn>` with the ARN of the attached Operator policy.
++
+.. Delete the role:
++
+[source,terminal]
+----
+$ aws iam delete-role --role-name <operator_role_name>
+----
++
+.. Repeat the steps to delete each of the cluster-specific Operator roles for the cluster.
+
+. Delete the account-wide Operator policies that you created for ROSA deployments that use STS. The following command deletes a single policy:
++
+[source,terminal]
+----
+$ aws iam delete-policy --policy-arn <operator_policy_arn>  <1>
+----
+<1> Replace `<operator_policy_arn>` with the ARN of one of the Operator policies. You can list the policies in your account by running `$ aws iam list-policies`.
++
+Repeat this step to delete each of the Operator policies.
+
+. Delete the account-wide IAM roles and inline policies that you created for ROSA deployments that use STS:
+.. List the inline policy for one of the account-wide IAM roles:
++
+[source,terminal]
+----
+$ aws iam list-role-policies --role-name <account_wide_role_name> <1>
+----
+<1> Replace `<account_wide_role_name>` with the name of one of the account-wide IAM roles. Specify the role name and not the full ARN. You can run `$ aws iam list-roles` to list the roles in your account.
++
+.. Delete the inline policy:
++
+[source,terminal]
+----
+$ aws iam delete-role-policy --role-name <account_wide_role_name> --policy-name <inline_role_policy_name><1>
+----
+<1> Replace `<inline_role_policy_name>` with the policy name that is included in the output of the preceding command.
++
+.. Delete the role:
++
+[source,terminal]
+----
+$ aws iam delete-role --role-name <account_wide_role_name>
+----
++
+.. Repeat the steps to delete each of the account-wide roles.

--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -1,8 +1,11 @@
-
 // Module included in the following assemblies:
 //
-// getting_started_rosa/rosa-creating-cluster.adoc
+// * rosa_getting_started/rosa-deleting-cluster.adoc
+// * rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
 
+ifeval::["{context}" == "rosa-sts-deleting-cluster"]
+:sts:
+endif::[]
 
 [id="rosa-deleting-cluster_{context}"]
 = Deleting a cluster
@@ -20,9 +23,15 @@ If add-ons are installed, the deletion takes longer because add-ons are uninstal
 $ rosa delete cluster --cluster=<cluster_name> --watch
 ----
 
+ifndef::sts[]
 . To clean up your CloudFormation stack, enter the following command:
 +
 [source, terminal]
 ----
 $ rosa init --delete-stack
 ----
+endif::sts[]
+
+ifeval::["{context}" == "rosa-sts-deleting-cluster"]
+:!sts:
+endif::[]

--- a/modules/rosa-sts-about-iam-resources.adoc
+++ b/modules/rosa-sts-about-iam-resources.adoc
@@ -1,0 +1,116 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-creating-cluster.adoc
+
+[id="rosa-sts-about-iam-resources_{context}"]
+= About IAM resources for clusters that use STS
+
+To deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you must create the following AWS Identity Access Management (IAM) resources:
+
+* Specific account-wide IAM roles and policies that provide the STS permissions required for ROSA support, installation, control plane and compute functionality. This includes account-wide Operator policies.
+* Cluster-specific Operator IAM roles that permit the ROSA cluster Operators to carry out core OpenShift functionality.
+* An OpenID Connect (OIDC) provider that the cluster Operators use to authenticate.
+
+This section provides an overview about each of the IAM resources that you must deploy when you create a ROSA cluster that uses STS. For detailed steps to create the resources, see the _Creating your cluster using STS_ section.
+
+[id="rosa-sts-account-wide-roles-and-policies_{context}"]
+== Account-wide IAM roles and policies
+
+The following account-wide IAM roles and policies are required for ROSA deployments that use STS. 
+
+The account-wide roles and policies are specific to an OpenShift version, for example OpenShift 4.8. You can minimize the required STS resources by reusing the account-wide roles and policies for multiple clusters of the same version.
+
+[NOTE]
+====
+If your use case requires it, you can deploy multiple sets of account-wide IAM roles and policies for a cluster version by specifying different prefixes for each set.
+====
+
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+|`ManagedOpenShift-Installer-Role`
+|An IAM role used by the ROSA installer.
+
+|`ManagedOpenShift-Installer-Role-Policy`
+|An inline IAM policy that provides the ROSA installer with the permissions required to complete cluster installation tasks.
+
+|`ManagedOpenShift-Support-Role`
+|An IAM role used by the Red Hat Site Reliability Engineering (SRE) support team.
+
+|`ManagedOpenShift-Support-Role-Policy`
+|An inline IAM policy that provides the Red Hat SRE support team with the permissions required to support ROSA clusters. 
+
+|`ManagedOpenShift-ControlPlane-Role`
+|An IAM role used by the ROSA control plane.
+
+|`ManagedOpenShift-ControlPlane-Role-Policy`
+|An inline IAM policy that provides the ROSA control plane with the permissions required to manage its components. 
+
+|`ManagedOpenShift-Worker-Role`
+|An IAM role used by the ROSA compute instances.
+
+|`ManagedOpenShift-Worker-Role-Policy`
+|An inline IAM policy that provides the ROSA compute instances with the permissions required to manage their components.  
+
+|`ManagedOpenShift-openshift-machine-api-aws-cloud-credentials`
+|A managed IAM policy that provides the ROSA Machine Config Operator with the permissions required to perform core cluster functionality. 
+
+|`ManagedOpenShift-openshift-cloud-credential-operator-cloud-credentials`
+|A managed IAM policy that provides the ROSA Cloud Credential Operator with the permissions required to manage cloud provider credentials.
+
+|`ManagedOpenShift-openshift-image-registry-installer-cloud-credentials`
+|A managed IAM policy that provides the ROSA Image Registry Operator with the permissions required to manage the internal registry storage in AWS S3 for a cluster.
+
+|`ManagedOpenShift-openshift-ingress-operator-cloud-credentials`
+|A managed IAM policy that provides the ROSA Ingress Operator with the permissions required to manage external access to a cluster. 
+
+|`ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials`
+|A managed IAM policy required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+|===
+
+[NOTE]
+====
+The IAM role and policy names include the role prefix that is specified when the STS resources are created. The resource names in the examples provided include the default prefix `ManagedOpenShift`.
+====
+
+[id="rosa-sts-operator-roles_{context}"]
+== Cluster-specific Operator IAM roles
+
+The following cluster-specific IAM roles are required by the cluster Operators in ROSA deployments that use STS.
+
+When you create the Operator roles by using the `rosa` CLI, the account-wide Operator policies for the matching cluster version are attached to the roles. The Operator policies are tagged with the Operator and version they are compatible with. The correct policy for an Operator role is determined by using the tags. 
+
+[NOTE]
+====
+If more than one matching policy is available in your account for an Operator role, an interactive list of options is provided when you create the Operator.
+====
+
+[cols="1,2",options="header"]
+|===
+
+|Resource|Description
+
+|`ManagedOpenShift-openshift-machine-api-aws-cloud-credentials`
+|An IAM role required by the ROSA Machine Config Operator to perform core cluster functionality.
+
+|`ManagedOpenShift-openshift-cloud-credential-operator-cloud-credentials`
+|An IAM role required by the ROSA Cloud Credential Operator to cloud provider credentials.
+
+|`ManagedOpenShift-openshift-image-registry-installer-cloud-credentials`
+|An IAM role required by the ROSA Image Registry Operator to manage the internal registry storage in AWS S3 for a cluster.
+
+|`ManagedOpenShift-openshift-ingress-operator-cloud-credentials`
+|An IAM role required by the ROSA Ingress Operator to manage external access to a cluster.
+
+|`ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credentials`
+|An IAM role required by ROSA to manage back-end storage through the Container Storage Interface (CSI).
+
+|===
+
+[id="rosa-sts-oidc-provider-for-operators_{context}"]
+== An OIDC provider for Operator authentication
+
+For ROSA installations that use STS, you must create a cluster-specific OIDC provider that is used by the cluster Operators to authenticate.

--- a/modules/rosa-sts-creating-cluster.adoc
+++ b/modules/rosa-sts-creating-cluster.adoc
@@ -5,7 +5,7 @@
 [id="rosa-sts-creating-cluster_{context}"]
 = Creating your cluster using STS
 
-You can use the {product-title} CLI (`rosa`) to create an OpenShift cluster that uses the AWS security token service (STS).
+Use the {product-title} CLI (`rosa`) to create an OpenShift cluster that uses the AWS Security Token Service (STS).
 
 [IMPORTANT]
 ====
@@ -32,20 +32,25 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Share
 ----
 $ rosa create account-roles --version 4.8 --prefix ManagedOpenShift <1> <2>
 ----
-<1> You must specify an OpenShift release by using the `--version` option.
-<2> The `ManagedOpenShift` prefix is the default. If you specify a different prefix, you must reference it when declaring the Amazon Resource Names (ARNs) when you create the cluster.
+<1> You must specify an OpenShift release by using the `--version` option. The version that is installed when a ROSA cluster is created is determined by the roles and policies that are used.
+<2> The `--prefix` argument is optional. The `ManagedOpenShift` prefix is the default. If you specify a different prefix, you must reference it when declaring the Amazon Resource Names (ARNs) when you create the cluster.
++
+[IMPORTANT]
+====
+The account-wide roles and policies are specific to a OpenShift version, for example OpenShift 4.8. If you are using multiple cluster versions in one account, you can specify a version-specific prefix to easily identify the roles for each cluster version.
+====
 +
 You can select from the following modes in the interactive prompt:
 +
 * `auto`: The account roles and policies are created directly using the current AWS account.
-* `manual`: The role and policy JSON files are saved in the current directory. The command output includes the `aws` CLI commands required to create the roles.
+* `manual`: The role and policy JSON files are saved in the current directory. The command output includes the `aws` CLI commands required to create the roles. This mode enables you to review the commands before running them manually.
 +
 [NOTE]
 ====
-Alternatively, you can specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
+You can optionally specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
 ====
 
-. Create a cluster by specifying the custom settings shown below or by using the interactive mode. To view other options when creating a cluster, enter `rosa create cluster --help`.
+. Create a cluster by using the interactive prompts, by specifying custom settings, or by using the default options. To view other options when creating a cluster, enter `rosa create cluster --help`.
 +
 Creating a cluster can take up to 40 minutes.
 +
@@ -54,7 +59,78 @@ Creating a cluster can take up to 40 minutes.
 Multiple availability zones (Multi-AZ) are recommended for production workloads. The default is a single availability zone. Use `--help` for an example of how to set this option manually or use interactive mode to be prompted for this setting.
 ====
 +
-* To create a cluster with STS using custom settings:
+* To create a cluster with STS using the defaults:
++
+[source,terminal]
+----
+$ rosa create cluster --cluster-name ${name} --sts
+----
++
+.Example output
+[source,terminal]
+----
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role for the Support role
+I: Creating cluster '<cluster_name>'
+I: To view a list of clusters and their status, run 'rosa list clusters'
+I: Cluster '<cluster_name>' has been created.
+I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
+I: To determine when your cluster is Ready, run 'rosa describe cluster -c <cluster_name>'.
+I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_name> --watch'.
+...
+----
++
+[NOTE]
+====
+If more than one matching set of account-wide roles are available in your account for a cluster version, an interactive list of options is provided.
+====
++
+* To create a cluster with STS using interactive prompts:
++
+[source,terminal]
+----
+$ rosa create cluster --interactive
+----
++
+.Example output
+[source,terminal]
+----
+I: Interactive mode enabled.
+Any optional fields can be left empty and a default will be selected.
+? Cluster name: <cluster_name>
+? Deploy cluster using AWS STS: Yes
+? OpenShift version: 4.8.9
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
+I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role for the Support role
+? External ID (optional): 
+? Operator roles prefix: <cluster_name>-z9y3
+? Multiple availability zones (optional): No
+? AWS region: us-east-1
+? PrivateLink cluster (optional): No
+? Install into an existing VPC (optional): No
+? Enable Customer Managed key (optional): No
+? Compute nodes instance type (optional): 
+? Enable autoscaling (optional): No
+? Compute nodes: 2
+? Machine CIDR: 10.0.0.0/16
+? Service CIDR: 172.30.0.0/16
+? Pod CIDR: 10.128.0.0/14
+? Host prefix: 23
+I: Creating cluster '<cluster_name>'
+I: To create this cluster again in the future, you can run:
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-z9y3 --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
+I: To view a list of clusters and their status, run 'rosa list clusters'
+I: Cluster '<cluster_name>' has been created.
+I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
+I: To determine when your cluster is Ready, run 'rosa describe cluster -c <cluster_name>'.
+I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_name> --watch'.
+----
++
+* To create a cluster with STS by specifying the installation options from the CLI:
 +
 [source,terminal]
 ----
@@ -66,18 +142,20 @@ $ rosa create cluster \
   --support-role-arn arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-Support-Role \
   --master-iam-role arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-ControlPlane-Role \
   --worker-iam-role arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-Worker-Role \
-  --operator-roles-prefix ManagedOpenShift
+  --operator-roles-prefix ManagedOpenShift <2>
 ----
-<1> If you specified a custom prefix in the preceding command, you must replace the `ManagedOpenShift` prefix with the custom one in each ARN declaration.
+<1> If you specified a custom prefix in the preceding command, you must replace the `ManagedOpenShift` prefix with the custom one in each ARN declaration. You must specify ARNs for STS account-wide roles that are created using `rosa create account-roles`.
+<2> Declares the prefix for the cluster-specific Operator roles that are defined in the following step.
 +
 .Example output
 [source,terminal]
 ----
-I: Creating cluster with identifier '<cluster_id>' and name '<cluster_name>'
-I: To view list of clusters and their status, run `rosa list clusters`
+I: Creating cluster '<cluster_name>'
+I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
-I: Once the cluster is 'Ready' you will need to add an Identity Provider and define the list of cluster administrators. See `rosa create idp --help` and `rosa create user --help` for more information.
-I: To determine when your cluster is Ready, run `rosa describe cluster <cluster_name>`.
+I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
+I: To determine when your cluster is Ready, run 'rosa describe cluster -c <cluster_name>'.
+I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_name> --watch'.
 ----
 +
 [NOTE]
@@ -90,15 +168,14 @@ You can configure the following default network IP ranges:
 
 For the CIDR-related `rosa` CLI arguments, see `rosa create cluster --help | grep cidr`. In the interactive mode, you are prompted for the settings.
 ====
-
-* To create a cluster with STS using interactive prompts:
 +
-[source,terminal]
-----
-$ rosa create cluster --interactive
-----
+[NOTE]
+====
+The cluster state is `Pending` until the following steps are complete.
+====
++
 
-. Create the cluster-specific Operator IAM roles. The roles created include the relevant prefix for the cluster name:
+. Create the cluster-specific Operator IAM roles:
 +
 [source,terminal]
 ----
@@ -109,14 +186,14 @@ $ rosa create operator-roles --cluster <cluster_name|cluster_id> <1>
 You can select from the following modes in the interactive prompt:
 +
 * `auto`: The Operator roles are created directly using the current AWS account.
-* `manual`: The role JSON files are saved in the current directory. The command output includes the `aws` CLI commands required to create the roles.
+* `manual`: The role JSON files are saved in the current directory. The command output includes the `aws` CLI commands required to create the roles. This mode enables you to review the commands before running them manually.
 +
 [NOTE]
 ====
-Alternatively, you can specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
+You can optionally specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
 ====
 
-. Create the OpenID Connect (OIDC) provider that the Operators will use to authenticate:
+. Create the OpenID Connect (OIDC) provider that the cluster Operators will use to authenticate:
 +
 [source,terminal]
 ----
@@ -127,11 +204,11 @@ $ rosa create oidc-provider --cluster <cluster_name|cluster_id> <1>
 You can select from the following modes in the interactive prompt:
 +
 * `auto`: The OIDC provider is created directly using the current AWS account.
-* `manual`: The command output includes the `aws` CLI commands required to create the OIDC provider.
+* `manual`: The command output includes the `aws` CLI commands required to create the OIDC provider, including the thumbprint. This mode enables you to review the commands before running them manually.
 +
 [NOTE]
 ====
-Alternatively, you can specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
+You can optionally specify the mode by using the `--mode auto -y` or `--mode manual` CLI arguments.
 ====
 
 . Check the status of your cluster and retrieve your cluster ID. The `State` field changes from `pending` to `installing` to `ready`:
@@ -181,6 +258,7 @@ If installation fails or the `State` field does not change to `ready` after 40 m
 +
 [source,terminal]
 ----
-$ rosa logs install --cluster=<cluster_name|cluster_id> --watch <1>
+$ rosa logs install --cluster=<cluster_name|cluster_id> --watch <1><2>
 ----
 <1> Replace `<cluster_name|cluster_id>` with the cluster name or the ID of the cluster.
+<2> Specify the `--watch` flag to watch for new log messages as the installation progresses. This argument is optional.

--- a/modules/rosa-using-sts.adoc
+++ b/modules/rosa-using-sts.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa-understanding.adoc
+
+[id="rosa-using-sts_{context}"]
+= Using the AWS Security Token Service
+
+The Amazon Web Services (AWS) Security Token Service (STS) is a global web service that provides short-term credentials for IAM or federated users. You can use AWS STS with {product-title} (ROSA) to allocate temporary, limited-privilege credentials for component-specific IAM roles. The service enables cluster components to make AWS API calls using secure cloud resource management practices.
+
+You can use the `rosa` CLI to create the IAM role, policy and identity provider resources that are required for ROSA clusters that use STS.

--- a/rosa_architecture/rosa-understanding.adoc
+++ b/rosa_architecture/rosa-understanding.adoc
@@ -7,3 +7,4 @@ toc::[]
 Learn about {product-title} (ROSA) access, supported consoles, consumption experience, and integration with Amazon Web Services (AWS) services.
 
 include::modules/rosa-understanding.adoc[leveloffset=+1]
+include::modules/rosa-using-sts.adoc[leveloffset=+2]

--- a/rosa_getting_started_sts/rosa-sts-creating-cluster.adoc
+++ b/rosa_getting_started_sts/rosa-sts-creating-cluster.adoc
@@ -1,12 +1,13 @@
 include::modules/attributes-openshift-dedicated.adoc[]
 :context: rosa-sts-creating-cluster
 [id="rosa-sts-creating-cluster"]
-= Creating a cluster for using STS
+= Creating a cluster that uses STS
 
 toc::[]
 
 After you have set up your environment, you can create an OpenShift cluster that uses the AWS Security Token Service (STS).
 
+include::modules/rosa-sts-about-iam-resources.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-cluster.adoc[leveloffset=+1]
 
 == Next steps
@@ -14,4 +15,6 @@ xref:../rosa_getting_started_sts/rosa-sts-accessing-cluster.adoc#rosa-sts-access
 
 == Additional resources
 
+* xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[AWS Prerequisites for ROSA with STS]
+* For more information about using OpenID Connect (OIDC) identity providers in AWS IAM, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html[Creating OpenID Connect (OIDC) identity providers] in the AWS documentation.
 * xref:../rosa_support/rosa-troubleshooting.adoc#rosa-troubleshooting[Troubleshooting]

--- a/rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
+++ b/rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc
@@ -8,3 +8,5 @@ toc::[]
 Delete a {product-title} (ROSA) cluster using the `rosa` command-line.
 
 include::modules/rosa-deleting-cluster.adoc[leveloffset=+1]
+include::modules/rosa-deleting-aws-resources-cli.adoc[leveloffset=+1]
+include::modules/rosa-deleting-aws-resources-aws-console.adoc[leveloffset=+1]

--- a/rosa_getting_started_sts/rosa-sts-getting-started-workflow.adoc
+++ b/rosa_getting_started_sts/rosa-sts-getting-started-workflow.adoc
@@ -6,6 +6,11 @@ include::modules/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+[id="rosa-getting-started-rosa-sts"]
+== Getting started with ROSA using STS
+
+The Amazon Web Services (AWS) Security Token Service (STS) is a global web service that provides short-term credentials for IAM or federated users. You can use AWS STS with {product-title} (ROSA) to allocate temporary, limited-privilege credentials for component-specific IAM roles. The service enables cluster components to make AWS API calls using secure cloud resource management practices.
+
 Follow this workflow to set up and access {product-title} (ROSA) clusters using AWS security token service (STS).
 
 . xref:../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc#rosa-sts-aws-prerequisites[Complete the AWS prerequisites for ROSA with STS].
@@ -14,6 +19,7 @@ Follow this workflow to set up and access {product-title} (ROSA) clusters using 
 . xref:../rosa_getting_started_sts/rosa-sts-creating-cluster.adoc#rosa-sts-creating-cluster[Create cluster using STS].
 . xref:../rosa_getting_started_sts/rosa-sts-accessing-cluster.adoc#rosa-sts-accessing-cluster[Access a cluster].
 
+[id="additional_resources_rosa-sts-getting-started-workflow"]
 == Additional resources
 * xref:../rosa_getting_started_sts/rosa-sts-config-identity-providers.adoc#rosa-sts-config-identity-providers[Configure identity providers using the OCM console]
 * xref:../rosa_getting_started_sts/rosa-sts-deleting-cluster.adoc#rosa-sts-deleting-cluster[Deleting a cluster]


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2272.

The primary preview pages are as follows:

* ROSA architecture -> [Using the AWS Security Token Service](https://deploy-preview-35762--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-understanding.html)
* Setting up accounts and clusters using AWS Security Token Service (STS) -> [Creating a cluster using STS](https://deploy-preview-35762--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-creating-cluster?utm_source=github&utm_campaign=bot_dp)
* Setting up accounts and clusters using AWS Security Token Service (STS) -> [Deleting a ROSA cluster](https://deploy-preview-35762--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-deleting-cluster.html)