### PR TITLE
Rn4 8 fix

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -638,15 +638,15 @@ A cluster administrator using Operator Lifecycle Manager (OLM) to install an Ope
 Because administrators should not require understanding of the interaction process between the various low-level APIs or access to the OLM pod logs to successfully debug such issues, {product-title} 4.8 introduces the following enhancements in OLM to provide administrators with more comprehensible error reporting and messages:
 
 [id="ocp-4-8-installplan-errors"]
-Retrying install plans::
+==== Retrying install plans
 Install plans, defined by an `InstallPlan` object, can encounter transient errors, for example, due to API server availability or conflicts with other writers. Previously, these errors would result in the termination of partially-applied install plans that required manual cleanup. With this enhancement, the Catalog Operator now retries errors during install plan execution for up to one minute. The new `.status.message` field provides a human-readable indication when retries are occurring.
 
 [id="ocp-4-8-operatorgroup-errors"]
-Indicating invalid Operator groups::
+==== Indicating invalid Operator groups
 Creating a subscription in a namespace with no Operator groups or multiple Operator groups would previously result in a stalled Operator installation with an install plan that stays in `phase=Installing` forever. With this enhancement, the install plan immediately transitions to `phase=Failed` so that the administrator can correct the invalid Operator group, and then delete and re-create the subscription again.
 
 [id="ocp-4-8-candidate-operator-errors"]
-Specific reporting when no candidate Operators found::
+==== Specific reporting when no candidate Operators found
 `ResolutionFailed` events, which are created when dependency resolution in a namespace fails, now provide more specific text when the namespace contains a subscription that references a package or channel that does not exist in the referenced catalog source. Previously, this message was generic:
 +
 [source,terminal]

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -648,32 +648,32 @@ Creating a subscription in a namespace with no Operator groups or multiple Opera
 [id="ocp-4-8-candidate-operator-errors"]
 ==== Specific reporting when no candidate Operators found
 `ResolutionFailed` events, which are created when dependency resolution in a namespace fails, now provide more specific text when the namespace contains a subscription that references a package or channel that does not exist in the referenced catalog source. Previously, this message was generic:
-+
+
 [source,terminal]
 ----
 no candidate operators found matching the spec of subscription '<name>'
 ----
-+
+
 With this enhancement, the messages are more specific:
-+
+
 .Operator does not exist
 [source,terminal]
 ----
 no operators found in package <name> in the catalog referenced by subscription <name>
 ----
-+
+
 .Catalog does not exist
 [source,terminal]
 ----
 no operators found from catalog <name> in namespace openshift-marketplace referenced by subscription <name>
 ----
-+
+
 .Channel does not exist
 [source,terminal]
 ----
 no operators found in channel <name> of package <name> in the catalog referenced by subscription <name>
 ----
-+
+
 .Cluster service version (CSV) does not exist
 [source,terminal]
 ----


### PR DESCRIPTION
Small formatting fix in the 4.8 RNs. 

No BZ

Preview: https://deploy-preview-36910--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-candidate-operator-errors

For 4.8 only. Can be merged once approved. 