### PR TITLE
TELCODOCS-293: Created new troubleshooting assembly, created new module, updated existing must-gather tool module to state inclusion in new assembly.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1823,6 +1823,8 @@ Topics:
   File: uninstalling-sandboxed-containers
 - Name: Upgrade OpenShift sandboxed containers
   File: upgrade-sandboxed-containers
+- Name: Collecting OpenShift sandboxed containers data for Red Hat Support
+  File: troubleshooting-sandboxed-containers
 ---
 Name: Logging
 Dir: logging

--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -5,6 +5,7 @@
 // * serverless/serverless-support.adoc
 // * service_mesh/v1x/servicemesh-release-notes.adoc
 // * service_mesh/v2x/servicemesh-release-notes.adoc
+// * troubleshooting-sandboxed-containers.adoc
 
 [id="about-must-gather_{context}"]
 = About the must-gather tool

--- a/modules/sandboxed-containers-collecting-data.adoc
+++ b/modules/sandboxed-containers-collecting-data.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * sandboxed_containers/troubleshooting-sandboxed-containers.adoc
+
+//This file contains UI elements and/or package names that need to be updated.
+
+[id="sandboxed-containers-collecting-data_{context}"]
+= About collecting {sandboxed-containers-first} data
+
+You can use the `oc adm must-gather` CLI command to collect information about your cluster. The following features and objects are associated with {sandboxed-containers-first}:
+
+* All namespaces and their child objects that belong to any {sandboxed-containers-first}
+resources
+* All {sandboxed-containers-first} custom resource definitions (CRDs)
+
+The `oc adm must-gather` CLI command collects the following component logs:
+
+* QEMU logs
+* Audit logs
+* {sandboxed-containers-first} logs
+* CRI-O logs
+
+These component logs are collected as long as there is at least one pod running with the `kata` runtime.
+
+To collect {sandboxed-containers-first} data with `must-gather`, you must specify the
+{sandboxed-containers-first} image:
+`--image=registry.redhat.io/openshift-sandboxed-containers-1.1.0/osc-must-gather:1.1.0`.

--- a/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
+++ b/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
@@ -1,0 +1,26 @@
+[id="troubleshooting-sandboxed-containers"]
+= Collecting {sandboxed-containers-first} data for Red Hat Support
+include::modules/common-attributes.adoc[]
+:context: troubleshooting-sandboxed-containers
+
+toc::[]
+
+[role="_abstract"]
+
+When opening a support case, it is helpful to provide debugging
+information about your cluster to Red Hat Support.
+
+The `must-gather` tool enables you to collect diagnostic information about your
+{product-title} cluster, including virtual machines and other data related to
+{sandboxed-containers-first}.
+
+For prompt support, supply diagnostic information for both {product-title}
+and {sandboxed-containers-first}.
+
+include::modules/about-must-gather.adoc[leveloffset=+1]
+
+include::modules/sandboxed-containers-collecting-data.adoc[leveloffset=+1]
+
+[id="{context}_additional-resources"]
+== Additional resources
+* For more information about gathering data for support, see xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster].


### PR DESCRIPTION
4.9 documentation for: [KATA-453](https://issues.redhat.com/browse/KATA-453)

Documentation preview: https://deploy-preview-36031--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/troubleshooting-sandboxed-containers.html

Approved by SMEs.

@zanetworker @fidencio 

@valtair1891 - can you review and move the doc user story to QA in progress? (https://issues.redhat.com/browse/TELCODOCS-293)