### PR TITLE
BZ1967977: steps for generating sos report when a node has taint with NoExecute configuration

### DIFF
--- a/modules/support-generating-a-sosreport-archive.adoc
+++ b/modules/support-generating-a-sosreport-archive.adoc
@@ -31,7 +31,24 @@ $ oc get nodes
 ----
 $ oc debug node/my-cluster-node
 ----
-
++
+To enter into a debug session on the target node that is tainted with the `NoExecute` effect, add a toleration to a dummy namespace, and start the debug pod in the dummy namespace:
++
+[source,terminal]
+----
+$ oc new-project dummy
+----
++
+[source,terminal]
+----
+$ oc patch namespace dummy --type=merge -p '{"metadata": {"annotations": { "scheduler.alpha.kubernetes.io/defaultTolerations": "[{\"operator\": \"Exists\"}]"}}}'
+----
++
+[source,terminal]
+----
+$ oc debug node/my-cluster-node
+----
++
 . Set `/host` as the root directory within the debug shell. The debug pod mounts the host's root file system in `/host` within the pod. By changing the root directory to `/host`, you can run binaries contained in the host's executable paths:
 +
 [source,terminal]


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1967977

Requires ack from @sunilcio 