### PR TITLE
CNV-11797: Adding NOTE about Volume and Access mode defaults for UI

### DIFF
--- a/modules/virt-storage-wizard-fields-web.adoc
+++ b/modules/virt-storage-wizard-fields-web.adoc
@@ -7,6 +7,7 @@
 [id="virt-storage-wizard-fields-web_{context}"]
 = Storage fields
 
+[cols="5a,3a,5a"]
 |===
 |Name |Selection |Description
 
@@ -49,11 +50,19 @@
 |
 |The storage class that is used to create the disk.
 
-|Advanced -> Volume Mode
+a|Advanced -> Volume Mode
+[NOTE]
+====
+Default values are used from the storage profile.
+====
 |
 |Defines whether the persistent volume uses a formatted file system or raw block state. Default is *Filesystem*.
 ifeval::["{context}" != "virt-importing-rhv-vm"]
-|Advanced -> Access Mode
+a|Advanced -> Access Mode
+[NOTE]
+====
+Default values are used from the storage profile.
+====
 |
 |Access mode of the persistent volume. Supported access modes are *Single User (RWO)*, *Shared Access (RWX)*, and *Read Only (ROX)*.
 endif::[]
@@ -67,11 +76,15 @@ ifeval::["{context}" != "virt-importing-rhv-vm"]
 The following advanced storage settings are available for *Blank*, *Import via URL*, and *Clone existing PVC* disks. These parameters are optional. If you do not specify these parameters, the system uses the default values from the `kubevirt-storage-class-defaults` config map.
 endif::[]
 
-[cols="2a,3a,5a"]
+[cols="5a,3a,5a"]
 |===
 |Name | Parameter |  Description
 
 .2+|Volume Mode
+[NOTE]
+====
+Default values are used from the storage profile.
+====
 |Filesystem
 |Stores the virtual disk on a file system-based volume.
 
@@ -83,6 +96,10 @@ ifeval::["{context}" == "virt-importing-rhv-vm"]
 endif::[]
 ifeval::["{context}" != "virt-importing-rhv-vm"]
 .3+|Access Mode
+[NOTE]
+====
+Default values are used from the storage profile.
+====
 endif::[]
 |Single User (RWO)
 |The disk can be mounted as read/write by a single node.

--- a/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.adoc
@@ -32,3 +32,7 @@ include::modules/virt-importing-vm-cli.adoc[leveloffset=+1]
 include::modules/virt-creating-configmap.adoc[leveloffset=+2]
 include::modules/virt-troubleshooting-vm-import.adoc[leveloffset=+1]
 :!virt-importing-rhv-vm:
+
+[id="additional-resources_virt-importing-rhv-vm_{context}"]
+== Additional resources
+* xref:../../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
+++ b/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.adoc
@@ -75,3 +75,7 @@ include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-updating-imported-vm-network-name.adoc[leveloffset=+2]
 include::modules/virt-troubleshooting-vm-import.adoc[leveloffset=+1]
 :!virt-importing-vmware-vm:
+
+[id="additional-resources_virt-importing-vmware-vm_{context}"]
+== Additional resources
+* xref:../../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -5,7 +5,6 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-
 Use one of these procedures to create a virtual machine:
 
 * Quick Start guided tour
@@ -49,6 +48,7 @@ include::modules/virt-creating-vm.adoc[leveloffset=+1]
 include::modules/virt-vm-storage-volume-types.adoc[leveloffset=+1]
 include::modules/virt-about-runstrategies-vms.adoc[leveloffset=+1]
 
+[id="additional-resources_virt-create-vms_{context}"]
 == Additional resources
 
 * The `VirtualMachineSpec` definition in the link:https://kubevirt.io/api-reference/{KubeVirtVersion}/definitions.html#_v1_virtualmachinespec[KubeVirt {KubeVirtVersion} API Reference] provides broader context for the parameters and hierarchy of the virtual machine specification.
@@ -59,7 +59,8 @@ include::modules/virt-about-runstrategies-vms.adoc[leveloffset=+1]
 The KubeVirt API Reference is the upstream project reference and might contain parameters that are not supported in {VirtProductName}.
 ====
 
-* xref:../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-using-container-disks-with-vms[Prepare a container disk] before adding it to a virtual machine as a `containerDisk` volume.
+* See xref:../../virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc#virt-using-container-disks-with-vms[Prepare a container disk] before adding it to a virtual machine as a `containerDisk` volume.
 * See xref:../../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[Deploying machine health checks] for further details on deploying and enabling machine health checks.
 * See xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[Installer-provisioned infrastructure overview] for further details on installer-provisioned infrastructure.
 * See xref:../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[Configuring the SR-IOV Network Operator] for further details on the SR-IOV Network Operator.
+* xref:../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -19,3 +19,7 @@ include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-add-nic-to-vm.adoc[leveloffset=+1]
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 include::modules/virt-edit-cdrom-vm.adoc[leveloffset=+1]
+
+[id="additional-resources_virt-edit-vms_{context}"]
+== Additional resources
+* xref:../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]

--- a/virt/vm_templates/virt-creating-vm-template.adoc
+++ b/virt/vm_templates/virt-creating-vm-template.adoc
@@ -28,5 +28,6 @@ include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+2]
 
 [id="additional-resources_creating-vm-template"]
 == Additional resources
-* xref:../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[Configuring the SR-IOV Network Operator] 
+* xref:../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[Configuring the SR-IOV Network Operator]
 * xref:../../virt/virtual_machines/virtual_disks/virt-creating-and-using-boot-sources.adoc#virt-creating-and-using-boot-sources[Creating and using boot sources]
+* xref:../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile]


### PR DESCRIPTION
This PR replaces CLOSED PR https://github.com/openshift/openshift-docs/pull/36548

For 4.9 only.

Jira: https://issues.redhat.com/browse/CNV-11797

This PR adds a note to the Access Mode and Volume Mode rows in the **Storage fields** and **Advanced storage settings** tables.

For clarity, an Xref is added to the assemblies in which these tables appear, so users can get more info on storage profiles from these 5 Web Console (UI) topics:
- Creating virtual machines
- Importing a single VMware virtual machine or template
- Importing a single Red Hat Virtualization virtual machine
- Editing virtual machines
- Creating virtual machine templates

Direct Doc preview links:
https://deploy-preview-36759--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html
https://deploy-preview-36759--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-vmware-vm.html
https://deploy-preview-36759--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-rhv-vm.html
https://deploy-preview-36759--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html
https://deploy-preview-36759--osdocs.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-creating-vm-template.html

Tagging @gouyang for final QE Review.