### PR TITLE
Adds xref to understanding compute resources section to configuring cluster memory assembly

### DIFF
--- a/nodes/clusters/nodes-cluster-resource-configure.adoc
+++ b/nodes/clusters/nodes-cluster-resource-configure.adoc
@@ -27,6 +27,10 @@ managing application memory by:
 
 include::modules/nodes-cluster-resource-configure-about.adoc[leveloffset=+1]
 
+.Additional resources
+* xref:../../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-overcommit-reserving-memory_nodes-cluster-overcommit[Understanding compute resources and containers]
+
+
 include::modules/nodes-cluster-resource-configure-jdk.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-configure-request-limit.adoc[leveloffset=+1]
@@ -34,5 +38,3 @@ include::modules/nodes-cluster-resource-configure-request-limit.adoc[leveloffset
 include::modules/nodes-cluster-resource-configure-oom.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-resource-configure-evicted.adoc[leveloffset=+1]
-
-


### PR DESCRIPTION
Small GH issue I thought I could tackle. 

GH: https://github.com/openshift/openshift-docs/issues/32986

Preview: https://deploy-preview-36149--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure?utm_source=github&utm_campaign=bot_dp#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure

Will need cherry-picked to 4.6 and 4.7. 