### PR TITLE
BZ1871806: Split the scaled registry recommendation into two sentences

### DIFF
--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -84,7 +84,8 @@ In a non-scaled/high-availability (HA) {product-title} registry cluster deployme
 
 In a scaled/HA {product-title} registry cluster deployment:
 
-* The storage technology must support RWX access mode and must ensure read-after-write consistency.
+* The storage technology must support RWX access mode.
+* The storage technology must ensure read-after-write consistency.
 * The preferred storage technology is object storage.
 * Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft Azure Blob Storage, and OpenStack Swift are supported.
 * Object storage should be S3 or Swift compliant.


### PR DESCRIPTION
The storage technology must support RWX access mode and must ensure read-after-write consistency is split into two sentences as they're two different recommendations.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1871806

OCP Version: 4.5

Direct link for Doc Preview: https://deploy-preview-35995--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimizing-storage.html#scaled-registry