### PR TITLE
BZ-1896679: Updated incorrect step

### DIFF
--- a/modules/update-oc-configmap-signature-verification.adoc
+++ b/modules/update-oc-configmap-signature-verification.adoc
@@ -18,7 +18,12 @@ If you are upgrading from a release prior to version 4.4.8, you must use the man
 
 .Procedure
 
-. Obtain the image signature for the version that you are upgrading to from either link:https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release[mirror.openshift.com] or link:https://storage.googleapis.com/openshift-release/official/signatures[Google Cloud Storage (GCS)].
+. Obtain the image signature for the version that you are upgrading to:
++
+[source,terminal]
+----
+$ oc adm release mirror --release-image-signature-to-dir 
+----
 
 . Use `oc` command-line interface (CLI) to log into the cluster that you are upgrading.
 


### PR DESCRIPTION
Applies to 4.6+
BZ Link: https://bugzilla.redhat.com/show_bug.cgi?id=1896679
Preview Link: [Creating the config map for image signature verification by using the `oc` CLI](https://deploy-preview-36116--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster?utm_source=github&utm_campaign=bot_dp#update-oc-configmap-signature-verification_updating-restricted-network-cluster), Step 1 of the procedure
QE ack required.