### PR TITLE
TELCODOCS-260: Ensure chronyd is disabled before enabling PTP

### DIFF
--- a/modules/cnf-disable-chronyd.adoc
+++ b/modules/cnf-disable-chronyd.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+[id="cnf-disable-chronyd_{context}"]
+= Disabling the chrony time service
+
+You can disable the chrony time service (`chronyd`) for nodes with a specific role by using a `MachineConfig` custom resource (CR).
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create the `MachineConfig` CR that disables `chronyd` for the specified node role.
+
+.. Save the following YAML in the `disable-chronyd.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: <node_role> <1>
+  name: disable-chronyd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+        - contents: |
+            [Unit]
+            Description=NTP client/server
+            Documentation=man:chronyd(8) man:chrony.conf(5)
+            After=ntpdate.service sntp.service ntpd.service
+            Conflicts=ntpd.service systemd-timesyncd.service
+            ConditionCapability=CAP_SYS_TIME
+            [Service]
+            Type=forking
+            PIDFile=/run/chrony/chronyd.pid
+            EnvironmentFile=-/etc/sysconfig/chronyd
+            ExecStart=/usr/sbin/chronyd $OPTIONS
+            ExecStartPost=/usr/libexec/chrony-helper update-daemon
+            PrivateTmp=yes
+            ProtectHome=yes
+            ProtectSystem=full
+            [Install]
+            WantedBy=multi-user.target
+          enabled: false
+          name: "chronyd.service"
+----
+<1> Node role where you want to disable `chronyd`, for example, `master`.
+
+.. Create the `MachineConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f disable-chronyd.yaml
+----

--- a/modules/nw-ptp-installing-operator-cli.adoc
+++ b/modules/nw-ptp-installing-operator-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/installing-ptp-operator.adoc
+// * networking/using-ptp.adoc
 
 [id="install-ptp-operator-cli_{context}"]
 = Installing the PTP Operator using the CLI

--- a/modules/nw-ptp-installing-operator-web-console.adoc
+++ b/modules/nw-ptp-installing-operator-web-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * networking/installing-ptp-operator.adoc
+// * networking/using-ptp.adoc
 
 [id="install-ptp-operator-web-console_{context}"]
 = Installing the PTP Operator using the web console

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -25,6 +25,11 @@ You can use the {product-title} console or `oc` CLI to install PTP by deploying 
 
 include::modules/nw-ptp-introduction.adoc[leveloffset=+1]
 
+[IMPORTANT]
+====
+Before enabling PTP, ensure that NTP is disabled for the required nodes. You can disable the chrony time service (`chronyd`) using a `MachineConfig` custom resource. For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#cnf-disable-chronyd_post-install-machine-configuration-tasks[Disabling chrony time service].
+====
+
 include::modules/nw-ptp-installing-operator-cli.adoc[leveloffset=+1]
 
 include::modules/nw-ptp-installing-operator-web-console.adoc[leveloffset=+1]

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -27,6 +27,7 @@ link:https://access.redhat.com/solutions/4510281[updating] SSH authorized keys, 
 {product-title} supports link:https://coreos.github.io/ignition/configuration-v3_2/[Ignition specification version 3.2]. All new machine configs you create going forward should be based on Ignition specification version 3.2. If you are upgrading your {product-title} cluster, any existing Ignition specification version 2.x machine configs will be translated automatically to specification version 3.2.
 
 include::modules/installation-special-config-chrony.adoc[leveloffset=+2]
+include::modules/cnf-disable-chronyd.adoc[leveloffset=+2]
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+2]
 include::modules/rhcos-enabling-multipath-day-2.adoc[leveloffset=+2]
 


### PR DESCRIPTION
main, enterprise-4.9 update for PTP for the following doc epics:

https://issues.redhat.com/browse/TELCODOCS-260
https://issues.redhat.com/browse/TELCODOCS-262

Added a note about disabling NTP:

https://deploy-preview-36867--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#ptp-advantages-over-ntp_using-ptp

