### PR TITLE
RHDEVDOCS-2911 - Uninstall GitOps operator

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1491,6 +1491,8 @@ Topics:
     File: understanding-openshift-gitops
   - Name: Installing OpenShift GitOps
     File: installing-openshift-gitops
+  - Name: Uninstalling OpenShift GitOps
+    File: uninstalling-openshift-gitops
   - Name: Configuring Argo CD to recursively sync a Git repository with your application
     Dir: configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application
     Topics:

--- a/cicd/gitops/uninstalling-openshift-gitops.adoc
+++ b/cicd/gitops/uninstalling-openshift-gitops.adoc
@@ -1,0 +1,22 @@
+[id="uninstalling-openshift-gitops"]
+= Uninstalling OpenShift GitOps
+include::modules/common-attributes.adoc[]
+include::modules/gitops-document-attributes.adoc[]
+:context: uninstalling-openshift-gitops
+
+toc::[]
+
+Uninstalling the GitOps Operator is a two-step process:
+
+. Delete the Argo CD instances that were added under the default namespace of the GitOps Operator.
+. Uninstall the GitOps Operator.
+
+Uninstalling only the Operator will not remove the Argo CD instances created.
+
+include::modules/go-deleting-argocd-instance.adoc[leveloffset=+1]
+
+include::modules/go-uninstalling-gitops-operator.adoc[leveloffset=+1]
+
+.Additional Resources
+
+* You can learn more about uninstalling Operators on {product-title} in the xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster] section.

--- a/modules/go-deleting-argocd-instance.adoc
+++ b/modules/go-deleting-argocd-instance.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// */gitops/uninstalling-openshift-gitops.adoc
+
+[id='go-deleting-argocd-instance_{context}']
+= Deleting the Argo CD instances
+
+Delete the Argo CD instances added to the namespace of the GitOps Operator.
+
+[discrete]
+.Procedure
+. In the *Terminal* type the following command:
+
+[source,terminal]
+----
+$ oc delete gitopsservice cluster -n openshift-gitops
+----
+
+[NOTE]
+====
+You cannot delete an Argo CD cluster from the web console UI.
+====
+
+After the command runs successfully all the Argo CD instances will be deleted from the `openshift-gitops` namespace.
+
+Delete any other Argo CD instances from other namespaces using the same command:
+
+[source,terminal]
+----
+$ oc delete gitopsservice cluster -n <namespace>
+----

--- a/modules/go-uninstalling-gitops-operator.adoc
+++ b/modules/go-uninstalling-gitops-operator.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// */gitops/uninstalling-openshift-gitops.adoc
+
+[id='go-uninstalling-gitops-operator_{context}']
+= Uninstalling the GitOps Operator
+
+[discrete]
+.Procedure
+. From the *Operators* -> *OperatorHub* page, use the *Filter by keyword* box to search for `{gitops-title} Operator` tile.
+
+. Click the *Red Hat OpenShift GitOps Operator* tile. The Operator tile indicates it is installed.
+
+. In the *Red Hat OpenShift GitOps Operator* descriptor page, click *Uninstall*.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.8`, `enterprise-4.9`
- **JIRA issues**: [RHDEVDOCS-2911 Uninstall-GitOps-Operator](https://issues.redhat.com/browse/RHDEVDOCS-2911)
- **Preview pages**: https://deploy-preview-37012--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/uninstalling-openshift-gitops?utm_source=github&utm_campaign=bot_dp
- **SME+QE review**: Regina Scott
- **Peer-review**: Preeti