### PR TITLE
OSDOCS:2357: Ingress empty requests policy release note

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -399,6 +399,13 @@ Cluster administrators can configure HTTP Strict Transport Security (HSTS) verif
 
 For more information, see xref:../networking/routes/route-configuration.adoc#nw-enabling-hsts_route-configuration[HTTP Strict Transport Security].
 
+[id="ocp-4-9-networking-ingress-empty-requests-policy"]
+==== Ingress empty requests policy
+
+In {product-title} {product-version} you can now configure the Ingress Controller to log or ignore empty requests by setting the `logEmptyRequests` and `HTTPEmptyRequestsPolicy` fields.
+
+For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress controller configuration parameters].
+
 [id="ocp-4-9-storage"]
 === Storage
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2357

Related to https://github.com/openshift/openshift-docs/pull/36272 and https://github.com/openshift/openshift-docs/issues/33497. 

Preview: https://deploy-preview-36933--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-networking-ingress-empty-requests-policy