### PR TITLE
OSDOCS-2363: Updating Kubernetes version to 1.22.1 for GA

### DIFF
--- a/_unused_topics/looking-inside-nodes.adoc
+++ b/_unused_topics/looking-inside-nodes.adoc
@@ -14,9 +14,9 @@ $ oc get nodes
 
 NAME                                     STATUS  ROLES  AGE    VERSION
 
-ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.22.0
+ip-10-0-0-1.us-east-2.compute.internal   Ready   worker 3h19m  v1.22.1
 
-ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.22.0
+ip-10-0-0-39.us-east-2.compute.internal  Ready   master 3h37m  v1.22.1
 
 …
 

--- a/_unused_topics/understanding-workers-masters.adoc
+++ b/_unused_topics/understanding-workers-masters.adoc
@@ -13,12 +13,12 @@ To see which workers and masters are running on your cluster, type:
 $ oc get nodes
 
 NAME                                   STATUS ROLES  AGE    VERSION
-ip-10-0-0-1.us-east-2.compute.internal Ready  worker 4h20m  v1.22.0
-ip-10-0-0-2.us-east-2.compute.internal Ready  master 4h39m  v1.22.0
-ip-10-0-0.3.us-east-2.compute.internal Ready  worker 4h20m  v1.22.0
-ip-10-0-0-4.us-east-2.compute.internal Ready  master 4h39m  v1.22.0
-ip-10-0-0-5.us-east-2.compute.internal Ready  master 4h39m  v1.22.0
-ip-10-0-0-6.us-east-2.compute.internal Ready  worker 4h20m  v1.22.0
+ip-10-0-0-1.us-east-2.compute.internal Ready  worker 4h20m  v1.22.1
+ip-10-0-0-2.us-east-2.compute.internal Ready  master 4h39m  v1.22.1
+ip-10-0-0.3.us-east-2.compute.internal Ready  worker 4h20m  v1.22.1
+ip-10-0-0-4.us-east-2.compute.internal Ready  master 4h39m  v1.22.1
+ip-10-0-0-5.us-east-2.compute.internal Ready  master 4h39m  v1.22.1
+ip-10-0-0-6.us-east-2.compute.internal Ready  worker 4h20m  v1.22.1
 ----
 
 To see more information about internal and external IP addresses, the type of operating system ({op-system}), kernel version, and container runtime (CRI-O), add the `-o wide` option.
@@ -27,7 +27,7 @@ To see more information about internal and external IP addresses, the type of op
 $ oc get nodes -o wide
 
 NAME                                       STATUS  ROLES  AGE  VERSION  INTERNAL-IP   EXTERNAL-IP  OS-IMAGE             KERNEL-VERSION             CONTAINER-RUNTIME
-ip-10-0-134-252.us-east-2.compute.internal Ready   worker 17h  v1.22.0  10.0.134.252  <none>       Red Hat CoreOS 4.0   3.10.0-957.5.1.el7.x86_64  cri-o://1.22.0-1.rhaos4.0.git2f0cb0d.el7
+ip-10-0-134-252.us-east-2.compute.internal Ready   worker 17h  v1.22.1  10.0.134.252  <none>       Red Hat CoreOS 4.0   3.10.0-957.5.1.el7.x86_64  cri-o://1.22.1-1.rhaos4.0.git2f0cb0d.el7
 
 ....
 ----

