### PR TITLE
RHDEVDOCS-3332 Add "Adding a subsection on making open source more inclusive" to the documentation guidelines

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-openshift-gitops.adoc#understanding-openshift-gitops[Understanding OpenShift GitOps].
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]

--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -18,7 +18,7 @@ toc::[]
 
 For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding OpenShift Pipelines].
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/op-release-notes-1-5.adoc[leveloffset=+1]

--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -286,6 +286,16 @@ You can replace "node" in the preceding examples with "machine", "host", or anot
 If you are cherry picking from `main` to `enterprise-4.8` or earlier, you must manually cherry pick to include the “(also known as master)” phrasing. This is required only if the phrase “control plane” is introduced for the first time in an assembly or module.
 ====
 
+[id="adding-a-subsection-on-making-open-source-more-inclusive"]
+=== Adding a subsection on making open source more inclusive
+
+If you create a release notes assembly for a sub-product within the `openshift/openshift-docs` repo, you might include a "Making open source more inclusive" statement. Instead of pasting the statement from the OpenShift Release Notes, use the following module, which is available in the `enterprise-4.8` branch and later:
+
+[source,text]
+----
+\include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
+----
+
 [id="product-name-and-version"]
 == Product name and version
 
@@ -588,9 +598,7 @@ To indicate that a feature is in Technology Preview, include the
 `modules/technology-preview.adoc` file in the feature's assembly to keep the
 supportability wording consistent across Technology Preview features and provide a value for the :FeatureName: variable before you include this module.
 
-See
-link:https://github.com/openshift/openshift-docs/pull/13878/files#diff-615ba1bf3b09d11a9c2604b775aa32f2[an
-example] of how this is applied.
+See link:https://github.com/openshift/openshift-docs/pull/13878/files#diff-615ba1bf3b09d11a9c2604b775aa32f2[an example] of how this is applied.
 
 == Indicating deprecated features
 

--- a/jaeger/rhbjaeger-release-notes.adoc
+++ b/jaeger/rhbjaeger-release-notes.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 include::modules/jaeger-product-overview.adoc[leveloffset=+1]
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::modules/support.adoc[leveloffset=+1]
 

--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 |RHOL 5.2|X            |X            |X
 |====
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Release Notes by version
 

--- a/modules/making-open-source-more-inclusive.adoc
+++ b/modules/making-open-source-more-inclusive.adoc
@@ -1,6 +1,6 @@
 :_module-type: CONCEPT
 
-[id="con_making-open-source-more-inclusive_{context}"]
+[id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].


### PR DESCRIPTION
Background and purpose: Presently, various product release notes within the openshift/openshift-docs repo include a "Making open source more inclusive" subsection. Many of those already do this by using an include statement that points to a `modules/con_making-open-source-more-inclusive.adoc` module. This PR adds guidance to `contributing_to_docs/doc_guidelines.adoc` to use this module, when needed.

- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3332
- Direct link to doc preview: https://github.com/rolfedh/openshift-docs/blob/RHDEVDOCS-3332/contributing_to_docs/doc_guidelines.adoc#using-conscious-language
- Reviewed by: @pneedle-rh, @jeana-redhat, @StephenJamesSmith,  @codyhoag 
- <All reviews complete. Please merge now>