### PR TITLE
[OSDOCS-2418] etcd-upgrade-to-3.5-rel-notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -106,6 +106,11 @@ For more information, see xref:../updating/updating-cluster-prepare.adoc#updatin
 
 {product-title} {product-version} introduces support for installation on {rh-openstack-first} deployments that rely on link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough[PCI passthrough].
 
+[id="ocp-4-9-upgrading-etcd-backup"]
+==== Upgrading etcd version 3.4 to 3.5
+
+{product-title} 4.9 supports etcd 3.5. Before you upgrade the cluster, verify that a valid etcd backup exists. An etcd backup ensures that the cluster can be restored if an upgrade failure occurs. In {product-title} 4.9, etcd upgrades are automatic. Depending on the cluster’s transition state to version 4.9, an etcd backup might be available. However, verifying that a backup exists before the cluster upgrade starts is recommended.
+
 [id="ocp-4-9-web-console"]
 === Web console
 


### PR DESCRIPTION
Update the 4.9 release notes for upgrading the etcd 3.5 (for OpenShift 4.9). A 4.8 backup must be present before the backup or the customer gets an alert.

Preview link: https://deploy-preview-36765--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-upgrading-etcd-3.4-to-3.5

Version: OCP 4.9 release notes

JIRA: https://issues.redhat.com/browse/OSDOCS-2418

