### PR TITLE
MTC 1.5.1 RN

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -42,4 +42,4 @@ endif::[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.5
-:mtc-version-z: 1.5.0
+:mtc-version-z: 1.5.1

--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -25,6 +25,8 @@ This release has the following new features and enhancements:
 [id="deprecated-features-1-5_{context}"]
 == Deprecated features
 
+The following features are deprecated:
+
 // https://issues.redhat.com/browse/MIG-623
 * {mtc-short} versions 1.2 and 1.3 are no longer supported.
 * The procedure for updating deprecated APIs has been removed from the troubleshooting section of the documentation because the `oc convert` command is deprecated.
@@ -37,3 +39,11 @@ This release has the following known issues:
 * PV resizing does not work as expected for AWS gp2 storage unless the `pv_resizing_threshold` is 42% or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973148[*BZ#1973148*])
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 * Microsoft Azure storage is unavailable if you create more than 400 migration plans. The `MigStorage` custom resource displays the following message: `The request is being throttled as the limit has been reached for operation type`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977226[*BZ#1977226*])
+
+[id="technical-changes-1-5_{context}"]
+== Technical changes
+
+This release has the following technical changes:
+
+* The legacy {mtc-full} Operator version 1.5.1 is installed manually on {product-title} versions 3.7 to 4.5.
+* The {mtc-full} Operator version 1.5.1 is installed on {product-title} versions 4.6 and later by using the Operator Lifecycle Manager.


### PR DESCRIPTION
No BZ or Jira #

Added technological changes for 1.5.1 to RN.

4.6+

Preview: https://deploy-preview-35886--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes?utm_source=github&utm_campaign=bot_dp#technical-changes-1-5_mtc-release-notes

QE approved. Ready for peer review