### PR TITLE
TELCODOCS-167: D/S doc: MGMT-3177, Install single-node using live-ISO with bootstrap in place

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -246,7 +246,7 @@ Topics:
     File: installing-restricted-networks-bare-metal
 - Name: Installing on a single node
   Dir: installing_sno
-  Distros: openshift-webscale
+  Distros: openshift-origin,openshift-enterprise
   Topics:
   - Name: Preparing to install on a single node
     File: install-sno-preparing-to-install-sno

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -5,11 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-[IMPORTANT]
-====
-Installing {product-title} on a single node is a Developer Preview feature only. Developer Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-====
-
 include::modules/install-sno-generate-the-discovery-iso.adoc[leveloffset=+1]
 
 include::modules/install-sno-installing-with-usb-media.adoc[leveloffset=+1]

--- a/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
+++ b/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
@@ -5,12 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-[IMPORTANT]
-====
-Installing {product-title} on a single node is a Developer Preview feature only. Developer Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
-
-====
-
 include::modules/install-sno-about-installing-on-a-single-node.adoc[leveloffset=+1]
 
 include::modules/install-sno-requirements-for-installing-on-a-single-node.adoc[leveloffset=+1]


### PR DESCRIPTION
Edits the distro in topic map file so that single node openshift docs appear in the OCP 4.9 docs.

Fixes: [TELCODOCS-167](https://issues.redhat.com/browse/TELCODOCS-167)

See https://issues.redhat.com/browse/TELCODOCS-167 for additional details.

Preview URL:

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
