### PR TITLE
[enterprise-4.6] BZ1921568: Updated parameters description to provision a machine with multiple network interfaces

### DIFF
--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -70,7 +70,7 @@ ifdef::infra[]
     metadata:
       creationTimestamp: null
       labels:
-        node-role.kubernetes.io/infra: ""     
+        node-role.kubernetes.io/infra: ""
       taints: <4>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
@@ -132,7 +132,7 @@ ifndef::infra[]
 <3> Specify the infrastructure ID and node label.
 <4> To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
-<5> Required for deployments to multiple networks. If deploying to multiple networks, this list must include the network that is used as the `primarySubnet` value.
+<5> Required for deployments to multiple networks. To specify multiple networks, add another entry in the networks array. Also, you must include the network that is used as the `primarySubnet` value.
 <6> Specify the {rh-openstack} subnet that you want the endpoints of nodes to be published on. Usually, this is the same subnet that is used as the value of `machinesSubnet` in the `install-config.yaml` file.
 endif::infra[]
 ifdef::infra[]
@@ -151,4 +151,3 @@ endif::[]
 ifeval::["{context}" == "cluster-tasks"]
 :!infra:
 endif::[]
-


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1921568

OCP Version: 4.6 +

Direct Preview Link: https://deploy-preview-36227--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp?utm_source=github&utm_campaign=bot_dp#machineset-yaml-osp_creating-machineset-osp