### PR TITLE
TELCODOCS-82 - removing unsupported mirror reg procedure for 4.9 ZTP GA

### DIFF
--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -28,16 +28,7 @@ include::modules/ztp-du-host-networking-requirements.adoc[leveloffset=+1]
 
 include::modules/ztp-acm-preparing-to-install-disconnected-acm.adoc[leveloffset=+1]
 
-[id="installing-preparing-mirror_{context}"]
-== Preparing the mirror host
-
-Before you perform the mirror registry procedure, you must prepare the mirror host to retrieve the {product-title} release images.
-
-include::modules/installation-about-mirror-registry.adoc[leveloffset=+2]
-
-.Additional information
-
-For information on viewing the CRI-O logs to view the image source, see xref:../installing/validating-an-installation.html#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
+Before you install a cluster on infrastructure that you provision in a restricted network, you must mirror the required container images into that environment. You can also use this procedure in unrestricted networks to ensure your clusters only use container images that have satisfied your organizational controls on external content.
 
 [IMPORTANT]
 ====
@@ -48,15 +39,38 @@ to a mirror host, use the disconnected procedure to copy images to a device you
 can move across network boundaries with.
 ====
 
-include::modules/installation-creating-mirror-registry.adoc[leveloffset=+2]
+[id="prerequisites_installing-mirroring-installation-images_{context}"]
+=== Prerequisites
 
-include::modules/cli-installing-cli.adoc[leveloffset=+2]
+* You must have a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2] in the location that will host the {product-title} cluster, such as one of the following registries:
++
+--
+** link:https://www.redhat.com/en/technologies/cloud-computing/quay[Red Hat Quay]
+** link:https://jfrog.com/artifactory/[JFrog Artifactory]
+** link:https://www.sonatype.com/products/repository-oss?topnav=true[Sonatype Nexus Repository]
+** link:https://goharbor.io/[Harbor]
+--
+If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/[by using the Quay Operator]. If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
+
+include::modules/installation-about-mirror-registry.adoc[leveloffset=+2]
+
+.Additional resources
+
+For information on viewing the CRI-O logs to view the image source, see xref:../installing/validating-an-installation.html#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
+
+[id="installing-preparing-mirror_{context}"]
+=== Preparing your mirror host
+
+Before you perform the mirror procedure, you must prepare the host to retrieve content
+and push it to the remote location.
+
+include::modules/cli-installing-cli.adoc[leveloffset=+3]
 
 include::modules/installation-adding-registry-pull-secret.adoc[leveloffset=+2]
 
-include::modules/installation-mirror-repository.adoc[leveloffset=+1]
+include::modules/installation-mirror-repository.adoc[leveloffset=+2]
 
-include::modules/ztp-acm-adding-images-to-mirror-registry.adoc[leveloffset=+1]
+include::modules/ztp-acm-adding-images-to-mirror-registry.adoc[leveloffset=+2]
 
 include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 


### PR DESCRIPTION
For main, enterprise-4.9

This update removes an unsupported mIrror registry procedure for 4.9 ZTP GA and reuses the canonical procedure and modules for disconnected mirror registry. 

https://issues.redhat.com/browse/TELCODOCS-82

Preview: https://deploy-preview-36970--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected#ztp-acm-preparing-to-install-disconnected-acm_ztp-deploying-disconnected