### PR TITLE
Adds 4.7.28 release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2784,3 +2784,30 @@ link:https://access.redhat.com/solutions/6258591[{product-title} 4.7.24 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-28"]
+=== RHSA-2021:3262 - {product-title} 4.7.28 bug fix and security update
+
+Issued: 2021-09-01
+
+{product-title} release 4.7.28 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:3262[RHSA-2021:3262] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3263[RHSA-2021:3263] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6284521[{product-title} 4.7.28 container image list]
+
+[id="ocp-4-7-28-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Insights widget did not display to the user that 0 issues were found when selecting *Insights status* for a cluster. Consequently, an empty widget with no information was presented to users. This update adds additional information to cases that return 0 issues when selecting *Insights status* for a cluster. As a result, when a cluster is healthy, the widget shows a chart with `Total Issues = 0` and provides a link to the OpenShift Cluster Manager. (link:https:/bugzilla.redhat.com/show_bug.cgi?id=1986724[*BZ#1986724*])
+
+* Previously, the backport in link:https://bugzilla.redhat.com/show_bug.cgi?id=1932452[*BZ#1932452*] allowed the `baremetal-operator` to report a provisioned registration error when failing to adopt in ironic. Consequently, the `cluster-baremetal-operator` contained a separate copy of the `BareMetalHost` Custom Resource Definition (CRD), which was installed in the cluster. Saving the new value of the host status caused an error. This update backports the CRD changes so that the error no longer occurs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976924[*BZ#1976924*])
+
+* Previously, client setup was missing in the `logs` command. Consquently, `oc logs` did not work with pipeline builds. This update fixes the client setup in the `logs` command. As a result, `oc logs` works with pipeline builds. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1974264[*BZ#1974264*])
+
+* Previously, when a deployment was created with an invalid image stream, or unresloved image, it resulted in an inconsistent state between the deployment controller and the API server's `imagepolicy` plugin. Consequently, it could cause an infinite number of replica sets and reach the etcd quota limit, which could crash the entire {product-title} cluster. This update lowers the responsibilities of the API server's `imagepolicy` plugin. As a result, inconsistent image stream resolution will not occur in the deployments. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981775[*BZ#1981775*])
+
+[id="ocp-4-7-28-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-35961--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-28

Not to be merged until 9-1. 