### PR TITLE
OSDOCS-2279: Document managementState API for DNS

### DIFF
--- a/modules/nw-dns-operator-managementState.adoc
+++ b/modules/nw-dns-operator-managementState.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * networking/dns-operator.adoc
+
+[id="nw-dns-operator-managementState_{context}"]
+= Changing the DNS Operator managementState
+
+DNS manages the CoreDNS component to provide a name resolution service for pods and services in the cluster. The `managementState` of the DNS Operator is set to `Managed` by default, which means that the DNS Operator is actively managing its resources. You can change it to `Unmanaged`, which means the DNS Operator is not managing its resources.
+
+The following are use cases for changing the DNS Operator `managementState`:
+
+* You are a developer and want to test a configuration change to see if it fixes an issue in CoreDNS. You can stop the DNS Operator from overwriting the fix by setting the `managementState` to `Unmanaged`.
+
+* You are a cluster administrator and have reported an issue with CoreDNS, but need to apply a workaround until the issue is fixed. You can set the `managementState` field of the DNS Operator to `Unmanaged` to apply the workaround.
+
+.Procedure
+
+* Change `managementState` DNS Operator:
++
+[source,terminal]
+----
+oc patch dns.operator.openshift.io default --type merge --patch '{"spec":{"managementState":"Unmanaged"}}'
+----

--- a/modules/nw-dns-operator.adoc
+++ b/modules/nw-dns-operator.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * networking/dns/dns-operator.adoc
 
-[id="dns-operator_{context}"]
+[id="nw-dns-operator_{context}"]
 = DNS Operator
 
 The DNS Operator implements the `dns` API from the `operator.openshift.io` API

--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -11,6 +11,8 @@ service to pods, enabling DNS-based Kubernetes Service discovery in
 
 include::modules/nw-dns-operator.adoc[leveloffset=+1]
 
+include::modules/nw-dns-operator-managementState.adoc[leveloffset=+1]
+
 include::modules/nw-controlling-dns-pod-placement.adoc[leveloffset=+1]
 
 include::modules/nw-dns-view.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2279

Preview: https://deploy-preview-36197--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator.html#nw-dns-operator-managementState_dns-operator

