### PR TITLE
[BZ1886382] Added prerequisites for provisioning local volumes

### DIFF
--- a/modules/persistent-storage-local-create-cr.adoc
+++ b/modules/persistent-storage-local-create-cr.adoc
@@ -10,7 +10,10 @@ Local volumes cannot be created by dynamic provisioning. Instead, persistent vol
 .Prerequisites
 
 * The Local Storage Operator is installed.
-* Local disks are attached to the {product-title} nodes.
+* You have a local disk that meets the following conditions:
+** It is attached to a node.
+** It is not mounted.
+** It does not contain partitions.
 
 .Procedure
 


### PR DESCRIPTION
* Fixes [BZ1886382](https://bugzilla.redhat.com/show_bug.cgi?id=1886382)
* [Direct link: Provisioning local volumes by using the Local Storage Operator](https://deploy-preview-36104--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local?utm_source=github&utm_campaign=bot_dp#local-volume-cr_persistent-storage-local)

* Applies to `enterprise-4.6`, `enterprise-4.7`, `enterprise-4.8`, `enterprise-4.9` 
* FYI: @lpettyjo 