### PR TITLE
BZ#1995435: Change update server

### DIFF
--- a/modules/update-changing-update-server-cli.adoc
+++ b/modules/update-changing-update-server-cli.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-cli.adoc
+// * updating/updating-cluster-rhel-compute.adoc
+
+[id="update-changing-update-server-cli_{context}"]
+= Changing the update server by using the CLI
+
+Changing the update server is optional. If you have an OpenShift Update Service (OSUS) installed and configured locally, you must set the URL for the server as the `upstream` to use the local server during updates. The default value for `upstream` is `\https://api.openshift.com/api/upgrades_info/v1/graph`.
+
+.Procedure
+
+* Change the `upstream` parameter value in the cluster version:
++
+[source,terminal]
+----
+$ oc patch clusterversion/version --patch '{"spec":{"upstream":"<update-server-url>"}}' --type=merge
+----
+The `<update-server-url>` variable specifies the URL for the update server.
++
+.Example output
++
+[source,terminal]
+----
+clusterversion.config.openshift.io/version patched
+----

--- a/modules/update-changing-update-server-web.adoc
+++ b/modules/update-changing-update-server-web.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster.adoc
+
+[id="update-changing-update-server-web_{context}"]
+= Changing the update server by using the web console
+
+Changing the update server is optional. If you have an OpenShift Update Service (OSUS) installed and configured locally, you must set the URL for the server as the `upstream` to use the local server during updates.
+
+.Procedure
+
+. Navigate to *Administration* -> *Cluster Settings*, click *version*.
+. Click the *YAML* tab and then edit the `upstream` parameter value:
++
+.Example output
++
+[source,yaml]
+----
+  ...
+  spec:
+    clusterID: db93436d-7b05-42cc-b856-43e11ad2d31a
+    upstream: '<update-server-url>' <1>
+  ...
+----
+<1> The `<update-server-url>` variable specifies the URL for the update server.
++
+The default `upstream` is `\https://api.openshift.com/api/upgrades_info/v1/graph`.
+
+. Click *Save*.

--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -44,3 +44,5 @@ include::modules/update-using-custom-machine-config-pools-canary.adoc[leveloffse
 If you want to use the canary rollout update process, see xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update].
 
 include::modules/update-upgrading-web.adoc[leveloffset=+1]
+
+include::modules/update-changing-update-server-web.adoc[leveloffset=+1]

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -35,3 +35,5 @@ include::modules/update-service-overview.adoc[leveloffset=+1]
 include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
 include::modules/update-upgrading-cli.adoc[leveloffset=+1]
+
+include::modules/update-changing-update-server-cli.adoc[leveloffset=+1]

--- a/updating/updating-cluster.adoc
+++ b/updating/updating-cluster.adoc
@@ -28,4 +28,6 @@ include::modules/update-service-overview.adoc[leveloffset=+1]
 
 include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
+include::modules/update-changing-update-server-web.adoc[leveloffset=+1]
+
 include::modules/update-upgrading-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes: [BZ1995435](https://bugzilla.redhat.com/show_bug.cgi?id=1995435)
This PR adds the steps to change the default upstream parameter in
Cluster Version. The step is added for both the procedures:
1. Updating a cluster by using the CLI
2. Updating a cluster by using the web console

Applicable OCP version: 4.6, 4.7, 4.8, 4.9
Preview: 

- [CLI](https://deploy-preview-36033--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#update-changing-update-server-cli_updating-cluster-cli)
- [Web1](https://deploy-preview-36033--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-between-minor.html#update-changing-update-server-web_updating-cluster-between-minor)
- [Web2](https://deploy-preview-36033--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster?utm_source=github&utm_campaign=bot_dp#update-changing-update-server-web_updating-cluster)


QA contact: @shellyyang1989 
