### PR TITLE
RHDEVDOCS-3328 Fix typo that causes rendering failure

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,4 +1,4 @@
-such as[id="cluster-logging-release-notes"]
+[id="cluster-logging-release-notes"]
 = Release notes for Red Hat OpenShift Logging 5.2
 include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
@@ -81,7 +81,7 @@ To see these metrics, open the *Administrator* perspective in the {product-title
 
 * Before this update, a missing license file for the `viaq/logerr` dependency caused license scanners to abort without success. With this update, the `viaq/logerr` dependency is licensed under Apache 2.0 and the license scanners run successfully. (link:https://issues.redhat.com/browse/LOG-1590[LOG-1590])
 
-* Before this update, an incorrect brew tag for `curator5` within the `elasticsearch-operator-bundle` build pipeline caused the pull of an image pinned to a dummy SHA1. With this update, the build pipeline uses the `logging-curator5-rhel8` reference for `curator5`, which and enables index management cronjobs to pull the correct image from `registry.redhat.io`. (link:https://issues.redhat.com/browse/LOG-1624[LOG-1624])
+* Before this update, an incorrect brew tag for `curator5` within the `elasticsearch-operator-bundle` build pipeline caused the pull of an image pinned to a dummy SHA1. With this update, the build pipeline uses the `logging-curator5-rhel8` reference for `curator5`, enabling index management cronjobs to pull the correct image from `registry.redhat.io`. (link:https://issues.redhat.com/browse/LOG-1624[LOG-1624])
 
 * Before this update, an issue with the `ServiceAccount` permissions caused errors such as `no permissions for [indices:admin/aliases/get]`. With this update, a permission fix resolves the issue. (link:https://issues.redhat.com/browse/LOG-1657[LOG-1657])
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3328
- Direct link to doc preview: https://deploy-preview-36780--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html
- SME review: not needed
- QE review: not needed
- Peer review: @Preeticp 
- Please review and merge now.