### PR TITLE
BZ1867056: Remove legacy forwarding from fluentd

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -81,7 +81,6 @@ To configure {product-title} to forward logs using the legacy Fluentd method:
     flush_thread_count "#{ENV['FLUSH_THREAD_COUNT'] || 2}"
     retry_max_interval "#{ENV['FORWARD_RETRY_WAIT'] || '300'}"
     retry_forever true
-    overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'exception'}"
   </buffer>
   <server>
     name <6>


### PR DESCRIPTION
Applicable for 4.6+

Direct docs preview link: https://deploy-preview-35885--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-legacy-fluentd_cluster-logging-external

https://bugzilla.redhat.com/show_bug.cgi?id=1867056

Requires QE ack from @anpingli 