### PR TITLE
OSDOCS-1922: Release Note OLM and Console Operand deletion

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -383,6 +383,12 @@ Starting in {product-title} {product-version}, Operator Lifecycle Manager (OLM) 
 Kubernetes 1.22 introduces link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122[several notable changes] to `v1` of the `CustomResorceDefinition` API.
 ====
 
+[id="ocp-4-9-olm-operand-deletion"]
+==== Removing Operands when uninstalling an Operator using the web console
+
+When you uninstall an Operator by using the web console, you can now remove Operands managed by the Operator automatically, including custom resources (CRs). For more information, see
+xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the web console].
+
 [id="ocp-4-9-osdk"]
 === Operator development
 


### PR DESCRIPTION
4.9 Release note

[OSDOCS-1922](https://issues.redhat.com/browse/OSDOCS-1922)

Docs preview: https://deploy-preview-36760--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-olm-operand-deletion

See #36348 for SME ack and previous comments from QE.

Docs PR: #36673