### PR TITLE
Typo fix: added missing full stop

### DIFF
--- a/modules/images-configuration-parameters.adoc
+++ b/modules/images-configuration-parameters.adoc
@@ -37,7 +37,7 @@ pods. For instance, whether or not to allow insecure access. It does not contain
 
 `blockedRegistries`: Registries for which image pull and push actions are denied. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name. For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are allowed. 
 
-`allowedRegistries`: Registries for which image pull and push actions are allowed. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are blocked.
+`allowedRegistries`: Registries for which image pull and push actions are allowed. To specify all subdomains, add the asterisk (`\*`) wildcard character as a prefix to the domain name. For example, `*.example.com`. You can specify an individual repository within a registry. For example: `reg1.io/myrepo/myapp:latest`. All other registries are blocked.
 
 `containerRuntimeSearchRegistries`: Registries for which image pull and push actions are allowed using image short names. All other registries are blocked.
 


### PR DESCRIPTION
This fixes a typo that I introduced in #35288.

* applies to `enterprise-4.9`
* [direct preview](https://deploy-preview-36367--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-parameters_image-configuration)