### PR TITLE
OSDOCS2415: release note for Ingress controller mutual TLS auth

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -334,6 +334,14 @@ This release introduces six timeout configurations for the Ingress Controller `t
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress controller configuration parameters].
 
+[id="ocp-4-9-nw-mutual-TLS-authentication"]
+==== Mutual TLS Authentication
+
+You can now configure the Ingress Controller to enable mutual TLS (mTLS) authentication by setting `spec.clientTLS`. The `clientTLS` field specifies configuration for the Ingress Controller to verify client certificates.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-mutual-tls-auth[Configuring Mutual TLS Authentication].
+
+
 [id="ocp-4-9-storage"]
 === Storage
 


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/OSDOCS-2415

for 4.9

Preview: https://deploy-preview-36668--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking

@lihongan ready for QA