### PR TITLE
OSSMDOC-404 Update control plane profiles documentation

### DIFF
--- a/modules/ossm-control-plane-profiles.adoc
+++ b/modules/ossm-control-plane-profiles.adoc
@@ -12,7 +12,7 @@ When you configure control plane profiles, which follow the same syntax as the `
 [id="ossm-create-configmap_{context}"]
 == Creating the ConfigMap
 
-To add custom profiles, you must first create a ConfigMap named `smcp-templates` in the `openshift-operators` project and then mount the ConfigMap in the Operator container at: `/usr/local/share/istio-operator/templates`.
+To add custom profiles, you must create a `ConfigMap` named `smcp-templates` in the `openshift-operators` project. The Operator container automatically mounts the `ConfigMap`.
 
 .Prerequisites
 
@@ -31,47 +31,6 @@ To add custom profiles, you must first create a ConfigMap named `smcp-templates`
 ----
 $ oc create configmap --from-file=<profiles-directory> smcp-templates -n openshift-operators
 ----
-
-. Locate the Operator ClusterServiceVersion name.
-+
-[source,terminal]
-----
-$ oc get clusterserviceversion -n openshift-operators | grep 'Service Mesh'
-----
-+
-.Example output
-[source,terminal]
-----
-maistra.v2.0.0            Red Hat OpenShift Service Mesh   2.0.0                Succeeded
-----
-
-. Edit the Operator cluster service version to instruct the Operator to use the `smcp-templates` ConfigMap.
-+
-[source,terminal]
-----
-$ oc edit clusterserviceversion -n openshift-operators servicemeshoperator.v2.0.0.1
-----
-
-. Add a volume mount and volume to the Operator deployment.
-+
-[source,yaml]
-----
-deployments:
-  - name: istio-operator
-    spec:
-      template:
-        spec:
-          containers:
-            volumeMounts:
-              - name: smcp-templates
-                mountPath: /usr/local/share/istio-operator/templates/
-          volumes:
-            - name: smcp-templates
-              configMap:
-                name: smcp-templates
-...
-----
-. Save your changes and exit the editor.
 
 . You can use the `profiles` parameter in the `ServiceMeshControlPlane` to specify one or more templates.
 +


### PR DESCRIPTION
[OSSMDOC-404](https://issues.redhat.com/browse/OSSMDOC-404) Update control plane profiles documentation

- Aligned team: Dev Tools
- For branches: 4.6+ 
- Jira: https://issues.redhat.com/browse/OSSMDOC-404
- Direct link to doc preview: https://deploy-preview-36857--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-profiles-users?utm_source=github&utm_campaign=bot_dp#ossm-create-configmap_ossm-profiles-users
- SME review: @luksa
- QE review: @yxun
- Peer review: @rolfedh
- Cherry pick to 4.6, 4.7, 4.8, 4.9, 4.10