### PR TITLE
OSDOCS-2474: rel notes for web console

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -82,6 +82,10 @@ In {product-title} {product-version}, you can expand an installer provisioned cl
 [id="ocp-4-9-web-console"]
 === Web console
 
+[id="ocp-4-9-assessing-node-logs-from-the-node-details-page"]
+==== Accessing node logs from the *Node Details* page
+With this update, admins now have the ability to access node logs from the *Node Details* page. From there, you can switch between individual log files and journal log units in order to inquire about the node. 
+
 [id="ocp-4-9-ibm-z"]
 === IBM Z and LinuxONE
 
@@ -97,7 +101,7 @@ With this release, IBM Z and LinuxONE are now compatible with {product-title} {p
 
 The following new features are supported on IBM Z and LinuxONE with {product-title} {product-version}:
 
-* Helm 
+* Helm
 * Support for multiple network interfaces
 * Service Binding Operator
 
@@ -167,10 +171,10 @@ With this release, IBM Power Systems are now compatible with {product-title} {pr
 
 The following new features are supported on IBM Power Systems with {product-title} {product-version}:
 
-* Helm  
-* Support for Power10 
+* Helm
+* Support for Power10
 * Support for multiple network interfaces
-* Service Binding Operator 
+* Service Binding Operator
 
 [discrete]
 ==== Supported features


### PR DESCRIPTION
[OSDOCS-2474](https://issues.redhat.com/browse/OSDOCS-2474)

- Needs `enterprise-4.9` label
- [Preview link](https://deploy-preview-36209--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-web-console)