### PR TITLE
Release note for pausing machine health check

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -68,6 +68,12 @@ You can incorporate example Azure Resource Manager (ARM) templates provided by R
 
 //See ../installing/install_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[Installing a cluster on Azure Stack Hub using ARM templates] for details.
 
+[id="ocp-4-9-upgrade-pause-mhc"]
+==== Pausing machine health checks before updating the cluster
+
+During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} {product-version} introduces `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster. 
+
+For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing[Pausing a MachineHealthCheck resource].
 
 [id=ocp-4.9-azure-cidr]
 ==== Increased size of Azure subnets within the machine CIDR


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-291: RN update for pausing the machine health check

This is a new PR based on https://github.com/openshift/openshift-docs/pull/36408 work. Owing to some git issue, the older PR got closed. Hence, creating this new one.

Preview: https://deploy-preview-36739--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-upgrade-pause-mhc