### PR TITLE
Rel Notes doc text for 4.8.9 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2471,7 +2471,7 @@ link:https://access.redhat.com/solutions/6221811[{product-title} 4.8.3 container
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-4"]
-=== RHSA-2021:2983 - {product-title} 4.8.4 bug fix update
+=== RHSA-2021:2983 - {product-title} 4.8.4 security and bug fix update
 
 Issued: 2021-08-09
 
@@ -2518,6 +2518,13 @@ Space precluded documenting all of the container images for this release in the 
 
 link:https://access.redhat.com/solutions/6261051[{product-title} 4.8.5 container image list]
 
+[id="ocp-4-8-5-features"]
+==== Features
+
+[id="ocp-4-8-5-egress-ip-enhancement"]
+===== Egress IP enhancement
+A new enhancement adds egress IP address support to the {product-title} 4.8 Anonymizer. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1974877[*BZ#1974877*].
+
 [id="ocp-4-8-5-bug-fixes"]
 ==== Bug fixes
 
@@ -2527,14 +2534,66 @@ link:https://access.redhat.com/solutions/6261051[{product-title} 4.8.5 container
 
 * Previously, `Kameletbinding` could be used to create `action` and `sink` Kamelets, however, only Kamelets of the `source` type should have been listed. This update removes the option to select `sink` and `action` type Kamelets. As a result, `source` Kamelets are the only type shown in the catalog for event sources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1972258[*BZ#1972258*])
 
-[id="ocp-4-8-5-features"]
-==== Features
-
-[id="ocp-4-8-5-egress-ip-enhancement"]
-===== Egress IP enhancement
-A new enhancement adds egress IP address support to the {product-title} 4.8 Anonymizer. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1974877[*BZ#1974877*]. 
-
 [id="ocp-4-8-5-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-9"]
+=== RHBA-2021:3247 - {product-title} 4.8.9 security and bug fix update
+
+Issued: 2021-08-31
+
+{product-title} release 4.8.9 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3247[RHBA-2021:3247] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3248[RHSA-2021:3248] advisory.
+
+[IMPORTANT]
+====
+The SHA-256 image digest information in the link:https://access.redhat.com/errata/RHBA-2021:3247[RHBA-2021:3247] advisory is incorrect. The correct information is as follows:
+====
+
+To inspect release image metadata, download the `oc` tool and run the following command:
+
+* For x86_64 architecture:
++
+[source,terminal]
+----
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.9-x86_64
+----
++
+The image digest is `sha256:5fb4b4225498912357294785b96cde6b185eaed20bbf7a4d008c462134a4edfd`
+
+* For s390x architecture:
++
+[source,terminal]
+----
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.9-s390x
+----
++
+The image digest is `sha256:2665dcca917890b3d06c339bb03dac65b84485fef36c90f219f2773393ba291d`
+
+* For ppc64le architecture:
++
+[source,terminal]
+----
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:4.8.9-ppc64le
+----
++
+The image digest is `sha256:ded5e8d61915f74d938668cf58cdc9f37eb4172bc24e80c16c7fe1a6f84eff43`
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6287821[{product-title} 4.8.9 container image list]
+
+[id="ocp-4-8-9-bug-fixes"]
+==== Bug fixes
+
+* This release adds additional localized content in Chinese, Japanese, and Korean. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1972987[*BZ#1972987*])
+
+* The address set naming convention used in OVN-Kubernetes for {product-title} 4.5 was changed in {product-title} 4.6, but the migration of existing address sets to the new naming convention was not handled as part of the upgrade. Network policies that were created in version 4.5 with namespace selector criteria for their ingress or egress sections rely on matching old address sets that were not kept up-to-date with the pod IP addresses within such namespaces. These policies might not work correctly in 4.6 or later releases and might allow or drop unexpected traffic.
++
+Previously, the workaround was to remove and recreate these policies. With this release, address sets with the old naming convention are removed, and policy ACLs referencing the old address sets are updated to reference the address sets following the new naming convention during the OVN-Kubernetes upgrade. Affected network policies created in version 4.5 work correctly again after upgrade. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976241[*BZ#1976241*])
+
+[id="ocp-4-8-9-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
For release 2021.08.31.

2021.08.30: version bumped to 4.8.9

Preview: https://deploy-preview-35867--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-9