### PR TITLE
[BZ2002579] Restricted install RHEL KVM on IBM Z - add missing sections

### DIFF
--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -42,11 +42,9 @@ Be sure to also review this site list if you are configuring a proxy.
 
 include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 
-include::modules/installation-requirements-user-infra-ibm-z-kvm.adoc[leveloffset=+1]
-
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
-include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
+include::modules/installation-requirements-user-infra-ibm-z-kvm.adoc[leveloffset=+1]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
@@ -56,6 +54,12 @@ include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 * xref:../install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Configuring chrony time service]
 
 include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
+
+include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
+
+include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
+
+include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
@@ -106,6 +110,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+
 include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffset=+1]
 
 [id="additional-resources_ibmz-kvm-restricted"]


### PR DESCRIPTION
OCP versions for cherry-picking: enterprise-4.8, 4.9

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2002579
Aligning RHEL KVM restricted with the other Install docs for IBM Z

Preview: [Installing restricted networks with RHEL KVM on IBM Z and LinuxONE](https://deploy-preview-36202--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm?utm_source=github&utm_campaign=bot_dp)

QE review: Alexander Klein 