### PR TITLE
OSDOCS-1805: Add release note for default OVN-Kubernetes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -89,6 +89,19 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 [id="ocp-4-9-networking"]
 === Networking
 
+[id="ocp-4-9-ovn-kubernetes-default-cluster-network-provider"]
+==== OVN-Kubernetes is now the default cluster network provider
+
+When installing a new cluster the OVN-Kubernetes cluster network provider is the default network provider. For all prior versions of {product-title}, OpenShift SDN was the default cluster network provider.
+
+The OVN-Kubernetes cluster network provider includes a wider array of features than OpenShift SDN, including:
+
+- Features
+
+For more information about OVN-Kubernetes, including a feature comparison matrix with OpenShift SDN, see xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes default Container Network Interface (CNI) network provider].
+
+For information on migrating to OVN-Kubernetes from OpenShift SDN, see xref:../networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc#migrate-from-openshift-sdn[Migrating from the OpenShift SDN cluster network provider].
+
 [id="ocp-4-9-ovn-kubernetes-egress-ips-balance"]
 ==== OVN-Kubernetes cluster network provider egress IP feature balances across nodes
 

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -96,7 +96,13 @@ When installing a new cluster the OVN-Kubernetes cluster network provider is the
 
 The OVN-Kubernetes cluster network provider includes a wider array of features than OpenShift SDN, including:
 
-- Features
+- Support for all existing OpenShift SDN features
+- Support for xref:../networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc#converting-to-dual-stack[IPv6 networks]
+- Support for xref:../networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc#about-ipsec-ovn[IPsec encryption]
+- Complete support for the xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[`NetworkPolicy` API]
+- Support for xref:../networking/network_policy/logging-network-policy.adoc#logging-network-policy[audit logging of network policy events]
+- Support for xref:../networking/ovn_kubernetes_network_provider/tracking-network-flows.adoc#tracking-network-flows[network flow tracking] in NetFlow, sFlow, and IPFIX formats
+- Support for xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[hybrid networks] for Windows containers
 
 For more information about OVN-Kubernetes, including a feature comparison matrix with OpenShift SDN, see xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes default Container Network Interface (CNI) network provider].
 


### PR DESCRIPTION
This adds a release note for OVN-Kubernetes as the default cluster network provider. Because this is an enormous milestone, I'm trying to include as many interesting facts as reasonable. This shouldn't come as a shock to anyone installing a new cluster if at all possible.

- https://issues.redhat.com/browse/OSDOCS-1805

Preview: [OVN-Kubernetes is now the default cluster network provider](https://deploy-preview-36275--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-ovn-kubernetes-default-cluster-network-provider)