### PR TITLE
Fix GitHub issue #36390: update Source-to-image information

### DIFF
--- a/openshift_images/using_images/using-s21-images.adoc
+++ b/openshift_images/using_images/using-s21-images.adoc
@@ -9,14 +9,22 @@ You can use the link:https://access.redhat.com/documentation/en-us/red_hat_softw
 
 S2I images include:
 
+* .NET
 * Java
+* Go
 * Node.js
 * Perl
 * PHP
 * Python
 * Ruby
 
-S2I images are available for you to use directly from the {product-title} web UI by selecting *Catalog* -> *Developer Catalog*.
+S2I images are available for you to use directly from the {product-title} web console by following procedure:
+
+. Log in to the {product-title} web console using your login credentials. The default view for the {product-title} web console is the *Administrator* perspective.
+. Use the perspective switcher to switch to the *Developer* perspective.
+. In the *+Add* view, select an existing project from the list or use the *Project* drop-down list to create a new project.
+. Choose *All services* under the tile *Developer Catalog*.
+. Select the Type *Builder Images* then can see the available S2I images.
 
 S2I images are also available though the xref:../../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator].
 


### PR DESCRIPTION
@vikram-redhat This PR is to fix the issue#36390, minimum version that the change applies to should be 4.5 in my opinion, could you arrange someone to review them? Thanks.

Major changes on my commit:
1. Add additional S2I images
2. Add detailed procedure to find the available S2I images