### PR TITLE
RHDEVDOCS-3335 Use the "Making open source more inclusive" module

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -17,10 +17,7 @@ toc::[]
 
 For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-openshift-gitops.adoc#understanding-openshift-gitops[Understanding OpenShift GitOps].
 
-[id="gitops-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
+include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-2.adoc[leveloffset=+1]

--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -18,10 +18,7 @@ toc::[]
 
 For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding OpenShift Pipelines].
 
-[id="openshift-pipelines-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
+include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/op-release-notes-1-5.adoc[leveloffset=+1]

--- a/jaeger/rhbjaeger-release-notes.adoc
+++ b/jaeger/rhbjaeger-release-notes.adoc
@@ -9,9 +9,7 @@ toc::[]
 
 include::modules/jaeger-product-overview.adoc[leveloffset=+1]
 
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
+include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::modules/support.adoc[leveloffset=+1]
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3335
- Direct link to doc preview: 
  - GitOps: https://deploy-preview-36820--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#con_making-open-source-more-inclusive_gitops-release-notes
  - Pipelines: https://deploy-preview-36820--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#con_making-open-source-more-inclusive_op-release-notes
  - https://deploy-preview-36820--osdocs.netlify.app/openshift-enterprise/latest/jaeger/rhbjaeger-release-notes.html#con_making-open-source-more-inclusive_jaeger-release-notes
- SME review: Not needed
- QE review: Not needed
- Peer review: @Preeticp 
- Please review and merge.