### PR TITLE
BZ1926142: Add clarity for machine requirements

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -99,7 +99,7 @@ these cluster machines.
 endif::ibm-z[]
 ====
 
-The bootstrap and control plane machines must use {op-system-first} as the operating system.
+The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first} or {op-system-base-full} 7.9.
 
 ifdef::bare-metal,agnostic[]
 [IMPORTANT]


### PR DESCRIPTION
In "Minimum resource requirements" table it's mentioned that compute
nodes can use both RHCOS or RHEL 7.9.
This commit fixes the contradiction between the table and the sentence
in the "Required machines" section.

Fixes: [BZ1926142](https://bugzilla.redhat.com/show_bug.cgi?id=1926142)

QA contact: @xltian 
OCP version: Applicable for 4.6.z versions

Preview: [Link](https://github.com/openshift/openshift-docs/pull/36327)