### PR TITLE
BZ:1933972 - Adding cookie setting section from 3.x to 4.x

### DIFF
--- a/modules/nw-using-cookies-keep-route-statefulness.adoc
+++ b/modules/nw-using-cookies-keep-route-statefulness.adoc
@@ -19,3 +19,10 @@ for the session. The cookie is passed back in the response to the request and
 the user sends the cookie back with the next request in the session. The cookie
 tells the Ingress Controller which endpoint is handling the session, ensuring
 that client requests use the cookie so that they are routed to the same pod.
+
+[NOTE]
+====
+Cookies cannot be set on passthrough routes, because the HTTP traffic cannot be seen. Instead, a number is calculated based on the source IP address, which determines the backend.
+
+If backends change, the traffic can be directed to the wrong server, making it less sticky. If you are using a load balancer, which hides source IP, the same number is set for all connections and traffic is sent to the same pod.
+====


### PR DESCRIPTION
For versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1933972

Comment: Passthrough and cookie setting 'Note' appears in OCP v3.x but not in OCPv4.x, so I added the new section based on the 'Note' from v3.x.

Preview: https://deploy-preview-36743--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-using-cookies-keep-route-statefulness_route-configuration

Ready for QA: @lihongan 

For Peer Reviews: Can you please add the labels  'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' and 'Peer Review needed', Thank you!!