### PR TITLE
CNV-11197: RN MAC spoof check

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -67,6 +67,7 @@ High-performance virtual machine templates are now available for xref:virt-guest
 [id="virt-4-9-networking-new"]
 === Networking
 //CNV-11197 MAC spoof filtering
+* You can now xref:../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-creating-bridge-nad-cli_virt-attaching-multiple-networks[enable or disable MAC spoof filtering] on secondary networks by configuring a Linux bridge network attachment definition in the CLI.
 
 [id="virt-4-9-storage-new"]
 === Storage


### PR DESCRIPTION
[CNV-11197](https://issues.redhat.com/browse/CNV-11197)

4.9 release note for the MAC spoof check feature

Preview: https://deploy-preview-36854--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-9-release-notes.html#virt-4-9-networking-new