### PR TITLE
OSDOCS-2211: Adding OSDK proxy docs

### DIFF
--- a/modules/osdk-run-proxy.adoc
+++ b/modules/osdk-run-proxy.adoc
@@ -1,0 +1,132 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+// * operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+// * operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:golang:
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:ansible:
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:helm:
+endif::[]
+
+[id="osdk-run-proxy_{context}"]
+= Enabling proxy support
+
+To support proxied clusters, your Operator must inspect the environment for the following standard proxy variables and pass the values to Operands:
+
+* `HTTP_PROXY`
+* `HTTPS_PROXY`
+* `NO_PROXY`
+
+[NOTE]
+====
+This tutorial uses `HTTP_PROXY` as an example environment variable.
+====
+
+.Prerequisites
+* A cluster with cluster-wide egress proxy enabled.
+
+.Procedure
+ifdef::golang[]
+. Add the `proxy.ReadProxyVarsFromEnv` helper function to the reconcile loop in the `controllers/memcached_controller.go` file and append the results to the Operand environments:
++
+[source,golang]
+----
+...
+for i, container := range dep.Spec.Template.Spec.Containers {
+		dep.Spec.Template.Spec.Containers[i].Env = append(container.Env, proxy.ReadProxyVarsFromEnv()...)
+}
+...
+----
+
+endif::[]
+
+ifdef::ansible[]
+. Add the environment variables to the deployment by updating the `roles/memcached/tasks/main.yml` file with the following:
++
+[source,yaml]
+----
+...
+env:
+   - name: HTTP_PROXY
+     value: '{{ lookup("env", "HTTP_PROXY") | default("", True) }}'
+   - name: http_proxy
+     value: '{{ lookup("env", "HTTP_PROXY") | default("", True) }}'
+...
+----
+
+endif::[]
+
+ifdef::helm[]
+* Edit the `watches.yaml` file to include overrides based on an environment variable by adding the `overrideValues` field:
++
+[source,yaml]
+----
+...
+- group: demo.example.com
+  version: v1alpha1
+  kind: Nginx
+  chart: helm-charts/nginx
+  overrideValues:
+    proxy.http: $HTTP_PROXY
+...
+----
+
+. Add the `proxy.http` value in the `helmcharts/nginx/values.yaml` file:
++
+[source,yaml]
+----
+...
+proxy:
+  http: ""
+  https: ""
+  no_proxy: ""
+----
+
+. To make sure the chart template supports using the variables, edit the chart template in the `helm-charts/nginx/templates/deployment.yaml` file to contain the following:
++
+[source,yaml]
+----
+containers:
+  - name: {{ .Chart.Name }}
+    securityContext:
+      - toYaml {{ .Values.securityContext | nindent 12 }}
+    image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    env:
+      - name: http_proxy
+        value: "{{ .Values.proxy.http }}"
+----
+
+endif::[]
+
+. Set the environment variable on the Operator deployment by adding the following to the `config/manager/manager.yaml` file:
++
+[source,yaml]
+----
+containers:
+ - args:
+   - --leader-elect
+   - --leader-election-id=ansible-proxy-demo
+   image: controller:latest
+   name: manager
+   env:
+     - name: "HTTP_PROXY"
+       value: "http_proxy_test"
+----
+
+
+ifeval::["{context}" == "osdk-golang-tutorial"]
+:!golang:
+endif::[]
+ifeval::["{context}" == "osdk-ansible-tutorial"]
+:!ansible:
+endif::[]
+ifeval::["{context}" == "osdk-helm-tutorial"]
+:!helm:
+endif::[]

--- a/operators/admin/olm-configuring-proxy-support.adoc
+++ b/operators/admin/olm-configuring-proxy-support.adoc
@@ -11,6 +11,8 @@ If a global proxy is configured on the {product-title} cluster, Operator Lifecyc
 
 * xref:../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy]
 * xref:../../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI] (custom CA certificate)
+* Developing Operators that support proxy settings for xref:../../operators/operator_sdk/golang/osdk-golang-tutorial.adoc#osdk-run-proxy_osdk-golang-tutorial[Go], xref:../../operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc#osdk-run-proxy_osdk-ansible-tutorial[Ansible], and xref:../../operators/operator_sdk/helm/osdk-helm-tutorial.adoc#osdk-run-proxy_osdk-helm-tutorial[Helm]
+
 
 include::modules/olm-overriding-proxy-settings.adoc[leveloffset=+1]
 include::modules/olm-injecting-custom-ca.adoc[leveloffset=+1]

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -30,6 +30,7 @@ include::modules/osdk-project-file.adoc[leveloffset=+2]
 include::modules/osdk-ansible-create-api.adoc[leveloffset=+1]
 include::modules/osdk-ansible-modify-manager.adoc[leveloffset=+1]
 
+include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
@@ -46,3 +47,4 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 - See xref:../../../operators/operator_sdk/ansible/osdk-ansible-project-layout.adoc#osdk-ansible-project-layout[Project layout for Ansible-based Operators] to learn about the directory structures created by the Operator SDK.
+- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -39,6 +39,7 @@ include::modules/osdk-golang-controller-configs.adoc[leveloffset=+2]
 include::modules/osdk-golang-controller-reconcile-loop.adoc[leveloffset=+2]
 include::modules/osdk-golang-controller-rbac-markers.adoc[leveloffset=+2]
 
+include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
@@ -55,3 +56,4 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 - See xref:../../../operators/operator_sdk/golang/osdk-golang-project-layout.adoc#osdk-golang-project-layout[Project layout for Go-based Operators] to learn about the directory structures created by the Operator SDK.
+- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -32,6 +32,7 @@ include::modules/osdk-helm-logic.adoc[leveloffset=+1]
 include::modules/osdk-helm-sample-chart.adoc[leveloffset=+2]
 include::modules/osdk-helm-modify-cr.adoc[leveloffset=+2]
 
+include::modules/osdk-run-proxy.adoc[leveloffset=+1]
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
@@ -48,3 +49,4 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 - See xref:../../../operators/operator_sdk/helm/osdk-helm-project-layout.adoc#osdk-helm-project-layout[Project layout for Helm-based Operators] to learn about the directory structures created by the Operator SDK.
+- If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).


### PR DESCRIPTION
Release: 4.9

[OSDOCS-2211](https://issues.redhat.com/browse/OSDOCS-2211)

Docs Preview:
- [Go tutorial proxy support](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-run-proxy_osdk-golang-tutorial) & [Additonal resources](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial.html#osdk-golang-tutorial-addtl-resources)
- [Ansible tutorial proxy support](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-run-proxy_osdk-ansible-tutorial) & [Additonal resources](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-tutorial.html#osdk-ansible-tutorial-addtl-resources)
- [Helm tutorial proxy support](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-run-proxy_osdk-helm-tutorial) & [Additonal resources](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-tutorial.html#osdk-helm-tutorial-addtl-resources)
- [Update to **Additional resources** section of Configuring proxy support (OLM)](https://deploy-preview-36738--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-configuring-proxy-support.html#olm-overriding-proxy-settings_olm-configuring-proxy-support)

Release note: #36775