### PR TITLE
Remove Kafka TP note

### DIFF
--- a/modules/serverless-kafka-source-kn.adoc
+++ b/modules/serverless-kafka-source-kn.adoc
@@ -3,9 +3,6 @@
 
 This section describes how to create a Kafka event source by using the `kn` command.
 
-:FeatureName: Creating a Kafka event source by using the `kn` CLI
-include::../modules/technology-preview.adoc[leveloffset=+0]
-
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Eventing, Knative Serving, and the `KnativeKafka` custom resource (CR) are installed on your cluster.

--- a/serverless/knative_eventing/serverless-kafka.adoc
+++ b/serverless/knative_eventing/serverless-kafka.adoc
@@ -6,9 +6,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Apache Kafka on {ServerlessProductName}
-include::modules/technology-preview.adoc[leveloffset=+2]
-
 You can use the `KafkaChannel` channel type and `KafkaSource` event source with {ServerlessProductName}.
 To do this, you must install the Knative Kafka components, and configure the integration between {ServerlessProductName} and a supported link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/index[Red Hat AMQ Streams] cluster.
 


### PR DESCRIPTION
Note was already removed in main branch, but that PR was not cherrypicked to 4.9 (1.14.0 release notes).