### PR TITLE
OSDOCS-2346: Updated the AWS Quota field to show a lower minimum value.

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -53,7 +53,7 @@ If you need to modify or increase a specific quota, see Amazon's documentation o
 |General Purpose SSD (gp2) volume storage
 |ebs
 |L-D18FCD1D
-|300
+|50
 |300
 
 |Number of EBS snapshots
@@ -71,7 +71,7 @@ If you need to modify or increase a specific quota, see Amazon's documentation o
 |Provisioned IOPS SSD (io1) volume storage
 |ebs
 |L-FD252861
-|300
+|50
 |300
 
 |Application Load Balancers per Region


### PR DESCRIPTION
Updated the minimum AWS Service quota values for `General Purpose SSD (gp2) volume storage` and `Provisioned IOPS SSD (io1) volume storage` to `50`.

JIRA: https://issues.redhat.com/browse/OSDOCS-2346

Preview: https://deploy-preview-36837--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-required-aws-service-quotas.html#rosa-required-aws-service-quotas_rosa-sts-required-aws-service-quotas