### PR TITLE
OSDOCS-2467: Creates a list of the SRE-supported services.

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -349,3 +349,6 @@ Topics:
 - Name: Summarizing cluster specifications
   File: summarizing-cluster-specifications
   Distros: openshift-dedicated
+- Name: OpenShift Dedicated managed resources
+  File: osd-managed-resources
+  Distros: openshift-dedicated

--- a/support/osd-managed-resources.adoc
+++ b/support/osd-managed-resources.adoc
@@ -1,0 +1,53 @@
+[id="osd-managed-resources"]
+= {product-title} managed resources
+include::modules/attributes-openshift-dedicated.adoc[]
+:context: osd-managed-resources
+
+toc::[]
+
+[id="osd-managed-resources-overview"]
+== Overview
+
+The following covers all resources managed or protected by the Service Reliability Engineering Platform (SRE-P) Team.  Customers should not attempt to modify these resources because doing so can lead to cluster instability.
+
+[id="osd-managed-resources-all"]
+== Hive managed resources
+
+The following list displays the {product-title} resources managed by OpenShift Hive, the centralized fleet configuration management system. These resources are in addition to the OpenShift Container Platform resources created during installation. OpenShift Hive continually attempts to maintain consistency across all {product-title} clusters. Changes to {product-title} resources should be made through OCM so that OCM and Hive are synchronized. Contact ocm-feedback@redhat.com if OCM does not support modifying the resources in question.
+
+.List of Hive managed resources
+[%collapsible]
+====
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/managed-cluster-config/master/resources/managed/all-osd-resources.yaml[]
+----
+====
+
+[id="osd-add-on-managed-namespaces"]
+== {product-title} add-on namespaces
+
+{product-title} add-ons are services available for installation after cluster installation. These additional services include AWS CloudWatch, Red Hat CodeReady Workspaces, Red Hat OpenShift API Management, and Cluster Logging Operator. Any changes to resources within the following namespaces might be overridden by the add-on during upgrades, which can lead to unsupported configurations for the add-on functionality.
+
+.List of add-on managed namespaces
+[%collapsible]
+====
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/managed-cluster-config/master/resources/addons-namespaces/main.yaml[]
+----
+====
+
+[id="osd-validating-webhooks"]
+== {product-title} validating webhooks
+
+{product-title} validating webhooks are a set of dynamic admission controls maintained by the OpenShift SRE team. These HTTP callbacks, also known as webhooks, are called for various types of requests to ensure cluster stability. Upon request the webhooks accept or reject the request. The following list describes the various webhooks with rules containing the registered operations and resources that are controlled. Any attempt to circumvent these validating webhooks could affect the stability and supportability of the cluster.
+
+.List of validating webhooks
+[%collapsible]
+====
+[source,json]
+----
+include::https://raw.githubusercontent.com/openshift/managed-cluster-validating-webhooks/master/docs/webhooks.json[]
+----
+====


### PR DESCRIPTION
This PR addresses [OSDOCS-2467](https://issues.redhat.com/browse/OSDOCS-2467). This PR adds a new assembly with modules to the Policy and Service Definitions book.

JIRA: https://issues.redhat.com/browse/OSDOCS-2467

Preview: https://deploy-preview-36468--osdocs.netlify.app/openshift-dedicated/latest/support/osd-managed-resources.html