### PR TITLE
BZ1925260: Updating VPA Operator deletion note - 4.8

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-uninstall.adoc
@@ -12,6 +12,11 @@ You can remove the Vertical Pod Autoscaler Operator (VPA) from your {product-tit
 You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The same actions apply for resource requests as uninstalling the vertical pod autoscaler.
 ====
 
+[NOTE]
+====
+This action removes the Operator as well as the Operator deployments and pods. Any Operands, and resources managed by the Operator, including CRDs and CRs, are not removed. To remove these after uninstalling the Operator, you might need to manually delete them.
+====
+
 .Prerequisites
 
 * The Vertical Pod Autoscaler Operator must be installed.
@@ -20,7 +25,7 @@ You can remove a specific VPA using the `oc delete vpa <vpa-name>` command. The 
 
 . In the {product-title} web console, click *Operators* → *Installed Operators*.
 
-. Switch to the *openshift-vertical-pod-autoscaler* project. 
+. Switch to the *openshift-vertical-pod-autoscaler* project.
 
 . Find the *VerticalPodAutoscaler*  Operator and click the Options menu. Select *Uninstall Operator*.
 

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -30,6 +30,6 @@ An *Uninstall Operator?* dialog box is displayed, reminding you that:
 *Removing the Operator will not remove any of its custom resource definitions or managed resources. If your Operator has deployed applications on the cluster or configured off-cluster resources, these will continue to run and need to be cleaned up manually.*
 --
 +
-The Operator, any Operator deployments, and pods are removed by this action. Any resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
+This action removes the Operator as well as the Operator deployments and pods, if any. Any Operands, and resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
 
 . Select *Uninstall*. This Operator stops running and no longer receives updates.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1925260

PR for 4.7 - #36552 
PR for 4.6 - #36553 

Preview links:
Working with pods - https://deploy-preview-36551--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-uninstall_nodes-pods-vertical-autoscaler

Deleting operators from cluster - https://deploy-preview-36551--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster.html#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster

@weinliu - Here's the fix for operator deletion for 4.8 version. Kindly review.