### PR TITLE
added notes for 4.7.32 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2876,3 +2876,29 @@ The minimum storage required to install an {product-title} cluster has decreased
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-32"]
+=== RHBA-2021:3636 - {product-title} 4.7.32 bug fix and security update
+
+Issued: 2021-09-28
+
+{product-title} release 4.7.32, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3636[RHBA-2021:3636] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3635[RHSA-2021:3635] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6362042[{product-title} 4.7.32 container image list]
+
+[id="ocp-4-7-32-features"]
+==== Features
+
+* Kubernetes v1.20.10 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#v12010[v1.20.10], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1209[v1.20.9], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1208[v1.20.8], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1207[v1.20.7], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1206[v1.20.6], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1205[v1.20.5], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1204[v1.20.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1203[v1.20.3], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1202[v1.20.2], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1201[v1.20.1], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1200[v1.20.0].
+
+[id="ocp-4-7-32-bug-fixes"]
+==== Bug fixes
+
+* Previously, a cluster was not fully operational when deployed on {rh-openstack} with the combination of a proxy and a custom CA certificate. This was due to the HTTP transport connection to {rh-openstack} endpoints using a custom CA certificate that was missing the proxy settings. With this update, the proxy settings to the HTTP transport are now used when connecting with a custom CA certificate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2000551[*BZ#2000551*])
+
+[id="ocp-4-7-32-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
RNs for 4.7.32 release

- Applies to `enterprise-4.7` only
- [Preview link](https://deploy-preview-36795--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-32)