### PR TITLE
BZ1986796: Controller takes too long to restart on OCP 3.10

### DIFF
--- a/modules/migration-mtc-release-notes-1-5.adoc
+++ b/modules/migration-mtc-release-notes-1-5.adoc
@@ -39,6 +39,7 @@ This release has the following known issues:
 * PV resizing does not work as expected for AWS gp2 storage unless the `pv_resizing_threshold` is 42% or greater. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1973148[*BZ#1973148*])
 * If a migration fails, the migration plan does not retain custom PV settings for quiesced pods. You must manually roll back the migration, delete the migration plan, and create a new migration plan with your PV settings. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1784899[*BZ#1784899*])
 * Microsoft Azure storage is unavailable if you create more than 400 migration plans. The `MigStorage` custom resource displays the following message: `The request is being throttled as the limit has been reached for operation type`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977226[*BZ#1977226*])
+* On {product-title} 3.10, the `MigrationController` pod takes too long to restart. The bug report contains a workaround. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986796[*BZ#1986796*])
 
 [id="technical-changes-1-5_{context}"]
 == Technical changes


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1986796

Add bug to Known Issues

4.6+

Preview: https://deploy-preview-35979--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes?utm_source=github&utm_campaign=bot_dp#known-issues-1-5_mtc-release-notes

QE approved. Ready for peer review.