### PR TITLE
[OSDOCS-2418]: Information about OpenShift 4.8 backup before etcd upgrade 3.4 to 3.5

### DIFF
--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -17,6 +17,14 @@ Use the web console or `oc adm upgrade channel _<channel>_` to change the update
 * Have access to the cluster as a user with `admin` privileges.
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].
 * Have a recent xref:../backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd backup] in case your upgrade fails and you must xref:../backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore your cluster to a previous state].
++
+{product-title} 4.9 requires an upgrade from etcd version 3.4 to 3.5. If the etcd Operator halts the upgrade, an alert is triggered. To clear this alert, ensure that you have a current etcd backup and restart the upgrade using the `--force` flag.
++
+[source,terminal]
+----
+$ oc adm upgrade --force
+----
+
 * Ensure all Operators previously installed through Operator Lifecycle Manager (OLM) are updated to their latest version in their latest channel. Updating the Operators ensures they have a valid upgrade path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster upgrade. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators] for more information.
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
 * If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see _Upgrading clusters with manually maintained credentials_ for xref:../installing/installing_aws/manually-creating-iam.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-aws[AWS], xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-azure[Azure], or xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-gcp[GCP].


### PR DESCRIPTION
Preview link: https://deploy-preview-36828--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-between-minor?utm_source=github&utm_campaign=bot_dp

JIRA: https://issues.redhat.com/browse/OSDOCS-2418

This update is for version **4.9 only**. Engineering is working on a fix for 4.10.

This content advises the user to complete a backup of OpenShift 4.8 before upgrading to 4.9. With 4.9, etcd 3.5 is supported, however, the etcd upgrade from 3.4 to 3.5 can terminate the upgrade (with an alert) and a valid 4.9 backup must be available if needed.