### PR TITLE
Changed mentions of 4.9 to 'future version'

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -950,7 +950,7 @@ New enhancements are available on the *Monitoring* -> *Dashboards* page in the {
 
 [id="ocp-4-8-metering"]
 === Metering
-The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled to be removed in {product-title} 4.9.
+The Metering Operator is deprecated as of {product-title} 4.6, and is scheduled to be removed in the next {product-title} release.
 
 [id="ocp-4-8-scale"]
 === Scale
@@ -1298,7 +1298,7 @@ Cluster Loader is now deprecated and will be removed in a future release.
 
 This release deprecates the `lastTriggeredImageID` in the `ImageChangeTrigger` object, which is one of the `BuildTriggerPolicy` types that can be set on a `BuildConfig` spec.
 
-{product-title} version 4.9 will remove support for `lastTriggeredImageID` and ignore it. Then, image change triggers will not start a build based on changes to the `lastTriggeredImageID` field in the `BuildConfig` spec. Instead, the image IDs that trigger a build will be recorded in the status of the `BuildConfig` object, which most users cannot change.
+{product-title} next release will remove support for `lastTriggeredImageID` and ignore it. Then, image change triggers will not start a build based on changes to the `lastTriggeredImageID` field in the `BuildConfig` spec. Instead, the image IDs that trigger a build will be recorded in the status of the `BuildConfig` object, which most users cannot change.
 
 Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` accordingly. (link:https://issues.redhat.com/browse/BUILD-213[*BUILD-213*])
 


### PR DESCRIPTION
A couple mentions of 4.9 made it into the 4.8 release notes. This PR fixes it to say 'future version' to leave room for modifications in the release. 

- Applies to `enterprise-4.8` only
- [Preview link #1](https://deploy-preview-36262--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-metering)
- [Preview link #2](https://deploy-preview-36262--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-builds-lasttriggeredimageid-parameter)