### PR TITLE
OSDCOS-2608: Added clarification that STS only supports public and AWS PrivateLink…

### DIFF
--- a/cloud_infrastructure_access/rosa-private-cluster.adoc
+++ b/cloud_infrastructure_access/rosa-private-cluster.adoc
@@ -5,7 +5,7 @@ include::modules/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-An {product-title} cluster can be made private so that internal applications can be hosted inside a corporate network. In addition, private clusters can be configured to have only internal API endpoints for increased security.
+A {product-title} cluster can be made private so that internal applications can be hosted inside a corporate network. In addition, private clusters can be configured to have only internal API endpoints for increased security.
 
 // {product-title} administrators can choose between public and private cluster configuration from within the *OpenShift Cluster Manager* (OCM).
 
@@ -17,5 +17,8 @@ Red Hat Service Reliability Engineers (SREs) can access a public or private clus
 ====
 ////
 include::modules/rosa-enable-private-cluster-new.adoc[leveloffset=+1]
-
 include::modules/rosa-enable-private-cluster-existing.adoc[leveloffset=+1]
+
+== Additional resources
+
+* xref:../rosa_getting_started/rosa-aws-privatelink-creating-cluster.adoc#rosa-aws-privatelink-creating-cluster[Creating an AWS PrivateLink cluster on ROSA]

--- a/modules/rosa-enable-private-cluster-existing.adoc
+++ b/modules/rosa-enable-private-cluster-existing.adoc
@@ -7,8 +7,12 @@
 [id="rosa-enabling-private-cluster-existing_{context}"]
 = Enabling private cluster on an existing cluster
 
-
 After a cluster has been created, you can later enable the cluster to be private.
+
+[IMPORTANT]
+====
+Private clusters cannot be used with AWS security token service (STS). However, STS supports AWS PrivateLink clusters.
+====
 
 .Prerequisites
 

--- a/modules/rosa-enable-private-cluster-new.adoc
+++ b/modules/rosa-enable-private-cluster-new.adoc
@@ -7,8 +7,12 @@
 [id="rosa-enabling-private-cluster-new_{context}"]
 = Enabling private cluster on a new cluster
 
-
 You can enable the private cluster setting when creating a new {product-title} cluster.
+
+[IMPORTANT]
+====
+Private clusters cannot be used with AWS security token service (STS). However, STS supports AWS PrivateLink clusters.
+====
 
 .Prerequisites
 
@@ -24,6 +28,6 @@ $ rosa create cluster --cluster-name=<cluster_name> --private
 ----
 
 [NOTE]
-===
+====
 Alternatively, use `--interactive` to be prompted for each cluster option.
-===
+====

--- a/modules/rosa-sts-creating-cluster.adoc
+++ b/modules/rosa-sts-creating-cluster.adoc
@@ -7,6 +7,11 @@
 
 You can use the {product-title} CLI (`rosa`) to create an OpenShift cluster that uses the AWS security token service (STS).
 
+[IMPORTANT]
+====
+Only public and AWS PrivateLink clusters are supported with STS. Regular private clusters (non-PrivateLink) are not available for use with STS.
+====
+
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.


### PR DESCRIPTION
… clusters.

**JIRA:** https://issues.redhat.com/browse/OSDOCS-2608

**Previews:** 

https://deploy-preview-35929--osdocs.netlify.app/openshift-rosa/latest/cloud_infrastructure_access/rosa-private-cluster?utm_source=github&utm_campaign=bot_dp

https://deploy-preview-35929--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-creating-cluster.html


**Branch:** dedicated-4. No CP, no milestones.