### PR TITLE
Remove WINC info that is now covered in new prereqs module

### DIFF
--- a/windows_containers/understanding-windows-container-workloads.adoc
+++ b/windows_containers/understanding-windows-container-workloads.adoc
@@ -7,18 +7,6 @@ toc::[]
 
 Windows Container Support for Red Hat OpenShift provides built-in support for running Microsoft Windows Server containers on {product-title}. For those that administer heterogeneous environments with a mix of Linux and Windows workloads, {product-title} allows you to deploy Windows workloads running on Windows Server containers while also providing traditional Linux workloads hosted on {op-system-first} or {op-system-base-full}.
 
-Windows container workloads are supported for clusters running on the following cloud providers:
-
-* Amazon Web Services (AWS)
-* Microsoft Azure
-* VMware vSphere
-
-The following Windows Server operating systems are supported for {product-title} {product-version}:
-
-* Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019
-
-For more information, see Microsoft's documentation on link:https://docs.microsoft.com/en-us/windows-server/get-started/editions-comparison-windows-server-2019[Windows Server channels].
-
 [NOTE]
 ====
 Multi-tenancy for clusters that have Windows nodes is not supported. Hostile multi-tenant usage introduces security concerns in all Kubernetes environments. Additional security features like link:https://kubernetes.io/docs/concepts/policy/pod-security-policy/[pod security policies], or more fine-grained role-based access control (RBAC) for nodes, make exploits more difficult. However, if you choose to run hostile multi-tenant workloads, a hypervisor is the only security option you should use. The security domain for Kubernetes encompasses the entire cluster, not an individual node. For these types of hostile multi-tenant workloads, you should use physically isolated clusters.


### PR DESCRIPTION
Follow-up to #33599

Content is now covered in new [prereqs](https://github.com/openshift/openshift-docs/blob/main/modules/wmco-prerequisites.adoc) module.

Preview: https://deploy-preview-37058--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/understanding-windows-container-workloads?utm_source=github&utm_campaign=bot_dp