### PR TITLE
adds note in 4.9 RNs  about removing metering feature

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -604,7 +604,7 @@ In the table, features are marked with the following statuses:
 |Metering Operator
 |DEP
 |DEP
-|
+|REM
 
 |Scheduler policy
 |DEP
@@ -663,6 +663,10 @@ In the table, features are marked with the following statuses:
 
 [id="ocp-4-9-removed-features"]
 === Removed features
+
+[id="ocp-4-9-removed-metering"]
+==== Metering
+This release removes the {product-title} Metering Operator feature. 
 
 [id="ocp-4-9-removed-kube-1-22-apis"]
 ==== Beta APIs removed from Kubernetes 1.22


### PR DESCRIPTION
Applies to `enterprise-4.9` only

- [OSDOCS-2249](https://issues.redhat.com/browse/OSDOCS-2249)
- [Preview link](https://deploy-preview-36803--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features)