### PR TITLE
OSDOCS-2660 - Updating CCS description

### DIFF
--- a/modules/understanding-clusters.adoc
+++ b/modules/understanding-clusters.adoc
@@ -6,14 +6,13 @@
 [id="understanding-clusters_{context}"]
 = Understanding your cluster cloud options
 
-
-{product-title} offers {OCP} clusters as a managed service on {AWS} or {GCP}. You can use your existing cloud account to leverage discounts, or purchase a standard cluster through Red Hat.
+{product-title} offers {OCP} clusters as a managed service on {AWS} or {GCP}. You can purchase a standard cluster through Red Hat. Alternatively, you can use your existing cloud account through the Customer Cloud Subscription (CCS) model to leverage discounts.
 
 == Standard clusters
 
-Standard {product-title} clusters are deployed into their own AWS or GCP infrastructure accounts, each owned by Red Hat. Red Hat is responsible for this account, and cloud infrastructure costs are paid directly by Red Hat. The customer only pays the Red Hat subscription costs.
+Standard {product-title} clusters are deployed into their own AWS or GCP infrastructure accounts, each owned by Red Hat. Red Hat is responsible for the account, and the cloud infrastructure costs are paid directly by Red Hat. The customer only pays the Red Hat subscription costs.
 
 == Customer Cloud Subscription (CCS)
-Red Hat {product-title} provides a Customer Cloud Subscription (CCS) model that allows Red Hat to deploy and manage {product-title} into a customer’s AWS or GCP account. Red Hat requires several prerequisites be met in order to provide this service and this service is supported by Red Hat Site Reliability Engineers (SRE).
+The Customer Cloud Subscription (CCS) model enables Red Hat to deploy and manage {product-title} clusters in an existing AWS or GCP account owned by the customer. Red Hat requires several prerequisites be met in order to provide this service, and this service is supported by Red Hat Site Reliability Engineers (SRE).
 
-In the Customer Cloud Subscription model, the customer pays the cloud infrastructure provider directly for cloud costs and the cloud infrastructure account is part of a customer’s Organization, with specific access granted to Red Hat. The customer will have restricted access to this account, but is able to view billing and usage information. In this model, the customer pays Red Hat for the CCS subscription and pays the cloud provider for the cloud costs.
+In the CCS model, the customer pays the cloud infrastructure provider directly for cloud costs, and the cloud infrastructure account is part of a customer’s organization, with specific access granted to Red Hat. In this model, the customer pays Red Hat for the CCS subscription and pays the cloud provider for the cloud costs.


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2660. The PR updates some aspects of the **Creating a cluster** -> **Creating your cluster** -> **Understanding your cluster cloud options** -> **Customer Cloud Subscription (CCS)** section. This includes the removal of a statement that indicated that the customer has restricted access to to cloud accounts used by CCS-based OSD clusters.

The preview is [here](https://deploy-preview-36641--osdocs.netlify.app/openshift-dedicated/latest/osd_cluster_create/creating-your-cluster?utm_source=github&utm_campaign=bot_dp#understanding-clusters_creating-your-cluster).