### PR TITLE
RHDEVDOCS-3336 Copy deprecation notices from legacy forwarding topics…

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -8,7 +8,7 @@ toc::[]
 [id="openshift-logging-supported-versions"]
 == Supported versions
 
-OpenShift Logging versions 5.0, 5.1, and 5.2 run on {product-title} versions 4.7 and 4.8.
+OpenShift Logging 5.0, 5.1, and 5.2 run on {product-title} 4.7 and 4.8.
 
 include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
@@ -19,8 +19,8 @@ include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 The following advisories are available for OpenShift Logging 5.2.x:
 
-* link:https://access.redhat.com/errata/RHBA-2021:3550[RHBA-2021:3550 OpenShift Logging Bug Fix Release 5.2.1].
-* link:https://access.redhat.com/errata/RHBA-2021:3393[RHBA-2021:3393 OpenShift Logging Bug Fix Release 5.2.0].
+* link:https://access.redhat.com/errata/RHBA-2021:3550[RHBA-2021:3550 OpenShift Logging Bug Fix Release 5.2.1]
+* link:https://access.redhat.com/errata/RHBA-2021:3393[RHBA-2021:3393 OpenShift Logging Bug Fix Release 5.2.0]
 
 [id="openshift-logging-5-2-0-new-features-and-enhancements"]
 === New features and enhancements
@@ -99,5 +99,25 @@ As a workaround, if you change the secret, you can force the Fluentd pods to red
 ----
 $ oc delete pod -l component=fluentd
 ----
+
+[id="openshift-logging-5-2-0-deprecated-removed-features"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+[id="openshift-logging-5-2-0-legacy-forwarding"]
+=== Forwarding logs using the legacy Fluentd and legacy syslog methods have been deprecated
+
+From {product-title} 4.6 to the present, forwarding logs by using the following legacy methods have been deprecated and will be removed in a future release:
+
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-legacy-fluentd_cluster-logging-external[Forwarding logs using the legacy Fluentd method]
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-legacy-syslog_cluster-logging-external[Forwarding logs using the legacy syslog method]
+
+Instead, use the following non-legacy methods:
+
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-log-forward-fluentd_cluster-logging-external[Forwarding logs using the Fluentd forward protocol]
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-log-forward-syslog_cluster-logging-external[Forwarding logs using the syslog protocol]
 
 include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+1]

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} versions 4.7 and 4.8 support OpenShift Logging versions 5.0, 5.1, and 5.2.
+{product-title} 4.7 and 4.8 support OpenShift Logging 5.0, 5.1, and 5.2.
 
 To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
 

--- a/modules/cluster-logging-collector-collecting-ovn-logs.adoc
+++ b/modules/cluster-logging-collector-collecting-ovn-logs.adoc
@@ -6,7 +6,7 @@ You can collect the OVN network policy audit logs from the `/var/log/ovn/acl-aud
 .Prerequisites
 
 * You are using {product-title} version 4.8 or later.
-* You are using Cluster Logging version 5.2 or later.
+* You are using Cluster Logging 5.2 or later.
 * You have already set up a `ClusterLogForwarder` custom resource (CR) object.
 * The {product-title} cluster is configured for OVN-Kubernetes network policy audit logging. See the following "Additional resources" section.
 

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-1.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-1.adoc
@@ -6,7 +6,7 @@
 
 = Supported log data output types in OpenShift Logging 5.1
 
-Red Hat OpenShift Logging version 5.1 provides the following output types and protocols for sending log data to target log collectors.
+Red Hat OpenShift Logging 5.1 provides the following output types and protocols for sending log data to target log collectors.
 
 Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
 
@@ -40,7 +40,7 @@ kafka 2.7.0
 
 |====
 
-// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
+// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
 // This file is the authoritative source of information about which items and versions Red Hat tests and supports.
 // According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
 // Logstash support is according to https://github.com/openshift/cluster-logging-operator/blob/master/test/functional/outputs/forward_to_logstash_test.go#L37

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-2.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins-5-2.adoc
@@ -6,7 +6,7 @@
 
 = Supported log data output types in OpenShift Logging 5.2
 
-Red Hat OpenShift Logging version 5.2 provides the following output types and protocols for sending log data to target log collectors.
+Red Hat OpenShift Logging 5.2 provides the following output types and protocols for sending log data to target log collectors.
 
 Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
 
@@ -49,7 +49,7 @@ kafka 2.7.0
 
 |====
 
-// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
+// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
 // This file is the authoritative source of information about which items and versions Red Hat tests and supports.
 // According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
 // Logstash support is according to https://github.com/openshift/cluster-logging-operator/blob/master/test/functional/outputs/forward_to_logstash_test.go#L37

--- a/modules/cluster-logging-release-notes-5.1.0.adoc
+++ b/modules/cluster-logging-release-notes-5.1.0.adoc
@@ -44,6 +44,11 @@ Deprecated functionality is still included in OpenShift Logging and continues to
 
 With this update, the Elasticsearch Curator has been removed and is no longer supported. Elasticsearch Curator helped you curate or manage your indices on {product-title} 4.4 and earlier. Instead of using Elasticsearch Curator, configure the log retention time.
 
+[id="openshift-logging-5-1-0-legacy-forwarding"]
+=== Forwarding logs using the legacy Fluentd and legacy syslog methods have been deprecated
+
+From {product-title} version 4.6 to the present, forwarding logs by using the legacy Fluentd and legacy syslog methods have been deprecated and will be removed in a future release. Use the standard non-legacy methods instead.
+
 [id="openshift-logging-5-1-0-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
… to release notes

Purpose: Copy the deprecation notices from legacy forwarding topics to the release notes.

- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3336
- Direct link to doc preview: 
  - https://deploy-preview-36833--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-2-0-legacy-forwarding
  - https://deploy-preview-36833--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-1-0-deprecated-removed-features
- SME review: @jcantrill 
- QE review: @kabirbhartiRH 
- Peer review: @missmesss
- All reviews complete. Please merge now.