### PR TITLE
BZ#1906643: Change alertmanagerMain and thanosRuler storage; add note about thanosRuler storage

### DIFF
--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -89,7 +89,7 @@ data:
           storageClassName: *local-storage*
           resources:
             requests:
-              storage: *40Gi*
+              storage: *10Gi*
 ----
 
 ** *To configure a PVC for a component that monitors user-defined projects*:
@@ -161,8 +161,13 @@ data:
           storageClassName: *local-storage*
           resources:
             requests:
-              storage: *40Gi*
+              storage: *10Gi*
 ----
++
+[NOTE]
+====
+Storage requirements for the `thanosRuler` component depend on the number of rules that are evaluated and how many samples each rule generates.
+====
 
 . Save the file to apply the changes. The pods affected by the new configuration are restarted automatically and the new storage configuration is applied.
 +


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1906643

OCP Version: 4.6, 4.7, 4.8

Old PR with reviewer feeback: https://github.com/openshift/openshift-docs/pull/36680

Direct doc preview link: https://deploy-preview-36838--osdocs.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack?utm_source=github&utm_campaign=bot_dp#configuring-a-local-persistent-volume-claim_configuring-the-monitoring-stack