### PR TITLE
[enterprise-4.6] SDN-1732: OVN-K does not support traf policies

### DIFF
--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+[id="nw-ovn-kubernetes-limitations_{context}"]
+= OVN-Kubernetes limitations
+
+The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has a limitation that is related to traffic policies.
+The network provider does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
+The default value, `cluster`, is supported for both parameters.
+This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
+

--- a/modules/nw-ovn-kubernetes-features.adoc
+++ b/modules/nw-ovn-kubernetes-features.adoc
@@ -5,10 +5,11 @@
 [id="nw-ovn-kubernetes-features_{context}"]
 = OVN-Kubernetes features
 
-The OVN-Kubernetes default Container Network Interface (CNI) network provider implements the following features:
+The OVN-Kubernetes Container Network Interface (CNI) cluster network provider implements the following features:
 
 // OVN (Open Virtual Network) is consistent with upstream usage.
 
-* Uses OVN (Open Virtual Network) to manage network traffic flows. OVN is a community developed, vendor agnostic network virtualization solution.
+* Uses OVN (Open Virtual Network) to manage network traffic flows. OVN is a community developed, vendor-agnostic network virtualization solution.
 * Implements Kubernetes network policy support, including ingress and egress rules.
 * Uses the Geneve (Generic Network Virtualization Encapsulation) protocol rather than VXLAN to create an overlay network between nodes.
+

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -17,9 +17,12 @@ include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]
 // This is a moving target; what is included isn't valid for 4.6
 //include::modules/nw-ovn-kubernetes-metrics.adoc[leveloffset=+1]
 
+include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
+
 .Additional resources
 
 * xref:../../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuring-egress-firewall-ovn[Configuring an egress firewall for a project]
 * xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy]
 * xref:../../networking/ovn_kubernetes_network_provider/enabling-multicast.adoc#nw-ovn-kubernetes-enabling-multicast[Enabling multicast for a project]
-* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]]
+* xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1\]]
+


### PR DESCRIPTION
* Engineering expects to lift the limitation
  in a 4.9.z release.

* Fix idiotic xref change that I made.

* Remove "default" in two files.

Cherry-picked from c643ced9acefdaa5d73abb68d9fa15628c3b500b  xref: https://github.com/openshift/openshift-docs/pull/36399