### PR TITLE
Release note fixup: OLM Kubernetes support

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -411,7 +411,7 @@ For more information, see xref:../storage/persistent_storage/persistent-storage-
 [id="ocp-4-9-olm"]
 === Operator lifecycle
 
-[id="ocp-4-9-olm-k8s-1.22"]
+[id="ocp-4-9-olm-k8s-1-22"]
 ==== Operator Lifecycle Manager (OLM) upgraded to Kubernetes 1.22
 
 Starting in {product-title} {product-version}, Operator Lifecycle Manager (OLM) supports Kubernetes 1.22. As a result, xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[a significant number of `v1beta1` APIs have been removed and updated to `v1`]. Operators that depend on the removed `v1beta1` APIs will not run on {product-title} {product-version}. Cluster administrators should xref:../operators/admin/olm-upgrading-operators.adoc[upgrade their installed Operators] to the `latest` channel before upgrading a cluster to {product-title} {product-version}.
@@ -629,7 +629,7 @@ For more information, see the xref:../operators/operator-reference.adoc#cluster-
 [id="ocp-4-9-canary-rollout-update-changes"]
 ==== Performing a canary rollout update
 
-With {product-title} 4.9, a new process to perform a canary rollout update has been introduced. For a detailed overview of this process, see xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]. 
+With {product-title} 4.9, a new process to perform a canary rollout update has been introduced. For a detailed overview of this process, see xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update].
 
 [id="ocp-4-9-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
4.9 release note

This fixes anchor id of this release note. The previous anchor id broke the Pantheon build, due to the period.

Docs preview: https://deploy-preview-36975--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-olm-k8s-1.22