### PR TITLE
SRVKS-772: Add disableRoute note

### DIFF
--- a/modules/serverless-openshift-routes.adoc
+++ b/modules/serverless-openshift-routes.adoc
@@ -20,7 +20,12 @@ You must modify the replaceable values in the example commands for the following
 .Procedure
 
 . Create a Knative service that includes the `serving.knative.openshift.io/disableRoute=true` annotation:
-.. Optional. Create a Knative service resource:
++
+[IMPORTANT]
+====
+The `serving.knative.openshift.io/disableRoute=true` annotation instructs {ServerlessProductName} to not automatically create a route for you. However, the service still shows a URL and reaches a status of `Ready`. This URL does not work externally until you create your own route with the same hostname as the hostname in the URL.
+====
+.. Create a Knative `Service` resource:
 +
 .Example resource
 [source,yaml]
@@ -30,12 +35,13 @@ kind: Service
 metadata:
   name: <service_name>
   annotations:
-    serving.knative.openshift.io/disableRoute: true
+    serving.knative.openshift.io/disableRoute: "true"
 spec:
   template:
     spec:
       containers:
       - image: <image>
+...
 ----
 .. Apply the `Service` resource:
 +


### PR DESCRIPTION
Applies for OCP 4.6+

Jira: https://issues.redhat.com/browse/SRVKS-772

Direct preview link: https://deploy-preview-36466--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-configuring-routes?utm_source=github&utm_campaign=bot_dp#serverless-openshift-routes_serverless-configuring-routes