### PR TITLE
BZ1886810: Updated operator-sdk appendices to have updated types

### DIFF
--- a/modules/osdk-project-staffolding-layout.adoc
+++ b/modules/osdk-project-staffolding-layout.adoc
@@ -8,23 +8,20 @@
 The `operator-sdk` CLI generates a number of packages for each Operator project. The following sections describes a basic rundown of each generated file and directory.
 
 [id="osdk-project-scaffolding-layout-go_{context}"]
-== Go-based projects
+== Ansible-based projects
 
-Go-based Operator projects (the default type) generated using the `operator-sdk new` command contain the following directories and files:
+Ansible-based Operator projects generated using the `operator-sdk new --type ansible` command contain the following directories and files:
 
 [options="header",cols="1,2"]
 |===
 
 |File/folders |Purpose
 
-|`cmd/`
-|Contains `manager/main.go` file, which is the main program of the Operator. This instantiates a new manager which registers all custom resource defintitions (CRDs) under `pkg/apis/` and starts all controllers under `pkg/controllers/`.
+|`molecule/`
+|Contains the files that are used for testing the Ansible roles.
 
-|`pkg/apis/`
-|Contains the directory tree that defines the APIs of the CRDs. Users are expected to edit the `pkg/apis/<group>/<version>/<kind>_types.go` files to define the API for each resource type and import these packages in their controllers to watch for these resource types.
-
-|`pkg/controller`
-|This `pkg` contains the controller implementations. Users are expected to edit the `pkg/controller/<kind>/<kind>_controller.go` files to define the reconcile logic of the controller for handling a resource type of the specified kind.
+|`roles/`
+|Contains the Helm chart used while creating the project.
 
 |`build/`
 |Contains the Dockerfile and build scripts used to build the Operator.
@@ -32,12 +29,11 @@ Go-based Operator projects (the default type) generated using the `operator-sdk 
 |`deploy/`
 |Contains various YAML manifests for registering CRDs, setting up RBAC, and deploying the Operator as a deployment.
 
-a|`Gopkg.toml` +
-`Gopkg.lock`
-|The link:https://github.com/golang/dep[Go Dep] manifests that describe the external dependencies of this Operator.
+|`requirements.yml`
+|Contains the Ansible content that needs to be installed.
 
-|`vendor/`
-|The Golang link:https://golang.org/cmd/go/#hdr-Vendor_Directories[vendor] folder that contains the local copies of the external dependencies that satisfy the imports of this project. link:https://github.com/golang/dep[Go Dep] manages the vendor directly.
+|`watches.yaml`
+|Contains group, version, kind and role.
 
 |===
 
@@ -61,6 +57,6 @@ Helm-based Operator projects generated using the `operator-sdk new --type helm` 
 |Contains the Dockerfile and build scripts used to build the Operator.
 
 |`watches.yaml`
-|Contains group/version/kind (GVK) and Helm chart location.
+|Contains group, version, kind and Helm chart location.
 
 |===


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1886810

Preview link: https://deploy-preview-36938--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-appendices.html#osdk-project-scaffolding-layout-go_operator-appendices

@tbuskey / @emmajiafan - Kindly help with QE review.
@jmrodri - Kindly help with SME review.