### PR TITLE
OSDOCS-2457: document procedures for Global Options to Enable HTTP Strict Transport Security (HSTS)

### DIFF
--- a/modules/nw-disabling-hsts.adoc
+++ b/modules/nw-disabling-hsts.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+// * networking/configuring-routing.adoc
+
+[id="nw-disabling-hsts_{context}"]
+= Disabling HTTP Strict Transport Security per-route
+
+To disable HTTP strict transport security (HSTS) per-route, you can set the `max-age` value in the route annotation to `0`.
+
+.Prerequisites
+
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You installed the `oc` CLI.
+
+.Procedure
+
+* To disable HSTS, set the `max-age` value in the route annotation to `0`, by entering the following command:
++
+[source,terminal]
+----
+$ oc annotate route <rout_name> -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to create the config map:
+
+.Example of disabling HSTS per-route
+[source,yaml]
+----
+metadata:
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=0
+----
+====
+
+* To disable HSTS for every route in a namespace, enter the followinf command:
++
+[source,terminal]
+----
+$ oc annotate <route> --all -n <namespace> --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=0"
+----
+
+.Verification
+
+. To query the annotation for all routes, enter the following command:
++
+[source,terminal]
+----
+$ oc get route  --all-namespaces -o go-template='{{range .items}}{{if .metadata.annotations}}{{$a := index .metadata.annotations "haproxy.router.openshift.io/hsts_header"}}{{$n := .metadata.name}}{{with $a}}Name: {{$n}} HSTS: {{$a}}{{"\n"}}{{else}}{{""}}{{end}}{{end}}{{end}}'
+----
++
+.Example output
+[source,terminal]
+----
+Name: routename HSTS: max-age=0
+----

