### PR TITLE
GH#35793 Update minimum storage requirements for all providers from 120GB -> 100GB

### DIFF
--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -91,7 +91,7 @@ On your {op-system-base} KVM host, set up:
 
 Each cluster virtual machine must meet the following minimum requirements:
 
-[cols="2,2,2,2,2",options="header"]
+[cols="2,2,2,2,2,2",options="header"]
 |===
 
 |Virtual Machine
@@ -99,28 +99,33 @@ Each cluster virtual machine must meet the following minimum requirements:
 |vCPU ^[1]^
 |Virtual RAM
 |Storage
+|IOPS
 
 |Bootstrap
 |{op-system}
 |4
 |16 GB
-|120 GB
+|100 GB
+|N/A
 
 |Control plane
 |{op-system}
 |4
 |16 GB
-|120 GB
+|100 GB
+|N/A
 
 |Compute
 |{op-system}
 |2
 |8 GB
-|120 GB
+|100 GB
+|N/A
 
 |===
+[.small]
 --
-^[1]^ 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
+1. One physical core (IFL) provides two logical cores (threads) when SMT-2 is enabled. The hypervisor can provide two or more vCPUs.
 --
 
 [id="preferred-ibm-z-system-requirements_{context}"]

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -125,7 +125,7 @@ endif::vsphere[]
 
 Each cluster machine must meet the following minimum requirements:
 
-[cols="2,2,2,2,2",options="header"]
+[cols="2,2,2,2,2,2",options="header"]
 |===
 
 |Machine
@@ -133,28 +133,53 @@ Each cluster machine must meet the following minimum requirements:
 |vCPU ^[1]^
 |Virtual RAM
 |Storage
+ifndef::ibm-z[]
+|IOPS ^[2]^
+endif::ibm-z[]
+ifdef::ibm-z[]
+|IOPS
+endif::ibm-z[]
 
 |Bootstrap
 |{op-system}
 ifdef::ibm-power[|2]
 ifndef::ibm-power[|4]
 |16 GB
-|120 GB
+|100 GB
+ifndef::ibm-z[]
+|300
+endif::ibm-z[]
+ifdef::ibm-z[]
+|N/A
+endif::ibm-z[]
+
 
 |Control plane
 |{op-system}
 ifdef::ibm-power[|2]
 ifndef::ibm-power[|4]
 |16 GB
-|120 GB
+|100 GB
+ifndef::ibm-z[]
+|300
+endif::ibm-z[]
+ifdef::ibm-z[]
+|N/A
+endif::ibm-z[]
 
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 7.9, or {op-system-base} 8.4 ^[2]^]
+ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 7.9, or {op-system-base} 8.4 ^[3]^]
 |2
 |8 GB
-|120 GB
+|100 GB
+ifndef::ibm-z[]
+|300
+endif::ibm-z[]
+ifdef::ibm-z[]
+|N/A
+endif::ibm-z[]
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
@@ -162,17 +187,24 @@ ifdef::openshift-origin[]
 |{op-system}
 |2
 |8 GB
-|120 GB
+|100 GB
+ifndef::ibm-z[]
+|300
+endif::ibm-z[]
+ifdef::ibm-z[]
+|N/A
+endif::ibm-z[]
 endif::openshift-origin[]
 |===
 [.small]
 --
 ifdef::ibm-z[]
-1. 1 physical core (IFL) provides 2 logical cores (threads) when SMT-2 is enabled. The hypervisor can provide 2 or more vCPUs.
+1. One physical core (IFL) provides two logical cores (threads) when SMT-2 is enabled. The hypervisor can provide two or more vCPUs.
 endif::ibm-z[]
 ifndef::ibm-z[]
-1. 1 vCPU is equivalent to 1 physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and planned for removal in a future release of {product-title} 4.
+1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
+2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
+3. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and planned for removal in a future release of {product-title} 4.
 endif::ibm-z[]
 --
 
@@ -306,9 +338,9 @@ On your IBM Power instance, set up:
 [discrete]
 === Storage / main memory
 
-* 120 GB / 16 GB for {product-title} control plane machines
-* 120 GB / 8 GB for {product-title} compute machines
-* 120 GB / 16 GB for the temporary {product-title} bootstrap machine
+* 100 GB / 16 GB for {product-title} control plane machines
+* 100 GB / 8 GB for {product-title} compute machines
+* 100 GB / 16 GB for the temporary {product-title} bootstrap machine
 
 [id="recommended-ibm-Power-system-requirements_{context}"]
 


### PR DESCRIPTION
Resolves #35793

Updates were made in the machine requirement section for all providers that specified that table. For example:
- [RHEL KVM on IBM Z and LinuxONE machine requirements](https://deploy-preview-36226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#minimum-resource-requirements_installing-ibm-z-kvm)
- [z/VM on IBM Z and LinuxONE machine requirements](https://deploy-preview-36226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#minimum-resource-requirements_installing-ibm-z)
- [bare metal machine requirements](https://deploy-preview-36226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#minimum-resource-requirements_installing-bare-metal)