### PR TITLE
Adds link to CRI-O RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md[Kubernetes 1.22] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md[Kubernetes 1.22] with link:https://github.com/cri-o/cri-o/releases/tag/v1.22.0[CRI-O 1.22 runtime]. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.9.0 as the GA version and, instead, is releasing {product-title} 4.9.TBD as the GA version.
 


### PR DESCRIPTION
It was requested that we add a link to the 1.22 CRI-O RNs. I am providing a direct link to those RNs and operating under the assumption that the link will change as we get closer to GA 4.9. 

Preview: 

Found on the RN tracker (see 'Look into linking to CRI-O 1.22 release notes'). 