### PR TITLE
CNV-11198: Added info about MAC spoof check

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -7,10 +7,11 @@
 
 As a network administrator, you can configure a network attachment definition of type `cnv-bridge` to provide Layer-2 networking to pods and virtual machines.
 
-[NOTE]
-====
-The network attachment definition must be in the same namespace as the pod or virtual machine.
-====
+.Prerequisites
+
+* The network attachment definition must be in the same namespace as the pod or virtual machine.
+
+* The node must support nftables and the `nft` binary must be deployed to enable MAC spoof check.
 
 .Procedure
 
@@ -33,10 +34,11 @@ spec:
       {
         "type": "cnv-bridge", <4>
         "bridge": "<bridge-interface>", <5>
-        "vlan": 1 <6>
+        "macspoofchk": true, <6>
+        "vlan": 1 <7>
       },
       {
-        "type": "cnv-tuning" <7>
+        "type": "cnv-tuning" <8>
       }
     ]
   }'
@@ -46,10 +48,11 @@ spec:
 <3> The name for the configuration. It is recommended to match the configuration name to the `name` value of the network attachment definition.
 <4> The actual name of the Container Network Interface (CNI) plug-in that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
 <5> The name of the Linux bridge configured on the node.
-<6> Optional: The VLAN tag.
-<7> The CNI plug-in that allows the MAC pool manager to assign a unique MAC address to the connection.
+<6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
+<7> Optional: The VLAN tag.
+<8> The CNI plug-in that allows the MAC pool manager to assign a unique MAC address to the connection.
 
-. Create the network attachment definition: 
+. Create the network attachment definition:
 +
 [source,terminal]
 ----
@@ -66,4 +69,3 @@ $ oc create -f <network-attachment-definition.yaml> <1>
 $ oc get network-attachment-definition <a-bridge-network> <1>
 ----
 <1> Where `<a-bridge-network>` is the name specified in the network attachment definition config.
-


### PR DESCRIPTION
This PR addresses [CNV-11198](https://issues.redhat.com/browse/CNV-11198)

Updated existing assembly "Attaching a VM to multiple networks" to add content about the MAC spoof check feature

Applies to enterprise-4.9

Preview: https://deploy-preview-35806--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks?utm_source=github&utm_campaign=bot_dp#virt-creating-bridge-nad-cli_virt-attaching-multiple-networks