### PR TITLE
Removes wrong TP note in Knative Kafka

### DIFF
--- a/serverless/knative_eventing/serverless-kafka.adoc
+++ b/serverless/knative_eventing/serverless-kafka.adoc
@@ -6,9 +6,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Apache Kafka on {ServerlessProductName}
-include::modules/technology-preview.adoc[leveloffset=+2]
-
 You can use the `KafkaChannel` channel type and `KafkaSource` event source with {ServerlessProductName}.
 To do this, you must install the Knative Kafka components, and configure the integration between {ServerlessProductName} and a supported link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/index[Red Hat AMQ Streams] cluster.
 


### PR DESCRIPTION
 Knative Kafka has been GA since Serverless 1.14 . This removes the TP note similar to branch 4.7 and master.