### PR TITLE
BZ1997337: move SAN certificate feature from deprecated to removed features list in 4.6

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -1419,11 +1419,6 @@ In the table, features are marked with the following statuses:
 
 The strategy to bring your own (BYO) {op-system-base-full} 7 compute machines is now deprecated. Support for using {op-system-base} 7 compute machines is planned for removal in a future release of OpenShift 4.
 
-[id="ocp-4-6-tls-common-name"]
-==== TLS verification falling back to the Common Name field
-
-The behavior of falling back to the Common Name field on X.509 certificates as a host name when no Subject Alternative Names are present is deprecated. In a future release, this behavior will be removed, and certificates must properly set the Subject Alternative Names field.
-
 [id="ocp-4-6-metering-operator-deprecated"]
 ==== Metering Operator
 
@@ -1433,18 +1428,23 @@ The Metering Operator is deprecated and will be removed in a future release.
 === Removed features
 
 [id="ocp-4-6-operatorsources-removed"]
-==== OperatorSource resource removed
+==== OperatorSource resource
 
 The `OperatorSource` resource, part of the Marketplace API for the Operator Framework, has been deprecated for several {product-title} releases and is now removed. In {product-title} 4.6, the default catalogs for OperatorHub in the `openshift-marketplace` namespace now only use `CatalogSource` resources with the `polling` feature enabled. The default catalogs poll for new updates in their referenced index images every 15 minutes.
 
 [id="ocp-4-6-mongodb-removed"]
-==== MongoDB templates removed
+==== MongoDB templates
 
 All MongoDB-based samples have been replaced, deprecated, or removed.
 
 [id="ocp-4-6-aws-efs-tp-removed-2nd"]
-==== External provisioner for AWS EFS (Technology Preview) feature has been removed
+==== External provisioner for AWS EFS (Technology Preview)
 The Amazon Web Services (AWS) Elastic File System (EFS) Technology Preview feature has been removed and is no longer supported.
+
+[id="ocp-4-6-tls-common-name"]
+==== TLS verification falling back to the Common Name field
+
+The behavior of falling back to the *Common Name* field on X.509 certificates as a host name when no Subject Alternative Names (SANs) are present is removed. Certificates must properly set the *Subject Alternative Names* field.
 
 [id="ocp-4-6-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Applies only to 4.6

Docs preview link: https://deploy-preview-36324--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp

https://bugzilla.redhat.com/show_bug.cgi?id=1997337

Requires ack from @yaoli-redhat @sttts @Anandnatraj 