### PR TITLE
Remove Container Linux refs

### DIFF
--- a/modules/architecture-platform-benefits.adoc
+++ b/modules/architecture-platform-benefits.adoc
@@ -32,11 +32,7 @@ unique features and benefits of {product-title}.
 [id="architecture-custom-os_{context}"]
 == Custom operating system
 
-{product-title} uses {op-system-first}, a container-oriented operating
-system that combines some of the best features and functions of the CoreOS and
-Red Hat Atomic Host operating systems. {op-system} is specifically designed for
-running containerized applications from {product-title} and works with new tools
-to provide fast installation, Operator-based management, and simplified upgrades.
+{product-title} uses {op-system-first}, a container-oriented operating system that is specifically designed for running containerized applications from {product-title} and works with new tools to provide fast installation, Operator-based management, and simplified upgrades.
 
 {op-system} includes:
 

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -5,7 +5,7 @@
 [id="rhcos-about_{context}"]
 = About {op-system}
 
-{op-system-first} represents the next generation of single-purpose container operating system technology. Created by the same development teams that created Red Hat Enterprise Linux Atomic Host and CoreOS Container Linux, {op-system} combines the quality standards of {op-system-base-full} with the automated, remote upgrade features from Container Linux.
+{op-system-first} represents the next generation of single-purpose container operating system technology by providing the quality standards of {op-system-base-full} with automated, remote upgrade features.
 
 {op-system} is supported only as a component of {product-title} {product-version} for all {product-title} machines. {op-system} is the only supported operating system for {product-title} control plane, or master, machines. While {op-system} is the default operating system for all cluster machines, you can create compute machines, which are also known as worker machines, that use {op-system-base} as their operating system. There are two general ways {op-system} is deployed in {product-title} {product-version}:
 


### PR DESCRIPTION
Container Linux is approx. 16 mos. since EOL, so the references in this module should be removed for current OCP docs sets (4.6+). (Additional updated content for RHCOS currently in development. This PR is simply to remove "Container Linux" from current docs.)
**Preview link:** https://deploy-preview-36576--osdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-rhcos#rhcos-about_architecture-rhcos

**Edit:** I also removed doc references to Atomic Host as they were also a bit long in the tooth.