### PR TITLE
BZ-1969946: Updating graph data container image

### DIFF
--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -9,7 +9,7 @@ The OpenShift Update Service requires a graph-data container image, from which t
 +
 [source,terminal]
 ----
-FROM registry.access.redhat.com/ubi8/ubi:8.1
+FROM registry.access.redhat.com/ubi8/ubi:latest
 
 RUN curl -L -o cincinnati-graph-data.tar.gz https://github.com/openshift/cincinnati-graph-data/archive/master.tar.gz
 


### PR DESCRIPTION
Applies to 4.6+ 
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1969946
Preview Link: [Creating the OpenShift Update Service graph data container image](https://deploy-preview-36114--osdocs.netlify.app/openshift-enterprise/latest/updating/installing-update-service.html#update-service-graph-data_update-service) procedure, Step 1.
QE ack required.
