### PR TITLE
BZ1904587: Note that Docker Engine is deprecated

### DIFF
--- a/architecture/understanding-development.adoc
+++ b/architecture/understanding-development.adoc
@@ -110,17 +110,12 @@ endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 [id="container-build-tool-options"]
 === Container build tool options
 
-While the Docker Container Engine and `docker` command are popular tools
-to work with containers, with {op-system-base} and many other Linux systems, you can
-instead choose a different set of container tools that includes podman, skopeo,
-and buildah. You can still use Docker Container Engine tools to create
-containers that will run in {product-title} and any other container platform.
+Building and managing containers with buildah, podman, and skopeo results in industry standard container images that include features specifically tuned for deploying containers in {product-title} or other Kubernetes environments. These tools are daemonless and can run without root privileges, requiring less overhead to run them.
 
-Building and managing containers with buildah, podman, and skopeo results in
-industry standard container images that include features tuned specifically
-for ultimately deploying those containers in {product-title} or other Kubernetes
-environments. These tools are daemonless and can be run without root privileges,
-so there is less overhead in running them.
+[IMPORTANT]
+====
+Support for Docker Container Engine as a container runtime is deprecated in Kubernetes 1.20 and will be removed in a future release. However, Docker-produced images will continue to work in your cluster with all runtimes, including CRI-O. For more information, see the link:https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/[Kubernetes blog announcement].
+====
 
 When you ultimately run your containers in {product-title}, you use the
 link:https://cri-o.io/[CRI-O] container engine. CRI-O runs on every worker and


### PR DESCRIPTION
[BZ1904587](https://bugzilla.redhat.com/show_bug.cgi?id=1904587)
Docker Container Engine is deprecated in Kubernetes 1.20 and therefore OCP 4.7, as described in this k8s blog post: https://kubernetes.io/blog/2020/12/02/dont-panic-kubernetes-and-docker/

This PR updates the wording to note this change. It's questionable whether the actual `IMPORTANT` admonition is necessary here, so feedback is welcome!

Might require change management notifications prior to merge.

**Preview link:** https://deploy-preview-36586--osdocs.netlify.app/openshift-enterprise/latest/architecture/understanding-development.html#container-build-tool-options