### PR TITLE
BZ1925260: Updated operator deletion steps

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -20,8 +20,10 @@ You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The 
 
 . In the {product-title} web console, click *Operators* → *Installed Operators*.
 
-. Switch to the *openshift-vertical-pod-autoscaler* project. 
+. Switch to the *openshift-vertical-pod-autoscaler* project.
 
 . Find the *VerticalPodAutoscaler*  Operator and click the Options menu. Select *Uninstall Operator*.
 
-. In the dialog box, click *Uninstall*.
+. Optional: To remove all operands associated with the Operator, in the dialog box, select *Delete all operand instances for this operator* checkbox.
+
+. Click *Uninstall*.

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -23,13 +23,15 @@ endif::[]
 
 . On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
 +
-An *Uninstall Operator?* dialog box is displayed, reminding you that:
+An *Uninstall Operator?* dialog box is displayed, alerting you that:
 +
 [.small]
 --
-*Removing the Operator will not remove any of its custom resource definitions or managed resources. If your Operator has deployed applications on the cluster or configured off-cluster resources, these will continue to run and need to be cleaned up manually.*
+*Operator VerticalPodAutoscaler will be removed from openshift-vertical-pod-autoscaler. Click on the checkbox below to also remove all Operands associated with this Operator. If your Operator configured off-cluster resources, these will continue to run and require manual cleanup.*
 --
 +
-The Operator, any Operator deployments, and pods are removed by this action. Any resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
+Any resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
+
+. Optional: To remove all operands associated with the Operator, select *Delete all operand instances for this operator* checkbox.
 
 . Select *Uninstall*. This Operator stops running and no longer receives updates.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1925260

Target release - 4.9

Preview links: 
Working with pods - https://deploy-preview-36232--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler

Deleting operators from cluster - https://deploy-preview-36232--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster

@weinliu - Kindly help with a QE review. This is only for 4.9.
@kevinrizza & @kdoberst - Kindly help with SME review. This is only for 4.9.