### PR TITLE
OSDOCS-2358: release notes for custom error code response pages

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -341,6 +341,12 @@ You can now configure the Ingress Controller to enable mutual TLS (mTLS) authent
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-mutual-tls-auth_configuring-ingress[Configuring Mutual TLS Authentication].
 
+[id="ocp-4-9-nw-customize-ingress-error-pages"]
+==== Customizing HAProxy error code response pages
+
+Cluster administrators can specify a custom HTTP error code response page for either 503, 404, or both error pages.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-customize-ingress-error-pages_configuring-ingress[Customizing HAProxy error code response pages].
 
 [id="ocp-4-9-storage"]
 === Storage
@@ -1205,6 +1211,16 @@ This script removes unauthenticated subjects from the following cluster role bin
 * Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*].
 
 * The SR-IOV network configuration daemon pod will cordon the node and mark it as unschedulable. It will use the add or delete `SriovNetworkNodePolicy` custom resource (CR) before waiting for the `syncStatus` of the CR to change to `Succeeded`. As a temporary workaround, before adding or deleting a `SriovNetworkNodePolicy` CR, make sure the `syncStatus` of the `SriovNetworkNodeState` CRs is in the `Succeeded` state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002508[*BZ#2002508*])
+
+* Cluster administrators can specify a custom HTTP error code response page for either 503, 404, or both error pages. The router does not reload to reflect custom error code pages updates. As a workaround, rsh in the router pods and run `reload-haproxy` in all the router pods that serve the custom http error code pages:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress rsh router-default-6647d984d8-q7b58
+sh-4.4$ bash -x /var/lib/haproxy/reload-haproxy
+----
++
+Alternatively, you can annotate the route to force a reload.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
 
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2358

For 4.9

Known Issue: https://deploy-preview-36498--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-known-issues

Preview: https://deploy-preview-36498--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking

@miheer @jechen0648 ready for QA.