### PR TITLE
[enterprise-4.6] Fix invalid YAML that cannot be parsed

### DIFF
--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -121,8 +121,8 @@ spec:
       httpGet: <8>
         path: /healthz
         port: 8080 <9>
-   failureThreshold: 30 <10>
-   periodSeconds: 10 <11>
+      failureThreshold: 30 <10>
+      periodSeconds: 10 <11>
 ...
 ----
 

--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -29,7 +29,7 @@ $ oc describe nodes <node_name>
 ----
 +
 .Sample output
-[source,yaml]
+[source,text]
 ----
 oc describe node ci-ln-iyhx092-f76d1-nvdfm-worker-b-wln2l
 Name:               ci-ln-iyhx092-f76d1-nvdfm-worker-b-wln2l
@@ -64,7 +64,7 @@ If a descheduler is used, pods violating node taints could be evicted from the c
 
 . Add tolerations for the pod configurations you want to schedule on the infra node, like router, registry, and monitoring workloads. Add the following code to the `Pod` object specification:
 +
-[source, yaml]
+[source,yaml]
 ----
 tolerations: 
   - effect: NoSchedule <1>

--- a/modules/builds-automatically-add-source-clone-secrets.adoc
+++ b/modules/builds-automatically-add-source-clone-secrets.adoc
@@ -49,7 +49,7 @@ metadata:
     build.openshift.io/source-secret-match-uri-1: https://*.mycorp.com/*
 data:
   ...
-
+---
 kind: Secret
 apiVersion: v1
 metadata:

--- a/modules/cluster-logging-clo-status.adoc
+++ b/modules/cluster-logging-clo-status.adoc
@@ -155,7 +155,7 @@ A status message similar to the following indicates a node has exceeded the conf
 A status message similar to the following indicates the Elasticsearch node selector in the CR does not match any nodes in the cluster:
 
 .Example output
-[source,yaml]
+[source,text]
 ----
     Elasticsearch Status:
       Shard Allocation Enabled:  shard allocation unknown
@@ -203,7 +203,7 @@ A status message similar to the following indicates the Elasticsearch node selec
 A status message similar to the following indicates that the requested PVC could not bind to PV:
 
 .Example output
-[source,yaml]
+[source,text]
 ----
       Node Conditions:
         elasticsearch-cdm-mkkdys93-1:

--- a/modules/cluster-logging-elasticsearch-storage.adoc
+++ b/modules/cluster-logging-elasticsearch-storage.adoc
@@ -29,17 +29,15 @@ apiVersion: "logging.openshift.io/v1"
 kind: "ClusterLogging"
 metadata:
   name: "instance"
-
-....
-
- spec:
-    logStore:
-      type: "elasticsearch"
-      elasticsearch:
-        nodeCount: 3
-        storage:
-          storageClassName: "gp2"
-          size: "200G"
+# ...
+spec:
+  logStore:
+    type: "elasticsearch"
+    elasticsearch:
+      nodeCount: 3
+      storage:
+        storageClassName: "gp2"
+        size: "200G"
 ----
 
 This example specifies each data node in the cluster is bound to a Persistent Volume Claim that requests "200G" of AWS General Purpose SSD (gp2) storage.

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -56,7 +56,7 @@ spec:
   realTimeKernel:
     enabled: true
   nodeSelector:
-   node-role.kubernetes.io/worker-rt: ""
+    node-role.kubernetes.io/worker-rt: ""
 ----
 
 . Verify that a matching machine config pool exists with a label:

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -65,7 +65,7 @@ The individual items of the list:
 - machineConfigLabels: <1>
     <mcLabels> <2>
   match: <3>
-  <match> <4>
+    <match> <4>
   priority: <priority> <5>
   profile: <tuned_profile_name> <6>
 ----
@@ -83,7 +83,7 @@ The individual items of the list:
 - label: <label_name> <1>
   value: <label_value> <2>
   type: <label_type> <3>
-  <match> <4>
+    <match> <4>
 ----
 <1> Node or pod label name.
 <2> Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.

--- a/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
+++ b/modules/how-to-plan-your-environment-according-to-application-requirements.adoc
@@ -82,90 +82,90 @@ links in the deployment's service specification file to overcome this:
 
 [source,yaml]
 ----
- ---
-    Kind: Template
-    apiVersion: v1
-    metadata:
-      name: deploymentConfigTemplate
-      creationTimestamp:
-      annotations:
-        description: This template will create a deploymentConfig with 1 replica, 4 env vars and a service.
-        tags: ''
-    objects:
-    - kind: DeploymentConfig
-      apiVersion: v1
+---
+apiVersion: v1
+kind: Template
+metadata:
+  name: deployment-config-template
+  creationTimestamp:
+  annotations:
+    description: This template will create a deploymentConfig with 1 replica, 4 env vars and a service.
+    tags: ''
+objects:
+- apiVersion: v1
+  kind: DeploymentConfig
+  metadata:
+    name: deploymentconfig${IDENTIFIER}
+  spec:
+    template:
       metadata:
-        name: deploymentconfig${IDENTIFIER}
-      spec:
-        template:
-          metadata:
-            labels:
-              name: replicationcontroller${IDENTIFIER}
-          spec:
-            enableServiceLinks: false
-            containers:
-            - name: pause${IDENTIFIER}
-              image: "${IMAGE}"
-              ports:
-              - containerPort: 8080
-                protocol: TCP
-              env:
-              - name: ENVVAR1_${IDENTIFIER}
-                value: "${ENV_VALUE}"
-              - name: ENVVAR2_${IDENTIFIER}
-                value: "${ENV_VALUE}"
-              - name: ENVVAR3_${IDENTIFIER}
-                value: "${ENV_VALUE}"
-              - name: ENVVAR4_${IDENTIFIER}
-                value: "${ENV_VALUE}"
-              resources: {}
-              imagePullPolicy: IfNotPresent
-              capabilities: {}
-              securityContext:
-                capabilities: {}
-                privileged: false
-            restartPolicy: Always
-            serviceAccount: ''
-        replicas: 1
-        selector:
+        labels:
           name: replicationcontroller${IDENTIFIER}
-        triggers:
-        - type: ConfigChange
-        strategy:
-          type: Rolling
-    - kind: Service
-      apiVersion: v1
-      metadata:
-        name: service${IDENTIFIER}
       spec:
-        selector:
-          name: replicationcontroller${IDENTIFIER}
-        ports:
-        - name: serviceport${IDENTIFIER}
-          protocol: TCP
-          port: 80
-          targetPort: 8080
-        portalIP: ''
-        type: ClusterIP
-        sessionAffinity: None
-      status:
-        loadBalancer: {}
-    parameters:
-    - name: IDENTIFIER
-      description: Number to append to the name of resources
-      value: '1'
-      required: true
-    - name: IMAGE
-      description: Image to use for deploymentConfig
-      value: gcr.io/google-containers/pause-amd64:3.0
-      required: false
-    - name: ENV_VALUE
-      description: Value to use for environment variables
-      generate: expression
-      from: "[A-Za-z0-9]{255}"
-      required: false
-    labels:
-      template: deploymentConfigTemplate
+        enableServiceLinks: false
+        containers:
+        - name: pause${IDENTIFIER}
+          image: "${IMAGE}"
+          ports:
+          - containerPort: 8080
+            protocol: TCP
+          env:
+          - name: ENVVAR1_${IDENTIFIER}
+            value: "${ENV_VALUE}"
+          - name: ENVVAR2_${IDENTIFIER}
+            value: "${ENV_VALUE}"
+          - name: ENVVAR3_${IDENTIFIER}
+            value: "${ENV_VALUE}"
+          - name: ENVVAR4_${IDENTIFIER}
+            value: "${ENV_VALUE}"
+          resources: {}
+          imagePullPolicy: IfNotPresent
+          capabilities: {}
+          securityContext:
+            capabilities: {}
+            privileged: false
+        restartPolicy: Always
+        serviceAccount: ''
+    replicas: 1
+    selector:
+      name: replicationcontroller${IDENTIFIER}
+    triggers:
+    - type: ConfigChange
+    strategy:
+      type: Rolling
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: service${IDENTIFIER}
+  spec:
+    selector:
+      name: replicationcontroller${IDENTIFIER}
+    ports:
+    - name: serviceport${IDENTIFIER}
+      protocol: TCP
+      port: 80
+      targetPort: 8080
+    portalIP: ''
+    type: ClusterIP
+    sessionAffinity: None
+  status:
+    loadBalancer: {}
+parameters:
+- name: IDENTIFIER
+  description: Number to append to the name of resources
+  value: '1'
+  required: true
+- name: IMAGE
+  description: Image to use for deploymentConfig
+  value: gcr.io/google-containers/pause-amd64:3.0
+  required: false
+- name: ENV_VALUE
+  description: Value to use for environment variables
+  generate: expression
+  from: "[A-Za-z0-9]{255}"
+  required: false
+labels:
+  template: deployment-config-template
 ----
 
 The number of application pods that can run in a namespace is dependent on the number of services and the

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -61,7 +61,7 @@ spec:
             - label: var
               sizeMiB: 240000
               startMiB: 0
-            filesystems:
+      filesystems:
         - device: /dev/disk/by-partlabel/var
           format: xfs
           path: /var

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -74,7 +74,7 @@ spec:
             - label: var
               sizeMiB: 240000
               startMiB: 0
-            filesystems:
+      filesystems:
         - device: /dev/disk/by-partlabel/var
           format: xfs
           path: /var

--- a/modules/migration-migrating-applications-api.adoc
+++ b/modules/migration-migrating-applications-api.adoc
@@ -218,7 +218,7 @@ The output resembles the following:
 +
 .Example output
 +
-[source,yaml]
+[source,text]
 ----
 Name:         c8b034c0-6567-11eb-9a4f-0bc004db0fbc
 Namespace:    openshift-migration

--- a/modules/migration-partial-failure-velero.adoc
+++ b/modules/migration-partial-failure-velero.adoc
@@ -51,7 +51,7 @@ $ oc exec $(oc get pods -n openshift-migration -o name | grep velero) -n openshi
 +
 .Example output
 +
-[source,yaml]
+[source,text]
 ----
 Phase:  PartiallyFailed (run 'velero restore logs ccc7c2d0-6017-11eb-afab-85d0007f5a19-x4lbf' for more information)
 

--- a/modules/migration-using-mtc-crs-for-troubleshooting.adoc
+++ b/modules/migration-using-mtc-crs-for-troubleshooting.adoc
@@ -64,7 +64,7 @@ $ oc describe migmigration 88435fe0-c9f8-11e9-85e6-5d593ce65e10 -n openshift-mig
 The output is similar to the following examples.
 
 .`MigMigration` example output
-[source,yaml]
+[source,text]
 ----
 name:         88435fe0-c9f8-11e9-85e6-5d593ce65e10
 namespace:    openshift-migration

--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -48,7 +48,7 @@ receivers:
 - name: default
 - name: watchdog
 - name: <receiver>
-  <receiver_configuration>
+#  <receiver_configuration>
 ----
 <1> `service` specifies the service that fires the alerts.
 <2> `<your_matching_rules>` specifies the target alerts.

--- a/modules/nodes-containers-sysctls-unsafe.adoc
+++ b/modules/nodes-containers-sysctls-unsafe.adoc
@@ -111,7 +111,7 @@ A message similar to the following appears when the cluster is ready:
 $ oc get machineconfig 99-worker-XXXXXX-XXXXX-XXXX-XXXXX-kubelet -o json | grep ownerReference -A7
 ----
 +
-[source,yaml]
+[source,json]
 ----
         "ownerReferences": [
             {
@@ -121,6 +121,8 @@ $ oc get machineconfig 99-worker-XXXXXX-XXXXX-XXXX-XXXXX-kubelet -o json | grep 
                 "kind": "KubeletConfig",
                 "name": "custom-kubelet",
                 "uid": "3f64a766-bae8-11e9-abe8-0a1a2a4813f2"
+            }
+        ]
 ----
 +
 You can now add unsafe sysctls to pods as needed.

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -101,7 +101,7 @@ $ oc describe node node1.example.com
 ----
 +
 .Example output
-[source,yaml]
+[source,text]
 ----
 Name:               node1.example.com <1>
 Roles:              worker <2>

--- a/modules/nodes-pods-autoscaling-status-about.adoc
+++ b/modules/nodes-pods-autoscaling-status-about.adoc
@@ -33,7 +33,7 @@ $ oc describe hpa cm-test
 ----
 +
 .Example output
-[source,yaml]
+[source,text]
 ----
 Name:                           cm-test
 Namespace:                      prom
@@ -61,7 +61,7 @@ Events:
 The following is an example of a pod that is unable to scale:
 
 .Example output
-[source,yaml]
+[source,text]
 ----
 Conditions:
   Type         Status  Reason          Message
@@ -76,7 +76,7 @@ Events:
 The following is an example of a pod that could not obtain the needed metrics for scaling:
 
 .Example output
-[source,yaml]
+[source,text]
 ----
 Conditions:
   Type                  Status    Reason                    Message
@@ -88,7 +88,7 @@ Conditions:
 The following is an example of a pod where the requested autoscaling was less than the required minimums:
 
 .Example output
-[source,yaml]
+[source,text]
 ----
 Conditions:
   Type              Status    Reason              Message

--- a/modules/nodes-pods-secrets-certificates-about.adoc
+++ b/modules/nodes-pods-secrets-certificates-about.adoc
@@ -18,12 +18,12 @@ masters.
 [source,yaml]
 ----
 apiVersion: v1
-  kind: Service
-  metadata:
-    name: registry
-    annotations:                                                        
-      service.alpha.openshift.io/serving-cert-secret-name: registry-cert<1>
-....
+kind: Service
+metadata:
+  name: registry
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: registry-cert<1>
+# ...
 ----
 <1> Specify the name for the certificate
 

--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -232,10 +232,10 @@ For example, a pod has two containers, the same resource requests and limits:
 
 [source,yaml]
 ----
-...
+# ...
 spec:
   containers:
-    name: frontend
+  - name: frontend
     resources:
       limits:
         cpu: 1
@@ -243,8 +243,7 @@ spec:
       requests:
         cpu: 500m
         memory: 100Mi
-...
-    name: backend
+  - name: backend
     resources:
       limits:
         cpu: "1"
@@ -252,7 +251,7 @@ spec:
       requests:
         cpu: 500m
         memory: 100Mi
-...
+# ...
 ----
 
 After launching a VPA CR with the `backend` container set to opt-out, the VPA terminates and recreates the pod with the recommended resources applied only to the `frontend` container:

--- a/modules/ossm-threescale-authentication.adoc
+++ b/modules/ossm-threescale-authentication.adoc
@@ -156,5 +156,5 @@ spec:
     action:
       path: request.url_path
       method: request.method | "get"
-        service: destination.labels["service-mesh.3scale.net/service-id"] | ""
+      service: destination.labels["service-mesh.3scale.net/service-id"] | ""
 ----

--- a/modules/virt-creating-offline-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-offline-vm-snapshot-cli.adoc
@@ -53,7 +53,7 @@ $ oc describe vmsnapshot <my-vmsnapshot>
 +
 .Example output
 
-[source, yaml]
+[source,yaml]
 ----
 apiVersion: snapshot.kubevirt.io/v1alpha1
 kind: VirtualMachineSnapshot

--- a/modules/virt-define-http-liveness-probe.adoc
+++ b/modules/virt-define-http-liveness-probe.adoc
@@ -17,7 +17,7 @@ Define an HTTP liveness probe by setting the `spec.livenessProbe.httpGet` field 
 .Sample liveness probe with an HTTP GET test
 [source,yaml]
 ----
-...
+# ...
 spec:
   livenessProbe:
     initialDelaySeconds: 120 <1>
@@ -25,11 +25,11 @@ spec:
     httpGet: <3>
       port: 1500 <4>
       path: /healthz <5>
-        httpHeaders:
-        - name: Custom-Header
-          value: Awesome
+      httpHeaders:
+      - name: Custom-Header
+        value: Awesome
     timeoutSeconds: 10 <6>
