### PR TITLE
OSDOCS-2203: RN OLM upgrade to k8s 1.22

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -156,6 +156,16 @@ For more information, see xref:../networking/multiple_networks/assigning-a-secon
 [id="ocp-4-9-olm"]
 === Operator lifecycle
 
+[id="ocp-4-9-olm-k8s-1.22"]
+==== Operator Lifecycle Manager (OLM) upgraded to Kubernetes 1.22
+
+Starting in {product-title} {product-version}, Operator Lifecycle Manager (OLM) supports Kubernetes 1.22. As a result, xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[a significant number of `v1beta1` APIs have been removed and updated to `v1`]. Operators that depend on the removed `v1beta1` APIs will not run on {product-title} {product-version}. Cluster administrators should xref:../operators/admin/olm-upgrading-operators.adoc[upgrade their installed Operators] to the `latest` channel before upgrading a cluster to {product-title} {product-version}.
+
+[IMPORTANT]
+====
+Kubernetes 1.22 introduces link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122[several notable changes] to `v1` of the `CustomResorceDefinition` API.
+====
+
 [id="ocp-4-9-osdk"]
 === Operator development
 


### PR DESCRIPTION
4.9 Release note

[OSDOCS-2203](https://issues.redhat.com/browse/OSDOCS-2203)

Docs Preview: https://deploy-preview-36313--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-olm-k8s-1.22

Requires: #36083