### PR TITLE
TELCODOCS-268: Release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -140,6 +140,13 @@ For this release, Red Hat only supports using MetalLB in layer 2 mode.
 
 For more information, see xref:../networking/metallb/about-metallb.adoc#about-metallb[About MetalLB and the MetalLB Operator].
 
+[id="ocp-4-9-networking-CNI-VRF-plug-in"]
+==== CNI VRF plug-in is generally available
+
+The CNI VRF plug-in was previously introduced as a Technology Preview feature in {product-title} 4.7 and is now generally available in {product-title} {product-version}.
+
+For more information, see xref:../networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc#cnf-assigning-a-secondary-network-to-a-vrf[Assigning a secondary network to a VRF].
+
 [id="ocp-4-9-storage"]
 === Storage
 
@@ -648,6 +655,11 @@ In the table below, features are marked with the following statuses:
 |
 |
 |TP
+
+|CNI VRF plug-in
+|TP
+|TP
+|GA
 
 |====
 


### PR DESCRIPTION
For 4.9: [Jira issue](https://issues.redhat.com/browse/TELCODOCS-268)

[Release note](https://deploy-preview-36368--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-networking-CNI-VRF-plug-in)

[Technology Preview table](https://deploy-preview-36368--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-technology-preview)