### PR TITLE
TELCODOCS-260 - PTP is GA  in 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -257,6 +257,13 @@ You can now customize the URL for the internal OAuth server. For more informatio
 [id="ocp-4-9-networking"]
 === Networking
 
+[id="ocp-4-9-ptp"]
+==== PTP is generally available
+
+Precision Time Protocol was previously introduced as a Technology Preview feature in {product-title} 4.7 and is now generally available in {product-title} {product-version}.
+
+For more information, see xref:../networking/using-ptp.adoc#about-using-ptp-hardware[About PTP hardware].
+
 [id="ocp-4-9-new-configs-linuxptp-services"]
 ==== Enhancements to linuxptp services
 
@@ -816,7 +823,7 @@ In the table below, features are marked with the following statuses:
 |Precision Time Protocol (PTP)
 |TP
 |TP
-|
+|GA
 
 |`oc` CLI plug-ins
 |TP


### PR DESCRIPTION
Removes PTP tech previews notices from 4.9 release notes.

https://deploy-preview-36724--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-ptp