### PR TITLE
TELCODOCS-288: New information and config added about clocks

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -1,0 +1,208 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-ptp.adoc
+
+[id="configuring-linuxptp-services-as-boundary-clock_{context}"]
+= Configuring linuxptp services as boundary clock
+
+The PTP Operator adds the `PtpConfig.ptp.openshift.io` custom resource definition (CRD) to {product-title}.
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) by creating a `PtpConfig` custom resource (CR) object.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the PTP Operator.
+
+.Procedure
+
+. Create the following `PtpConfig` CR, and then save the YAML in the `boundary-clock-ptp-config.yaml` file.
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: boundary-clock-ptp-config <1>
+  namespace: openshift-ptp
+spec:
+  profile: <2>
+  - name: "profile1" <3>
+    interface: "" <4>
+    ptp4lOpts: "-s -2" <5>
+    ptp4lConf: | <6>
+      [ens1f0] <7>
+      masterOnly 0
+      [ens1f3] <8> 
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag                       1
+      #slaveOnly                        1
+      priority1                         128
+      priority2                         128
+      domainNumber                      24
+      #utc_offset                       37
+      clockClass                        248
+      clockAccuracy                     0xFE
+      offsetScaledLogVariance         0xFFFF
+      free_running                      0
+      freq_est_interval               1
+      dscp_event                        0
+      dscp_general                      0
+      dataset_comparison              G.8275.x
+      G.8275.defaultDS.localPriority  128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval          -3
+      logSyncInterval                -4
+      logMinDelayReqInterval       -4
+      logMinPdelayReqInterval      -4
+      announceReceiptTimeout       3
+      syncReceiptTimeout           0
+      delayAsymmetry                 0
+      fault_reset_interval         4
+      neighborPropDelayThresh      20000000
+      masterOnly                     0
+      G.8275.portDS.localPriority  128
+      #
+      # Run time options
+      #
+      assume_two_step              0
+      logging_level                6
+      path_trace_enabled         0
+      follow_up_info               0
+      hybrid_e2e                   0
+      inhibit_multicast_service  0
+      net_sync_monitor           0
+      tc_spanning_tree           0
+      tx_timestamp_timeout       10
+      #was 1 (default !)
+      unicast_listen          0
+      unicast_master_table  0
+      unicast_req_duration  3600
+      use_syslog              1
+      verbose                   0
+      summary_interval      -4
+      kernel_leap             1
+      check_fup_sync          0
+      #
+      # Servo Options
+      #
+      pi_proportional_const     0.0
+      pi_integral_const         0.0
+      pi_proportional_scale     0.0
+      pi_proportional_exponent  -0.3
+      pi_proportional_norm_max  0.7
+      pi_integral_scale         0.0
+      pi_integral_exponent      0.4
+      pi_integral_norm_max      0.3
+      step_threshold              0
+      first_step_threshold      0.00002
+      max_frequency               900000000
+      clock_servo                 pi
+      sanity_freq_limit         200000000
+      ntpshm_segment              0
+      #
+      # Transport options
+      #
+      transportSpecific   0x0
+      ptp_dst_mac          01:1B:19:00:00:00
+      p2p_dst_mac          01:80:C2:00:00:0E
+      udp_ttl                1
+      udp6_scope           0x0E
+      uds_address          /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type             OC
+      network_transport    UDPv4
+      delay_mechanism        E2E
+      time_stamping          hardware
+      tsproc_mode            filter
+      delay_filter           moving_median
+      delay_filter_length  10
+      egressLatency          0
+      ingressLatency         0
+      boundary_clock_jbod  1
+      #
+      # Clock description
+      #
+      productDescription    ;;
+      revisionData            ;;
+      manufacturerIdentity  00:00:00
+      userDescription         ;
+      timeSource              0xA0
+    phc2sysOpts: "-a -r" <9> 
+  recommend: <10>
+  - profile: "profile1" <11>
+    priority: 10 <12>
+    match: <13>
+    - nodeLabel: "node-role.kubernetes.io/worker" <14>
+      nodeName: "compute-0.example.com" <15>
+----
+<1> The name of the `PtpConfig` CR.
+<2> Specify an array of one or more `profile` objects.
+<3> Specify the name of a profile object which uniquely identifies a profile object.
+<4> This field should remain empty for boundary clock.
+<5> Specify system config options for the `ptp4l` service, for example `-s -2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+<6> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
+<7> The interface name to synchronize from.
+<8> The interface to synchronize devices connected to the interface.
+<9> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
+<10> Specify an array of one or more `recommend` objects which define rules on how the `profile` should be applied to nodes.
+<11> Specify the `profile` object name defined in the `profile` section.
+<12> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+<13> Specify `match` rules with `nodeLabel` or `nodeName`.
+<14> Specify `nodeLabel` with the `key` of `node.Labels` from the node object.
+<15> Specify `nodeName` with `node.Name` from the node object.
+
+. Create the CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f boundary-clock-ptp-config.yaml
+----
+
+.Verification steps
+
+. Check that the `PtpConfig` profile is applied to node.
+
+.. Get the list of pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE   IP               NODE
+linuxptp-daemon-4xkbb           1/1     Running   0          43m   10.1.196.24      compute-0.example.com
+linuxptp-daemon-tdspf           1/1     Running   0          43m   10.1.196.25      compute-1.example.com
+ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61      control-plane-1.example.com
+----
+
+.. Check that the profile is correct. Examine the logs of the `linuxptp` daemon that corresponds to the node you specified in the `PtpConfig` profile. Run the folllowing command:
++
+[source,terminal]
+----
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+----
++
+.Example output
+[source,terminal]
+----
+I1115 09:41:17.117596 4143292 daemon.go:107] in applyNodePTPProfile
+I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
+I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
+I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
+I1115 09:41:17.117616 4143292 daemon.go:102] Interface:               
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -s -2        
+I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r        
+I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
+----

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -1,0 +1,101 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-ptp.adoc
+
+[id="configuring-linuxptp-services-as-ordinary-clock_{context}"]
+= Configuring linuxptp services as ordinary clock
+
+The PTP Operator adds the `PtpConfig.ptp.openshift.io` custom resource definition (CRD) to {product-title}.
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) by creating a `PtpConfig` custom resource (CR) object.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the PTP Operator.
+
+.Procedure
+
+. Create the following `PtpConfig` CR, and then save the YAML in the `ordinary-clock-ptp-config.yaml` file.
++
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: ordinary-clock-ptp-config <1>
+  namespace: openshift-ptp
+spec:
+  profile: <2>
+  - name: "profile1" <3>
+    interface: "ens787f1" <4>
+    ptp4lOpts: "-s -2" <5>
+    phc2sysOpts: "-a -r" <6>
+    ptp4lConf: "" <7>
+  recommend: <8>
+  - profile: "profile1" <9>
+    priority: 10 <10>
+    match: <11>
+    - nodeLabel: "node-role.kubernetes.io/worker" <12>
+      nodeName: "compute-0.example.com" <13>
+----
+<1> The name of the `PtpConfig` CR.
+<2> Specify an array of one or more `profile` objects.
+<3> Specify the name of a profile object which uniquely identifies a profile object.
+<4> Specify the network interface name to use by the `ptp4l` service, for example `ens787f1`.
+<5> Specify system config options for the `ptp4l` service, for example `-s -2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+<6> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
+<7> Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
+<8> Specify an array of one or more `recommend` objects which define rules on how the `profile` should be applied to nodes.
+<9> Specify the `profile` object name defined in the `profile` section.
+<10> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+<11> Specify `match` rules with `nodeLabel` or `nodeName`.
+<12> Specify `nodeLabel` with the `key` of `node.Labels` from the node object.
+<13> Specify `nodeName` with `node.Name` from the node object.
+
+. Create the CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f ordinary-clock-ptp-config.yaml
+----
+
+.Verification steps
+
+. Check that the `PtpConfig` profile is applied to node.
+
+.. Get the list of pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                            READY   STATUS    RESTARTS   AGE   IP               NODE
+linuxptp-daemon-4xkbb           1/1     Running   0          43m   10.1.196.24      compute-0.example.com
+linuxptp-daemon-tdspf           1/1     Running   0          43m   10.1.196.25      compute-1.example.com
+ptp-operator-657bbb64c8-2f8sj   1/1     Running   0          43m   10.129.0.61      control-plane-1.example.com
+----
+
+.. Check that the profile is correct. Examine the logs of the `linuxptp` daemon that corresponds to the node you specified in the `PtpConfig` profile. Run the folllowing command:
++
+[source,terminal]
+----
+$ oc logs linuxptp-daemon-4xkbb -n openshift-ptp
+----
++
+.Example output
+[source,terminal]
+----
+I1115 09:41:17.117596 4143292 daemon.go:107] in applyNodePTPProfile
+I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
+I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
+I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1  
+I1115 09:41:17.117616 4143292 daemon.go:102] Interface: ens787f1      
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -s -2         
+I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r       
+I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
+----

