### PR TITLE
BZ#1949274: New info on migrating compute and control nodes to a different RHV storage domain.

### DIFF
--- a/machine_management/modifying-machineset.adoc
+++ b/machine_management/modifying-machineset.adoc
@@ -5,13 +5,27 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+You can modify a machine set, such as adding labels, changing the instance type, or changing block storage.
 
-You can make changes to a machine set, such as adding labels, changing the instance type, or changing block storage.
+On {rh-virtualization-first}, you can also change a machine set to provision new nodes on a different storage domain.
 
 [NOTE]
 ====
 If you need to scale a machine set without making other changes, see xref:../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scaling a machine set].
 ====
 
-
 include::modules/machineset-modifying.adoc[leveloffset=+1]
+
+[id="migrating-nodes-to-a-different-storage-domain-rhv_{context}"]
+== Migrating nodes to a different storage domain on {rh-virtualization}
+
+You can migrate the {product-title} control plane and compute nodes to a different storage domain in a {rh-virtualization-first} cluster.
+
+include::modules/machineset-migrating-compute-nodes-to-diff-sd-rhv.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#machineset-creating_creating-machineset-rhv[Creating a machine set].
+* xref:../machine_management/manually-scaling-machineset.adoc#machineset-manually-scaling_manually-scaling-machineset[Scaling a machine set manually]
+* xref:../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
+
+include::modules/machineset-migrating-control-plane-nodes-to-diff-sd-rhv.adoc[leveloffset=+2]

--- a/modules/machineset-migrating-compute-nodes-to-diff-sd-rhv.adoc
+++ b/modules/machineset-migrating-compute-nodes-to-diff-sd-rhv.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * machine_management/modifying-machineset.adoc
+[id="machineset-migrating-compute-nodes-to-diff-sd-rhv_{context}"]
+= Migrating compute nodes to a different storage domain in {rh-virtualization}
+
+.Prerequisites
+
+* You are logged in to the {rh-virtualization-engine-name}.
+* You have the name of the target storage domain.
+
+.Procedure
+
+. Identify the virtual machine template:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.items[0].spec.template.spec.providerSpec.value.template_name}{"\n"}' machineset -A
+----
+
+. Create a new virtual machine in the {rh-virtualization-engine-name}, based on the template you identified. Leave all other settings unchanged. For details, see  link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Creating_a_Virtual_Machine_Based_on_a_Template[Creating a Virtual Machine Based on a Template] in the Red Hat Virtualization _Virtual Machine Management Guide_.
++
+[TIP]
+====
+You do not need to start the new virtual machine.
+====
+
+. Create a new template from the new virtual machine. Specify the target storage domain under *Target*. For details, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Creating_a_template_from_an_existing_virtual_machine[Creating a Template] in the Red Hat Virtualization _Virtual Machine Management Guide_.
+
+. Add a new machine set to the {product-title} cluster with the new template.
+.. Get the details of the current machine set:
++
+[source,terminal]
+----
+$ oc get machineset -o yaml
+----
+.. Use these details to create a machine set. For more information see _Creating a machine set_.
++
+Enter the new virtual machine template name in the *template_name* field. Use the same template name you used in the *New template* dialog in the {rh-virtualization-engine-name}.
+.. Note the names of both the old and new machine sets. You need to refer to them in subsequent steps.
+
+. Migrate the workloads.
+.. Scale up the new machine set. For details on manually scaling machine sets, see _Scaling a machine set manually_.
++
+{product-title} moves the pods to an available worker when the old machine is removed.
+.. Scale down the old machine set.
+
+. Remove the old machine set:
++
+[source,terminal]
+----
+$ oc delete machineset <machineset-name>
+----

--- a/modules/machineset-migrating-control-plane-nodes-to-diff-sd-rhv.adoc
+++ b/modules/machineset-migrating-control-plane-nodes-to-diff-sd-rhv.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * machine_management/modifying-machineset.adoc
+[id="machineset-migrating-control-plane-nodes-to-diff-sd-rhv_{context}"]
+= Migrating control plane nodes to a different storage domain on {rh-virtualization}
+
+{product-title} does not manage control plane nodes, so they are easier to migrate than compute nodes. You can migrate them like any other virtual machine on {rh-virtualization-first}.
+
+Perform this procedure for each node separately.
+
+.Prerequisites
+
+* You are logged in to the {rh-virtualization-engine-name}.
+* You have identified the control plane nodes. They are labeled *master* in the {rh-virtualization-engine-name}.
+
+.Procedure
+
+. Select the virtual machine labeled *master*.
+
+. Shut down the virtual machine.
+
+. Click the *Disks* tab.
+
+. Click the virtual machine's disk.
+
+. Click *More Actions*{kebab} and select *Move*.
+
+. Select the target storage domain and wait for the migration process to complete.
+
+. Start the virtual machine.
+
+. Verify that the {product-title} cluster is stable:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+The output should display the node with the status `Ready`.
+
+. Repeat this procedure for each control plane node.


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=1949274.

This applies to:
enterprise-4.9
enterprise-4.8
enterprise-4.7
enterprise-4.6

Preview: https://deploy-preview-36305--osdocs.netlify.app/openshift-enterprise/latest/machine_management/modifying-machineset?utm_source=github&utm_campaign=bot_dp

New topics:
Migrating compute nodes to a different storage domain in RHV
Migrating control plane nodes to a different storage domain on RHV