### PR TITLE
TELCODOCS-250: D/S Docs & RN: MPINSTALL-1, Worker deployment via virtualmedia on either provisioning/controlplane network

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -74,6 +74,11 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 
 //For more information, ../installing/installing_aws/installing-aws-china.adoc[Installing a cluster on AWS into a China region].
 
+[id="ocp-4-9-expanding-with-virtual-media-on-baremetal-network"]
+==== Expanding the cluster with Virtual Media on the baremetal network
+
+In {product-title} {product-version}, you can expand an installer provisioned cluster deployed using the `provisioning` network by using Virtual Media on the `baremetal` network. You can use this feature when the `ProvisioningNetwork` configuration setting is set to `Managed`. To use this feature, you must set the `virtualMediaViaExternalNetwork` configuration setting to `true` in the `provisioning` custom resource (CR). You must also edit the machineset to use the API VIP address. See xref:../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding[Preparing to deploy with Virtual Media on the baremetal network] for details. 
+
 [id="ocp-4-9-web-console"]
 === Web console
 
@@ -203,7 +208,7 @@ For more information, see xref:../support/remote_health_monitoring/insights-oper
 
 In {product-title} 4.9, the Insights Operator collects the following additional information:
 
-* All of the `MachineConfig` resource definitions from a cluster. 
+* All of the `MachineConfig` resource definitions from a cluster.
 * The names of the `PodSecurityPolicies` installed in a cluster.
 * If installed, the `ClusterLogging` resource definition.
 * If the `SamplesImagestreamImportFailing` alert is firing, then the `ImageStream` definitions and the last 100 lines of container logs from the `openshift-cluster-samples-operator` namespace.


### PR DESCRIPTION
This commit contains release notes for [TELCODOCS-250](https://issues.redhat.com/browse/TELCODOCS-250).

Fixes: [TELCODOCS-250](https://issues.redhat.com/browse/TELCODOCS-250)

See https://issues.redhat.com/browse/TELCODOCS-250 for additional details.

Preview URL: https://deploy-preview-36270--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-expanding-with-virtual-media-on-baremetal-network

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
