### PR TITLE
OSDOCS-2686: UPI machine mgmt xref assembly

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1673,6 +1673,8 @@ Topics:
 - Name: User-provisioned infrastructure
   Dir: user_infra
   Topics:
+  - Name: Adding compute machines to user-provisioned infrastructure clusters
+    File: adding-compute-user-infra-general
   - Name: Adding compute machines to AWS using CloudFormation templates
     File: adding-aws-compute-user-infra
   - Name: Adding compute machines to vSphere

--- a/machine_management/user_infra/adding-compute-user-infra-general.adoc
+++ b/machine_management/user_infra/adding-compute-user-infra-general.adoc
@@ -1,0 +1,38 @@
+[id="adding-compute-user-infra-general"]
+= Adding compute machines to clusters with user-provisioned infrastructure
+include::modules/common-attributes.adoc[]
+:context: adding-compute-user-infra-general
+
+toc::[]
+
+You can add compute machines to a cluster on user-provisioned infrastructure either as part of the installation process or after installation. The post-installation process requires some of the same configuration files and parameters that were used during installation.
+
+[id="upi-adding-compute-aws"]
+== Adding compute machines to Amazon Web Services
+
+To add more compute machines to your {product-title} cluster on Amazon Web Services (AWS), see xref:../../machine_management/user_infra/adding-aws-compute-user-infra.adoc#adding-aws-compute-user-infra[Adding compute machines to AWS by using CloudFormation templates].
+
+[id="upi-adding-compute-azure"]
+== Adding compute machines to Microsoft Azure
+
+To add more compute machines to your {product-title} cluster on Microsoft Azure, see xref:../../installing/installing_azure/installing-azure-user-infra.adoc#installation-creating-azure-worker_installing-azure-user-infra[Creating additional worker machines in Azure].
+
+[id="upi-adding-compute-ash"]
+== Adding compute machines to Azure Stack Hub
+
+To add more compute machines to your {product-title} cluster on Azure Stack Hub, see xref:../../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installation-creating-azure-worker_installing-azure-stack-hub-user-infra[Creating additional worker machines in Azure Stack Hub].
+
+[id="upi-adding-compute-gcp"]
+== Adding compute machines to Google Cloud Platform
+
+To add more compute machines to your {product-title} cluster on Google Cloud Platform (GCP), see xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installation-creating-gcp-worker_installing-restricted-networks-gcp[Creating additional worker machines in GCP].
+
+[id="upi-adding-compute-vsphere"]
+== Adding compute machines to vSphere
+
+To add more compute machines to your {product-title} cluster on vSphere, see xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere].
+
+[id="upi-adding-compute-bare-metal"]
+== Adding compute machines to bare metal
+
+To add more compute machines to your {product-title} cluster on bare metal, see xref:../../machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc#adding-bare-metal-compute-user-infra[Adding compute machines to bare metal].


### PR DESCRIPTION
New for 4.9 to cover ASH use case, but this should also be ***manually*** cherrypicked back to 4.6+ to get the relevant links into those earlier versions as well.

Preview: https://deploy-preview-36835--osdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-compute-user-infra-general.html

This PR addresses:
- https://issues.redhat.com/browse/OSDOCS-2331 (4.9 only)
- https://issues.redhat.com/browse/OSDOCS-2670 (4.6+)
- https://issues.redhat.com/browse/OSDOCS-2686 (4.6+)