### PR TITLE
BZs apiserver-auth-1

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -857,6 +857,14 @@ The deprecated `dhclient` binary has been removed from {op-system}. Starting wit
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes
 
+*apiserver-auth*
+
+* Previously, encryption conditions could remain indefinitely and be reported as a degraded condition for some Operators. Stale encryption conditions are now cleared properly and no longer improperly reported.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1974520[*BZ#1974520*])
+
+* Previously, the CA for API server client certificates was rotated early in the lifetime of a cluster, which prevented the Authentication Operator from creating a certificate signing request (CSR) because a previous CSR with the same name still existed. The Kubernetes API server was unable to authenticate itself to the OAuth API server when sending `TokenReview` requests, which caused authentication to fail. Generated names are now used when creating CSRs by the Authentication Operator, so an early rotation of the CA for API server client certificates no longer causes authentication failures.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1978193[*BZ#1978193*])
+
 *assisted-installer*
 
 *Bare Metal Hardware Provisioning*


### PR DESCRIPTION
BZs for apiserver-auth, batch 1

preview: https://deploy-preview-36988--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-bug-fixes