### PR TITLE
Adds 4.6.45 release notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3261,3 +3261,33 @@ link:https://access.redhat.com/solutions/6303991[{product-title} 4.6.44 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-45"]
+=== RHBA-2021:3517 - {product-title} 4.6.45 bug fix update
+
+Issued: 2021-09-22
+
+{product-title} release 4.6.45 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3517[RHBA-2021:3517] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3518[RHBA-2021:3518] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6341481[{product-title} 4.6.45 container image list]
+
+[id="ocp-4-6-45-features"]
+==== Features
+
+[id="ocp-4-6-45-new-minimum-storage-requirement"]
+===== New minimum storage requirement for clusters
+
+The minimum storage required to install an {product-title} cluster has decreased from 120 GB to 100 GB. This update applies to all supported platforms.
+
+
+[id="ocp-4-6-45-bug-fixes"]
+==== Bug fixes
+
+* Previously, when a deployment was created with an invalid image stream, or unresloved image, it resulted in an inconsistent state between the deployment controller and the API server's `imagepolicy` plug-in. Consequently, it could cause an infinite number of replica sets and reach the etcd quota limit, which could crash the entire {product-title} cluster. This update lowers the responsibilities of the API server's `imagepolicy` plug-in. As a result, inconsistent image stream resolution will not occur in the deployments. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981775[*BZ#1981784*]).
+
+[id="ocp-4-6-45-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ

Preview: https://deploy-preview-36593--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-45

Not to be merged until 9-22.