### PR TITLE
Remove custom metrics entry from OKD What's New

### DIFF
--- a/whats_new/new-features.adoc
+++ b/whats_new/new-features.adoc
@@ -156,7 +156,7 @@ in the cluster, one per node.
 
 [id="ocp-cluster-monitoring"]
 == Cluster monitoring
-
+////
 [id="ocp-autoscale-pods-horizontally-based-on-custom-metrics-api"]
 === Autoscale pods horizontally based on the custom metrics API (Technology Preview)
 
@@ -174,6 +174,7 @@ load-balanced replicas, using Kubernetes services).
 * The `APIService` configuration to wire Kubernetes' API aggregation to the
 instance of the custom metrics adapter will be overwritten in future releases,
 if {product-title} ships an out-of-the-box custom metrics adapter.
+////
 
 [id="ocp-cluster-monitoring-alerting-UI"]
 === New alerting user interface


### PR DESCRIPTION
The section on [using custom metrics](https://docs.openshift.com/container-platform/4.7/monitoring/exposing-custom-application-metrics-for-autoscaling.html) was [removed from the OpenShift docs for main and 4.8](https://github.com/openshift/openshift-docs/commit/15b81bb6c681772ad37e87ce9324a0fffbb27f9f). I am hiding the section in the OKD What's New topic (as there is talk that the feature might return in the near future). See [current what's new](https://docs.okd.io/latest/whats_new/new-features.html#ocp-cluster-monitoring).  

Preview with hidden section:
http://file.rdu.redhat.com/~mburke/okd-remove-custom-metrics/whats_new/new-features.html#ocp-cluster-monitoring