### PR TITLE
RHDEVDOCS-3295 Add a link to the OL 5.0.8 and 5.1.2 advisories to the 5.0 release…

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,17 +1,46 @@
 [id="cluster-logging-release-notes"]
-= Release notes for Red Hat OpenShift Logging 5.1
+= Release notes for Red Hat OpenShift Logging
 include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
 toc::[]
 
-[id="openshift-logging-about-this-release"]
-== About this release
+[id="openshift-logging-inclusive-language"]
+== Making open source more inclusive
+
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
+
+[id="openshift-logging-about-this-release-5-1"]
+
+== Red Hat OpenShift Logging 5.1
+
+.Supported versions
+
+OpenShift Logging version 5.1 runs on {product-title} versions 4.7 and 4.8.
+
+.Advisories
 
 The following advisories are available for OpenShift Logging 5.1.x:
 
+* link:https://access.redhat.com/errata/RHBA-2021:3545[RHBA-2021:3545 - Bug Fix Advisory. Openshift Logging Bug Fix Release 5.1.2]
 * link:https://access.redhat.com/errata/RHBA-2021:2885[RHBA-2021:2885 - Bug Fix Advisory. Openshift Logging Bug Fix Release 5.1.1]
 * link:https://access.redhat.com/errata/RHBA-2021:2112[RHBA-2021:2112 - Bug Fix Advisory. OpenShift Logging Bug Fix Release 5.1.0]
+
+// Release Notes by version
+include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+2]
+
+[id="cluster-logging-release-notes-5-0"]
+== Red Hat OpenShift Logging 5.0
+
+.Supported versions
+
+OpenShift Logging version 5.0 runs on {product-title} versions 4.7.
+
+.Advisories
+
+The following advisories are available for OpenShift Logging 5.0.x:
+
+* link:https://access.redhat.com/errata/RHBA-2021:3526[RHBA-2021:3526 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.8)]
 * link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.7)]
 * link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]
 * link:https://access.redhat.com/errata/RHSA-2021:2374[RHSA-2021:2374 - Security Advisory. Moderate: Openshift Logging Bug Fix Release (5.0.5)]
@@ -21,23 +50,13 @@ The following advisories are available for OpenShift Logging 5.1.x:
 * link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)]
 * link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0]
 
-[id="openshift-logging-supported-versions"]
-== Supported versions
 
-* OpenShift Logging version 5.1 runs on {product-title} versions 4.7 and 4.8.
-
-[id="openshift-logging-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
-
-// Release Notes by version
-include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.7.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.6.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.5.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.4.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+1]
-include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+1]
+include::modules/cluster-logging-release-notes-5.0.8.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.7.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.6.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.5.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.4.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.3.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.2.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.1.adoc[leveloffset=+2]
+include::modules/cluster-logging-release-notes-5.0.0.adoc[leveloffset=+2]

--- a/modules/cluster-logging-release-notes-5.0.7.adoc
+++ b/modules/cluster-logging-release-notes-5.0.7.adoc
@@ -1,7 +1,7 @@
 [id="cluster-logging-release-notes-5-0-7"]
 = OpenShift Logging 5.0.7
 
-This release includes link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.6)].
+This release includes link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.7)].
 
 [id="openshift-logging-5-0-7-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.0.8.adoc
+++ b/modules/cluster-logging-release-notes-5.0.8.adoc
@@ -1,0 +1,12 @@
+[id="cluster-logging-release-notes-5-0-8"]
+= OpenShift Logging 5.0.8
+
+This release includes link:https://access.redhat.com/errata/RHBA-2021:3526[RHBA-2021:3526 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.8)].
+
+[id="openshift-logging-5-0-8-bug-fixes"]
+== Bug fixes
+
+This release also includes the following bug fixes:
+
+* Due to an issue in the release pipeline scripts, the value of the `olm.skipRange` field remained unchanged at `5.2.0` and was not updated when the z-stream number, `0`, increased. The current release fixes the pipeline scripts to update the value of this field when the release numbers change.
+ (link:https://issues.redhat.com/browse/LOG-1741[LOG-1741])


### PR DESCRIPTION
… notes

- Aligned team: Dev Tools
- For branches: enterprise-4.7 only (NOT main)
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3295
- Direct link to doc preview: https://deploy-preview-36329--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes?utm_source=github&utm_campaign=bot_dp
- SME review: @periklis 
- QE review: @kabirbhartiRH 
- Peer review: @robin-owen
- All reviews complete. Please merge now.