### PR TITLE
BZ1908124: Consider enhancing the existing doc on infra nodes

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -1,20 +1,24 @@
 [id="creating-infrastructure-machinesets"]
 = Creating infrastructure machine sets
 include::modules/common-attributes.adoc[]
+include::modules/ossm-document-attributes.adoc[]
 :context: creating-infrastructure-machinesets
 
 toc::[]
 
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
-You can create a machine set to host only infrastructure components. You apply specific Kubernetes labels to these machines and then update the infrastructure components to run on only those machines. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment.
+
+You can use infrastructure machine sets to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and the components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]
+
+For information on infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.   
 
 [id="creating-infrastructure-machinesets-production"]
 == Creating infrastructure machine sets for production environments
 
-In a production deployment, deploy at least three machine sets to hold infrastructure components. Both the logging aggregation solution and the service mesh deploy Elasticsearch, and Elasticsearch requires three instances that are installed on different nodes. For high availability, deploy these nodes to different availability zones. Since you need different machine sets for each availability zone, create at least three machine sets.
+In a production deployment, it is recommended that you deploy at least three machine sets to hold infrastructure components. Both OpenShift Logging and {ProductName} deploy Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. A configuration like this requires three different machine sets, one for each availability zone.
 
 [id="creating-infrastructure-machinesets-clouds"]
 === Creating machine sets for different clouds

--- a/modules/infrastructure-components.adoc
+++ b/modules/infrastructure-components.adoc
@@ -11,11 +11,17 @@ The following infrastructure workloads do not incur {product-title} worker subsc
 * Kubernetes and {product-title} control plane services that run on masters
 * The default router
 * The integrated container image registry
+* The HAProxy-based Ingress Controller
 * The cluster metrics collection, or monitoring service, including components for monitoring user-defined projects
 * Cluster aggregated logging
 * Service brokers
 * Red Hat Quay
 * Red Hat OpenShift Container Storage
 * Red Hat Advanced Cluster Manager
+* Red Hat Advanced Cluster Security for Kubernetes
+* Red Hat OpenShift GitOps
+* Red Hat OpenShift Pipelines
+
+// Updated the list to match the list under "Red Hat OpenShift control plane and infrastructure nodes" in https://www.redhat.com/en/resources/openshift-subscription-sizing-guide
 
 Any node that runs any other container, pod, or component is a worker node that your subscription must cover.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -2,6 +2,7 @@
 [id="post-install-cluster-tasks"]
 = Post-installation cluster tasks
 include::modules/common-attributes.adoc[]
+include::modules/ossm-document-attributes.adoc[]
 
 toc::[]
 
@@ -505,9 +506,13 @@ include::modules/nodes-scheduler-node-selectors-cluster.adoc[leveloffset=+2]
 [id="post-install-creating-infrastructure-machinesets-production"]
 == Creating infrastructure machine sets for production environments
 
-In a production deployment, deploy at least three machine sets to hold infrastructure components. Both the logging aggregation solution and the service mesh deploy Elasticsearch, and Elasticsearch requires three instances that are installed on different nodes. For high availability, install deploy these nodes to different availability zones. Since you need different machine sets for each availability zone, create at least three machine sets.
+You can create a machine set to create machines that host only infrastructure components, such as the default router, the integrated container image registry, and components for cluster metrics and monitoring. These infrastructure machines are not counted toward the total number of subscriptions that are required to run the environment.
 
-For sample machine sets that you can use with these procedures, see xref:../machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets-clouds_creating-infrastructure-machinesets[Creating machine sets for different clouds].
+In a production deployment, it is recommended that you deploy at least three machine sets to hold infrastructure components.  Both OpenShift Logging and {ProductName} deploy Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. A configuration like this requires three different machine sets, one for each availability zone.
+
+For information on infrastructure nodes and which components can run on infrastructure nodes, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].
+
+For sample machine sets that you can use with these procedures, see xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets-clouds[Creating machine sets for different clouds].
 
 include::modules/machineset-creating.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -1,6 +1,7 @@
 [id="recommended-host-practices"]
 = Recommended host practices
 include::modules/common-attributes.adoc[]
+include::modules/ossm-document-attributes.adoc[]
 :context:
 
 toc::[]
@@ -30,6 +31,8 @@ include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 
 include::modules/infrastructure-components.adoc[leveloffset=+1]
+
+For information on infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.   
 
 include::modules/infrastructure-moving-monitoring.adoc[leveloffset=+1]
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1908124

Added to the Post-install/Cluster tasks/[Creating infrastructure machine sets for production environments](https://deploy-preview-35915--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-creating-infrastructure-machinesets-production) module the paragraph and Important notes from [Creating infrastructure machine sets](https://deploy-preview-35915--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html).

Updated the list of [OpenShift Container Platform infrastructure components](https://deploy-preview-35915--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#infrastructure-components_creating-infrastructure-machinesets) to match the list under _Red Hat OpenShift control plane and infrastructure nodes_ in the [OpenShift sizing and subscription guide for enterprise Kubernetes](https://www.redhat.com/en/resources/openshift-subscription-sizing-guide).