### PR TITLE
OSDOCS-2617: clarify credentials rotation for Azure

### DIFF
--- a/modules/manually-rotating-cloud-creds.adoc
+++ b/modules/manually-rotating-cloud-creds.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * post_installation_configuration/cluster-tasks.adoc
+// * authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc
 
 [id="manually-rotating-cloud-creds_{context}"]
 = Rotating cloud provider credentials manually
@@ -27,6 +28,11 @@ You can also use the command line interface to complete all parts of this proced
 * You have changed the credentials that are used to interface with your cloud provider.
 
 * The new credentials have sufficient permissions for the mode CCO is configured to use in your cluster.
+
+[NOTE]
+====
+When rotating the credentials for an Azure cluster that is using mint mode, do not delete or replace the service principal that was used during installation. Instead, generate new Azure service principal client secrets and update the {product-title} secrets accordingly.
+====
 
 .Procedure
 


### PR DESCRIPTION
Addressing https://issues.redhat.com/browse/OSDOCS-2617 for 4.7+

Preview: https://deploy-preview-36093--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-mint.html#manually-rotating-cloud-creds_cco-mode-mint