### PR TITLE
Adds RHCOS batch to 4.9 RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -943,6 +943,9 @@ The deprecated `dhclient` binary has been removed from {op-system}. Starting wit
 
 *RHCOS*
 
+* Previously, systemd was unable to read environment files in `/etc/kubernetes`. The SELinux policy caused this and as a result, the kubelet did not start. The policy has been modified. The kubelet starts and the environment files are read. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1969998[*BZ#1969998*])
+
+
 *Routing*
 
 *Samples*


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-36997--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-bug-fixes

RNs for 4.9. 