### PR TITLE
Added notes for release 4.8.12

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2643,3 +2643,34 @@ link:https://access.redhat.com/solutions/6324771[{product-title} 4.8.11 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-12"]
+=== RHBA-2021:3511 - {product-title} 4.8.12 bug fix update
+
+Issued: 2021-09-21
+
+{product-title} release 4.8.12 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3511[RHBA-2021:3511] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3512[RHBA-2021:3512] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6338301[{product-title} 4.8.12 container image list]
+
+[id="ocp-4-8-12-features"]
+==== Features
+
+[id="ocp-4-8-12-new-minimum-storage-requirement"]
+===== New minimum storage requirement for clusters
+
+The minimum storage required to install an {product-title} cluster has decreased from 120 GB to 100 GB. This update applies to all supported platforms.
+
+[id="ocp-4-8-12-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `oc` tool sent headers that were too big for some registries, which caused those registries to reject large mirroring requests. This update puts a limit on header size for the `oc adm catalog mirror` command, allowing mirroring to work as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1874106[*BZ#1874106*])
+
+* Before this update, the cluster autoscaler was unable to access the `csidrivers.storage.k8s.io` or `csistoragecapacities.storage.k8s.io` resources, which resulted in permissions errors. This fix updates the role assigned to the cluster autoscaler so that it includes permissions for these resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1995595[*BZ#1995595*])
+
+[id="ocp-4-8-12-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the release notes for version 4.8.12.

- applies only to `enterprise-4.8`
- [direct preview](https://deploy-preview-36568--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-12)