### PR TITLE
OSDOCS-2471: Update capabilities list for SR-IOV DPDK and RDMA examples

### DIFF
--- a/modules/nw-sriov-dpdk-example-intel.adoc
+++ b/modules/nw-sriov-dpdk-example-intel.adoc
@@ -75,7 +75,7 @@ spec:
 +
 [NOTE]
 =====
-See the `Configuring SR-IOV additional network` section for a detailed explanation on each option in `SriovNetwork`.
+See the "Configuring SR-IOV additional network" section for a detailed explanation on each option in `SriovNetwork`.
 =====
 +
 An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
@@ -103,8 +103,9 @@ spec:
   - name: testpmd
     image: <DPDK_image> <2>
     securityContext:
-     capabilities:
-        add: ["IPC_LOCK"] <3>
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
     - mountPath: /dev/hugepages <4>
       name: hugepage
@@ -127,7 +128,7 @@ spec:
 ----
 <1> Specify the same `target_namespace` where the `SriovNetwork` object `intel-dpdk-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetowrk` object.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
-<3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside container.
+<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
 <4> Mount a hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Optional: Specify the number of DPDK devices allocated to DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by the SR-IOV Operator. It is enabled by default and can be disabled by setting `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
 <6> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -78,7 +78,7 @@ spec:
 +
 [NOTE]
 =====
-See the `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
+See the "Configuring SR-IOV additional network" section for a detailed explanation on each option in `SriovNetwork`.
 =====
 +
 An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
@@ -106,8 +106,9 @@ spec:
   - name: testpmd
     image: <DPDK_image> <2>
     securityContext:
-     capabilities:
-        add: ["IPC_LOCK","NET_RAW"] <3>
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
     - mountPath: /dev/hugepages <4>
       name: hugepage
@@ -130,7 +131,7 @@ spec:
 ----
 <1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-dpdk-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both `Pod` spec and `SriovNetowrk` object.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
-<3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container and `NET_RAW` for the application to access the network interface.
+<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
 <4> Mount the hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Optional: Specify the number of DPDK devices allocated to the DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
 <6> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs be allocated from kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.

--- a/modules/nw-sriov-example-vf-function-in-pod.adoc
+++ b/modules/nw-sriov-example-vf-function-in-pod.adoc
@@ -24,8 +24,9 @@ spec:
     image: <RDMA_image>
     imagePullPolicy: IfNotPresent
     securityContext:
-     capabilities:
-        add: ["IPC_LOCK"]
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
     command: ["sleep", "infinity"]
 ----
 
@@ -45,8 +46,9 @@ spec:
   - name: testpmd
     image: <DPDK_image>
     securityContext:
-     capabilities:
-        add: ["IPC_LOCK"]
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"]
     volumeMounts:
     - mountPath: /dev/hugepages
       name: hugepage

--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -82,7 +82,7 @@ spec:
 +
 [NOTE]
 =====
-See the `Configuring SR-IOV additional network` section for detailed explanation on each option in `SriovNetwork`.
+See the "Configuring SR-IOV additional network" section for a detailed explanation on each option in `SriovNetwork`.
 =====
 +
 An optional library, app-netutil, provides several API methods for gathering network information about a container's parent pod.
@@ -110,8 +110,9 @@ spec:
   - name: testpmd
     image: <RDMA_image> <2>
     securityContext:
-     capabilities:
-        add: ["IPC_LOCK"] <3>
+      runAsUser: 0
+      capabilities:
+        add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
     - mountPath: /dev/hugepages <4>
       name: hugepage
@@ -132,7 +133,7 @@ spec:
 ----
 <1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-rdma-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both `Pod` spec and `SriovNetowrk` object.
 <2> Specify the RDMA image which includes your application and RDMA library used by application.
-<3> Specify the `IPC_LOCK` capability which is required by the application to allocate hugepage memory inside the container.
+<3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
 <4> Mount the hugepage volume to RDMA pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Specify number of CPUs. The RDMA pod usually requires exclusive CPUs be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and create pod with `Guaranteed` QoS.
 <6> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the RDMA pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes.


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2471

This updates the examples with some required capabilities. Applies to all versions.

Preview: https://deploy-preview-35934--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-dpdk-and-rdma