### PR TITLE
Bug 2004317: add missing template specific permissions

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -138,6 +138,8 @@ An additional role is required if the installation program is to create a vSpher
 `VirtualMachine.Inventory.CreateFromExisting`
 `VirtualMachine.Inventory.Delete`
 `VirtualMachine.Provisioning.Clone`
+`VirtualMachine.Provisioning.DeployTemplate`
+`VirtualMachine.Provisioning.MarkAsTemplate`
 `Folder.Create`
 `Folder.Delete`
 |===


### PR DESCRIPTION
Additional permissions are required as the base RHCOS virtual machine is now being marked as a template by the IPI installer.  The intent of this PR is to add the required permissions.

@jcpowermac @bostrt 