### PR TITLE
Multiple tickets: Release notes updates for OCPCLOUD features

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -541,6 +541,20 @@ The {product-title} Ingress Controller is upgraded to HAProxy version 2.2.15.
 
 In {product-title} {product-version}, CoreDNS uses version 1.8.4, which includes bug fixes.
 
+[discrete]
+[id="ocp-4-9-cluster-cloud-controller-manager-operator"]
+==== Implementation of cloud controller managers for cloud providers
+
+The Kubernetes controller manager that manages cloud provider deployments does not include support for Azure Stack Hub as a provider. Because using cloud controller managers is the preferred method for interacting with underlying cloud platforms, there is no plan to add this support. As a result, the Azure Stack Hub implementation in {product-title} uses cloud controller managers.
+
+In addition, this release supports using cloud controller managers for Amazon Web Services (AWS), Microsoft Azure, and {rh-openstack-first} as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. Any new cloud platform support that is added to {product-title} will also use cloud controller managers.
+
+To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes documentation on this component].
+
+To manage the cloud controller manager and cloud node manager deployments and lifecycles, this release introduces the Cluster Cloud Controller Manager Operator.
+
+For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_red-hat-operators[Cluster Cloud Controller Manager Operator] entry in the _Red Hat Operators reference_.
+
 [id="ocp-4-9-deprecated-removed-features"]
 == Deprecated and removed features
 
@@ -1034,6 +1048,21 @@ In the table below, features are marked with the following statuses:
 |TP
 |TP
 |GA
+
+|Cloud controller manager for AWS
+|-
+|-
+|TP
+
+|Cloud controller manager for Azure
+|-
+|-
+|TP
+
+|Cloud controller manager for OpenStack
+|-
+|-
+|TP
 
 |====
 


### PR DESCRIPTION
For:
- https://issues.redhat.com/browse/OSDOCS-2485 (CCCMO)
- https://issues.redhat.com/browse/OSDOCS-2331 (ASH GA)
- https://issues.redhat.com/browse/OSDOCS-2480 (AWS TP)
- https://issues.redhat.com/browse/OSDOCS-2332 (Azure TP)
- Also for OpenStack TP (not tracked as an OCPCLOUD docs item)

Previews: 
- [Implementation of cloud controller managers for cloud providers](https://deploy-preview-36681--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-cluster-cloud-controller-manager-operator) in _Notable technical changes_
- [Technology Preview tracker](https://deploy-preview-36681--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-technology-preview) table