### PR TITLE
OSDOCS-2654: Add missing --name flag for suppressing unexpected result at ROSA docs

### DIFF
--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -16,14 +16,14 @@ Labels are assigned as key=value pairs. Each key must be unique to the object it
 +
 [source,terminal]
 ----
-$ rosa create machinepool --cluster=<cluster-name> <machinepool_ID> --replicas=<number-nodes> --labels=<key=pair>
+$ rosa create machinepool --cluster=<cluster-name> --name=<machinepool_ID> --replicas=<number-nodes> --labels=<key=pair>
 ----
 +
 This example shows how to use labels to assign a database workload to a group of worker nodes, and creates 2 replica worker nodes that you can manage as one unit:
 +
 [source,terminal]
 ----
-$ rosa create machinepool --cluster=mycluster db-nodes-mp --replicas=2 --labels=app=db,tier=backend
+$ rosa create machinepool --cluster=mycluster --name=db-nodes-mp --replicas=2 --labels=app=db,tier=backend
 ----
 +
 .Example output


### PR DESCRIPTION
* Description: 
  If missing "--name" flag, rosa cli always works as the interactive mode. It's not an expected result, because all arguments you specified will be ignored.
* Reference: https://github.com/openshift/rosa/blob/7bd586b231465f6bdadcb930a1e96da8ebd78814/cmd/create/machinepool/cmd.go#L224-L229
```golang
	// Machine pool name:
	name := strings.Trim(args.name, " \t")
	if name == "" && !interactive.Enabled() {
		interactive.Enable()
		reporter.Infof("Enabling interactive mode")
	}
```