### PR TITLE
CNV-11058: OpenShift Virtualization dashboard

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2999,6 +2999,8 @@ Topics:
     File: virt-monitoring-vm-health
   - Name: Viewing cluster information
     File: virt-using-dashboard-to-get-cluster-info
+  - Name: Reviewing resource usage by virtual machines
+    File: virt-reviewing-vm-dashboard
   - Name: OpenShift cluster monitoring, logging, and Telemetry
     File: virt-openshift-cluster-monitoring
   - Name: Prometheus queries for virtual resources

--- a/modules/virt-about-reviewing-resource-consumption.adoc
+++ b/modules/virt-about-reviewing-resource-consumption.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
+//
+
+[id="virt-about-reviewing-resource-consumption_{context}"]
+
+= About reviewing resource consumption
+
+Line chart graphs in the {VirtProductName} dashboard present data for virtual machines or `virt-launcher` pods that are consuming the most resources for a selected time range.
+
+The following table shows monitored resources and describes the metrics associated with each resource for top consumers in each pod.
+
+[cols="1,1"]
+|===
+|Monitored resources| Description
+
+|Memory swap traffic
+|Virtual machines consuming the most memory pressure when swapping memory.
+|vCPU wait
+|Virtual machines experiencing the maximum wait time (in seconds) for their vCPUs.
+|CPU Usage
+|The `virt-launcher` pods with virtual machines that are using the most CPU.
+|Network traffic
+|Virtual machines that are saturating the network by receiving the most amount of network traffic (in bytes).
+|Storage traffic
+|Virtual machines with the highest amount (in bytes) of storage-related traffic.
+|Storage IOPS
+|Virtual machines with the highest amount of I/O operations per second over a time period.
+|Memory usage
+|The `virt-launcher` pods with virtual machines that are using the most memory (in bytes).
+|===
+
+[NOTE]
+====
+Viewing the maximum resource consumption is limited to the top five consumers.
+====

--- a/modules/virt-about-reviewing-top-consumers.adoc
+++ b/modules/virt-about-reviewing-top-consumers.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assembly:
+//
+// * virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
+//
+
+[id="virt-about-reviewing-top-consumers_{context}"]
+= About reviewing top consumers
+
+In the {VirtProductName} dashboard, you can select a specific time period and view the top consumers of resources within that time period. Top consumers are virtual machines or `virt-launcher` pods that are consuming the highest amount of resources.
+
+The following table shows resources monitored in the dashboard and describes the metrics associated with each resource for top consumers.
+
+[cols="1,1"]
+|===
+|*Monitored resources* | *Description*
+|Memory swap traffic
+|Virtual machines consuming the most memory pressure when swapping memory.
+|vCPU wait
+|Virtual machines experiencing the maximum wait time (in seconds) for their vCPUs.
+|CPU usage by pod
+|The `virt-launcher` pods that are using the most CPU.
+|Network traffic
+|Virtual machines that are saturating the network by receiving the most amount of network traffic (in bytes).
+|Storage traffic
+|Virtual machines with the highest amount (in bytes) of storage-related traffic.
+|Storage IOPS
+|Virtual machines with the highest amount of I/O operations per second over a time period.
+|Memory usage
+|The `virt-launcher` pods that are using the most memory (in bytes).
+|===
+
+[NOTE]
+====
+Viewing the maximum resource consumption is limited to the top five consumers.
+====

--- a/modules/virt-reviewing-resource-consumption.adoc
+++ b/modules/virt-reviewing-resource-consumption.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
+
+[id="virt-reviewing-resource-consumption_{context}"]
+= Reviewing resource consumption
+
+In the Developer perspective, you can view dashboards relating to a selected `namespace`. You must have access to monitor a `namespace` to view resource data for pods and virtual machines. Line chart graphs in the {VirtProductName} dashboard present data for virtual machines that are consuming the most resources within a pod.
+
+.Prerequisites
+
+* You have access to the cluster as a developer or as a user with view permissions for the `namespace` that you are viewing the dashboard for.
+
+.Procedure
+
+. In the Developer perspective in the {product-title} web console, navigate to *Observe* -> *Dashboards*.
+
+. Choose a namespace in the *Namespace:* list.
+
+. Choose a workload in the *All Workloads* list.
+
+. Optional: Select a time range for the graphs in the *Time Range* list.
++
+** Select a pre-defined time period.
++
+** Set a custom time range by selecting *Custom time range* in the *Time Range* list.
++
+.. Input or select the *From* and *To* dates and times.
++
+.. Click *Save* to save the custom time range.
+
+. Optional: Select a *Refresh Interval*.
+
+. Hover over each of the line chart graphs within a dashboard to display detailed information about a pod and the virtual machines within that pod.

--- a/modules/virt-reviewing-top-consumers.adoc
+++ b/modules/virt-reviewing-top-consumers.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
+
+[id="virt-reviewing-top-consumers_{context}"]
+= Reviewing top consumers
+
+In the *Administrator* perspective, you can view the {VirtProductName} dashboard where top consumers of resources are displayed.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. In the *Administrator* perspective in the {VirtProductName} web console, navigate to *Observe* -> *Dashboards*.
+
+. Select the `KubeVirt/Infrastructure Resources/Top Consumers` dashboard from the *Dashboard* list.
+
+. Select a pre-defined time period from the drop-down menu for *Period.* You can review the data for top consumers in the tables.
+
+. Optional: Click *Inspect* to view or edit the Prometheus Query Language (PromQL) query associated with the top consumers for a table.

--- a/virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
+++ b/virt/logging_events_monitoring/virt-reviewing-vm-dashboard.adoc
@@ -1,0 +1,27 @@
+[id="virt-reviewing-vm-dashboard"]
+= Reviewing resource usage by virtual machines
+include::modules/virt-document-attributes.adoc[]
+:context: virt-reviewing-vm-dashboard
+
+toc::[]
+
+Dashboards in the {ProductName} web console provide visual representations of cluster metrics to help you to quickly understand the state of your cluster. Dashboards belong to the xref:../../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[monitoring stack] that provides monitoring for core platform components.
+
+The {VirtProductName} dashboard provides data on resource consumption for virtual machines and associated pods. The visualization metrics displayed in the {VirtProductName} dashboard are based on xref:../../virt/logging_events_monitoring/virt-prometheus-queries.adoc#virt-prometheus-queries[Prometheus Query Language (PromQL) queries].
+
+A xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[monitoring role] is required to monitor user-defined namespaces in the OpenShift Virtualization dashboard.
+
+include::modules/virt-about-reviewing-top-consumers.adoc[leveloffset=+1]
+
+include::modules/virt-reviewing-top-consumers.adoc[leveloffset=+1]
+
+include::modules/virt-about-reviewing-resource-consumption.adoc[leveloffset=+1]
+
+include::modules/virt-reviewing-resource-consumption.adoc[leveloffset=+1]
+
+[id="{context}-additional-resources"]
+== Additional resources
+
+* xref:../../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Understanding the {product-title} monitoring stack]
+
+* xref:../../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[Reviewing monitoring dashboards]


### PR DESCRIPTION
This PR is associated with https://issues.redhat.com/browse/CNV-11058 and the new features for reviewing monitored data for resource consumption by virtual machines. We now have tables that show top five consumers of resources and line chart graphs that show resource consumption for VMs and pods.