### PR TITLE
added notes for 4.6.44 release

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3235,8 +3235,23 @@ Space precluded documenting all of the container images for this release in the 
 
 link:https://access.redhat.com/solutions/6278101[{product-title} 4.6.43 container image list]
 
-
 [id="ocp-4-6-43-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-44"]
+=== RHBA-2021:3395 - {product-title} 4.6.44 bug fix update
+
+Issued: 2021-09-08
+
+{product-title} release 4.6.44 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3395[RHBA-2021:3395] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3396[RHSA-2021:3396] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6303991[{product-title} 4.6.44 container image list]
+
+[id="ocp-4-6-44-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.6.44

- Applies to `enterprise-4.6`
- [Preview link](https://deploy-preview-36060--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-44)