### PR TITLE
Added notes for release 3.11.523

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -4999,7 +4999,6 @@ openshift3/ose-template-service-broker:v3.11.487-1.git.0b26065
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
 
 [[ocp-3-11-501]]
-
 === RHBA-2021:3192 - {product-title} 3.11.501 bug fix and security update
 
 Issued: 2021-08-25
@@ -5007,7 +5006,6 @@ Issued: 2021-08-25
 {product-title} release 3.11.501 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2021:3193[RHSA-2021:3193] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3192[RHBA-2021:3192] advisory.
 
 [[ocp-3-11-501-images]]
-
 ==== Images
 
 This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
@@ -5097,7 +5095,6 @@ openshift3/ose-template-service-broker:v3.11.501-1.git.f8c4746
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
 
 [[ocp-3-11-521]]
-
 === RHBA-2021:3423 - {product-title} 3.11.521 bug fix update
 
 Issued: 2021-09-15
@@ -5105,7 +5102,6 @@ Issued: 2021-09-15
 {product-title} release 3.11.521 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHBA-2021:3424[RHBA-2021:3424] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3423[RHBA-2021:3423] advisory.
 
 [[ocp-3-11-521-images]]
-
 ==== Images
 
 This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
@@ -5190,6 +5186,102 @@ openshift3/ose-template-service-broker:v3.11.521-1.git.59aef03
 ----
 
 [[ocp-3-11-521-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
+
+[[ocp-3-11-523]]
+=== RHSA-2021:3646 - {product-title} 3.11.523 bug fix and security update
+
+Issued: 2021-09-30
+
+{product-title} release 3.11.523, which includes security updates, is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2021:3646[RHSA-2021:3646] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3647[RHBA-2021:3647] advisory.
+
+[[ocp-3-11-523-images]]
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
+----
+openshift3/ose-ansible:v3.11.524-1.git.150f8a9
+openshift3/ose-cluster-autoscaler:v3.11.524-1.git.99b2acf
+openshift3/ose-descheduler:v3.11.524-1.git.d435537
+openshift3/ose-metrics-server:v3.11.524-1.git.f8bf728
+openshift3/ose-node-problem-detector:v3.11.524-1.git.c8f26da
+openshift3/automation-broker-apb:v3.11.524-1
+openshift3/ose-cluster-monitoring-operator:v3.11.524-1.git.a9fd527
+openshift3/ose-configmap-reloader:v3.11.524-1.git.bb85bd3
+openshift3/csi-attacher:v3.11.524-1
+openshift3/csi-driver-registrar:v3.11.524-1
+openshift3/csi-livenessprobe:v3.11.524-1
+openshift3/csi-provisioner:v3.11.524-1
+openshift3/ose-efs-provisioner:v3.11.524-1.git.04aa20d
+openshift3/oauth-proxy:v3.11.524-1.git.edebe84
+openshift3/prometheus-alertmanager:v3.11.524-1.git.13de638
+openshift3/prometheus-node-exporter:v3.11.524-1.git.609cd20
+openshift3/prometheus:v3.11.524-1.git.99aae51
+openshift3/grafana:v3.11.524-1.git.2ea5517
+openshift3/image-inspector:v3.11.524-1
+openshift3/jenkins-agent-maven-35-rhel7:v3.11.524-1.git.10eb612
+openshift3/jenkins-agent-maven-36-rhel7:v3.11.524-1.git.10eb612
+openshift3/jenkins-agent-nodejs-10-rhel7:v3.11.524-1.git.10eb612
+openshift3/jenkins-agent-nodejs-12-rhel7:v3.11.524-1.git.10eb612
+openshift3/jenkins-slave-base-rhel7:v3.11.524-1.git.10eb612
+openshift3/ose-kube-rbac-proxy:v3.11.524-1.git.31106c3
+openshift3/ose-kube-state-metrics:v3.11.524-1.git.b7c6d38
+openshift3/kuryr-cni:v3.11.524-1.git.b234b49
+openshift3/ose-logging-curator5:v3.11.524-1.git.c31bbac
+openshift3/ose-logging-elasticsearch5:v3.11.524-1.git.c31bbac
+openshift3/ose-logging-eventrouter:v3.11.524-1
+openshift3/logging-fluentd:v3.11.524-1.git.c31bbac
+openshift3/ose-logging-kibana5:v3.11.524-1.git.c31bbac
+openshift3/metrics-cassandra:v3.11.524-1
+openshift3/metrics-hawkular-metrics:v3.11.524-1
+openshift3/metrics-hawkular-openshift-agent:v3.11.524-1
+openshift3/metrics-heapster:v3.11.524-1
+openshift3/metrics-schema-installer:v3.11.524-1
+openshift3/apb-base:v3.11.524-1.git.f7a0168
+openshift3/apb-tools:v3.11.524-1
+openshift3/ose-ansible-service-broker:v3.11.524-1
+openshift3/ose-docker-builder:v3.11.524-1.git.2dffce7
+openshift3/ose-cli:v3.11.524-1.git.2dffce7
+openshift3/ose-cluster-capacity:v3.11.524-1.git.22be164
+openshift3/ose-console:v3.11.524-1.git.34f65c8
+openshift3/ose:v3.11.524-1.git.2dffce7
+openshift3/ose-deployer:v3.11.524-1.git.2dffce7
+openshift3/ose-egress-dns-proxy:v3.11.524-1.git.2dffce7
+openshift3/ose-egress-router:v3.11.524-1.git.2dffce7
+openshift3/ose-haproxy-router:v3.11.524-1.git.2dffce7
+openshift3/ose-hyperkube:v3.11.524-1.git.2dffce7
+openshift3/ose-hypershift:v3.11.524-1.git.2dffce7
+openshift3/ose-keepalived-ipfailover:v3.11.524-1.git.2dffce7
+openshift3/mariadb-apb:v3.11.524-1
+openshift3/mediawiki-apb:v3.11.524-1
+openshift3/mediawiki:v3.11.524-1
+openshift3/mysql-apb:v3.11.524-1
+openshift3/node:v3.11.524-1.git.2dffce7
+openshift3/ose-pod:v3.11.524-1.git.2dffce7
+openshift3/postgresql-apb:v3.11.524-1
+openshift3/ose-recycler:v3.11.524-1.git.2dffce7
+openshift3/ose-docker-registry:v3.11.524-1.git.3571208
+openshift3/ose-service-catalog:v3.11.524-1.git.2e6be86
+openshift3/ose-tests:v3.11.524-1.git.2dffce7
+openshift3/jenkins-2-rhel7:v3.11.524-1.git.10eb612
+openshift3/local-storage-provisioner:v3.11.524-1
+openshift3/manila-provisioner:v3.11.524-1
+openshift3/ose-operator-lifecycle-manager:v3.11.524-1.git.1054881
+openshift3/ose-web-console:v3.11.524-1.git.56ad978
+openshift3/ose-egress-http-proxy:v3.11.524-1.git.2dffce7
+openshift3/kuryr-controller:v3.11.524-1.git.b234b49
+openshift3/ose-ovn-kubernetes:v3.11.524-1.git.21370b4
+openshift3/ose-prometheus-config-reloader:v3.11.524-1.git.d4bae2d
+openshift3/ose-prometheus-operator:v3.11.524-1.git.d4bae2d
+openshift3/registry-console:v3.11.524-1
+openshift3/snapshot-controller:v3.11.524-1
+openshift3/snapshot-provisioner:v3.11.524-1
+openshift3/ose-template-service-broker:v3.11.524-1.git.2dffce7
+----
+
+[[ocp-3-11-523-upgrading]]
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.


### PR DESCRIPTION
These are the release notes for OpenShift version 3.11.523.

* no bugs for this one
* applies only to `enterprise-3.11`
* [direct preview link](https://deploy-preview-36821--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes?utm_source=github&utm_campaign=bot_dp#ocp-3-11-523)