### PR TITLE
Adds a forward slash to the ArgoCD policy in a config map yaml

### DIFF
--- a/modules/gitops-configuring-groups-and-argocd-rbac.adoc
+++ b/modules/gitops-configuring-groups-and-argocd-rbac.adoc
@@ -34,5 +34,5 @@ metadata:
   name: argocd-rbac-cm
 data:
   policy.csv: |
-    g, ArgoCDAdmins, role:admin
+    g, /ArgoCDAdmins, role:admin
 ----


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/36289

Applies from Enterprise-4.7 Onwards

Preview: https://deploy-preview-36502--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.html#in-built-permissions_configuring-sso-for-argo-cd-on-openshift

Pending QE review. 