### PR TITLE
TELCODOCS: 293/294/303 - Added release notes for FIPS support, operator in disconnected mode, and must-gather tool. Also marked as TP for 4.9 in table.

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -195,6 +195,12 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 [id="ocp-4-9-sandboxed-containers"]
 === {sandboxed-containers-first}
 
+FIPS mode is now automatically enabled for {sandboxed-containers-first}. {sandboxed-containers-first} deployed on an {product-title} cluster installed in FIPS mode will not taint the cluster's FIPS support. For more information, see
+
+The {sandboxed-containers-operator} now includes a must-gather image, allowing you to collect custom resources and log files specific to this operator and the underlying runtime components for diagnostic purposes. For more information, see
+
+You can now install the Sandboxed container operator in a disconnected environment. For more information, see
+
 [id="ocp-4-9-notable-technical-changes"]
 == Notable technical changes
 
@@ -504,7 +510,7 @@ In the table below, features are marked with the following statuses:
 |OpenShift sandboxed containers
 |-
 |TP
-|
+|TP
 
 |Vertical Pod Autoscaler
 |TP


### PR DESCRIPTION
4.9 Release notes for:
- [KATA-453](https://issues.redhat.com/browse/KATA-453) ([TELCODOCS-293](https://issues.redhat.com/browse/TELCODOCS-293))
- [KATA-579](https://issues.redhat.com/browse/KATA-579) ([TELCODOCS-294](https://issues.redhat.com/browse/TELCODOCS-294))
- [KATA-752](https://issues.redhat.com/browse/KATA-752) ([TELCODOCS-303](https://issues.redhat.com/browse/TELCODOCS-303))

Content reviewed and approved by SMEs.

Also marked Sandboxed containers as TP for 4.9 in tech preview table.

RN preview: https://deploy-preview-36222--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-sandboxed-containers

TP table preview: https://deploy-preview-36222--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-technology-preview