### PR TITLE
Update the resource name of router table(s) to route table(s)

### DIFF
--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -65,7 +65,7 @@ Customers should expect to see one VPC per cluster. Additionally, the VPC needs 
 
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
 
-* *Router tables*: One router table per private subnet, and one additional table per cluster.
+* *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.
 


### PR DESCRIPTION
Also refer to: https://github.com/openshift/openshift-docs/issues/36778

Following the AWS document, I understood that the "router table(s)" should be the "route table(s)" per the resource name from the AWS official document: https://docs.aws.amazon.com/vpc/latest/userguide/VPC_Route_Tables.html.