### PR TITLE
CNV-3033: Adding cloning strategy (CSI volume cloning) sub-topic to storage profile module 

### DIFF
--- a/modules/virt-cloning-a-datavolume.adoc
+++ b/modules/virt-cloning-a-datavolume.adoc
@@ -11,6 +11,7 @@ For smart-cloning to occur, the following conditions are required:
 
 * Your storage provider must support snapshots.
 * The source and target PVCs must be defined to the same storage class.
+* The source and target PVCs share the same *volumeMode*.
 * The `VolumeSnapshotClass` object must reference the storage class defined to both the source and target PVCs.
 
 .Procedure

--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -13,7 +13,7 @@ You can specify default parameters by editing the `StorageProfile` object for th
 
 [NOTE]
 ====
-An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Interface (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by the CDI. In this case, the administrator sets appropriate values in the storage profile  to ensure successful allocations.
+An empty `status` section in a storage profile indicates that a storage provisioner is not recognized by the Containerized Data Interface (CDI). Customizing a storage profile is necessary if you have a storage provisioner that is not recognized by the CDI. In this case, the administrator sets appropriate values in the storage profile to ensure successful allocations.
 ====
 
 [WARNING]
@@ -35,12 +35,12 @@ $ oc edit -n openshift-cnv storageprofile <storage_class>
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
 metadata:
-  name: <some_unknown_provisioner_class>
+  name: <unknown_provisioner_class>
 #   ...
 spec: {}
 status:
-  provisioner: <some_unknown_provisioner>
-  storageClass: <some_unknown_provisioner_class>
+  provisioner: <unknown_provisioner>
+  storageClass: <unknown_provisioner_class>
 ----
 +
 . Provide the needed attribute values in the storage profile:
@@ -51,7 +51,7 @@ status:
 apiVersion: cdi.kubevirt.io/v1beta1
 kind: StorageProfile
 metadata:
-  name: <some_unknown_provisioner_class>
+  name: <unknown_provisioner_class>
 #   ...
 spec:
   claimPropertySets:
@@ -60,10 +60,50 @@ spec:
     volumeMode:
       Filesystem <2>
 status:
-  provisioner: <some_unknown_provisioner>
-  storageClass: <some_unknown_provisioner_class>
+  provisioner: <unknown_provisioner>
+  storageClass: <unknown_provisioner_class>
 ----
 <1> The `accessModes` that you select.
 <2> The `volumeMode` that you select.
 +
 After you save your changes, the selected values appear in the storage profile `status` element.
+
+[id="virt-customizing-storage-profile-default-cloning-strategy_{context}"]
+== Setting a default cloning strategy using a storage profile
+
+You can use storage profiles to set a default cloning method for a storage class, creating a _cloning strategy_. Setting cloning strategies can be helpful, for example, if your storage vendor only supports certain cloning methods. It also allows you to select a method that limits resource usage or maximizes performance.
+
+Cloning strategies can be specified by setting the `cloneStrategy` attribute in a storage profile to one of these values:
+
+* `snapshot` - This method is used by default when snapshots are configured. This cloning strategy uses a temporary volume snapshot to clone the volume. The storage provisioner must support CSI snapshots.
+* `copy` - This method uses a source pod and a target pod to copy data from the source volume to the target volume. Host-assisted cloning is the least efficient method of cloning.
+* `csi-clone` - This method uses the CSI clone API to efficiently clone an existing volume without using an interim volume snapshot. Unlike `snapshot` or `copy`, which are used by default if no storage profile is defined, CSI volume cloning is only used when you specify it in the `StorageProfile` object for the provisioner's storage class.
+
+[NOTE]
+====
+You can also set clone strategies usng the CLI without modifying the default `claimPropertySets` in your YAML `spec` section.
+====
+
+.Example storage profile
+[source,yaml]
+----
+apiVersion: cdi.kubevirt.io/v1beta1
+kind: StorageProfile
+metadata:
+  name: <provisioner_class>
+#   ...
+spec:
+  claimPropertySets:
+  - accessModes:
+    - ReadWriteOnce <1>
+    volumeMode:
+      Filesystem <2>
+  cloneStrategy:
+  csi-clone <3>
+status:
+  provisioner: <provisioner>
+  storageClass: <provisioner_class>
+----
+<1> The `accessModes` that you select.
+<2> The `volumeMode` that you select.
+<3> The default cloning method of your choice. In this example, CSI volume cloning is specified.

--- a/virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.adoc
@@ -10,7 +10,7 @@ designed to enhance performance of the cloning process. Clones created with smar
 
 You do not need to perform any action to enable smart-cloning, but you need to ensure your storage environment is compatible with smart-cloning to use this feature.
 
-When you create a data volume with a persistent volume claim (PVC) source, you automatically initiate the cloning process. You always receive a clone of the data volume, if your environment supports smart-cloning or not. However, you will only receive the performance benefits of smart cloning if you storage provider supports smart-cloning.
+When you create a data volume with a persistent volume claim (PVC) source, you automatically initiate the cloning process. You always receive a clone of the data volume if your environment supports smart-cloning or not. However, you will only receive the performance benefits of smart cloning if your storage provider supports smart-cloning.
 
 include::modules/virt-understanding-smart-cloning.adoc[leveloffset=+1]
 
@@ -22,3 +22,5 @@ include::modules/virt-cloning-a-datavolume.adoc[leveloffset=+1]
 * xref:../../../virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc#virt-cloning-pvc-of-vm-disk-into-new-datavolume_virt-cloning-vm-disk-into-new-datavolume[Cloning the persistent volume claim of a virtual machine disk into a new data volume]
 
 * xref:../../../virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Configure preallocation mode] to improve write performance for data volume operations.
