### PR TITLE
ENTESB-17309: Camel-K bug for Serverless relnotes

### DIFF
--- a/modules/serverless-rn-1-17-0.adoc
+++ b/modules/serverless-rn-1-17-0.adoc
@@ -32,9 +32,6 @@ spec:
 
 ** The `v1alpha1` version of the `KafkaChannel` API, which was deprecated in {ServerlessProductName} version 1.14.0, has been removed. If the `ChannelTemplateSpec` parameters of your config maps contain references to this older version, you must update this part of the spec to use the correct API version.
 
-[id="fixed-issues-1-17-0_{context}"]
-== Fixed issues
-
 [id="known-issues-1-17-0_{context}"]
 == Known issues
 
@@ -50,3 +47,5 @@ Ensure that you are using the latest `kn` CLI version for your {ServerlessProduc
 +
 As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
 // add KB article link when ready
+
+* The Camel-K 1.4 release is not compatible with {ServerlessProductName} version 1.17.0. This is because Camel-K 1.4 uses APIs that were removed in Knative version 0.23.0. There is currently no workaround available for this issue. If you need to use Camel-K 1.4 with {ServerlessProductName}, do not upgrade to {ServerlessProductName} version 1.17.0.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/ENTESB-17309

Direct preview link: https://deploy-preview-36457--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes?utm_source=github&utm_campaign=bot_dp#known-issues-1-17-0_serverless-release-notes

Applies for OCP 4.6+