### PR TITLE
TELCODOCS-268: Removed TP, added new note

### DIFF
--- a/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc
@@ -11,6 +11,8 @@ As a cluster administrator, you can configure an additional network for your VRF
 [NOTE]
 ====
 Applications that use VRFs need to bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. `SO_BINDTODEVICE` binds the socket to a device that is specified in the passed interface name, for example, `eth1`. To use `SO_BINDTODEVICE`, the application must have `CAP_NET_RAW` capabilities.
+
+Using a VRF through the `ip vrf exec` command is not supported in {product-title} pods. To use VRF, bind applications directly to the VRF interface.
 ====
 
 [id="cnf-creating-an-additional-network-attachment-with-the-cni-vrf-plug-in_{context}"]

--- a/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
@@ -12,6 +12,8 @@ To do this, add the VRF configuration to the optional `metaPlugins` parameter of
 [NOTE]
 ====
 Applications that use VRFs need to bind to a specific device. The common usage is to use the `SO_BINDTODEVICE` option for a socket. `SO_BINDTODEVICE` binds the socket to a device that is specified in the passed interface name, for example, `eth1`. To use `SO_BINDTODEVICE`, the application must have `CAP_NET_RAW` capabilities.
+
+Using a VRF through the `ip vrf exec` command is not supported in {product-title} pods. To use VRF, bind applications directly to the VRF interface.
 ====
 
 [id="cnf-creating-an-additional-sriov-network-with-vrf-plug-in_{context}"]

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -16,9 +16,6 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
 
-:FeatureName: CNI VRF plug-in
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 include::modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc[leveloffset=+1]
 
 [id="configuring-sriov-device-next-steps"]

--- a/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
+++ b/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc
@@ -5,7 +5,4 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: CNI VRF plug-in
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 include::modules/cnf-assigning-a-secondary-network-to-a-vrf.adoc[leveloffset=+1]


### PR DESCRIPTION
4.9 documentation for: https://issues.redhat.com/browse/TELCODOCS-268

https://deploy-preview-36113--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.html

https://deploy-preview-36113--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-troubleshooting_configuring-sriov-device