### PR TITLE
Add warning about runlevels.

### DIFF
--- a/modules/cnf-installing-the-operators.adoc
+++ b/modules/cnf-installing-the-operators.adoc
@@ -98,7 +98,6 @@ metadata:
   annotations:
     workload.openshift.io/allowed: management
   labels:
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
 
 EOF
@@ -193,8 +192,6 @@ metadata:
   name: openshift-sriov-network-operator
   annotations:
     workload.openshift.io/allowed: management
-  labels:
-    openshift.io/run-level: "1"
 
 EOF
 ----

--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -35,8 +35,6 @@ metadata:
   name: openshift-performance-addon-operator
   annotations:
     workload.openshift.io/allowed: management
-  labels:
-    openshift.io/run-level: "1"
 ----
 
 .. Create the namespace by running the following command:

--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -2,16 +2,6 @@
 //
 // * networking/hardware_networks/installing-sriov-operator.adoc
 
-ifeval::["{product-version}" == "4.2"]
-:run-level:
-endif::[]
-ifeval::["{product-version}" == "4.3"]
-:run-level:
-endif::[]
-ifeval::["{product-version}" == "4.4"]
-:run-level:
-endif::[]
-
 [id="installing-sr-iov-operator_{context}"]
 = Installing SR-IOV Network Operator
 
@@ -41,10 +31,6 @@ metadata:
   name: openshift-sriov-network-operator
   annotations:
     workload.openshift.io/allowed: management
-ifdef::run-level[]
-  labels:
-    openshift.io/run-level: "1"
-endif::run-level[]
 EOF
 ----
 
@@ -134,22 +120,6 @@ You must create the operator group by using the CLI.
 
 .. In the *Name* field, enter `openshift-sriov-network-operator`, and then click *Create*.
 
-ifdef::run-level[]
-.. In the *Filter by name* field, enter `openshift-sriov-network-operator`.
-
-.. From the list of results, click `openshift-sriov-network-operator`, and then click *YAML*.
-
-.. Update the namespace by adding the following stanza to the namespace definition:
-+
-[source,yaml]
-----
-  labels:
-    openshift.io/run-level: "1"
-----
-
-.. Click *Save*.
-endif::run-level[]
-
 . Install the SR-IOV Network Operator:
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
@@ -179,7 +149,3 @@ If the operator does not appear as installed, to troubleshoot further:
 * Inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
 * Navigate to the *Workloads* -> *Pods* page and check the logs for pods in the
 `openshift-sriov-network-operator` project.
-
-ifdef::run-level[]
-:!run-level:
-endif::[]

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -21,6 +21,11 @@ Security context constraints allow an administrator to control:
 * The usage of volume types
 * The configuration of allowable `seccomp` profiles
 
+[IMPORTANT]
+====
+Do not set the `openshift.io/run-level` label on any namespaces in {product-title}. This label is for use by internal {product-title} components to manage the startup of major API groups, such as the Kubernetes API server and OpenShift API server. If the `openshift.io/run-level` label is set, no SCCs are applied to pods in that namespace, causing any workloads running in that namespace to be highly privileged.
+====
+
 [id="default-sccs_{context}"]
 == Default security context constraints
 


### PR DESCRIPTION
Missing entirely is a warning about runlevels and the fact that they disable SCCs on a given namespace

Replaces #33484.

Preview: https://deploy-preview-35852--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints?utm_source=github&utm_campaign=bot_dp#security-context-constraints-about_configuring-internal-oauth