### PR TITLE
GH#36271: redirect loop on docs.okd.io

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -39,11 +39,13 @@ You can also deploy a cluster on AWS infrastructure that you provisioned yoursel
 
 - **xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[Install a cluster on VMware vSphere]**: You can install {product-title} on supported versions of vSphere.
 
+ifndef::openshift-origin[]
 - **xref:../installing/installing_ibm_z/installing-ibm-z.adoc#installing-ibm-z[Install a cluster with z/VM on IBM Z and LinuxONE]**: You can install {product-title} with z/VM on IBM Z and LinuxONE on user-provisioned infrastructure.
 
 - **xref:../installing/installing_ibm_z/installing-ibm-z-kvm.adoc#installing-ibm-z-kvm[Install a cluster with RHEL KVM on IBM Z and LinuxONE]**: You can install {product-title} with RHEL KVM on IBM Z and LinuxONE on user-provisioned infrastructure.
 
 - **xref:../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[Install a cluster on IBM Power Systems]**: You can install {product-title} on IBM Power Systems on user-provisioned infrastructure.
+endif::openshift-origin[]
 
 - **xref:../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Install an installer-provisioned cluster on bare metal]**: You can install {product-title} on bare metal with an installer-provisioned architecture.
 
@@ -63,16 +65,29 @@ xref:../installing/installing_openstack/installing-openstack-troubleshooting.ado
 xref:../installing/installing_rhv/installing-rhv-default.adoc#installing-rhv-default[quick install] or an
 xref:../installing/installing_rhv/installing-rhv-customizations.adoc#installing-rhv-customizations[install with customizations].
 
+ifndef::openshift-origin[]
 - **Install a cluster in a restricted network**: If your cluster that uses
 user-provisioned infrastructure on
 xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS],
 xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[GCP],
 xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[vSphere],
-xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[IBM Z and LinuxONE with z/VM], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[IBM Z and LinuxONE with RHEL KVM], xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[IBM Power Systems],
-or
+xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[IBM Z and LinuxONE with z/VM], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[IBM Z and LinuxONE with RHEL KVM], xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[IBM Power Systems], 
+ or
 xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]
 does not have full access to the internet, then
 xref:../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[mirror the {product-title} installation images] and install a cluster in a restricted network.
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+- **Install a cluster in a restricted network**: If your cluster that uses
+user-provisioned infrastructure on
+xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS],
+xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[GCP],
+ or
+xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]
+does not have full access to the internet, then
+xref:../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[mirror the {product-title} installation images] and install a cluster in a restricted network.
+endif::openshift-origin[]
 
 - **Install a cluster in an existing network**: If you use an existing Virtual Private Cloud (VPC) in
 xref:../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-vpc[AWS] or


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/36271
For OKD, hiding links to IBM installs from the Welcome page.

OKD Preview (VPN needed) http://file.rdu.redhat.com/~mburke/okd-fix-welcome-ibm/welcome/#cluster-installer-activities
OCP Preview: https://deploy-preview-36328--osdocs.netlify.app/openshift-enterprise/latest/welcome/?utm_source=github&utm_campaign=bot_dp#cluster-installer-activities

Change is for 4.8+ and main only. See PR where the text was added to 4.8/main: https://github.com/openshift/openshift-docs/pull/33427