### PR TITLE
CCXDEV-6017 CCXDEV-5989 add clarification on Insights Operator configuration

### DIFF
--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -17,6 +17,7 @@ This procedure describes how to update the import interval to one hour.
 .Procedure
 
 . Navigate to *Workloads* -> *Secrets*.
+. Select the *openshift-config* project.
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -15,6 +15,7 @@ You can disable the import of RHEL Simple Content Access certificates using the 
 .Procedure
 
 . Navigate to *Workloads* -> *Secrets*.
+. Select the *openshift-config* project.
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.

--- a/modules/insights-operator-enable-obfuscation.adoc
+++ b/modules/insights-operator-enable-obfuscation.adoc
@@ -18,6 +18,8 @@ Obfuscation assigns non-identifying values to cluster IPv4 addresses, and uses a
 
 For cluster base domains, obfuscation changes the base domain to a hardcoded substring. For example, `cluster-api.openshift.example.com` becomes `cluster-api.<CLUSTER_BASE_DOMAIN>`.
 
+The following procedure enables obfuscation using the `support` secret in the `openshift-config` namespace. 
+
 .Prerequisites
 
 * You are logged in to the {product-title} web console as `cluster-admin`.
@@ -25,6 +27,7 @@ For cluster base domains, obfuscation changes the base domain to a hardcoded sub
 .Procedure
 
 . Navigate to *Workloads* -> *Secrets*.
+. Select the *openshift-config* project.
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
@@ -33,3 +36,13 @@ For cluster base domains, obfuscation changes the base domain to a hardcoded sub
 . Select the `openshift-insights` project.
 . Find the `insights-operator` pod.
 . To restart the `insights-operator` pod, click the *Options* menu {kebab}, and then click *Delete Pod*.
+
+.Verification 
+
+. Navigate to *Workloads* -> *Secrets*.
+. Select the *openshift-insights* project.
+. Search for the *obfuscation-translation-table* secret using the *Search by name* field.
+
+If the `obfuscation-translation-table` secret exists, then obfuscation is enabled and working. 
+
+Alternatively, you can inspect `/insights-operator/gathers.json` in your Insights Operator archive for the value `"is_global_obfuscation_enabled": true`.

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -21,3 +21,6 @@ include::modules/insights-operator-manual-upload.adoc[leveloffset=+1]
 
 include::modules/insights-operator-enable-obfuscation.adoc[leveloffset=+1]
 
+.Additional resources
+
+* For more information on how to download your Insights Operator archive, see xref:../../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#insights-operator-showing-data-collected-from-the-cluster_showing-data-collected-by-remote-health-monitoring[Showing data collected by the Insights Operator].


### PR DESCRIPTION
This change clarifies what namespace to generate the `support` secret in per customer feedback and how to verify operator configuration.

Versions: enterprise-4.8, enterprise-4.9, enterprise-4.10


https://issues.redhat.com/browse/CCXDEV-6017 

https://issues.redhat.com/browse/CCXDEV-5989




Preview:
https://deploy-preview-36741--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.html#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network

