### PR TITLE
[RHACS] Added release notes for 3.65

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -33,6 +33,8 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-acs
 Topics:
+- Name: Red Hat Advanced Cluster Security for Kubernetes 3.65
+  File: 365-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.64
   File: 364-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.63

--- a/configuration/enable-offline-mode.adoc
+++ b/configuration/enable-offline-mode.adoc
@@ -80,7 +80,7 @@ include::modules/upload-definitions-to-central-api-token.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../cli/getting-started-cli.html#cli-authentication_cli-getting-started[Authenticating using the roxctl CLI]
+* xref:../cli/getting-started-cli.adoc#cli-authentication_cli-getting-started[Authenticating using the roxctl CLI]
 
 //Upload the definitions to Central (admin password)
 include::modules/upload-definitions-to-central-admin-pass.adoc[leveloffset=+3]

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -40,10 +40,10 @@ endif::[]
 :mtc-version: 1.4
 :mtc-version-z: 1.4.2
 :ocp: OpenShift Container Platform
-:rhacs-version: 3.64.1
+:rhacs-version: 3.65.0
 :ocp-supported-version: 4.5
-:scanner-version: 2.18.3
-:collector-version: 3.2.2-latest
+:scanner-version: 2.19.0
+:collector-version: 3.3.0-latest
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty
 // Following variables are used in modules/adding-comments.adoc and modules/adding-tags.adoc

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -56,6 +56,15 @@ The default value is `false`.
 | `admissionControl.resources.requests`
 | Use this parameter to override the default resource requests for the admission controller.
 
+| `admissionControl.bypass`
+| Use this parameter to bypass the admission controller.
+
+| `admissionControl.contactImageScanners`
+| Specify `true` to enable inline scanning of images that are not already scanned during a deployment's admission review.
+
+| `admissionControl.timeoutSeconds`
+| Use this parameter to specify the maximum number of seconds {product-title} should wait for an admission review before marking it as fail open.
+
 |===
 
 [id="image-configuration-settings_{context}"]

--- a/release_notes/365-release-notes.adoc
+++ b/release_notes/365-release-notes.adoc
@@ -1,0 +1,87 @@
+[id="365-release-notes"]
+= Red Hat Advanced Cluster Security for Kubernetes 3.65
+include::modules/common-attributes.adoc[]
+:context: 365-release-notes
+
+toc::[]
+
+{product-title} (RHACS) 3.65 includes feature enhancements, bug fixes, scale improvements, and other changes.
+
+*Release date:* September 6, 2021
+
+[id="new-features"]
+== New features
+
+[id="mitre-attck-containers-matrix"]
+=== MITRE ATT&CK Containers Matrix
+You can now use the link:https://attack.mitre.org/matrices/enterprise/containers/[MITRE ATT&CK Containers Matrix] to categorize policies in the {product-title}. When you xref:../operating/manage-security-policies.adoc#create-custom-policies[create custom security policies], you can now add MITRE ATT&CK Matrix adversary tactics and techniques related information.
+
+[id="install-on-more-platforms"]
+=== Install on more platforms
+You can now install {product-title} on:
+
+* link:https://aws.amazon.com/rosa/[Red Hat OpenShift Service on AWS (ROSA)]
+* link:https://azure.microsoft.com/en-au/services/openshift/#overview[Azure Red Hat OpenShift]
+
+[id="admission-control-configuration"]
+=== Admission control configuration
+You can now configure the dynamic admission control settings in the {product-title} Operator. It now includes the following new admission control settings:
+
+* `admissionControl.bypass`: Use this parameter to bypass the admission controller.
+* `admissionControl.contactImageScanners`: Specify `true` to enable inline scanning of images that are not already scanned during a deployment's admission review.
+* `admissionControl.timeoutSeconds`: Use this parameter to specify the maximum number of seconds {product-title} should wait for an admission review before marking it as fail open.
+
+See xref:../installing/install-ocp-operator.adoc#addmission-controller-settings_install-ocp-operator[admission controller settings] to view all available configuration options.
+
+[id="important-bug-fixes"]
+== Important bug fixes
+
+* *ROX-6988*: Previously, {product-title} did not delete the CVEs and did not update the advisory when some Red Hat packages that transitioned from unfixable to a fixable state.
+* *ROX-7170*: Previously, {product-title} only collected the error logs in the diagnostic bundle if you have installed {product-title} services in the `stackrox` namespace.
+* *ROX-7861*: Previously, {product-title} compliance control NIST 800-190 Control 4.1.4 did not correctly detect policies used for secrets protection.
+
+[id="important-system-changes"]
+== Important system changes
+
+* {product-title} 3.65 includes the updated `host-pid` policy, which adds an exception for the `openshift-sdn` namespace because the `sdn` deployment in the `openshift-sdn` namespace shares the host process namespace, and it resulted in an inaccurate violation.
+* The alert notification titles for PagerDuty, Slack, Microsoft Teams, JIRA, and email notifiers now include the cluster and the policy names in addition to the deployment or image name if it exists.
+* The alert notification for PagerDuty now includes the full alert in the JSON format as a custom detail.
+* All default policy criteria for security policies are now read-only. However, you can still edit the policy criteria fields for the custom policies or policies you create by cloning a system policy.
+
+[id="upcoming-changes"]
+== Upcoming changes
+
+* In {product-title} 3.66, Red Hat will deprecate the following default security policies:
+
+** `DockerHub NGINX 1.10`
+** `Shellshock: Multiple CVEs`
+** `Heartbleed: CVE-2014-0160`
+
+* In {product-title} 3.66, Red Hat will disable the following default security policy:
+** `DOCKER CIS 4.4: Ensure images are scanned and rebuilt to include security patches`
+
+You can create custom policies to monitor for these violations.
+
+[id="image-versions"]
+== Image versions
+
+|===
+| Image | Description | Current version
+
+| Main
+| Includes Central, Sensor, Admission Controller, and Compliance.
+Also includes `roxctl` for use in continuous integration (CI) systems.
+| registry.redhat.io/rh-acs/main:3.65.0
+
+| Scanner
+| Scans images and nodes.
+| registry.redhat.io/rh-acs/scanner:2.19.0
+
+| Scanner DB
+| Stores image scan results and vulnerability definitions.
+| registry.redhat.io/rh-acs/scanner-db:2.19.0
+
+| Collector
+| Collects runtime activity in Kubernetes or {ocp} clusters.
+| registry.redhat.io/rh-acs/collector:3.3.0-latest
+|===


### PR DESCRIPTION
Includes:
- Release notes for 3.65
- Updated image tags
- new settings for admission control
- 1 nit fix

Preview: https://openshift-docs-git-rel-notes-65-gnelson.vercel.app/openshift-acs/master/release_notes/365-release-notes.html

NOTES:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
