### PR TITLE
BZ20000645: rm incorrect mpath sentence

### DIFF
--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -26,6 +26,13 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :ibm-z:
 :restricted:
 endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z-kvm:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z-kvm:
+:restricted:
+endif::[]
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
@@ -146,8 +153,8 @@ command.
 If the pod logs display, the Kubernetes API server can communicate with the
 cluster machines.
 
-ifndef::ibm-power[]
-. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing. Do not enable multipathing during installation.
+ifndef::ibm-power,ibm-z,ibm-z-kvm[]
+. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing.
 +
 [NOTE]
 ====
@@ -155,7 +162,7 @@ When installing with multipath, it is strongly recommended to enable it at insta
 ====
 +
 See "Enabling multipathing with kernel arguments on {op-system}" in the _Installing on bare metal_ documentation for more information.
-endif::ibm-power[]
+endif::ibm-power,ibm-z,ibm-z-kvm[]
 ifdef::ibm-power[]
 . Additional steps are required to enable multipathing. Do not enable multipathing during installation.
 +
@@ -180,7 +187,7 @@ sde
 +
 If the original boot disk path is down, the node reboots from the alternate device registered in the normal boot device list.
 endif::ibm-power[]
-ifdef::ibm-z,ibm-power[]
+ifdef::ibm-power[]
 .. All the worker nodes are restarted. To monitor the process, enter the following command:
 +
 [source,terminal]
@@ -192,7 +199,13 @@ $ oc get nodes -w
 ====
 If you have additional machine types such as infrastructure nodes, repeat the process for these types.
 ====
-endif::ibm-z,ibm-power[]
+endif::ibm-power[]
+
+ifdef::ibm-z[]
+. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing. Do not enable multipathing during installation.
++
+See "Enabling multipathing with kernel arguments on {op-system}" in the _Post-installation machine configuration tasks_ documentation for more information.
+endif::ibm-z[]
 
 ifdef::restricted[]
 . Register your cluster on the link:https://console.redhat.com/openshift/register[Cluster registration] page.
@@ -223,4 +236,11 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
 :restricted:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z-kvm:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z-kvm:
+:!restricted:
 endif::[]

--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -11,7 +11,6 @@
 ====
 Enabling multipathing during installation is supported and recommended for nodes provisioned in {product-title} 4.8 or higher. In setups where any I/O to non-optimized paths results in I/O system errors, you must enable multipathing at installation time. For more information about enabling multipathing during installation time, see "Enabling multipathing with kernel arguments on RHCOS" in the _Installing on bare metal_ documentation.
 ====
-
 [IMPORTANT]
 ====
 On IBM Z and LinuxONE, you can enable multipathing only if you configured your cluster for it during installation. For more information, see "Installing {op-system} and starting the {product-title} bootstrap process" in _Installing a cluster with z/VM on IBM Z and LinuxONE_.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2000645
The sentence, "Do not enable multipathing during installation", conflicts with the note that follows it and should be removed.

This applies to 4.8+.

**Preview link for bare metal UPI doc (see step 3):**
https://deploy-preview-36051--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-complete-user-infra_installing-bare-metal

**Preview link for Power Z UPI doc (see step 3):**
https://deploy-preview-36051--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html

Cc: @SNiemann15 