### PR TITLE
Fixing image syntax so that it works on the portal

### DIFF
--- a/modules/op-viewing-pipeline-logs-in-kibana.adoc
+++ b/modules/op-viewing-pipeline-logs-in-kibana.adoc
@@ -49,7 +49,7 @@ To view pipeline logs in the Kibana web console:
 ... Filter all containers that are not `place-tools` container. As an illustration of using the graphical drop-down menus instead of editing the query DSL, consider the following approach:
 +
 .Example of filtering using the drop-down fields
-image::../../images/not-placetools.png[Not place-tools]
+image::not-placetools.png[Not place-tools]
 +
 ... Filter `pipelinerun` in labels for highlighting:
 +
@@ -94,4 +94,4 @@ Ensure that the selected fields are displayed under the *Selected fields* list.
 .. The logs are displayed under the *message* field.
 +
 .Filtered messages
-image::../../images/filtered-messages.png[Filtered messages]
+image::filtered-messages.png[Filtered messages]


### PR DESCRIPTION
The CI/CD book on the portal is failing, and I believe it's due to the image syntax here. Even though the image renders fine on docs.openshift.com.

Hoping this fix will fix the portal book.

Preview: https://deploy-preview-37024--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/viewing-pipeline-logs-using-the-openshift-logging-operator.html#op-viewing-pipeline-logs-in-kibana_viewing-pipeline-logs-using-the-openshift-logging-operator