### PR TITLE
CNV-13292: bumping HCO var for 2.5.8

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.5
 :KubeVirtVersion: v0.34.1
-:HCOVersion: 2.5.7
+:HCOVersion: 2.5.8
 // :LastHCOVersion: 2.4.4
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- [CNV-13292](https://issues.redhat.com/browse/CNV-13292)
- no cherrypick