### PR TITLE
BZ1986280: Added a kubelet config note about using valid values

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -10,6 +10,11 @@
 The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new
 `kubelet-config-controller` added to the Machine Config Controller (MCC). This allows you to create a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
 
+[NOTE]
+====
+As the fields in the `kubletConfig` object are passed directly to the kubelet from upstream Kubernetes, the kubelet validates those values directly. Invalid values in the `kubeletConfig` object might cause cluster nodes to become unavailable. For valid values, see the link:https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubernetes documentation].
+====
+
 .Procedure
 
 . Run:


### PR DESCRIPTION
This PR only applies to 4.6.

https://bugzilla.redhat.com/show_bug.cgi?id=1986280

- Updated **Post-installation machine configuration tasks** > **Creating a KubeletConfig CRD to edit kubelet parameters** to include a note that clarifies `kubeletConfig` validation.
https://deploy-preview-36587--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-machine-configuration-tasks
- The same note appears in **Recommended host practices** > **Creating a KubeletConfig CRD to edit kubelet parameters**
https://deploy-preview-36587--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters

Worth noting that this is the first of two PRs for this issue. The second PR applies to 4.7+ (https://github.com/openshift/openshift-docs/pull/36657)