### PR TITLE
Use callout syntax in nodes jobs docs

### DIFF
--- a/nodes/jobs/nodes-nodes-jobs.adoc
+++ b/nodes/jobs/nodes-nodes-jobs.adoc
@@ -37,12 +37,12 @@ spec:
         command: ["perl",  "-Mbignum=bpi", "-wle", "print bpi(2000)"]
       restartPolicy: OnFailure    <6>
 ----
-1. The pod replicas a job should run in parallel.
-2. Successful pod completions are needed to mark a job completed.
-3. The maximum duration the job can run.
-4. The number of retries for a job.
-5. The template for the pod the controller creates.
-6. The restart policy of the pod.
+<1> The pod replicas a job should run in parallel.
+<2> Successful pod completions are needed to mark a job completed.
+<3> The maximum duration the job can run.
+<4> The number of retries for a job.
+<5> The template for the pod the controller creates.
+<6> The restart policy of the pod.
 
 See the http://kubernetes.io/docs/user-guide/jobs/[Kubernetes documentation] for
 more information about jobs.


### PR DESCRIPTION
Fixes #36914 by replacing the regular number list format with the proper callout format.

Preview Link: https://deploy-preview-36919--osdocs.netlify.app/openshift-enterprise/latest/nodes/jobs/nodes-nodes-jobs.html

![Screen Shot 2021-09-29 at 10 37 25 AM](https://user-images.githubusercontent.com/1442227/135320360-be2a00dc-0aae-470c-abdc-6b6698a3c2cc.png)
