### PR TITLE
RHDEVDOCS-3277 Entry out of order when forward logs to loki

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -43,10 +43,14 @@ include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+
 include::modules/cluster-logging-collector-log-forward-cloudwatch.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-collector-log-forward-loki.adoc[leveloffset=+1]
+include::modules/cluster-logging-troubleshooting-loki-entry-out-of-order-errors.adoc[leveloffset=+2]
+
 
 .Additional resources
 
 * xref:../logging/cluster-logging-exported-fields.adoc#cluster-logging-exported-fields-kubernetes_cluster-logging-exported-fields[Log Record Fields].
+* link:https://grafana.com/docs/loki/latest/configuration/[Configuring Loki server]
+
 
 include::modules/cluster-logging-collector-log-forward-project.adoc[leveloffset=+1]
 

--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -30,7 +30,7 @@ The following advisories are available for OpenShift Logging 5.2.x:
 
 * With this update, you can forward log data to Amazon CloudWatch, which provides application and infrastructure monitoring. For more information, see xref:../logging/cluster-logging-external.html#cluster-logging-collector-log-forward-cloudwatch_cluster-logging-external[Forwarding logs to Amazon CloudWatch]. (link:https://issues.redhat.com/browse/LOG-1173[LOG-1173])
 
-* With this update, you can forward log data to Grafana Loki, a horizontally scalable, highly available, multi-tenant log aggregation system. For more information, see xref:../logging/cluster-logging-external.html#cluster-logging-collector-log-forward-loki_cluster-logging-external[Forwarding logs to Grafana Loki]. (link:https://issues.redhat.com/browse/LOG-684[LOG-684])
+* With this update, you can forward log data to Loki, a horizontally scalable, highly available, multi-tenant log aggregation system. For more information, see xref:../logging/cluster-logging-external.html#cluster-logging-collector-log-forward-loki_cluster-logging-external[Forwarding logs to Loki]. (link:https://issues.redhat.com/browse/LOG-684[LOG-684])
 
 * With this update, if you use the Fluentd forward protocol to forward log data over a TLS-encrypted connection, you can now use a password-encrypted private key file and specify the passphrase in the Cluster Log Forwarder configuration. For more information, see xref:../logging/cluster-logging-external.html#cluster-logging-collector-log-forward-fluentd_cluster-logging-external[Forwarding logs using the Fluentd forward protocol]. (link:https://issues.redhat.com/browse/LOG-1525[LOG-1525])
 

--- a/modules/cluster-logging-collector-log-forward-loki.adoc
+++ b/modules/cluster-logging-collector-log-forward-loki.adoc
@@ -1,5 +1,5 @@
 [id="cluster-logging-collector-log-forward-loki_{context}"]
-= Forwarding logs to Grafana Loki
+= Forwarding logs to Loki
 
 You can forward logs to an external Loki logging system in addition to, or instead of, the internal default {product-title} Elasticsearch instance.
 

--- a/modules/cluster-logging-collector-log-forwarding-about.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-about.adoc
@@ -14,7 +14,7 @@ Forwarding cluster logs to external third-party systems requires a combination o
 
 * `cloudwatch`. Amazon CloudWatch, a monitoring and log storage service hosted by Amazon Web Services (AWS).
 
-* `loki`. Grafana Loki, a horizontally scalable, highly available, multi-tenant log aggregation system.
+* `loki`. Loki, a horizontally scalable, highly available, multi-tenant log aggregation system.
 
 * `kafka`. A Kafka broker. The `kafka` output can use a TCP or TLS connection.
 

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-2.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-2.adoc
@@ -33,7 +33,7 @@ a| fluentd 1.7.4
 
 logstash 7.10.1
 
-| Grafana Loki
+| Loki
 | REST over HTTP and HTTPS
 | Loki 2.3.0 deployed on OCP and Grafana labs
 

