### PR TITLE
OSDOCS-2203: Add a table of `v1beta1` APIs removed by k8s v1.22

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -203,7 +203,7 @@ For more information, see xref:../support/remote_health_monitoring/insights-oper
 
 In {product-title} 4.9, the Insights Operator collects the following additional information:
 
-* All of the `MachineConfig` resource definitions from a cluster. 
+* All of the `MachineConfig` resource definitions from a cluster.
 * The names of the `PodSecurityPolicies` installed in a cluster.
 * If installed, the `ClusterLogging` resource definition.
 * If the `SamplesImagestreamImportFailing` alert is firing, then the `ImageStream` definitions and the last 100 lines of container logs from the `openshift-cluster-samples-operator` namespace.
@@ -338,6 +338,106 @@ In the table, features are marked with the following statuses:
 
 [id="ocp-4-9-removed-features"]
 === Removed features
+
+[id="ocp-4-9-removed-kube-1-22-apis"]
+==== Beta APIs removed from Kubernetes 1.22
+
+Kubernetes 1.22 removed the following deprecated `v1beta1` APIs. Migrate manifests and API clients to use the `v1` API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22[Kubernetes documentation].
+
+.`v1beta1` APIs removed from Kubernetes 1.22
+[cols="2,2,1",options="header",]
+|===
+|Resource |API |Notable changes
+
+|`APIService`
+|`apiregistration.k8s.io/v1beta1`
+|No
+
+|`CertificateSigningRequest`
+|`certificates.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#certificatesigningrequest-v122[Yes]
+
+|`ClusterRole`
+|`rbac.authorization.k8s.io/v1beta1`
+|No
+
+|`ClusterRoleBinding`
+|`rbac.authorization.k8s.io/v1beta1`
+|No
+
+|`CSIDriver`
+|`storage.k8s.io/v1beta1`
+|No
+
+|`CSINode`
+|`storage.k8s.io/v1beta1`
+|No
+
+|`CustomResourceDefinition`
+|`apiextensions.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122[Yes]
+
+|`Ingress`
+|`extensions/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122[Yes]
+
+|`Ingress`
+|`networking.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#ingress-v122[Yes]
+
+|`IngressClass`
+|`networking.k8s.io/v1beta1`
+|No
+
+|`Lease`
+|`coordination.k8s.io/v1beta1`
+|No
+
+|`LocalSubjectAccessReview`
+|`authorization.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#subjectaccessreview-resources-v122[Yes]
+
+|`MutatingWebhookConfiguration`
+|`admissionregistration.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122[Yes]
+
+|`PriorityClass`
+|`scheduling.k8s.io/v1beta1`
+|No
+
+|`Role`
+|`rbac.authorization.k8s.io/v1beta1`
+|No
+
+|`RoleBinding`
+|`rbac.authorization.k8s.io/v1beta1`
+|No
+
+|`SelfSubjectAccessReview`
+|`authorization.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#subjectaccessreview-resources-v122[Yes]
+
+|`StorageClass`
+|`storage.k8s.io/v1beta1`
+|No
+
+|`SubjectAccessReview`
+|`authorization.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#subjectaccessreview-resources-v122[Yes]
+
+|`TokenReview`
+|`authentication.k8s.io/v1beta1`
+|No
+
+|`ValidatingWebhookConfiguration`
+|`admissionregistration.k8s.io/v1beta1`
+|link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#webhook-resources-v122[Yes]
+
+|`VolumeAttachment`
+|`storage.k8s.io/v1beta1`
+|No
+
+|===
 
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
4.9 Release notes  

Part of [OSDOCS-2203](https://issues.redhat.com/browse/OSDOCS-2203)

Docs preview: https://deploy-preview-36083--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-removed-kube-1-22-apis

Merge before: #36313