### PR TITLE
Picking OCM SCA merge from enterprise-4.9 to main

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -480,6 +480,8 @@ Topics:
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network
+  - Name: Configuring RHEL Simple Content Access
+    File: insights-operator-simple-access
 - Name: Gathering data about your cluster
   File: gathering-cluster-data
   Distros: openshift-enterprise,openshift-origin

--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/insights-operator-simple-access.adoc
+
+
+[id="insights-operator-configuring-sca_{context}"]
+= Configuring Simple Content Access import interval
+
+You can configure how often the Insights Operator imports the RHEL Simple Content Access (SCA) certificates using the `support` secret in the `openshift-config` namespace. The certificate import normally occurs every 8 hours, but you may want to shorten this interval if you update your SCA configuration in Red Hat Subscription Management.
+
+This procedure describes how to update the import interval to one hour. 
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as `cluster-admin`.
+
+.Procedure
+
+. Navigate to *Workloads* -> *Secrets*.
+. Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+. Click the *Options* menu {kebab}, and then click *Edit Secret*.
+. Click *Add Key/Value*.
+. Create a key named `ocmInterval` with a value of `1h`, and click *Save*.
++
+[NOTE]
+====
+The interval `1h` can also be entered as `60m` for 60 minutes. 
+====
++
+. Navigate to *Workloads* -> *Pods*
+. Select the `openshift-insights` project.
+. Find the `insights-operator` pod.
+. To restart the `insights-operator` pod, click the *Options* menu {kebab}, and then click *Delete Pod*.

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/insights-operator-simple-access.adoc
+
+
+[id="insights-operator-disabling-sca_{context}"]
+= Disabling Simple Content Access import
+
+You can disable the import of RHEL Simple Content Access certificates using the `support` secret in the `openshift-config` namespace.
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as `cluster-admin`.
+
+.Procedure
+
+. Navigate to *Workloads* -> *Secrets*.
+. Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+. Click the *Options* menu {kebab}, and then click *Edit Secret*.
+. Click *Add Key/Value*.
+. Create a key named `ocmPullDisabled` with a value of `true`, and click *Save*.
+. Navigate to *Workloads* -> *Pods*
+. Select the `openshift-insights` project.
+. Find the `insights-operator` pod.
+. To restart the `insights-operator` pod, click the *Options* menu {kebab}, and then click *Delete Pod*.

--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -22,6 +22,7 @@ The following Technology Preview features are enabled by this feature set:
 
 * link:https://kubernetes.io/docs/reference/command-line-tools-reference/kubelet-tls-bootstrapping/#certificate-rotation[RotateKubeletServerCertificate]. Enables the rotation of the server TLS certificate on the kubelet.
 * link:https://kubernetes.io/docs/concepts/policy/pid-limiting/#pod-pid-limits[Pod PID limits (SupportPodPidsLimit)]. Enables limiting process IDs (PIDs) in pods.
+* `InsightsOperatorPullingSCA`. Enables importing of RHEL Simple Content Access (SCA) certificates from {cloud-redhat-com}.
 
 |===
 

--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -1,0 +1,21 @@
+[id="insights-operator-simple-access"]
+= Importing RHEL Simple Content Access certificates with Insights Operator
+include::modules/common-attributes.adoc[]
+:context: remote-health-reporting-from-restricted-network
+:FeatureName: `InsightsOperatorPullingSCA`
+
+toc::[]
+
+Insights Operator can import your RHEL Simple Content Access (SCA) certificates from {cloud-redhat-com}. SCA is a capability in Red Hat’s subscription tools which simplifies the behavior of the entitlement tooling. It is easier to consume the content provided by your Red Hat subscriptions without the complexity of configuring subscription tooling. After importing the certificates, they are stored in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace. 
+
+Insights Operator imports SCA certificates every 8 hours by default, but can be configured or disabled using the `support` secret in the `openshift-config` namespace. 
+
+In {product-title} 4.9, this feature is in Technology Preview and must be enabled using the `TechPreviewNoUpgrade` Feature Set. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[_Enabling OpenShift Container Platform features using FeatureGates_] for more information. 
+
+For more information about Simple Content Access certificates see the link:https://access.redhat.com/articles/simple-content-access[_Simple Content Access_] article in the Red Hat Knowledgebase.
+
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+include::modules/insights-operator-configuring-sca.adoc[leveloffset=+1]
+
+include::modules/insights-operator-disabling-sca.adoc[leveloffset=+1]


### PR DESCRIPTION
As per guidance, I have opened this PR to mirror this one from 4.9: https://github.com/openshift/openshift-docs/pull/35938 

There are no changes from that PR so it should be good to merge. 


Preview: 
https://deploy-preview-36246--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html