### PR TITLE
BZ2005187: add CSR authentication steps in the "Restoring to a previous cluster state" procedure

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -145,6 +145,50 @@ static-pod-resources/kube-scheduler-pod-8/kube-scheduler-pod.yaml
 
 .. Repeat this step on all other control plane hosts.
 
+. Approve the pending CSRs:
+
+.. Get the list of current CSRs:
++
+[source,terminal]
+----
+$ oc get csr
+----
++
+.Example output
+----
+NAME        AGE    SIGNERNAME                                    REQUESTOR                                                                   CONDITION
+csr-2s94x   8m3s   kubernetes.io/kubelet-serving                 system:node:<node_name>                                                     Pending <1>
+csr-4bd6t   8m3s   kubernetes.io/kubelet-serving                 system:node:<node_name>                                                     Pending <1>
+csr-4hl85   13m    kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending <2>
+csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-operator:node-bootstrapper   Pending <2>
+...
+----
+<1> A pending kubelet service CSR (for user-provisioned installations).
+<2> A pending `node-bootstrapper` CSR.
++
+.. Review the details of a CSR to verify that it is valid:
++
+[source,terminal]
+----
+$ oc describe csr <csr_name> <1>
+----
+<1> `<csr_name>` is the name of a CSR from the list of current CSRs.
+
+.. Approve each valid `node-bootstrapper` CSR:
++
+[source,terminal]
+----
+$ oc adm certificate approve <csr_name>
+----
+
+.. For user-provisioned installations, approve each valid kubelet service CSR:
++
+[source,terminal]
+----
+$ oc adm certificate approve <csr_name>
+----
+
+
 . Verify that the single member control plane has started successfully.
 
 .. From the recovery host, verify that the etcd container is running.


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=2005187

View the doc at [Preview](https://deploy-preview-37019--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

Requires QE ack from @jianzhangbjz 