### PR TITLE
Fix minor version examples

### DIFF
--- a/modules/life-cycle-minor-versions.adoc
+++ b/modules/life-cycle-minor-versions.adoc
@@ -10,10 +10,10 @@ Red Hat supports two minor versions of the major release.
 * Y: The latest available minor release. For example, 4.8.
 * Y-1: The previous minor version. For example, 4.7.
 
-After an upgrade path from the previous minor version (Y-1) to the latest minor version (Y) is available, clusters running Y-2 must upgrade their cluster within a 30 day grace period. Any cluster remaining on Y-2 30 days after notification of upgrade availability are classified as being in limited support status until the cluster is upgraded to a supported release.
+After a new minor version (Y) is available, clusters running Y-2 must upgrade their cluster within a 30 day grace period. Any cluster remaining on Y-2 30 days after notification of upgrade availability are classified as being in limited support status until the cluster is upgraded to a supported release.
 
 .Example
 . A customer's cluster is currently running on 4.5.18. The latest version for 4.6 is 4.6.27.
-. On February 25, 4.7.2 is released as an available upgrade path from 4.6.27 and the customer is notified.
+. On February 25, 4.7.0 is released as a newly available version.
 . The cluster must be upgraded to 4.6.27 or later by March 25.
 . If the upgrade has not been performed, then the cluster will have SRE alerting disabled and will be unsupported until it is upgraded to 4.6.27 or later.


### PR DESCRIPTION
In `modules/life-cycle-dates.adoc` we have minor version support ending at the GA of new version + 30d, but in `modules/life-cycle-minor-versions.adoc` we have it at release of new stable edge + 30d. This change unifies the text to match the practice of GA + 30d.

/cc @wgordon17 @arendej @jharrington22 