### PR TITLE
RHDEVDOCS-3314 Add link from 5.0 RNs to RHBA-2021:81705-01 Openshift …

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -40,6 +40,7 @@ OpenShift Logging 5.0 runs on {product-title} 4.7.
 
 The following advisories are available for OpenShift Logging 5.0.x:
 
+* link:https://access.redhat.com/errata/RHBA-2021:3705[RHBA-2021:3705 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.9)]
 * link:https://access.redhat.com/errata/RHBA-2021:3526[RHBA-2021:3526 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.8)]
 * link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.7)]
 * link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]
@@ -50,7 +51,7 @@ The following advisories are available for OpenShift Logging 5.0.x:
 * link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)]
 * link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0]
 
-
+include::modules/cluster-logging-release-notes-5.0.9.adoc[leveloffset=+2]
 include::modules/cluster-logging-release-notes-5.0.8.adoc[leveloffset=+2]
 include::modules/cluster-logging-release-notes-5.0.7.adoc[leveloffset=+2]
 include::modules/cluster-logging-release-notes-5.0.6.adoc[leveloffset=+2]

--- a/modules/cluster-logging-release-notes-5.0.9.adoc
+++ b/modules/cluster-logging-release-notes-5.0.9.adoc
@@ -1,0 +1,25 @@
+[id="cluster-logging-release-notes-5-0-9"]
+= OpenShift Logging 5.0.9
+
+This release includes link:https://access.redhat.com/errata/RHBA-2021:3705[RHBA-2021:3705 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.9)].
+
+[id="openshift-logging-5-0-9-bug-fixes"]
+== Bug fixes
+
+This release includes the following bug fixes:
+
+* Before this update, some log entries had unrecognized UTF-8 bytes, which caused Elasticsearch to reject messages and block the entire buffered payload. This update resolves the issue: rejected payloads drop the invalid log entries and resubmit the remaining entries. (link:https://issues.redhat.com/browse/LOG-1574[LOG-1574])
+
+* Before this update, editing the `ClusterLogging` custom resource (CR) did not apply the value of `totalLimitSize` to the Fluentd `total_limit_size` field, which limits the size of the buffer plugin instance. As a result, Fluentd applied the default values. With this update, the CR applies the value of `totalLimitSize` to the Fluentd `total_limit_size` field. Fluentd uses the value of the `total_limit_size` field or the default value, whichever is less. (link:https://issues.redhat.com/browse/LOG-1736[LOG-1736])
+
+[id="openshift-logging-5-0-9-cves"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-25648[CVE-2020-25648]
+* link:https://access.redhat.com/security/cve/CVE-2021-22922[CVE-2021-22922]
+* link:https://access.redhat.com/security/cve/CVE-2021-22923[CVE-2021-22923]
+* link:https://access.redhat.com/security/cve/CVE-2021-22924[CVE-2021-22924]
+* link:https://access.redhat.com/security/cve/CVE-2021-36222[CVE-2021-36222]
+* link:https://access.redhat.com/security/cve/CVE-2021-37576[CVE-2021-37576]
+* link:https://access.redhat.com/security/cve/CVE-2021-37750[CVE-2021-37750]
+* link:https://access.redhat.com/security/cve/CVE-2021-38201[CVE-2021-38201]


### PR DESCRIPTION
…Logging Bug Fix Release (5.0.9)

- Aligned team: Dev Tools
- For branches: 4.7 only
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3314
- Direct link to doc preview: https://deploy-preview-36961--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-0-9
- SME review: @jcantrill 
- QE review: @kabirbhartiRH 
- Peer review: tbd
- <All reviews complete. Please merge now>