### PR TITLE
OSDOCS-1922: OLM-1733 Client deletion of operands for OLM Operators

### DIFF
--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -19,19 +19,23 @@ endif::[]
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll or type a keyword into the *Filter by name* to find the Operator you want. Then, click on it.
+. From the *Operators* → *Installed Operators* page, scroll or enter a keyword into the *Filter by name* field to find the Operator you want. Then, click on it.
 
-. On the right-hand side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
+. On the right side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
 +
-An *Uninstall Operator?* dialog box is displayed, alerting you that:
+An *Uninstall Operator?* dialog box opens, listing the Operands associated with the Operator.
 +
-[.small]
---
-*Operator VerticalPodAutoscaler will be removed from openshift-vertical-pod-autoscaler. Click on the checkbox below to also remove all Operands associated with this Operator. If your Operator configured off-cluster resources, these will continue to run and require manual cleanup.*
---
-+
-Any resources managed by the Operator, including CRDs and CRs, are not removed. The web console enables dashboards and navigation items for some Operators. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
+. Choose one of the following options for the *Delete all operand instances for this Operator* checkbox:
 
-. Optional: To remove all operands associated with the Operator, select *Delete all operand instances for this operator* checkbox.
+* To remove Operands managed by the Operator automatically, including custom resources (CRs), select the checkbox.
+* To keep the Operands in place or remove them manually later, leave the checkbox clear.
+. Select *Uninstall* to remove the Operator, any Operator deployments, and pods. This Operator stops running and no longer receives updates.
 
-. Select *Uninstall*. This Operator stops running and no longer receives updates.
+.Verification
+
+- If you choose to remove Operands managed by the Operator automatically, the *Uninstall Operator?* dialog box confirms if the uninstall process is a success. If there are errors, the dialog lists the Operands that you need to delete manually.
+
+[NOTE]
+====
+Dashboards and navigation items enabled by the web console and off-cluster resources that continue to run might need manual clean up.
+====


### PR DESCRIPTION
Release: enterprise-4.9

[OSDOCS-1922](https://issues.redhat.com/browse/OSDOCS-1922)

Docs preview: https://deploy-preview-36673--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster?utm_source=github&utm_campaign=bot_dp#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster

Release note PR: #36760