### PR TITLE
IBM Z Performance Recommendations - update attribute for rhel first

### DIFF
--- a/scalability_and_performance/ibm-z-recommended-host-practices.adoc
+++ b/scalability_and_performance/ibm-z-recommended-host-practices.adoc
@@ -14,7 +14,7 @@ The s390x architecture is unique in many aspects. Therefore, some recommendation
 
 [NOTE]
 ====
-Unless stated otherwise, these practices apply to both z/VM and {op-system-base-first} KVM installations on IBM Z and LinuxONE.
+Unless stated otherwise, these practices apply to both z/VM and {op-system-base-full} KVM installations on IBM Z and LinuxONE.
 ====
 
 include::modules/ibm-z-managing-cpu-overcommitment.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP versions to cherrypick: 4.7, 4.8 and later

Attribute suggested here didn' resolve https://github.com/openshift/openshift-docs/pull/35822#discussion_r700284638

https://deploy-preview-36072--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ibm-z-recommended-host-practices.html
