### PR TITLE
TELCODOCS-269: D/S Docs & RN: MPINSTALL-6, Support Baremetal IPI clusters on hosts that have different provisioning NIC names

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -8,6 +8,7 @@
 See the following tables for the required parameters, the `hosts` parameter,
 and the `bmc` parameter for the `install-config.yaml` file.
 
+[options="header"]
 .Required parameters
 |===
 |Parameters |Default |Description
@@ -89,8 +90,7 @@ controlPlane:
 |Replicas sets the number of control plane (master) nodes included as part of the {product-title} cluster.
 
 ifeval::[{product-version} >= 4.4]
-a| [[provisioningNetworkInterface]]`provisioningNetworkInterface` |  | The name of the network interface on control plane nodes connected to the
-provisioning network.
+a| [[provisioningNetworkInterface]]`provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the `provisioning` network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
 endif::[]
 
 
@@ -126,7 +126,7 @@ endif::[]
 ifeval::[{product-version} > 4.3]
 ifeval::[{product-version} < 4.6]
 |`provisioningDHCPExternal`
-| false
+| `false`
 |Defines if the installer uses an external DHCP or the provisioner node DHCP.
 endif::[]
 endif::[]
@@ -185,11 +185,14 @@ endif::[]
 
 | `provisioningNetwork`
 |
-| Set this parameter to `Disabled` to disable the requirement for a `provisioning` network. User may only do virtual media based provisioning, or bring up the cluster using assisted installation. If using power management, BMC's must be accessible from the machine networks. User must provide two IP addresses on the external network that are used for the provisioning services.
-ifeval::[{product-version} >= 4.6]
-Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
+| The `provisioningNetwork` configuration setting determines whether the cluster uses the `provisioning` network. If it does, the configuration setting also determines if the cluster manages the network.
 
-Set this parameter to `Unmanaged` to still enable the provisioning network but take care of manual configuration of DHCP. Virtual media provisioning is recommended but PXE is still available if required.
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a `provisioning` network. When set to `Disabled`, you must only use virtual media based provisioning, or bring up the cluster using the assisted installer. If `Disabled` and using power management, BMCs must be accessible from the `baremetal` network. If `Disabled`, you must provide two IP addresses on the `baremetal` network that are used for the provisioning services.
+
+ifeval::[{product-version} >= 4.6]
+`Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
+
+`Unmanaged`: Set this parameter to `Unmanaged` to enable the provisioning network but take care of manual configuration of DHCP. Virtual media provisioning is recommended but PXE is still available if required.
 endif::[]
 
 ifeval::[{product-version} == 4.6]
@@ -219,6 +222,8 @@ endif::[]
 
 The `hosts` parameter is a list of separate bare metal assets used to build the cluster.
 
+[options="header"]
+.Hosts
 |===
 |Name |Default |Description
 | [[name]]`name`
@@ -238,7 +243,7 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | [[bootMACAddress]]`bootMACAddress`
 |
-| The MAC address of the NIC the host will use to boot on the `provisioning`  network.
+| The MAC address of the NIC that the host uses for the `provisioning` network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
 
 ifeval::[{product-version} < 4.6]
 | [[hardwareProfile]]`hardwareProfile`

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -32,7 +32,6 @@ platform:
   baremetal:
     apiVIP: <api-ip>
     ingressVIP: <wildcard-ip>
-    provisioningNetworkInterface: <NIC1>
     provisioningNetworkCIDR: <CIDR>
     hosts:
       - name: openshift-master-0

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -13,20 +13,13 @@ Installer-provisioned installation of {product-title} involves several network r
 
 - `provisioning`: The `provisioning` network is an optional non-routable network used for provisioning the underlying operating system on each node that is a part of the {product-title} cluster. The network interface for the `provisioning` network on each cluster node must have the BIOS or UEFI configured to PXE boot.
 +
-In {product-title} 4.3, when deploying using the `provisioning` network, the first NIC on each node, such as `eth0` or `eno1`, must interface with the `provisioning` network.
-+
-In {product-title} 4.4 and later releases, you can specify the provisioning network NIC with the `provisioningNetworkInterface` configuration setting.
+In {product-title} versions 4.6 through 4.8, the `provisioningNetworkInterface` configuration setting specifies the `provisioning` network NIC. In {product-title} 4.9 and later releases, you can specify the `provisioning` network NIC with the `bootMACAddress` configuration setting.
 
 - `baremetal`: The `baremetal` network is a routable network.
 +
 In {product-title} 4.3, when deploying using the `provisioning` network, the second NIC on each node, such as `eth1` or `eno2`, must interface with the `baremetal` network.
 +
