### PR TITLE
Release notes for ASH UPI and upgrade note for RHEL compute 7 -> 8

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -54,6 +54,16 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-9-installation-and-upgrade"]
 === Installation and upgrade
 
+[id="ocp-4-9-installation-ash-upi"]
+==== Installing a cluster on Microsoft Azure Stack Hub using user-provisioned infrastructure
+
+{product-title} 4.9 introduces support for installing a cluster on Azure Stack Hub using user-provisioned infrastructure.
+
+You can incorporate example Azure Resource Manager (ARM) templates provided by Red Hat to assist in the deployment process, or create your own. You are also free to create the required resources through other methods; the ARM templates are just an example.
+
+//See ../installing/install_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[Installing a cluster on Azure Stack Hub using ARM templates] for details.
+
+
 [id=ocp-4.9-azure-cidr]
 ==== Increased size of Azure subnets within the machine CIDR
 The {product-title} installation program for Microsoft Azure now creates subnets as large as possible within the machine CIDR. This lets the cluster use a machine CIDR that is appropriately sized to accommodate the number of nodes in the cluster.
@@ -96,7 +106,9 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 
 [id="ocp-4-9-machine-api-rhel8"]
 ==== {op-system-base-full} 8 now supported for compute machines
-Starting in {product-title} {product-version}, you can now use {op-system-base-full} 8 for compute machines. Previously, RHEL 8 was not supported for compute machines.
+Starting in {product-title} {product-version}, you can now use {op-system-base-full} 8 for compute machines. Previously, {op-system-base} 8 was not supported for compute machines.
+
+You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. You must deploy new {op-system-base} 8 hosts, and the old {op-system-base} 7 hosts should be removed.
 
 [id="ocp-4-9-nodes"]
 === Nodes


### PR DESCRIPTION
Preview: https://deploy-preview-35809--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-installation-and-upgrade