### PR TITLE
GH#36147 BM IPI support missed in intro text

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -16,6 +16,7 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * {rh-virtualization-first}
 * VMware vSphere
 * VMware Cloud (VMC) on AWS
+* Bare metal
 
 For these clusters, all machines, including the computer that you run the installation process on, must have direct internet access to pull images for platform containers and provide telemetry data to Red Hat.
 


### PR DESCRIPTION
Resolves #36147

Preview: https://deploy-preview-36158--osdocs.netlify.app/openshift-enterprise/latest/installing/index.html#supported-platforms-for-openshift-clusters_ocp-installation-overview

BM IPI support was introduced in OCP 4.6