### PR TITLE
Add link to KB article

### DIFF
--- a/modules/serverless-rn-1-14-0.adoc
+++ b/modules/serverless-rn-1-14-0.adoc
@@ -29,4 +29,5 @@ Only the `v1beta1` version of the APIs for `KafkaChannel` and `KafkaSource` obje
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
 As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
-// add KB article link when ready
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -22,4 +22,5 @@ The `serving.knative.dev/visibility` label, which was previously used to create 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
 As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
-// add KB article link when ready
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -126,4 +126,5 @@ The `3scale-kourier-control` service reconciles all previously existing Knative 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
 As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
-// add KB article link when ready
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-17-0.adoc
+++ b/modules/serverless-rn-1-17-0.adoc
@@ -46,6 +46,7 @@ Ensure that you are using the latest `kn` CLI version for your {ServerlessProduc
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
 As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
-// add KB article link when ready
++
+For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].
 
 * The Camel-K 1.4 release is not compatible with {ServerlessProductName} version 1.17.0. This is because Camel-K 1.4 uses APIs that were removed in Knative version 0.23.0. There is currently no workaround available for this issue. If you need to use Camel-K 1.4 with {ServerlessProductName}, do not upgrade to {ServerlessProductName} version 1.17.0.


### PR DESCRIPTION
There is no docs Jira issue tracking this addition; it was requested by our PM to add the link for this article to the 1.17.0 release notes (see Slack thread: https://coreos.slack.com/archives/CD87JDUB0/p1632161563274900).

Preview link: https://deploy-preview-36577--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes?utm_source=github&utm_campaign=bot_dp#known-issues-1-17-0_serverless-release-notes

Applies for OCP 4.6+