--- a/modules/cluster-logging-troubleshooting-loki-entry-out-of-order-errors.adoc
+++ b/modules/cluster-logging-troubleshooting-loki-entry-out-of-order-errors.adoc
@@ -1,0 +1,135 @@
+:_module-type: PROCEDURE
+
+[id="cluser-logging-troubleshooting-loki-entry-out-of-order-messages_{context}"]
+= Troubleshooting Loki "entry out of order" errors
+
+If your Fluentd forwards a large block of messages to a Loki logging system that exceeds the rate limit, Loki to generates "entry out of order" errors. To fix this issue, you update some values in the Loki server configuration file, `loki.yaml`.
+
+[NOTE]
+====
+`loki.yaml` is not available on Grafana-hosted Loki. This topic does not apply to Grafana-hosted Loki servers.
+====
+
+.Conditions
+
+* The `ClusterLogForwarder` custom resource is configured to forward logs to Loki.
+
+* Your system sends a block of messages that is larger than 2 MB to Loki, such as:
++
+----
+"values":[["1630410392689800468","{\"kind\":\"Event\",\"apiVersion\":\
+.......
+......
+......
+......
+\"received_at\":\"2021-08-31T11:46:32.800278+00:00\",\"version\":\"1.7.4 1.6.0\"}},\"@timestamp\":\"2021-08-31T11:46:32.799692+00:00\",\"viaq_index_name\":\"audit-write\",\"viaq_msg_id\":\"MzFjYjJkZjItNjY0MC00YWU4LWIwMTEtNGNmM2E5ZmViMGU4\",\"log_type\":\"audit\"}"]]}]}
+----
+
+* When you enter `oc logs -c fluentd`, the Fluentd logs in your OpenShift Logging cluster show the following messages:
++
+[source,text]
+----
+429 Too Many Requests Ingestion rate limit exceeded (limit: 8388608 bytes/sec) while attempting to ingest '2140' lines totaling '3285284' bytes
+
+429 Too Many Requests Ingestion rate limit exceeded' or '500 Internal Server Error rpc error: code = ResourceExhausted desc = grpc: received message larger than max (5277702 vs. 4194304)'
+----
+
+* When you open the logs on the Loki server, they display `entry out of order` messages like these:
++
+[source,text]
+----
+,\nentry with timestamp 2021-08-18 05:58:55.061936 +0000 UTC ignored, reason: 'entry out of order' for stream:
+
+{fluentd_thread=\"flush_thread_0\", log_type=\"audit\"},\nentry with timestamp 2021-08-18 06:01:18.290229 +0000 UTC ignored, reason: 'entry out of order' for stream: {fluentd_thread="flush_thread_0", log_type="audit"}
+----
+
+.Procedure
+
+. Update the following fields in the `loki.yaml` configuration file on the Loki server with the values shown here:
++
+  * `grpc_server_max_recv_msg_size: 8388608`
+  * `chunk_target_size: 8388608`
+  * `ingestion_rate_mb: 8`
+  * `ingestion_burst_size_mb: 16`
+
+. Apply the changes in `loki.yaml` to the Loki server.
+
+.Example `loki.yaml` file
+[source,yaml]
+----
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+  grpc_listen_port: 9096
+  grpc_server_max_recv_msg_size: 8388608
+
+ingester:
+  wal:
+    enabled: true
+    dir: /tmp/wal
+  lifecycler:
+    address: 127.0.0.1
+    ring:
+      kvstore:
+        store: inmemory
+      replication_factor: 1
+    final_sleep: 0s
+  chunk_idle_period: 1h       # Any chunk not receiving new logs in this time will be flushed
+  chunk_target_size: 8388608
+  max_chunk_age: 1h           # All chunks will be flushed when they hit this age, default is 1h
+  chunk_retain_period: 30s    # Must be greater than index read cache TTL if using an index cache (Default index read cache TTL is 5m)
+  max_transfer_retries: 0     # Chunk transfers disabled
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /tmp/loki/boltdb-shipper-active
+    cache_location: /tmp/loki/boltdb-shipper-cache
+    cache_ttl: 24h         # Can be increased for faster performance over longer query periods, uses more disk space
+    shared_store: filesystem
+  filesystem:
+    directory: /tmp/loki/chunks
+
+compactor:
+  working_directory: /tmp/loki/boltdb-shipper-compactor
+  shared_store: filesystem
+
+limits_config:
+  reject_old_samples: true
+  reject_old_samples_max_age: 12h
+  ingestion_rate_mb: 8
+  ingestion_burst_size_mb: 16
+
+chunk_store_config:
+  max_look_back_period: 0s
+
+table_manager:
+  retention_deletes_enabled: false
+  retention_period: 0s
+
+ruler:
+  storage:
+    type: local
+    local:
+      directory: /tmp/loki/rules
+  rule_path: /tmp/loki/rules-temp
+  alertmanager_url: http://localhost:9093
+  ring:
+    kvstore:
+      store: inmemory
+  enable_api: true
+----
+
+.Additional resources
+
+* link:https://grafana.com/docs/loki/latest/configuration/[Configuring Loki]


### PR DESCRIPTION
- Purpose of the PR: Add a troubleshooting subsection to the "Forwarding logs to Grafana Loki" section.
- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3277
- Direct link to doc preview: https://deploy-preview-36013--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-loki_cluster-logging-external, and scroll down to "Troubleshooting"
- SME review: @alanconway 
- QE review: @anpingli 
- Peer review: @libander 
- All reviews complete. Please merge now.