### PR TITLE
Added notes for release 4.7.29

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2745,11 +2745,11 @@ With this update, installation in the Amazon Web Services (AWS) `ap-northeast-3`
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-23"]
-=== RHSA-2021:2977 - {product-title} 4.7.23 bug fix update
+=== RHSA-2021:2977 - {product-title} 4.7.23 bug fix and security update
 
 Issued: 2021-08-10
 
-{product-title} release 4.7.23 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:2977[RHSA-2021:2977] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2979[RHBA-2021:2979] advisory.
+{product-title} release 4.7.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:2977[RHSA-2021:2977] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:2979[RHBA-2021:2979] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2808,6 +2808,29 @@ link:https://access.redhat.com/solutions/6284521[{product-title} 4.7.28 containe
 * Previously, when a deployment was created with an invalid image stream, or unresloved image, it resulted in an inconsistent state between the deployment controller and the API server's `imagepolicy` plugin. Consequently, it could cause an infinite number of replica sets and reach the etcd quota limit, which could crash the entire {product-title} cluster. This update lowers the responsibilities of the API server's `imagepolicy` plugin. As a result, inconsistent image stream resolution will not occur in the deployments. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981775[*BZ#1981775*])
 
 [id="ocp-4-7-28-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-29"]
+=== RHSA-2021:3303 - {product-title} 4.7.29 bug fix and security update
+
+Issued: 2021-09-07
+
+{product-title} release 4.7.29, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2021:3303[RHSA-2021:3303] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3304[RHBA-2021:3304] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6306331[{product-title} 4.7.29 container image list]
+
+[id="ocp-4-7-29-bug-fixes"]
+==== Bug fixes
+
+* The address set naming convention used in OVN-Kubernetes for {product-title} 4.5 was changed in {product-title} 4.6, but the migration of existing address sets to the new naming convention was not handled as part of the upgrade. Network policies that were created in version 4.5 with namespace selector criteria for their ingress or egress sections rely on matching old address sets that were not kept up-to-date with the pod IP addresses within such namespaces. These policies might not work correctly in 4.6 or later releases and might allow or drop unexpected traffic.
++
+Previously, the workaround was to remove and recreate these policies. With this release, address sets with the old naming convention are removed, and policy ACLs referencing the old address sets are updated to reference the address sets following the new naming convention during the OVN-Kubernetes upgrade. Affected network policies created in version 4.5 work correctly again after upgrade. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976242[*BZ#1976242*])
+
+[id="ocp-4-7-29-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.7.29.

* applies only to `enterprise-4.7`
* the bug, BZ#1976242, was ported from a 4.8 release, and the doc text was already peer reviewed in #35867
* [direct preview link](https://deploy-preview-36071--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-29)