### PR TITLE
BZ1986280: Added a kubelet config note about using valid values

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -7,16 +7,22 @@
 [id="create-a-kubeletconfig-crd-to-edit-kubelet-parameters_{context}"]
 = Creating a KubeletConfig CRD to edit kubelet parameters
 
-The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new
-`kubelet-config-controller` added to the Machine Config Controller (MCC). This allows you to use a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
+The kubelet configuration is currently serialized as an Ignition configuration, so it can be directly edited. However, there is also a new `kubelet-config-controller` added to the Machine Config Controller (MCC). This lets you use a `KubeletConfig` custom resource (CR) to edit the kubelet parameters.
 
-You should have one `KubeletConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all the pools, you only need one `KubeletConfig` CR for all the pools.
+[NOTE]
+====
+As the fields in the `kubletConfig` object are passed directly to the kubelet from upstream Kubernetes, the kubelet validates those values directly. Invalid values in the `kubeletConfig` object might cause cluster nodes to become unavailable. For valid values, see the link:https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubernetes documentation].
+====
 
-You should edit an existing `KubeletConfig` CR to modify existing settings or add new settings instead of creating a new CR for each change. It is recommended to create a new CR only to modify a different machine config pool, or for changes that are intended to be temporary so that you can revert the changes.
+Consider the following guidance:
 
-You can create multiple `KubeletConfig` CRs, as needed, with a limit of 10 per cluster. For the first `KubeletConfig` CR, the MCO creates a machine config appended with `kubelet`. With each subsequent CR, the controller creates a new `kubelet` machine config with a numeric suffix. For example, if you have a `kubelet` machine config with a `-2` suffix, the next `kubelet` machine config is appended with `-3`.
+* Create one `KubeletConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all of the pools, you need only one `KubeletConfig` CR for all of the pools.
 
-If you want to delete the machine configs, you should delete them in reverse order to avoid exceeding the limit. For example, you should delete the `kubelet-3` machine config before deleting the `kubelet-2` machine config.
+* Edit an existing `KubeletConfig` CR to modify existing settings or add new settings, instead of creating a CR for each change. It is recommended that you create a CR only to modify a different machine config pool, or for changes that are intended to be temporary, so that you can revert the changes.
+
+* As needed, create multiple `KubeletConfig` CRs with a limit of 10 per cluster. For the first `KubeletConfig` CR, the Machine Config Operator (MCO) creates a machine config appended with `kubelet`. With each subsequent CR, the controller creates another `kubelet` machine config with a numeric suffix. For example, if you have a `kubelet` machine config with a `-2` suffix, the next `kubelet` machine config is appended with `-3`.
+
+If you want to delete the machine configs, delete them in reverse order to avoid exceeding the limit. For example, you delete the `kubelet-3` machine config before deleting the `kubelet-2` machine config.
 
 [NOTE]
 ====


### PR DESCRIPTION
CP to 4.7, 4.8, and 4.9

https://bugzilla.redhat.com/show_bug.cgi?id=1986280

- Updated Post-installation machine configuration tasks > Creating a KubeletConfig CRD to edit kubelet parameters to include a note that clarifies kubeletConfig validation.
https://deploy-preview-36657--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-machine-configuration-tasks

- The same note appears in Recommended host practices > Creating a KubeletConfig CRD to edit kubelet parameters
https://deploy-preview-36657--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_

Worth noting:
- This is the second of two PRs for this issue. The first PR applied to 4.6 only (https://github.com/openshift/openshift-docs/pull/36587). QE ack'd this change in the 4.6 PR.
- I applied bullets to the paragraphs immediately following the note. I made the change in the interest of readability. Content was not changed.