### PR TITLE
SRVOCF-311: Updated kn func commands, add missing link

### DIFF
--- a/modules/describe-function-kn.adoc
+++ b/modules/describe-function-kn.adoc
@@ -1,11 +1,7 @@
-// Module included in the following assemblies
-
-// * /serverless/cli_reference/kn-func-ref.adoc
-
 [id="describe-function-kn_{context}"]
 = Describing a function
 
-The `kn func describe` command prints information about a deployed function, such as the function name, image, namespace, information about the Knative service, route information, and event subscriptions.
+The `kn func info` command prints information about a deployed function, such as the function name, image, namespace, Knative service information, route information, and event subscriptions.
 
 .Procedure
 
@@ -13,13 +9,13 @@ The `kn func describe` command prints information about a deployed function, suc
 +
 [source,termnal]
 ----
-$ kn func describe [-f <format> -n <namespace> -p <path>]
+$ kn func info [-f <format> -n <namespace> -p <path>]
 ----
 +
 .Example command
 [source,terminal]
 ----
-$ kn func describe -p function/example-function
+$ kn func info -p function/example-function
 ----
 +
 .Example output

--- a/modules/serverless-build-func-kn.adoc
+++ b/modules/serverless-build-func-kn.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/serverless-functions-getting-started.adoc
-
 [id="serverless-build-func-kn_{context}"]
 = Building functions
 

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -1,30 +1,9 @@
-// Module included in the following assemblies:
-//
-// * serverless/serverless-functions-getting-started.adoc
-
 [id="serverless-create-func-kn_{context}"]
 = Creating functions
 
 You can create a basic serverless function using the `kn` CLI.
 
-You can specify the runtime, trigger, image, and namespace as flags on the command line, or use the `-c` flag to start the interactive experience using the CLI prompt.
-
-The values provided for image and registry are persisted to the `func.yaml` file, so that subsequent invocations do not require the user to specify these again.
-
-.Example `func.yaml`
-[source,yaml]
-----
-name: example-function
-namespace: default
-runtime: node
-image: <image_from_registry>
-imageDigest: ""
-trigger: http
-builder: default
-builderMap:
-  default: quay.io/boson/faas-nodejs-builder
-envs: {}
-----
+You can specify the path, runtime, and template as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
 
 .Procedure
 
@@ -32,22 +11,23 @@ envs: {}
 +
 [source,terminal]
 ----
-$ kn func create <path> -r <registry> -l <runtime> -t <trigger> -i <image> -n <namespace>
+$ kn func create <path> -l <runtime> -t <template>
 ----
-** Supported runtimes include `node`, `go`, `python`, and `quarkus`.
-** If the image is unspecified, you are prompted for a registry name. The image name is derived from this registry and the function name.
+** Supported runtimes include `node`, `go`, `python`, `quarkus`, and `typescript`.
+** Supported templates include `http` and `events`.
 +
 .Example command
 [source,terminal]
 ----
-$ kn func create functions/example-function
+$ kn func create -l typescript -t events examplefunc
 ----
 +
 .Example output
 [source,terminal]
 ----
-Project path: /home/user/functions/example-function
-Function name: example-function
-Runtime: node
-Trigger: http
+Project path:  /home/user/demo/examplefunc
+Function name: examplefunc
+Runtime:       typescript
+Template:      events
+Writing events to /home/user/demo/examplefunc
 ----

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * serverless/serverless-functions-getting-started.adoc
-
 [id="serverless-deploy-func-kn_{context}"]
 = Deploying functions
 

--- a/serverless/functions/serverless-functions-about.adoc
+++ b/serverless/functions/serverless-functions-about.adoc
@@ -23,6 +23,7 @@ The `kn func` CLI is provided as a plug-in for the Knative `kn` CLI. {FunctionsP
 * xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
 * xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Golang]
 * xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
+* xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 
 [id="next-steps_serverless-functions-about"]
 == Next steps

--- a/serverless/functions/serverless-functions-reference-guide.adoc
+++ b/serverless/functions/serverless-functions-reference-guide.adoc
@@ -15,7 +15,8 @@ include::modules/technology-preview.adoc[leveloffset=+2]
 * xref:../../serverless/functions/serverless-developing-nodejs-functions.adoc#serverless-developing-nodejs-functions[Node.js]
 * xref:../../serverless/functions/serverless-developing-python-functions.adoc#serverless-developing-python-functions[Python]
 * xref:../../serverless/functions/serverless-developing-go-functions.adoc#serverless-developing-go-functions[Golang]
-* Quarkus
+* xref:../../serverless/functions/serverless-developing-quarkus-functions.adoc#serverless-developing-quarkus-functions[Quarkus]
+* xref:../../serverless/functions/serverless-developing-typescript-functions.adoc#serverless-developing-typescript-functions[TypeScript]
 //* SpringBoot - TBC
 
 This guide provides reference information that you can use to develop functions.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVOCF-311

Applies for OCP 4.6+

Direct preview link:
- Fixed link: https://deploy-preview-35959--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-reference-guide.html
- https://deploy-preview-35959--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html
- https://deploy-preview-35959--osdocs.netlify.app/openshift-enterprise/latest/serverless/cli_tools/kn-func-ref.html

@lance let me know if there are any instances of repository here that are incorrect or need to be undone / removed, thanks!