### PR TITLE
Adding RN for descheduler v1beta1 API removed

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -764,6 +764,11 @@ Kubernetes 1.22 removed the following deprecated `v1beta1` APIs. Migrate manifes
 
 |===
 
+[id="ocp-4-9-removed-descheduler-v1beta1-api"]
+==== Descheduler v1beta1 API removed
+
+The deprecated `v1beta1` API for the descheduler has been removed in {product-title} 4.9. Migrate any resources using the descheduler `v1beta1` API version to `v1`.
+
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Addresses this comment in the RN tracker: https://github.com/openshift/openshift-docs/issues/33497#issuecomment-865003080

Preview: https://deploy-preview-36832--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-removed-descheduler-v1beta1-api