### PR TITLE
BZ1995099: Adds mountOptions attribute

### DIFF
--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -238,8 +238,8 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="pv-mount-options_{context}"]
 === Mount options
 
-You can specify mount options while mounting a PV by using the annotation
-`volume.beta.kubernetes.io/mount-options`.
+You can specify mount options while mounting a PV by using the attribute
+`mountOptions`.
 
 For example:
 
@@ -250,13 +250,13 @@ apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: pv0001
-  annotations:
-    volume.beta.kubernetes.io/mount-options: rw,nfsvers=4,noexec <1>
 spec:
   capacity:
     storage: 1Gi
   accessModes:
-  - ReadWriteOnce
+    - ReadWriteOnce
+  mountOptions: <1>
+    - nfsvers=4.1
   nfs:
     path: /tmp
     server: 172.17.0.2


### PR DESCRIPTION
Removed annotation `volume.beta.kubernetes.io/mount-options` because it will be fully deprecated in a future Kubernetes release. Instead, `mountOptions` attribute is added.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1995099

OCP Version: 4.6+

Direct doc preview link: https://deploy-preview-36420--osdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage?utm_source=github&utm_campaign=bot_dp#pv-mount-options_understanding-persistent-storage