### PR TITLE
OSDOCS-2423 RHEL 8 compute node support

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -11,6 +11,11 @@ include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
 
+[id="additional-resources_adding-rhel-compute"]
+== Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
+
 [id="adding-rhel-compute-preparing-image-cloud"]
 == Preparing an image for your cloud
 

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -11,6 +11,11 @@ include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
 
+[id="additional-resources_more-rhel-compute"]
+== Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
+
 [id="more-rhel-compute-preparing-image-cloud"]
 == Preparing an image for your cloud
 

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -151,7 +151,7 @@ ifndef::ibm-power[|4]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system} or {op-system-base} 7.9 ^[2]^]
+ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 7.9, or {op-system-base} 8.4 ^[2]^]
 |2
 |8 GB
 |120 GB
@@ -172,7 +172,7 @@ ifdef::ibm-z[]
 endif::ibm-z[]
 ifndef::ibm-z[]
 1. 1 vCPU is equivalent to 1 physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-2. As with all user-provisioned installations, if you choose to use {op-system-base} 7 compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and planned for removal in a future release of {product-title} 4.
+2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and planned for removal in a future release of {product-title} 4.
 endif::ibm-z[]
 --
 

--- a/modules/rhel-adding-more-nodes.adoc
+++ b/modules/rhel-adding-more-nodes.adoc
@@ -35,15 +35,15 @@ ansible_user=root
 openshift_kubeconfig_path="~/.kube/config"
 
 [workers]
-mycluster-rhel7-0.example.com
-mycluster-rhel7-1.example.com
+mycluster-rhel8-0.example.com
+mycluster-rhel8-1.example.com
 
 [new_workers]
-mycluster-rhel7-2.example.com
-mycluster-rhel7-3.example.com
+mycluster-rhel8-2.example.com
+mycluster-rhel8-3.example.com
 ----
 +
-In this example, the `mycluster-rhel7-0.example.com` and `mycluster-rhel7-1.example.com` machines are in the cluster and you add the `mycluster-rhel7-2.example.com` and `mycluster-rhel7-3.example.com` machines.
+In this example, the `mycluster-rhel8-0.example.com` and `mycluster-rhel8-1.example.com` machines are in the cluster and you add the `mycluster-rhel8-2.example.com` and `mycluster-rhel8-3.example.com` machines.
 
 . Navigate to the Ansible playbook directory:
 +

--- a/modules/rhel-adding-node.adoc
+++ b/modules/rhel-adding-node.adoc
@@ -27,8 +27,8 @@ ansible_user=root <1>
 openshift_kubeconfig_path="~/.kube/config" <3>
 
 [new_workers] <4>
-mycluster-rhel7-0.example.com
-mycluster-rhel7-1.example.com
+mycluster-rhel8-0.example.com
+mycluster-rhel8-1.example.com
 ----
 <1> Specify the user name that runs the Ansible tasks on the remote compute machines.
 <2> If you do not specify `root` for the `ansible_user`, you must set `ansible_become` to `True` and assign the user sudo permissions.

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -19,13 +19,13 @@ ifdef::openshift-origin[]
 ** Base OS: CentOS 7.4.
 endif::[]
 ifdef::openshift-enterprise,openshift-webscale[]
-** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[{op-system-base} 7.9] with "Minimal" installation option.
+** Base OS: link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html-single/installation_guide/index[{op-system-base} 7.9] or link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_a_standard_rhel_installation/index[{op-system-base} 8.4] with "Minimal" installation option.
 +
 [IMPORTANT]
 ====
 Adding {op-system-base} 7 compute machines to an {product-title} cluster is deprecated. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
-In addition, you must not upgrade your compute machines to {op-system-base} 8 because support is not available in this release.
+In addition, you cannot upgrade your {op-system-base} 7 compute machines to {op-system-base} 8. You must deploy new {op-system-base} 8 hosts, and the old {op-system-base} 7 hosts should be removed. See the "Deleting nodes" section for more information.
 
 For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
 ====

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -8,6 +8,13 @@
 After you update your cluster, you must update the Red Hat Enterprise Linux (RHEL)
 compute machines in your cluster.
 
+[IMPORTANT]
+====
+You cannot upgrade {op-system-base} 7 compute machines to {op-system-base} 8. You must deploy new {op-system-base} 8 hosts, and the old {op-system-base} 7 hosts should be removed.
+====
+
+// TODO: This module needs to be updated to reflect RHEL 8 compute machines in 4.10. Because initial support for RHEL 8 starts in 4.9, and upgrading RHEL 7 -> 8 in-place is not supported, this is being left to reflect RHEL 7 upgrades.
+
 .Prerequisites
 
 * You updated your cluster.
@@ -42,9 +49,9 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 +
 [source,terminal]
 ----
