### PR TITLE
BZ1902087: Swapped mysql example for nodejs

### DIFF
--- a/modules/nw-creating-project-and-service.adoc
+++ b/modules/nw-creating-project-and-service.adoc
@@ -17,32 +17,21 @@ service to create a route.
 
 .Procedure
 
-. Create a new project for your service:
-+
-[source,terminal]
-----
-$ oc new-project <project_name>
-----
-+
-For example:
+. Create a new project for your service by running the `oc new-project` command:
 +
 [source,terminal]
 ----
 $ oc new-project myproject
 ----
 
-. Use the `oc new-app` command to create a service. For example:
+. Use the `oc new-app` command to create your service:
 +
 [source,terminal]
 ----
-$ oc new-app \
-    -e MYSQL_USER=admin \
-    -e MYSQL_PASSWORD=redhat \
-    -e MYSQL_DATABASE=mysqldb \
-    registry.redhat.io/rhscl/mysql-80-rhel7
+$ oc new-app nodejs:12~https://github.com/sclorg/nodejs-ex.git
 ----
 
-. Run the following command to see that the new service is created:
+. To verify that the service was created, run the following command:
 +
 [source,terminal]
 ----
@@ -52,8 +41,10 @@ $ oc get svc -n myproject
 .Example output
 [source,terminal]
 ----
-NAME             TYPE        CLUSTER-IP     EXTERNAL-IP   PORT(S)    AGE
-mysql-80-rhel7   ClusterIP   172.30.63.31   <none>        3306/TCP   4m55s
+NAME        TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)    AGE
+nodejs-ex   ClusterIP   172.30.197.157   <none>        8080/TCP   70s
 ----
 +
 By default, the new service does not have an external IP address.
+
+

--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -25,67 +25,57 @@ $ oc project myproject
 ----
 
 ifndef::nodeport[]
-. Run the following command to expose the route:
+. Run the `oc expose service` command to expose the route:
 +
+
 [source,terminal]
 ----
-$ oc expose service <service_name>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc expose service mysql-80-rhel7
+$ oc expose service nodejs-ex
 ----
 +
 .Example output
 [source,terminal]
 ----
-route "mysql-80-rhel7" exposed
+route.route.openshift.io/nodejs-ex exposed
 ----
 
-. Use a tool, such as cURL, to make sure you can reach the service using the
-cluster IP address for the service:
+. To verify that the service is exposed, you can use a tool, such as cURL, to make sure the service is accessible from outside the cluster.
+
+.. Use the `oc get route` command to find the route's host name:
 +
 [source,terminal]
 ----
-$ curl <pod_ip>:<port>
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ curl 172.30.131.89:3306
-----
-+
-The examples in this section uses a MySQL service, which requires a client
-application. If you get a string of characters with the `Got packets out of order`
-message, you are connected to the service.
-+
-If you have a MySQL client, log in with the standard CLI command:
-+
-[source,terminal]
-----
-$ mysql -h 172.30.131.89 -u admin -p
+$ oc get route
 ----
 +
 .Example output
 [source,terminal]
 ----
-Enter password:
-Welcome to the MariaDB monitor.  Commands end with ; or \g.
-
-MySQL [(none)]>
+NAME        HOST/PORT                        PATH   SERVICES    PORT       TERMINATION   WILDCARD
+nodejs-ex   nodejs-ex-myproject.example.com         nodejs-ex   8080-tcp                 None
 ----
+
+.. Use cURL to check that the host responds to a GET request:
++
+[source,terminal]
+----
+$ curl --head nodejs-ex-myproject.example.com
+----
++
+.Example output
+[source,terminal]
+----
+HTTP/1.1 200 OK
+...
+----
+
 endif::nodeport[]
 ifdef::nodeport[]
 . To expose a node port for the application, enter the following command. {product-title} automatically selects an available port in the `30000-32767` range.
 +
 [source,terminal]
 ----
-$ oc expose dc mysql-80-rhel7 --type=NodePort --name=mysql-ingress
+$ oc expose dc nodejs-ex --type=NodePort --name=nodejs-ex-ingress
 ----
 
 . Optional: To confirm the service is available with a node port exposed, enter the following command:
@@ -98,16 +88,16 @@ $ oc get svc -n myproject
 .Example output
 [source,terminal]
 ----
-NAME             TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
-mysql-80-rhel7   ClusterIP   172.30.217.127   <none>        3306/TCP         9m44s
-mysql-ingress    NodePort    172.30.107.72    <none>        3306:31345/TCP   39s
+NAME                TYPE        CLUSTER-IP       EXTERNAL-IP   PORT(S)          AGE
+nodejs-ex           ClusterIP   172.30.217.127   <none>        3306/TCP         9m44s
+nodejs-ex-ingress   NodePort    172.30.107.72    <none>        3306:31345/TCP   39s
 ----
 
 . Optional: To remove the service created automatically by the `oc new-app` command, enter the following command:
 +
 [source,terminal]
 ----
-$ oc delete svc mysql-80-rhel7
+$ oc delete svc nodejs-ex
 ----
 endif::nodeport[]
 


### PR DESCRIPTION
I changed the example app from mySQL to NodeJS.

https://bugzilla.redhat.com/show_bug.cgi?id=1902087

Applies to 4.6+

https://deploy-preview-36417--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html
https://deploy-preview-36417--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.html