### PR TITLE
BYO RHEL 7 compute machines is still deprecated in 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1247,6 +1247,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|Bring your own RHEL 7 compute machines
+|DEP
+|DEP
+|DEP
+
 |External provisioner for AWS EFS
 |REM
 |REM


### PR DESCRIPTION
Preview: https://deploy-preview-36056--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-removed-features