### PR TITLE
BZ1867056: remove legacy forwarding from fluentd

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -41,7 +41,7 @@ To send logs using the Fluentd *forward* protocol, create a configuration file c
     flush_thread_count "2"
     retry_max_interval "300"
     retry_forever true
-    overflow_action "exception"
+    overflow_action "#{ENV['BUFFER_QUEUE_FULL_ACTION'] || 'throw_exception'}"
   </buffer>
   <server>
     host fluent-receiver.example.com


### PR DESCRIPTION
Applies to 4.6+

Direct docs preview link: https://deploy-preview-36200--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external?utm_source=github&utm_campaign=bot_dp#cluster-logging-collector-legacy-fluentd_cluster-logging-external


https://bugzilla.redhat.com/show_bug.cgi?id=1867056

Requires QE ack from @anpingli