### PR TITLE
[MULTIARCH-1125, 1067] Adding images for IBM Z and Power

### DIFF
--- a/applications/working_with_helm_charts/installing-helm.adoc
+++ b/applications/working_with_helm_charts/installing-helm.adoc
@@ -15,10 +15,26 @@ You can also find the URL to the latest binaries from the {product-title} web co
 == On Linux
 
 . Download the Helm binary and add it to your path:
+
+* Linux (x86_64, amd64)
 +
 [source,terminal]
 ----
 # curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-amd64 -o /usr/local/bin/helm
+----
+
+* Linux on IBM Z and LinuxONE (s390x)
++
+[source,terminal]
+----
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-s390x -o /usr/local/bin/helm
+----
+
+* Linux on IBM Power Systems (ppc64le)
++
+[source,terminal]
+----
+# curl -L https://mirror.openshift.com/pub/openshift-v4/clients/helm/latest/helm-linux-ppc64le -o /usr/local/bin/helm
 ----
 
 . Make the binary file executable:


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.9

- Jira: 
  - IBM Z: https://issues.redhat.com/browse/MULTIARCH-1125
  - IBM P: https://issues.redhat.com/browse/MULTIARCH-1067

- Preview: [Installing Helm on Linux](https://deploy-preview-36132--osdocs.netlify.app/openshift-enterprise/latest/applications/working_with_helm_charts/installing-helm?utm_source=github&utm_campaign=bot_dp) 

- QE review: 
  - IBM Z: Tom Dale, Wolfgang Voesch
  - IBM P: Pravin D-Silva

@ktania46 