### PR TITLE
SRVKS-805: Add emptyDir config

### DIFF
--- a/modules/serverless-config-emptydir.adoc
+++ b/modules/serverless-config-emptydir.adoc
@@ -1,0 +1,16 @@
+[id="serverless-config-emptydir_{context}"]
+= Configuring the EmptyDir extension
+
+This extension controls whether `emptyDir` volumes can be specified.
+
+To enable using `emptyDir` volumes, you must modify the `KnativeServing` custom resource (CR) to include the following YAML:
+
+[source,yaml]
+----
+...
+spec:
+  config:
+    features:
+      "kubernetes.podspec-volumes-emptydir": enabled
+...
+----

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -10,6 +10,7 @@ This guide describes how cluster administrators can manage settings for develope
 
 // config options
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
+include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
 
 [id="additional-resources_knative-serving-CR-config"]
 == Additional resources


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKS-805

Applies for OCP 4.6+

Direct preview link: https://deploy-preview-35989--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config#serverless-config-emptydir_knative-serving-CR-config