### PR TITLE
OSSMDOC-359: Update supported configurations

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -10,6 +10,8 @@
 The following configurations are supported for the current release of {ProductName}:
 
 * Red Hat {product-title} version 4.x.
+* Red Hat {product-dedicated} version 4.
+* Azure Red Hat OpenShift version 4.
 
 [NOTE]
 ====


### PR DESCRIPTION
Minor change. Added Red Hat OpenShift Dedicated 4 and Azure Red Hat OpenShift 4 as supported configurations. 

Cherry pick to 4.6, 4.7, 4.8, and 4.9.

