### PR TITLE
BZ1970360: Adding RHEL 8 requirement for opm

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -9,13 +9,13 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Prerequisites
 
-* For Linux, you must provide the following packages:
+* For Linux, you must provide the following packages. RHEL 8 meets these requirements:
 ** `podman` version 1.9.3+ (version 2.0+ recommended)
 ** `glibc` version 2.28+
 
 .Procedure
 
-. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-4.7/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-{product-version}/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
 
 . Unpack the archive.
 


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1970360

Releases targeted: 4.7, 4.8, 4.9

Preview link: 
opm installation: https://deploy-preview-35957--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm-cli.html#olm-installing-opm_opm-cli

@jianzhangbjz - Kindly review the fix.