### PR TITLE
BZ:1889286 - Removing the 'internal' type from the sourceTypes

### DIFF
--- a/modules/olm-catalogsource.adoc
+++ b/modules/olm-catalogsource.adoc
@@ -70,7 +70,7 @@ Set the `olm.catalogImageTemplate` annotation to your index image name and use o
 --
 * `grpc` with an `image` reference: OLM pulls the image and runs the pod, which is expected to serve a compliant API.
 * `grpc` with an `address` field: OLM attempts to contact the gRPC API at the given address. This should not be used in most cases.
-* `internal` or `configmap`: OLM parses config map data and runs a pod that can serve the gRPC API over it.
+* `configmap`: OLM parses config map data and runs a pod that can serve the gRPC API over it.
 --
 <.> Automatically check for new versions at a given interval to stay up-to-date.
 <.> Last observed state of the catalog connection. For example:


### PR DESCRIPTION
Applies to versions 4.6+ 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1889286

Comment: The 'internal' type from sourceTypes has been deprecated and is unsupported by OLM

Preview: https://deploy-preview-35906--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-olm

Ready for QA: @scolange 
