### PR TITLE
OSDOCS-1805: OVN-Kubernetes is the default

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -129,12 +129,7 @@ The values for the `defaultNetwork` object are defined in the following table:
 |Either `OpenShiftSDN` or `OVNKubernetes`. The cluster network provider is selected during installation. This value cannot be changed after cluster installation.
 [NOTE]
 ====
-ifdef::openshift-origin[]
 {product-title} uses the OVN-Kubernetes Container Network Interface (CNI) cluster network provider by default.
-endif::openshift-origin[]
-ifndef::openshift-origin[]
-{product-title} uses the OpenShift SDN Container Network Interface (CNI) cluster network provider by default.
-endif::openshift-origin[]
 ====
 
 |`openshiftSDNConfig`


### PR DESCRIPTION
Now OKD and OCP use the same network provider.

- https://issues.redhat.com/browse/OSDOCS-1805

Preview: [Cluster Network Operator configuration object](https://deploy-preview-35865--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#nw-operator-cr-cno-object_installing-aws-network-customizations)