### PR TITLE
PTP is out of Tech Preview in OCP 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -257,19 +257,30 @@ You can now customize the URL for the internal OAuth server. For more informatio
 [id="ocp-4-9-networking"]
 === Networking
 
+[id="ocp-4-9-ptp"]
+==== PTP is generally available
+
+Precision Time Protocol was previously introduced as a Technology Preview feature in {product-title} 4.6 and is now generally available in {product-title} {product-version}.
+
+For more information, see xref:../networking/using-ptp.adoc#about-using-ptp-hardware[About PTP hardware].
+
 [id="ocp-4-9-new-configs-linuxptp-services"]
 ==== Enhancements to linuxptp services
 
 {product-title} {product-version} introduces the following updates to PTP:
 
-* The `ptp4lConf` field
+* New `ptp4lConf` field
 
 * New option to configure `linuxptp` services as a boundary clock
+
+For more information, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-boundary-clock_using-ptp[Configuring linuxptp services as boundary clock].
 
 [id="ocp-4-9-ptp-fast-event-notifications"]
 ==== Monitoring PTP fast events with the PTP fast event notification framework
 
 Fast event notifications for PTP events are now available for bare-metal clusters. The PTP Operator generates event notifications for every configured PTP-capable network interface. Events are made available through a REST API for applications running on the same node. Fast event notifications are transported by an Advanced Message Queuing Protocol (AMQP) message bus provided by the AMQ Interconnect Operator.
+
+For more information, see xref:../networking/using-ptp.adoc#cnf-about-ptp-and-clock-synchronization_using-ptp[About PTP and clock synchronization error events].
 
 [id="ocp-4-9-ovn-kubernetes-egress-ips-balance"]
 ==== OVN-Kubernetes cluster network provider egress IP feature balances across nodes


### PR DESCRIPTION
Removes PTP tech previews notices from 4.9 release notes. 

https://deploy-preview-36722--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-ptp