### PR TITLE
[RHACS] Added missing command for patching role configuration

### DIFF
--- a/modules/upgrade-central.adoc
+++ b/modules/upgrade-central.adoc
@@ -28,6 +28,15 @@ $ oc -n stackrox patch deploy/central -p '{"spec":{"template":{"spec":{"containe
 ----
 $ oc -n stackrox set image deploy/central central=registry.redhat.io/rh-acs/main:{rhacs-version}
 ----
++
+[IMPORTANT]
+====
+If you are upgrading from {product-title} 3.65.0, you must run the following additional command to create the `stackrox-central-diagnostics` role:
+[source,terminal]
+----
+$ oc -n stackrox patch role stackrox-central-diagnostics -p '{"rules":[{"apiGroups":["*"],"resources":["deployments","daemonsets","replicasets","configmaps","services"],"verbs":["get","list"]}]}'
+----
+====
 
 .Verification
 


### PR DESCRIPTION
- Added a missing command 

Preview: https://openshift-docs-git-upgrade-cmd-fix-gnelson.vercel.app/openshift-acs/master/upgrading/upgrading_roxctl/upgrade-from-44.html#upgrade-central_upgrade-from-44


NOTES:

- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
