### PR TITLE
The new-app command creates a Deployment object, not a DeploymentConf…

### DIFF
--- a/modules/applications-create-using-cli-source-code.adoc
+++ b/modules/applications-create-using-cli-source-code.adoc
@@ -3,7 +3,7 @@
 
 With the `new-app` command you can create applications from source code in a local or remote Git repository.
 
-The `new-app` command creates a build configuration, which itself creates a new application image from your source code. The `new-app` command typically also creates a `DeploymentConfig` object to deploy the new image, and a service to provide load-balanced access to the deployment running your image.
+The `new-app` command creates a build configuration, which itself creates a new application image from your source code. The `new-app` command typically also creates a `Deployment` object to deploy the new image, and a service to provide load-balanced access to the deployment running your image.
 
 {product-title} automatically detects whether the pipeline or source build strategy should be used, and in the case of source builds, detects an appropriate language builder image.
 


### PR DESCRIPTION
For 4.6+

Fixes https://github.com/openshift/openshift-docs/issues/36055

QE approved. 

Preview: https://deploy-preview-36522--osdocs.netlify.app/openshift-enterprise/latest/applications/creating_applications/creating-applications-using-cli.html#applications-create-using-cli-source-code_creating-applications-using-cli