-# subscription-manager repos --disable=rhel-7-server-ose-4.7-rpms \
+# subscription-manager repos --disable=rhel-7-server-ose-4.8-rpms \
                              --enable=rhel-7-server-ansible-2.9-rpms \
-                             --enable=rhel-7-server-ose-4.8-rpms
+                             --enable=rhel-7-server-ose-4.9-rpms
 ----
 
 .. On the machine that you run the Ansible playbooks, update the required packages, including `openshift-ansible`:
@@ -58,8 +65,8 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 +
 [source,terminal]
 ----
-# subscription-manager repos --disable=rhel-7-server-ose-4.7-rpms \
-                             --enable=rhel-7-server-ose-4.8-rpms  \
+# subscription-manager repos --disable=rhel-7-server-ose-4.8-rpms \
+                             --enable=rhel-7-server-ose-4.9-rpms  \
                              --enable=rhel-7-fast-datapath-rpms   \
                              --enable=rhel-7-server-optional-rpms
 ----

--- a/modules/rhel-images-aws.adoc
+++ b/modules/rhel-images-aws.adoc
@@ -14,14 +14,14 @@ AMI IDs correspond to native boot images for AWS. Because an AMI must exist befo
 
 .Procedure
 
-* Use this command to list {op-system-base} 7.9 Amazon Machine Images (AMI):
+* Use this command to list {op-system-base} 8.4 Amazon Machine Images (AMI):
 +
 --
 [source,terminal]
 ----
 $ aws ec2 describe-images --owners 309956199498 \ <1>
 --query 'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]' \ <2>
---filters "Name=name,Values=RHEL-7.9*" \ <3>
+--filters "Name=name,Values=RHEL-8.4*" \ <3>
 --region us-east-1 \ <4>
 --output table <5>
 ----
@@ -32,24 +32,25 @@ $ aws ec2 describe-images --owners 309956199498 \ <1>
 This account ID is required to display AMI IDs for images that are provided by Red Hat.
 ====
 <2> The `--query` command option sets how the images are sorted with the parameters `'sort_by(Images, &CreationDate)[*].[CreationDate,Name,ImageId]'`. In this case, the images are sorted by the creation date, and the table is structured to show the creation date, the name of the image, and the AMI IDs.
-<3> The `--filter` command option sets which version of {op-system-base} is shown. In this example, since the filter is set by `"Name=name,Values=RHEL-7.9*"`, then {op-system-base} 7.9 AMIs are shown.
+<3> The `--filter` command option sets which version of {op-system-base} is shown. In this example, since the filter is set by `"Name=name,Values=RHEL-8.4*"`, then {op-system-base} 8.4 AMIs are shown.
 <4> The `--region` command option sets where the region where an AMI is stored.
 <5> The `--output` command option sets how the results are displayed.
 --
 
 [NOTE]
 ====
-When creating a {op-system-base} compute machine for AWS, ensure that the AMI is {op-system-base} 7.9.
+When creating a {op-system-base} compute machine for AWS, ensure that the AMI is {op-system-base} 8.4.
 ====
 
 .Example output
 [source,terminal]
 ----
-----------------------------------------------------------------------------------------------------------
-|                                             DescribeImages                                             |
-+---------------------------+----------------------------------------------------+-----------------------+
-|  2020-05-13T09:50:36.000Z |  RHEL-7.9_HVM_BETA-20200422-x86_64-0-Hourly2-GP2  |  ami-038714142142a6a64 |
-|  2020-09-18T07:51:03.000Z |  RHEL-7.9_HVM_GA-20200917-x86_64-0-Hourly2-GP2    |  ami-005b7876121b7244d |
-|  2021-02-09T09:46:19.000Z |  RHEL-7.9_HVM-20210208-x86_64-0-Hourly2-GP2       |  ami-030e754805234517e |
-+---------------------------+----------------------------------------------------+-----------------------+
+------------------------------------------------------------------------------------------------------------
+|                                              DescribeImages                                              |
++---------------------------+-----------------------------------------------------+------------------------+
+|  2021-03-18T14:23:11.000Z |  RHEL-8.4.0_HVM_BETA-20210309-x86_64-1-Hourly2-GP2  |  ami-07eeb4db5f7e5a8fb |
+|  2021-03-18T14:38:28.000Z |  RHEL-8.4.0_HVM_BETA-20210309-arm64-1-Hourly2-GP2   |  ami-069d22ec49577d4bf |
+|  2021-05-18T19:06:34.000Z |  RHEL-8.4.0_HVM-20210504-arm64-2-Hourly2-GP2        |  ami-01fc429821bf1f4b4 |
+|  2021-05-18T20:09:47.000Z |  RHEL-8.4.0_HVM-20210504-x86_64-2-Hourly2-GP2       |  ami-0b0af3577fe5e3532 |
++---------------------------+-----------------------------------------------------+------------------------+
 ----

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -68,7 +68,9 @@ Alternatively, disable all repositories:
 +
 Note that this might take a few minutes if you have a large number of available repositories
 
