### PR TITLE
MIG-834: Update PVs in MigPlan CR

### DIFF
--- a/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
@@ -10,8 +10,8 @@ You can automate your migrations and modify the `MigPlan` and `MigrationControll
 
 include::modules/migration-terminology.adoc[leveloffset=+1]
 
-[id="migrating-your-applications-api_{context}"]
-== Migrating applications by using the CLI
+[id="migrating-applications-cli_{context}"]
+== Migrating applications by using the command line
 
 You can migrate applications with the {mtc-short} API by using the command line interface (CLI) in order to automate the migration.
 
@@ -19,22 +19,37 @@ include::modules/migration-prerequisites.adoc[leveloffset=+2]
 include::modules/migration-creating-registry-route-for-dim.adoc[leveloffset=+2]
 include::modules/migration-configuring-proxies.adoc[leveloffset=+2]
 include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
+include::modules/migration-state-migration-cli.adoc[leveloffset=+2]
 
-include::modules/migration-state-migration-cli.adoc[leveloffset=+1]
-include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
-include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
-include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
+[id="additional-resources-for-state-migration_{context}"]
+[discrete]
+=== Additional resources for state migration
+
+* See xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-excluding-pvcs_advanced-migration-options-3-4[Excluding PVCs from migration] to select PVCs for state migration.
+* See xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-mapping-pvcs_advanced-migration-options-3-4[Mapping PVCs] to migrate source PV data to provisioned PVCs on the destination cluster.
+* See xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-kubernetes-objects_advanced-migration-options-3-4[Migrating Kubernetes objects] to migrate the Kubernetes objects that constitute an application's state.
 
 include::modules/migration-hooks.adoc[leveloffset=+1]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
-[id="configuration-options_{context}"]
-== Configuration options
+[id="migration-plan-options_{context}"]
+== Migration plan options
 
-You can configure the following options for the `MigPlan` and `MigrationController` custom resources (CRs) to perform large-scale migrations and to improve performance.
+You can exclude, edit, and map components in the `MigPlan` custom resource (CR).
+
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+include::modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc[leveloffset=+2]
+include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
+include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
+include::modules/migration-editing-pvs-in-migplan.adoc[leveloffset=+2]
+include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
+
+[id="migration-controller-options_{context}"]
+== Migration controller options
+
+You can edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
 
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-enabling-pv-resizing-dvm.adoc[leveloffset=+2]
 include::modules/migration-enabling-cached-kubernetes-clients.adoc[leveloffset=+2]
 

--- a/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migrating-your-applications-api_advanced-migration-options-3-4[command line].
+You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migrating-applications-cli_advanced-migration-options-3-4[command line].
 
 You can use stage migration and cutover migration to migrate an application between clusters:
 

--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -11,8 +11,11 @@ This section describes resources for troubleshooting the {mtc-full} ({mtc-short}
 For known issues, see the xref:../migration_toolkit_for_containers/mtc-release-notes.adoc#mtc-release-notes[{mtc-short} release notes].
 
 include::modules/migration-mtc-workflow.adoc[leveloffset=+1]
+
+[discrete]
 include::modules/migration-about-mtc-custom-resources.adoc[leveloffset=+2]
-include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
+
+include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+1]
 
 [id="logs-and-debugging-tools_{context}"]
 == Logs and debugging tools

--- a/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
+++ b/migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
@@ -9,8 +9,8 @@ You can automate your migrations and modify the `MigPlan` and `MigrationControll
 
 include::modules/migration-terminology.adoc[leveloffset=+1]
 
-[id="migrating-your-applications-api_{context}"]
-== Migrating applications by using the CLI
+[id="migrating-applications-cli_{context}"]
+== Migrating applications by using the command line
 
 You can migrate applications with the {mtc-short} API by using the command line interface (CLI) in order to automate the migration.
 
@@ -18,22 +18,38 @@ include::modules/migration-prerequisites.adoc[leveloffset=+2]
 include::modules/migration-creating-registry-route-for-dim.adoc[leveloffset=+2]
 include::modules/migration-configuring-proxies.adoc[leveloffset=+2]
 include::modules/migration-migrating-applications-api.adoc[leveloffset=+2]
-include::modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc[leveloffset=+2]
+include::modules/migration-state-migration-cli.adoc[leveloffset=+2]
 
-include::modules/migration-state-migration-cli.adoc[leveloffset=+1]
-include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
-include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
-include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
+[id="additional-resources-for-state-migration_{context}"]
+[discrete]
+=== Additional resources for state migration
+
+* See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-excluding-pvcs_advanced-migration-options-mtc[Excluding PVCs from migration] to select PVCs for state migration.
+* See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-mapping-pvcs_advanced-migration-options-mtc[Mapping PVCs] to migrate source PV data to provisioned PVCs on the destination cluster.
+* See xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-kubernetes-objects_advanced-migration-options-mtc[Migrating Kubernetes objects] to migrate the Kubernetes objects that constitute an application's state.
 
 include::modules/migration-hooks.adoc[leveloffset=+1]
 include::modules/migration-writing-ansible-playbook-hook.adoc[leveloffset=+2]
 
