### PR TITLE
CNV11325: Adding information about support for preallocation disk parameter

### DIFF
--- a/modules/virt-add-disk-to-vm.adoc
+++ b/modules/virt-add-disk-to-vm.adoc
@@ -38,6 +38,8 @@ Use this procedure to add a virtual disk to a {object}.
 
 . In the *Add Disk* window, specify the *Source*, *Name*, *Size*, *Type*, *Interface*, and *Storage Class*.
 
+.. Advanced: You can enable preallocation if you use a blank disk source and require maximum write performance when creating data volumes. To do so, select the *Enable preallocation* checkbox.
+
 .. Optional: In the *Advanced* list, specify the *Volume Mode* and *Access Mode* for the virtual disk. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` config map.
 
 . Click *Add*.


### PR DESCRIPTION
This PR addresses JIRA story [CNV-11325](https://issues.redhat.com/browse/CNV-11325) ( https://issues.redhat.com/browse/CNV-11325 ).

The story asks to document support for the preallocation disk parameter when adding a VM disk.

CP: 4.9

Preview: Sub-letter a. under number 5 in https://deploy-preview-36308--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html#virt-vm-add-disk_virt-edit-vms