### PR TITLE
Added kubeletConfig API note to the Nodes docs

### DIFF
--- a/modules/nodes-nodes-managing-about.adoc
+++ b/modules/nodes-nodes-managing-about.adoc
@@ -5,7 +5,12 @@
 [id="nodes-nodes-managing-about_{context}"]
 = Modifying nodes
 
-To make configuration changes to a cluster, or machine pool, you must create a custom resource definition (CRD), or `KubeletConfig` object. {product-title} uses the Machine Config Controller to watch for changes introduced through the CRD to apply the changes to the cluster.
+To make configuration changes to a cluster, or machine pool, you must create a custom resource definition (CRD), or `kubeletConfig` object. {product-title} uses the Machine Config Controller to watch for changes introduced through the CRD to apply the changes to the cluster.
+
+[NOTE]
+====
+Because the fields in a `kubeletConfig` object are passed directly to the kubelet from upstream Kubernetes, the validation of those fields is handled directly by the kubelet itself. Please refer to the relevant Kubernetes documentation for the valid values for these fields. Invalid values in the `kubeletConfig` object can render cluster nodes unusable.
+====
 
 .Procedure
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2001130

Qi Wang suggested adding the [admonition in the 4.8 kubeletConfig API docs](https://docs.openshift.com/container-platform/4.8/rest_api/machine_apis/kubeletconfig-machineconfiguration-openshift-io-v1.html#apismachineconfiguration-openshift-iov1kubeletconfigs) to the API docs for 4.6 or 4.7. However, we cannot make edits to the API docs directly. 

The  seems to be important information that should be added to the proper doc set.  Qi agreed with adding the node "It's important to note..." sentences from the API docs to the [Managing Node assembly](https://docs.openshift.com/container-platform/4.8/nodes/nodes/nodes-nodes-managing.html) where we introduce the kubeletConfig object.