### PR TITLE
RHDEVDOCS-3285 Tracker for 1988271 ClusterLogging retentionPolicy doe…

### DIFF
--- a/modules/cluster-logging-elasticsearch-retention.adoc
+++ b/modules/cluster-logging-elasticsearch-retention.adoc
@@ -5,33 +5,21 @@
 [id="cluster-logging-elasticsearch-retention_{context}"]
 = Configuring log retention time
 
-You can specify how long the default Elasticsearch log store keeps indices using a separate _retention policy_ for each of the three log sources: infrastructure logs, application logs, and audit logs. The retention policy, which you configure using the `maxAge` parameter in the Cluster Logging custom resource (CR), is considered for the Elasticsearch roll over schedule and determines when Elasticsearch deletes the rolled-over indices.
+You can configure a _retention policy_ that specifies how long the default Elasticsearch log store keeps indices for each of the three log sources: infrastructure logs, application logs, and audit logs.
 
-Elasticsearch rolls over an index, moving the current index and creating a new
-index, when an index matches any of the following conditions:
+To configure the retention policy, you set a `maxAge` parameter for each log source in the `ClusterLogging` custom resource (CR). The CR applies these values to the Elasticsearch rollover schedule, which determines when Elasticsearch deletes the rolled-over indices.
+
+Elasticsearch rolls over an index, moving the current index and creating a new index, when an index matches any of the following conditions:
 
 * The index is older than the `rollover.maxAge` value in the `Elasticsearch` CR.
 * The index size is greater than 40 GB × the number of primary shards.
 * The index doc count is greater than 40960 KB × the number of primary shards.
 
-Elasticsearch deletes the rolled-over indices are deleted based on the
-retention policy you configure.
-
-If you do not create a retention policy for any of the log sources, logs
-are deleted after seven days by default.
-
-[IMPORTANT]
-====
-If you do not specify a retention policy  for all three log sources, only logs
-from the sources with a retention policy are stored. For example, if you
-set a retention policy for the infrastructure and applicaiton logs, but do not
-set a retention policy for audit logs, the audit logs will not be retained
-and there will be no *audit-* index in Elasticsearch or Kibana.
-====
+Elasticsearch deletes the rolled-over indices based on the retention policy you configure. If you do not create a retention policy for any log sources, logs are deleted after seven days by default.
 
 .Prerequisites
 
-* OpenShift Logging and Elasticsearch must be installed.
+* OpenShift Logging and the OpenShift Elasticsearch Operator must be installed.
 
 .Procedure
 
@@ -59,18 +47,11 @@ spec:
       nodeCount: 3
 ...
 ----
-<1> Specify the time that Elasticsearch should retain each log source. Enter an
-integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s).
-For example, `1d` for one day. Logs older than the `maxAge` are deleted.
-By default, logs are retained for seven days.
+<1> Specify the time that Elasticsearch should retain each log source. Enter an integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s). For example, `1d` for one day. Logs older than the `maxAge` are deleted. By default, logs are retained for seven days.
 
 . You can verify the settings in the `Elasticsearch` custom resource (CR).
 +
-For example, the Red Hat OpenShift Logging Operator updated the following
-`Elasticsearch` CR to configure a retention policy that includes settings
-to roll over active indices for the infrastructure logs every eight hours and
-the rolled-ver indices are deleted seven days after rollover. {product-title} checks
-every 15 minutes to determine if the indices need to be rolled over.
+For example, the Red Hat OpenShift Logging Operator updated the following `Elasticsearch` CR to configure a retention policy that includes settings to roll over active indices for the infrastructure logs every eight hours and the rolled-over indices are deleted seven days after rollover. {product-title} checks every 15 minutes to determine if the indices need to be rolled over.
 +
 [source,yaml]
 ----
@@ -93,23 +74,17 @@ spec:
         pollInterval: 15m <4>
 ...
 ----
-<1> For each log source, the retention policy indicates when to delete and
-rollover logs for that source.
-<2> When {product-title} deletes the rolled-over indices. This setting
-is the `maxAge` you set in the `ClusterLogging` CR.
-<3> The index age for {product-title} to consider when rolling over the indices.
-This value is determined from the `maxAge` you set in the `ClusterLogging` CR.
-<4> When {product-title} checks if the indices should be rolled over.
-This setting is the default and cannot be changed.
+<1> For each log source, the retention policy indicates when to delete and roll over logs for that source.
+<2> When {product-title} deletes the rolled-over indices. This setting is the `maxAge` you set in the `ClusterLogging` CR.
+<3> The index age for {product-title} to consider when rolling over the indices. This value is determined from the `maxAge` you set in the `ClusterLogging` CR.
+<4> When {product-title} checks if the indices should be rolled over. This setting is the default and cannot be changed.
 +
 [NOTE]
 ====
-Modifying the `Elasticsearch` CR is not supported. All changes to the retention
-policies must be made in the `ClusterLogging` CR.
+Modifying the `Elasticsearch` CR is not supported. All changes to the retention policies must be made in the `ClusterLogging` CR.
 ====
 +
-The OpenShift Elasticsearch Operator deploys a cron job to roll over indices for each
-mapping using the defined policy, scheduled using the `pollInterval`.
+The OpenShift Elasticsearch Operator deploys a cron job to roll over indices for each mapping using the defined policy, scheduled using the `pollInterval`.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
…sn't work as documented

This PR has the following purposes:
- Fix the specified bug by removing IMPORTANT admonition that contained incorrect and confusing information. 
- Remove line breaks.
- Create a strong abstract. 
- Not to refactor or rewrite the content. 

Other PR information:
- Aligned team: Dev Tools
- For branches: 4.6+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3285
- Direct link to doc preview: [Configuring log retention time
](https://deploy-preview-36121--osdocs.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-log-store.html#cluster-logging-elasticsearch-retention_cluster-logging-store)
- SME review: @periklis 
- QE review: @kabirbhartiRH 
- Peer review: @ 	tbd
- Ready for peer-review and merge.