### PR TITLE
GH#34106:Select document version dropdown only includes 3.x, 1.x versions and OKD Latest

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -9,18 +9,15 @@ openshift-origin:
     main:
       name: 4
       dir: latest
-    enterprise-3.2:
-      name: '1.2'
-      dir: '1.2'
-    enterprise-3.3:
-      name: '1.3'
-      dir: '1.3'
-    enterprise-3.4:
-      name: '1.4'
-      dir: '1.4'
-    enterprise-3.5:
-      name: '1.5'
-      dir: '1.5'
+    enterprise-4.6:
+      name: '4.6'
+      dir: '4.6'
+    enterprise-4.7:
+      name: '4.7'
+      dir: '4.7'
+    enterprise-4.8:
+      name: '4.8'
+      dir: '4.8'
     enterprise-3.6:
       name: '3.6'
       dir: '3.6'

--- a/index-community.html
+++ b/index-community.html
@@ -50,15 +50,14 @@
              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
              <ul class="dropdown-menu" role="menu">
                <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> OKD Latest</a></li>
+               <li><a href="4.8/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.8</a></li>
+               <li><a href="4.7/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.7</a></li>
+               <li><a href="4.6/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.6</a></li>
                <li><a href="3.11/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.11</a></li>
                <li><a href="3.10/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.10</a></li>
                <li><a href="3.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.9</a></li>
                <li><a href="3.7/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.7</a></li>
                <li><a href="3.6/"><i class="fa fa-arrow-circle-o-right"></i> OKD 3.6</a></li>
-               <li><a href="1.5/"><i class="fa fa-arrow-circle-o-right"></i> OKD 1.5</a></li>
-               <li><a href="1.4/"><i class="fa fa-arrow-circle-o-right"></i> OKD 1.4</a></li>
-               <li><a href="1.3/"><i class="fa fa-arrow-circle-o-right"></i> OKD 1.3</a></li>
-               <li><a href="1.2/"><i class="fa fa-arrow-circle-o-right"></i> OKD 1.2</a></li>
              </ul>
            </div>
          </div>


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/34106

At recent OKD Working Group Documentation Subgroup meetings, we discussed adding the OKD doc versions back for the 4.x docs on docs.okd.io and to remove some of the early 3.x versions.  