### PR TITLE
monitoring: Describe query log file feature for Prometheus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module openshift-docs
+
+go 1.17

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -1,0 +1,136 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+[id="setting-query-log-file-for-prometheus_{context}"]
+= Enabling the query log file for Prometheus
+
+You can configure Prometheus to log all the queries run by the engine to a log file.
+
+[WARNING]
+====
+Since there is no support of log rotation, this feature should only be enabled temporarily to support troubleshooting.
+====
+
+.Prerequisites
+
+* *If you are enabling the query log file feature for Prometheus in the `openshift-monitoring` project*:
+** You have access to the cluster as a user with the `cluster-admin` role.
+** You have created the `cluster-monitoring-config` `ConfigMap` object.
+* *If you are enabling the query log file feature for Prometheus in the `openshift-user-workload-monitoring` project*:
+** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have created the `user-workload-monitoring-config` `ConfigMap` object.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Edit the `ConfigMap` object:
+** *To set the query log file for Prometheus in the `openshift-monitoring` project*:
+.. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+.. Add `queryLogFile: <path>` for `prometheusK8s` under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      queryLogFile: <path> <1>
+----
+<1> The path for the file you wish to log queries to.
+
+. Save the file to apply the changes.
+
++
+[WARNING]
+====
+When changes are saved to a monitoring config map, the pods and other resources in the related project might be redeployed. The running monitoring processes in that project might also be restarted.
+====
+
+. Check that the pods for the component are running. The following example lists the status of pods in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring get pods
+----
++
+
+. Read the query log:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring exec prometheus-k8s-0 -- cat <path>
+----
++
+
+[NOTE]
+====
+Do not forget to revert the setting after you have digested the required information.
+====
+
+** *To set the query log file for Prometheus in the `openshift-user-workload-monitoring` project*:
+.. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring edit configmap user-workload-monitoring-config
+----
+
+.. Add `queryLogFile: <path>` for `prometheus` under `data/config.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: user-workload-monitoring-config
+  namespace: openshift-user-workload-monitoring
+data:
+  config.yaml: |
+    prometheus:
+      queryLogFile: <path> <1>
+----
+<1> The path for the file you wish to log queries to.
+
+. Save the file to apply the changes.
++
+[NOTE]
+====
+Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
+====
++
+[WARNING]
+====
+When changes are saved to a monitoring config map, the pods and other resources in the related project might be redeployed. The running monitoring processes in that project might also be restarted.
+====
+
+. Check that the pods for the component are running. The following example lists the status of pods in the `openshift-user-workload-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring get pods
+----
++
+
+. Read the query log:
++
+[source,terminal]
+----
+$ oc -n openshift-user-workload-monitoring exec prometheus-k8s-0 -- cat <path>
+----
++
+
+[NOTE]
+====
+Do not forget to revert the setting after you have digested the required information.
+====

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -149,6 +149,9 @@ include::modules/monitoring-attaching-additional-labels-to-your-time-series-and-
 // Setting log levels for monitoring components
 include::modules/monitoring-setting-log-levels-for-monitoring-components.adoc[leveloffset=+1]
 
+// Setting query log for Prometheus
+include::modules/monitoring-setting-query-log-file-for-prometheus.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
This documents the changes made in https://github.com/openshift/cluster-monitoring-operator/pull/1373 which enables Prometheus query log file https://prometheus.io/docs/guides/query-log/