### PR TITLE
MTC 1.6 compatibility guidelines

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -41,4 +41,4 @@ endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
-:mtc-version: 1.5
+:mtc-version: 1.6

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -10,9 +10,9 @@
 
 You must install the {mtc-full} ({mtc-short}) version that is compatible with your {product-title} version.
 
-// You cannot install {mtc-short} 1.6.x on {product-title} versions 3.7 to 4.5 because the custom resource definition API versions are incompatible.
-//
-// You can migrate workloads from a source cluster with {mtc-short} 1.5.1 to a target cluster with {mtc-short} 1.6 as long as the `MigrationController` custom resource and the {mtc-short} web console are running on the target cluster.
+You cannot install {mtc-short} 1.6.x on {product-title} versions 3.7 to 4.5 because the custom resource definition API versions are incompatible.
+
+You can migrate workloads from a source cluster with {mtc-short} 1.5.1 to a target cluster with {mtc-short} 1.6.x as long as the `MigrationController` custom resource and the {mtc-short} web console are running on the target cluster.
 
 [cols="1,1,2a", options="header"]
 .{product-title} and {mtc-short} compatibility
@@ -26,14 +26,8 @@ Installed manually with the `operator-3.7.yml` file.
 
 Installed manually with the `operator.yml` file.
 
-|4.6 and later versions |1.5.1 |{mtc-full} Operator.
+|4.6 and later |1.6.x^[1]^ |{mtc-full} Operator.
 
 Installed with the Operator Lifecycle Manager.
 |===
-
-// For OCP 4.9 and later
-// |4.9 |1.6.x^[1]^ |{mtc-full} Operator.
-//
-// Installed with the Operator Lifecycle Manager.
-// |===
-// ^1^ Latest z-stream release.
+^1^ Latest z-stream release.


### PR DESCRIPTION
No BZ/Jira #

Update compatibility guidelines for MTC 1.6

4.6+

Preview: https://deploy-preview-36535--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-compatibility-guidelines_installing-3-4

No QE required. Ready for peer review