### PR TITLE
removed ref to aws

### DIFF
--- a/modules/dynamic-provisioning-change-default-class.adoc
+++ b/modules/dynamic-provisioning-change-default-class.adoc
@@ -8,10 +8,8 @@
 [id="change-default-storage-class_{context}"]
 = Changing the default storage class
 
-If you are using AWS, use the following process to change the default
-storage class. This process assumes you have two storage classes
-defined, `gp2` and `standard`, and you want to change the default
-storage class from `gp2` to `standard`.
+Use the following process to change the default storage class.
+For example you have two defined storage classes, `gp2` and `standard`, and you want to change the default storage class from `gp2` to `standard`.
 
 . List the storage class:
 +
@@ -29,17 +27,14 @@ standard             kubernetes.io/aws-ebs
 ----
 <1> `(default)` denotes the default storage class.
 
-. Change the value of the annotation
-`storageclass.kubernetes.io/is-default-class` to `false` for the default
-storage class:
+. Change the value of the `storageclass.kubernetes.io/is-default-class` annotation to `false` for the default storage class:
 +
 [source,terminal]
 ----
 $ oc patch storageclass gp2 -p '{"metadata": {"annotations": {"storageclass.kubernetes.io/is-default-class": "false"}}}'
 ----
 
-. Make another storage class the default by adding or modifying the
-annotation as `storageclass.kubernetes.io/is-default-class=true`.
+. Make another storage class the default by setting the `storageclass.kubernetes.io/is-default-class` annotation to `true`:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[https://bugzilla.redhat.com/show_bug.cgi?id=2007552](url)

Changing the default storage class is not specific to AWS and is a generic process. Also mentioned that the storage classes are examples for illustrative purposes.

OCP V4.8+
Preview:
https://deploy-preview-37014--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/storage-configuration.html#change-default-storage-class_post-install-storage-configuration

@david juran @ropatil010  Please review and provide your feedback
