### PR TITLE
Remove text that pull secret change reboots node

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -16,17 +16,9 @@ You can update the global pull secret for your cluster by either replacing the c
 Cluster resources must adjust to the new pull secret, which can temporarily limit the usability of the cluster.
 ====
 
-Updating the global pull secret causes the Machine Config Operator to drain the nodes, apply the change, and uncordon the nodes.
-
-[NOTE]
-====
-As of {product-title} 4.7, changes to the global pull secret no longer trigger a reboot.
-====
-
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-
 
 .Procedure
 . Optional: To append a new pull secret to the existing pull secret, complete the following steps:
@@ -60,7 +52,11 @@ Alternatively, you can perform a manual update to the pull secret file.
 $ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=<pull_secret_location> <1>
 ----
 <1> Provide the path to the new pull secret file.
-
-This update is rolled out to all nodes, which can take some time depending on the size of your cluster. During this time, nodes are drained and pods are rescheduled on the remaining nodes.
-
++
+This update is rolled out to all nodes, which can take some time depending on the size of your cluster. 
++
+[NOTE]
+====
+As of {product-title} 4.7.4, changes to the global pull secret no longer trigger a node drain or reboot.
+====
 //Also referred to as the cluster-wide pull secret.


### PR DESCRIPTION
Per [conversation in #forum-mco](https://coreos.slack.com/archives/C02CZNQHGN8/p1631037158019600) _Changing the cluster pull secret shouldn't cause a drain_.

Preview: https://deploy-preview-36129--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#images-update-global-pull-secret_post-install-cluster-tasks