### PR TITLE
[BZ2003724] Add installer note for IBM Z and P

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -13,6 +13,11 @@
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_openstack/installing-openstack-user.adoc
 
 
@@ -73,6 +78,27 @@ endif::[]
 ifeval::["{context}" == "installing-platform-agnostic"]
 :baremetal:
 endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+:restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+:restricted:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:ibm-power:
+:restricted:
+endif::[]
 
 [id="installation-user-infra-generate-k8s-manifest-ignition_{context}"]
 = Creating the Kubernetes manifest and Ignition config files
@@ -85,6 +111,21 @@ The installation configuration file transforms into the Kubernetes manifests. Th
 ====
 The Ignition config files that the {product-title} installation program generates contain certificates that expire after 24 hours, which are then renewed at that time. If the cluster is shut down before renewing the certificates and the cluster is later restarted after the 24 hours have elapsed, the cluster automatically recovers the expired certificates. The exception is that you must manually approve the pending `node-bootstrapper` certificate signing requests (CSRs) to recover kubelet certificates. See the documentation for _Recovering from expired control plane certificates_ for more information.
 ====
+
+ifdef::ibm-z[]
+[NOTE]
+====
+The installation program that generates the manifest and Ignition files is architecture specific and can be obtained from the
+link:https://mirror.openshift.com/pub/openshift-v4/s390x/clients/ocp/latest/[client image mirror]. The Linux version of the installation program runs on s390x only. This installer program is also available as a Mac OS version.
+====
+endif::ibm-z[]
+ifdef::ibm-power[]
+[NOTE]
+====
+The installation program that generates the manifest and Ignition files is architecture specific and can be obtained from the
+link:https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/latest/[client image mirror]. The Linux version of the installation program runs on ppc64le only. This installer program is also available as a Mac OS version.
+====
+endif::ibm-power[]
 
 .Prerequisites
 
@@ -157,13 +198,13 @@ to initialize them.
 +
 * You can preserve the machine set files to create compute machines by using the machine API, but you must update references to them to match your environment.
 endif::osp,vsphere,vmc[]
-ifdef::baremetal,baremetal-restricted[]
+ifdef::baremetal,baremetal-restricted,ibm-z,ibm-power[]
 +
 [WARNING]
 ====
 If you are installing a three-node cluster, skip the following step to allow the control plane nodes to be schedulable.
 ====
-endif::baremetal,baremetal-restricted[]
+endif::baremetal,baremetal-restricted,ibm-z,ibm-power[]
 
 . Check that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file is set to `false`. This setting prevents pods from being scheduled on the control plane machines:
 +
@@ -370,4 +411,25 @@ ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 endif::[]
 ifeval::["{context}" == "installing-platform-agnostic"]
 :!baremetal:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z-kvm:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z-kvm:
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!ibm-power:
+:!restricted:
 endif::[]


### PR DESCRIPTION
OCP versions for cherry-picking: enterprise-4.7, 4.8, 4.9

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2003724

Preview 
 - IBM Z: https://deploy-preview-36325--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-generate-k8s-manifest-ignition_installing-ibm-z
 - IBM Power Systems: https://deploy-preview-36325--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#installation-user-infra-generate-k8s-manifest-ignition_installing-ibm-power
(I've verified the change is shown in all 6 IBM Z/P install docs) 

QE review: 
 - Z: Wolfgang Voesch
 - P: Pravin D-Silva