### PR TITLE
MON-1798 - Added content for disabling the local Alertmanager in the Monitoring stack

### DIFF
--- a/modules/monitoring-disabling-the-local-alertmanager.adoc
+++ b/modules/monitoring-disabling-the-local-alertmanager.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+[id="monitoring-disabling-the-local-alertmanager_{context}"]
+= Disabling the local Alertmanager
+
+A local Alertmanager that routes alerts from Prometheus instances is enabled by default in the `openshift-monitoring` project of the {product-title} monitoring stack.
+
+If you do not need the local Alertmanager, you can disable it by configuring the `cluster-monitoring-config` config map in the `openshift-monitoring` project.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have created the `cluster-monitoring-config` config map.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Edit the `cluster-monitoring-config` config map in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+. Add `enabled: false` for the `alertmanagerMain` component under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    alertmanagerMain:
+      enabled: false
+----
+
+. Save the file to apply the changes. The Alertmanager instance is disabled automatically when you apply the change.
+

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -140,6 +140,13 @@ include::modules/monitoring-disabling-grafana.adoc[leveloffset=+1]
 
 * See xref:../monitoring/configuring-the-monitoring-stack.adoc#preparing-to-configure-the-monitoring-stack[Preparing to configure the monitoring stack] for steps to create monitoring config maps
 
+// Disabling the local Alertmanager
+include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1]
+
+.Additional resources
+* link:https://prometheus.io/docs/alerting/latest/alertmanager/[Prometheus Alertmanager documentation]
+* xref:../monitoring/managing-alerts.adoc#[Managing alerts]
+
 == Next steps
 
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/MON-1798
- Direct link to doc preview: https://deploy-preview-36300--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#disabling_the_local_alertmanager_configuring-the-monitoring-stack
- SME review: @fpetkovski (approved)
- QE review: @juzhao (approved)
- Peer review: @rolfedh (approved)
- All reviews complete. Please merge now.