### PR TITLE
OSDOCS-2645 - Removing environment variables from ROSA STS procedures

### DIFF
--- a/modules/rosa-sts-creating-cluster.adoc
+++ b/modules/rosa-sts-creating-cluster.adoc
@@ -63,16 +63,17 @@ Multiple availability zones (Multi-AZ) are recommended for production workloads.
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name ${name} --sts
+$ rosa create cluster --cluster-name <cluster_name> --sts <1>
 ----
+<1> Replace `<cluster_name>` with the name of your cluster.
 +
 .Example output
 [source,terminal]
 ----
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role for the Support role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
 I: Creating cluster '<cluster_name>'
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
@@ -102,10 +103,10 @@ Any optional fields can be left empty and a default will be selected.
 ? Cluster name: <cluster_name>
 ? Deploy cluster using AWS STS: Yes
 ? OpenShift version: 4.8.9
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
-I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role for the Support role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
 ? External ID (optional): 
 ? Operator roles prefix: <cluster_name>-z9y3
 ? Multiple availability zones (optional): No
@@ -122,7 +123,7 @@ I: Using arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role for the Su
 ? Host prefix: 23
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-z9y3 --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-z9y3 --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
@@ -135,17 +136,21 @@ I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_n
 [source,terminal]
 ----
 $ rosa create cluster \
-  --cluster-name ${name} \
-  --region ${region} \
-  --version ${version} \
-  --role-arn arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-Installer-Role \ <1>
-  --support-role-arn arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-Support-Role \
-  --master-iam-role arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-ControlPlane-Role \
-  --worker-iam-role arn:aws:iam::${aws_account_id}:role/ManagedOpenShift-Worker-Role \
-  --operator-roles-prefix ManagedOpenShift <2>
+  --cluster-name <cluster_name> \ <1>
+  --region <aws_region> \ <2>
+  --version <openshift_version> \ <3>
+  --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role \ <4><5>
+  --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role \
+  --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role \
+  --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role \
+  --operator-roles-prefix ManagedOpenShift <6>
 ----
-<1> If you specified a custom prefix in the preceding command, you must replace the `ManagedOpenShift` prefix with the custom one in each ARN declaration. You must specify ARNs for STS account-wide roles that are created using `rosa create account-roles`.
-<2> Declares the prefix for the cluster-specific Operator roles that are defined in the following step.
+<1> Replace `<cluster_name>` with the name of your cluster.
+<2> Replace `<aws_region>` with the name of the AWS region, for example `us-east-1`.
+<3> Replace `<openshift_version>` with the OpenShift version, for example `4.8.9`.
+<4> Replace `<aws_account_id>` with your AWS account ID.
+<5> If you specified a custom prefix in the preceding command, you must replace the `ManagedOpenShift` prefix with the custom one in each ARN declaration. You must specify ARNs for STS account-wide roles that are created using `rosa create account-roles`.
+<6> Declares the prefix for the cluster-specific Operator roles that are defined in the following step.
 +
 .Example output
 [source,terminal]

--- a/modules/rosa-sts-creating-roles.adoc
+++ b/modules/rosa-sts-creating-roles.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-creating-roles.adoc
+
 [id="rosa-sts-creating-roles_{context}"]
 = Creating IAM roles and policies for STS in ROSA
 
@@ -52,7 +56,7 @@ If relying on a permissions boundary ARN, use the following `aws iam create-role
 $ aws iam create-role \
     --role-name ManagedOpenShift-IAM-Role \
     --assume-role-policy-document file://ManagedOpenShift_IAM_Role.json \
-    --permissions-boundary ${permissions_boundary_arn}
+    --permissions-boundary <permissions_boundary_arn>
 ----
 ====
 . To create the permissions policy document, write the `ManagedOpenShift-IAM-Role-Policy` inline policy to the [filename]`ManagedOpenShift_IAM_Role_Policy.json` file.
@@ -292,7 +296,7 @@ If relying on a permissions boundary ARN, use the following `aws iam create-role
 $ aws iam create-role \
     --role-name ManagedOpenShift-ControlPlane-Role \
     --assume-role-policy-document file://ManagedOpenShift_ControlPlane_Role.json \
-    --permissions-boundary ${permissions_boundary_arn}
+    --permissions-boundary <permissions_boundary_arn>
 ----
 ====
 . To create the permissions policy document, write the `ManagedOpenShift-ControlPlane-Role-Policy` inline policy
@@ -403,7 +407,7 @@ If relying on a permissions boundary ARN, use the following `aws iam create-role
 $ aws iam create-role \
     --role-name ManagedOpenShift-Worker-Role \
     --assume-role-policy-document file://ManagedOpenShift_Worker_Role.json \
-    --permissions-boundary ${permissions_boundary_arn}
+    --permissions-boundary <permissions_boundary_arn>
 ----
 ====
 . Write the `ManagedOpenShift-Worker-Role-Policy` policy to the [filename]`ManagedOpenShift_Worker_Role_Policy.json` file to create the permissions policy document.
@@ -481,7 +485,7 @@ If relying on a permissions boundary ARN, use the following `aws iam create-role
 $ aws iam create-role \
     --role-name ManagedOpenShift-Support-Role \
     --assume-role-policy-document file://RH_Support_Role.json \
-    --permissions-boundary ${permissions_boundary_arn}
+    --permissions-boundary <permissions_boundary_arn>
 ----
 ====
 

--- a/modules/rosa-sts-setting-up-environment.adoc
+++ b/modules/rosa-sts-setting-up-environment.adoc
@@ -201,31 +201,6 @@ $ rosa download openshift-client
 ----
 $ rosa verify openshift-client
 ----
-. Optional: If you use a permissions boundary policy, gather the permissions boundary policy Amazon resource name (ARN) from your AWS account.
-+
-Set the permissions boundary ARN as an environment variable:
-+
-[source,terminal]
-----
-$ export permissions_boundary_arn=<ARN from AWS account>
-----
-. You can bring your own virtual private cloud (VPC) or let the installer create a VPC for you.
-.. Optional: If you are using your own Virtual Private Cloud (VPC) Gather subnet IDs for the VPC you will be installing into, and export them into a comma-separated list.
-+
-[source,terminal]
-----
-$ export subnet_ids=<subnet-0abcdefg,subnet-000111222333>
-----
-. Set the rest of the static environment variables.
-+
-[source,terminal]
-----
-$ export version=<4.7.11_or_greater> \
-  name=<cluster name> \
-  aws_account_id=<AWS Account ID> \
-  region=<region> \
-  AWS_PAGER="" # for v2 of the aws cli, unless you want commands to show you the output in `less` by default
-----
 
 .Create roles
 After completing these steps, you are ready to set up IAM and OIDC access-based roles.


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2645. The PR replaces the use of environment variables of the style `${VAR}` in the ROSA STS procedures with angle bracket replaceables (i.e. `<>`). The update adheres to the guidelines for replaceable values outlined in the [Code blocks, command syntax, and example output section of the OpenShift documentation guidelines](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output).

The previews are as follows:

*  **Setting up accounts and clusters using AWS security token service (STS)** -> [**Setting up the environment for STS**](https://deploy-preview-36701--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-setting-up-environment.html#rosa-sts-setting-up-environment_rosa-sts-setting-up-environment)
* **Setting up accounts and clusters using AWS security token service (STS)** -> [**Creating your cluster using STS**](https://deploy-preview-36701--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-creating-cluster.html#rosa-sts-creating-cluster_rosa-sts-creating-cluster)