--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -155,12 +155,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES    AGE   VERSION
-ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.22.0
-ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.22.0
-ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.22.0
-ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.22.0
-ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.22.0
-ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.22.0
+ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.22.1
+ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.22.1
+ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.22.1
+ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.22.1
+ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.22.1
+ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.22.1
 ----
 --
 

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -87,9 +87,9 @@ Note the worker with the role `worker-rt` that contains the string `4.18.0-211.r
 NAME                               	STATUS   ROLES           	AGE 	VERSION                  	INTERNAL-IP
 EXTERNAL-IP   OS-IMAGE                                       	KERNEL-VERSION
 CONTAINER-RUNTIME
-cnf-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.22.0
+cnf-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.22.1
 128.66.135.107   <none>    	        Red Hat Enterprise Linux CoreOS 46.82.202008252340-0 (Ootpa)
-4.18.0-211.rt5.23.el8.x86_64   cri-o://1.22.0-90.rhaos4.8.git4a0ac05.el8-rc.1
+4.18.0-211.rt5.23.el8.x86_64   cri-o://1.22.1-90.rhaos4.8.git4a0ac05.el8-rc.1
 [...]
 ----
 

--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -34,9 +34,9 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.22.0
-ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.22.0
-ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.22.0
+ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.22.1
+ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.22.1
+ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.22.1
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -75,9 +75,9 @@ The worker nodes are ready if the status is `Ready`, as shown in the following o
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.22.0
-ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.22.0
-ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.22.0
+ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.22.1
+ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.22.1
+ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.22.1
 ----
 
 . If the worker nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -141,12 +141,12 @@ Check that the status for all nodes is `Ready`.
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.22.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.22.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.22.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.22.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.22.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.22.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.22.1
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.22.1
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.22.1
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.22.1
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.22.1
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.22.1
 ----
 
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.

--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -75,10 +75,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-j5cd0qt-f76d1-vfj5x-master-0         Ready                         master   98m   v1.22.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-1         Ready,SchedulingDisabled      master   99m   v1.22.0
-ci-ln-j5cd0qt-f76d1-vfj5x-master-2         Ready                         master   98m   v1.22.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-b-nsnd4   Ready                         worker   90m   v1.22.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-c-5z2gz   NotReady,SchedulingDisabled   worker   90m   v1.22.0
-ci-ln-j5cd0qt-f76d1-vfj5x-worker-d-stsjv   Ready                         worker   90m   v1.22.0
+ci-ln-j5cd0qt-f76d1-vfj5x-master-0         Ready                         master   98m   v1.22.1
+ci-ln-j5cd0qt-f76d1-vfj5x-master-1         Ready,SchedulingDisabled      master   99m   v1.22.1
+ci-ln-j5cd0qt-f76d1-vfj5x-master-2         Ready                         master   98m   v1.22.1
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-b-nsnd4   Ready                         worker   90m   v1.22.1
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-c-5z2gz   NotReady,SchedulingDisabled   worker   90m   v1.22.1
+ci-ln-j5cd0qt-f76d1-vfj5x-worker-d-stsjv   Ready                         worker   90m   v1.22.1
 ----

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -106,12 +106,12 @@ $ oc get node
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE  VERSION
-ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.22.0
-ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.22.0
-ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.22.0
-ip-10-0-147-35.ec2.internal    Ready,SchedulingDisabled   worker   7m   v1.22.0
-ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.22.0
-ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.22.0
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.22.1
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.22.1
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.22.1
+ip-10-0-147-35.ec2.internal    Ready,SchedulingDisabled   worker   7m   v1.22.1
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.22.1
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.22.1
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -97,13 +97,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES          AGE   VERSION
-ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.22.0
-ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.22.0
-ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.22.0
-ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.22.0
-ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.22.0
-ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.22.0
-ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.22.0
+ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.22.1
+ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.22.1
+ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.22.1
+ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.22.1
+ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.22.1
+ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.22.1
+ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.22.1
 ----
 +
 Note that the node has a `node-role.kubernetes.io/infra: ''` label:

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -97,7 +97,7 @@ $ oc get node <node_name> <1>
 [source,terminal]
 ----
 NAME                          STATUS  ROLES         AGE   VERSION
-ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.22.0
+ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.22.1
 ----
 +
 Because the role list includes `infra`, the pod is running on the correct node.

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -55,11 +55,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  63m  v1.22.0
-master-1  Ready     master  63m  v1.22.0
-master-2  Ready     master  64m  v1.22.0
-worker-0  NotReady  worker  76s  v1.22.0
-worker-1  NotReady  worker  70s  v1.22.0
+master-0  Ready     master  63m  v1.22.1
+master-1  Ready     master  63m  v1.22.1
+master-2  Ready     master  64m  v1.22.1
+worker-0  NotReady  worker  76s  v1.22.1
+worker-1  NotReady  worker  70s  v1.22.1
 ----
 +
 The output lists all of the machines that you created.
@@ -179,11 +179,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  73m  v1.22.0
-master-1  Ready     master  73m  v1.22.0
-master-2  Ready     master  74m  v1.22.0
-worker-0  Ready     worker  11m  v1.22.0
-worker-1  Ready     worker  11m  v1.22.0
+master-0  Ready     master  73m  v1.22.1
+master-1  Ready     master  73m  v1.22.1
+master-2  Ready     master  74m  v1.22.1
+worker-0  Ready     worker  11m  v1.22.1
+worker-1  Ready     worker  11m  v1.22.1
 ----
 +
 [NOTE]

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -39,7 +39,7 @@ stored the installation files in.
 [source,terminal]
 ----
 INFO Waiting up to 20m0s for the Kubernetes API at https://api.mycluster.example.com:6443...
-INFO API v1.22.0 up
+INFO API v1.22.1 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 INFO Time elapsed: 1s

--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -58,7 +58,7 @@ $ ./openshift-install --dir=<installation_directory> wait-for bootstrap-complete
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
-INFO API v1.22.0 up
+INFO API v1.22.1 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 ----

--- a/modules/installation-osp-creating-control-plane.adoc
+++ b/modules/installation-osp-creating-control-plane.adoc
@@ -39,7 +39,7 @@ You will see messages that confirm that the control plane machines are running a
 +
 [source,terminal]
 ----
-INFO API v1.22.0 up
+INFO API v1.22.1 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 ...
 INFO It is now safe to remove the bootstrap resources

--- a/modules/installation-rhv-creating-control-plane-nodes.adoc
+++ b/modules/installation-rhv-creating-control-plane-nodes.adoc
@@ -27,7 +27,7 @@ $ openshift-install wait-for bootstrap-complete --dir $ASSETS_DIR
 .Example output
 [source,terminal]
 ----
-INFO API v1.22.0 up
+INFO API v1.22.1 up
 INFO Waiting up to 40m0s for bootstrapping to complete...
 ----
 

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -91,12 +91,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.22.0
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.22.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.22.0
-ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.22.0
-ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.22.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.0
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.22.1
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.22.1
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.22.1
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.22.1
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.22.1
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.1
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -34,12 +34,12 @@ $ oc get nodes
 [source,bash]
 ----
 NAME                                                STATUS   ROLES           AGE     VERSION
-provisioner.openshift.example.com                   Ready    master          30h     v1.22.0
-openshift-master-1.openshift.example.com            Ready    master          30h     v1.22.0
-openshift-master-2.openshift.example.com            Ready    master          30h     v1.22.0
-openshift-master-3.openshift.example.com            Ready    master          30h     v1.22.0
-openshift-worker-0.openshift.example.com            Ready    master          30h     v1.22.0
-openshift-worker-1.openshift.example.com            Ready    master          30h     v1.22.0
+provisioner.openshift.example.com                   Ready    master          30h     v1.22.1
+openshift-master-1.openshift.example.com            Ready    master          30h     v1.22.1
+openshift-master-2.openshift.example.com            Ready    master          30h     v1.22.1
+openshift-master-3.openshift.example.com            Ready    master          30h     v1.22.1
+openshift-worker-0.openshift.example.com            Ready    master          30h     v1.22.1
+openshift-worker-1.openshift.example.com            Ready    master          30h     v1.22.1
 ----
 
 . Get the machine set.
@@ -99,13 +99,13 @@ $ oc get nodes
 [source,bash]
 ----
 NAME                                          STATUS   ROLES   AGE     VERSION
-provisioner.openshift.example.com             Ready    master  30h     v1.22.0
-openshift-master-1.openshift.example.com      Ready    master  30h     v1.22.0
-openshift-master-2.openshift.example.com      Ready    master  30h     v1.22.0
-openshift-master-3.openshift.example.com      Ready    master  30h     v1.22.0
-openshift-worker-0.openshift.example.com      Ready    master  30h     v1.22.0
-openshift-worker-1.openshift.example.com      Ready    master  30h     v1.22.0
-openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.22.0
+provisioner.openshift.example.com             Ready    master  30h     v1.22.1
+openshift-master-1.openshift.example.com      Ready    master  30h     v1.22.1
+openshift-master-2.openshift.example.com      Ready    master  30h     v1.22.1
+openshift-master-3.openshift.example.com      Ready    master  30h     v1.22.1
+openshift-worker-0.openshift.example.com      Ready    master  30h     v1.22.1
+openshift-worker-1.openshift.example.com      Ready    master  30h     v1.22.1
+openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.22.1
 ----
 +
 You can also check the kubelet.

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -19,10 +19,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES    AGE   VERSION
-master-0.cloud.example.com   Ready    master   145m   v1.22.0
-master-1.cloud.example.com   Ready    master   135m   v1.22.0
-master-2.cloud.example.com   Ready    master   145m   v1.22.0
-worker-2.cloud.example.com   Ready    worker   100m   v1.22.0
+master-0.cloud.example.com   Ready    master   145m   v1.22.1
+master-1.cloud.example.com   Ready    master   135m   v1.22.1
+master-2.cloud.example.com   Ready    master   145m   v1.22.1
+worker-2.cloud.example.com   Ready    worker   100m   v1.22.1
 ----
 
 . Check for inconsistent timing delays due to clock drift. For example:

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -19,9 +19,9 @@ $ oc get nodes
 [source,bash]
 ----
 NAME                   STATUS   ROLES           AGE  VERSION
-master-0.example.com   Ready    master,worker   4h   v1.22.0
-master-1.example.com   Ready    master,worker   4h   v1.22.0
-master-2.example.com   Ready    master,worker   4h   v1.22.0
+master-0.example.com   Ready    master,worker   4h   v1.22.1
+master-1.example.com   Ready    master,worker   4h   v1.22.1
+master-2.example.com   Ready    master,worker   4h   v1.22.1
 ----
 
 . Confirm the installer deployed all pods successfully. The following command

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -137,12 +137,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.22.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.22.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.22.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.22.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.22.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.22.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.22.1
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.22.1
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.22.1
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.22.1
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.22.1
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.22.1
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -57,9 +57,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.22.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.22.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.0
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.22.1
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.22.1
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.1
 ----
 +
 [source,terminal]

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -25,9 +25,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-master.example.com     Ready     master    7h        v1.22.0
-node1.example.com      Ready     worker    7h        v1.22.0
-node2.example.com      Ready     worker    7h        v1.22.0
+master.example.com     Ready     master    7h        v1.22.1
+node1.example.com      Ready     worker    7h        v1.22.1
+node2.example.com      Ready     worker    7h        v1.22.1
 ----
 +
 The following example is a cluster with one unhealthy node:
@@ -41,9 +41,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS                      ROLES     AGE       VERSION
-master.example.com     Ready                       master    7h        v1.22.0
-node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.22.0
-node2.example.com      Ready                       worker    7h        v1.22.0
+master.example.com     Ready                       master    7h        v1.22.1
+node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.22.1
+node2.example.com      Ready                       worker    7h        v1.22.1
 ----
 +
 The conditions that trigger a `NotReady` status are shown later in this section.
@@ -59,9 +59,9 @@ $ oc get nodes -o wide
 [source,terminal]
 ----
 NAME                STATUS   ROLES    AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
-master.example.com  Ready    master   171m   v1.22.0   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.0-30.rhaos4.8.gitf2f339d.el8-dev
-node1.example.com   Ready    worker   72m    v1.22.0   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.0-30.rhaos4.8.gitf2f339d.el8-dev
-node2.example.com   Ready    worker   164m   v1.22.0   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.0-30.rhaos4.8.gitf2f339d.el8-dev
+master.example.com  Ready    master   171m   v1.22.1   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.1-30.rhaos4.8.gitf2f339d.el8-dev
+node1.example.com   Ready    worker   72m    v1.22.1   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.1-30.rhaos4.8.gitf2f339d.el8-dev
+node2.example.com   Ready    worker   164m   v1.22.1   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.22.1-30.rhaos4.8.gitf2f339d.el8-dev
 ----
 
 * The following command lists information about a single node:
@@ -82,7 +82,7 @@ $ oc get node node1.example.com
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-node1.example.com      Ready     worker    7h        v1.22.0
+node1.example.com      Ready     worker    7h        v1.22.1
 ----
 
 * The following command provides more detailed information about a specific node, including the reason for
@@ -155,8 +155,8 @@ System Info:    <9>
  Operating System:                        linux
  Architecture:                            amd64
  Container Runtime Version:               cri-o://1.16.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
- Kubelet Version:                         v1.22.0
- Kube-Proxy Version:                      v1.22.0
+ Kubelet Version:                         v1.22.1
+ Kube-Proxy Version:                      v1.22.1
 PodCIDR:                                  10.128.4.0/24
 ProviderID:                               aws:///us-east-2a/i-04e87b31dc6b3e171
 Non-terminated Pods:                      (13 in total)  <10>

--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -43,7 +43,7 @@ $ oc get node <node1>
 [source,terminal]
 ----
 NAME        STATUS                        ROLES     AGE       VERSION
-<node1>     NotReady,SchedulingDisabled   worker    1d        v1.22.0
+<node1>     NotReady,SchedulingDisabled   worker    1d        v1.22.1
 ----
 
 . Evacuate the pods using one of the following methods:

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -170,7 +170,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.22.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.22.1
 ----
 
 * Add labels directly to a node:
@@ -223,5 +223,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.22.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.22.1
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -167,7 +167,7 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.22.0
+ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.22.1
 ----
 
 . Add the matching node selector to a pod:

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -160,7 +160,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.22.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.22.1
 ----
 
 * Add labels directly to a node:
@@ -213,5 +213,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.22.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.22.1
 ----

--- a/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
+++ b/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
@@ -25,12 +25,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-compute-1.example.com         Ready    worker   33m   v1.22.0
-control-plane-1.example.com   Ready    master   41m   v1.22.0
-control-plane-2.example.com   Ready    master   45m   v1.22.0
-compute-2.example.com         Ready    worker   38m   v1.22.0
-compute-3.example.com         Ready    worker   33m   v1.22.0
-control-plane-3.example.com   Ready    master   41m   v1.22.0
+compute-1.example.com         Ready    worker   33m   v1.22.1
+control-plane-1.example.com   Ready    master   41m   v1.22.1
+control-plane-2.example.com   Ready    master   45m   v1.22.1
+compute-2.example.com         Ready    worker   38m   v1.22.1
+compute-3.example.com         Ready    worker   33m   v1.22.1
+control-plane-3.example.com   Ready    master   41m   v1.22.1
 ----
 
 . Review CPU and memory resource availability for each cluster node:

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -70,7 +70,7 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.22.0 <1>
+ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.22.1 <1>
 ----
 <1> If the node is listed as `NotReady`, then the *node is not ready*.
 
@@ -94,9 +94,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.22.0
-ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.22.0
-ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.22.0
+ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.22.1
+ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.22.1
+ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.22.1
 ----
 
 .. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -91,7 +91,7 @@ $ oc get node | grep worker
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.22.1
 ----
 +
 [source,terminal]

--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -104,12 +104,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.22.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.22.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.22.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.22.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.22.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.22.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.22.1
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.22.1
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.22.1
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.22.1
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.22.1
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.22.1
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -80,13 +80,13 @@ You must not enable firewalld later. If you do, you cannot access {product-title
 [source,terminal]
 ----
 NAME                        STATUS                        ROLES    AGE    VERSION
-mycluster-control-plane-0   Ready                         master   145m   v1.22.0
-mycluster-control-plane-1   Ready                         master   145m   v1.22.0
-mycluster-control-plane-2   Ready                         master   145m   v1.22.0
-mycluster-rhel7-0           NotReady,SchedulingDisabled   worker   98m    v1.22.0
-mycluster-rhel7-1           Ready                         worker   98m    v1.22.0
-mycluster-rhel7-2           Ready                         worker   98m    v1.22.0
-mycluster-rhel7-3           Ready                         worker   98m    v1.22.0
+mycluster-control-plane-0   Ready                         master   145m   v1.22.1
+mycluster-control-plane-1   Ready                         master   145m   v1.22.1
+mycluster-control-plane-2   Ready                         master   145m   v1.22.1
+mycluster-rhel7-0           NotReady,SchedulingDisabled   worker   98m    v1.22.1
+mycluster-rhel7-1           Ready                         worker   98m    v1.22.1
+mycluster-rhel7-2           Ready                         worker   98m    v1.22.1
+mycluster-rhel7-3           Ready                         worker   98m    v1.22.1
 ----
 +
 Note which machine has the `NotReady,SchedulingDisabled` status.
@@ -137,13 +137,13 @@ The `upgrade` playbook only upgrades the {product-title} packages. It does not u
 [source,terminal]
 ----
 NAME                        STATUS                        ROLES    AGE    VERSION
-mycluster-control-plane-0   Ready                         master   145m   v1.22.0
-mycluster-control-plane-1   Ready                         master   145m   v1.22.0
-mycluster-control-plane-2   Ready                         master   145m   v1.22.0
-mycluster-rhel7-0           NotReady,SchedulingDisabled   worker   98m    v1.22.0
-mycluster-rhel7-1           Ready                         worker   98m    v1.22.0
-mycluster-rhel7-2           Ready                         worker   98m    v1.22.0
-mycluster-rhel7-3           Ready                         worker   98m    v1.22.0
+mycluster-control-plane-0   Ready                         master   145m   v1.22.1
+mycluster-control-plane-1   Ready                         master   145m   v1.22.1
+mycluster-control-plane-2   Ready                         master   145m   v1.22.1
+mycluster-rhel7-0           NotReady,SchedulingDisabled   worker   98m    v1.22.1
+mycluster-rhel7-1           Ready                         worker   98m    v1.22.1
+mycluster-rhel7-2           Ready                         worker   98m    v1.22.1
+mycluster-rhel7-3           Ready                         worker   98m    v1.22.1
 ----
 . Optional: Update the operating system packages that were not updated by the `upgrade` playbook. To update packages that are not on {product-version}, use the following command:
 +

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -188,10 +188,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.22.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.22.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.22.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.22.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.22.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.22.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.22.1
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.22.1
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.22.1
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.22.1
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.22.1
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.22.1
 ----

--- a/modules/virt-accessing-vm-yaml-ssh.adoc
+++ b/modules/virt-accessing-vm-yaml-ssh.adoc
@@ -158,7 +158,7 @@ $ oc get node __<node_name>__ -o wide
 [source,terminal]
 ----
 NAME    STATUS   ROLES   AGE    VERSION  INTERNAL-IP      EXTERNAL-IP
-node01  Ready    worker  6d22h  v1.22.0  192.168.55.101   <none>
+node01  Ready    worker  6d22h  v1.22.1  192.168.55.101   <none>
 ----
 
 . Log in to the VM via SSH by specifying the IP address of the node where the VM is running and the port number. Use the port number displayed by the `oc get svc` command and the IP address of the node displayed by the `oc get node` command. The following example shows the `ssh` command with the username, node's IP address, and the port number:


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2363

Preview: https://deploy-preview-35958--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html (throughout doc set)