### PR TITLE
OSDOCS-2325:adding timeout configuaration parameters for spec.TuningOptions

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -163,6 +163,17 @@ For request headers, these adjustments are applied only for routes that have the
 * `threadCount` specifies the number of threads to create per HAProxy process. Creating more threads allows each Ingress Controller pod to handle more connections, at the cost of more system resources being used. HAProxy
 supports up to `64` threads. If this field is empty, the Ingress Controller uses the default value of `4` threads. The default value can change in future releases. Setting this field is not recommended because increasing the number of HAProxy threads allows Ingress Controller pods to use more CPU time under load, and prevent other pods from receiving the CPU resources they need to perform. Reducing the number of threads can cause the Ingress Controller to perform poorly.
 
+* `clientTimeout` specifies how long a connection is held open while waiting for a client response. If unset, the default timeout is `30s`.
+
+* `serverFinTimeout` specifies how long a connection is held open while waiting for the server response to the client that is closing the connection. If unset, the default timeout is `1s`.
+
+* `serverTimeout` specifies how long a connection is held open while waiting for a server response. If unset, the default timeout is `30s`.
+
+* `clientFinTimeout` specifies how long a connection is held open while waiting for the client response to the server closing the connection. If unset, the default timeout is `1s`.
+
+* `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated or reencrypted routes, even when using a better matched certificate. If unset, the default inspect delay is `5s`.
+
+* `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. If unset, the default timeout is `1h`.
 |===
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2325

for 4.9+

Preview: https://deploy-preview-35927--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration-parameters_configuring-ingress

Ready for QA @quarterpin 