### PR TITLE
GH#35804 Add Performance Profile Creator to tuning module

### DIFF
--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -14,6 +14,11 @@ The performance profile lets you control latency tuning aspects of nodes that be
 
 You can use a performance profile to specify whether to update the kernel to kernel-rt, to allocate huge pages, and to partition the CPUs for performing housekeeping duties or running workloads.
 
+[NOTE]
+====
+You can manually create the `PerformanceProfile` object or use the Performance Profile Creator (PPC) to generate a performance profile. See the additional resources below for more information on the PPC.
+====
+
 .Sample performance profile
 [source,yaml]
 ----

--- a/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+++ b/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
@@ -29,6 +29,10 @@ include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
 
 include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[leveloffset=+1]
 
+.Additional resources
+
+For information on using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+
 include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+2]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/35804

Preview: https://deploy-preview-35805--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes?utm_source=github&utm_campaign=bot_dp#cnf-tuning-nodes-for-low-latency-via-performanceprofile_cnf-master