### PR TITLE
BZs kube-apiserver-1

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -912,6 +912,12 @@ The deprecated `dhclient` binary has been removed from {op-system}. Starting wit
 
 *kube-apiserver*
 
+* Previously, when a deployment and image stream were created at the same time, a race condition could occur which caused the deployment controller to create replica sets in an infinite loop. The responsibilities of the API server's image policy plug-in were lowered and concurrent creation of a deployment and image stream no longer causes infinite replica sets.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1925180[*BZ#1925180*]), (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976775[*BZ#1976775*])
+
+* Previously, there was a race between the installer pod and the cert-syncer container, which were writing to the same path. This could leave some certificates empty and prevent the server from running. Kubernetes API server certificates are now written in an atomic way to prevent races between multiple processes.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1971624[*BZ#1971624*])
+
 *Machine Config Operator*
 
 *Metering Operator*


### PR DESCRIPTION
BZs for kube-apiserver, batch 1

preview: https://deploy-preview-36995--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-bug-fixes