### PR TITLE
Adds two known issues for Kuryr and OpenStack

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -409,6 +409,16 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 
 {product-title} 4.9 introduces the following notable technical changes.
 
+[discrete]
+[id="octavia-ovn-nodeport-changes"]
+==== Octavia OVN NodePort changes
+Previously, on {rh-openstack-first} deployments, opening traffic on NodePorts was constrained to the CIDR of the node's subnet. In order to support LoadBalancer services using the Octavia Open Virtual Network (OVN) provider, the security group rules that allow NodePort traffic to master and worker nodes are now changed to open `0.0.0.0/0`. 
+
+[discrete]
+[id="osp-loadbalancer-configuration-changes"]
+==== OpenStack Platform LoadBalancer configuration changes
+The {rh-openstack-first} cloud provider LoadBalancer configuration now defaults to `use-octavia=True`. An exception to this rule is a deployment with Kuryr, in which case `use-octavia` is set to `false`, because Kuryr handles LoadBalancer services on its own.
+
 // Note: use [discrete] for these sub-headings.
 
 [id="ocp-4-9-deprecated-removed-features"]
@@ -939,7 +949,11 @@ This script removes unauthenticated subjects from the following cluster role bin
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])
 
-* An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets which are created for each OpenShift namespace at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*])
+* An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured. This will be fixed in a future release of {rh-openstack}. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*])
+
+* Installations on {rh-openstack-first} with Kuryr will not work if configured with a cluster-wide proxy when the cluster-wide proxy is required to access {rh-openstack} APIs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985486[*BZ#1985486*])
+
+* Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*]. 
 
 
 [id="ocp-4-9-asynchronous-errata-updates"]


### PR DESCRIPTION
Adds two known issues for Kuryr and RHOSP and two technical changes. 

Preview: https://deploy-preview-36661--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-known-issues

No BZ.

Found at https://github.com/openshift/openshift-docs/issues/33497 and submitted by Dulek. 

To be merged to the 4.9 RNs upon @dulek 's approval. 

