### PR TITLE
BZ1996029: Add ingress default values managed by ingress operator

### DIFF
--- a/modules/nw-route-specific-annotations.adoc
+++ b/modules/nw-route-specific-annotations.adoc
@@ -70,6 +70,30 @@ This value is applicable to re-encrypt and edge routes only. For more informatio
 Environment variables cannot be edited.
 ====
 
+.Router timeout variables
+
+`TimeUnits` are represented by a number followed by the unit: `us` *(microseconds), `ms` (milliseconds, default), `s` (seconds), `m` (minutes), `h` *(hours), `d` (days).
+
+The regular expression is: [1-9][0-9]*(`us`\|`ms`\|`s`\|`m`\|`h`\|`d`).
+[cols="2,1,2a", options="header"]
+|===
+|Variable | Default | Description
+| `ROUTER_BACKEND_CHECK_INTERVAL` | `5000ms` | Length of time between subsequent liveness checks on back ends.
+| `ROUTER_CLIENT_FIN_TIMEOUT` | `1s` | Controls the TCP FIN timeout period for the client connecting to the route. If the FIN sent to close the connection does not answer within the given time, HAProxy closes the connection. This is harmless if set to a low value and uses fewer resources on the router.
+| `ROUTER_DEFAULT_CLIENT_TIMEOUT` | `30s` | Length of time that a client has to acknowledge or send data.
+| `ROUTER_DEFAULT_CONNECT_TIMEOUT` | `5s` | The maximum connection time.
+| `ROUTER_DEFAULT_SERVER_FIN_TIMEOUT` | `1s` | Controls the TCP FIN timeout from the router to the pod backing the route.
+| `ROUTER_DEFAULT_SERVER_TIMEOUT` | `30s` | Length of time that a server has to acknowledge or send data.
+| `ROUTER_DEFAULT_TUNNEL_TIMEOUT` | `1h` | Length of time for TCP or WebSocket connections to remain open. This timeout period resets whenever HAProxy reloads.
+| `ROUTER_SLOWLORIS_HTTP_KEEPALIVE` | `300s` | Set the maximum time to wait for a new HTTP request to appear. If this is set too low, it can cause problems with browsers and applications not expecting a small `keepalive` value.
+
+Some effective timeout values can be the sum of certain variables, rather than the specific expected timeout. For example, `ROUTER_SLOWLORIS_HTTP_KEEPALIVE` adjusts `timeout http-keep-alive`. It is set to `300s` by default, but HAProxy also waits on `tcp-request inspect-delay`, which is set to `5s`. In this case, the overall timeout would be `300s` plus `5s`. 
+| `ROUTER_SLOWLORIS_TIMEOUT` | `10s` | Length of time the transmission of an HTTP request can take.
+| `RELOAD_INTERVAL` | `5s` | Allows the minimum frequency for the router to reload and accept new changes.
+| `ROUTER_METRICS_HAPROXY_TIMEOUT` | `5s` | Timeout for the gathering of HAProxy metrics.
+
+|===
+
 .A route setting custom timeout
 [source,yaml]
 ----


### PR DESCRIPTION
The customer wants to include the unchangeable router timeout variables from 3.11 to 4.6 docs
for their reference.

OCP version: 4.6.z versions i. e 4.6, 4.7, 4.8, 4.9
QA contact: @lihongan 
Fixes: [1996029](https://bugzilla.redhat.com/show_bug.cgi?id=1996029)
preview: [Link](https://deploy-preview-36692--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-route-specific-annotations_route-configuration)