### PR TITLE
OSDOCS-2700: Fixed a typo in ROSA documentation and header.

### DIFF
--- a/modules/rosa-aws-scp.adoc
+++ b/modules/rosa-aws-scp.adoc
@@ -2,14 +2,14 @@
 //
 // * rosa_getting_started/rosa-aws-prereqs.adoc
 
-[id="rosa-minimum-spc_{context}"]
+[id="rosa-minimum-scp_{context}"]
 == Minimum required Service Control Policy (SCP)
 
 Service Control Policy (SCP) management is the responsibility of the customer. These policies are maintained in the AWS Organizations and control what services are available within the attached AWS accounts.
 
 [NOTE]
 ====
-The minimum SPC requirement does not apply when using AWS security token service (STS). For more information about STS, see link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html[AWS prerequisites for ROSA with STS].
+The minimum SCP requirement does not apply when using AWS security token service (STS). For more information about STS, see link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html[AWS prerequisites for ROSA with STS].
 ====
 
 [cols="2a,2a,2a,2a",options="header"]


### PR DESCRIPTION
Corrected a typo in an ID reference as well as a note. The typo was `SPC` but it needed to be `SCP`.

JIRA: https://issues.redhat.com/browse/OSDOCS-2700

Preview: https://deploy-preview-37002--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs?utm_source=github&utm_campaign=bot_dp#rosa-minimum-scp_prerequisites