### PR TITLE
BZ1895009 - removes 'latest' tag for explicit product version

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -65,10 +65,10 @@ spec:
 +
 You can use the `ROLE_WORKER_CNF` variable to override the worker pool name:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e
-ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 +
 [NOTE]
@@ -80,9 +80,9 @@ Currently, not all tests run selectively on the nodes belonging to the pool.
 == Running the tests
 Assuming the `kubeconfig` file is in the current folder, the command for running the test suite is:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 This allows your `kubeconfig` file to be consumed from inside the running container.
@@ -102,9 +102,9 @@ Additionally, you can set the following environment variables for latency tests:
 
 To perform the latency tests, run the following command:
 
-[source,termina]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 [NOTE]
 ====
@@ -112,9 +112,9 @@ You must run the latency test in discovery mode. For more information, see the D
 ====
 
 .Excerpt of a sample result of a 10-second latency test using the following command:
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-[root@cnf12-installer ~]# podman run --rm -v $KUBECONFIG:/kubeconfig:Z -e PERF_TEST_PROFILE=worker-cnf-2 -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=10 -e OSLAT_MAXIMUM_LATENCY=20 -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+[root@cnf12-installer ~]# podman run --rm -v $KUBECONFIG:/kubeconfig:Z -e PERF_TEST_PROFILE=worker-cnf-2 -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=10 -e OSLAT_MAXIMUM_LATENCY=20 -e DISCOVERY_MODE=true registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 -ginkgo.focus="Latency"
 running /0_config.test -ginkgo.focus=Latency
 ----
@@ -172,9 +172,9 @@ Depending on the requirements, the tests can use different images. There are two
 
 For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the following command:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:{product-version}" registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
@@ -184,18 +184,18 @@ The test suite is built upon the ginkgo BDD framework. This means that it accept
 
 You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
 ----
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
 
 To run only the latency test, you must provide the `-ginkgo.focus` parameter and the `PERF_TEST_PROFILE` environment variable that contains the name of the performance profile that needs to be tested. For example:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
 ----
 
 [NOTE]
@@ -221,9 +221,9 @@ The set of available features to filter are:
 
 Use this command to run in dry-run mode. This is useful for checking what is in the test suite and provides output for all of the tests the image would run.
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
 ----
 
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
@@ -242,9 +242,9 @@ A `mirror` executable is shipped in the image to provide the input required by `
 
 Run this command from an intermediate machine that has access both to the cluster and to link:https://catalog.redhat.com/software/containers/explore[registry.redhat.io] over the internet:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
 ----
 
 Then, follow the instructions in the following section about overriding the registry used to fetch the images.
@@ -254,9 +254,9 @@ Then, follow the instructions in the following section about overriding the regi
 
 This is done by setting the `IMAGE_REGISTRY` environment variable:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:{product-version}" registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
@@ -351,16 +351,16 @@ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 
 . Do the mirroring:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
 ----
 
 . Run the tests:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:latest /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY=image-registry.openshift-image-registry.svc:5000/cnftests cnf-tests-local:{product-version} /usr/bin/test-run.sh
 ----
 
 [id="mirroring-different-set-of-images_{context}"]
@@ -386,9 +386,9 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 
 . Pass it to the `mirror` command, for example saving it locally as `images.json`. With the following command, the local path is mounted in `/kubeconfig` inside the container and that can be passed to the mirror command.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
 ----
 
 [id="discovery-mode_{context}"]
@@ -579,9 +579,9 @@ CNF end-to-end tests produce two outputs: a JUnit test output and a test failure
 
 A JUnit-compliant XML is produced by passing the `--junit` parameter together with the path where the report is dumped:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --junit /path/to/junit
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --junit /path/to/junit
 ----
 
 [id="cnf-performing-end-to-end-tests-test-failure-report_{context}"]
@@ -589,9 +589,9 @@ $ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECO
 
 A report with information about the cluster state and resources for troubleshooting can be produced by passing the `--report` parameter with the path where the report is dumped:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --report /path/to/report
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh --report /path/to/report
 ----
 
 [id="cnf-performing-end-to-end-tests-podman_{context}"]
@@ -650,9 +650,9 @@ When you configure reserved and isolated CPUs, the infra containers in pods use 
 
 To override the performance profile, the manifest must be mounted inside the container and the tests must be instructed by setting the `PERFORMANCE_PROFILE_MANIFEST_OVERRIDE`:
 
-[source,termal]
+[source,terminal,subs="attributes+"]
 ----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-cluster-impacts_{context}"]


### PR DESCRIPTION
Fixes for https://bugzilla.redhat.com/show_bug.cgi?id=1895009

This work is for openshift-docs 4.6, 4.7, 4.8, 4.9, main.