### PR TITLE
Changed supported NIC device list to table 4.7

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -5,14 +5,40 @@
 [id="supported-devices_{context}"]
 = Supported devices
 
-{product-title} supports the following Network Interface Card (NIC) models:
+{product-title} supports the following network interface controllers:
 
-* Intel X710 10GbE SFP+ with vendor ID `0x8086` and device ID `0x1572`
-* Intel XXV710 25GbE SFP28 with vendor ID `0x8086` and device ID `0x158b`
-* Mellanox MT27710 Family [ConnectX-4 Lx] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1015`
-* Mellanox MT27800 Family [ConnectX-5] 25GbE dual-port SFP28 with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT27800 Family [ConnectX-5] 100GbE with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT27700 Family [ConnectX-4] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1013`
-* Mellanox MT27800 Family [ConnectX-5] VPI adapter card, EDR IB (100Gb/s), single-port QSFP28 with vendor ID `0x15b3` and device ID `0x1017`
-* Mellanox MT28908 Family [ConnectX-6] VPI adapter card, 100Gb/s (HDR100, EDR IB), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`
-* Mellanox MT28908 Family [ConnectX-6] VPI adapter card, HDR200 IB (200Gb/s), single-port QSFP56 with vendor ID `0x15b3` and device ID `0x101b`
+.Supported network interface controllers
+[cols="1,2,1,1"]
+|===
+|Manufacturer |Model |Vendor ID | Device ID 
+
+|Intel
+|X710
+|8086
+|1572
+
+|Intel
+|XXV710
+|8086
+|158b
+
+|Mellanox
+|MT27700 Family [ConnectX&#8209;4]
+|15b3
+|1013
+
+|Mellanox
+|MT27710 Family [ConnectX&#8209;4{nbsp}Lx]
+|15b3
+|1015
+
+|Mellanox
+|MT27800 Family [ConnectX&#8209;5]
+|15b3
+|1017
+
+|Mellanox
+|MT28908 Family [ConnectX&#8209;6]
+|15b3
+|101b
+|===


### PR DESCRIPTION
I converted the list of supported NIC devices to table to make it easier to read. 

This PR reproduces the changes in #35174, but also removes devices from the table that weren't yet supported in this version.

* applies only to `enterprise-4.7`
* [direct preview](https://deploy-preview-35977--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov)