### PR TITLE
[BZ: 2004921][MULTIARCH:1392][WIP]: Updates for IBM Power OCP 4.9

### DIFF
--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -79,6 +79,8 @@ include::modules/installation-user-infra-machines-static-network.adoc[leveloffse
 
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
+include::modules/rhcos-enabling-multipath-day-1-power.adoc[leveloffset=+2]
+
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
@@ -103,6 +105,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 == Next steps
 
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Enabling multipathing with kernel arguments on {op-system}].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -87,6 +87,8 @@ include::modules/installation-user-infra-machines-static-network.adoc[leveloffse
 
 include::modules/installation-user-infra-machines-pxe.adoc[leveloffset=+2]
 
+include::modules/rhcos-enabling-multipath-day-1-power.adoc[leveloffset=+2]
+
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
@@ -115,5 +117,6 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 == Next steps
 
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#rhcos-enabling-multipath_post-install-machine-configuration-tasks[Enabling multipathing with kernel arguments on {op-system}].
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -153,62 +153,17 @@ command.
 If the pod logs display, the Kubernetes API server can communicate with the
 cluster machines.
 
-ifndef::ibm-power,ibm-z,ibm-z-kvm[]
-. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing.
-+
-[NOTE]
-====
-When installing with multipath, it is strongly recommended to enable it at installation time, and not at a later time, which can cause problems.
-====
-+
-See "Enabling multipathing with kernel arguments on {op-system}" in the _Installing on bare metal_ documentation for more information.
-endif::ibm-power,ibm-z,ibm-z-kvm[]
+ifndef::ibm-power[]
+. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing. Do not enable multipathing during installation.
+endif::ibm-power[]
 ifdef::ibm-power[]
 . Additional steps are required to enable multipathing. Do not enable multipathing during installation.
-+
-See the _Installing {op-system} and starting the {product-title} bootstrap process_ documentation for more information.
-
-.. To display a boot list and specify the possible boot devices if the system is booted in normal mode, enter the following command:
-+
-[source,terminal]
-----
-$ bootlist -m normal -o
-sda
-----
-.. To update the boot list for normal mode and add alternate device names, enter the following command:
-+
-[source,terminal]
-----
-$ bootlist -m normal -o /dev/sdc /dev/sdd /dev/sde
-sdc
-sdd
-sde
-----
-+
-If the original boot disk path is down, the node reboots from the alternate device registered in the normal boot device list.
 endif::ibm-power[]
-ifdef::ibm-power[]
-.. All the worker nodes are restarted. To monitor the process, enter the following command:
-+
-[source,terminal]
-----
-$ oc get nodes -w
-----
-+
-[NOTE]
-====
-If you have additional machine types such as infrastructure nodes, repeat the process for these types.
-====
-endif::ibm-power[]
-
-ifdef::ibm-z[]
-. For an installation with Fibre Channel Protocol (FCP), additional steps are required to enable multipathing. Do not enable multipathing during installation.
 +
 See "Enabling multipathing with kernel arguments on {op-system}" in the _Post-installation machine configuration tasks_ documentation for more information.
-endif::ibm-z[]
 
 ifdef::restricted[]
-. Register your cluster on the link:https://console.redhat.com/openshift/register[Cluster registration] page.
+. Register your cluster on the link:https://cloud.redhat.com/openshift/register[Cluster registration] page.
 endif::restricted[]
 
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]

--- a/modules/rhcos-enabling-multipath-day-1-power.adoc
+++ b/modules/rhcos-enabling-multipath-day-1-power.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+
+[id="rhcos-enabling-multipathday-1-power_{context}"]
+= Enabling multipathing with kernel arguments on {op-system}
+
+In {product-title} 4.9 or later, during installation, you can enable multipathing for provisioned nodes.  {op-system} supports multipathing on the primary disk. Multipathing provides added benefits of stronger resilience to hardware failure to achieve higher host availability.
+
+During the initial cluster creation, you might want to add kernel arguments to all master or worker nodes. To add kernel arguments to master or worker nodes, you can create a `MachineConfig` object and inject that object into the set of manifest files used by Ignition during cluster setup. 
+
+.Procedure
+
+. Change to the directory that contains the installation program and generate the Kubernetes manifests for the cluster:
++
+[source,terminal]
+----
+$ ./openshift-install create manifests --dir=<installation_directory>
+----
+
+. Decide if you want to add kernel arguments to worker or master nodes.
+
+* Create a machine config file. For example, create a `99-master-kargs-mpath.yaml` that instructs the cluster to add the `master` label and identify the multipath kernel argument:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "master"
+  name: 99-master-kargs-mpath
+spec:
+  kernelArguments:
+    - 'rd.multipath=default'
+    - 'root=/dev/disk/by-label/dm-mpath-root'
+----
+
+. To enable multipathing post-installation on worker nodes:
+
+* Create a machine config file. For example, create a `99-worker-kargs-mpath.yaml` that instructs the cluster to add the `worker` label and identify the multipath kernel argument:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: "worker"
+  name: 99-worker-kargs-mpath
+spec:
+  kernelArguments:
+    - 'rd.multipath=default'
+    - 'root=/dev/disk/by-label/dm-mpath-root'
+----
++
+You can now continue on to create the cluster.
+
+[IMPORTANT]
+====
+Additional post-installation steps are required to fully enable multipathing. For more information, see “Enabling multipathing with kernel arguments on {op-system}" in _Post-installation machine configuration tasks_.
+====
+
+In case of MPIO failure, use the bootlist command to update the boot device list with alternate logical device names.
+The command displays a boot list and it designates the possible boot devices for when the system is booted in normal mode.
+
+.. To display a boot list and specify the possible boot devices if the system is booted in normal mode, enter the following command:
++
+[source,terminal]
+----
+$ bootlist -m normal -o
+sda
+----
+.. To update the boot list for normal mode and add alternate device names, enter the following command:
++
+[source,terminal]
+----
+$ bootlist -m normal -o /dev/sdc /dev/sdd /dev/sde
+sdc
+sdd
+sde
+----
++
+If the original boot disk path is down, the node reboots from the alternate device registered in the normal boot device list.


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.9

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2004921
Jira: https://issues.redhat.com/browse/MULTIARCH-1392 

Drafts:
for P : https://docs.google.com/document/d/1ltvH5VztEmgAuFoIaWrbBR1i8rvmr55KwPwUF7AQXqY/edit?usp=sharing

Reviewers :
For P : Manoj Kumar, Pravin D-Silva

Preview :
Newly added MPIO Day 1 operations:  https://deploy-preview-36418--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#rhcos-enabling-multipathday-1-power_installing-ibm-power  

added new link Enabling multipathing with kernel arguments on RHCOS.  https://deploy-preview-36418--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power.html#next-steps

Step 3: https://deploy-preview-36418--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#installation-complete-user-infra_installing-ibm-power 

