### PR TITLE
OSDOCS-1837: Release note for Ingress TLS 1.3 support

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -389,6 +389,12 @@ For clusters that run on {rh-openstack}, you can now configure Octavia for load 
 
 // TODO: Link when doc is merged.
 // For more information, see xref:../
+[id="ocp-4-9-nw-tls-profile"]
+==== Support added for TLS 1.3 and the Modern profile
+
+This release adds Ingress Controller support for TLS 1.3 and the `Modern` profile in HAProxy.
+
+For more information, see xref:../networking/ingress-operator.adoc#configuring-ingress-controller-tls[Ingress Controller TLS security profiles].
 
 [id="ocp-4-9-storage"]
 === Storage


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1837

For 4.9

Preview: https://deploy-preview-36649--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking

@miheer ready for review.