### PR TITLE
OSDOCS-2184: Add features to vSphere CSI Operator Driver (TP)

### DIFF
--- a/modules/persistent-storage-csi-tp-enable.adoc
+++ b/modules/persistent-storage-csi-tp-enable.adoc
@@ -33,7 +33,7 @@ $ oc get co storage
 [source, terminal]
 ----
 NAME    VERSION                             AVAILABLE   PROGRESSING DEGRADED    SINCE
-storage 4.8.0-0.nightly-2021-04-30-201824   True        False       False       4h26m
+storage 4.9.0-0.nightly-2021-09-08-162532   True        False       False       4h26m
 ----
 +
 * `AVAILABLE` should be "True".

--- a/modules/persistent-storage-csi-vsphere-stor-policy.adoc
+++ b/modules/persistent-storage-csi-vsphere-stor-policy.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// persistent-storage-csi-vsphere.adoc
+//
+
+[id="persistent-storage-csi-vsphere-stor-policy_{context}"]
+= vSphere storage policy
+
+The vSphere CSI Operator Driver storage class uses vSphere's storage policy. {product-title} automatically creates a storage policy that targets datastore configured in cloud configuration:
+[output, yaml]
+----
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: thin-csi
+provisioner: csi.vsphere.vmware.com
+parameters:
+  StoragePolicyName: "$openshift-storage-policy-xxxx"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: false
+reclaimPolicy: Delete
+----

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -30,11 +30,12 @@ After full migration, in-tree plug-ins will eventually be removed in future vers
 ====
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
-.Additional resources
-* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
+
+include::modules/persistent-storage-csi-vsphere-stor-policy.adoc[leveloffset=+1]
 
 :FeatureName: vSphere
 include::modules/persistent-storage-csi-tp-enable.adoc[leveloffset=+1]
 
 == Additional resources
 * xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#[Enabling features using feature gates]
+* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
4.9+

[OSDOCS-2184](https://issues.redhat.com/browse/OSDOCS-2184): Add features to vSphere CSI Driver Operator as Tech Preview (TP).

Preview: https://deploy-preview-36145--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html

PTAL: @gnufied, @jhou1 