-[id="configuration-options_{context}"]
-== Configuration options
+[id="migration-plan-options_{context}"]
+== Migration plan options
 
-You can configure the following options for the `MigPlan` and `MigrationController` custom resources (CRs) to perform large-scale migrations and to improve performance.
+You can exclude, edit, and map components in the `MigPlan` custom resource (CR).
+
+include::modules/migration-excluding-resources.adoc[leveloffset=+2]
+include::modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc[leveloffset=+2]
+include::modules/migration-excluding-pvcs.adoc[leveloffset=+2]
+include::modules/migration-mapping-pvcs.adoc[leveloffset=+2]
+include::modules/migration-editing-pvs-in-migplan.adoc[leveloffset=+2]
+include::modules/migration-kubernetes-objects.adoc[leveloffset=+2]
+
+[id="migration-controller-options_{context}"]
+== Migration controller options
+
+You can edit migration plan limits, enable persistent volume resizing, or enable cached Kubernetes clients in the `MigrationController` custom resource (CR) for large migrations and improved performance.
 
 include::modules/migration-changing-migration-plan-limits.adoc[leveloffset=+2]
-include::modules/migration-excluding-resources.adoc[leveloffset=+2]
 include::modules/migration-enabling-pv-resizing-dvm.adoc[leveloffset=+2]
 include::modules/migration-enabling-cached-kubernetes-clients.adoc[leveloffset=+2]
+
+:advanced-migration-options-mtc!:

--- a/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
+++ b/migration_toolkit_for_containers/migrating-applications-with-mtc.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or from the xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-migrating-applications-api_advanced-migration-options-mtc[command line].
+You can migrate your applications by using the {mtc-full} ({mtc-short}) web console or the xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migrating-applications-cli_advanced-migration-options-mtc[command line].
 
 Most cluster-scoped resources are not yet handled by {mtc-short}. If your applications require cluster-scoped resources, you might have to create them manually on the target cluster.
 

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -11,8 +11,11 @@ This section describes resources for troubleshooting the {mtc-full} ({mtc-short}
 For known issues, see the xref:../migration_toolkit_for_containers/mtc-release-notes.adoc#mtc-release-notes[{mtc-short} release notes].
 
 include::modules/migration-mtc-workflow.adoc[leveloffset=+1]
+
+[discrete]
 include::modules/migration-about-mtc-custom-resources.adoc[leveloffset=+2]
-include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+2]
+
+include::modules/migration-mtc-cr-manifests.adoc[leveloffset=+1]
 
 [id="logs-and-debugging-tools_{context}"]
 == Logs and debugging tools

