### PR TITLE
CNV-5635: Documented UI for sysprep

### DIFF
--- a/modules/virt-creating-vm-wizard-web.adoc
+++ b/modules/virt-creating-vm-wizard-web.adoc
@@ -43,13 +43,16 @@ Create Network interface cards (NICs) and storage disks later and attach them to
 
 .. Optional: Click the Options menu {kebab} to edit the disk and save your changes.
 
-. Click *Next* to go to the *Advanced* step to review the details for *Cloud-init* and configure SSH access.
+. Click *Next* to go to the *Advanced* step and choose one of the following options:
 
+.. If you selected a Linux template to create the VM, review the details for *Cloud-init* and configure SSH access.
 +
 [NOTE]
 ====
 Statically inject an SSH key by using the custom script in cloud-init or in the wizard. This allows you to securely and remotely manage virtual machines and manage and transfer information. This step is strongly recommended to secure your VM. 
 ====
+
+.. If you selected a Windows template to create the VM, use the *SysPrep* section to upload answer files in XML format for automated Windows setup.
 
 . Click *Next* to go to the *Review* step and review the settings for the virtual machine.
 


### PR DESCRIPTION
This PR addresses [CNV-5635](https://issues.redhat.com/browse/CNV-5635)

Documented workflow for the new SysPrep section in the UI

Preview: https://deploy-preview-36115--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms?utm_source=github&utm_campaign=bot_dp#virt-creating-vm-wizard-web_virt-create-vms