### PR TITLE
OSDOCS-2168: 4-9 RN that dhclient is removed

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -651,10 +651,10 @@ In the table, features are marked with the following statuses:
 |DEP
 |
 
-|Use of `dhclient` in {op-system-first}
+|Use of `dhclient` in {op-system}
 |DEP
 |DEP
-|
+|REM
 
 |Cluster Loader
 |GA
@@ -691,7 +691,7 @@ In the table, features are marked with the following statuses:
 
 [id="ocp-4-9-removed-metering"]
 ==== Metering
-This release removes the {product-title} Metering Operator feature. 
+This release removes the {product-title} Metering Operator feature.
 
 [id="ocp-4-9-removed-kube-1-22-apis"]
 ==== Beta APIs removed from Kubernetes 1.22
@@ -797,6 +797,11 @@ Kubernetes 1.22 removed the following deprecated `v1beta1` APIs. Migrate manifes
 ==== Descheduler v1beta1 API removed
 
 The deprecated `v1beta1` API for the descheduler has been removed in {product-title} 4.9. Migrate any resources using the descheduler `v1beta1` API version to `v1`.
+
+[id="ocp-4-9-dhclient-removed"]
+==== Use of dhclient in {op-system} removed
+
+The deprecated `dhclient` binary has been removed from {op-system}. Starting with {product-title} 4.6, {op-system} switched to using `NetworkManager` in the `initramfs` to configure networking during early boot. Use the `NetworkManager` internal DHCP client for networking configuration instead. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1908462[*BZ#1908462*] for more information.
 
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2168
Updates `dhclient` library from DEP --> REM
(Previous DEP announcement: https://github.com/openshift/openshift-docs/blob/enterprise-4.8/release_notes/ocp-4-8-release-notes.adoc#use-of-dhclient-in-op-system-first-is-deprecated)

**4.9 Preview link:** https://deploy-preview-36794--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-dhclient-removed