### PR TITLE
[enterprise-4.6} BZ1976328: Document the CRI-O can logs the image pull source in the info level log

### DIFF
--- a/installing/installing-mirroring-installation-images.adoc
+++ b/installing/installing-mirroring-installation-images.adoc
@@ -31,6 +31,10 @@ If you have an entitlement to Red Hat Quay, see the documentation on deploying R
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
+.Additional information
+
+For information on viewing the CRI-O logs to view the image source, see xref:../installing/validating-an-installation.html#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
+
 [id="installing-preparing-mirror"]
 == Preparing your mirror host
 

--- a/installing/validating-an-installation.adoc
+++ b/installing/validating-an-installation.adoc
@@ -10,6 +10,9 @@ You can check the status of an {product-title} cluster after an installation by 
 //Reviewing the installation log
 include::modules/reviewing-the-installation-log.adoc[leveloffset=+1]
 
+//Viewing the image pull source
+include::modules/viewing-the-image-pull-source.adoc[leveloffset=+1]
+
 //Getting cluster version, status, and update details
 include::modules/getting-cluster-version-status-and-update-details.adoc[leveloffset=+1]
 

--- a/modules/installation-about-mirror-registry.adoc
+++ b/modules/installation-about-mirror-registry.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
-// * installing/install_config/installing-restricted-networks-preparations.adoc
+// * installing/installing-mirroring-installation-images.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
+// * scalability_and_performance/ztp-deploying-disconnected.adoc
 
 [id="installation-about-mirror-registry_{context}"]
 = About the mirror registry
@@ -13,3 +14,6 @@ The mirror registry can be any container registry that supports link:https://doc
 The mirror registry must be reachable by every machine in the clusters that you provision. If the registry is unreachable installation, updating, or normal operations such as workload relocation might fail. For that reason, you must run mirror registries in a highly available way, and the mirror registries must at least match the production availability of your {product-title} clusters.
 
 When you populate a mirror registry with {product-title} images, you can follow two scenarios. If you have a host that can access both the internet and your mirror registry, but not your cluster nodes, you can directly mirror the content from that machine. This process is referred to as _connected mirroring_. If you have no such host, you must mirror the images to a file system and then bring that host or removable media into your restricted environment. This process is referred to as _disconnected mirroring_.
+
+For mirrored registries, to view the source of pulled images, you must review the `Trying to access` log entry in the CRI-O logs. Other methods to view the image pull source, such as using the `crictl images` command on a node, show the non-mirrored image name, even though the image is pulled from the mirrored location.
+

--- a/modules/viewing-the-image-pull-source.adoc
+++ b/modules/viewing-the-image-pull-source.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// *installing/validating-an-installation.adoc
+
+[id="viewing-the-image-pull-source_{context}"]
+= Viewing the image pull source
+
+For clusters with unrestricted network connectivity, you can view the source of your pulled images by using a command on a node, such as `crictl images`.
+
+However, for disconnected installations, to view the source of pulled images, you must review the CRI-O logs to locate the `Trying to access` log entry, as shown in the following procedure. Other methods to view the image pull source, such as the `crictl images` command, show the non-mirrored image name, even though the image is pulled from the mirrored location. 
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* Review the CRI-O logs for a master or worker node:
++
+[source,terminal]
+----
+$  oc adm node-logs <node_name> -u crio
+----
++
+.Example output
++
+The `Trying to access` log entry indicates where the image is being pulled from.
++
+[source,terminal]
+----
+...
+Mar 17 02:52:50 ip-10-0-138-140.ec2.internal crio[1366]: time="2021-08-05 10:33:21.594930907Z" level=info msg="Pulling image: quay.io/openshift-release-dev/ocp-release:4.8.4-ppc64le" id=abcd713b-d0e1-4844-ac1c-474c5b60c07c name=/runtime.v1alpha2.ImageService/PullImage
+Mar 17 02:52:50 ip-10-0-138-140.ec2.internal crio[1484]: time="2021-03-17 02:52:50.194341109Z" level=info msg="Trying to access \"li0317gcp1.mirror-registry.qe.gcp.devcluster.openshift.com:5000/ocp/release@sha256:1926eae7cacb9c00f142ec98b00628970e974284b6ddaf9a6a086cb9af7a6c31\""
+Mar 17 02:52:50 ip-10-0-138-140.ec2.internal crio[1484]: time="2021-03-17 02:52:50.226788351Z" level=info msg="Trying to access \"li0317gcp1.mirror-registry.qe.gcp.devcluster.openshift.com:5000/ocp/release@sha256:1926eae7cacb9c00f142ec98b00628970e974284b6ddaf9a6a086cb9af7a6c31\""
+...
+----
++
+The log might show the image pull source twice, as shown in the preceding example. 
++
+If your `ImageContentSourcePolicy` object lists multiple mirrors, {product-title} attempts to pull the images in the order listed in the configuration, for example:
++
+----
+Trying to access \"li0317gcp1.mirror-registry.qe.gcp.devcluster.openshift.com:5000/ocp/release@sha256:1926eae7cacb9c00f142ec98b00628970e974284b6ddaf9a6a086cb9af7a6c31\"
+Trying to access \"li0317gcp2.mirror-registry.qe.gcp.devcluster.openshift.com:5000/ocp/release@sha256:1926eae7cacb9c00f142ec98b00628970e974284b6ddaf9a6a086cb9af7a6c31\"
+----
+

--- a/openshift_images/samples-operator-alt-registry.adoc
+++ b/openshift_images/samples-operator-alt-registry.adoc
@@ -14,6 +14,10 @@ You must have access to the internet to obtain the necessary container images. I
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
+.Additional information
+
+For information on viewing the CRI-O logs to view the image source, see xref:../installing/validating-an-installation.html#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
+
 [id="samples-preparing-bastion"]
 === Preparing the mirror host
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/35283