### PR TITLE
OSDOCS-1801: Adding release notes for new audit policy options

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -91,6 +91,25 @@ In {product-title} {product-version}, you can expand an installer provisioned cl
 [id="ocp-4-9-security"]
 === Security and compliance
 
+[id="ocp-4-9-security-custom-audit-policy"]
+==== Configuring the audit log policy with custom rules
+
+You now have more fine-grained control over the audit logging level for {product-title}. You can use custom rules to specify a different audit policy profile (`Default`, `WriteRequestBodies`, `AllRequestBodies`, or `None`) for different groups.
+
+For more information, see xref:../security/audit-log-policy-config.adoc#configuring-audit-policy-custom_audit-log-policy-config[Configuring the audit log policy with custom rules].
+
+[id="ocp-4-9-security-disable-audit-logging"]
+==== Disabling audit logging
+
+You can now disable audit logging for {product-title} by using the `None` audit policy profile.
+
+[WARNING]
+====
+It is not recommended to disable audit logging unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly.
+====
+
+For more information, see xref:../security/audit-log-policy-config.adoc#configuring-audit-policy-disable_audit-log-policy-config[Disabling audit logging].
+
 [id="ocp-4-9-networking"]
 === Networking
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1801

Previews:
* https://deploy-preview-36234--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-security-custom-audit-policy
* https://deploy-preview-36234--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-security-disable-audit-logging

**NOTE:** The links won't take you to the correct section yet, since this PR is dependent on #36229.