### PR TITLE
Removing a warning that no longer applies in 4.8+

### DIFF
--- a/modules/nodes-nodes-audit-config-about.adoc
+++ b/modules/nodes-nodes-audit-config-about.adoc
@@ -25,7 +25,7 @@ Audit log profiles define how to log requests that come to the OpenShift API ser
 |===
 [.small]
 --
-1. Sensitive resources, such as `Secret`, `Route`, and `OAuthClient` objects, are never logged past the metadata level. OAuth tokens are not logged at all if your cluster was upgraded from {product-title} 4.5, because their object names might contain secret information.
+1. Sensitive resources, such as `Secret`, `Route`, and `OAuthClient` objects, are never logged past the metadata level.
 --
 
 By default, {product-title} uses the `Default` audit log profile. You can use another audit policy profile that also logs request bodies, but be aware of the increased resource usage (CPU, memory, and I/O).


### PR DESCRIPTION
Preview: https://deploy-preview-35956--osdocs.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config?utm_source=github&utm_campaign=bot_dp#about-audit-log-profiles_audit-log-policy-config