### PR TITLE
TELCODOCS-296: Documentation for the Node Health Check Operator

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1788,6 +1788,8 @@ Topics:
     File: eco-poison-pill-operator 
   - Name: Understanding node rebooting
     File: nodes-nodes-rebooting
+  - Name: Deploying node health checks by using the Node Health Check Operator
+    File: eco-node-health-check-operator
   - Name: Freeing node resources using garbage collection
     File: nodes-nodes-garbage-collection
   - Name: Allocating resources for nodes

--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/node-health-check-operator-installation.adoc
+
+[id="about-node-health-check-operator_{context}"]
+= About the Node Health Check Operator
+
+The Node Health Check Operator deploys the `NodeHealthCheck` controller, which in turn creates the `NodeHealthCheck` custom resource (CR). The Node Health Check Operator also installs the Poison Pill Operator as a default remediation provider.
+
+The Operator uses the controller to detect the health of a node in the cluster. The controller creates a `NodeHealthCheck` custom resource (CR), which defines a set of criteria and thresholds to determine the node's health. 
+
+When node health check detects an unhealthy node, it creates a remediation CR that triggers the remediation provider. For example, the node health check creates the `PoisonPillRemediation` CR, which triggers the Poison Pill Operator to remediate the unhealthy node. 
+
+The `NodeHealthCheck` CR resembles the following YAML file:
+
+[source,yaml]
+----
+apiVersion: remediation.medik8s.io/v1alpha1
+kind: NodeHealthCheck
+metadata:
+  name: nodehealthcheck-sample
+  namespace: openshift-operators
+spec:
+  minHealthy: 51% <1>
+  remediationTemplate: <2>
+    apiVersion: poison-pill.medik8s.io/v1alpha1
+    name: group-x
+    namespace: openshift-operators
+    kind: PoisonPillRemediationTemplate
+  selector: <3>
+    matchExpressions:
+      - key: node-role.kubernetes.io/worker
+        operator: Exists
+  unhealthyConditions: <4>
+    - type: Ready
+      status: "False"
+      duration: 300s <5>
+    - type: Ready
+      status: Unknown
+      duration: 300s <5>
+----
+
+<1> Specifies the amount (in percentage) of nodes allowed to be concurrently remediated in the targeted pool. If the number of healthy nodes equals to or exceeds the limit set by `minHealthy`, remediation occurs. The default value is 51%.
+<2> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator. 
+<3> Specifies a `selector` that matches labels or expressions that you want to check. The default value is empty, which selects all nodes.
+<4> Specifies a list of the conditions that determine whether a node is considered unhealthy. 	
+<5> Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the node will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy node.
+
+[id="understanding-nhc-operator-workflow_{context}"]
+== Understanding the Node Health Check Operator workflow
+
+When a node is identified as unhealthy, the Operator checks how many other nodes are unhealthy. If the number of healthy nodes exceeds the amount that is specified in the `minHealthy` field of the `NodeHealthCheck` CR, the controller creates a remediation CR from the details that are provided in the external remediation template by the remediation provider. After remediation, the node's health status is updated accordingly.
+
+When the node turns healthy, the controller deletes the external remediation template
+and updates the node's health status.

