### PR TITLE
TELCODOCS-303: Added additional resources at the bottom of the assembly with info about the operator in disconnected mode

### DIFF
--- a/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
+++ b/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
@@ -37,3 +37,9 @@ include::modules/sandboxed-containers-triggering-installation-kata-runtime.adoc[
 include::modules/sandboxed-containers-selecting-nodes.adoc[leveloffset=+3]
 include::modules/sandboxed-containers-scheduling-workloads.adoc[leveloffset=+3]
 include::modules/sandboxed-containers-viewing-workloads-from-cli.adoc[leveloffset=+2]
+
+[id="{context}_additional-resources"]
+== Additional resources
+
+* The {sandboxed-containers-operator} is supported in a restricted network environment. For more information, xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+* When using a disconnected cluster on a restricted network, you must xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager] to access the OperatorHub. Using a proxy allows the cluster to fetch the {sandboxed-containers-operator}.


### PR DESCRIPTION
Documentation for [KATA-752](https://issues.redhat.com/browse/KATA-752).

Documentation preview: https://deploy-preview-35960--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads?utm_source=github&utm_campaign=bot_dp#additional-resources

@jensfr @zanetworker @dmaizel

Approved by SMEs and QE.