### PR TITLE
BZ1889217: Run PVs on master nodes

### DIFF
--- a/modules/persistent-storage-local-tolerations.adoc
+++ b/modules/persistent-storage-local-tolerations.adoc
@@ -52,4 +52,14 @@ To configure local volumes for scheduling on tainted nodes:
 <4> The volume mode, either `Filesystem` or `Block`, defining the type of the local volumes.
 <5> The path containing a list of local storage devices to choose from.
 
+. Optional: To create local persistent volumes on only tainted nodes, modify the YAML file and add the `LocalVolume` spec, as shown in the following example:
++
+[source,yaml]
+----
+spec:
+  tolerations:
+    - key: node-role.kubernetes.io/master
+      operator: Exists
+----
+
 The defined tolerations will be passed to the resulting daemon sets, allowing the diskmaker and provisioner pods to be created for nodes that contain the specified taints.


### PR DESCRIPTION
Added a note on what tolerations are needed for running local PVs on master nodes.
Fixes: BZ1889217
OCP version: 4.6.z - 4.6, 4.7, 4.8, 4.9
QA contact: @duanwei33 
Fixes: [BZ1889217](https://bugzilla.redhat.com/show_bug.cgi?id=1889217)
Preview: [Link](https://deploy-preview-36654--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local?utm_source=github&utm_campaign=bot_dp#local-tolerations_persistent-storage-local)