### PR TITLE
Updated a typo AWS AFS to AWS EFS

### DIFF
--- a/storage/persistent_storage/osd-persistent-storage-aws.adoc
+++ b/storage/persistent_storage/osd-persistent-storage-aws.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 The Amazon Web Services Elastic File System (AWS EFS) is a Network File System (NFS) that can be provisioned on {product-title} clusters. AWS also provides and supports a CSI EFS Driver to be used with Kubernetes that allows Kubernetes workloads to leverage this shared file storage.
 
-This document describes the basic steps needed to set up your AWS account to prepare EFS to be used by {product-title}. For more information about AWS AFS, see the link:https://docs.aws.amazon.com/efs/index.html[AWS EFS documentation].
+This document describes the basic steps needed to set up your AWS account to prepare EFS to be used by {product-title}. For more information about AWS EFS, see the link:https://docs.aws.amazon.com/efs/index.html[AWS EFS documentation].
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Following the reported issue: https://github.com/openshift/openshift-docs/issues/36638, I spotted that there is a typo explaining about AWS EFS.