+
+* xref:../../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc
@@ -1,5 +1,5 @@
 [id="virt-creating-data-volumes"]
-= Creating data volumes using profiles
+= Creating data volumes
 include::modules/virt-document-attributes.adoc[]
 :context: virt-creating-data-volumes
 
@@ -25,7 +25,11 @@ include::modules/virt-creating-data-volumes-using-pvc-api.adoc[leveloffset=+1]
 include::modules/virt-customizing-storage-profile.adoc[leveloffset=+1]
 
 [id="additional-resources_creating-data-volumes-using-profiles"]
-
 == Additional resources
 * xref:../../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-creating-storage-class_virt-configuring-local-storage-for-vms[Creating a storage class]
+
 * xref:../../../virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.adoc#virt-overriding-default-fs-overhead-value_virt-reserving-pvc-space-fs-overhead[Overriding the default file system overhead value]
+
+* xref:../../../virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.adoc#virt-cloning-a-datavolume-using-smart-cloning[Cloning a data volume using smart cloning]
+
+* xref:../../../virt/virtual_machines/virtual_disks/virt-storage-defaults-for-datavolumes.adoc#virt-storage-defaults-for-datavolumes[Storage defaults for data volumes]


### PR DESCRIPTION
For 4.9 only.

This PR adds the new sub-topic (Head 2) **Setting a default cloning strategy using a storage profile**. It also adds xrefs for smart-cloning and storage defaults to the data volume assembly introduced in 4.8. An xref to the data volume assembly is also added to the smart cloning assembly. 

Peer Reviewers: Ordinarily I would create a new module for this content but it cannot separated from the storage profile module, therefore it is a Head2.

Jira: https://issues.redhat.com/browse/CNV-3033

Direct Doc preview link: https://deploy-preview-36550--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-creating-data-volumes?utm_source=github&utm_campaign=bot_dp#setting-a-default-cloning-strategy-using-a-storage-profile
https://deploy-preview-36550--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-cloning-a-datavolume-using-smart-cloning.html#virt-cloning-a-datavolume-using-smart-cloning

Tagging @aglitke for code review.
Tagging Bartosz Rybacki in Jira for QE review.
