### PR TITLE
OSDOCS-2542: CLI Tools overview

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -571,6 +571,8 @@ Name: CLI tools
 Dir: cli_reference
 Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
 Topics:
+- Name: CLI tools overview
+  File: index
 - Name: OpenShift CLI (oc)
   Dir: openshift_cli
   Topics:

--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -1,0 +1,32 @@
+[id="cli-tools-overview"]
+= {product-title} CLI tools overview
+include::modules/common-attributes.adoc[]
+:context: cli-tools-overview
+
+toc::[]
+
+A user performs a range of operations while working on {product-title} such as the following:
+
+* Managing clusters
+* Building, deploying, and managing applications
+* Managing deployment processes
+* Developing Operators
+* Creating and maintaining Operator catalogs
+
+{product-title} offers a set of command-line interface (CLI) tools that simplify these tasks by enabling users to perform various administration and development operations from the terminal.
+These tools expose simple commands to manage the applications, as well as interact with each component of the system.
+
+[id="cli-tools-list"]
+== List of CLI tools
+
+The following set of CLI tools are available in {product-title}:
+
+* xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (oc)]: This is the most commonly used CLI tool by {product-title} users. It helps both cluster administrators and developers to perform end-to-end operations across {product-title} using the terminal. Unlike the web console, it allows the user to work directly with the project source code using command scripts.
+
+* xref:../cli_reference/kn-cli-tools.adoc#kn-cli-tools[Knative CLI (kn)]: The `kn` CLI tool provides simple and intuitive terminal commands that can be used to interact with OpenShift Serverless components, such as Knative Serving and Eventing.
+
+* xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[Pipelines CLI (tkn)]: OpenShift Pipelines is a continuous integration and continuous delivery (CI/CD) solution in {product-title}, which internally uses Tekton. The `tkn` CLI tool provides simple and intuitive commands to interact with OpenShift Pipelines using the terminal.
+
+* xref:../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[opm CLI]: The `opm` CLI tool helps the Operator developers and cluster administrators to create and maintain the catalogs of Operators from the terminal.
+
+* xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Operator SDK]: The Operator SDK, a component of the Operator Framework, provides a CLI tool that Operator developers can use to build, test, and deploy an Operator from the terminal. It simplifies the process of building Kubernetes-native applications, which can require deep, application-specific operational knowledge.


### PR DESCRIPTION
JIRA ticket: https://issues.redhat.com/browse/OSDOCS-2542

Target Release: 4.9

@adellape, @Preeticp, @sounix000  - Here's the first draft. It has all the CLI tools mentioned in overview. However, I have provided the versions they don't belong to, in the bracket. While removing WIP, I will be filtering out the irrelevant tools for every OCP version PR.

@abrennan89 - Kindly review the overview for kn CLI tool.

4.6 PR: #37451
4.7 PR: #37429
4.8 PR: #37427

Preview: https://deploy-preview-36492--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/index.html