### PR TITLE
[Closed] RHDEVDOCS-2815 Authenticating pipelines using git secret

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1452,6 +1452,8 @@ Topics:
     File: using-pods-in-a-privileged-security-context
   - Name: Securing webhooks with event listeners
     File: securing-webhooks-with-event-listeners
+  - Name: Authenticating pipelines using git secret
+    File: authenticating-pipelines-using-git-secret
 - Name: GitOps
   Dir: gitops
   Distros: openshift-enterprise

--- a/cicd/pipelines/authenticating-pipelines
+++ b/cicd/pipelines/authenticating-pipelines
@@ -1,0 +1,1 @@
+LOrem IPsum

--- a/cicd/pipelines/authenticating-pipelines
+++ b/cicd/pipelines/authenticating-pipelines
@@ -1,1 +1,0 @@
-LOrem IPsum

--- a/cicd/pipelines/authenticating-pipelines-using-git-secret.adoc
+++ b/cicd/pipelines/authenticating-pipelines-using-git-secret.adoc
@@ -1,0 +1,75 @@
+[id="authenticating-pipelines-using-git-secret"]
+= Authenticating pipelines using git secret
+include::modules/common-attributes.adoc[]
+include::modules/pipelines-document-attributes.adoc[]
+:context: authenticating-pipelines-using-git-secret
+
+toc::[]
+
+This document describes how Tekton handles authentication when executing
+`TaskRuns` and `PipelineRuns`. Since authentication concepts and processes
+apply to both of those entities in the same manner, this document collectively
+refers to `TaskRuns` and `PipelineRuns` as `Runs` for the sake of brevity.
+
+Overview
+Tekton supports authentication via the Kubernetes first-class Secret types listed below.
+
+Git	Docker
+kubernetes.io/basic-auth
+kubernetes.io/ssh-auth	kubernetes.io/basic-auth
+kubernetes.io/dockercfg
+kubernetes.io/dockerconfigjson
+A Run gains access to these Secrets through its associated ServiceAccount. Tekton requires that each supported Secret includes a Tekton-specific annotation.
+
+Tekton converts properly annotated Secrets of the supported types and stores them in a Step's container as follows:
+
+Git: Tekton produces a ~/.gitconfig file or a ~/.ssh directory.
+Docker: Tekton produces a ~/.docker/config.json file.
+Each Secret type supports multiple credentials covering multiple domains and establishes specific rules governing credential formatting and merging. Tekton follows those rules when merging credentials of each supported type.
+
+To consume these Secrets, Tekton performs credential initialization within every Pod it instantiates, before executing any Steps in the Run. During credential initialization, Tekton accesses each Secret associated with the Run and aggregates them into a /tekton/creds directory. Tekton then copies or symlinks files from this directory into the user's $HOME directory.
+
+Understanding credential selection
+A Run might require multiple types of authentication. For example, a Run might require access to multiple private Git and Docker repositories. You must properly annotate each Secret to specify the domains for which Tekton can use the credentials that the Secret contains. Tekton ignores all Secrets that are not properly annotated.
+
+A credential annotation key must begin with tekton.dev/git- or tekton.dev/docker- and its value is the URL of the host for which you want Tekton to use that credential. In the following example, Tekton uses a basic-auth (username/password pair) Secret to access Git repositories at github.com and gitlab.com as well as Docker repositories at gcr.io:
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tekton.dev/git-0: https://github.com
+    tekton.dev/git-1: https://gitlab.com
+    tekton.dev/docker-0: https://gcr.io
+type: kubernetes.io/basic-auth
+stringData:
+  username: <cleartext username>
+  password: <cleartext password>
+And in this example, Tekton uses an ssh-auth Secret to access Git repositories at github.com only:
+
+apiVersion: v1
+kind: Secret
+metadata:
+  annotations:
+    tekton.dev/git-0: github.com
+type: kubernetes.io/ssh-auth
+stringData:
+  ssh-privatekey: <private-key>
+  # This is non-standard, but its use is encouraged to make this more secure.
+  # Omitting this results in the server's public key being blindly accepted.
+Using Secrets as a non-root user
+In certain scenarios you might need to use Secrets as a non-root user. For example:
+
+Your platform randomizes the user and/or groups that your containers use to execute.
+The Steps in your Task define a non-root securityContext.
+Your Task specifies a global non-root securityContext that applies to all Steps in the Task.
+The following are considerations for executing Runs as a non-root user:
+
+ssh-auth for Git requires the user to have a valid home directory configured in /etc/passwd. Specifying a UID that has no valid home directory results in authentication failure.
+Since SSH authentication ignores the $HOME environment variable, you must either move or symlink the appropriate Secret files from the $HOME directory defined by Tekton (/tekton/home) to the non-root user's valid home directory to use SSH authentication for either Git or Docker.
+For an example of configuring SSH authentication in a non-root securityContext, see authenticating-git-commands.
+
+Limiting Secret access to specific Steps
+As described earlier in this document, Tekton stores supported Secrets in $HOME/tekton/home and makes them available to all Steps within a Task.
+
+If you want to limit a Secret to only be accessible to specific Steps but not others, you must explicitly specify a Volume using the Secret definition and manually VolumeMount it into the desired Steps instead of using the procedures described later in this document.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`
- **JIRA issues**: [RHDEVDOCS-2815 Document prunning of PipelineRun and TaskRun](https://issues.redhat.com/browse/RHDEVDOCS-2815)
- **Preview pages**: [TBD]()
- **SME+QE review**: TBD
- **Peer-review**: TBD