### PR TITLE
[TELCODOCS-257] Performing end-to-end tests for platform verification

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -76,6 +76,449 @@ ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8
 Currently, not all tests run selectively on the nodes belonging to the pool.
 ====
 
+[id="cnf-performing-end-to-end-tests-dry-run_{context}"]
+== Dry run
+
+Use this command to run in dry-run mode. This is useful for checking what is in the test suite and provides output for all of the tests the image would run.
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+----
+
+[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
+== Disconnected mode
+
+The CNF tests image support running tests in a disconnected cluster, meaning a cluster that is not able to reach outer registries. This is done in two steps:
+
+. Performing the mirroring.
+
+. Instructing the tests to consume the images from a custom registry.
+
+[id="cnf-performing-end-to-end-tests-mirroring-images-to-custom-registry_{context}"]
+=== Mirroring the images to a custom registry accessible from the cluster
+
+A `mirror` executable is shipped in the image to provide the input required by `oc` to mirror the images needed to run the tests to a local registry.
+
+Run this command from an intermediate machine that has access both to the cluster and to link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io] over the internet:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+----
+
+Then, follow the instructions in the following section about overriding the registry used to fetch the images.
+
+[id="instruct-the-tests-to-consume-images-from-a-custom-registry_{context}"]
+=== Instruct the tests to consume those images from a custom registry
+
+This is done by setting the `IMAGE_REGISTRY` environment variable:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+----
+
+[id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
+=== Mirroring to the cluster internal registry
+
+{product-title} provides a built-in container image registry, which runs as a standard workload on the cluster.
+
+.Procedure
+
+. Gain external access to the registry by exposing it with a route:
++
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+----
+
+. Fetch the registry endpoint:
++
+[source,terminal]
+----
+REGISTRY=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+----
+
+. Create a namespace for exposing the images:
++
+[source,terminal]
+----
+$ oc create ns cnftests
+----
+
+. Make that image stream available to all the namespaces used for tests. This is required to allow the tests namespaces to fetch the images from the `cnftests` image stream.
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:sctptest:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:cnf-features-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:performance-addon-operators-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:dpdk-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:sriov-conformance-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:xt-u32-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:vrf-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:gatekeeper-testing:default --namespace=cnftests
+----
++
+[source,terminal]
+----
+$ oc policy add-role-to-user system:image-puller system:serviceaccount:ovs-qos-testing:default --namespace=cnftests
+----
+
+. Retrieve the docker secret name and auth token:
++
+[source,bash]
+----
+SECRET=$(oc -n cnftests get secret | grep builder-docker | awk {'print $1'}
+TOKEN=$(oc -n cnftests get secret $SECRET -o jsonpath="{.data['\.dockercfg']}" | base64 --decode | jq '.["image-registry.openshift-image-registry.svc:5000"].auth')
+----
+
+. Write a `dockerauth.json` similar to this:
++
+[source,bash]
+----
+echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
+----
+
+. Do the mirroring:
++
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+----
+
+. Run the tests:
++
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:latest /usr/bin/test-run.sh
+----
+
+[id="mirroring-different-set-of-images_{context}"]
+=== Mirroring a different set of images
+
+.Procedure
+
+. The `mirror` command tries to mirror the u/s images by default. This can be overridden by passing a file with the following format to the image:
++
+[source,yaml]
+----
+[
+    {
+        "registry": "public.registry.io:5000",
+        "image": "imageforcnftests:4.8"
+    },
+    {
+        "registry": "public.registry.io:5000",
+        "image": "imagefordpdk:4.8"
+    }
+]
+----
+
+. Pass it to the `mirror` command, for example saving it locally as `images.json`. With the following command, the local path is mounted in `/kubeconfig` inside the container and that can be passed to the mirror command.
++
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+----
+
+[id="cnf-performing-end-to-end-tests-running-in-single-node-cluster_{context}"]
+== Running in a single node cluster
+
+Running tests on a single node cluster causes the following limitations to be imposed:
+
+* Longer timeouts for certain tests, including SR-IOV and SCTP tests
+* Tests requiring master and worker nodes are skipped
+
+Longer timeouts concern SR-IOV and SCTP tests. Reconfiguration requiring node reboots cause a reboot of the entire environment, including the OpenShift control plane, and therefore takes longer to complete. All PTP tests requiring a master and worker node are skipped. No additional configuration is needed because the tests check for the number of nodes at startup and adjust test behavior accordingly.
+
+PTP tests can run in Discovery mode. The tests look for a PTP master configured outside of the cluster.
+
+For more information, see the Discovery mode section.
+// TODO update to xref
+
+To enable Discovery mode, the tests must be instructed by setting the `DISCOVERY_MODE` environment variable as follows:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
+DISCOVERY_MODE=true registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
+----
+
+[discrete]
+=== Required parameters
+
+* `ROLE_WORKER_CNF=master` - Required because master is the only machine pool to which the node will belong.
+* `XT_U32TEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the xt_u32 negative test to skip because there are only nodes where the module is loaded.
+* `SCTPTEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the SCTP negative test to skip because there are only nodes where the module is loaded.
+
+[id="cnf-performing-end-to-end-tests-cluster-impacts_{context}"]
+== Impact of tests on the cluster
+
+Depending on the feature, running the test suite could cause different impacts on the cluster. In general, only the SCTP tests do not change the cluster configuration. All of the other features have various impacts on the configuration.
+
+[id="cnf-performing-end-to-end-tests-sctp_{context}"]
+=== SCTP
+
+SCTP tests just run different pods on different nodes to check connectivity. The impacts on the cluster are related to running simple pods on two nodes.
+
+[id="cnf-performing-end-to-end-tests-xtu32_{context}"]
+=== XT_U32
+
+XT_U32 tests run pods on different nodes to check iptables rule that utilize xt_u32. The impacts on the cluster are related to running simple pods on two nodes.
+
+[id="cnf-performing-end-to-end-tests-sr-iov_{context}"]
+=== SR-IOV
+
+SR-IOV tests require changes in the SR-IOV network configuration, where the tests create and destroy different types of configuration.
+
+This might have an impact if existing SR-IOV network configurations are already installed on the cluster, because there may be conflicts depending on the priority of such configurations.
+
+At the same time, the result of the tests might be affected by existing configurations.
+
+[id="cnf-performing-end-to-end-tests-ptp_{context}"]
+=== PTP
+
+PTP tests apply a PTP configuration to a set of nodes of the cluster. As with SR-IOV, this might conflict with any existing PTP configuration already in place, with unpredictable results.
+
+[id="cnf-performing-end-to-end-tests-performance_{context}"]
+=== Performance
+
+Performance tests apply a performance profile to the cluster. The effect of this is changes in the node configuration, reserving CPUs, allocating memory huge pages, and setting the kernel packages to be realtime. If an existing profile named `performance` is already available on the cluster, the tests do not deploy it.
+
+[id="cnf-performing-end-to-end-tests-dpdk_{context}"]
+=== DPDK
+
+DPDK relies on both performance and SR-IOV features, so the test suite configures both a performance profile and SR-IOV networks, so the impacts are the same as those described in SR-IOV testing and performance testing.
+
+[id="cnf-performing-end-to-end-tests-container-mount-namespace_{context}"]
+=== Container-mount-namespace
+
+The validation test for `container-mount-namespace` mode only checks that the appropriate `MachineConfig` objects are present and active, and has no additional impact on the node.
+
+[id="cnf-performing-end-to-end-tests-cleaning-up_{context}"]
+=== Cleaning up
+
+After running the test suite, all the dangling resources are cleaned up.
+
+[id="cnf-performing-end-to-end-tests-image-parameters_{context}"]
+== Override test image parameters
+
+Depending on the requirements, the tests can use different images. There are two images used by the tests that can be changed using the following environment variables:
+
+* `CNF_TESTS_IMAGE`
+* `DPDK_TESTS_IMAGE`
+
+For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the following command:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+----
+
+[id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
+=== Ginkgo parameters
+
+The test suite is built upon the ginkgo BDD framework. This means that it accepts parameters for filtering or skipping tests.
+
+You can use the `-ginkgo.focus` parameter to filter a set of tests:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+----
+
+You can run only the latency test using the `-ginkgo.focus` parameter.
+
+To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that contains the name of the performance profile that needs to be tested. For example:
+
+[source,terminal]
+----
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+----
+
+[NOTE]
+====
+There is a particular test that requires both SR-IOV and SCTP. Given the selective nature of the `focus` parameter, this test is triggered by only placing the `sriov` matcher. If the tests are executed against a cluster where SR-IOV is installed but SCTP is not, adding the `-ginkgo.skip=SCTP` parameter causes the tests to skip SCTP testing.
+====
+
+[id="cnf-performing-end-to-end-tests-available-features_{context}"]
+=== Available features
+
+The set of available features to filter are:
+
+* `performance`
+* `sriov`
+* `ptp`
+* `sctp`
+* `xt_u32`
+* `dpdk`
+* `container-mount-namespace`
+
+[id="discovery-mode_{context}"]
+== Discovery mode
+
+Discovery mode allows you to validate the functionality of a cluster without altering its configuration. Existing environment configurations are used for the tests. The tests attempt to find the configuration items needed and use those items to execute the tests. If resources needed to run a specific test are not found, the test is skipped, providing an appropriate message to the user. After the tests are finished, no cleanup of the pre-configured configuration items is done, and the test environment can be immediately used for another test run.
+
+Some configuration items are still created by the tests. These are specific items needed for a test to run; for example, a SR-IOV Network. These configuration items are created in custom namespaces and are cleaned up after the tests are executed.
+
+An additional bonus is a reduction in test run times. As the configuration items are already there, no time is needed for environment configuration and stabilization.
+
+To enable discovery mode, the tests must be instructed by setting the `DISCOVERY_MODE` environment variable as follows:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
+DISCOVERY_MODE=true registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
+----
+
+[id="required-environment-config-prereqs_{context}"]
+=== Required environment configuration prerequisites
+
+.SR-IOV tests
+
+Most SR-IOV tests require the following resources:
+
+* `SriovNetworkNodePolicy`.
+* At least one with the resource specified by `SriovNetworkNodePolicy` being allocatable; a resource count of at least 5 is considered sufficient.
+
+Some tests have additional requirements:
+
+* An unused device on the node with available policy resource, with link state `DOWN` and not a bridge slave.
+* A `SriovNetworkNodePolicy` with a MTU value of `9000`.
+
+.DPDK tests
+
+The DPDK related tests require:
+
+* A performance profile.
+* A SR-IOV policy.
+* A node with resources available for the SR-IOV policy and available with the `PerformanceProfile` node selector.
+
+.PTP tests
+
+* A slave `PtpConfig` (`ptp4lOpts="-s" ,phc2sysOpts="-a -r"`).
+* A node with a label matching the slave `PtpConfig`.
+
+.SCTP tests
+
+* `SriovNetworkNodePolicy`.
+* A node matching both the `SriovNetworkNodePolicy` and a `MachineConfig` that enables SCTP.
+
+.XT_U32 tests
+
+* A node with a machine config that enables XT_U32.
+
+.Performance Operator tests
+
+Various tests have different requirements. Some of them are:
+
+* A performance profile.
+* A performance profile having `profile.Spec.CPU.Isolated = 1`.
+* A performance profile having `profile.Spec.RealTimeKernel.Enabled == true`.
+* A node with no huge pages usage.
+
+.Container-mount-namespace tests
+
+* A node with a machine config which enables `container-mount-namespace` mode
+
+[id="limiting-nodes-used-during-tests_{context}"]
+=== Limiting the nodes used during tests
+
+The nodes on which the tests are executed can be limited by specifying a `NODES_SELECTOR` environment variable. Any resources created by the test are then limited to the specified nodes.
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
+NODES_SELECTOR=node-role.kubernetes.io/worker-cnf registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
+----
+
+[id="using-single-performance-profile_{context}"]
+=== Using a single performance profile
+
+The resources needed by the DPDK tests are higher than those required by the performance test suite. To make the execution faster, the performance profile used by tests can be overridden using one that also serves the DPDK test suite.
+
+To do this, a profile like the following one can be mounted inside the container, and the performance tests can be instructed to deploy it.
+
+[source,yaml]
+----
+apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: performance
+spec:
+  cpu:
+    isolated: "4-15"
+    reserved: "0-3"
+  hugepages:
+    defaultHugepagesSize: "1G"
+    pages:
+    - size: "1G"
+      count: 16
+      node: 0
+  realTimeKernel:
+    enabled: true
+  nodeSelector:
+    node-role.kubernetes.io/worker-cnf: ""
+----
+
+[NOTE]
+====
+When you configure reserved and isolated CPUs, the infra containers in pods use the reserved CPUs and the application containers use the isolated CPUs.
+====
+
+To override the performance profile used, the manifest must be mounted inside the container and the tests must be instructed by setting the `PERFORMANCE_PROFILE_MANIFEST_OVERRIDE` parameter as follows:
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
+PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
+----
+
+[id="disabling-performance-profile-cleanup_{context}"]
+=== Disabling the performance profile cleanup
+
+When not running in discovery mode, the suite cleans up all the created artifacts and configurations. This includes the performance profile.
+
+When deleting the performance profile, the machine config pool is modified and nodes are rebooted. After a new iteration, a new profile is created. This causes long test cycles between runs.
+
+To speed up this process, set `CLEAN_PERFORMANCE_PROFILE="false"` to instruct the tests not to clean the performance profile. In this way, the next iteration will not need to create it and wait for it to be applied.
+
+[source,terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
+CLEAN_PERFORMANCE_PROFILE="false" registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
+----
+
 [id="cnf-performing-end-to-end-tests-running-the-tests_{context}"]
 == Running the latency tests
 Assuming the `kubeconfig` file is in the current folder, the command for running the test suite is:
@@ -376,400 +819,6 @@ Test completed.
 <2> The user is notified about the measured latency and the configured latency.
 <3> The maximum latency values in microseconds that are measured on each CPU.
 
-[id="cnf-performing-end-to-end-tests-image-parameters_{context}"]
-== Image parameters
-
-Depending on the requirements, the tests can use different images. There are two images used by the tests that can be changed using the following environment variables:
-
-* `CNF_TESTS_IMAGE`
-* `DPDK_TESTS_IMAGE`
-
-For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the following command:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
-----
-
-[id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
-=== Ginkgo parameters
-
-The test suite is built upon the ginkgo BDD framework. This means that it accepts parameters for filtering or skipping tests.
-
-You can use the `-ginkgo.focus` parameter to filter a set of tests:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
-----
-
-You can run only the latency test using the `-ginkgo.focus` parameter.
-
-To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that contains the name of the performance profile that needs to be tested. For example:
-
-[source,terminal]
-----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
-----
-
-[NOTE]
-====
-There is a particular test that requires both SR-IOV and SCTP. Given the selective nature of the `focus` parameter, this test is triggered by only placing the `sriov` matcher. If the tests are executed against a cluster where SR-IOV is installed but SCTP is not, adding the `-ginkgo.skip=SCTP` parameter causes the tests to skip SCTP testing.
-====
-
-[id="cnf-performing-end-to-end-tests-available-features_{context}"]
-=== Available features
-
-The set of available features to filter are:
-
-* `performance`
-* `sriov`
-* `ptp`
-* `sctp`
-* `xt_u32`
-* `dpdk`
-* `container-mount-namespace`
-
-[id="cnf-performing-end-to-end-tests-dry-run_{context}"]
-== Dry run
-
-Use this command to run in dry-run mode. This is useful for checking what is in the test suite and provides output for all of the tests the image would run.
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
-----
-
-[id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
-== Disconnected mode
-
-The CNF tests image support running tests in a disconnected cluster, meaning a cluster that is not able to reach outer registries. This is done in two steps:
-
-. Performing the mirroring.
-
-. Instructing the tests to consume the images from a custom registry.
-
-[id="cnf-performing-end-to-end-tests-mirroring-images-to-custom-registry_{context}"]
-=== Mirroring the images to a custom registry accessible from the cluster
-
-A `mirror` executable is shipped in the image to provide the input required by `oc` to mirror the images needed to run the tests to a local registry.
-
-Run this command from an intermediate machine that has access both to the cluster and to link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io] over the internet:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
-----
-
-Then, follow the instructions in the following section about overriding the registry used to fetch the images.
-
-[id="instruct-the-tests-to-consume-images-from-a-custom-registry_{context}"]
-=== Instruct the tests to consume those images from a custom registry
-
-This is done by setting the `IMAGE_REGISTRY` environment variable:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
-----
-
-[id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
-=== Mirroring to the cluster internal registry
-
-{product-title} provides a built-in container image registry, which runs as a standard workload on the cluster.
-
-.Procedure
-
-. Gain external access to the registry by exposing it with a route:
-+
-[source,terminal]
-----
-$ oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
-----
-
-. Fetch the registry endpoint:
-+
-[source,terminal]
-----
-REGISTRY=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
-----
-
-. Create a namespace for exposing the images:
-+
-[source,terminal]
-----
-$ oc create ns cnftests
-----
-
-. Make that image stream available to all the namespaces used for tests. This is required to allow the tests namespaces to fetch the images from the `cnftests` image stream.
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:sctptest:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:cnf-features-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:performance-addon-operators-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:dpdk-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:sriov-conformance-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:xt-u32-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:vrf-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:gatekeeper-testing:default --namespace=cnftests
-----
-+
-[source,terminal]
-----
-$ oc policy add-role-to-user system:image-puller system:serviceaccount:ovs-qos-testing:default --namespace=cnftests
-----
-
-. Retrieve the docker secret name and auth token:
-+
-[source,bash]
-----
-SECRET=$(oc -n cnftests get secret | grep builder-docker | awk {'print $1'}
-TOKEN=$(oc -n cnftests get secret $SECRET -o jsonpath="{.data['\.dockercfg']}" | base64 --decode | jq '.["image-registry.openshift-image-registry.svc:5000"].auth')
-----
-
-. Write a `dockerauth.json` similar to this:
-+
-[source,bash]
-----
-echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
-----
-
-. Do the mirroring:
-+
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
-----
-
-. Run the tests:
-+
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:latest /usr/bin/test-run.sh
-----
-
-[id="mirroring-different-set-of-images_{context}"]
-=== Mirroring a different set of images
-
-.Procedure
-
-. The `mirror` command tries to mirror the u/s images by default. This can be overridden by passing a file with the following format to the image:
-+
-[source,yaml]
-----
-[
-    {
-        "registry": "public.registry.io:5000",
-        "image": "imageforcnftests:4.8"
-    },
-    {
-        "registry": "public.registry.io:5000",
-        "image": "imagefordpdk:4.8"
-    }
-]
-----
-
-. Pass it to the `mirror` command, for example saving it locally as `images.json`. With the following command, the local path is mounted in `/kubeconfig` inside the container and that can be passed to the mirror command.
-+
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
-----
-
-[id="discovery-mode_{context}"]
-== Discovery mode
-
-Discovery mode allows you to validate the functionality of a cluster without altering its configuration. Existing environment configurations are used for the tests. The tests attempt to find the configuration items needed and use those items to execute the tests. If resources needed to run a specific test are not found, the test is skipped, providing an appropriate message to the user. After the tests are finished, no cleanup of the pre-configured configuration items is done, and the test environment can be immediately used for another test run.
-
-Some configuration items are still created by the tests. These are specific items needed for a test to run; for example, a SR-IOV Network. These configuration items are created in custom namespaces and are cleaned up after the tests are executed.
-
-An additional bonus is a reduction in test run times. As the configuration items are already there, no time is needed for environment configuration and stabilization.
-
-To enable discovery mode, the tests must be instructed by setting the `DISCOVERY_MODE` environment variable as follows:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
-DISCOVERY_MODE=true registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
-----
-
-[id="required-environment-config-prereqs_{context}"]
-=== Required environment configuration prerequisites
-
-.SR-IOV tests
-
-Most SR-IOV tests require the following resources:
-
-* `SriovNetworkNodePolicy`.
-* At least one with the resource specified by `SriovNetworkNodePolicy` being allocatable; a resource count of at least 5 is considered sufficient.
-
-Some tests have additional requirements:
-
-* An unused device on the node with available policy resource, with link state `DOWN` and not a bridge slave.
-* A `SriovNetworkNodePolicy` with a MTU value of `9000`.
-
-.DPDK tests
-
-The DPDK related tests require:
-
-* A performance profile.
-* A SR-IOV policy.
-* A node with resources available for the SR-IOV policy and available with the `PerformanceProfile` node selector.
-
-.PTP tests
-
-* A slave `PtpConfig` (`ptp4lOpts="-s" ,phc2sysOpts="-a -r"`).
-* A node with a label matching the slave `PtpConfig`.
-
-.SCTP tests
-
-* `SriovNetworkNodePolicy`.
-* A node matching both the `SriovNetworkNodePolicy` and a `MachineConfig` that enables SCTP.
-
-.XT_U32 tests
-
-* A node with a machine config that enables XT_U32.
-
-.Performance Operator tests
-
-Various tests have different requirements. Some of them are:
-
-* A performance profile.
-* A performance profile having `profile.Spec.CPU.Isolated = 1`.
-* A performance profile having `profile.Spec.RealTimeKernel.Enabled == true`.
-* A node with no huge pages usage.
-
-.Container-mount-namespace tests
-
-* A node with a machine config which enables `container-mount-namespace` mode
-
-[id="limiting-nodes-used-during-tests_{context}"]
-=== Limiting the nodes used during tests
-
-The nodes on which the tests are executed can be limited by specifying a `NODES_SELECTOR` environment variable. Any resources created by the test are then limited to the specified nodes.
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
-NODES_SELECTOR=node-role.kubernetes.io/worker-cnf registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
-----
-
-[id="using-single-performance-profile_{context}"]
-=== Using a single performance profile
-
-The resources needed by the DPDK tests are higher than those required by the performance test suite. To make the execution faster, the performance profile used by tests can be overridden using one that also serves the DPDK test suite.
-
-To do this, a profile like the following one can be mounted inside the container, and the performance tests can be instructed to deploy it.
-
-[source,yaml]
-----
-apiVersion: performance.openshift.io/v2
-kind: PerformanceProfile
-metadata:
-  name: performance
-spec:
-  cpu:
-    isolated: "4-15"
-    reserved: "0-3"
-  hugepages:
-    defaultHugepagesSize: "1G"
-    pages:
-    - size: "1G"
-      count: 16
-      node: 0
-  realTimeKernel:
-    enabled: true
-  nodeSelector:
-    node-role.kubernetes.io/worker-cnf: ""
-----
-
-[NOTE]
-====
-When you configure reserved and isolated CPUs, the infra containers in pods use the reserved CPUs and the application containers use the isolated CPUs.
-====
-
-To override the performance profile used, the manifest must be mounted inside the container and the tests must be instructed by setting the `PERFORMANCE_PROFILE_MANIFEST_OVERRIDE` parameter as follows:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
-PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
-----
-
-[id="disabling-performance-profile-cleanup_{context}"]
-=== Disabling the performance profile cleanup
-
-When not running in discovery mode, the suite cleans up all the created artifacts and configurations. This includes the performance profile.
-
-When deleting the performance profile, the machine config pool is modified and nodes are rebooted. After a new iteration, a new profile is created. This causes long test cycles between runs.
-
-To speed up this process, set `CLEAN_PERFORMANCE_PROFILE="false"` to instruct the tests not to clean the performance profile. In this way, the next iteration will not need to create it and wait for it to be applied.
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
-CLEAN_PERFORMANCE_PROFILE="false" registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
-----
-
-[id="cnf-performing-end-to-end-tests-running-in-single-node-cluster_{context}"]
-== Running in a single node cluster
-
-Running tests on a single node cluster causes the following limitations to be imposed:
-
-* Longer timeouts for certain tests, including SR-IOV and SCTP tests
-* Tests requiring master and worker nodes are skipped
-
-Longer timeouts concern SR-IOV and SCTP tests. Reconfiguration requiring node reboots cause a reboot of the entire environment, including the OpenShift control plane, and therefore takes longer to complete. All PTP tests requiring a master and worker node are skipped. No additional configuration is needed because the tests check for the number of nodes at startup and adjust test behavior accordingly.
-
-PTP tests can run in Discovery mode. The tests look for a PTP master configured outside of the cluster.
-
-For more information, see the Discovery mode section.
-// TODO update to xref
-
-To enable Discovery mode, the tests must be instructed by setting the `DISCOVERY_MODE` environment variable as follows:
-
-[source,terminal]
-----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e
-DISCOVERY_MODE=true registry.redhat.io/openshift-kni/cnf-tests /usr/bin/test-run.sh
-----
-
-[discrete]
-=== Required parameters
-
-* `ROLE_WORKER_CNF=master` - Required because master is the only machine pool to which the node will belong.
-* `XT_U32TEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the xt_u32 negative test to skip because there are only nodes where the module is loaded.
-* `SCTPTEST_HAS_NON_CNF_WORKERS=false` - Required to instruct the SCTP negative test to skip because there are only nodes where the module is loaded.
-
 [id="cnf-performing-end-to-end-tests-troubleshooting_{context}"]
 == Troubleshooting
 
@@ -868,52 +917,3 @@ To override the performance profile, the manifest must be mounted inside the con
 ----
 $ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
 ----
-
-[id="cnf-performing-end-to-end-tests-cluster-impacts_{context}"]
-== Impacts on the cluster
-
-Depending on the feature, running the test suite could cause different impacts on the cluster. In general, only the SCTP tests do not change the cluster configuration. All of the other features have various impacts on the configuration.
-
-[id="cnf-performing-end-to-end-tests-sctp_{context}"]
-=== SCTP
-
-SCTP tests just run different pods on different nodes to check connectivity. The impacts on the cluster are related to running simple pods on two nodes.
-
-[id="cnf-performing-end-to-end-tests-xtu32_{context}"]
-=== XT_U32
-
-XT_U32 tests run pods on different nodes to check iptables rule that utilize xt_u32. The impacts on the cluster are related to running simple pods on two nodes.
-
-[id="cnf-performing-end-to-end-tests-sr-iov_{context}"]
-=== SR-IOV
-
-SR-IOV tests require changes in the SR-IOV network configuration, where the tests create and destroy different types of configuration.
-
-This might have an impact if existing SR-IOV network configurations are already installed on the cluster, because there may be conflicts depending on the priority of such configurations.
-
-At the same time, the result of the tests might be affected by existing configurations.
-
-[id="cnf-performing-end-to-end-tests-ptp_{context}"]
-=== PTP
-
-PTP tests apply a PTP configuration to a set of nodes of the cluster. As with SR-IOV, this might conflict with any existing PTP configuration already in place, with unpredictable results.
-
-[id="cnf-performing-end-to-end-tests-performance_{context}"]
-=== Performance
-
-Performance tests apply a performance profile to the cluster. The effect of this is changes in the node configuration, reserving CPUs, allocating memory huge pages, and setting the kernel packages to be realtime. If an existing profile named `performance` is already available on the cluster, the tests do not deploy it.
-
-[id="cnf-performing-end-to-end-tests-dpdk_{context}"]
-=== DPDK
-
-DPDK relies on both performance and SR-IOV features, so the test suite configures both a performance profile and SR-IOV networks, so the impacts are the same as those described in SR-IOV testing and performance testing.
-
-[id="cnf-performing-end-to-end-tests-container-mount-namespace_{context}"]
-=== Container-mount-namespace
-
-The validation test for `container-mount-namespace` mode only checks that the appropriate `MachineConfig` objects are present and active, and has no additional impact on the node.
-
-[id="cnf-performing-end-to-end-tests-cleaning-up_{context}"]
-=== Cleaning up
-
-After running the test suite, all the dangling resources are cleaned up.

--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -77,7 +77,7 @@ Currently, not all tests run selectively on the nodes belonging to the pool.
 ====
 
 [id="cnf-performing-end-to-end-tests-running-the-tests_{context}"]
-== Running the tests
+== Running the latency tests
 Assuming the `kubeconfig` file is in the current folder, the command for running the test suite is:
 
 [source,terminal]
@@ -87,80 +87,294 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registr
 
 This allows your `kubeconfig` file to be consumed from inside the running container.
 
-[id="cnf-performing-end-to-end-tests-running-the-latency_tests"]
-=== Running the latency tests
-In {product-title} {product-version}, you can also run latency tests from the CNF-test container. The latency test allows you to set a latency limit so that you can determine performance, throughput, and latency.
+[WARNING]
+====
+You must run the latency tests in Discovery mode. The latency tests can change the configuration of your cluster if you do not run in Discovery mode.
+====
 
-The latency test runs the `oslat` tool, which is an open source program to detect OS level latency. For more information, see the Red Hat Knowledgebase solution link:https://access.redhat.com/solutions/5315541[How to measure OS and hardware latency on isolated CPUs?].
+In {product-title} {product-version}, you can also run latency tests from the CNF-test container. The latency test allows the to validate that node tuning is sufficient for your workload.
 
-By default, the latency tests are disabled. To enable the latency test, you must add the `LATENCY_TEST_RUN` variable and set its value to `true`. For example, `LATENCY_TEST_RUN=true`.
+Three tools measure the latency of the system:
 
-Additionally, you can set the following environment variables for latency tests:
+* `hwlatdetect`
+* `cyclictest`
+* `oslat`
 
-* `LATENCY_TEST_RUNTIME` - Specifies the amount of time (in seconds) that the latency test must run.
-* `OSLAT_MAXIMUM_LATENCY` - Specifies the maximum latency (in microseconds) that is expected from all buckets during the `oslat` test run.
+Each tool has a specific use. Use the tools in sequence to achieve reliable test results.
 
-To perform the latency tests, run the following command:
+. The `hwlatdetect` tool measures the baseline that the bare hardware can achieve. Before proceeding with the next latency test, ensure that the number measured by `hwlatdetect` meets the required threshold because hardware latency spikes cannot be fixed by operating system tuning.
 
-[source,termina]
-----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
-----
+.  The `cyclictest` tool verifies the timer latency after `hwlatdetect` passes validation. The `cyclictest` tool schedules a repeated timer and measures the difference between the desired and the actual trigger times. The difference can uncover basic issues with the tuning caused by interrupts or process priorities.
+
+. The `oslat` tool behaves similarly to a CPU-intensive DPDK application and measures all the interruptions and disruptions to the busy loop that simulates CPU heavy data processing.
+
+By default, the latency tests are disabled. To enable the latency test, you must add the `LATENCY_TEST_RUN` environment variable to the test invocation and set its value to `true`. For example, `LATENCY_TEST_RUN=true`.
+
+The test introduces the following environment variables:
+
+* `LATENCY_TEST_CPUS` variable specifies the number of CPUs that the pod running the latency tests uses.
+* `LATENCY_TEST_RUNTIME` variable specifies the amount of time in seconds that the latency test must run.
+* `CYCLICTEST_MAXIMUM_LATENCY` variable specifies the maximum latency in microseconds that all threads expect before waking up during the `cyclictest` run.
+* `HWLATDETECT_MAXIMUM_LATENCY` variable specifies the maximum acceptable hardware latency in microseconds for the workload and operating system.
+* `OSLAT_MAXIMUM_LATENCY` variable specifies the maximum acceptable latency in microseconds for the `oslat` test results.
+* `MAXIMUM_LATENCY` is a unified variable you can apply for all tests.
+
 [NOTE]
 ====
-You must run the latency test in discovery mode. For more information, see the Discovery mode section.
+A variable that is specific to certain tests has precedence over the unified variable.
 ====
 
-.Excerpt of a sample result of a 10-second latency test using the following command:
-[source,terminal]
+You can use the `ginkgo.focus` flag to run a specific test.
+
+[id="cnf-performing-end-to-end-tests-running-hwlatdetect"]
+=== Running hwlatdetect
+
+To perform the `hwlatdetect`, run the following command:
+
+[source, terminal]
 ----
-[root@cnf12-installer ~]# podman run --rm -v $KUBECONFIG:/kubeconfig:Z -e PERF_TEST_PROFILE=worker-cnf-2 -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=10 -e OSLAT_MAXIMUM_LATENCY=20 -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
--ginkgo.focus="Latency"
-running /0_config.test -ginkgo.focus=Latency
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DICOVERY_MODE=true -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginko.focus=”hwladetect”
 ----
-.Example output
-[source,terminal]
+
+The above command runs the `hwlatdetect` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+
+.Example failure output
+[source, terminal]
 ----
-I1106 15:09:08.087085       7 request.go:621] Throttling request took 1.037172581s, request: GET:https://api.cnf12.kni.lab.eng.bos.redhat.com:6443/apis/autoscaling.openshift.io/v1?timeout=32s
-Running Suite: Performance Addon Operator configuration
+$ docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=40 -e MAXIMUM_LATENCY=1 -e LATENCY_TEST_CPUS=10 -e DISCOVERY_MODE=true quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.focus="hwlatdetect" <1>
+running /usr/bin//validationsuite -ginkgo.focus=hwlatdetect
+...
+Discovery mode enabled, skipping setup
+running /usr/bin//cnftests -ginkgo.focus=hwlatdetect
+I0812 09:53:57.108148      19 request.go:668] Waited for 1.049207747s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/autoscaling/v1?timeout=32s
+Running Suite: CNF Features e2e integration tests
+=================================================
+Random Seed: 1628762033
+Will run 1 of 138 specs
 
-Random Seed: 1604675347
-Will run 0 of 1 specs
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+• [SLOW TEST:26.144 seconds]
+[performance] Latency Test
+/go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:84
+  with the hwlatdetect image
+  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:224
+    should succeed
+    /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:232
+------------------------------
+SSSSSSSSSSSSSSSSSSSSSS
 
-JUnit report was created: /unit_report_performance_config.xml
+detector: tracer
+   parameters:
+        Latency threshold: 1us <2>
+        Sample window:     10000000us
+        Sample width:      950000us
+     Non-sampling period:  9050000us
+        Output File:       None
 
-Ran 0 of 1 Specs in 0.000 seconds
-SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped
-PASS
-running /4_latency.test -ginkgo.focus=Latency
-I1106 15:09:10.735795      23 request.go:621] Throttling request took 1.037276624s, request: GET:https://api.cnf12.kni.lab.eng.bos.redhat.com:6443/apis/certificates.k8s.io/v1?timeout=32s
-Running Suite: Performance Addon Operator latency e2e tests
+Starting test
+test finished
+Max Latency: 35us <3>
+Samples recorded: 2
+Samples exceeding threshold: 2
+ts: 1628174377.074638224, inner:20, outer:35
+ts: 1628174387.359881340, inner:21, outer:34
+; err: exit status 1
+goroutine 1 [running]:
+k8s.io/klog.stacks(0xc000070200, 0xc000106400, 0x21b, 0x3c2)
+	/remote-source/app/vendor/k8s.io/klog/klog.go:875 +0xb9
+k8s.io/klog.(*loggingT).output(0x5bed00, 0xc000000003, 0xc00010a0e0, 0x53ea81, 0x7, 0x33, 0x0)
+	/remote-source/app/vendor/k8s.io/klog/klog.go:826 +0x35f
+k8s.io/klog.(*loggingT).printf(0x5bed00, 0x3, 0x5082da, 0x33, 0xc000113f58, 0x2, 0x2)
+	/remote-source/app/vendor/k8s.io/klog/klog.go:707 +0x153
+k8s.io/klog.Fatalf(...)
+	/remote-source/app/vendor/k8s.io/klog/klog.go:1276
+main.main()
+	/remote-source/app/cnf-tests/pod-utils/hwlatdetect-runner/main.go:51 +0x897
+----
+<1> The docker arguments provided by the user.
+<2> The latency threshold configured by the user using the `MAX_LATENCY` or the `HWLATDETECT_MAX_LATENCY` environment variables.
+<3> The maximum latency value measured during the test.
 
-Random Seed: 1604675349
-Will run 1 of 1 specs
+[id="cnf-performing-end-to-end-tests-running-cyclictest"]
+=== Running cyclictest
 
-I1106 15:10:06.401180      23 nodes.go:86] found mcd machine-config-daemon-r78qc for node cnfdd8.clus2.t5g.lab.eng.bos.redhat.com
-I1106 15:10:06.738120      23 utils.go:23] run command 'oc [exec -i -n openshift-machine-config-operator -c machine-config-daemon --request-timeout 30 machine-config-daemon-r78qc -- cat /rootfs/var/log/oslat.log]' (err=<nil>):
-  stdout=
-Version: v0.1.7
+To perform the `cyclictest`, run the following command:
 
-Total runtime: 		10 seconds
+[source, terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DICOVERY_MODE=true -e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="cyclictest"
+----
+
+The above command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+
+.Example failure output
+[source, terminal]
+----
+$docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=10 -e DISCOVERY_MODE=true quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="cyclictest" <1>
+
+Discovery mode enabled, skipping setup
+running /usr/bin//cnftests -ginkgo.v -ginkgo.focus=cyclictest
+I0811 15:02:36.350033      20 request.go:668] Waited for 1.049965918s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/machineconfiguration.openshift.io/v1?timeout=32s
+Running Suite: CNF Features e2e integration tests
+=================================================
+Random Seed: 1628694153
+Will run 1 of 138 specs
+
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[performance] Latency Test with the cyclictest image
+  should succeed
+  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:200
+STEP: Waiting two minutes to download the latencyTest image
+STEP: Waiting another two minutes to give enough time for the cluster to move the pod to Succeeded phase
+Aug 11 15:03:06.826: [INFO]: found mcd machine-config-daemon-wf4w8 for node cnfdc8.clus2.t5g.lab.eng.bos.redhat.com
+
+• Failure [22.527 seconds]
+[performance] Latency Test
+/go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:84
+  with the cyclictest image
+  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:188
+    should succeed [It]
+    /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:200
+
+    The current latency 17 is bigger than the expected one 20 <2>
+    Expected
+        <bool>: false
+    to be true
+
+    /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:219
+
+Log file created at: 2021/08/11 15:02:51
+Running on machine: cyclictest-knk7d
+Binary: Built with gc go1.16.6 for linux/amd64
+Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
+I0811 15:02:51.092254       1 node.go:37] Environment information: /proc/cmdline: BOOT_IMAGE=(hd0,gpt3)/ostree/rhcos-612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/vmlinuz-4.18.0-305.10.2.rt7.83.el8_4.x86_64 ip=dhcp random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ostree=/ostree/boot.1/rhcos/612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/0 ignition.platform.id=openstack root=UUID=5a4ddf16-9372-44d9-ac4e-3ee329e16ab3 rw rootflags=prjquota skew_tick=1 nohz=on rcu_nocbs=1-3 tuned.non_isolcpus=000000ff,ffffffff,ffffffff,fffffff1 intel_pstate=disable nosoftlockup tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,1-3 systemd.cpu_affinity=0,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103 default_hugepagesz=1G hugepagesz=2M hugepages=128 nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
+I0811 15:02:51.092427       1 node.go:44] Environment information: kernel version 4.18.0-305.10.2.rt7.83.el8_4.x86_64
+I0811 15:02:51.092450       1 main.go:48] running the cyclictest command with arguments [-D 600 -p 1 -t 10 -a 2,4,6,8,10,54,56,58,60,62 -h 30 -i 1000 --quiet] <3>
+I0811 15:03:06.147253       1 main.go:54] succeeded to run the cyclictest command: # /dev/cpu_dma_latency set to 0us
+# Histogram
+000000 000000	000000	000000	000000	000000	000000	000000	000000	000000	000000
+000001 000000	005561	027778	037704	011987	000000	120755	238981	081847	300186
+000002 587440	581106	564207	554323	577416	590635	474442	357940	513895	296033
+000003 011751	011441	006449	006761	008409	007904	002893	002066	003349	003089
+000004 000527	001079	000914	000712	001451	001120	000779	000283	000350	000251
+
+More histogram entries ...
+# Min Latencies: 00002 00001 00001 00001 00001 00002 00001 00001 00001 00001
+# Avg Latencies: 00002 00002 00002 00001 00002 00002 00001 00001 00001 00001
+# Max Latencies: 00018 00465 00361 00395 00208 00301 02052 00289 00327 00114 <4>
+# Histogram Overflows: 00000 00220 00159 00128 00202 00017 00069 00059 00045 00120
+# Histogram Overflow at cycle number:
+# Thread 0:
+# Thread 1: 01142 01439 05305 … # 00190 others
+# Thread 2: 20895 21351 30624 … # 00129 others
+# Thread 3: 01143 17921 18334 … # 00098 others
+# Thread 4: 30499 30622 31566 ... # 00172 others
+# Thread 5: 145221 170910 171888 ...
+# Thread 6: 01684 26291 30623 ...# 00039 others
+# Thread 7: 28983 92112 167011 … 00029 others
+# Thread 8: 45766 56169 56171 ...# 00015 others
+# Thread 9: 02974 08094 13214 ... # 00090 others
+----
+<1> The docker arguments provided by the user.
+<2> The user is notified about the measured latency and the configured latency.
+<3> The arguments for the `cyclictest` command.
+<4> The maximum latencies measured on each thread.
+
+[id="cnf-performing-end-to-end-tests-running-oslat"]
+=== Running oslat
+
+[source, terminal]
+----
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e DICOVERY_MODE=true -e LATENCY_TEST_CPUS=7 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20  registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="oslat"
+----
+
+The above command runs the `cyclictest` tool for 10 minutes (600 seconds). The test runs successfully when the maximum observed latency is lower than `MAXIMUM_LATENCY` (20 μs), and the command line displays `SUCCESS!`.
+
+.Example failure output
+[source, terminal]
+----
+$ docker run -v $KUBECONFIG:/root/kubeconfig:Z -e KUBECONFIG=/root/kubeconfig -e IMAGE_REGISTRY=quay.io/titzhak -e CNF_TESTS_IMAGE=cnf-tests:latest -e PERF_TEST_PROFILE=performance -e ROLE_WORKER_CNF=worker-cnf -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e DISCOVERY_MODE=true -e MAXIMUM_LATENCY=20 -e LATENCY_TEST_CPUS=7 quay.io/titzhak/cnf-tests:latest usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat" <1>
+
+running /usr/bin//validationsuite -ginkgo.v -ginkgo.focus=oslat
+I0829 12:36:55.386776       8 request.go:668] Waited for 1.000303471s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/authentication.k8s.io/v1?timeout=32s
+Running Suite: CNF Features e2e validation
+==========================================
+
+Discovery mode enabled, skipping setup
+running /usr/bin//cnftests -ginkgo.v -ginkgo.focus=oslat
+I0829 12:37:01.219077      20 request.go:668] Waited for 1.050010755s due to client-side throttling, not priority and fairness, request: GET:https://api.cnfdc8.t5g.lab.eng.bos.redhat.com:6443/apis/snapshot.storage.k8s.io/v1beta1?timeout=32s
+Running Suite: CNF Features e2e integration tests
+=================================================
+Random Seed: 1630240617
+Will run 1 of 142 specs
+
+SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
+------------------------------
+[performance] Latency Test with the oslat image
+  should succeed
+  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:134
+STEP: Waiting two minutes to download the latencyTest image
+STEP: Waiting another two minutes to give enough time for the cluster to move the pod to Succeeded phase
+Aug 29 12:37:59.324: [INFO]: found mcd machine-config-daemon-wf4w8 for node cnfdc8.clus2.t5g.lab.eng.bos.redhat.com
+
+• Failure [49.246 seconds]
+[performance] Latency Test
+/go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:59
+  with the oslat image
+  /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:112
+    should succeed [It]
+    /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:134
+
+    The current latency 27 is bigger than the expected one 20 <2>
+    Expected
+        <bool>: false
+    to be true
+ /go/src/github.com/openshift-kni/cnf-features-deploy/vendor/github.com/openshift-kni/performance-addon-operators/functests/4_latency/latency.go:168
+
+Log file created at: 2021/08/29 13:25:21
+Running on machine: oslat-57c2g
+Binary: Built with gc go1.16.6 for linux/amd64
+Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg
+I0829 13:25:21.569182       1 node.go:37] Environment information: /proc/cmdline: BOOT_IMAGE=(hd0,gpt3)/ostree/rhcos-612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/vmlinuz-4.18.0-305.10.2.rt7.83.el8_4.x86_64 ip=dhcp random.trust_cpu=on console=tty0 console=ttyS0,115200n8 ostree=/ostree/boot.0/rhcos/612d89f4519a53ad0b1a132f4add78372661bfb3994f5fe115654971aa58a543/0 ignition.platform.id=openstack root=UUID=5a4ddf16-9372-44d9-ac4e-3ee329e16ab3 rw rootflags=prjquota skew_tick=1 nohz=on rcu_nocbs=1-3 tuned.non_isolcpus=000000ff,ffffffff,ffffffff,fffffff1 intel_pstate=disable nosoftlockup tsc=nowatchdog intel_iommu=on iommu=pt isolcpus=managed_irq,1-3 systemd.cpu_affinity=0,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59,60,61,62,63,64,65,66,67,68,69,70,71,72,73,74,75,76,77,78,79,80,81,82,83,84,85,86,87,88,89,90,91,92,93,94,95,96,97,98,99,100,101,102,103 default_hugepagesz=1G hugepagesz=2M hugepages=128 nmi_watchdog=0 audit=0 mce=off processor.max_cstate=1 idle=poll intel_idle.max_cstate=0
+I0829 13:25:21.569345       1 node.go:44] Environment information: kernel version 4.18.0-305.10.2.rt7.83.el8_4.x86_64
+I0829 13:25:21.569367       1 main.go:53] Running the oslat command with arguments [--duration 600 --rtprio 1 --cpu-list 4,6,52,54,56,58 --cpu-main-thread 2] <1>
+I0829 13:35:22.632263       1 main.go:59] Succeeded to run the oslat command: oslat V 2.00
+Total runtime: 		600 seconds
 Thread priority: 	SCHED_FIFO:1
-CPU list: 		3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50
+CPU list: 		4,6,52,54,56,58
 CPU for main thread: 	2
 Workload: 		no
 Workload mem: 		0 (KiB)
-Preheat cores: 		48
+Preheat cores: 		6
 
 Pre-heat for 1 seconds...
 Test starts...
 Test completed.
 
-Core: 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50
-CPU Freq: 2096 2096 2096 2096 2096 2096 2096 2096 2096 2096 2096 2096 2096 2092 2096 2096 2096 2092 2092 2096 2096 2096 2096 2096 2096 2096 2096 2096 2096 2092 2096 2096 2092 2096 2096 2096 2096 2092 2096 2096 2096 2092 2096 2096 2096 2096 2096 2096 (Mhz)
-...
-Maximum: 3 4 3 3 3 3 3 3 4 3 3 3 3 4 3 3 3 3 3 4 3 3 3 3 3 3 3 3 3 4 3 3 3 3 3 3 3 4 3 3 3 3 3 4 3 3 3 4 (us)
+        Core:	 4 6 52 54 56 58
+    CPU Freq:	 2096 2096 2096 2096 2096 2096 (Mhz)
+    001 (us):	 19390720316 19141129810 20265099129 20280959461 19391991159 19119877333
+    002 (us):	 5304 5249 5777 5947 6829 4971
+    003 (us):	 28 14 434 47 208 21
+    004 (us):	 1388 853 123568 152817 5576 0
+    005 (us):	 207850 223544 103827 91812 227236 231563
+    006 (us):	 60770 122038 277581 323120 122633 122357
+    007 (us):	 280023 223992 63016 25896 214194 218395
+    008 (us):	 40604 25152 24368 4264 24440 25115
+    009 (us):	 6858 3065 5815 810 3286 2116
+    010 (us):	 1947 936 1452 151 474 361
+  ...
+     Minimum:	 1 1 1 1 1 1 (us)
+     Average:	 1.000 1.000 1.000 1.000 1.000 1.000 (us)
+     Maximum:	 37 38 49 28 28 19 (us) <3>
+     Max-Min:	 36 37 48 27 27 18 (us)
+    Duration:	 599.667 599.667 599.667 599.667 599.667 599.667 (sec)
 ----
+<1> The list of CPUs running the `oslat` command. Seven CPUs are provided through the `LATENCY_TEST_CPUS` variable. Only six CPUs are displayed in total because one is used to run the `oslat` tool.
+<2> The user is notified about the measured latency and the configured latency.
+<3> The maximum latency values in microseconds that are measured on each CPU.
 
 [id="cnf-performing-end-to-end-tests-image-parameters_{context}"]
 == Image parameters


### PR DESCRIPTION
For 4.9: [Jira issue](https://issues.redhat.com/browse/TELCODOCS-257) 

[Performing end-to-end tests for platform verification](https://deploy-preview-36024--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes?utm_source=github&utm_campaign=bot_dp#cnf-performing-end-to-end-tests-for-platform-verification_cnf-master)