### PR TITLE
Misc edits to the main body of the 4.9 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -24,9 +24,11 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 7.9 or 8.4 for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517
 
+//TODO: Add the line below for EUS releases.
 //{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
-With the release of {product-title} 4.9, version 4.6 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+//TODO: The line below is not true for 4.9 but should be used when it is next appropriate. Revisit in October 2022 timeframe.
+//With the release of {product-title} 4.9, version 4.6 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [id="ocp-4-9-inclusive-language"]
 == Making open source more inclusive
@@ -785,12 +787,12 @@ In the table, features are marked with the following statuses:
 |v1beta1 CRDs
 |DEP
 |DEP
-|
+|REM
 
 |Docker Registry v1 API
 |DEP
 |DEP
-|
+|REM
 
 |Metering Operator
 |DEP
@@ -846,6 +848,11 @@ In the table, features are marked with the following statuses:
 |TP
 |REM
 |
+
+|vSphere 6.7 Update 2 or earlier and virtual hardware version 13
+|GA
+|GA
+|DEP
 
 |====
 
@@ -1434,7 +1441,7 @@ In the table below, features are marked with the following statuses:
 |Service Binding
 |TP
 |TP
-|
+|TP
 
 |Raw Block with Cinder
 |TP
@@ -1592,13 +1599,18 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |Memory Manager feature
-|
-|
+|-
+|-
 |TP
 
 |CNI VRF plug-in
 |TP
 |TP
+|GA
+
+|Cluster Cloud Controller Manager Operator
+|-
+|-
 |GA
 
 |Cloud controller manager for AWS


### PR DESCRIPTION
Some updates to the main body of the 4.9 release notes:
- [EUS stuff for 4.6](https://deploy-preview-36987--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-about-this-release) (removed the end of life message we normally publish, added some notes to guide future RN leads on this topic)
- Updates with [DEP/REM](https://deploy-preview-36987--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-removed-features) and [TP/GA](https://deploy-preview-36987--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-technology-preview) features we have so far