### PR TITLE
puts back PTP xrefs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -262,14 +262,18 @@ You can now customize the URL for the internal OAuth server. For more informatio
 
 {product-title} {product-version} introduces the following updates to PTP:
 
-* The `ptp4lConf` field
+* New `ptp4lConf` field
 
 * New option to configure `linuxptp` services as a boundary clock
+
+For more information, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-boundary-clock_using-ptp[Configuring linuxptp services as boundary clock].
 
 [id="ocp-4-9-ptp-fast-event-notifications"]
 ==== Monitoring PTP fast events with the PTP fast event notification framework
 
 Fast event notifications for PTP events are now available for bare-metal clusters. The PTP Operator generates event notifications for every configured PTP-capable network interface. Events are made available through a REST API for applications running on the same node. Fast event notifications are transported by an Advanced Message Queuing Protocol (AMQP) message bus provided by the AMQ Interconnect Operator.
+
+For more information, see xref:../networking/using-ptp.adoc#cnf-about-ptp-and-clock-synchronization_using-ptp[About PTP and clock synchronization error events].
 
 [id="ocp-4-9-ovn-kubernetes-egress-ips-balance"]
 ==== OVN-Kubernetes cluster network provider egress IP feature balances across nodes


### PR DESCRIPTION
xref fixes for enterprise-4.9 release note for PTP fast event notifications for the following doc epics:

https://issues.redhat.com/browse/TELCODOCS-260
https://issues.redhat.com/browse/TELCODOCS-262

https://deploy-preview-36718--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-new-configs-linuxptp-services