### PR TITLE
Fix the xref in the RN for MHC pausing

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -73,7 +73,7 @@ See xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-use
 
 During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} {product-version} introduces `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster.
 
-For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing[Pausing a MachineHealthCheck resource].
+For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing_updating-cluster-cli[Pausing a MachineHealthCheck resource].
 
 [id=ocp-4.9-azure-cidr]
 ==== Increased size of Azure subnets within the machine CIDR


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-291: Fixed the xref in the RN for pausing the machine health check
(Pls ignore the branch name. It was erroneously named 296 instead of 291)

Release note for OpenShift 4.9 

Addresses https://github.com/openshift/openshift-docs/pull/37065#discussion_r721807765.

Preview: https://deploy-preview-37079--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-upgrade-pause-mhc