### PR TITLE
BZ-2002311: Removing stray paragraph

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -91,12 +91,6 @@ $ oc label machineconfigpool worker custom-kubelet=set-max-pods
 
 .Procedure
 
-By default, only one machine is allowed to be unavailable when applying the
-kubelet-related configuration to the available worker nodes. For a large
-cluster, it can take a long time for the configuration change to be reflected.
-At any time, you can adjust the number of machines that are updating to speed up
-the process.
-
 . View the available machine configuration objects that you can select:
 +
 [source,terminal]

--- a/modules/modify-unavailable-workers.adoc
+++ b/modules/modify-unavailable-workers.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+// * post_installation_configuration/node-tasks.adoc
+
+[id="modify-unavailable-workers_{context}"]
+= Modifying the number of unavailable worker nodes
+
+By default, only one machine is allowed to be unavailable when applying the kubelet-related configuration to the available worker nodes. For a large cluster, it can take a long time for the configuration change to be reflected. At any time, you can adjust the number of machines that are updating to speed up the process.
+
+.Procedure
+
+. To edit the `worker` machine config pool, run the following command:
++
+----
+$ oc edit machineconfigpool worker
+----
+
+. Add the `maxUnavailable` parameter and value to the spec:
++
+----
+spec:
+  maxUnavailable: <node_count>
+----
++
+[IMPORTANT]
+====
+When setting the value, consider the number of worker nodes that can be
+unavailable without affecting the applications running on the cluster.
+====

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -55,6 +55,7 @@ include::modules/differences-between-machinesets-and-machineconfigpool.adoc[leve
 
 include::modules/recommended-node-host-practices.adoc[leveloffset=+1]
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+2]
+include::modules/modify-unavailable-workers.adoc[leveloffset=+2]
 include::modules/master-node-sizing.adoc[leveloffset=+2]
 include::modules/setting-up-cpu-manager.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -16,6 +16,8 @@ include::modules/recommended-node-host-practices.adoc[leveloffset=+1]
 
 include::modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc[leveloffset=+1]
 
+include::modules/modify-unavailable-workers.adoc[leveloffset=+1]
+
 include::modules/master-node-sizing.adoc[leveloffset=+1]
 
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2002311

**A paragraph somehow got added via a cherrypick. This removes the paragraph.**

Original PR: https://github.com/openshift/openshift-docs/pull/33056/files#diff-f8526981ec89a35c745acc038fb1fa91f5090e9d2f36bc9ac144c4452b67161aR94

Cherrypicks that added the paragraph: 
4.8
https://github.com/openshift/openshift-docs/pull/34269/files#diff-f8526981ec89a35c745acc038fb1fa91f5090e9d2f36bc9ac144c4452b67161aR94
4.7
https://github.com/openshift/openshift-docs/pull/34268/files#diff-f8526981ec89a35c745acc038fb1fa91f5090e9d2f36bc9ac144c4452b67161aR94

**The [cherrypicks from this PR](https://github.com/openshift/openshift-docs/pull/19034#issuecomment-574304898) did not work. I am adding the "modify-unavailable-workers.adoc" file created in PR 19034.**

Previews:
Scalability and Perf -> Recommended Host Practices -> [Modifying the number of unavailable worker nodes](https://deploy-preview-36164--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#modify-unavailable-workers_)

Post-installation -> Node Tasks -> https://deploy-preview-36164--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#modify-unavailable-workers_post-install-node-tasks