### PR TITLE
BZ#1889250: Add the output for "openshift create manifests" command

### DIFF
--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -94,8 +94,29 @@ $ mkdir $HOME/clusterconfig
 [source,terminal]
 ----
 $ openshift-install create manifests --dir $HOME/clusterconfig
+----
++
+.Example output
++
+[source,terminal]
+----
 ? SSH Public Key ...
+INFO Credentials loaded from the "myprofile" profile in file "/home/myuser/.aws/credentials"
+INFO Consuming Install Config from target directory
+INFO Manifests created in: $HOME/clusterconfig/manifests and $HOME/clusterconfig/openshift
+----
+
+. Optional: Confirm that the installation program created manifests in the `clusterconfig/openshift` directory:
++
+[source,terminal]
+----
 $ ls $HOME/clusterconfig/openshift/
+----
++
+.Example output
++
+[source,terminal]
+----
 99_kubeadmin-password-secret.yaml
 99_openshift-cluster-api_master-machines-0.yaml
 99_openshift-cluster-api_master-machines-1.yaml


### PR DESCRIPTION
The PR adds the example output for "openshift create manifests" command.
This fix is for BZ1889250.
OCP version: 4.6
Preview: [link](https://deploy-preview-36078--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-disk-partitioning-upi-templates_installing-gcp-user-infra)
QA contact: @jianli-wei

Signed-off-by: Servesha Dudhgaonkar sdudhgao@redhat.com