-In {product-title} 4.4 and later releases, you can use any NIC order to interface with the `baremetal` network, provided it is the same NIC order across worker and control plane nodes and not the NIC specified in the `provisioningNetworkInterface` configuration setting for the `provisioning` network.
-
-[NOTE]
-====
-Use a compatible approach such that cluster nodes use the same NIC ordering on all cluster nodes. NICs must have heterogeneous hardware with the same NIC naming convention such as `eth0` or `eno1`.
-====
+In {product-title} 4.4 and later releases, you can use any NIC to interface with the `baremetal` network, provided it is the same NIC order across worker and control plane nodes when using the `provisioningNetworkInterface` configuration setting. In {product-title} 4.9 and later releases, you can use any NIC, provided it is not the NIC associated to the `bootMACAddress` configuration setting for the `provisioning` network when using the `bootMACAddress` configuration setting instead of the `provisioningNetworkInterface` setting.
 
 [IMPORTANT]
 ====

--- a/modules/nw-enabling-a-provisioning-network-after-installation.adoc
+++ b/modules/nw-enabling-a-provisioning-network-after-installation.adoc
@@ -15,22 +15,22 @@ In {product-title} 4.8 and later, you can enable a `provisioning` network after 
 * A dedicated physical network must exist, connected to all worker and control plane nodes.
 * You must isolate the native, untagged physical network.
 * The network cannot have a DHCP server when the `provisioningNetwork` configuration setting is set to `Managed`.
-* You must connect the control plane nodes to the network with the same network interface, such as `eth0` or `eno1`.
+* You can omit the `provisioningInterface` setting in {product-title} 4.9 to use the `bootMACAddress` configuration setting.
 
 .Procedure
 
-. Identify the provisioning interface name for the cluster nodes. For example, `eth0` or `eno1`.
+. When setting the `provisioningInterface` setting, first identify the provisioning interface name for the cluster nodes. For example, `eth0` or `eno1`.
 
 . Enable the Preboot eXecution Environment (PXE) on the `provisioning` network interface of the cluster nodes.
 
-. Retrieve the current state of the `provisioning` network and save it to a provisioning configuration resource file:
+. Retrieve the current state of the `provisioning` network and save it to a provisioning custom resource (CR) file:
 +
 [source,terminal]
 ----
 $ oc get provisioning -o yaml > enable-provisioning-nw.yaml
 ----
 
-. Modify the provisioning configuration resource file:
+. Modify the provisioning CR file:
 +
 [source,terminal]
 ----
@@ -57,8 +57,6 @@ items:
     watchAllNameSpaces: <7>
 ----
 +
-where:
-+
 <1> The `provisioningNetwork` is one of `Managed`, `Unmanaged`, or `Disabled`. When set to `Managed`, Metal3 manages the provisioning network and the CBO deploys the Metal3 pod with a configured DHCP server. When set to `Unmanaged`, the system administrator configures the DHCP server manually.
 +
 <2> The `provisioningOSDownloadURL` is a valid HTTPS URL with a valid sha256 checksum that enables the Metal3 pod to download a qcow2 operating system image ending in `.qcow2.gz` or `.qcow2.xz`. This field is required whether the provisioning network is `Managed`, `Unmanaged`, or `Disabled`. For example: `\http://192.168.0.1/images/rhcos-_<version>_.x86_64.qcow2.gz?sha256=_<sha>_`.
@@ -69,13 +67,13 @@ where:
 +
 <5> The DHCP range. This setting is only applicable to a `Managed` provisioning network. Omit this configuration setting if the `provisioning` network is `Disabled`. For example: `192.168.0.64, 192.168.0.253`.
 +
-<6> The NIC name for the `provisioning` interface on cluster nodes. This setting is only applicable to `Managed` and `Unamanged` provisioning networks. Omit this configuration setting if the `provisioning` network is `Disabled`.
+<6> The NIC name for the `provisioning` interface on cluster nodes. The `provisioningInterface` setting is only applicable to `Managed` and `Unmanaged` provisioning networks. Omit the `provisioningInterface` configuration setting if the `provisioning` network is `Disabled`. Omit the `provisioningInterface` configuration setting to use the `bootMACAddress` configuration setting instead.
 +
 <7> Set this setting to `true` if you want metal3 to watch namespaces other than the default `openshift-machine-api` namespace. The default value is `false`.
 
-. Save the changes to the provisioning configuration resource file.
+. Save the changes to the provisioning CR file.
 
-. Apply the provisioning configuration resource file to the cluster:
+. Apply the provisioning CR file to the cluster:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Provides language to use bootMACAddress in lieu of provisioningNetworkInterface where applicable.

Fixes: [TELCODOCS-269](https://issues.redhat.com/browse/TELCODOCS-269)

See https://issues.redhat.com/browse/TELCODOCS-269 for additional details.

Preview URL: https://deploy-preview-36926--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements_ipi-install-prerequisites

https://deploy-preview-36926--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-configuration-files

NOTE: Conditional text will not appear, because of hard-coding of product-version in the asciibinder tool in local and preview builds. 

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
