### PR TITLE
BZ1867750: Replace the "ssh core@" command to shut down nodes

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -37,24 +37,23 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 ----
 <1> To ensure that the cluster can restart gracefully, plan to restart it on or before the specified date. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
 
-. Shut down all of the nodes in the cluster. You can do this from your cloud provider's web console, or you can use the below commands:
-
-.. Obtain the list of nodes:
+. Shut down all of the nodes in the cluster. You can do this from your cloud provider's web console, or run the following loop:
 +
 [source,terminal]
 ----
-$ nodes=$(oc get nodes -o jsonpath='{.items[*].metadata.name}')
+$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
 ----
-
-.. Shut down all of the nodes:
 +
-[source,terminal]
+.Example output
 ----
-$ for node in ${nodes[@]}
-do
-    echo "==== Shut down $node ===="
-    ssh core@$node sudo shutdown -h 1
-done
+Starting pod/ip-10-0-130-169us-east-2computeinternal-debug ...
+To use host binaries, run `chroot /host`
+Shutdown scheduled for Mon 2021-09-13 09:36:17 UTC, use 'shutdown -c' to cancel.
+
+Removing debug pod ...
+Starting pod/ip-10-0-150-116us-east-2computeinternal-debug ...
+To use host binaries, run `chroot /host`
+Shutdown scheduled for Mon 2021-09-13 09:36:29 UTC, use 'shutdown -c' to cancel.
 ----
 +
 Shutting down the nodes using one of these methods allows pods to terminate gracefully, which reduces the chance for data corruption.


### PR DESCRIPTION
The existing command "ssh core@$node sudo shutdown -h 1"
doesn't actually shut down all the nodes. This commit fixes the command to shut down all the
nodes properly.

Fixes: [BZ1867750](https://bugzilla.redhat.com/show_bug.cgi?id=1867750)

QA contact: @wabouhamad 
Applicable for 4.6.z versions

Preview: [Link](https://deploy-preview-36290--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown)