### PR TITLE
OSDOCS-2623: release note for HAProxy 2.2.15 version bump

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -77,7 +77,7 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 [id="ocp-4-9-expanding-with-virtual-media-on-baremetal-network"]
 ==== Expanding the cluster with Virtual Media on the baremetal network
 
-In {product-title} {product-version}, you can expand an installer provisioned cluster deployed using the `provisioning` network by using Virtual Media on the `baremetal` network. You can use this feature when the `ProvisioningNetwork` configuration setting is set to `Managed`. To use this feature, you must set the `virtualMediaViaExternalNetwork` configuration setting to `true` in the `provisioning` custom resource (CR). You must also edit the machineset to use the API VIP address. See xref:../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding[Preparing to deploy with Virtual Media on the baremetal network] for details. 
+In {product-title} {product-version}, you can expand an installer provisioned cluster deployed using the `provisioning` network by using Virtual Media on the `baremetal` network. You can use this feature when the `ProvisioningNetwork` configuration setting is set to `Managed`. To use this feature, you must set the `virtualMediaViaExternalNetwork` configuration setting to `true` in the `provisioning` custom resource (CR). You must also edit the machineset to use the API VIP address. See xref:../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding[Preparing to deploy with Virtual Media on the baremetal network] for details.
 
 [id="ocp-4-9-web-console"]
 === Web console
@@ -234,6 +234,12 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 {product-title} 4.9 introduces the following notable technical changes.
 
 // Note: use [discrete] for these sub-headings.
+
+[discrete]
+[id="ocp-4-9-haproxy-2.2.15-upgrade"]
+=== Ingress Controller upgraded to HAProxy 2.2.15
+
+The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.15.
 
 [id="ocp-4-9-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2623

Preview: https://deploy-preview-36192--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-notable-technical-changes

Tagging Release Notes Tracker: https://github.com/openshift/openshift-docs/issues/33497