### PR TITLE
BZ:1958931 - Replacing instances of scp with sftp

### DIFF
--- a/modules/installation-ibm-z-troubleshooting-and-debugging.adoc
+++ b/modules/installation-ibm-z-troubleshooting-and-debugging.adoc
@@ -40,4 +40,4 @@ $ toolbox
 $ dbginfo.sh
 ----
 
-. You can then retrieve the data, for example, using `scp`.
+. You can then retrieve the data, for example, using `sftp`.

--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -141,7 +141,7 @@ Copy the pull secret file from the provisioner node to the registry node and mod
 +
 [source,terminal]
 ----
-$ scp kni@provisioner:/home/kni/pull-secret.txt pull-secret.txt
+$ sftp kni@provisioner:/home/kni/pull-secret.txt pull-secret.txt
 ----
 
 . Update the `host_fqdn` environment variable with the fully qualified domain name of the registry node.
@@ -182,7 +182,7 @@ $ jq ".auths += $AUTHSTRING" < pull-secret.txt > pull-secret-update.txt
 +
 [source,terminal]
 ----
-$ sudo scp kni@provisioner:/usr/local/bin/oc /usr/local/bin
+$ sudo sftp kni@provisioner:/usr/local/bin/oc /usr/local/bin
 ----
 
 . Mirror the remote install images to the local repository.

--- a/modules/ldap-failover-generate-certs.adoc
+++ b/modules/ldap-failover-generate-certs.adoc
@@ -54,12 +54,12 @@ remote basic authentication server, the HTTPS connection will fail.
 . Copy the necessary certificates and key to the remote basic authentication server:
 +
 ----
-# scp /etc/origin/master/ca.crt \
+# sftp /etc/origin/master/ca.crt \
       root@remote-basic.example.com:/etc/pki/CA/certs/
 
-# scp /etc/origin/remote-basic/remote-basic.example.com.crt \
+# sftp /etc/origin/remote-basic/remote-basic.example.com.crt \
       root@remote-basic.example.com:/etc/pki/tls/certs/
 
-# scp /etc/origin/remote-basic/remote-basic.example.com.key \
+# sftp /etc/origin/remote-basic/remote-basic.example.com.key \
       root@remote-basic.example.com:/etc/pki/tls/private/
 ----


### PR DESCRIPTION
For versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1958931 [BZ#1958931]

Description: Reporter mentions that we should teach our users to use sftp instead of scp, so I replaced the instances of scp with sftp. 

Preview: There were 6 instances of scp I found in our docs, if you know of any others please lmk. 
1 & 2: https://deploy-preview-37043--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html
The others are in the 


Ready for QA: @xltian 

For Peer reviewers: Labels needed  'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' and 'Peer Review needed'. Thank you!!