-...
+# ...
 ----
 <1> The time, in seconds, after the VMI starts before the liveness probe is initiated.
 <2> The delay, in seconds, between performing probes. The default delay is 10 seconds. This value must be greater than `timeoutSeconds`.

--- a/modules/virt-define-http-readiness-probe.adoc
+++ b/modules/virt-define-http-readiness-probe.adoc
@@ -16,21 +16,21 @@ Define an HTTP readiness probe by setting the `spec.readinessProbe.httpGet` fiel
 .Sample readiness probe with an HTTP GET test
 [source,yaml]
 ----
-...
+# ...
 spec:
   readinessProbe:
     httpGet: <1>
       port: 1500 <2>
       path: /healthz <3>
-        httpHeaders:
-        - name: Custom-Header
-          value: Awesome
+      httpHeaders:
+      - name: Custom-Header
+        value: Awesome
     initialDelaySeconds: 120 <4>
     periodSeconds: 20 <5>
     timeoutSeconds: 10 <6>
     failureThreshold: 3 <7>
     successThreshold: 3 <8>
-...
+# ...
 ----
 <1> The HTTP GET request to perform to connect to the VMI.
 <2> The port of the VMI that the probe queries. In the above example, the probe queries port 1500.

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -64,41 +64,41 @@ name: my-vmrestore
 namespace: default
 ownerReferences:
 - apiVersion: kubevirt.io/v1alpha3
-blockOwnerDeletion: true
-controller: true
-kind: VirtualMachine
-name: my-vm
-uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
-resourceVersion: "5512"
-selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
-uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
-spec:
-target:
-apiGroup: kubevirt.io
-kind: VirtualMachine
-name: my-vm
-virtualMachineSnapshotName: my-vmsnapshot
-status:
-complete: true <1>
-conditions:
-- lastProbeTime: null
-lastTransitionTime: "2020-09-30T14:46:28Z"
-reason: Operation complete
-status: "False" <2>
-type: Progressing
-- lastProbeTime: null
-lastTransitionTime: "2020-09-30T14:46:28Z"
-reason: Operation complete
-status: "True" <3>
-type: Ready
-deletedDataVolumes:
-- test-dv1
-restoreTime: "2020-09-30T14:46:28Z"
-restores:
-- dataVolumeName: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
-persistentVolumeClaim: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
-volumeName: datavolumedisk1
-volumeSnapshotName: vmsnapshot-28eedf08-5d6a-42c1-969c-2eda58e2a78d-volume-datavolumedisk1
+  blockOwnerDeletion: true
+  controller: true
+  kind: VirtualMachine
+  name: my-vm
+  uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
+  resourceVersion: "5512"
+  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
+  uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
+  spec:
+    target:
+      apiGroup: kubevirt.io
+      kind: VirtualMachine
+      name: my-vm
+  virtualMachineSnapshotName: my-vmsnapshot
+  status:
+  complete: true <1>
+  conditions:
+  - lastProbeTime: null
+  lastTransitionTime: "2020-09-30T14:46:28Z"
+  reason: Operation complete
+  status: "False" <2>
+  type: Progressing
+  - lastProbeTime: null
+  lastTransitionTime: "2020-09-30T14:46:28Z"
+  reason: Operation complete
+  status: "True" <3>
+  type: Ready
+  deletedDataVolumes:
+  - test-dv1
+  restoreTime: "2020-09-30T14:46:28Z"
+  restores:
+  - dataVolumeName: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
+  persistentVolumeClaim: restore-71c679a8-136e-46b0-b9b5-f57175a6a041-datavolumedisk1
+  volumeName: datavolumedisk1
+  volumeSnapshotName: vmsnapshot-28eedf08-5d6a-42c1-969c-2eda58e2a78d-volume-datavolumedisk1
 ----
 <1> Specifies if the process of restoring the VM to the state represented by the snapshot is complete.
 <2> The `status` field of the `Progressing` condition specifies if the VM is still being restored.


### PR DESCRIPTION
The YAML in these files cannot be parsed successfully for several reasons:

- Incorrect indentation
- Incorrect [source,yaml] block when content is not YAML
- Missing --- for listing with multiple YAML blocks

Refs https://github.com/openshift/openshift-docs/pull/35741.