### PR TITLE
BZ2008990: Updates to ASH for internal load balancer

### DIFF
--- a/modules/installation-azure-create-dns-zones.adoc
+++ b/modules/installation-azure-create-dns-zones.adoc
@@ -19,16 +19,24 @@ is used, so you will create a new public DNS zone for external (internet)
 visibility and a private DNS zone for internal cluster resolution.
 endif::ash[]
 ifdef::ash[]
-For this example, link:https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-integrate-dns?view=azs-2102[Azure Stack Hub's datacenter DNS integration] is used, so you will create a public DNS zone.
+For this example, link:https://docs.microsoft.com/en-us/azure-stack/operator/azure-stack-integrate-dns?view=azs-2102[Azure Stack Hub's datacenter DNS integration] is used, so you will create a DNS zone.
 endif::ash[]
 
+ifndef::ash[]
 [NOTE]
 ====
 The public DNS zone is not required to exist in the same resource group as the
-cluster deployment and might already exist in your organization for the desired
-base domain. If that is the case, you can skip creating the public DNS zone; be
-sure the installation config you generated earlier reflects that scenario.
+cluster deployment and might already exist in your organization for the desired base domain. If that is the case, you can skip creating the public DNS zone; be sure the installation config you generated earlier reflects that scenario.
 ====
+endif::ash[]
+
+ifdef::ash[]
+[NOTE]
+====
+The DNS zone is not required to exist in the same resource group as the
+cluster deployment and might already exist in your organization for the desired base domain. If that is the case, you can skip creating the DNS zone; be sure the installation config you generated earlier reflects that scenario.
+====
+endif::ash[]
 
 .Prerequisites
 
@@ -38,15 +46,22 @@ sure the installation config you generated earlier reflects that scenario.
 
 .Procedure
 
+ifndef::ash[]
 . Create the new public DNS zone in the resource group exported in the
 `BASE_DOMAIN_RESOURCE_GROUP` environment variable:
+endif::ash[]
+ifdef::ash[]
+* Create the new DNS zone in the resource group exported in the
+`BASE_DOMAIN_RESOURCE_GROUP` environment variable:
+endif::ash[]
 +
 [source,terminal]
 ----
 $ az network dns zone create -g ${BASE_DOMAIN_RESOURCE_GROUP} -n ${CLUSTER_NAME}.${BASE_DOMAIN}
 ----
 +
-You can skip this step if you are using a public DNS zone that already exists.
+ifndef::ash[You can skip this step if you are using a public DNS zone that already exists.]
+ifdef::ash[You can skip this step if you are using a DNS zone that already exists.]
 
 ifndef::ash[]
 . Create the private DNS zone in the same resource group as the rest of this

--- a/modules/installation-azure-create-ingress-dns-records.adoc
+++ b/modules/installation-azure-create-ingress-dns-records.adoc
@@ -49,7 +49,7 @@ router-default   LoadBalancer   172.30.20.10   35.130.120.110   80:32288/TCP,443
 ----
 $ export PUBLIC_IP_ROUTER=`oc -n openshift-ingress get service router-default --no-headers | awk '{print $4}'`
 ----
-
+ifndef::ash[]
 . Add a `*.apps` record to the public DNS zone.
 
 .. If you are adding this cluster to a new public zone, run:
@@ -65,6 +65,23 @@ $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${C
 ----
 $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${BASE_DOMAIN} -n *.apps.${CLUSTER_NAME} -a ${PUBLIC_IP_ROUTER} --ttl 300
 ----
+endif::ash[]
+ifdef::ash[]
+. Add a `*.apps` record to the DNS zone.
+
+.. If you are adding this cluster to a new DNS zone, run:
++
+[source,terminal]
+----
+$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n *.apps -a ${PUBLIC_IP_ROUTER} --ttl 300
+----
+.. If you are adding this cluster to an already existing DNS zone, run:
++
+[source,terminal]
+----
+$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${BASE_DOMAIN} -n *.apps.${CLUSTER_NAME} -a ${PUBLIC_IP_ROUTER} --ttl 300
+----
+endif::ash[]
 
 ifndef::ash[]
 . Add a `*.apps` record to the private DNS zone:

--- a/modules/installation-azure-limits.adoc
+++ b/modules/installation-azure-limits.adoc
@@ -145,9 +145,10 @@ security groups for the control plane and for the compute node subnets:
 `node`:: Allows worker nodes to be reached from the internet on ports 80 and 443
 
 |Network load balancers
-ifndef::upi,ash[]
 | 3
+ifndef::ash[]
 | 1000 per region
+endif::ash[]
 |Each cluster creates the following
 link:https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview[load balancers]:
 
@@ -158,22 +159,6 @@ link:https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview
 
 If your applications create more Kubernetes `LoadBalancer` service objects,
 your cluster uses more load balancers.
-endif::upi,ash[]
-ifdef::upi[]
-| 2
-ifndef::ash[]
-| 1000 per region
-endif::ash[]
-|Each cluster creates the following
-link:https://docs.microsoft.com/en-us/azure/load-balancer/load-balancer-overview[load balancers]:
-
-[horizontal]
-`default`:: Public IP address that load balances requests to ports 80 and 443 across worker machines
-`api`:: Public IP address that load balances requests to ports 6443 and 22623 across control plane machines
-
-If your applications create more Kubernetes `LoadBalancer` service objects,
-your cluster uses more load balancers.
-endif::upi[]
 
 |Public IP addresses
 ifndef::ash[]

--- a/modules/installation-creating-azure-dns.adoc
+++ b/modules/installation-creating-azure-dns.adoc
@@ -19,6 +19,13 @@ You must configure networking and load balancing in Microsoft {cp} for your
 {product-title} cluster to use. One way to create these components is
 to modify the provided Azure Resource Manager (ARM) template.
 
+ifdef::ash[]
+Load balancing requires the following DNS records:
+
+* An `api` DNS record for the API public load balancer in the DNS zone.
+* An `api-int` DNS record for the API internal load balancer in the DNS zone.
+endif::ash[]
+
 [NOTE]
 ====
 If you do not use the provided ARM template to create your {cp} infrastructure,
@@ -52,11 +59,8 @@ $ az deployment group create -g ${RESOURCE_GROUP} \
 ----
 <1> The name of the private DNS zone.
 <2> The base name to be used in resource names; this is usually the cluster's infrastructure ID.
-
-. Create an `api` DNS record in the public zone for the API public load
-balancer. The `${BASE_DOMAIN_RESOURCE_GROUP}` variable must point to the
-resource group where the public DNS zone exists.
 endif::azure[]
+
 ifdef::ash[]
 [source,terminal]
 ----
@@ -65,10 +69,16 @@ $ az deployment group create -g ${RESOURCE_GROUP} \
   --parameters baseName="${INFRA_ID}"<1>
 ----
 <1> The base name to be used in resource names; this is usually the cluster's infrastructure ID.
+endif::ash[]
 
-. Create an `api` and `api-int` DNS record in the public zone for the API public load
+ifdef::azure[]
+. Create an `api` DNS record in the public zone for the API public load
 balancer. The `${BASE_DOMAIN_RESOURCE_GROUP}` variable must point to the
 resource group where the public DNS zone exists.
+endif::azure[]
+
+ifdef::ash[]
+. Create an `api` DNS record and an `api-int` DNS record. When creating the API DNS records, the `${BASE_DOMAIN_RESOURCE_GROUP}` variable must point to the resource group where the DNS zone exists.
 endif::ash[]
 
 .. Export the following variable:
@@ -77,16 +87,33 @@ endif::ash[]
 ----
 $ export PUBLIC_IP=`az network public-ip list -g ${RESOURCE_GROUP} --query "[?name=='${INFRA_ID}-master-pip'] | [0].ipAddress" -o tsv`
 ----
+ifdef::ash[]
+.. Export the following variable:
++
+[source,terminal]
+----
+$ export PRIVATE_IP=`az network lb frontend-ip show -g "$RESOURCE_GROUP" --lb-name "${INFRA_ID}-internal" -n internal-lb-ip --query "privateIpAddress" -o tsv`
+----
+endif::ash[]
 
+ifdef::azure[]
 .. Create the `api` DNS record in a new public zone:
+endif::azure[]
+ifdef::ash[]
+.. Create the `api` DNS record in a new DNS zone:
+endif::ash[]
 +
 [source,terminal]
 ----
 $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${CLUSTER_NAME}.${BASE_DOMAIN} -n api -a ${PUBLIC_IP} --ttl 60
 ----
 +
-If you are adding the cluster to an existing public zone, you can create the `api` DNS
-record in it instead:
+ifdef::azure[]
+If you are adding the cluster to an existing public zone, you can create the `api` DNS record in it instead:
+endif::azure[]
+ifdef::ash[]
+If you are adding the cluster to an existing DNS zone, you can create the `api` DNS record in it instead:
+endif::ash[]
 +
 [source,terminal]
 ----
@@ -94,19 +121,19 @@ $ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${B
 ----
 
 ifdef::ash[]
-.. Create the `api-int` DNS record in a new public zone:
+.. Create the `api-int` DNS record in a new DNS zone:
 +
 [source,terminal]
 ----
-$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api-int -a ${PUBLIC_IP} --ttl 60
+$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z "${CLUSTER_NAME}.${BASE_DOMAIN}" -n api-int -a ${PRIVATE_IP} --ttl 60
 ----
 +
-If you are adding the cluster to an existing public zone, you can create the `api-int` DNS
+If you are adding the cluster to an existing DNS zone, you can create the `api-int` DNS
 record in it instead:
 +
 [source,terminal]
 ----
-$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${BASE_DOMAIN} -n api-int.${CLUSTER_NAME} -a ${PUBLIC_IP} --ttl 60
+$ az network dns record-set a add-record -g ${BASE_DOMAIN_RESOURCE_GROUP} -z ${BASE_DOMAIN} -n api-int.${CLUSTER_NAME} -a ${PRIVATE_IP} --ttl 60
 ----
 endif::ash[]
 

--- a/modules/installation-user-infra-exporting-common-variables-arm-templates.adoc
+++ b/modules/installation-user-infra-exporting-common-variables-arm-templates.adoc
@@ -49,8 +49,18 @@ ifdef::ash[]
 <2> The region to deploy the cluster into. This is the value of the `.platform.azure.region` attribute from the `install-config.yaml` file.
 endif::ash[]
 <3> The SSH RSA public key file as a string. You must enclose the SSH key in quotes since it contains spaces. This is the value of the `.sshKey` attribute from the `install-config.yaml` file.
+ifndef::ash[]
 <4> The base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster. This is the value of the `.baseDomain` attribute from the `install-config.yaml` file.
+endif::ash[]
+ifdef::ash[]
+<4> The base domain to deploy the cluster to. The base domain corresponds to the DNS zone that you created for your cluster. This is the value of the `.baseDomain` attribute from the `install-config.yaml` file.
+endif::ash[]
+ifndef::ash[]
 <5> The resource group where the public DNS zone exists. This is the value of the `.platform.azure.baseDomainResourceGroupName` attribute from the `install-config.yaml` file.
+endif::ash[]
+ifdef::ash[]
+<5> The resource group where the DNS zone exists. This is the value of the `.platform.azure.baseDomainResourceGroupName` attribute from the `install-config.yaml` file.
+endif::ash[]
 +
 For example:
 +


### PR DESCRIPTION
CP to 4.9

https://bugzilla.redhat.com/show_bug.cgi?id=2008990

Updates to Installing a cluster on Azure Stack Hub using ARM templates:

- Updated the Network load balancer row in the table that is under Azure Stack Hub account limits.
  - Number of components required by default value is now `3`.
  - Description now references `internal` and `external` load balancers.
 https://deploy-preview-36950--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-azure-limits_installing-azure-stack-hub-user-infra

- Updated Creating networking and load balancing components in Azure Stack Hub.
  - Intro text lists the `api` and `api-int` DNS records being required for load balancing.
  - Added step 3b to export the private IP for the internal load balancer
  - Updated step 3d and supporting terminal examples to specify that the DNS record is for the private zone.
  https://deploy-preview-36950--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-creating-azure-dns_installing-azure-stack-hub-user-infra