### PR TITLE
added notes for 4.7.31 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2852,3 +2852,27 @@ link:https://access.redhat.com/solutions/6327721[{product-title} 4.7.30 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-31"]
+=== RHBA-2021:3510 - {product-title} 4.7.31 bug fix update
+
+Issued: 2021-09-21
+
+{product-title} release 4.7.31 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3510[RHBA-2021:3510] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3509[RHBA-2021:3509] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6338101[{product-title} 4.7.31 container image list]
+
+[id="ocp-4-7-31-features"]
+==== Features
+
+[id="ocp-4-7-31-new-minimum-storage-requirement"]
+===== New minimum storage requirement for clusters
+
+The minimum storage required to install an {product-title} cluster has decreased from 120 GB to 100 GB. This update applies to all supported platforms.
+
+[id="ocp-4-7-31-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
RNs for 4.7.31 release

- applies to `enterprise-4.7 only`
- [Preview link](https://deploy-preview-36513--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-31)