--- a/modules/nw-ptp-configuring-linuxptp.adoc
+++ b/modules/nw-ptp-configuring-linuxptp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/multiple_networks/configuring-ptp.adoc
+//
 
 [id="configuring-linuxptp_{context}"]
 = Configuring Linuxptp services
@@ -12,7 +12,7 @@ You can configure the Linuxptp services (ptp4l, phc2sys) by creating a `PtpConfi
 
 * Install the OpenShift CLI (`oc`).
 * Log in as a user with `cluster-admin` privileges.
-* You must have installed the PTP Operator.
+* Install the PTP Operator.
 
 .Procedure
 
@@ -43,7 +43,7 @@ spec:
 <3> Specify an array of one or more `profile` objects.
 <4> Specify the name of a profile object which is used to uniquely identify a profile object.
 <5> Specify the network interface name to use by the `ptp4l` service, for example `ens787f1`.
-<6> Specify system config options for the `ptp4l` service, for example `-s -2`. This should not include the interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because these will be automatically appended.
+<6> Specify system config options for the `ptp4l` service, for example `-s -2`. The options should not include the interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the interface name and the service config file are automatically appended.
 <7> Specify system config options for the `phc2sys` service, for example `-a -r`.
 <8> Specify an array of one or more `recommend` objects which define rules on how the `profile` should be applied to nodes.
 <9> Specify the `profile` object name defined in the `profile` section.

--- a/modules/nw-ptp-introduction.adoc
+++ b/modules/nw-ptp-introduction.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-ptp.adoc
+
+[id="ptp-introduction_{context}"]
+= About PTP
+
+The Precision Time Protocol (PTP) is used to synchronize clocks in a network. When used in conjunction with hardware support, PTP is capable of sub-microsecond accuracy, and is more accurate than Network Time Protocol (NTP).
+
+The `linuxptp` package includes the `ptp4l` and `phc2sys` programs for clock synchronization. `ptp4l` implements the PTP boundary clock and ordinary clock. `ptp4l` synchronizes the PTP hardware clock to the source clock with hardware time stamping and synchronizes the system clock to the source clock with software time stamping. `phc2sys` is used for hardware time stamping to synchronize the system clock to the PTP hardware clock on the network interface card (NIC).
+
+[id="ptp-elements_{context}"]
+== Elements of a PTP domain
+
+PTP is used to synchronize multiple nodes connected in a network, with clocks for each node. The following type of clocks can be included in configurations:
+
+Grandmaster clock:: The grandmaster clock provides standard time information to other clocks across the network and ensures accurate and stable synchronisation. The grandmaster clock writes time stamps and responds to time requests from other clocks.
+
+Ordinary clock:: The ordinary clock has a single port connection that can play the role of source or destination clock, depending on its position in the network. The ordinary clock can read and write time stamps.
+
+Boundary clock:: The boundary clock has ports in two or more communication paths and can be a source and a destination to other destination clocks at the same time. The boundary clock works as a destination clock upstream. The destination clock receives the timing message, adjusts for delay, and then creates a new source time signal to pass down the network. The boundary clock produces a new timing packet that is still correctly synced with the source clock and can reduce the number of connected devices reporting directly to the source clock. 
+
+[id="ptp-advantages-over-ntp_{context}"]
+== Advantages of PTP over NTP
+One of the main advantages that PTP has over NTP is the hardware support present in various network interface controllers (NIC) and network switches. The specialized hardware allows PTP to account for delays in message transfer and improves the accuracy of time synchronization. To achieve the best possible accuracy, it is recommended that all networking components between PTP clocks are PTP hardware enabled.
+
+Hardware-based PTP provides optimal accuracy, since the NIC can time stamp the PTP packets at the exact moment they are sent and received. Compare this to software-based PTP, which requires additional processing of the PTP packets by the operating system.

--- a/networking/configuring-ptp.adoc
+++ b/networking/configuring-ptp.adoc
@@ -11,7 +11,7 @@ include::modules/technology-preview.adoc[leveloffset=+1]
 [id="about-using-ptp-hardware"]
 == About PTP hardware
 
-{product-title} includes the capability to use Precision Time Protocol (PTP)hardware on your nodes.
+{product-title} includes the capability to use Precision Time Protocol (PTP) hardware on your nodes.
 You can configure linuxptp services on nodes in your cluster that have PTP-capable hardware.
 
 [NOTE]
@@ -24,6 +24,8 @@ You can use the {product-title} console to install PTP by deploying the PTP Oper
 * Discovery of the PTP-capable devices in a cluster.
 * Management of the configuration of linuxptp services.
 
+include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 include::modules/nw-ptp-device-discovery.adoc[leveloffset=+1]
 include::modules/nw-ptp-installing-operator.adoc[leveloffset=+1]
-include::modules/nw-ptp-configuring-linuxptp.adoc[leveloffset=+1]
+include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[leveloffset=+1]
+include::modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc[leveloffset=+1]


### PR DESCRIPTION
For 4.9: [Jira issue](https://issues.redhat.com/browse/TELCODOCS-288)

List of added sections:
- [Introduction](https://deploy-preview-36295--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html#ptp-introduction_configuring-ptp)
- [Elements](https://deploy-preview-36295--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html#ptp-elements_configuring-ptp)
- [Advantages](https://deploy-preview-36295--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html#ptp-advantages-over-ntp_configuring-ptp)
- [Configuring linuxptp services as ordinary clock](https://deploy-preview-36295--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html#configuring-linuxptp-services-as-ordinary-clock_configuring-ptp)
- [Configuring linuxptp services as boundary clock](https://deploy-preview-36295--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html#configuring-linuxptp-services-as-boundary-clock_configuring-ptp)