### PR TITLE
Added notes for 4.8.11 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2622,3 +2622,24 @@ link:https://access.redhat.com/solutions/6308491[{product-title} 4.8.10 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-11"]
+=== RHBA-2021:3429 - {product-title} 4.8.11 bug fix update
+
+Issued: 2021-09-14
+
+{product-title} release 4.8.11 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3429[RHBA-2021:3429] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6324771[{product-title} 4.8.11 container image list]
+
+[id="ocp-4-8-11-bug-fixes"]
+==== Bug fixes
+
+* Previously, `Event Sources` could be found in the `Developer Catalog Group`. With this update, the `Serverless` add group has been renamed to `Eventing` and `Event Sources` can now be found within the `Eventing` add group. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1999931[BZ#1999931])
+
+[id="ocp-4-8-11-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.8.11

- Applies to `enterprise-4.8`
- [Preview link](https://deploy-preview-36255--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-11)