### PR TITLE
OSDOCS-2325: release note for ingress controller timeout config

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -147,6 +147,25 @@ The CNI VRF plug-in was previously introduced as a Technology Preview feature in
 
 For more information, see xref:../networking/multiple_networks/assigning-a-secondary-network-to-a-vrf.adoc#cnf-assigning-a-secondary-network-to-a-vrf[Assigning a secondary network to a VRF].
 
+[id="ocp-4-9-nw-timeout-configuration-parameters"]
+==== Ingress controller timeout configuration parameters
+
+This release introduces six timeout configurations for the Ingress Controller `tuningOptions` parameter:
+
+* `clientTimeout` specifies how long a connection is held open while waiting for a client response.
+
+* `serverFinTimeout` specifies how long a connection is held open while waiting for the server response to the client that is closing the connection.
+
+* `serverTimeout` specifies how long a connection is held open while waiting for a server response.
+
+* `clientFinTimeout` specifies how long a connection is held open while waiting for the client response to the server closing the connection.
+
+* `tlsInspectDelay` specifies how long the router can hold data to find a matching route.
+
+* `tunnelTimeout` specifies how long a tunnel connection, including WebSocket connections, remains open while the tunnel is idle.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress controller configuration parameters].
+
 [id="ocp-4-9-storage"]
 === Storage
 


### PR DESCRIPTION
Release note for: https://issues.redhat.com/browse/OSDOCS-2325

For 4.9

Preview: https://deploy-preview-36645--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking

@quarterpin ready for review