### PR TITLE
RN for TELCODOCS-53 - Poison Pill Operator

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -810,6 +810,15 @@ The Node Feature Discovery (NFD) Operator detects hardware features available on
 
 - `cstate status`: If the `intel_idle` driver has C-states or idle states, the `cstate status` label is `true`. Otherwise, it is `false`.
 
+[id="ocp-4-8-poison-pill-operator"]
+==== Remediate unhealthy nodes with the Poison Pill Operator
+
+You can use the Poison Pill Operator to allow unhealthy nodes to reboot automatically. This minimizes downtime for stateful applications and ReadWriteOnce (RWO) volumes, and restores compute capacity if transient failures occur.
+
+The Poison Pill Operator works with all cluster and hardware types.
+
+For more information, see xref:../nodes/nodes/eco-poison-pill-operator.adoc#poison-pill-operator-remediate-nodes[Remediating nodes with the Poison Pill Operator].
+
 [id="ocp-4-8-nodes-no-reboot-cert"]
 ==== Automatic rotation of kubelet-ca.crt does not require reboot
 


### PR DESCRIPTION
The Poison Pill Operator was delivered in 4.8, but not documented
https://issues.redhat.com/browse/TELCODOCS-53 - Addresses RN for the Poison Pill Operator

Preview link: https://deploy-preview-36244--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-poison-pill-operator