### PR TITLE
[enterprise-4.7] fixing a table

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -255,5 +255,6 @@ endif::openshift-origin[]
 |
 |
 |
+|
 
 |===


### PR DESCRIPTION
I found a busted table while working on https://github.com/openshift/openshift-docs/pull/37006.

4.6, 4.7

preview: https://deploy-preview-37007--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms