### PR TITLE
CNV-8875: New release note - stable channel update

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -46,6 +46,9 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 
 //CNV-9540 High performance windows
 
+//CNV-8875
+* If your {VirtProductName} Operator subscription used any update channel other than *stable*, it is now automatically subscribed to the *stable* channel. This single update channel delivers z-stream and minor version updates and ensures that your {VirtProductName} and {product-title} versions are compatible.
+
 [id="virt-4-9-quick-starts"]
 === Quick starts
 


### PR DESCRIPTION
Re: [CNV-8875](https://issues.redhat.com/browse/CNV-8875)
For 4.9 release notes

Preview: https://deploy-preview-36349--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-9-release-notes