### PR TITLE
Adds a DEP feature note regarding vSphere and VW versions

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -30,15 +30,6 @@ You must use {op-system} machines for the control plane, and you can use either 
 //TODO: The line below is not true for 4.9 but should be used when it is next appropriate. Revisit in October 2022 timeframe.
 //With the release of {product-title} 4.9, version 4.6 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
-[id="ocp-4-9-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties.
-
-As part of that effort, with this release the following changes are in place:
-
-* The link:https://github.com/openshift/openshift-docs[OpenShift Docs GitHub repository] `master` branch has been renamed to `main`.
-* We have begun to progressively replace the terminology of "master" with "control plane". You will notice throughout the documentation that we use both terms, with "master" in parenthesis. For example "... the control plane node (also known as the master node)". In a future release, we will update this to be "the control plane node".
 
 [id="ocp-4-9-add-on-support-status"]
 == {product-title} layered and dependant component support and compatibility
@@ -1082,6 +1073,12 @@ The SQLite database format used by Operator Lifecycle Manager (OLM) for catalogs
 The default xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs] for {product-title} 4.6 and later are currently still shipped in the SQLite database format.
 ====
 
+[id="ocp-4-9-vsphere-and-virtual-hardware-version-deprecations"]
+==== vSphere 6.7 Update 2 and earlier cluster installation and virtual hardware version 13 are now deprecated
+Installing a cluster on VMware vSphere version 6.7 Update 2 or earlier and virtual hardware version 13 is now deprecated. Support for these versions will end in a future version of {product-title}. 
+
+Hardware version 15 is now the default for vSphere virtual machines in {product-title}. Hardware version 15 will be the only supported version in a future version of {product-title}. 
+
 [id="ocp-4-9-removed-features"]
 === Removed features
 
@@ -1841,7 +1838,7 @@ In the table below, features are marked with the following statuses:
 |Kdump
 |TP
 |TP
-|
+|TP
 
 |OpenShift Serverless
 |-


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-36742--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-deprecated-removed-features

GH issue at https://github.com/openshift/openshift-docs/issues/33497 (last entry on page). 

Original content by Cody Hoag at https://github.com/openshift/openshift-docs/pull/35530

QE unlikely needed, but maybe?

