### PR TITLE
SRVCOM-1373: Add CR sections for serverless components

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -3062,9 +3062,15 @@ Topics:
     # Eventing
   - Name: Creating Knative Eventing components in the Administrator perspective
     File: serverless-cluster-admin-eventing
+#  - Name: Configuring the Knative Eventing custom resource
+#    File: knative-eventing-CR-config
+# Uncomment once we add some configs to this section, adding now for consistency with Serving docs as a placeholder
     # Serving
   - Name: Creating Knative Serving components in the Administrator perspective
     File: serverless-cluster-admin-serving
+#  - Name: Configuring the Knative Serving custom resource
+#    File: knative-serving-CR-config
+# Uncomment at 1.18.0 release
     # Monitoring
   - Name: Monitoring serverless components
     File: serverless-admin-monitoring

--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -1,0 +1,40 @@
+[id="knative-serving-CR-system-deployments_{context}"]
+= Overriding system deployment configurations
+
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resource (CR).
+
+Currently, overriding default configuration settings for the `replicas`, `labels`, `annotations`, and `nodeSelector` fields are supported.
+
+In the following example, a `KnativeServing` CR overrides the `webhook` deployment so that:
+
+* The deployment has 3 replicas.
+* The label is set to `example-label: label`.
+* The label `example-label: label` is added.
+* The `nodeSelector` field is set to select nodes with the `disktype: hdd` label.
+
+[NOTE]
+====
+The `KnativeServing` CR label and annotation settings override the deployment's labels and annotations for both the deployment itself and the resulting pods.
+====
+
+.KnativeServing CR example
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: ks
+  namespace: knative-serving
+spec:
+  high-availability:
+    replicas: 2
+  deployments:
+  - name: webhook
+    replicas: 3
+    labels:
+      example-label: label
+    annotations:
+      example-annotation: annotation
+    nodeSelector:
+      disktype: hdd
+----

--- a/serverless/admin_guide/knative-eventing-CR-config.adoc
+++ b/serverless/admin_guide/knative-eventing-CR-config.adoc
@@ -1,0 +1,16 @@
+include::modules/common-attributes.adoc[]
+include::modules/serverless-document-attributes.adoc[]
+[id="knative-eventing-CR-config"]
+= Configuring the Knative Eventing custom resource
+:context: knative-eventing-CR-config
+
+toc::[]
+
+This guide describes how cluster administrators can manage settings for developer-created custom resources (CRs) that are created from the Knative Eventing CR.
+
+// config options
+
+[id="additional-resources_knative-eventing-CR-config"]
+== Additional resources
+
+* See xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions].

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -1,0 +1,17 @@
+include::modules/common-attributes.adoc[]
+include::modules/serverless-document-attributes.adoc[]
+[id="knative-serving-CR-config"]
+= Configuring the Knative Serving custom resource
+:context: knative-serving-CR-config
+
+toc::[]
+
+This guide describes how cluster administrators can manage settings for developer-created custom resources (CRs) that are created from the Knative Serving CR.
+
+// config options
+include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
+
+[id="additional-resources_knative-serving-CR-config"]
+== Additional resources
+
+* See xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions].


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1373

Applies for OCP 4.6+

Direct preview link: https://deploy-preview-35924--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config