### PR TITLE
BZ#1906643: Change alertmanagerMain storage; add note about thanosRuler storage

### DIFF
--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -89,7 +89,7 @@ data:
           storageClassName: *local-storage*
           resources:
             requests:
-              storage: *40Gi*
+              storage: *10Gi*
 ----
 
 ** *To configure a PVC for a component that monitors user-defined projects*:
@@ -161,8 +161,13 @@ data:
           storageClassName: *local-storage*
           resources:
             requests:
-              storage: *40Gi*
+              storage: *10Gi*
 ----
++
+[NOTE]
+====
+Storage requirements for `thanosRuler` depend on the number of rules evaluated and how many samples each rule generates.
+====
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically and the new storage configuration is applied.
 +


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1906643

OCP Version: 4.6

Current 4.6 doc: https://docs.openshift.com/container-platform/4.6/monitoring/configuring-the-monitoring-stack.html#configuring-a-local-persistent-volume-claim_configuring-the-monitoring-stack

Direct doc preview link: https://deploy-preview-36680--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack?utm_source=github&utm_campaign=bot_dp#configuring-a-local-persistent-volume-claim_configuring-the-monitoring-stack

