### PR TITLE
TELCODOCS-260/262  - OCP 4.9 release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -262,11 +262,14 @@ You can now customize the URL for the internal OAuth server. For more informatio
 
 {product-title} {product-version} introduces the following updates to PTP:
 
-* the `ptp4lConf` field
+* The `ptp4lConf` field
 
-* new option to configure `linuxptp` services as a boundary clock
+* New option to configure `linuxptp` services as a boundary clock
 
-For more information, see xref:../networking/configuring-ptp.adoc#configuring-linuxptp-services-as-boundary-clock_configuring-ptp[Configuring linuxptp services as boundary clock].
+[id="ocp-4-9-ptp-fast-event-notifications"]
+==== Monitoring PTP fast events with the PTP fast event notification framework
+
+Fast event notifications for PTP events are now available for bare-metal clusters. The PTP Operator generates event notifications for every configured PTP-capable network interface. Events are made available through a REST API for applications running on the same node. Fast event notifications are transported by an Advanced Message Queuing Protocol (AMQP) message bus provided by the AMQ Interconnect Operator.
 
 [id="ocp-4-9-ovn-kubernetes-egress-ips-balance"]
 ==== OVN-Kubernetes cluster network provider egress IP feature balances across nodes


### PR DESCRIPTION
enterprise-4.9 release note for PTP fast event notifications for the following doc epics:

https://issues.redhat.com/browse/TELCODOCS-260
https://issues.redhat.com/browse/TELCODOCS-262 

Preview:

https://deploy-preview-36427--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-ptp-fast-event-notifications