### PR TITLE
Adds a small note on an OVN bug that is being carried over from 4.8

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -805,6 +805,9 @@ This script removes unauthenticated subjects from the following cluster role bin
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
+* An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets which are created for each OpenShift namespace at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*])
+
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
RN Tracker item found at https://github.com/openshift/openshift-docs/issues/33497 by Dulek: 

We need this note from 4.8 added to 4.9 as well:

An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace, at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift Service objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, OpenShift Container Platform 4.9 deployments that use Kuryr SDN are not recommended on Red Hat OpenStack Platform (RHOSP) 16.1 with OVN and OVN Octavia configured until the bug is fixed. (BZ#1937392)

This is a carry-over from 4.8. I don't think it needs Michel Dulek's ack. since he requested it, but I am happy to reach out to him. 

Preview: https://deploy-preview-36626--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-known-issues

To be merged to 4.9 only. 