### PR TITLE
OSSMDOC-397: Ability to opt-out automatic route creation for specific Gateways

### DIFF
--- a/modules/ossm-auto-route.adoc
+++ b/modules/ossm-auto-route.adoc
@@ -56,6 +56,14 @@ If you need specific annotations in the OpenShift Routes created by {ProductShor
 
 By default, the `ServiceMeshControlPlane` resource automatically synchronizes the Gateway resources with OpenShift routes. Disabling the automatic route creation allows you more flexibility to control routes if you have a special case or prefer to control routes manually.
 
+== Skipping automatic route creation for specific cases
+
+If you want to skip the automatic management of OpenShift routes for a specific Istio Gateway, you must add the annotation `maistra.io/manageRoute: false` to the Gateway metadata definition. {ProductName} will ignore Istio Gateways with this annotation, while keeping the automatic management of the other Istio Gateways.
+
+== Disabling automatic route creation for all cases
+
+You can disable the automatic management of OpenShift routes for all Gateways in your mesh.
+
 Disable integration between Istio Gateways and OpenShift Routes by setting the `ServiceMeshControlPlane` field `gateways.openshiftRoute.enabled` to `false`. For example, see the following resource snippet.
 
 [source,yaml]


### PR DESCRIPTION
Note that this applies only to OSSM 2.1.