### PR TITLE
OSDOCS-2406 - Removing telemetry section from the OSD docs

### DIFF
--- a/modules/osd-intro.adoc
+++ b/modules/osd-intro.adoc
@@ -38,21 +38,3 @@ Operator Lifecycle Manager (OLM) and the OperatorHub provide facilities for stor
 The Red Hat Quay Container Registry is a Quay.io container registry that serves most of the container images and Operators to {product-title} clusters. Quay.io is a public registry version of Red Hat Quay that stores millions of images and tags.
 
 Other enhancements to Kubernetes in {product-title} include improvements in software defined networking (SDN), authentication, log aggregation, monitoring, and routing. {product-title} also offers a comprehensive web console and the custom OpenShift CLI (`oc`) interface.
-
-[id="telemetry_{context}"]
-== Internet and Telemetry access for {product-title}
-
-In {product-title}, you require access to the Internet to install your cluster. The Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, also requires Internet access. If your cluster is connected to the Internet, Telemetry runs automatically, and your cluster is registered to the {cloud-redhat-com}.
-
-Once you confirm that your Red Hat OpenShift Cluster Manager inventory is correct, either maintained automatically by Telemetry or manually using OCM, use link:https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-to-select-datacollection-tool_assembly-requirements-and-your-responsibilities-ctxt#red_hat_openshift[subscription watch] to track your {product-title} subscriptions at the account or multi-cluster level.
-
-You must have Internet access to:
-
-* Access the {cloud-redhat-com} page to download the installation program and perform subscription management. If the cluster has Internet access and you do not disable Telemetry, that service automatically entitles your cluster.
-
-* Obtain the packages that are required to perform cluster updates.
-
-[IMPORTANT]
-====
-If your cluster cannot have direct Internet access, you can perform a restricted network installation on some types of infrastructure that you provision. During that process, you download the content that is required and use it to populate a mirror registry with the packages that you need to install a cluster and generate the installation program. With some installation types, the environment that you install your cluster in will not require Internet access. Before you update the cluster, you update the content of the mirror registry.
-====


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2406. The PR removes the Architecture -> [Internet and Telemetry access for OpenShift Dedicated](https://docs.openshift.com/dedicated/osd_architecture/osd-understanding.html#telemetry_osd-understanding) section of the OSD docs. In the Jira, the section is stated as not relevant to OSD.

The preview is [here](https://deploy-preview-36740--osdocs.netlify.app/openshift-dedicated/latest/osd_architecture/osd-understanding.html).