### PR TITLE
BZ:1828609 - Adding section for setting SELinux booleans

### DIFF
--- a/modules/nodes-nodes-working-setting-booleans.adoc
+++ b/modules/nodes-nodes-working-setting-booleans.adoc
@@ -1,0 +1,56 @@
+[id="nodes-nodes-working-setting-booleans"]
+
+= Setting SELinux booleans
+
+{product-title} allows you to enable and disable an SELinux boolean on a {op-system-first} node. The following procedure explains how to modify SELinux booleans on nodes using the Machine Config Operator (MCO). This procedure uses `container_manage_cgroup` as the example boolean. You can modify this value to whichever boolean you need.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (oc).
+
+.Procedure
+
+. Create a new YAML file with a `MachineConfig` object, displayed in the following example:
++
+[source, yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-setsebool
+spec:
+  config:
+    ignition:
+      version: 2.2.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Set SELinux booleans
+          Before=kubelet.service
+
+          [Service]
+          Type=oneshot
+          ExecStart=/sbin/setsebool container_manage_cgroup=on
+          RemainAfterExit=true
+
+          [Install]
+          WantedBy=multi-user.target graphical.target
+        enabled: true
+        name: setsebool.service
+----
++
+
+. Create the new `MachineConfig` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f 99-worker-setsebool.yaml
+----
+
+[NOTE]
+====
+Applying any changes to the `MachineConfig` object causes all affected nodes to gracefully reboot after the change is applied.
+====

--- a/nodes/nodes/nodes-nodes-working.adoc
+++ b/nodes/nodes/nodes-nodes-working.adoc
@@ -28,6 +28,7 @@ include::modules/nodes-nodes-working-master-schedulable.adoc[leveloffset=+1]
 include::modules/nodes-nodes-working-deleting.adoc[leveloffset=+2]
 include::modules/nodes-nodes-working-deleting-bare-metal.adoc[leveloffset=+2]
 
+include::modules/nodes-nodes-working-setting-booleans.adoc[leveloffset=+1]
 include::modules/nodes-nodes-kernel-arguments.adoc[leveloffset=+1]
 ifdef::openshift-webscale[]
 include::modules/nodes-nodes-rtkernel-arguments.adoc[leveloffset=+1]


### PR DESCRIPTION
For Versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1828609[BZ#1828609]

Description: Adding a new section that goes through the process of enabling and disable SELinux booleans on a RHEL CoreOC node.

Preview: https://deploy-preview-36977--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-working?utm_source=github&utm_campaign=bot_dp#nodes-nodes-working-setting-booleans

Ready for QA: @sunilcio 

For Peer reviewers: Can you please add 'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' and 'Peer Review needed'. Thank you!!