### PR TITLE
GitOps- Change default namespace to spring-petclinic namespace

### DIFF
--- a/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc
@@ -33,7 +33,7 @@ Repository URL:: `https://github.com/redhat-developer/openshift-gitops-getting-s
 Revision:: `HEAD`
 Path:: `cluster`
 Destination:: `https://kubernetes.default.svc`
-Namespace:: `default`
+Namespace:: `spring-petclinic`
 Directory Recurse:: `checked`
 endif::cluster[]
 

--- a/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
+++ b/modules/gitops-creating-an-application-by-using-the-oc-tool.adoc
@@ -54,13 +54,13 @@ ifdef::app[]
 +
 [source,terminal]
 ----
-$ oc label namespace springpet-clinic argocd.argoproj.io/managed-by=openshift-gitops
+$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
 ----
 endif::app[]
 ifdef::cluster[]
 +
 [source,terminal]
 ----
-$ oc label namespace default argocd.argoproj.io/managed-by=openshift-gitops
+$ oc label namespace spring-petclinic argocd.argoproj.io/managed-by=openshift-gitops
 ----
 endif::cluster[]


### PR DESCRIPTION
Changed `default` namespace to `spring-petclinic`; using `default` namespace is not encouraged. 

Would fix [GITOPS-1363](https://issues.redhat.com/browse/GITOPS-1363?focusedCommentId=19032813&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-19032813).

OCP Version - 4.7, 4.8, 4.9

cc @wtam2018