### PR TITLE
Fix capitalisation typos in the Operator clean up module

### DIFF
--- a/modules/ossm-remove-cleanup.adoc
+++ b/modules/ossm-remove-cleanup.adoc
@@ -17,11 +17,11 @@ You can manually remove resources left behind after removing the {ProductName} O
 
 . Log in to the {product-title} CLI as a cluster administrator.
 
-. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using Jaeger as a stand alone service without service mesh, do not delete the Jaeger resources.
+. Run the following commands to clean up resources after uninstalling the Operators. If you intend to keep using Jaeger as a stand-alone service without service mesh, do not delete the Jaeger resources.
 +
 [NOTE]
 ====
-The Openshift Elasticsearch operator is installed in `openshift-operators-redhat` by default. The other Operators are installed in the `openshift-operators` namespace by default. If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
+The OpenShift Elasticsearch Operator is installed in `openshift-operators-redhat` by default. The other Operators are installed in the `openshift-operators` namespace by default. If you installed the Operators in another namespace, replace `openshift-operators` with the name of the project where the {ProductName} Operator was installed.
 ====
 +
 [source,terminal]


### PR DESCRIPTION
This applies to main, enterprise 4.7, enterprise-4.8 and enterprise-4.9.

This pull request fixes a capitalisation typo in `modules/ossm-remove-cleanup.adoc`.

The preview is [here](https://deploy-preview-35966--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/removing-ossm.html#ossm-remove-cleanup_removing-ossm).