### PR TITLE
OSDOCS-2172: Add release note for secondary network external gw

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -95,6 +95,11 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 The egress IP feature of OVN-Kubernetes now balances network traffic approximately equally across nodes for a given namespace, if that namespace is assigned multiple egress IP addresses. Each IP address must reside on a different node.
 For more information, refer to xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring egress IPs for a project] for OVN-Kubernetes.
 
+[id="ocp-4-9-"]
+==== A
+
+Add release note.
+
 [id="ocp-4-9-sriov-dpdk-ga"]
 ==== SR-IOV containerized Data Plane Development Kit (DPDK) is GA
 

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -95,10 +95,10 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 The egress IP feature of OVN-Kubernetes now balances network traffic approximately equally across nodes for a given namespace, if that namespace is assigned multiple egress IP addresses. Each IP address must reside on a different node.
 For more information, refer to xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring egress IPs for a project] for OVN-Kubernetes.
 
-[id="ocp-4-9-"]
-==== A
+[id="ocp-4-9-ovn-kubernetes-secondary-network-external-gw"]
+==== OVN-Kubernetes cluster network provider supports configuring an external gateway on a secondary network
 
-Add release note.
+With the OVN-Kubernetes cluster network provider, you can configure a secondary network as an external gateway for one or more namespaces in your cluster. Each node in the cluster configured with a secondary network must have an additional network interface controller (NIC) available. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-secondary-external-gw.adoc#configuring-secondary-external-gw[Configuring a secondary network as an external gateway].
 
 [id="ocp-4-9-sriov-dpdk-ga"]
 ==== SR-IOV containerized Data Plane Development Kit (DPDK) is GA


### PR DESCRIPTION
This PR adds a release note entry for secondary network external gateway support in OVN-Kubernetes. The build will fail until the associated content is merged in https://github.com/openshift/openshift-docs/pull/35801.

- https://issues.redhat.com/browse/OSDOCS-2172

Preview: [OVN-Kubernetes cluster network provider supports configuring an external gateway on a secondary network](https://deploy-preview-36274--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-ovn-kubernetes-secondary-network-external-gw)