### PR TITLE
Update steps to account for cross-namespace Argo CD permission cleanup

### DIFF
--- a/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
@@ -52,3 +52,7 @@ Directory Recurse:: `checked`
 endif::app[]
 
 . Click *Create* to create your application.
+
+. Open the *Administrator* perspective of the web console and navigate to *Administration* -> *Namespaces* in the menu on the left.
+
+. Search for and select the namespace, then enter `argocd.argoproj.io/managed-by=openshift-gitops` in the *Labels* field so that the Argo CD instance in the `openshift-gitops` namespace can manage your namespace.

--- a/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
@@ -47,3 +47,20 @@ endif::cluster[]
 ----
 $ oc get application -n openshift-gitops
 ----
+
+. Add a label to the namespace your application is deployed in so that the Argo CD instance in the `openshift-gitops` namespace can manage it:
+
+ifdef::app[]
++
+[source,terminal]
+----
+$ oc label namespace springpet-clinic argocd.argoproj.io/managed-by=openshift-gitops
+----
+endif::app[]
+ifdef::cluster[]
++
+[source,terminal]
+----
+$ oc label namespace default argocd.argoproj.io/managed-by=openshift-gitops
+----
+endif::cluster[]


### PR DESCRIPTION
Added step to add label to namespace to be managed by `openshift-gitop` namespace. 

Closes #35811 
Related to JIRA story https://issues.redhat.com/browse/GITOPS-1069

OCP Version - 4.7, 4.8

cc @wtam2018 please double check that content is correct and if the only version affected is for 4.8, I believe a netlify bot should provide a preview according to other pull requests (?)

Direct preview links: 

- https://deploy-preview-35854--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html#creating-an-application-by-using-the-argo-cd-dashboard_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
- https://deploy-preview-35854--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html#creating-an-application-by-using-the-oc-tool_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
