### PR TITLE
TELCODOCS-260: Adding back PTP Tech Preview notice

### DIFF
--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -5,6 +5,9 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+:FeatureName: Precision Time Protocol (PTP) hardware
+include::modules/technology-preview.adoc[leveloffset=+1]
+
 [id="about-using-ptp-hardware"]
 == About PTP hardware
 


### PR DESCRIPTION
main, enterprise-4.9 update for PTP for the following doc epics:

https://issues.redhat.com/browse/TELCODOCS-260
https://issues.redhat.com/browse/TELCODOCS-262

PTP Tech Preview notice was removed in error. PTP is still Tech Preview for 4.9