-. Enable only the repositories required by {product-title} {product-version}:
+. Enable only the repositories required by {product-title} {product-version}.
+
+.. For {op-system-base} 7 nodes, you must enable the following repositories:
 +
 [source,terminal]
 ----
@@ -77,7 +79,23 @@ Note that this might take a few minutes if you have a large number of available 
     --enable="rhel-7-fast-datapath-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-optional-rpms" \
-    --enable="rhel-7-server-ose-4.8-rpms"
+    --enable="rhel-7-server-ose-4.9-rpms"
+----
++
+[NOTE]
+====
+Use of {op-system-base} 7 nodes is deprecated and planned for removal in a future release of {product-title} 4.
+====
+
+.. For {op-system-base} 8 nodes, you must enable the following repositories:
++
+[source,terminal]
+----
+# subscription-manager repos \
+    --enable="rhel-8-for-x86_64-baseos-rpms" \
+    --enable="rhel-8-for-x86_64-appstream-rpms" \
+    --enable="rhocp-4.9-for-rhel-8-x86_64-rpms" \
+    --enable="fast-datapath-for-rhel-8-x86_64-rpms"
 ----
 
 . Stop and disable firewalld on the host:

--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -55,7 +55,9 @@ If you use SSH key-based authentication, you must manage the key with an SSH age
 # subscription-manager attach --pool=<pool_id>
 ----
 
-. Enable the repositories required by {product-title} {product-version}:
+. Enable the repositories required by {product-title} {product-version}.
+
+.. For {op-system-base} 7 nodes, you must enable the following repositories:
 +
 [source,terminal]
 ----
@@ -63,7 +65,23 @@ If you use SSH key-based authentication, you must manage the key with an SSH age
     --enable="rhel-7-server-rpms" \
     --enable="rhel-7-server-extras-rpms" \
     --enable="rhel-7-server-ansible-2.9-rpms" \
-    --enable="rhel-7-server-ose-4.8-rpms"
+    --enable="rhel-7-server-ose-4.9-rpms"
+----
++
+[NOTE]
+====
+Use of {op-system-base} 7 nodes is deprecated and planned for removal in a future release of {product-title} 4.
+====
+
+.. For {op-system-base} 8 nodes, you must enable the following repositories:
++
+[source,terminal]
+----
+# subscription-manager repos \
+    --enable="rhel-8-for-x86_64-baseos-rpms" \
+    --enable="rhel-8-for-x86_64-appstream-rpms" \
+    --enable="ansible-2.9-for-rhel-8-x86_64-rpms" \
+    --enable="rhocp-4.9-for-rhel-8-x86_64-rpms"
 ----
 
 . Install the required packages, including `openshift-ansible`:

--- a/modules/security-hosts-vms-rhcos.adoc
+++ b/modules/security-hosts-vms-rhcos.adoc
@@ -34,8 +34,8 @@ Those containers that need direct access to host namespaces need to have
 elevated permissions to request that access.
 ifdef::openshift-enterprise,openshift-webscale,openshift-aro[]
 See
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux_atomic_host/7/html/overview_of_containers_in_red_hat_systems/introduction_to_linux_containers#linux_containers_architecture[Overview of Containers in Red Hat Systems]
-from the {op-system-base} 7 container documentation for details on the types of namespaces.
+link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/building_running_and_managing_containers/index[Overview of Containers in Red Hat Systems]
+from the {op-system-base} 8 container documentation for details on the types of namespaces.
 endif::[]
 
 * _SELinux_ provides an additional layer of security to keep containers isolated

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -15,6 +15,12 @@ Understand and work with RHEL compute nodes.
 
 include::modules/rhel-compute-overview.adoc[leveloffset=+2]
 include::modules/rhel-compute-requirements.adoc[leveloffset=+2]
+
+[id="additional-resources_post-install-node-tasks"]
+== Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
+
 include::modules/rhel-preparing-playbook-machine.adoc[leveloffset=+2]
 include::modules/rhel-preparing-node.adoc[leveloffset=+2]
 include::modules/rhel-adding-node.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2423

Main previews:

- [Preparing a RHEL compute node](https://deploy-preview-35928--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-preparing-node_adding-rhel-compute)
- [Preparing the machine to run the playbook](https://deploy-preview-35928--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-preparing-playbook-machine_adding-rhel-compute)
- [Listing latest available RHEL images on AWS](https://deploy-preview-35928--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-images-aws_adding-rhel-compute)
- [Minimum resource requirements](https://deploy-preview-35928--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#minimum-resource-requirements_installing-vsphere)