### PR TITLE
BZ#1881453: Document unused namespace for Manila CSI driver operator after upgrading from 4.5 to 4.6

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -775,7 +775,7 @@ For AWS EBS and oVirt, this feature installs the CSI Driver Operator and driver 
 If you installed a CSI Driver Operator and driver on an {product-title} 4.5 cluster:
 
 * The AWS EBS CSI Driver Operator and driver must be uninstalled before you update to a newer version of {product-title}.
-* The OpenStack Manila CSI Driver Operator is no longer available in Operator Lifecycle Manager (OLM). It has been automatically converted by the Cluster Version Operator.
+* The OpenStack Manila CSI Driver Operator is no longer available in Operator Lifecycle Manager (OLM). It has been automatically converted by the Cluster Version Operator. The original `openshift-manila-csi-driver-operator` namespace might still exist and can be deleted manually by a cluster administrator.
 ====
 
 [id="ocp-4-6-lso-automation"]


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1881453

OCP Version: 4.6

Current 4.6 doc: https://docs.openshift.com/container-platform/4.6/release_notes/ocp-4-6-release-notes.html#ocp-4-6-csi-driver-cso

Direct doc preview link: https://deploy-preview-37066--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-csi-driver-cso