### PR TITLE
BZ2004502: Removed cnv-tuning info from the bridge NAD config

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -30,17 +30,10 @@ spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "<a-bridge-network>", <3>
-    "plugins": [
-      {
-        "type": "cnv-bridge", <4>
-        "bridge": "<bridge-interface>", <5>
-        "macspoofchk": true, <6>
-        "vlan": 1 <7>
-      },
-      {
-        "type": "cnv-tuning" <8>
-      }
-    ]
+    "type": "cnv-bridge", <4>
+    "bridge": "<bridge-interface>", <5>
+    "macspoofchk": true, <6>
+    "vlan": 1 <7>
   }'
 ----
 <1> The name for the `NetworkAttachmentDefinition` object.
@@ -50,7 +43,6 @@ spec:
 <5> The name of the Linux bridge configured on the node.
 <6> Optional: Flag to enable MAC spoof check. When set to `true`, you cannot change the MAC address of the pod or guest interface. This attribute provides security against a MAC spoofing attack by allowing only a single MAC address to exit the pod.
 <7> Optional: The VLAN tag.
-<8> The CNI plug-in that allows the MAC pool manager to assign a unique MAC address to the connection.
 
 . Create the network attachment definition:
 +


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=2004502

Removed `cnv-tuning` CNI from the Linux bridge network attachment definition because the `cnv-bridge` CNI now supports MAC configuration natively.

Preview: https://deploy-preview-36622--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks?utm_source=github&utm_campaign=bot_dp#virt-creating-bridge-nad-cli_virt-attaching-multiple-networks