--- a/modules/nw-enabling-hsts-per-route.adoc
+++ b/modules/nw-enabling-hsts-per-route.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+// * networking/configuring-routing.adoc
+
+[id="nw-enabling-hsts-per-route_{context}"]
+= Enabling HTTP Strict Transport Security per-route
+
+HTTP strict transport security (HSTS) is implemented in the HAProxy template and applied to edge and re-encrypt routes that have the `haproxy.router.openshift.io/hsts_header` annotation.
+
+.Prerequisites
+
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You installed the `oc` CLI.
+
+.Procedure
+
+* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header` value to the edge-terminated or re-encrypt route:
++
+.Example route configured with an annotation
+[source,yaml]
+----
+apiVersion: v1
+kind: Route
+metadata:
+  annotations:
+    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload <1> <2> <3>
+...
+spec:
+  host: def.abc.com
+  tls:
+    termination: "reencrypt"
+    ...
+  wildcardPolicy: "Subdomain"
+----
+<1> Required. `max-age` measures the length of time, in seconds, that the HSTS policy is in effect. If set to `0`, it negates the policy.
+<2> Optional. When included, `includeSubDomains` tells the client
+that all subdomains of the host must have the same HSTS policy as the host.
+<3> Optional. When `max-age` is greater than 0, you can add `preload` in  `haproxy.router.openshift.io/hsts_header` to allow external services to include this site in their HSTS preload lists. For example, sites such as Google can construct a list of sites that have `preload` set. Browsers can then use these lists to determine which sites they can communicate with over HTTPS, even before they have interacted with the site. Without `preload` set, browsers must have interacted with the site over HTTPS, at least once, to get the header.

--- a/modules/nw-enabling-hsts.adoc
+++ b/modules/nw-enabling-hsts.adoc
@@ -3,54 +3,19 @@
 // * networking/configuring-routing.adoc
 
 [id="nw-enabling-hsts_{context}"]
-= Enabling HTTP strict transport security
+= HTTP Strict Transport Security
 
-HTTP Strict Transport Security (HSTS) policy is a security enhancement, which
-ensures that only HTTPS traffic is allowed on the host. Any HTTP requests are
-dropped by default. This is useful for ensuring secure interactions with
-websites, or to offer a secure application for the user's benefit.
+HTTP Strict Transport Security (HSTS) policy is a security enhancement, which signals to the browser client that only HTTPS traffic is allowed on the route host. HSTS also optimizes web traffic by signaling HTTPS transport is required, without using HTTP redirects. HSTS is useful for speeding up interactions with websites.
 
-When HSTS is enabled, HSTS adds a Strict Transport Security header to HTTPS
-responses from the site. You can use the `insecureEdgeTerminationPolicy` value
-in a route to redirect to send HTTP to HTTPS. However, when HSTS is enabled, the
-client changes all requests from the HTTP URL to HTTPS before the request is
-sent, eliminating the need for a redirect. This is not required to be supported
-by the client, and can be disabled by setting `max-age=0`.
+When HSTS policy is enforced, HSTS adds a Strict Transport Security header to HTTP and HTTPS responses from the site. You can use the `insecureEdgeTerminationPolicy` value in a route to redirect HTTP to HTTPS. When HSTS is enforced, the client changes all requests from the HTTP URL to HTTPS before the request is sent, eliminating the need for a redirect.
+
+Cluster administrators can configure HSTS to do the following:
+
+* Enable HSTS per-route
+* Disable HSTS per-route
+* Enforce HSTS per-domain, for a set of domains, or use namespace labels in combination with domains
 
 [IMPORTANT]
 ====
-HSTS works only with secure routes (either edge terminated or re-encrypt). The
-configuration is ineffective on HTTP or passthrough routes.
+HSTS works only with secure routes, either edge-terminated or re-encrypt. The configuration is ineffective on HTTP or passthrough routes.
 ====
-
-.Procedure
-* To enable HSTS on a route, add the `haproxy.router.openshift.io/hsts_header`
-value to the edge terminated or re-encrypt route:
-+
-[source,yaml]
-----
-apiVersion: v1
-kind: Route
-metadata:
-  annotations:
-    haproxy.router.openshift.io/hsts_header: max-age=31536000;includeSubDomains;preload <1> <2> <3>
-----
-+
-<1> `max-age` is the only required parameter.
-It measures the length of time, in seconds, that the
-HSTS policy is in effect. The client updates `max-age` whenever a response
-with a HSTS header is received from the host. When `max-age` times out, the
-client discards the policy.
-+
-<2> `includeSubDomains` is optional. When included, it tells the client
-that all subdomains
-of the host are to be treated the same as the host.
-+
-<3> `preload` is optional. When `max-age` is greater than 0, then including
-`preload` in  `haproxy.router.openshift.io/hsts_header` allows external
-services to include this site in their HSTS preload lists. For example, sites
-such as Google can construct a list of sites that have `preload` set. Browsers
-can then use these lists to determine which sites they can communicate with
-over HTTPS,
-before they have interacted with the site. Without `preload` set, browsers must
-have interacted with the site over HTTPS to get the header.

--- a/modules/nw-enforcing-hsts-per-domain.adoc
+++ b/modules/nw-enforcing-hsts-per-domain.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+// * networking/configuring-routing.adoc
+
+[id="nw-enforcing-hsts-per-domain_{context}"]
+= Enforcing HTTP Strict Transport Security per-domain
+
+To enforce HTTP Strict Transport Security (HSTS) per-domain for secure routes, add a `requiredHSTSPolicies` record to the Ingress spec to capture the configuration of the HSTS policy.
+
+If you configure a `requiredHSTSPolicy` to enforce HSTS, then any newly created route must be configured with a compliant HSTS policy annotation.
+
+[NOTE]
+====
+To handle upgraded clusters with non-compliant HSTS routes, you can update the manifests at the source and apply the updates.
+====
+
+[NOTE]
+====
+You cannot use `oc expose route` or `oc create route` commands to add a route in a domain that enforces HSTS, because the API for these commands does not accept annotations.
+====
+
+[IMPORTANT]
+====
+HSTS cannot be applied to secure, or non-TLS routes, even if HSTS is requested for all routes globally.
+====
+
+.Prerequisites
+
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You installed the `oc` CLI.
+
+.Procedure
+
+. Edit the Ingress config file:
++
+[source,terminal]
+----
+$ oc edit ingresses.config.openshift.io/cluster
+----
++
+.Example HSTS policy
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Ingress
+metadata:
+  name: cluster
+spec:
+  domain: 'hello-openshift-default.apps.username.devcluster.openshift.com'
+  requiredHSTSPolicies: <1>
+  - domainPatterns: <2>
+    - '*hello-openshift-default.apps.username.devcluster.openshift.com'
+    - '*hello-openshift-default2.apps.username.devcluster.openshift.com'
+    namespaceSelector: <3>
+      matchLabels:
+        myPolicy: strict
+    maxAge: <4>
+      smallestMaxAge: 1
+      largestMaxAge: 31536000
+    preloadPolicy: RequirePreload <5>
+    includeSubDomainsPolicy: RequireIncludeSubDomains <6>
+  - domainPatterns: <2>
+    - 'abc.example.com'
+    - '*xyz.example.com'
+    namespaceSelector:
+      matchLabels: {}
+    maxAge: {}
+    preloadPolicy: NoOpinion
+    includeSubDomainsPolicy: RequireNoIncludeSubDomains
+----
+<1> Required. `requiredHSTSPolicies` are validated in order, and the first matching `domainPatterns` applies.
+<2> Required. You must specify at least one `domainPatterns` hostname. Any number of domains can be listed. You can include multiple sections of enforcing options for different `domainPatterns`.
+<3> Optional. If you include `namespaceSelector`, it must match the labels of the project where the routes reside, to enforce the set HSTS policy on the routes. Routes that only match the `namespaceSelector` and not the `domainPatterns` are not validated.
+<4> Required. `max-age` measures the length of time, in seconds, that the HSTS policy is in effect. This policy setting allows for a smallest and largest `max-age` to be enforced.
+
+- The `largestMaxAge` value must be between `0` and `2147483647`. It can be left unspecified, which means no upper limit is enforced.
+- The `smallestMaxAge` value must be between `0` and `2147483647`. Enter `0` to disable HSTS for troubleshooting, otherwise enter `1` if you never want HSTS to be disabled. It can be left unspecified, which means no lower limit is enforced.
+<5> Optional. Including `preload` in `haproxy.router.openshift.io/hsts_header` allows external services to include this site in their HSTS preload lists. Browsers can then use these lists to determine which sites they can communicate with over HTTPS, before they have interacted with the site. Without `preload` set, browsers need to interact at least once with the site to get the header. `preload` can be set with one of the following:
+
+- `RequirePreload`: `preload` is required by the `RequiredHSTSPolicy`.
+- `RequireNoPreload`: `preload` is forbidden by the `RequiredHSTSPolicy`.
+- `NoOpinion`: `preload` does not matter to the `RequiredHSTSPolicy`.
+<6> Optional. `includeSubDomainsPolicy` can be set with one of the following:
+
+- `RequireIncludeSubDomains`: `includeSubDomains` is required by the `RequiredHSTSPolicy`.
+- `RequireNoIncludeSubDomains`: `includeSubDomains` is forbidden by the `RequiredHSTSPolicy`.
+- `NoOpinion`: `includeSubDomains` does not matter to the `RequiredHSTSPolicy`.
++
+. You can apply HSTS to all routes in the cluster or in a particular namespace by entering the `oc annotate command`.
++
+* To apply HSTS to all routes in the cluster, enter the `oc annotate command`. For example:
++
+[source,terminal]
+----
+$ oc annotate route --all --all-namespaces --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000"
+----
++
+* To apply HSTS to all routes in a particular namespace, enter the `oc annotate command`. For example:
++
+[source,terminal]
+----
+$ oc annotate route --all -n my-namespace --overwrite=true "haproxy.router.openshift.io/hsts_header"="max-age=31536000"
+----
+
+.Verification
+
+You can review the HSTS policy you configured. For example:
+
+* To review the `maxAge` set for required HSTS policies, enter the following command:
++
+[source,terminal]
+----
+$ oc get clusteroperator/ingress -n openshift-ingress-operator -o jsonpath='{range .spec.requiredHSTSPolicies[*]}{.spec.requiredHSTSPolicies.maxAgePolicy.largestMaxAge}{"\n"}{end}'
+----
++
+* To review the HSTS annotations on all routes, enter the following command:
++
+[source,terminal]
+----
+$ oc get route  --all-namespaces -o go-template='{{range .items}}{{if .metadata.annotations}}{{$a := index .metadata.annotations "haproxy.router.openshift.io/hsts_header"}}{{$n := .metadata.name}}{{with $a}}Name: {{$n}} HSTS: {{$a}}{{"\n"}}{{else}}{{""}}{{end}}{{end}}{{end}}'
+----
++
+.Example output
+[source,terminal]
+----
+Name: <_routename_> HSTS: max-age=31536000;preload;includeSubDomains
+----

--- a/networking/routes/route-configuration.adoc
+++ b/networking/routes/route-configuration.adoc
@@ -9,15 +9,25 @@ toc::[]
 
 //Creating route timeouts
 include::modules/nw-configuring-route-timeouts.adoc[leveloffset=+1]
-//
-//Enabling HTTP Strict Transport Security
+
+//HTTP Strict Transport Security
 include::modules/nw-enabling-hsts.adoc[leveloffset=+1]
-//
+
+//Enabling HTTP strict transport security per-route
+include::modules/nw-enabling-hsts-per-route.adoc[leveloffset=+2]
+
+//Disabling HTTP strict transport security per-route
+include::modules/nw-disabling-hsts.adoc[leveloffset=+2]
+
+//Enforcing HTTP strict transport security per-domain
+include::modules/nw-enforcing-hsts-per-domain.adoc[leveloffset=+2]
+
 //Troubleshooting Throughput Issues
 include::modules/nw-throughput-troubleshoot.adoc[leveloffset=+1]
-//
+
 //Using cookies to keep route statefulness
 include::modules/nw-using-cookies-keep-route-statefulness.adoc[leveloffset=+1]
+
 include::modules/nw-annotating-a-route-with-a-cookie-name.adoc[leveloffset=+2]
 
 include::modules/nw-path-based-routes.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2457

Previews [updated]: 
HTTP strict transport security: https://deploy-preview-35812--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-enabling-hsts_route-configuration
Engorcing HTTP strict transport security per-route: https://deploy-preview-35812--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-enabling-hsts-per-route_route-configuration
Disabling HTTP strict transport security per-route: https://deploy-preview-35812--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-disabling-hsts_route-configuration
Enforcing HTTP strict transport security per-domain: https://deploy-preview-35812--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-enforcing-hsts-per-domain_route-configuration

