### PR TITLE
CNV11177: Adding new comment to original CNV11177 PR for virtctl guestfs command

### DIFF
--- a/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
+++ b/modules/virt-about-libguestfs-tools-virtctl-guestfs.adoc
@@ -68,7 +68,7 @@ If not set, the `libguestfs-tools` pod remains pending because it cannot be sche
 You can also overwrite the image's pull policy by setting the `pull-policy` option.
 |===
 
-The command also checks if a PVC is used by another pod and fails if the PVC is used by another pod. However, once the `libguestfs-tools` process starts, the setup cannot avoid a new pod using the same PVC. You must verify that there are no active `virtctl guestfs` pods before starting the VM that accesses the same PVC.
+The command also checks if a PVC is in use by another pod, in which case an error message appears. However, once the `libguestfs-tools` process starts, the setup cannot avoid a new pod using the same PVC. You must verify that there are no active `virtctl guestfs` pods before starting the VM that accesses the same PVC.
 
 [NOTE]
 =====


### PR DESCRIPTION
A new comment was left for the original CNV11177 story (https://issues.redhat.com/browse/CNV-11177) and its associated PR (https://github.com/openshift/openshift-docs/pull/35825) was merged, asking for a minor wording change.

This PR addresses that minor wording change.

CP: 4.9

Preview: Sentence starting with "The command also checks if" at https://deploy-preview-37047--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-using-the-cli-tools.html#virt-about-libguestfs-tools-virtctl-guestfs_virt-using-the-cli-tools