### PR TITLE
Fix broken IP address lookup command

### DIFF
--- a/modules/sdpolicy-networking.adoc
+++ b/modules/sdpolicy-networking.adoc
@@ -57,7 +57,7 @@ Customers can determine their public static IP addresses by running a pod on the
 
 [source,terminal]
 ----
-$ oc run ip-lookup --image=busybox -i -t --restart=Never --rm -- /bin/sh -c "/bin/nslookup
+$ oc run ip-lookup --image=busybox -i -t --restart=Never --rm -- /bin/sh -c "/bin/nslookup -type=a myip.opendns.com resolver1.opendns.com | grep -E 'Address: [0-9.]+'"
 ----
 
 [id="cloud-network-configuration_{context}"]


### PR DESCRIPTION
This command was broken when it was copied over from the previous service definition