### PR TITLE
[OSDOCS-2343]: Add etcd as an option for ctrl plane component

### DIFF
--- a/modules/tls-profiles-kubernetes-configuring.adoc
+++ b/modules/tls-profiles-kubernetes-configuring.adoc
@@ -13,6 +13,7 @@ To configure a TLS security profile for the control plane, edit the `APIServer` 
 * OpenShift API server
 * OpenShift OAuth API server
 * OpenShift OAuth server
+* etcd
 
 If a TLS security profile is not configured, the default TLS security profile is `Intermediate`.
 
@@ -115,5 +116,38 @@ Spec:
         ECDHE-ECDSA-AES128-GCM-SHA256
       Min TLS Version:  VersionTLS11
     Type:               Custom
+ ...
+----
+.Verification
+
+* Verify that the TLS security profile is set in the `etcd` CR:
++
+[source,terminal]
+----
+$ oc describe etcd cluster
+----
++
+.Example output
+[source,terminal]
+----
+Name:         cluster
+Namespace:
+ ...
+API Version:  operator.openshift.io/v1
+Kind:         Etcd
+ ...
+Spec:
+  Log Level:         Normal
+  Management State:  Managed
+  Observed Config:
+    Serving Info:
+      Cipher Suites:
+        TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256
+        TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384
+        TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
+        TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256
+        TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256
+      Min TLS Version:           VersionTLS12
  ...
 ----

--- a/security/tls-security-profiles.adoc
+++ b/security/tls-security-profiles.adoc
@@ -12,9 +12,9 @@ Cluster administrators can choose which TLS security profile to use for each of 
 * the Ingress Controller
 * the control plane
 +
-This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, and OpenShift OAuth server.
+This includes the Kubernetes API server, Kubernetes controller manager, Kubernetes scheduler, OpenShift API server, OpenShift OAuth API server, OpenShift OAuth server, and etcd.
 +
-// NOTE: etcd and OpenShift controller manager are not included
+// NOTE: OpenShift controller manager are not included
 
 * the kubelet, when it acts as an HTTP server for the Kubernetes API server
 


### PR DESCRIPTION
In 4.9 and later, etcd is a TLS security profile option for the control plane component.
https://deploy-preview-35923--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles