### PR TITLE
OSDOCS-2250: Removed metering book

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1965,47 +1965,6 @@ Topics:
 - Name: Troubleshooting monitoring issues
   File: troubleshooting-monitoring-issues
 ---
-Name: Metering
-Dir: metering
-Distros: openshift-enterprise
-Topics:
-- Name: About metering
-  File: metering-about-metering
-- Name: Installing metering
-  File: metering-installing-metering
-- Name: Upgrading metering
-  File: metering-upgrading-metering
-- Name: Configuring metering
-  Dir: configuring_metering
-  Topics:
-  - Name: About configuring metering
-    File: metering-about-configuring
-  - Name: Common configuration options
-    File: metering-common-config-options
-  - Name: Configuring persistent storage
-    File: metering-configure-persistent-storage
-  - Name: Configuring the Hive metastore
-    File: metering-configure-hive-metastore
-  - Name: Configuring the reporting operator
-    File: metering-configure-reporting-operator
-  - Name: Configuring AWS billing correlation
-    File: metering-configure-aws-billing-correlation
-- Name: Reports
-  Dir: reports
-  Topics:
-  - Name: About reports
-    File: metering-about-reports
-  - Name: Storage Locations
-    File: metering-storage-locations
-- Name: Using metering
-  File: metering-using-metering
-- Name: Examples of using metering
-  File: metering-usage-examples
-- Name: Troubleshooting and debugging
-  File: metering-troubleshooting-debugging
-- Name: Uninstalling metering
-  File: metering-uninstall
----
 Name: Scalability and performance
 Dir: scalability_and_performance
 Distros: openshift-origin,openshift-enterprise,openshift-webscale


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/OSDOCS-2250

Applies to enterprise-4.9 branch only.

Preview: https://deploy-preview-36779--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html