### PR TITLE
OSDOCS-2485: Added CCCMO entry to the RH Operators reference assembly

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="cluster-cloud-controller-manager-operator_{context}"]
+= Cluster Cloud Controller Manager Operator
+
+[discrete]
+== Purpose
+
+[NOTE]
+====
+This Operator is only fully supported for Azure Stack Hub.
+
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Microsoft Azure, and {rh-openstack-first}.
+====
+
+The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).
+
+It contains the following components:
+
+* Operator
+* Cloud configuration observer
+
+By default, the Operator exposes Prometheus metrics through the `metrics` service.
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/cluster-cloud-controller-manager-operator[cluster-cloud-controller-manager-operator]

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -13,14 +13,14 @@ include::modules/cloud-credential-operator.adoc[leveloffset=+1]
 * xref:../rest_api/security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[CredentialsRequest custom resource]
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc[About the Cloud Credential Operator]
 
-include::modules/cluster-config-operator.adoc[leveloffset=+1]
 include::modules/cluster-authentication-operator.adoc[leveloffset=+1]
 include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
+include::modules/cluster-cloud-controller-manager-operator.adoc[leveloffset=+1]
+include::modules/cluster-config-operator.adoc[leveloffset=+1]
 include::modules/cluster-image-registry-operator.adoc[leveloffset=+1]
 include::modules/cluster-machine-approver-operator.adoc[leveloffset=+1]
 include::modules/cluster-monitoring-operator.adoc[leveloffset=+1]
 include::modules/cluster-network-operator.adoc[leveloffset=+1]
-include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 include::modules/cluster-samples-operator.adoc[leveloffset=+1]
 include::modules/cluster-storage-operator.adoc[leveloffset=+1]
 include::modules/cluster-version-operator.adoc[leveloffset=+1]
@@ -35,6 +35,8 @@ include::modules/machine-api-operator.adoc[leveloffset=+1]
 include::modules/machine-config-operator.adoc[leveloffset=+1]
 include::modules/operator-marketplace.adoc[leveloffset=+1]
 include::modules/node-tuning-operator.adoc[leveloffset=+1]
+include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
+include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 
 [id="red-hat-operators-olm"]
 == Operator Lifecycle Manager Operators
@@ -54,7 +56,6 @@ include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
 
 For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
 
-include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
 include::modules/prometheus-operator.adoc[leveloffset=+1]
 include::modules/vsphere-problem-detector-operator.adoc[leveloffset=+1]
 include::modules/windows-machine-config-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2485

Preview: 
https://deploy-preview-36669--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_red-hat-operators