### PR TITLE
BZ-2006797: updated yaml file with correct details

### DIFF
--- a/modules/sandboxed-containers-installing-operator-cli.adoc
+++ b/modules/sandboxed-containers-installing-operator-cli.adoc
@@ -37,7 +37,7 @@ metadata:
   namespace: openshift-sandboxed-containers-operator
 spec:
   targetNamespaces:
-    - openshift-sandboxed-containers
+    - openshift-sandboxed-containers-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -47,8 +47,8 @@ metadata:
 spec:
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  name: sandboxed-containers-kataconfig
-  startingCSV: openshift-sandboxed-containers-kataconfig.v1.0.0
+  name: sandboxed-containers-operator
+  startingCSV: sandboxed-containers-operator.v1.0.0
   channel: "preview-1.0"
   approval: "Automatic"
 ----


### PR DESCRIPTION
[Bugzilla 2006797](https://bugzilla.redhat.com/show_bug.cgi?id=2006797) update for OpenShift Docs 4.8:

Preview link: https://deploy-preview-37013--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-installing-operator-cli_deploying-sandboxed-containers

Review and approved by QE.