### PR TITLE
Swaps NodePortService for hostNetwork in the hostNetwork source yaml

### DIFF
--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -36,7 +36,7 @@ $ oc -n openshift-ingress-operator edit ingresscontroller/default
     endpointPublishingStrategy:
       hostNetwork:
         protocol: PROXY
-      type: NodePortService
+      type: hostNetwork
 ----
 * If your Ingress Controller uses the NodePortService endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.nodePort.protocol` subfield to `PROXY`:
 +


### PR DESCRIPTION
For 4.8+

Fixes https://github.com/openshift/openshift-docs/issues/35774

Preview: https://deploy-preview-36526--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress

Pending QE review 