### PR TITLE
[OSDOCS-2652]: etcd 4.9 release note information

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -297,6 +297,19 @@ For more information, see xref:../security/audit-log-policy-config.adoc#configur
 
 You can now customize the URL for the internal OAuth server. For more information, see xref:../authentication/configuring-internal-oauth.adoc#customizing-the-oauth-server-url_configuring-internal-oauth[Customizing the internal OAuth server URL].
 
+[id="ocp-4-9-etcd"]
+=== etcd
+
+[id="ocp-4-9-security-auto-rotate-cert"]
+==== Automatic rotation of etcd certificates
+
+In {product-title} 4.9, etcd certificates are automatically rotated and are managed by the system.
+
+[id="ocp-4-9-security-tls-profile-setting"]
+==== Additional TLS security profile setting on the API server
+
+The Kubernetes API server TLS security profile setting is now also honored by etcd.
+
 [id="ocp-4-9-networking"]
 === Networking
 
@@ -739,6 +752,11 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 {product-title} 4.9 introduces the following notable technical changes.
 
 // Note: use [discrete] for these sub-headings.
+
+[discrete]
+[id="ocp-4-9-security-etcd-auto-defrag"]
+==== Automatic defragmentation for etcd data
+In {product-title} 4.9, etcd data is automatically defragmented by the etcd Operator.
 
 [discrete]
 [id="octavia-ovn-nodeport-changes"]


### PR DESCRIPTION
Preview link: https://deploy-preview-36618--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes

Additions made to the following sections of the 4.9 release note file for etcd:

 - **Security and Compliance**: etcd as a control plane option
 - **Security and Compliance**: automatic rotation of etcd certificates
 - **Notable Technical Changes**: auto defragmentation of etcd data