### PR TITLE
[enterprise-4.8] BZ2004502: Removed cnv-tuning info

### DIFF
--- a/modules/virt-creating-bridge-nad-cli.adoc
+++ b/modules/virt-creating-bridge-nad-cli.adoc
@@ -29,16 +29,9 @@ spec:
   config: '{
     "cniVersion": "0.3.1",
     "name": "<a-bridge-network>", <3>
-    "plugins": [
-      {
-        "type": "cnv-bridge", <4>
-        "bridge": "<bridge-interface>", <5>
-        "vlan": 1 <6>
-      },
-      {
-        "type": "cnv-tuning" <7>
-      }
-    ]
+    "type": "cnv-bridge", <4>
+    "bridge": "<bridge-interface>", <5>
+    "vlan": 1 <6>
   }'
 ----
 <1> The name for the `NetworkAttachmentDefinition` object.
@@ -47,9 +40,8 @@ spec:
 <4> The actual name of the Container Network Interface (CNI) plug-in that provides the network for this network attachment definition. Do not change this field unless you want to use a different CNI.
 <5> The name of the Linux bridge configured on the node.
 <6> Optional: The VLAN tag.
-<7> The CNI plug-in that allows the MAC pool manager to assign a unique MAC address to the connection.
 
-. Create the network attachment definition: 
+. Create the network attachment definition:
 +
 [source,terminal]
 ----
@@ -66,4 +58,3 @@ $ oc create -f <network-attachment-definition.yaml> <1>
 $ oc get network-attachment-definition <a-bridge-network> <1>
 ----
 <1> Where `<a-bridge-network>` is the name specified in the network attachment definition config.
-


### PR DESCRIPTION
This is a manual cherry-pick of commit ac72507d19eae879be8449d0d3954dc5bf9d2867 from https://github.com/openshift/openshift-docs/pull/36622