### PR TITLE
OSDOCS-2279: DNS Operator managementState release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -71,7 +71,7 @@ See xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-use
 [id="ocp-4-9-upgrade-pause-mhc"]
 ==== Pausing machine health checks before updating the cluster
 
-During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} {product-version} introduces `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster. 
+During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} {product-version} introduces `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster.
 
 For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing[Pausing a MachineHealthCheck resource].
 
@@ -358,6 +358,19 @@ For more information, see xref:../networking/ingress-operator.adoc#nw-customize-
 ==== The provisioningNetworkInterface configuration setting is optional
 
 In {product-title} 4.9, the `provisioningNetworkInterface` configuration setting for installer-provisioned clusters is optional. The `provisioningNetworkInterface` configuration setting identifies the NIC name used for the `provisioning` network. In {product-title} 4.9, you can alternatively specify the `bootMACAddress` configuration setting in the `install-config.yml` file, which enables Ironic to identify the IP address for the NIC connected to the `provisioning` network and bind to it. You can also omit the `provisioningInterface` configuration setting in the provisioning custom resource so that the provisioning custom resource uses the `bootMACAddress` configuration setting instead.
+
+[id="ocp-4-9-networking-dns-management-state"]
+==== DNS Operator managementState
+
+In {product-title} {product-version}, you can now change the DNS Operator `managementState`. The `managementState` of the DNS Operator is set to `Managed` by default, which means that the DNS Operator is actively managing its resources. You can change it to `Unmanaged`, which means the DNS Operator is not managing its resources.
+
+The following are use cases for changing the DNS Operator `managementState`:
+
+* You are a developer and want to test a configuration change to see if it fixes an issue in CoreDNS. You can stop the DNS Operator from overwriting the change by setting the `managementState` to `Unmanaged`.
+
+* You are a cluster administrator and have reported an issue with CoreDNS, but need to apply a workaround until the issue is fixed. You can set the `managementState` field of the DNS Operator to `Unmanaged` to apply the workaround.
+
+For more information, see xref:../networking/dns-operator.adoc#nw-dns-operator-managementState_dns-operator[Changing the DNS Operator managementState].
 
 [id="ocp-4-9-storage"]
 === Storage


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2279

Related to https://github.com/openshift/openshift-docs/pull/36197 and https://github.com/openshift/openshift-docs/issues/33497. 

Preview: 
https://deploy-preview-36871--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking-dns-management-state