--- a/modules/eco-node-health-check-operator-installation-cli.adoc
+++ b/modules/eco-node-health-check-operator-installation-cli.adoc
@@ -1,0 +1,107 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/node-health-check-operator-installation.adoc
+
+[id="installing-node-health-check-operator-using-cli_{context}"]
+= Installing the Node Health Check Operator by using the CLI
+You can use the OpenShift CLI (`oc`) to install the Node Health Check Operator.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a `Namespace` custom resource (CR) for the Node Health Check Operator:
+.. Define the `Namespace` CR and save the YAML file, for example, `node-health-check-namespace.yaml`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-operators
+----
+.. To create the `Namespace` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-health-check-namespace.yaml
+----
+
+. Create an `OperatorGroup` CR:
+.. Define the `OperatorGroup` CR and save the YAML file, for example, `node-health-check-operator-group.yaml`:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: node-health-check-operator
+  namespace: openshift-operators
+spec:
+  targetNamespaces:
+  - openshift-operators
+----
+.. To create the `OperatorGroup` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-health-check-operator-group.yaml
+----
+
+. Create a `Subscription` CR:
+.. Define the `Subscription` CR and save the YAML file, for example, `node-health-check-subscription.yaml`:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+    name: node-health-check-operator
+    namespace: openshift-operators
+spec:
+    channel: alpha
+    name: node-healthcheck-operator
+    source: redhat-operators
+    sourceNamespace: openshift-marketplace
+    package: node-health-check-operator
+----
+.. To create the `Subscription` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f node-health-check-subscription.yaml
+----
+
+.Verification
+
+. Verify that the installation succeeded by inspecting the CSV resource:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-operators
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                               DISPLAY                      VERSION   REPLACES   PHASE
+node-health-check-operator.v0.1.1  Node Health Check Operator   0.1.1                Succeeded
+----
+. Verify that the Node Health Check Operator is up and running:
++
+[source,terminal]
+----
+$ oc get deploy -n openshift-operators
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                                           READY   UP-TO-DATE   AVAILABLE   AGE
+node-health-check-operator-controller-manager  1/1     1            1           10d
+----

--- a/modules/eco-node-health-check-operator-installation-web-console.adoc
+++ b/modules/eco-node-health-check-operator-installation-web-console.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/node-health-check-operator-installation.adoc
+
+[id="installing-node-health-check-operator-using-web-console_{context}"]
+= Installing the Node Health Check Operator by using the web console
+
+You can use the {product-title} web console to install the Node Health Check Operator.
+
+.Prerequisites
+
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. In the {product-title} web console, navigate to *Operators* -> *OperatorHub*.
+. Search for the Node Health Check Operator, then click *Install*.
+. Keep the default selection of *Installation mode* and *namespace* to ensure that the Operator will be installed to the `openshift-operators` namespace.
+. Click *Install*.
+
+.Verification
+
+To confirm that the installation is successful:
+
+. Navigate to the *Operators* -> *Installed Operators* page.
+. Check that the Operator is installed in the `openshift-operators` namespace and that its status is `Succeeded`.
+
+If the Operator is not installed successfully:
+
+. Navigate to the *Operators* -> *Installed Operators* page and inspect the `Status` column for any errors or failures.
+. Navigate to the *Workloads* -> *Pods* page and check the logs in any pods in the `openshift-operators` project that are reporting issues.

--- a/nodes/nodes/eco-node-health-check-operator.adoc
+++ b/nodes/nodes/eco-node-health-check-operator.adoc
@@ -1,0 +1,22 @@
+[id="node-health-check-operator"]
+= Deploying node health checks by using the Node Health Check Operator
+include::modules/common-attributes.adoc[]
+:context: node-health-check-operator
+
+toc::[]
+
+Use the Node Health Check Operator to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Poison Pill Operator to remediate the unhealthy nodes.
+
+.Additional resources
+
+xref:../../nodes/nodes/eco-poison-pill-operator.adoc#poison-pill-operator-remediate-nodes[Remediating nodes with the Poison Pill Operator]
+
+:FeatureName: Node Health Check Operator
+
+include::modules/technology-preview.adoc[leveloffset=+1]
+
+include::modules/eco-node-health-check-operator-about.adoc[leveloffset=+1]
+
+include::modules/eco-node-health-check-operator-installation-web-console.adoc[leveloffset=+1]
+
+include::modules/eco-node-health-check-operator-installation-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-296: Documentation for the Node Health Check Operator (which is in Tech Preview for 4.9)

Applies to OpenShift version 4.9+ 

Preview link: https://deploy-preview-36730--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-node-health-check-operator.html