### PR TITLE
OSDOCS-2191: New metrics for LSO

### DIFF
--- a/modules/persistent-storage-local-metrics.adoc
+++ b/modules/persistent-storage-local-metrics.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * storage/persistent_storage/persistent-storage-local.adoc
+
+[id="local-storage-metrics_{context}"]
+= Local Storage Operator Metrics
+
+{product-title} provides the following metrics for the Local Storage Operator:
+
+* `lso_discovery_disk_count`: total number of discovered devices on each node
+
+* `lso_lvset_provisioned_PV_count`: total number of PVs created by `LocalVolumeSet` objects
+
+* `lso_lvset_unmatched_disk_count`: total number of disks that Local Storage Operator did not select for provisioning because of mismatching criteria
+
+* `lso_lvset_orphaned_symlink_count`: number of devices with PVs that no longer match `LocalVolumeSet` object criteria
+
+* `lso_lv_orphaned_symlink_count`: number of devices with PVs that no longer match `LocalVolume` object criteria
+
+* `lso_lv_provisioned_PV_count`: total number of provisioned PVs for `LocalVolume`
+
+To use these metrics, be sure to:
+
+* Enable support for monitoring when installing the Local Storage Operator.
+
+* When upgrading to {product-title} 4.9 or later, enable metric support manually by adding the `operator-metering=true` label to the namespace.

--- a/storage/persistent_storage/persistent-storage-local.adoc
+++ b/storage/persistent_storage/persistent-storage-local.adoc
@@ -34,6 +34,10 @@ include::modules/persistent-storage-local-discovery.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-local-tolerations.adoc[leveloffset=+1]
 
+include::modules/persistent-storage-local-metrics.adoc[leveloffset=+1]
+
+For more information about metrics, see xref:../../monitoring/managing-metrics.adoc#managing-metric[Managing metrics].
+
 == Deleting the Local Storage Operator resources
 
 include::modules/persistent-storage-local-removing-devices.adoc[leveloffset=+2]


### PR DESCRIPTION
**4.9+**

[OSDOCS-2191](https://issues.redhat.com/browse/OSDOCS-2191): New metrics for Local Storage Operator (LSO).

**Preview**: https://deploy-preview-36567--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local?utm_source=github&utm_campaign=bot_dp#local-storage-metrics_persistent-storage-local

**PTAL**: @gnufied , @chao007