### PR TITLE
OSDOCS-2622: release note for CoreDNS version bump

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -469,7 +469,7 @@ For more information, see xref:../scalability_and_performance/using-topology-man
 * `hwladetect` measures the baseline that the bare hardware can achieve
 * `cyclictest` schedules a repeated timer after `hwlatdetect` passes validation and measures the difference between the desired and the actual trigger times
 
-For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-performing-end-to-end-tests-running-the-tests_cnf-master[Running the latency tests]. 
+For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-performing-end-to-end-tests-running-the-tests_cnf-master[Running the latency tests].
 
 [id="ocp-4-9-backup-and-restore"]
 === Backup and restore
@@ -520,7 +520,7 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 [discrete]
 [id="octavia-ovn-nodeport-changes"]
 ==== Octavia OVN NodePort changes
-Previously, on {rh-openstack-first} deployments, opening traffic on NodePorts was constrained to the CIDR of the node's subnet. In order to support LoadBalancer services using the Octavia Open Virtual Network (OVN) provider, the security group rules that allow NodePort traffic to master and worker nodes are now changed to open `0.0.0.0/0`. 
+Previously, on {rh-openstack-first} deployments, opening traffic on NodePorts was constrained to the CIDR of the node's subnet. In order to support LoadBalancer services using the Octavia Open Virtual Network (OVN) provider, the security group rules that allow NodePort traffic to master and worker nodes are now changed to open `0.0.0.0/0`.
 
 [discrete]
 [id="osp-loadbalancer-configuration-changes"]
@@ -531,9 +531,15 @@ The {rh-openstack-first} cloud provider LoadBalancer configuration now defaults 
 
 [discrete]
 [id="ocp-4-9-haproxy-2.2.15-upgrade"]
-=== Ingress Controller upgraded to HAProxy 2.2.15
+==== Ingress Controller upgraded to HAProxy 2.2.15
 
 The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.15.
+
+[discrete]
+[id="ocp-4-9-coreDNS-version-update"]
+==== CoreDNS update to version 1.8.4
+
+In {product-title} {product-version}, CoreDNS uses version 1.8.4, which includes bug fixes.
 
 [id="ocp-4-9-deprecated-removed-features"]
 == Deprecated and removed features
@@ -1077,7 +1083,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 
 * Installations on {rh-openstack-first} with Kuryr will not work if configured with a cluster-wide proxy when the cluster-wide proxy is required to access {rh-openstack} APIs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985486[*BZ#1985486*])
 
-* Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*]. 
+* Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*].
 
 
 [id="ocp-4-9-asynchronous-errata-updates"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2622

Preview: https://deploy-preview-36191--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-notable-technical-changes

Tagging Release Notes Tracker: https://github.com/openshift/openshift-docs/issues/33497