### PR TITLE
[enterprise-4.9] Add 4.9 ShiftStack release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -101,6 +101,11 @@ All {product-title} 4.8 clusters require this administrator acknowledgment befor
 
 For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.9].
 
+[id="ocp-4-9-openshift-on-openstack-pci-passthrough-support"]
+==== Support for installation on {rh-openstack} deployments that use PCI passthrough
+
+{product-title} {product-version} introduces support for installation on {rh-openstack-first} deployments that rely on link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough[PCI passthrough]. 
+
 [id="ocp-4-9-web-console"]
 === Web console
 
@@ -371,6 +376,14 @@ The following are use cases for changing the DNS Operator `managementState`:
 * You are a cluster administrator and have reported an issue with CoreDNS, but need to apply a workaround until the issue is fixed. You can set the `managementState` field of the DNS Operator to `Unmanaged` to apply the workaround.
 
 For more information, see xref:../networking/dns-operator.adoc#nw-dns-operator-managementState_dns-operator[Changing the DNS Operator managementState].
+
+[id="ocp-4-9-networking-openshift-on-openstack-cloud-provider-options"]
+==== Load balancer configuration as a cloud provider option for clusters on {rh-openstack}
+
+For clusters that run on {rh-openstack}, you can now configure Octavia for load balancing as a cloud provider option. 
+
+// TODO: Link when doc is merged.
+// For more information, see xref:../
 
 [id="ocp-4-9-storage"]
 === Storage


### PR DESCRIPTION
4.9 RN additions for ShiftStack. Will need dev input on this--a lot of 4.9 in ShiftStack was no-doc.

Preview link: https://deploy-preview-36531--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes