### PR TITLE
OSDOCS-2423 Missed a RHEL 8.4 reference for compute machines

### DIFF
--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -99,7 +99,7 @@ these cluster machines.
 endif::ibm-z[]
 ====
 
-The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first} or {op-system-base-full} 7.9.
+The bootstrap and control plane machines must use {op-system-first} as the operating system. However, the compute machines can choose between {op-system-first}, {op-system-base-full} 7.9, or {op-system-base} 8.4.
 
 ifdef::bare-metal,agnostic[]
 [IMPORTANT]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2423

Follow-up to #35928

Preview: https://deploy-preview-36670--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#machine-requirements_installing-vsphere