### PR TITLE
OSDOCS-2627: Adding admin ack to 4.9 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -84,6 +84,17 @@ For more information, see xref:../installing/installing_aws/installing-aws-china
 
 In {product-title} {product-version}, you can expand an installer provisioned cluster deployed using the `provisioning` network by using Virtual Media on the `baremetal` network. You can use this feature when the `ProvisioningNetwork` configuration setting is set to `Managed`. To use this feature, you must set the `virtualMediaViaExternalNetwork` configuration setting to `true` in the `provisioning` custom resource (CR). You must also edit the machineset to use the API VIP address. See xref:../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-to-deploy-with-virtual-media-on-the-baremetal-network_ipi-install-expanding[Preparing to deploy with Virtual Media on the baremetal network] for details.
 
+[id="ocp-4-9-admin-ack-upgrading"]
+==== Required administrator acknowledgment when upgrading from {product-title} 4.8 to 4.9
+
+{product-title} 4.9 uses Kubernetes 1.22, which removed a xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[significant number of deprecated `v1beta1` APIs].
+
+4.8.14 introduced a requirement that an administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.8 clusters require this administrator acknowledgment before they can be upgraded to {product-title} 4.9.
+
+For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.9].
+
 [id="ocp-4-9-web-console"]
 === Web console
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2627

Preview: https://deploy-preview-36811--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-admin-ack-upgrading

**NOTE**: The xref won't work until #36809 is merged.