### PR TITLE
[RHACS] Nit fixes for modular docs guidelines

### DIFF
--- a/configuration/enable-offline-mode.adoc
+++ b/configuration/enable-offline-mode.adoc
@@ -44,7 +44,7 @@ You can enable offline mode during the installation of {product-title}.
 include::modules/enable-offline-mode-helm.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+==== Additional resources
 * xref:../installing/installing_helm/install-helm-customization.adoc#configure-central-services-helm-chart[Configuring the central-services Helm chart]
 * xref:../installing/installing_helm/install-helm-customization.adoc#configure-secured-cluster-services-helm-chart[Configuring the secured-cluster-services Helm chart]
 
@@ -79,7 +79,7 @@ To upload Scanner definitions to Central, you can either use an API token or you
 include::modules/upload-definitions-to-central-api-token.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
-.Additional resources
+===== Additional resources
 * xref:../cli/getting-started-cli.adoc#cli-authentication_cli-getting-started[Authenticating using the roxctl CLI]
 
 //Upload the definitions to Central (admin password)

--- a/installing/install-ocp-operator.adoc
+++ b/installing/install-ocp-operator.adoc
@@ -54,7 +54,7 @@ include::modules/portal-generate-init-bundle.adoc[leveloffset=+2]
 include::modules/roxctl-generate-init-bundle.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+==== Additional resources
 * xref:../cli/getting-started-cli.adoc#installing-roxctl-cli[Installing the roxctl CLI]
 
 include::modules/create-resource-init-bundle.adoc[leveloffset=+1]

--- a/integration/integrate-using-syslog-protocol.adoc
+++ b/integration/integrate-using-syslog-protocol.adoc
@@ -6,7 +6,6 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-
 https://tools.ietf.org/html/rfc5424[Syslog] is an event logging protocol that applications use to send messages to a central location, such as a SIEM or a syslog collector, for data retention and security investigations.
 With {product-title}, you can send alerts and audit events using the syslog protocol.
 

--- a/integration/integrate-with-amazon-s3.adoc
+++ b/integration/integrate-with-amazon-s3.adoc
@@ -6,7 +6,6 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-
 You can integrate {product-title} with link:https://aws.amazon.com/s3/[Amazon S3] to enable data backups.
 You can use these backups for data restoration in the case of an infrastructure disaster or corrupt data.
 After you integrate with Amazon S3, you can schedule daily or weekly backups and do manual on-demand backups.

--- a/integration/integrate-with-ci-systems.adoc
+++ b/integration/integrate-with-ci-systems.adoc
@@ -42,7 +42,7 @@ To scan images, you must provide {product-title} with access to the image regist
 include::modules/check-for-existing-registry-integration.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
+==== Additional resources
 * xref:../integration/integrate-with-image-registries.adoc#integrating-with-image-registries[Integrating with image registries]
 
 [id="configure-access"]

--- a/integration/integrate-with-google-cloud-storage.adoc
+++ b/integration/integrate-with-google-cloud-storage.adoc
@@ -23,7 +23,6 @@ include::modules/google-cloud-storage-configuring-acs.adoc[leveloffset=+1]
 include::modules/perform-on-demand-backups-google-cloud-storage.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-.Additional resources
-
+==== Additional resources
 * xref:../backup_and_restore/backing-up-acs.adoc[Backing up {product-title}]
 * xref:../backup_and_restore/restore-acs.adoc[Restoring from a backup]

--- a/modules/apply-generated-policies.adoc
+++ b/modules/apply-generated-policies.adoc
@@ -6,7 +6,6 @@
 = Applying generated policies
 
 [role="_abstract"]
-
 You can apply the generated network policies from the RHACS portal.
 
 .Procedure

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -51,3 +51,6 @@ endif::[]
 :smallpluralporv: processes
 :capsporv: Process
 :capspluralporv: Processes
+// Following variables are required for publishing using PV2
+:product-title: Red Hat Advanced Cluster Security for Kubernetes
+:product-version: 3.65

--- a/modules/google-cloud-storage-configuring-acs.adoc
+++ b/modules/google-cloud-storage-configuring-acs.adoc
@@ -6,7 +6,7 @@
 = Configuring {product-title}
 
 [role="_abstract"]
-
+To configure data backups on Google Cloud Storage (GCS), create an integration in {product-title}.
 
 .Prerequisites
 * An existing *bucket*.

--- a/modules/rbac-resource-definitions.adoc
+++ b/modules/rbac-resource-definitions.adoc
@@ -6,7 +6,6 @@
 = Resource definitions
 
 [role="_abstract"]
-
 {product-title} includes multiple resources.
 The following table lists the resources and describes the actions that users can perform with the `read` or `write` permission.
 

--- a/modules/unused-kubernetes-roles.adoc
+++ b/modules/unused-kubernetes-roles.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/review-cluster-configuration.adoc
+:experimental:
 :_module-type: PROCEDURE
 [id="unused-kubernetes-roles_{context}"]
 = Finding unused Kubernetes roles

--- a/operating/examine-images-for-vulnerabilities.adoc
+++ b/operating/examine-images-for-vulnerabilities.adoc
@@ -55,7 +55,7 @@ include::modules/fetching-vulnerability-definitions.adoc[leveloffset=+1]
 include::modules/understanding-vulnerability-scores.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+=== Additional resources
 * xref:../operating/examine-images-for-vulnerabilities.adoc#scan-inactive-images_examine-images-for-vulnerabilities[Scanning inactive images]
 * xref:../cli/getting-started-cli.adoc#getting-started-with-the-roxctl-cli[Getting started with the roxctl CLI]
 //Add link to integrate image scanners topic

--- a/operating/use-system-health-dashboard.adoc
+++ b/operating/use-system-health-dashboard.adoc
@@ -18,5 +18,5 @@ include::modules/system-health-dashboard-details.adoc[leveloffset=+1]
 include::modules/generate-diagnostic-bundle-using-acs-portal.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+=== Additional resources
 * xref:../configuration/generate-diagnostic-bundle.adoc#generating-a-diagnostic-bundle[Generating a diagnostic bundle]

--- a/upgrading/upgrade-helm.adoc
+++ b/upgrading/upgrade-helm.adoc
@@ -17,7 +17,7 @@ If you have installed {product-title} by using Helm charts, to upgrade to the la
 include::modules/updating-helm-repository.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+== Additional resources
 * xref:../installing/installing_helm/install-helm-customization.adoc#configure-central-services-helm-chart[Configuring the central-services Helm chart]
 
 include::modules/change-config-options-after-deployment-central-service.adoc[leveloffset=+1]


### PR DESCRIPTION
Updated content based on modular documentation guidelines.
- Additional resources section heading when used in Assemblies
- No empty line after `[role="_abstract"]`
- Experimental tag for using `kbd:[Shift]`


Preview at https://openshift-docs-git-pv2-fixes-gnelson.vercel.app/openshift-acs/master/welcome/index.html

NOTES:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
