### PR TITLE
IPI Compatibility Adjust BM Restricted Network

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -155,7 +155,7 @@ endif::openshift-origin[]
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[X]
 |xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[X]
 |xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[X]
-|
+|xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[X]
 |xref:../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[X]
 |xref:../installing/installing_vmc/installing-restricted-networks-vmc.adoc#installing-restricted-networks-vmc[X]
 |


### PR DESCRIPTION
According to the documentation /installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow in the topic ipi-install-creating-a-disconnected-registry_{context}, the OpenShift IPI deployment in Bare Metal can be performed on a restricted network using an internal registry.