### PR TITLE
RHDEVDOCS-3329 Create Release Notes (RNs) for OpenShift Logging 5.3

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,5 +1,5 @@
 [id="cluster-logging-release-notes"]
-= Release notes for Red Hat OpenShift Logging 5.2
+= Release notes for Red Hat OpenShift Logging
 include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
@@ -8,14 +8,42 @@ toc::[]
 [id="openshift-logging-supported-versions"]
 == Supported versions
 
-* OpenShift Logging versions 5.0, 5.1, and 5.2 run on {product-title} versions 4.7 and 4.8.
+OpenShift Logging versions 5.0, 5.1, 5.2, and 5.3 run on {product-title} versions 4.7 and 4.8.
 
 [id="openshift-logging-inclusive-language"]
 == Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright’s message].
 
-// Release Notes by version
+
+[id="cluster-logging-release-notes-5-3-0"]
+== OpenShift Logging 5.3.0
+
+The following advisories are available for OpenShift Logging 5.2.x:
+
+* link:https://access.redhat.com/errata/RHBA-TBD[RHBA-TBD OpenShift Logging Bug Fix Release 5.3.0]
+
+[id="openshift-logging-5-3-0-new-features-and-enhancements"]
+=== New features and enhancements
+
+TBD
+
+[id="openshift-logging-5-3-0-bug-fixes"]
+=== Bug fixes
+
+TBD
+
+[id="openshift-logging-5-3-0-known-issues"]
+=== Known issues
+
+* If you forward logs to an external Elasticsearch server and then change a configured value in the pipeline secret, such as the username and password, the Fluentd forwarder loads the new secret but uses the old value to connect to an external Elasticsearch server. This issue happens because the Red Hat OpenShift Logging Operator does not currently monitor secrets for content changes. (link:https://issues.redhat.com/browse/LOG-1652[LOG-1652])
++
+As a workaround, if you change the secret, you can force the Fluentd pods to redeploy by entering:
++
+[source,terminal]
+----
+$ oc delete pod -l component=fluentd
+----
 
 [id="cluster-logging-release-notes-5-2-0"]
 == OpenShift Logging 5.2.0


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3329
- Direct link to doc preview: https://deploy-preview-36787--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-3-0
- SME review: @ tbd
- QE review: @ tbd
- Peer review: @ 	tbd
- <All reviews complete. Please merge now>