### PR TITLE
TELCODOCS-269: D/S Docs & RN: MPINSTALL-6, Support Baremetal IPI clusters on hosts that have different provisioning NIC names

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -348,6 +348,11 @@ Cluster administrators can specify a custom HTTP error code response page for ei
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-customize-ingress-error-pages_configuring-ingress[Customizing HAProxy error code response pages].
 
+[id="ocp-4-9-nw-provisioningnetworkinterface-optional"]
+==== The provisioningNetworkInterface configuration setting is optional
+
+In {product-title} 4.9, the `provisioningNetworkInterface` configuration setting for installer-provisioned clusters is optional. The `provisioningNetworkInterface` configuration setting identifies the NIC name used for the `provisioning` network. In {product-title} 4.9, you can alternatively specify the `bootMACAddress` configuration setting in the `install-config.yml` file, which enables Ironic to identify the IP address for the NIC connected to the `provisioning` network and bind to it. You can also omit the `provisioningInterface` configuration setting in the provisioning custom resource so that the provisioning custom resource uses the `bootMACAddress` configuration setting instead.
+
 [id="ocp-4-9-storage"]
 === Storage
 


### PR DESCRIPTION
Release notes for [TELCODOCS-269](https://issues.redhat.com/browse/TELCODOCS-269)

Fixes: [TELCODOCS-269](https://issues.redhat.com/browse/TELCODOCS-269)

See https://issues.redhat.com/browse/TELCODOCS-269 for additional details.

Preview URL: https://deploy-preview-36996--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-nw-provisioningnetworkinterface-optional

For release(s): 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
