### PR TITLE
Add release notes for gitops 1.2.1

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,8 @@ For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-open
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-2-1.adoc
+++ b/modules/gitops-release-notes-1-2-1.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-2-1_{context}"]
+= Release notes for {gitops-title} 1.2.1
+
+{gitops-title} 1.2.1 is now available on {product-title} 4.7 and 4.8.
+
+[id="support-matrix-1-2-1_{context}"]
+== Support matrix
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+In the table below, features are marked with the following statuses:
+
+- *TP*: _Technology Preview_
+
+- *GA*: _General Availability_
+
+Note the following scope of support on the Red Hat Customer Portal for these features:
+
+.Support matrix
+[cols="1,1",options="header"]
+|===
+| Feature | {gitops-title} 1.2.1
+| Argo CD
+| GA
+| Argo CD ApplicationSet
+| TP
+| {gitops-title} Application Manager (kam)
+| TP
+| {gitops-title} Service
+| TP
+|===
+
+[id="fixed-issues-1-2-1_{context}"]
+== Fixed issues
+The following issues were resolved in the current release:
+
+* Previously, huge memory spikes were observed on the application controller on startup. The flag `--kubectl-parallelism-limit` for the application controller is now set to 10 by default, however
+this value can be overridden by specifying a number for `.spec.controller.kubeParallelismLimit` in the Argo CD CR specification.
+link:https://issues.redhat.com/browse/GITOPS-1255[GITOPS-1255]
+
+*  The latest Triggers APIs caused Kubernetes build failure due to duplicate entries in the kustomization.yaml when using the `kam bootstrap` command. The Pipelines and Tekton triggers components have now been updated to v0.24.2 and v0.14.2, respectively, to address this issue.
+link:https://issues.redhat.com/browse/GITOPS-1273[GITOPS-1273]
+
+* Persisting RBAC roles and bindings are now automatically removed from the target namespace when the Argo CD instance from the source namespace is deleted.
+link:https://issues.redhat.com/browse/GITOPS-1228[GITOPS-1228]
+
+* Previously, when deploying an Argo CD instance into a namespace, the Argo CD instance would change the "managed-by" label to be its own namespace. This fix would make namespaces unlabelled while also making sure the required RBAC roles and bindings are created and deleted for the namespace.
+link:https://issues.redhat.com/browse/GITOPS-1247[GITOPS-1247]
+
+* Previously, the default resource request limits on Argo CD workloads, specifically for the repo-server and application controller, were found to be very restrictive. The existing resource quota has now been removed and the default memory limit has been increased to 1024M in the repo server. Please note that this change will only affect new installations; existing Argo CD instance workloads will not be affected.
+link:https://issues.redhat.com/browse/GITOPS-1274[GITOPS-1274]


### PR DESCRIPTION
These are the release notes for GitOps1.2.1, please review for accuracy @wtam2018 @iam-veeramalla@shubhamagarwal19 @jannfis, thanks! 

cc @Preeticp 