### PR TITLE
[BZ1964540] Remove ShiftStack trunking support statement 

### DIFF
--- a/modules/machineset-yaml-osp-sr-iov-port-security.adoc
+++ b/modules/machineset-yaml-osp-sr-iov-port-security.adoc
@@ -90,9 +90,9 @@ spec:
 
 [NOTE]
 ====
-Trunking is enabled for ports that are created by entries in the networks and subnets lists. The name of ports that are created from these lists follow the pattern `<machine_name>-<nameSuffix>`. The `nameSuffix` field is required in port definitions.
+Trunking is enabled for ports that are created by entries in the networks and subnets lists. The names of ports that are created from these lists follow the pattern `<machine_name>-<nameSuffix>`. The `nameSuffix` field is required in port definitions.
 
-Trunking is not enabled for ports that are defined in the ports list.
+You can enable trunking for each port.
 
 Optionally, you can add tags to ports as part of their `tags` lists.
 ====

--- a/modules/machineset-yaml-osp-sr-iov.adoc
+++ b/modules/machineset-yaml-osp-sr-iov.adoc
@@ -103,9 +103,9 @@ You cannot set security groups and allowed address pairs for ports when port sec
 
 [NOTE]
 ====
-Trunking is enabled for ports that are created by entries in the networks and subnets lists. The name of ports that are created from these lists follow the pattern `<machine_name>-<nameSuffix>`. The `nameSuffix` field is required in port definitions.
+Trunking is enabled for ports that are created by entries in the networks and subnets lists. The names of ports that are created from these lists follow the pattern `<machine_name>-<nameSuffix>`. The `nameSuffix` field is required in port definitions.
 
-Trunking is not enabled for ports that are defined in the ports list.
+You can enable trunking for each port.
 
 Optionally, you can add tags to ports as part of their `tags` lists.
 ====


### PR DESCRIPTION
As a consequence of [BZ1964540](https://bugzilla.redhat.com/show_bug.cgi?id=1964540), a statement on ports + trunking support is no longer valid. 

4.9+

Preview: https://deploy-preview-36911--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-osp