### PR TITLE
OSDOCS-2443: Adding release note link to Installing a cluster on AWS China

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -72,7 +72,7 @@ The {product-title} installation program for Microsoft Azure now creates subnets
 ==== Support for AWS regions in China
 {product-title} {product-version} introduces support for AWS regions in China. You can now install and update {product-title} clusters in the `cn-north-1` (Beijing) and `cn-northwest-1`(Ningxia) regions.
 
-//For more information, ../installing/installing_aws/installing-aws-china.adoc[Installing a cluster on AWS into a China region].
+For more information, see xref:../installing/installing_aws/installing-aws-china.adoc[Installing a cluster on AWS China].
 
 [id="ocp-4-9-expanding-with-virtual-media-on-baremetal-network"]
 ==== Expanding the cluster with Virtual Media on the baremetal network


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2443

Updated Support for AWS regions in China to include the link the respective help topic. Please verify that the link opens Installing a cluster on AWS China.

https://deploy-preview-36509--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-aws-china-regions

QE ack is not required.