### PR TITLE
BZ1998086: Update MTC migration plan options to match UI changes (MTC 1.6)

### DIFF
--- a/modules/migration-adding-replication-repository-to-cam.adoc
+++ b/modules/migration-adding-replication-repository-to-cam.adoc
@@ -34,7 +34,7 @@ You can add an object storage as a replication repository to the {mtc-full} ({mt
 ** *S3 endpoint*: Specify the URL of the S3 service, not the bucket, for example, `\https://<s3-storage.apps.cluster.com>`. *Required* for a generic S3 provider. You must use the `https://` prefix.
 ** *S3 provider access key*: Specify the `<AWS_SECRET_ACCESS_KEY>` for AWS or the S3 provider access key for MCG and other S3 providers.
 ** *S3 provider secret access key*: Specify the `<AWS_ACCESS_KEY_ID>` for AWS or the S3 provider secret access key for MCG and other S3 providers.
-** *Require SSL verification*: Clear this check box if you are using a generic S3 provider.
+** *Require SSL verification*: Clear this checkbox if you are using a generic S3 provider.
 ** If you created a custom CA certificate bundle for self-signed certificates, click *Browse* and browse to the Base64-encoded file.
 
 * *GCP*:

--- a/modules/migration-mtc-workflow.adoc
+++ b/modules/migration-mtc-workflow.adoc
@@ -58,10 +58,12 @@ image::migration-PV-move.png[]
 
 . Run the migration plan, with one of the following options:
 
-* *Stage* (optional) copies data to the target cluster without stopping the application.
+* *Stage* copies data to the target cluster without stopping the application.
 +
-Staging can be run multiple times so that most of the data is copied to the target before migration. This minimizes the duration of the migration and the application downtime.
+A stage migration can be run multiple times so that most of the data is copied to the target before migration. Running one or more stage migrations reduces the duration of the cutover migration.
 
-* *Migrate* stops the application on the source cluster and recreates its resources on the target cluster. Optionally, you can migrate the workload without stopping the application.
+* *Cutover* stops the application on the source cluster and moves the resources to the target cluster.
++
+Optional: You can clear the *Halt transactions on the source cluster during migration* checkbox.
 
 image::OCP_3_to_4_App_migration.png[]

--- a/modules/migration-rolling-back-migration-web-console.adoc
+++ b/modules/migration-rolling-back-migration-web-console.adoc
@@ -28,7 +28,7 @@ Rollback is not required if the application was not stopped during migration bec
 .Procedure
 
 . In the {mtc-short} web console, click *Migration plans*.
-. Click the Options menu {kebab} beside a migration plan and select *Rollback*.
+. Click the Options menu {kebab} beside a migration plan and select *Rollback* under *Migration*.
 . Click *Rollback* and wait for rollback to complete.
 +
 In the migration plan details, *Rollback succeeded* is displayed.

--- a/modules/migration-viewing-migration-plan-log.adoc
+++ b/modules/migration-viewing-migration-plan-log.adoc
@@ -20,8 +20,8 @@ The command displays the filtered logs of the following pods:
 .Procedure
 
 . In the {mtc-short} web console, click *Migration Plans*.
-. Click the *Migrations* number next to a migration plan to view the *Migrations* page.
-. Next to a migration, click *View logs*.
+. Click the *Migrations* number next to a migration plan.
+. Click *View logs*.
 . Click the Copy icon to copy the `oc logs` command to your clipboard.
 . Log in to the relevant cluster and enter the command on the CLI.
 +

--- a/modules/migration-viewing-migration-plan-resources.adoc
+++ b/modules/migration-viewing-migration-plan-resources.adoc
@@ -12,12 +12,8 @@ You can view migration plan resources to monitor a running migration or to troub
 
 . In the {mtc-short} web console, click *Migration Plans*.
 . Click the *Migrations* number next to a migration plan to view the *Migrations* page.
-+
-The *Migrations* page displays the migration types associated with the migration plan, for example, *Stage*, *Migration*, or *Rollback*.
-
-. Click the *Type* link to view the *Migration details* page.
-
-. Expand *Migration resources* to view the migration resources and their status.
+. Click a migration to view the *Migration details*.
+. Expand *Migration resources* to view the migration resources and their status in a tree view.
 +
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1998086

Update docs to match UI: Migrate > Cutover 

4.6+

Previews:

https://deploy-preview-35829--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html#migration-mtc-workflow_about-mtc

https://deploy-preview-35829--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/migrating-applications-with-mtc.html#migration-running-migration-plan-cam_migrating-applications-with-mtc

https://deploy-preview-35829--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-viewing-migration-plan-resources_troubleshooting-mtc

https://deploy-preview-35829--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-rolling-back-migration-web-console_troubleshooting-mtc

QE approved. Ready for peer review.