### PR TITLE
Adds 4.8.10 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2606,3 +2606,19 @@ Previously, the workaround was to remove and recreate these policies. With this 
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-10"]
+=== RHBA-2021:3299 - {product-title} 4.8.10 bug fix update
+
+Issued: 2021-09-06
+
+{product-title} release 4.8.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3299[RHBA-2021:3299] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3300[RHBA-2021:3300] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6308491[{product-title} 4.8.10 container image list]
+
+[id="ocp-4-8-10-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
No BZ

Preview: https://deploy-preview-36097--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-10

Merge on 9-6 when the advisories status is ready to be shipped.