### PR TITLE
[RHACS] Fixed the instructions for genrating init bundle

### DIFF
--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -1,6 +1,8 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_helm/install-helm-customization.adoc
+//
+// You must declare the `topic-helm` or `topic-operator` attribute when using this module.
 :_module-type: PROCEDURE
 [id="portal-generate-init-bundle_{context}"]
 = Generating an init bundle by using the RHACS portal
@@ -32,12 +34,17 @@ $ oc port-forward svc/central 18443:443 -n stackrox
 ... Navigate to `\https://localhost:18443/`.
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Authentication Tokens* section, click on *Cluster Init Bundle*.
-. Click *Generate Bundle* (*`add`* icon) on the top right.
+. Click *New Integration*.
 . Enter a name for the cluster init bundle and click *Generate*.
+ifdef::topic-helm[]
 . Click *Download Helm Values File* to download the generated bundle.
+endif::[]
+ifdef::topic-operator[]
+. Click *Download Kubernetes Secret File* to download the generated bundle.
+endif::[]
 
 [IMPORTANT]
 ====
-Make sure that you store this bundle securely because it contains secrets.
-You can use the same bundle to set up multiple secured clusters.
+Store this bundle securely because it contains secrets.
+You can use the same bundle to create multiple secured clusters.
 ====


### PR DESCRIPTION
- Fixed the instructions to download secrets when using the Operator.
- minor nits

Preview:
- Operator, instruction 6 https://openshift-docs-g8xvm1bhu-gnelson.vercel.app/openshift-acs/master/installing/installing_helm/install-helm-customization.html#portal-generate-init-bundle_acs-install-helm-customization 
- Helm, instruction 6 https://openshift-docs-g8xvm1bhu-gnelson.vercel.app/openshift-acs/master/installing/install-ocp-operator.html#portal-generate-init-bundle_install-ocp-operator

NOTES:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones