### PR TITLE
TELCODOCS-250: D/S Docs & RN: MPINSTALL-1, Worker deployment via virtualmedia on either provisioning/controlplane network

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
@@ -3,6 +3,8 @@
 include::modules/common-attributes.adoc[]
 :context: ipi-install-expanding
 
+toc::[]
+
 After deploying an installer-provisioned {product-title} cluster, you can use the following procedures to expand the number of worker nodes. Ensure that each prospective worker node meets the prerequisites.
 
 [NOTE]
@@ -12,6 +14,8 @@ Expanding the cluster using RedFish Virtual Media involves meeting minimum firmw
 
 include::modules/ipi-install-preparing-the-bare-metal-node.adoc[leveloffset=+1]
 
-include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+2]
+include::modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc[leveloffset=+1]
+
+include::modules/ipi-install-diagnosing-duplicate-mac-address.adoc[leveloffset=+1]
 
 include::modules/ipi-install-provisioning-the-bare-metal-node.adoc[leveloffset=+1]

--- a/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
+++ b/modules/ipi-install-preparing-to-deploy-with-virtual-media-on-the-baremetal-network.adoc
@@ -1,0 +1,123 @@
+// This is included in the following assemblies:
+//
+// installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc
+
+[id="preparing-to-deploy-with-virtual-media-on-the-baremetal-network_{context}"]
+= Preparing to deploy with Virtual Media on the baremetal network
+
+If the `provisioning` network is enabled and you want to expand the cluster using Virtual Media on the `baremetal` network, use the following procedure.
+
+.Prerequisites
+
+* There is an existing cluster with a `baremetal` network and a `provisioning` network.
+
+.Procedure
+
+. Edit the `provisioning` custom resource (CR) to enable deploying with Virtual Media on the `baremetal` network:
++
+[source,terminmal]
+----
+oc edit provisioning
+----
++
+[source,yaml]
+----
+  apiVersion: metal3.io/v1alpha1
+  kind: Provisioning
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:50Z"
+    finalizers:
+    - provisioning.metal3.io
+    generation: 8
+    name: provisioning-configuration
+    resourceVersion: "551591"
+    uid: f76e956f-24c6-4361-aa5b-feaf72c5b526
+  spec:
+    preProvisioningOSDownloadURLs: {}
+    provisioningDHCPRange: 172.22.0.10,172.22.0.254
+    provisioningIP: 172.22.0.3
+    provisioningInterface: enp1s0
+    provisioningNetwork: Managed
+    provisioningNetworkCIDR: 172.22.0.0/24
+    provisioningOSDownloadURL: http://192.168.111.1/images/rhcos-<version>.x86_64.qcow2.gz?sha256=<sha256>
+    virtualMediaViaExternalNetwork: true <1>
+  status:
+    generations:
+    - group: apps
+      hash: ""
+      lastGeneration: 7
+      name: metal3
+      namespace: openshift-machine-api
+      resource: deployments
+    - group: apps
+      hash: ""
+      lastGeneration: 1
+      name: metal3-image-cache
+      namespace: openshift-machine-api
+      resource: daemonsets
+    observedGeneration: 8
+    readyReplicas: 0
+----
++
+<1> Add `virtualMediaViaExternalNetwork: true` to the `provisioning` CR.
+
+
+. Edit the machineset to use the API VIP address:
++
+[source,terminal]
+----
+oc edit machineset
+----
++
+[source,yaml]
+----
+  apiVersion: machine.openshift.io/v1beta1
+  kind: MachineSet
+  metadata:
+    creationTimestamp: "2021-08-05T18:51:52Z"
+    generation: 11
+    labels:
+      machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+      machine.openshift.io/cluster-api-machine-role: worker
+      machine.openshift.io/cluster-api-machine-type: worker
+    name: ostest-hwmdt-worker-0
+    namespace: openshift-machine-api
+    resourceVersion: "551513"
+    uid: fad1c6e0-b9da-4d4a-8d73-286f78788931
+  spec:
+    replicas: 2
+    selector:
+      matchLabels:
+        machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+        machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+    template:
+      metadata:
+        labels:
+          machine.openshift.io/cluster-api-cluster: ostest-hwmdt
+          machine.openshift.io/cluster-api-machine-role: worker
+          machine.openshift.io/cluster-api-machine-type: worker
+          machine.openshift.io/cluster-api-machineset: ostest-hwmdt-worker-0
+      spec:
+        metadata: {}
+        providerSpec:
+          value:
+            apiVersion: baremetal.cluster.k8s.io/v1alpha1
+            hostSelector: {}
+            image:
+              checksum: http:/172.22.0.3:6181/images/rhcos-<version>.x86_64.qcow2.<md5sum> <1>
+              url: http://172.22.0.3:6181/images/rhcos-<version>.x86_64.qcow2 <2>
+            kind: BareMetalMachineProviderSpec
+            metadata:
+              creationTimestamp: null
+            userData:
+              name: worker-user-data
+  status:
+    availableReplicas: 2
+    fullyLabeledReplicas: 2
+    observedGeneration: 11
+    readyReplicas: 2
+    replicas: 2
+----
++
+<1> Edit the `checksum` URL to use the API VIP address.
+<2> Edit the `url` URL to use the API VIP address.


### PR DESCRIPTION
Enables deployment with Virtual Media over baremetal network even if provisioning network is available.

Fixes: [TELCODOCS-250](https://issues.redhat.com/browse/TELCODOCS-250)

See https://issues.redhat.com/browse/TELCODOCS-250 for additional details.

Preview URL: https://deploy-preview-36089--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster?utm_source=github&utm_campaign=bot_dp#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
