### PR TITLE
OSDK release notes for OSDOCS-2214 and OSDOCS-2210

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -566,6 +566,10 @@ By accessing the cluster high-availability mode API provided in {product-title},
 
 For more information, see xref:../operators/operator_sdk/osdk-ha-sno.adoc#osdk-ha-sno[High-availability or single node cluster detection and support].
 
+[id="ocp-4-9-osdk-proxy-support"]
+==== Operator support for network proxies
+Operator authors can now develop Operators that support network proxies. Operators with proxy support inspect the Operator deployment for environment variables and pass the variables on to the required Operands. Cluster administrators configure proxy support for the environment variables that are handled by Operator Lifecycle Manager (OLM). For more information, see the Operator SDK tutorials for developing Operators using xref:../operators/operator_sdk/golang/osdk-golang-tutorial.adoc#osdk-run-proxy[Go], xref:../operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc#osdk-run-proxy[Ansible], and xref:../operators/operator_sdk/helm/osdk-helm-tutorial.adoc#osdk-run-proxy[Helm].
+
 [id="ocp-4-9-builds"]
 === Builds
 


### PR DESCRIPTION
4.9 release notes

- [OSDOCS-2214](https://issues.redhat.com/browse/OSDOCS-2214): [OSDK-1544](https://issues.redhat.com/browse/OSDK-1544) support for k8s 1.21
- [OSDOCS-2211](https://issues.redhat.com/browse/OSDOCS-2211): [OSDK-1698](https://issues.redhat.com/browse/OSDK-1698) proxied cluster support

Docs preview: https://deploy-preview-36775--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-osdk-proxy-support
