### PR TITLE
Adding guidance to introduce command line commands

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -730,6 +730,13 @@ This renders as:
 The following guidelines go into more detail about specific requirements and
 recommendations when using code blocks:
 
+* If a step in a procedure is to run a command, make sure that the step
+text includes an explicit instruction to "run" or "enter" the command. In most cases,
+use one of the following patterns to introduce the code block:
+
+** <Step description>, run the following command:
+** <Step description>, enter the following command:
+
 * Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
 
 * For all code blocks, you must include an empty line above a code block (unless
@@ -782,7 +789,7 @@ syntax highlighting. For example:
 be split up into three separate code blocks:
 +
 ....
-Run the following commands to create templates you can modify:
+To create templates you can modify, run the following commands :
 
 [source,terminal]
 ----
@@ -830,7 +837,7 @@ angle brackets (`<>`) with the required command parameter, using underscores
 (`_`) between words as necessary for legibility. For example:
 +
 ....
-The following command returns a list of objects for the specified object type:
+To view a list of objects for the specified object type, enter the following command:
 
 [source,terminal]
 ----
@@ -841,7 +848,7 @@ $ oc get <object_type> <object_id>
 This renders as:
 +
 --
-> The following command returns a list of objects for the specified object type:
+> To view a list of objects for the specified object type, enter the following command:
 >
 > ----
 > $ oc get <object_type> <object_id>


### PR DESCRIPTION
To better align with the intention of the style guide, we should explicitly instruct users to run the commands that we include in steps.