### PR TITLE
Fix URL of link to download playbooks RHV user infra

### DIFF
--- a/modules/installation-rhv-downloading-ansible-playbooks.adoc
+++ b/modules/installation-rhv-downloading-ansible-playbooks.adoc
@@ -9,17 +9,50 @@ Download the Ansible playbooks for installing {product-title} version {product-v
 
 .Procedure
 
-. On your installation machine, run the following commands:
+* On your installation machine, run the following commands:
 +
+ifdef::openshift-origin[]
 [source,terminal,subs=attributes+]
 ----
 $ mkdir playbooks
+----
++
+[source,terminal,subs=attributes+]
+----
 $ cd playbooks
-$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-{product-version}  |
+----
++
+[source,terminal,subs=attributes+]
+----
+$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-<version>  |
 grep 'download_url.*\.yml' |
 awk '{ print $2 }' | sed -r 's/("|",)//g' |
 xargs -n 1 curl -O
 ----
++
+where:
++
+<version>:: Specifies the minor release version, such as `release-4.8`. See the branch drop-down list in the link:https://github.com/openshift/installer/tree/master/upi/ovirt[`openshift/installer` repository] for the available minor versions. 
+endif::openshift-origin[]
+ifndef::openshift-origin[]
+[source,terminal,subs=attributes+]
+----
+$ mkdir playbooks
+----
++
+[source,terminal,subs=attributes+]
+----
+$ cd playbooks
+----
++
+[source,terminal,subs=attributes+]
+----
+$ curl -s -L -X GET https://api.github.com/repos/openshift/installer/contents/upi/ovirt?ref=release-{product-version} |
+grep 'download_url.*\.yml' |
+awk '{ print $2 }' | sed -r 's/("|",)//g' |
+xargs -n 1 curl -O
+----
+endif::openshift-origin[]
 
 .Next steps
 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/36617
https://github.com/openshift/okd/issues/875

A link in [Downloading the Ansible playbooks](https://docs.okd.io/latest/installing/installing_rhv/installing-rhv-user-infra.html) in _Installing a cluster on oVirt with user-provisioned infrastructure_ uses a {product-version} variable. In OKD this renders as `4`, causing the link to not work, as it needs a `.x` value (for ex: `4.8`). 

~~Used an `ifdef` to hard-code the version number in the link for OKD. Will need to be manually cherry-picked back.~~ 


Preview OKD: http://file.rdu.redhat.com/~mburke/okd-fix-playbook-link/installing/installing_rhv/installing-rhv-user-infra.html#installation-rhv-downloading-ansible-playbooks_installing-rhv-user-infra 
Preview OCP: https://deploy-preview-36623--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-user-infra.html#installation-rhv-downloading-ansible-playbooks_installing-rhv-user-infra