### PR TITLE
TELCODOCS-257: Release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -229,6 +229,16 @@ The Memory Manager feature is now enabled by default for all pods running on the
 
 For more information, see xref:../scalability_and_performance/using-topology-manager.adoc#topology_manager_policies_using-topology-manager[Topology Manager policies].
 
+[id="ocp-4-9-scale-latency-tools-for-latency-testing"]
+==== Additional tools for latency testing
+
+{product-title} {product-version} introduces two additional tools to measure system latency:
+
+* `hwladetect` measures the baseline that the bare hardware can achieve
+* `cyclictest` schedules a repeated timer after `hwlatdetect` passes validation and measures the difference between the desired and the actual trigger times
+
+For more information, see xref:../scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc#cnf-performing-end-to-end-tests-running-the-tests_cnf-master[Running the latency tests]. 
+
 [id="ocp-4-9-backup-and-restore"]
 === Backup and restore
 


### PR DESCRIPTION
For 4.9: [Jira issue](https://issues.redhat.com/browse/TELCODOCS-257)

[Release note](https://deploy-preview-36419--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-scale-latency-tools-for-latency-testing)