--- a/modules/migration-editing-pvs-in-migplan.adoc
+++ b/modules/migration-editing-pvs-in-migplan.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
+// * migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
+
+[id="migration-editing-pvs-in-migplan_{context}"]
+= Editing persistent volume attributes
+
+You can edit the storage class and the access mode of persistent volumes (PVs) in the `MigPlan` custom resource (CR) after the PVs have been discovered by the `MigrationController` CR.
+
+.Prerequisites
+
+* `MigPlan` CR is in a `Ready` state.
+
+.Procedure
+
+* Edit the values of `spec.persistentVolumes.selection.storageClass` and `spec.persistentVolumes.selection.accessMode` in the `MigPlan` CR:
++
+[source,yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigPlan
+metadata:
+  name: <migplan>
+  namespace: openshift-migration
+spec:
+  persistentVolumes:
+  - capacity: 10Gi
+    name: pvc-095a6559-b27f-11eb-b27f-021bddcaf6e4
+    proposedCapacity: 10Gi
+    pvc:
+      accessModes:
+      - ReadWriteMany
+      hasReference: true
+      name: mysql
+      namespace: mysql-persistent
+    selection:
+      action: copy
+      copyMethod: filesystem
+      storageClass: cephrbd <1>
+      accessMode: ReadWriteMany <2>
+    storageClass: cephfs
+----
+<1> Destination storage class.
+<2> Destination access mode.

--- a/modules/migration-excluding-pvcs.adoc
+++ b/modules/migration-excluding-pvcs.adoc
@@ -10,7 +10,7 @@ You select persistent volume claims (PVCs) for state migration by excluding the 
 
 .Prerequisites
 
-* `MigPlan` CR with discovered PVs.
+* `MigPlan` CR is in a `Ready` state.
 
 .Procedure
 

--- a/modules/migration-excluding-resources.adoc
+++ b/modules/migration-excluding-resources.adoc
@@ -4,7 +4,7 @@
 // * migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
 
 [id="migration-excluding-resources_{context}"]
-= Excluding resources from a migration plan
+= Excluding resources
 
 You can exclude resources, for example, image streams, persistent volumes (PVs), or subscriptions, from a {mtc-full} ({mtc-short}) migration plan to reduce the resource load for migration or to migrate images or PVs with a different tool.
 

--- a/modules/migration-kubernetes-objects.adoc
+++ b/modules/migration-kubernetes-objects.adoc
@@ -31,15 +31,15 @@ metadata:
   name: <migplan>
   namespace: openshift-migration
 spec:
-  includedResources: <1>
-  - kind: <Secret>
+  includedResources:
+  - kind: <kind> <1>
     group: ""
-  - kind: <ConfigMap>
+  - kind: <kind>
     group: ""
 ...
   labelSelector:
     matchLabels:
-      <app: frontend> <2>
+      <label> <2>
 ----
-<1> Specify the `kind` and `group` of each resource.
-<2> Specify the label of the resources to migrate.
+<1> Specify the Kubernetes object, for example, `Secret` or `ConfigMap`.
+<2> Specify the label of the resources to migrate, for example, `app: frontend`.

--- a/modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc
+++ b/modules/migration-mapping-destination-namespaces-in-the-migplan-cr.adoc
@@ -3,9 +3,9 @@
 // * migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc
 
 [id="migration-mapping-destination-namespaces-in-the-migplan-cr_{context}"]
-= Mapping destination namespaces in the MigPlan custom resource
+= Mapping namespaces
 
-If you map destination namespaces in the `MigPlan` custom resource (CR), you must ensure that the namespaces are not duplicated on the source or the destination clusters because the UID and GID ranges of the namespaces are copied during migration.
+If you map namespaces in the `MigPlan` custom resource (CR), you must ensure that the namespaces are not duplicated on the source or the destination clusters because the UID and GID ranges of the namespaces are copied during migration.
 
 .Two source namespaces mapped to the same destination namespace
 [source,yaml]

--- a/modules/migration-mapping-pvcs.adoc
+++ b/modules/migration-mapping-pvcs.adoc
@@ -6,13 +6,13 @@
 [id="migration-mapping-pvcs_{context}"]
 = Mapping persistent volume claims
 
-You can migrate PV data from the source cluster to PVCs that are already provisioned in the target cluster by mapping PVCs in the `MigPlan` CR. This ensures that the target PVCs of migrated applications are synchronized with the source PVCs.
+You can migrate persistent volume (PV) data from the source cluster to persistent volume claims (PVCs) that are already provisioned in the destination cluster in the `MigPlan` CR by mapping the PVCs. This mapping ensures that the destination PVCs of migrated applications are synchronized with the source PVCs.
 
-You map persistent volume claims (PVCs) by updating the `spec.persistentVolumes.pvc.name` parameter in the `MigPlan` custom resource (CR) after the persistent volumes (PVs) have been discovered.
+You map PVCs by updating the `spec.persistentVolumes.pvc.name` parameter in the `MigPlan` custom resource (CR) after the PVs have been discovered.
 
 .Prerequisites
 
-* `MigPlan` CR with discovered PVs.
+* `MigPlan` CR is in a `Ready` state.
 
 .Procedure
 

--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -4,7 +4,7 @@
 // * migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
 
 [id="migration-migrating-applications-api_{context}"]
-= Migrating an application from the command line
+= Migrating an application by using the {mtc-short} API
 
 You can migrate an application from the command line by using the {mtc-full} ({mtc-short}) API.
 

--- a/modules/migration-state-migration-cli.adoc
+++ b/modules/migration-state-migration-cli.adoc
@@ -6,7 +6,7 @@
 [id="migration-state-migration-cli_{context}"]
 = State migration
 
-You can perform repeatable, state-only migrations by using {mtc-full} ({mtc-short}) to migrate persistent volume claims (PVCs) that constitute an application's state. Persistent volume (PV) data is copied to the target cluster. The PV references are not moved. The application pods continue to run on the source cluster.
+You can perform repeatable, state-only migrations by using {mtc-full} ({mtc-short}) to migrate persistent volume claims (PVCs) that constitute an application's state. You migrate specified PVCs by excluding other PVCs from the migration plan. Persistent volume (PV) data is copied to the target cluster. The PV references are not moved. The application pods continue to run on the source cluster. You can map the PVCs to ensure that the source and target PVCs are synchronized.
 
 You can perform a one-time migration of Kubernetes objects that constitute an application's state.
 

--- a/modules/migration-terminology.adoc
+++ b/modules/migration-terminology.adoc
@@ -6,7 +6,7 @@
 // * migration_toolkit_for_containers/advanced-migration-options-mtc.adoc
 
 [id="migration-terminology_{context}"]
-= {mtc-short} terminology
+= Terminology
 
 [cols="1,3a", options="header"]
 .{mtc-short} terminology


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-834

Added module for editing PVs in MigPlan. 
Reorganized the topics in the Advanced migration options assembly.
Changed the header level of the MTC CR manifests in "Troubleshooting" so that the CRs show up in the TOC.

4.6+

Previews:
Editing PVs in MigPlan: https://deploy-preview-37010--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html#migration-editing-pvs-in-migplan_advanced-migration-options-3-4

Advanced migration options:  https://deploy-preview-37010--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html

Troubleshooting: https://deploy-preview-37010--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/troubleshooting-3-4.html

QE approved. Ready for peer review.