### PR TITLE
Added "limit" to the definition of max resource constraint for containers

### DIFF
--- a/modules/nodes-cluster-limit-ranges-limits.adoc
+++ b/modules/nodes-cluster-limit-ranges-limits.adoc
@@ -20,7 +20,7 @@ the container CPU and memory requests in the `Pod` spec must comply with the val
 * The container CPU or memory request and limit must be greater than or equal to the
 `min` resource constraint for containers that are specified in the `LimitRange` object.
 
-* The container CPU or memory request must be less than or equal to the
+* The container CPU or memory request and limit must be less than or equal to the
 `max` resource constraint for containers that are specified in the `LimitRange` object.
 +
 If the `LimitRange` object defines a `max` CPU, you do not need to define a CPU
@@ -88,7 +88,7 @@ spec:
 A limit range allows you to specify the minimum and maximum CPU and memory limits for all containers
 across a pod in a given project. To create a container in the project, the container CPU and memory
 requests in the `Pod` spec must comply with the values set in the `LimitRange` object. If not,
-the pod does not get created. 
+the pod does not get created.
 
 If the `Pod` spec does not specify a container resource memory or limit,
 the `default` or `defaultRequest` CPU and memory values for containers


### PR DESCRIPTION
[https://bugzilla.redhat.com/show_bug.cgi?id=1959689](url)

Added ` limit` word to the definition of `max` resource constraint.

OCP 4.6+
Preview:
https://deploy-preview-37027--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges?utm_source=github&utm_campaign=bot_dp

@wabouhamad please ack.
