### PR TITLE
Removed "warm migration"

### DIFF
--- a/modules/migration-viewing-migration-plan-log.adoc
+++ b/modules/migration-viewing-migration-plan-log.adoc
@@ -21,10 +21,7 @@ The command displays the filtered logs of the following pods:
 
 . In the {mtc-short} web console, click *Migration Plans*.
 . Click the *Migrations* number next to a migration plan to view the *Migrations* page.
-+
-The *Migrations* page displays the migration types associated with the migration plan, for example, *Stage* or *Cutover* for warm migration.
-
-. Click *View logs*.
+. Next to a migration, click *View logs*.
 . Click the Copy icon to copy the `oc logs` command to your clipboard.
 . Log in to the relevant cluster and enter the command on the CLI.
 +


### PR DESCRIPTION
No BZ or Jira.

Removed "warm migration" because that does not exist in MTC.

4.6+

Preview: https://deploy-preview-35936--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/troubleshooting-mtc.html#migration-viewing-migration-plan-log_troubleshooting-mtc

No QE required. Peer review needed.