### PR TITLE
 Add restrictions and requirements of Proxy installation with Kuryr

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -97,6 +97,12 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :vmc:
 endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:kuryr:
+endif::[]
 
 [id="installation-configure-proxy_{context}"]
 = Configuring the cluster-wide proxy during installation
@@ -115,8 +121,27 @@ range that is specified in the `networking.machineNetwork[].cidr` field in the
 ====
 endif::bare-metal[]
 
+ifdef::kuryr[]
+[NOTE]
+====
+Kuryr installations default to HTTP proxies.
+====
+endif::kuryr[]
+
 .Prerequisites
 
+ifdef::kuryr[]
+
+* For Kuryr installations on restricted networks that use the `Proxy` object, the proxy must be able to reply to the router that the cluster uses. To add a static route for the proxy configuration, from a command line as the root user, enter:
++
+[source,terminal]
+----
+$ ip route add <cluster_network_cidr> via <installer_subnet_gateway>
+----
+
+* The restricted subnet must have a gateway that is defined and available to be linked to the `Router` resource that Kuryr creates.
+
+endif::kuryr[]
 * You have an existing `install-config.yaml` file.
 // TODO: xref (../../installing/install_config/configuring-firewall.adoc#configuring-firewall)
 * You reviewed the sites that your cluster requires access to and determined whether any of them need to bypass the proxy. By default, all cluster egress traffic is proxied, including calls to hosting cloud provider APIs. You added sites to the `Proxy` object's `spec.noProxy` field to bypass the proxy if necessary.
@@ -232,4 +257,10 @@ ifeval::["{context}" == "installing-vmc-network-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :!vmc:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-kuryr"]
+:!kuryr:
+endif::[]
+ifeval::["{context}" == "installing-openstack-installer-restricted"]
+:!kuryr:
 endif::[]


### PR DESCRIPTION
Kuryr installation requires for a route entry to be added to the
Proxy host, and Kuryr defaults to always using http Proxy.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1985486

Preview: https://deploy-preview-36621--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-restricted.html#installation-configure-proxy_installing-openstack-installer-restricted