### PR TITLE
OSSMDOC-389: Release Notes for OSSMDOC-389

### DIFF
--- a/modules/ossm-document-attributes.adoc
+++ b/modules/ossm-document-attributes.adoc
@@ -13,7 +13,7 @@
 :product-dedicated: Red Hat OpenShift Dedicated
 :ProductShortName: Service Mesh
 :ProductRelease:
-:ProductVersion: 2.0.6
+:ProductVersion: 2.0.8
 :MaistraVersion: 2.0
 :product-build:
 :DownloadURL: registry.redhat.io

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,6 +19,8 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {ProductShortName} fixed issues
 
+* link:https://issues.redhat.com/browse/OSSM-569[OSSM-569] There is no CPU memory limit for the Prometheus `istio-proxy` container. The Prometheus `istio-proxy` sidecar now uses the resource limits defined in `spec.proxy.runtime.container`.
+
 * link:https://issues.redhat.com/browse/OSSM-449[OSSM-449] VirtualService and Service causes an error "Only unique values for domains are permitted. Duplicate entry of domain."
 
 * link:https://issues.redhat.com/browse/OSSM-419[OSSM-419] Namespaces with similar names will all show in Kiali namespace list, even though namespaces may not be defined in Service Mesh Member Role.
@@ -30,6 +32,10 @@ The following issues been resolved in the current release:
 * link:https://issues.redhat.com/browse/OSSM-289[OSSM-289] In the Kiali console, on the Service Details pages for the 'istio-ingressgateway' and 'jaeger-query' services there are no Traces being displayed. The traces exist in Jaeger.
 
 * link:https://issues.redhat.com/browse/OSSM-287[OSSM-287] In the Kiali console there are no traces being displayed on the Graph Service.
+
+* link:https://issues.redhat.com/browse/MAISTRA-2635[MAISTRA-2635] Replace deprecated Kubernetes API. To remain compatible with {product-title} 4.8, the `apiextensions.k8s.io/v1beta1` API was deprecated as of {ProductName} 2.0.8.
+
+* link:https://issues.redhat.com/browse/MAISTRA-2631[MAISTRA-2631] The WASM feature is not working because podman is failing due to nsenter binary not being present. {ProductName} generates the following error message: `Error: error configuring CNI network plugin exec: "nsenter": executable file not found in $PATH`. The container image now contains nsenter and WASM works as expected.
 
 * link:https://issues.redhat.com/browse/MAISTRA-2534[MAISTRA-2534] When istiod attempted to fetch the JWKS for an issuer specified in a JWT rule, the issuer service responded with a 502.  This prevented the proxy container from becoming ready and caused deployments to hang. The fix for the link:https://github.com/istio/istio/issues/24629[community bug] has been included in the  {ProductShortName} 2.0.7 release.
 
@@ -60,11 +66,13 @@ Upgrading the operator to 2.0 might break client tools that read the SMCP status
 +
 This also causes the READY and STATUS columns to be empty when you run `oc get servicemeshcontrolplanes.v1.maistra.io`.
 
-* link:https://issues.jboss.org/browse/MAISTRA-1089[MAISTRA-1089] _Migration to 2.0_ Gateways created in a non-control plane namespace are automatically deleted. Users will need to manually delete these resources after removing the gateway definition from the SMCP spec.
-
 * link:https://issues.redhat.com/browse/MAISTRA-1983[MAISTRA-1983] _Migration to 2.0_ Upgrading to 2.0.0 with an existing invalid `ServiceMeshControlPlane` cannot easily be repaired. The invalid items in the `ServiceMeshControlPlane` resource caused an unrecoverable error. The fix makes the errors recoverable. You can delete the invalid resource and replace it with a new one or edit the resource to fix the errors. For more information about editing your resource, see [Configuring the Red Hat OpenShift Service Mesh installation].
 
 * link:https://issues.redhat.com/browse/MAISTRA-1502[Maistra-1502] As a result of CVEs fixes in version 1.0.10, the Istio dashboards are not available from the *Home Dashboard* menu in Grafana. The Istio dashboards still exist. To access them, click the *Dashboard* menu in the navigation panel and select the *Manage* tab.
+
+* link:https://issues.redhat.com/browse/MAISTRA-1399[MAISTRA-1399] {ProductName} no longer prevents you from installing unsupported CNI protocols. The supported network configurations has not changed.
+
+* link:https://issues.jboss.org/browse/MAISTRA-1089[MAISTRA-1089] _Migration to 2.0_ Gateways created in a non-control plane namespace are automatically deleted. After removing the gateway definition from the SMCP spec, you need to manually delete these resources.
 
 * link:https://issues.jboss.org/browse/MAISTRA-858[MAISTRA-858] The following Envoy log messages describing link:https://www.envoyproxy.io/docs/envoy/latest/intro/deprecated[deprecated options and configurations associated with Istio 1.1.x] are expected:
 +

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -27,10 +27,10 @@ Module included in the following assemblies:
 |1.6.14
 
 |Jaeger
-|1.24.0
+|1.24.1
 
 |Kiali
-|1.24.10
+|1.24.10-1
 
 |3scale Istio Adapter
 |2.0.0


### PR DESCRIPTION
Draft release notes for the 2.0.8 z release.

Content to be reviewed.

Will later be cherry picked to 4.6, 4.7, 4.8, and 4.9.

Preview link: https://deploy-preview-36268--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html