### PR TITLE
Adds routing bug doc text to the 4.9 RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -922,6 +922,10 @@ The deprecated `dhclient` binary has been removed from {op-system}. Starting wit
 
 *Routing*
 
+* Previously, there was config drift when the Cluster Network Operator (CNO) attempted to sanitize the proxy configuration, specifically the `no_proxy` config. This resulted in a specific IPv6 CIDR missing from the `no_proxy`. This fix implements logic that updates the dual stack (IPV4 and IPV6) for all scenarios. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1981975[*BZ#1981975*])
+
+* Previously, if the `.spec.privateZone` field of the `dns.config.openshift.io` Operator was filled out incorrectly so that the Ingress Operator was not able to find the private hosted zone, then the Ingress Operator became degraded. However, even after fixing the `.spec.privateZone` field, the Ingress Operator stayed degraded. The Ingress Operator finds the hosted zone and adds the `.apps` resource record, but the Ingress Operator does not reset the degraded status. This fix watches the DNS config object and monitors changes regarding the `spec.privateZone` field. It applies the appropriate logic and updates the Operator status accordingly. The Operator status returns to degraded, or `False`, once the correct `.spec.privateZone` field is set. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1942657[*BZ#1942657*])
+
 *Samples*
 
 *service-ca*


### PR DESCRIPTION
No BZ.

Bug doc text for 4.9 RNs.

Preview: https://deploy-preview-36994--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-bug-fixes