### PR TITLE
BZ:1951854 - Fixing named certificates section and adding deployment of web console

### DIFF
--- a/install_config/redeploying_certificates.adoc
+++ b/install_config/redeploying_certificates.adoc
@@ -399,12 +399,12 @@ The `etcd` certificate redeployment can result in copying the `serial` to all ma
 ====
 
 [[redeploying-master-certificates]]
-=== Redeploying Master Certificates Only
+=== Redeploying Master and Web Console Certificates
 
-The *_openshift-master/redeploy-certificates.yml_* playbook only redeploys master
-certificates. This also includes serial restarts of master services.
+The *_openshift-master/redeploy-certificates.yml_* playbook redeploys master
+certificates and web console certificates. This also includes serial restarts of master services.
 
-To redeploy master certificates, change to the playbook directory and run this playbook, specifying your inventory
+To redeploy master certificates and web console certificates, change to the playbook directory and run this playbook, specifying your inventory
 file:
 
 ----


### PR DESCRIPTION
For Version 3.11
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1951854[BZ#1951854]

Description: The openshift-master/redeploy-named-certificates.yml playbook also works for redeploying web console certificated, not just named certificates. 

Preview:https://deploy-preview-36992--osdocs.netlify.app/openshift-enterprise/latest/install_config/redeploying_certificates?utm_source=github&utm_campaign=bot_dp#redeploying-named-certificates

Ready for QA: @gpei 

For Peer reviewers: Please add label for 'enterprise-3.11' and 'Peer review needed'  