### PR TITLE
BZ1918136: adding note re: DDoS protection

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -24,11 +24,16 @@ To create a whitelist with multiple source IPs or subnets, use a space-delimited
 |`router.openshift.io/cookie_name`| Specifies an optional cookie to use for
 this route. The name must consist of any combination of upper and lower case letters, digits, "_",
 and "-". The default is the hashed internal key name for the route. |
-|`haproxy.router.openshift.io/pod-concurrent-connections`| Sets the maximum number of connections that are allowed to a backing pod from a router.  Note: if there are multiple pods, each can have this many connections.  But if you have multiple routers, there is no coordination among them, each may connect this many times. If not set, or set to 0, there is no limit. |
-|`haproxy.router.openshift.io/rate-limit-connections`| Setting `true` or `TRUE` to enables rate limiting functionality. |
-|`haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp`| Limits the number of concurrent TCP connections shared by an IP address. |
-|`haproxy.router.openshift.io/rate-limit-connections.rate-http`| Limits the rate at which an IP address can make HTTP requests. |
-|`haproxy.router.openshift.io/rate-limit-connections.rate-tcp`| Limits the rate at which an IP address can make TCP connections. |
+|`haproxy.router.openshift.io/pod-concurrent-connections`| Sets the maximum number of connections that are allowed to a backing pod from a router. +
+Note: If there are multiple pods, each can have this many connections.  If you have multiple routers, there is no coordination among them, each may connect this many times. If not set, or set to 0, there is no limit. |
+|`haproxy.router.openshift.io/rate-limit-connections`| Setting `true` or `TRUE` enables rate limiting functionality which is implemented through stick-tables on the specific backend per route. +
+Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+|`haproxy.router.openshift.io/rate-limit-connections.concurrent-tcp`| Limits the number of concurrent TCP connections made through the same source IP address. It accepts a numeric value. +
+Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+|`haproxy.router.openshift.io/rate-limit-connections.rate-http`| Limits the rate at which a client with the same source IP address can make HTTP requests. It accepts a numeric value.  +
+Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
+|`haproxy.router.openshift.io/rate-limit-connections.rate-tcp`| Limits the rate at which a client with the same source IP address can make TCP connections. It accepts a numeric value.  +
+Note: Using this annotation provides basic protection against distributed denial-of-service (DDoS) attacks. |
 |`haproxy.router.openshift.io/timeout` | Sets a server-side timeout for the route. (TimeUnits) | `ROUTER_DEFAULT_SERVER_TIMEOUT`
 |`router.openshift.io/haproxy.health.check.interval`| Sets the interval for the back-end health checks. (TimeUnits) | `ROUTER_BACKEND_CHECK_INTERVAL`
 |`haproxy.router.openshift.io/ip_whitelist`


### PR DESCRIPTION
This is for 4.6, 4.7, 4.8, and 4.9.

This follows on from [a previous PR](https://github.com/openshift/openshift-docs/pull/35684), now closed. QE and SME comments are in the previous PR.

Bug:bugzilla.redhat.com/show_bug.cgi?id=1918136

Direct link: https://deploy-preview-36012--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration

QA Review: @quarterpin
SME Review: @rfredette