### PR TITLE
RHDEVDOCS-3337 Update deprecation notices in the 4.7 release notes

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -16,7 +16,7 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 
 .Supported versions
 
-OpenShift Logging version 5.1 runs on {product-title} versions 4.7 and 4.8.
+OpenShift Logging 5.1 runs on {product-title} 4.7 and 4.8.
 
 .Advisories
 
@@ -34,7 +34,7 @@ include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+2]
 
 .Supported versions
 
-OpenShift Logging version 5.0 runs on {product-title} versions 4.7.
+OpenShift Logging 5.0 runs on {product-title} 4.7.
 
 .Advisories
 

--- a/logging/cluster-logging-upgrading.adoc
+++ b/logging/cluster-logging-upgrading.adoc
@@ -5,9 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} versions 4.7 and 4.8 both support OpenShift Logging versions 5.0 and 5.1.
+{product-title} 4.7 and 4.8 both support OpenShift Logging 5.0 and 5.1.
 
-To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
+To upgrade from cluster logging in {product-title} 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to 4.7 or 4.8. Then, you update the following operators:
 
 * From Elasticsearch Operator 4.x to OpenShift Elasticsearch Operator 5.x
 * From Cluster Logging Operator 4.x to Red Hat OpenShift Logging Operator 5.x

--- a/modules/cluster-logging-collector-log-forwarding-supported-plugins.adoc
+++ b/modules/cluster-logging-collector-log-forwarding-supported-plugins.adoc
@@ -6,7 +6,7 @@
 
 = Supported log data output types
 
-Red Hat OpenShift Logging version 5.0 provides the following output types and protocols for sending log data to target log collectors.
+Red Hat OpenShift Logging 5.0 provides the following output types and protocols for sending log data to target log collectors.
 
 Red Hat tests each of the combinations shown in the following table. However, you should be able to send log data to a wider range target log collectors that ingest these protocols.
 
@@ -36,7 +36,7 @@ Elasticsearch 7.10.1
 
 |====
 
-// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging version 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
+// Note to tech writer, validate these items against the corresponding line of the test configuration file that Red Hat OpenShift Logging 5.0 uses: https://github.com/openshift/origin-aggregated-logging/blob/release-5.0/fluentd/Gemfile.lock
 // This file is the authoritative source of information about which items and versions Red Hat tests and supports.
 // According to this link:https://github.com/zendesk/ruby-kafka#compatibility[Zendesk compatibility list for ruby-kafka], the fluent-plugin-kafka plug-in supports Kafka version 0.11.
 

--- a/modules/cluster-logging-release-notes-5.0.0.adoc
+++ b/modules/cluster-logging-release-notes-5.0.0.adoc
@@ -13,7 +13,7 @@ This release adds improvements related to the following concepts.
 [id="ocp-4-7-cluster-logging-renamed-openshift-logging"]
 === Cluster Logging becomes Red Hat OpenShift Logging
 
-With this release, Cluster Logging becomes Red Hat OpenShift Logging, version 5.0.
+With this release, Cluster Logging becomes Red Hat OpenShift Logging 5.0.
 
 [discrete]
 [id="openshift-logging-5-0-eo-max-five-shards"]
@@ -97,35 +97,24 @@ In the table below, features are marked with the following statuses:
 //
 // {ProductName} 5.0 introduces the following notable technical changes.
 //
-// [id="openshift-logging-5-0-deprecated-removed-features"]
-// == Deprecated and removed features
-//
-// Some features available in previous releases have been deprecated or removed.
-//
-// Deprecated functionality is still included in {ProductName} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. For the most recent list of major functionality deprecated and removed within {ProductName} {product-version}, refer to the table below. Additional details for more fine-grained functionality that has been deprecated and removed are listed after the table.
-//
-// In the table, features are marked with the following statuses:
-//
-// * *GA*: _General Availability_
-// * *DEP*: _Deprecated_
-// * *REM*: _Removed_
-//
-// .Deprecated and removed features tracker
-// [cols="3,1,1,1",options="header"]
-// |====
-// |Feature |OCP 4.5 |OCP 4.6 |OCP 4.7
-//
-// |`OperatorSource` objects
-// |DEP
-// |REM
-// |REM
-// |====
-//
-// [id="openshift-logging-5-0-deprecated-features"]
-// === Deprecated features
-//
-// [id="openshift-logging-5-0-removed-features"]
-// === Removed features
+
+
+[id="openshift-logging-5-0-0-deprecated-removed-features"]
+== Deprecated and removed features
+
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+[id="openshift-logging-5-0-0-elasticsearch-curator"]
+=== Elasticsearch Curator has been deprecated
+
+The Elasticsearch Curator has been deprecated and will be removed in a future release. Elasticsearch Curator helped you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator, configure the log retention time.
+
+[id="openshift-logging-5-0-0-legacy-forwarding"]
+=== Forwarding logs using the legacy Fluentd and legacy syslog methods have been deprecated
+
+From {product-title} 4.6 to the present, forwarding logs by using the legacy Fluentd and legacy syslog methods have been deprecated and will be removed in a future release. Use the standard non-legacy methods instead.
 
 [id="openshift-logging-5-0-bug-fixes"]
 == Bug fixes

--- a/modules/cluster-logging-release-notes-5.1.0.adoc
+++ b/modules/cluster-logging-release-notes-5.1.0.adoc
@@ -40,6 +40,11 @@ Deprecated functionality is still included in OpenShift Logging and continues to
 
 With this update, the Elasticsearch Curator has been removed and is no longer supported. Elasticsearch Curator helped you curate or manage your indices on OpenShift Container Platform 4.4 and earlier. Instead of using Elasticsearch Curator, configure the log retention time.
 
+[id="openshift-logging-5-1-0-legacy-forwarding"]
+=== Forwarding logs using the legacy Fluentd and legacy syslog methods have been deprecated
+
+From {product-title} 4.6 to the present, forwarding logs by using the legacy Fluentd and legacy syslog methods have been deprecated and will be removed in a future release. Use the standard non-legacy methods instead.
+
 [id="openshift-logging-5-1-0-bug-fixes"]
 == Bug fixes
 

--- a/modules/cluster-logging-updating-logging-to-5-0.adoc
+++ b/modules/cluster-logging-updating-logging-to-5-0.adoc
@@ -7,7 +7,7 @@
 * The _Cluster Logging_ Operator became the _Red Hat OpenShift Logging_ Operator.
 * The _Elasticsearch_ Operator became _OpenShift Elasticsearch_ Operator.
 
-To upgrade from cluster logging in {product-title} version 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to version 4.7 or 4.8. Then, you update the following operators:
+To upgrade from cluster logging in {product-title} 4.6 and earlier to OpenShift Logging 5.x, you update the {product-title} cluster to 4.7 or 4.8. Then, you update the following operators:
 
 * From Elasticsearch Operator 4.x to OpenShift Elasticsearch Operator 5.x
 * From Cluster Logging Operator 4.x to Red Hat OpenShift Logging Operator 5.x


### PR DESCRIPTION
Purpose: Copy the deprecation notices from legacy forwarding topics to the release notes.

- Aligned team: Dev Tools
- For branches: enterprise-4.7 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3337
- Direct link to doc preview: 
  - 5.1 Deprecated and removed features: https://deploy-preview-36846--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-1-0-deprecated-removed-features
  - 5.0 Deprecated and removed features: https://deploy-preview-36846--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#openshift-logging-5-0-0-deprecated-removed-features
- SME review: @jcantrill 
- QE review: @kabirbhartiRH 
- Peer review: @missmesss
- All reviews complete. Please merge now.