### PR TITLE
Added clarifying language for adding an API record to the external DNS

### DIFF
--- a/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
+++ b/modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc
@@ -9,21 +9,21 @@ Configure networking components to run exclusively on the control plane nodes. B
 
 .Procedure
 
-. Change to the directory storing the `install-config.yaml` file.
+. Change to the directory storing the `install-config.yaml` file:
 +
 [source,terminal]
 ----
 $ cd ~/clusterconfigs
 ----
 
-. Switch to the `manifests` subdirectory.
+. Switch to the `manifests` subdirectory:
 +
 [source,terminal]
 ----
 $ cd manifests
 ----
 
-. Create a file named `cluster-network-avoid-workers-99-config.yaml`.
+. Create a file named `cluster-network-avoid-workers-99-config.yaml`:
 +
 [source,terminal]
 ----
@@ -83,7 +83,7 @@ This manifest places the `apiVIP` and `ingressVIP` virtual IP addresses on the c
 
 . Save the `cluster-network-avoid-workers-99-config.yaml` file.
 
-. Create a `manifests/cluster-ingress-default-ingresscontroller.yaml` file.
+. Create a `manifests/cluster-ingress-default-ingresscontroller.yaml` file:
 +
 [source,yaml]
 ----
@@ -112,9 +112,9 @@ $ sed -i "s;mastersSchedulable: false;mastersSchedulable: true;g" clusterconfigs
 If control plane nodes are not schedulable, deploying the cluster will fail.
 ====
 
-. Before deploying the cluster, ensure that the `api.<cluster-name>.<domain>` domain name is resolvable in the DNS. When you configure network components to run exclusively on the control plane, the internal DNS resolution no longer works for worker nodes, which is an expected outcome.
+. Before deploying the cluster, ensure that the `api.<cluster-name>.<domain>` domain name is resolvable in the external DNS server. When you configure network components to run exclusively on the control plane, the internal DNS resolution no longer works for worker nodes, which is an expected outcome.
 +
 [IMPORTANT]
 ====
-Failure to create a DNS record for the API precludes worker nodes from joining the cluster.
+Failure to create a DNS record for the `api.<cluster-name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
 ====

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -49,6 +49,11 @@ test-cluster.example.com
 
 ifeval::[{product-version}>4.7]
 {product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. After the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
+
+[IMPORTANT]
+====
+You must create a DNS entry for the `api.<cluster-name>.<domain>` domain name on the external DNS because removing CoreDNS causes the local entry to disappear. Failure to create a DNS record for the `api.<cluster-name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
+====
 endif::[]
 
 ifdef::upstream[]


### PR DESCRIPTION
There was already some existing language expressly telling the user to add the API to the DNS. I've made it clearer that it is the api.<cluster-name>.<domain> and that the entry must be on the external DNS. There is also a mention of removing CoreDNS-mDNS in the requirements section. I've also added an admonishment there that in 4.8 and later releases, you must create and API entry on the external DNS server.

Fixes: BZ1913975

Signed-off-by: John Wilkins <jowilkin@redhat.com>