### PR TITLE
4.9 RN: Installation Ignition config file removed

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -51,6 +51,11 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-9-rhcos"]
 === {op-system-first}
 
+[id="ocp-4-9-install-ign-removed"]
+==== Installation Ignition config is removed upon boot
+
+Nodes installed with the `coreos-installer` program previously retained the installation Ignition config in the `/boot/ignition/config.ign` file. Starting with the {product-title} 4.9 installation image, that file is removed when the node is provisioned. This change does not affect clusters that were installed on previous {product-title} versions because they still use an older bootimage.
+
 [id="ocp-4-9-installation-and-upgrade"]
 === Installation and upgrade
 
@@ -84,7 +89,7 @@ In {product-title} {product-version}, you can expand an installer provisioned cl
 
 [id="ocp-4-9-assessing-node-logs-from-the-node-details-page"]
 ==== Accessing node logs from the *Node Details* page
-With this update, admins now have the ability to access node logs from the *Node Details* page. From there, you can switch between individual log files and journal log units in order to inquire about the node. 
+With this update, admins now have the ability to access node logs from the *Node Details* page. From there, you can switch between individual log files and journal log units in order to inquire about the node.
 
 [id="ocp-4-9-ibm-z"]
 === IBM Z and LinuxONE


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/issues/33497#issuecomment-880311344, adding a release note about the installation Ignition config file being removed after coreos-installer node install.

Preview link: https://deploy-preview-36245--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-install-ign-removed