### PR TITLE
bz1960696: Added warning concerning lengthy boot with no progress report

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -33,3 +33,8 @@ For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabl
 ====
 The installer will not initiate installation on a node if the node firmware is below the foregoing versions when installing with virtual media.
 ====
+//Warning added by tm on 24 August 2021 for bug bz1960696
+[WARNING]
+====
+Boot times are protracted without any indication of progress. Do not assume the boot is stuck, or abort or reboot during this installation.
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1960696
Intended for 4.7.
Added warning (Boot times are protracted without any indication of progress. Do not assume the boot is stuck, or abort or reboot during this installation.) to https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites