### PR TITLE
TELCODOCS-296: RN for the Node Health Check Operator

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -601,6 +601,11 @@ When configuring the `docker/config.json` file to allow pods to pull images from
 
 Node-related metrics and alerts have been enhanced to give you an earlier indication of when the stability of a node is compromised.
 
+[id="ocp-4-9-node-health-check-operator"]
+==== Deploy node health checks with the Node Health Check Operator (Technology Preview)
+
+You can use the Node Health Check Operator to deploy the `NodeHealthCheck` controller. The controller identifies unhealthy nodes and uses the Poison Pill Operator to remediate the unhealthy nodes.
+
 [id="ocp-4-9-logging"]
 === Red Hat OpenShift Logging
 
@@ -1648,6 +1653,11 @@ In the table below, features are marked with the following statuses:
 |TP
 
 |Special Resource Operator (SRO)
+|-
+|-
+|TP
+
+|Node Health Check Operator
 |-
 |-
 |TP


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-296 - Adds RN for the Node Health Check Operator.

Preview: https://deploy-preview-36816--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-node-health-check-operator
