### PR TITLE
OSDOCS-1836: Add global admission plug-in for HSTS release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -392,6 +392,13 @@ For clusters that run on {rh-openstack}, you can now configure Octavia for load 
 // TODO: Link when doc is merged.
 // For more information, see xref:../
 
+[id="ocp-4-9-networking-hsts"]
+==== Global admission plug-in for HTTP Strict Transport Security requirements
+
+Cluster administrators can configure HTTP Strict Transport Security (HSTS) verification on a per-domain basis with the addition of an admission plug-in for the router, called `route.openshift.io/RequiredRouteAnnotations`. If a cluster administrator configures this plug-in to enforce HSTS, then any newly created route must be configured with a compliant HSTS Policy, which is verified against the global setting on the cluster Ingress configuration, called `ingresses.config.openshift.io/cluster`.
+
+For more information, see xref:../networking/routes/route-configuration.adoc#nw-enabling-hsts_route-configuration[HTTP Strict Transport Security].
+
 [id="ocp-4-9-storage"]
 === Storage
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1836

Related to https://github.com/openshift/openshift-docs/pull/35812 and https://github.com/openshift/openshift-docs/issues/33497.

Preview: https://deploy-preview-36815--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking-hsts
