### PR TITLE
OSDOCS-2629: Document enabling http-ignore-probes and dontlognull as defaults

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -182,6 +182,24 @@ supports up to `64` threads. If this field is empty, the Ingress Controller uses
 * `tlsInspectDelay` specifies how long the router can hold data to find a matching route. Setting this value too short can cause the router to fall back to the default certificate for edge-terminated or reencrypted routes, even when using a better matched certificate. If unset, the default inspect delay is `5s`.
 
 * `tunnelTimeout` specifies how long a tunnel connection, including websockets, remains open while the tunnel is idle. If unset, the default timeout is `1h`.
+
+|`logEmptyRequests`
+|`logEmptyRequests` specifies connections for which no request is received and logged. These empty requests come from load balancer health probes or web browser speculative connections (preconnect) and logging these requests can be undesirable. However, these requests can be caused by network errors, in which case logging empty requests can be useful for diagnosing the errors. These requests can be caused by port scans, and logging empty requests can aid in detecting intrusion attempts. Allowed values for this field are `Log` and `Ignore`. The default value is `Log`.
+
+The `LoggingPolicy` type accepts either one of two values:
+
+* `Log`: Setting this value to `Log` indicates that an event should be logged.
+* `Ignore`: Setting this value to `Ignore` sets the `dontlognull` option in the HAproxy configuration.
+
+|`HTTPEmptyRequestsPolicy`
+|`HTTPEmptyRequestsPolicy` describes how HTTP connections are handled if the connection times out before a request is received. Allowed values for this field are `Respond` and `Ignore`. The default value is `Respond`.
+
+The `HTTPEmptyRequestsPolicy` type accepts either one of two values:
+
+* `Respond`: If the field is set to `Respond`, the Ingress Controller sends an HTTP `400` or `408` response, logs the connection if access logging is enabled, and counts the connection in the appropriate metrics.
+* `Ignore`: Setting this option to `Ignore` adds the `http-ignore-probes` parameter in the HAproxy configuration. If the field is set to `Ignore`, the Ingress Controller closes the connection without sending a response, then logs the connection, or incrementing metrics.
+
+These connections come from load balancer health probes or web browser speculative connections (preconnect) and can be safely ignored. However, these requests can be caused by network errors, so setting this field to `Ignore` can impede detection and diagnosis of problems. These requests can be caused by port scans, in which case logging empty requests can aid in detecting intrusion attempts.
 |===
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2629

Preview: https://deploy-preview-36272--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration-parameters_configuring-ingress

