### PR TITLE
BZ1970360: Adding RHEL 8 requirement for opm - 4.6

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -9,7 +9,7 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Prerequisites
 
-* For Linux, you must provide the following packages:
+* For Linux, you must provide the following packages. RHEL 8 meets these requirements:
 ** `podman` version 1.9.3+ (version 2.0+ recommended)
 ** `glibc` version 2.28+
 


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1970360
Related to 4.7+ PR: #35957 

Preview: https://deploy-preview-36021--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm-cli?utm_source=github&utm_campaign=bot_dp#olm-installing-opm_opm-cli

@mikemckiernan - Kindly review this fix for 4.6