### PR TITLE
CNV11326: Adding info about VM disk hot-plugging and un-plugging via web console

### DIFF
--- a/modules/virt-hot-plugging-a-virtual-disk-using-the-cli.adoc
+++ b/modules/virt-hot-plugging-a-virtual-disk-using-the-cli.adoc
@@ -21,5 +21,5 @@ $ virtctl addvolume <virtual-machine|virtual-machine-instance> --volume-name=<da
 [--persist] [--serial=<label-name>]
 ----
 +
-** Use the optional `--persist` flag to add the hot-plugged disk to the virtual machine specification as a permanently mounted virtual disk. Stop, restart, or reboot the virtual machine to permanently mount the virtual disk. After specifying the `--persist` flag, you can no longer hot-plug or hot-unplug the virtual disk. The `--persist` flag applies to virtual machines, not virtual machine interfaces.
+** Use the optional `--persist` flag to add the hot-plugged disk to the virtual machine specification as a permanently mounted virtual disk. Stop, restart, or reboot the virtual machine to permanently mount the virtual disk. After specifying the `--persist` flag, you can no longer hot-plug or hot-unplug the virtual disk. The `--persist` flag applies to virtual machines, not virtual machine instances.
 ** The optional `--serial` flag allows you to add an alphanumeric string label of your choice. This helps you to identify the hot-plugged disk in a guest virtual machine. If you do not specify this option, the label defaults to the name of the hot-plugged data volume or PVC.

--- a/modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc
+++ b/modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+
+[id="virt-hot-plugging-a-virtual-disk-using-the-web-console{context}"]
+= Hot-plugging a virtual disk using the web console
+
+Hot-plug virtual disks that you want to attach to a virtual machine instance (VMI) while a virtual machine is running.
+
+.Prerequisites
+* You must have a running virtual machine to hot-plug a virtual disk.
+
+.Procedure
+
+. Click *Workloads* → *Virtualization* from the side menu.
+
+. On the *Virtual Machines* tab, select the running virtual machine select the running virtual machine to which you want to hot-plug a virtual disk.
+
+. On the *Disks* tab, click *Add Disk*.
+
+. In the *Add Disk* window, fill in the information for the virtual disk that you want to hot-plug.
+
+. Click *Add*.

--- a/modules/virt-hot-unplugging-a-virtual-disk-using-the-web-console.adoc
+++ b/modules/virt-hot-unplugging-a-virtual-disk-using-the-web-console.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+
+[id="virt-hot-unplugging-a-virtual-disk-using-the-web-console{context}"]
+= Hot-unplugging a virtual disk using the web console
+
+Hot-unplug virtual disks that you want to attach to a virtual machine instance (VMI) while a virtual machine is running.
+
+.Prerequisites
+* Your virtual machine must be running with a hot-plugged disk attached.
+
+.Procedure
+
+. Click *Workloads* → *Virtualization* from the side menu.
+
+. On the *Virtual Machines* tab, select the running virtual machine with the disk you want to hot-unplug.
+
+. On the *Disks* tab, click the Options menu {kebab} of the virtual disk that you want to hot-unplug.
+
+. Click *Delete*.

--- a/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -4,11 +4,10 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-hot-plugging-virtual-disks
 
 :FeatureName: Hot-plugging virtual disks
-include::modules/technology-preview.adoc[leveloffset=+1]
 
 toc::[]
 
-Hot-plug and hot-unplug virtual disks when you want to add or remove them  without stopping your virtual machine or virtual machine instance. This capability is helpful when you need to add storage to a running virtual machine without incurring down-time.
+Hot-plug and hot-unplug virtual disks when you want to add or remove them without stopping your virtual machine or virtual machine instance. This capability is helpful when you need to add storage to a running virtual machine without incurring down-time.
 
 When you _hot-plug_ a virtual disk, you attach a virtual disk to a virtual machine instance while the virtual machine is running.
 
@@ -16,10 +15,7 @@ When you _hot-unplug_ a virtual disk, you detach a virtual disk from a virtual m
 
 Only data volumes and persistent volume claims (PVCs) can be hot-plugged and hot-unplugged. You cannot hot-plug or hot-unplug container disks.
 
-[WARNING]
-====
-When you attach a hot-plugged virtual disk to a virtual machine, you cannot perform live migration on the virtual machine. If you attempt to perform live migration on a virtual machine with a hot-plugged disk attached, live migration fails.
-====
-
 include::modules/virt-hot-plugging-a-virtual-disk-using-the-cli.adoc[leveloffset=+1]
 include::modules/virt-hot-unplugging-a-virtual-disk-using-the-cli.adoc[leveloffset=+1]
+include::modules/virt-hot-plugging-a-virtual-disk-using-the-web-console.adoc[leveloffset=+1]
+include::modules/virt-hot-unplugging-a-virtual-disk-using-the-web-console.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR addresses JIRA story [CNV-11326](https://issues.redhat.com/browse/CNV-11326) ( https://issues.redhat.com/browse/CNV-11326 ).

The story asks to add information about hot-plugging and hot-unplugging a VM disk using the web console.

CP: 4.9

Preview: https://deploy-preview-36723--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks?utm_source=github&utm_campaign=bot_dp