### PR TITLE
BYO RHEL 7 compute machines is still deprecated in 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -259,6 +259,11 @@ In the table, features are marked with the following statuses:
 |DEP
 |
 
+|Bring your own RHEL 7 compute machines
+|DEP
+|DEP
+|DEP
+
 |`lastTriggeredImageID` field in the `BuildConfig` spec for Builds
 |GA
 |DEP


### PR DESCRIPTION
Preview: https://deploy-preview-36058--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features