### PR TITLE
CNV-13271: Renaming Learn About page - not file name

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2750,7 +2750,7 @@ Distros: openshift-enterprise
 Topics:
 - Name: About OpenShift Virtualization
   File: about-virt
-- Name: Learn more about deploying and managing virtual machines in your OpenShift cluster
+- Name: Start here with OpenShift Virtualization
   File: virt-learn-more-about-openshift-virtualization
 - Name: OpenShift Virtualization release notes
   File: virt-4-8-release-notes

--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -1,5 +1,5 @@
 [id="virt-learn-more-about-openshift-virtualization"]
-= Learn more about deploying and managing virtual machines in your {product-title} cluster
+= Start here with {VirtProductName}
 include::modules/virt-document-attributes.adoc[]
 :context: virt-learn-more-about-openshift-virtualization
 


### PR DESCRIPTION
For 4.8 and 4.9

Jira: https://issues.redhat.com/browse/CNV-13271
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1987577

Code reviewed and approved. No QE needed. Replaces closed PR: https://github.com/openshift/openshift-docs/pull/35290

Note that @vikram-redhat has recommended only re-titling the page not changing the file name in order to preserve validity of an exiting redirect in place for the original file name.

Direct doc preview link: https://deploy-preview-35864--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-learn-more-about-openshift-virtualization.html