### PR TITLE
OSDOCS-2669 - Adding a 4.7 to 4.8 upgrade section

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -154,6 +154,9 @@ Topics:
 - Name: Upgrading ROSA
   File: rosa-upgrading
   Distros: openshift-rosa
+- Name: Upgrading ROSA with STS
+  File: rosa-upgrading-sts
+  Distros: openshift-rosa
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades
   Distros: openshift-dedicated

--- a/modules/rosa-upgrading-automatic-ocm.adoc
+++ b/modules/rosa-upgrading-automatic-ocm.adoc
@@ -1,23 +1,20 @@
 // Module included in the following assemblies:
 //
 // * rosa_upgrading/rosa-upgrading.adoc
+// * rosa_upgrading/rosa-upgrading-sts.adoc
 
 [id="rosa-scheduling-upgrade_{context}"]
 = Scheduling automatic upgrades
 
-
-There are three methods that can be used to upgrade {product-title} clusters. This procedure describes scheduling automatic upgrades.
+You can schedule automatic upgrades for a {product-title} cluster through the OpenShift Cluster Manager (OCM) console.
 
 .Procedure
 
-. Log in to the link:https://cloud.redhat.com/openshift[OCM console].
+. Log in to the {cloud-redhat-com}.
 . Select a cluster to upgrade.
-. Click the *Update settings* tab.
-. In the _Update Strategy_ pane, click *Automatic*.
+. Click the *Settings* tab.
+. In the *Update strategy* pane, click *Automatic* and select a preferred day of the week and start time for the automatic upgrades.
+. In the *Node draining* pane, select a grace period interval from the list. The grace period enables the nodes to gracefully drain before forcing the pod eviction. The default is *1 hour*.
+. In the *Update strategy* pane, click *Save* to apply your update strategy.
 +
-The scheduling options are displayed.
-. Select the day of the week and the time for upgrades to occur.
-. In the _Node draining_ pane, select a grace period interval from the drop-down list to allow the nodes to gracefully drain before forcing the pod eviction. Default: `1 hour`
-. Click *Save*.
-+
-When upgrades are available, they are automatically applied to the cluster at the specified day of the week and time.
+When upgrades are available, they are automatically applied to the cluster on the preferred day of the week and start time.

--- a/modules/rosa-upgrading-cli-tutorial.adoc
+++ b/modules/rosa-upgrading-cli-tutorial.adoc
@@ -1,14 +1,29 @@
 // Module included in the following assemblies:
 //
 // * rosa_upgrading/rosa-upgrading.adoc
+// * rosa_upgrading/rosa-upgrading-sts.adoc
+
+ifeval::["{context}" == "rosa-upgrading-sts"]
+:sts:
+endif::[]
 
 [id="rosa-upgrading-cli_{context}"]
-= Upgrading with the rosa CLI
+= Upgrading manually with the rosa CLI
 
-
-There are three methods that can be used to upgrade {product-title} clusters. This procedure describes upgrading using the `rosa` CLI.
+You can upgrade a {product-title} cluster 
+ifdef::sts[]
+that uses the AWS Security Token Service (STS) 
+endif::sts[]
+manually by using the `rosa` CLI.
 
 This method schedules the cluster for an immediate upgrade, if a more recent version is available.
+
+.Prerequisites
+
+* You have installed and configured the latest ROSA CLI on your installation host.
+ifdef::sts[]
+* If you are upgrading your cluster from 4.7 to 4.8, you have upgraded the AWS Identity and Access Management (IAM) account-wide roles and policies to version 4.8. You have also updated the `cloudcredential.openshift.io/upgradeable-to` annotation in the `CloudCredential` custom resource. For more information, see _Preparing an upgrade from 4.7 to 4.8_.
+endif::sts[]
 
 .Procedure
 
@@ -16,14 +31,15 @@ This method schedules the cluster for an immediate upgrade, if a more recent ver
 +
 [source,terminal]
 ----
-$ rosa describe cluster
+$ rosa describe cluster --cluster=<cluster_name|cluster_id> <1>
 ----
+<1> Replace `<cluster_name|cluster_id>` with the cluster name or the ID of the cluster.
 
 . To verify that an upgrade is available, enter the following command:
 +
 [source,terminal]
 ----
-$ rosa list upgrade --cluster=<cluster_name>
+$ rosa list upgrade --cluster=<cluster_name|cluster_id>
 ----
 +
 The command returns a list of versions to which the the cluster can be upgraded, including a recommended version.
@@ -32,9 +48,13 @@ The command returns a list of versions to which the the cluster can be upgraded,
 +
 [source,terminal]
 ----
-$ rosa upgrade cluster --cluster=<cluster_name>
+$ rosa upgrade cluster --cluster=<cluster_name|cluster_id>
 ----
 +
-The cluster is scheduled for an immediate upgrade. This action can take an hour or longer, depending on your workload configuration, such as PodDisruptionBudgets.
+The cluster is scheduled for an immediate upgrade. This action can take an hour or longer, depending on your workload configuration, such as pod disruption budgets.
 +
 You will receive an email when the upgrade is complete. You can also check the status by running `rosa describe cluster` again from the `rosa` CLI or view the status in the OpenShift Cluster Manager (OCM) console.
+
+ifeval::["{context}" == "rosa-upgrading-sts"]
+:!sts:
+endif::[]

--- a/modules/rosa-upgrading-manual-ocm.adoc
+++ b/modules/rosa-upgrading-manual-ocm.adoc
@@ -1,26 +1,54 @@
 // Module included in the following assemblies:
 //
 // * rosa_upgrading/rosa-upgrading.adoc
+// * rosa_upgrading/rosa-upgrading-sts.adoc
+
+ifeval::["{context}" == "rosa-upgrading-sts"]
+:sts:
+endif::[]
 
 [id="rosa-upgrade-ocm_{context}"]
 = Upgrading manually using the console
 
+You can upgrade a {product-title} cluster 
+ifdef::sts[]
+that uses the AWS Security Token Service (STS) 
+endif::sts[]
+manually by using the OpenShift Cluster Manager (OCM) console.
 
-There are three methods that can be used to upgrade {product-title} clusters. This procedure describes manually upgrading using the OpenShift Cluster Manager (OCM) console.
+ifdef::sts[]
+.Prerequisites
+
+* If you are upgrading your cluster from 4.7 to 4.8, you have upgraded the AWS Identity and Access Management (IAM) account-wide roles and policies to version 4.8. You have also updated the `cloudcredential.openshift.io/upgradeable-to` annotation in the `CloudCredential` custom resource. For more information, see _Preparing an upgrade from 4.7 to 4.8_.
+endif::sts[]
 
 .Procedure
 
-. Log in to the link:https://cloud.redhat.com/openshift[OCM console].
+. Log in to the {cloud-redhat-com}.
 . Select a cluster to upgrade.
-. Click the *Update settings* tab.
-. In the _Update Strategy_ pane, click *Manual*.
+. Click the *Settings* tab.
+. In the *Update strategy* pane, click *Manual*.
+. In the *Node draining* pane, select a grace period interval from the list. The grace period enables the nodes to gracefully drain before forcing the pod eviction. The default is *1 hour*.
+. In the *Update strategy* pane, click *Save* to apply your update strategy.
+. In the *Update status* pane, review the *Update available* information and click *Update*.
 +
-The scheduling options are displayed.
-. Select the day of the week and the time for upgrades to occur.
-. In the _Node draining_ pane, select a grace period interval from the drop-down list to allow the nodes to gracefully drain before forcing the pod eviction. Default: `1 hour`
-. In the _Update Status_ pane, review the `Update available` information.
-. Click *Update*. This button is enabled only when an upgrade is available.
+[NOTE]
+====
+The *Update* button is enabled only when an upgrade is available.
+====
 +
-The cluster is scheduled for an immediate upgrade to the latest version. This action can take an hour or longer, depending on your workload configuration, such as PodDisruptionBudgets.
+. In the *Select version* dialog, choose a target upgrade version and click *Next*.
+. In the *Schedule update* dialog, schedule your cluster upgrade.
 +
-The status is displayed in the _Update Status_ pane.
+* To upgrade within an hour, select *Update now* and click *Next*.
+* To upgrade at a later time, select *Schedule a different time* and set a time and date for your upgrade. Click *Next* to proceed to the confirmation dialog.
++
+. After reviewing the version and schedule summary, select *Confirm update*.
++
+The cluster is scheduled for an upgrade to the target version. This action can take an hour or longer, depending on the selected upgrade schedule and your workload configuration, such as pod disruption budgets.
++
+The status is displayed in the *Update status* pane.
+
+ifeval::["{context}" == "rosa-upgrading-sts"]
+:!sts:
+endif::[]

--- a/modules/rosa-upgrading-preparing-4-7-to-4-8.adoc
+++ b/modules/rosa-upgrading-preparing-4-7-to-4-8.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * rosa_upgrading/rosa-upgrading-sts.adoc
+
+[id="rosa-upgrading-4-7-to-4-8-preparing_{context}"]
+= Preparing an upgrade from 4.7 to 4.8
+
+You must meet the following requirements before upgrading a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS) from version 4.7 to 4.8:
+
+* Update the AWS Identity and Access Management (IAM) account-wide roles and policies, including the Operator policies to version 4.8.
+* After updating the roles and policies, you must update the value of the `cloudcredential.openshift.io/upgradeable-to` annotation in the `CloudCredential` custom resource to `v4.8`. This indicates that the cluster is ready to upgrade.
+
+.Prerequisites
+
+* You have installed the latest AWS CLI on your installation host.
+* You have installed version 1.1.3 or later of the ROSA CLI on your installation host.
+* You have installed version 4.8 or later of the OpenShift CLI (`oc`) on your installation host.
+* You have the permissions required to update the AWS account-wide roles and policies.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Update the account-wide roles and policies, including the Operator policies, to version 4.8:
++
+[source,terminal]
+----
+$ rosa create account-roles --mode auto --version 4.8
+----
++
+[IMPORTANT]
+====
+If you created the roles and policies for version 4.7 with a custom prefix, you must include the `--prefix` option and specify the same prefix name. Specifying the prefix name ensures that the existing roles and policies used by the cluster are updated.
+====
+
+. As a cluster administrator, update the value of the `cloudcredential.openshift.io/upgradeable-to` annotation in the `CloudCredential` custom resource to `v4.8`:
++
+[source,terminal]
+----
+$ oc annotate cloudcredential cluster cloudcredential.openshift.io/upgradeable-to="v4.8"
+----
+
+You can now proceed to upgrade the cluster.

--- a/upgrading/rosa-upgrading-sts.adoc
+++ b/upgrading/rosa-upgrading-sts.adoc
@@ -1,7 +1,7 @@
-[id="rosa-upgrading"]
-= Upgrading ROSA clusters
+[id="rosa-upgrading-sts"]
+= Upgrading ROSA clusters with STS
 include::modules/attributes-openshift-dedicated.adoc[]
-:context: rosa-upgrading
+:context: rosa-upgrading-sts
 
 toc::[]
 
@@ -10,19 +10,20 @@ toc::[]
 
 To plan an upgrade, review the xref:../rosa_policy/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle]. The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
 
-[id="rosa-sts-upgrading-a-cluster"]
-== Upgrading a ROSA cluster
-There are three methods to upgrade {product-title} (ROSA) clusters:
+include::modules/rosa-upgrading-preparing-4-7-to-4-8.adoc[leveloffset=+1]
+
+[id="rosa-sts-upgrading-a-cluster-with-sts"]
+== Upgrading a ROSA cluster that uses STS
+
+There are two methods to upgrade {product-title} (ROSA) clusters that uses the AWS Security Token Service (STS):
 
 * Manual upgrades through the `rosa` CLI
 * Manual upgrades through the {cloud-redhat-com} console
-* Automatic upgrades through the {cloud-redhat-com} console
 
 [NOTE]
 ====
-For steps to upgrade a ROSA cluster that uses the AWS Security Token Service (STS), see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading ROSA clusters with STS].
+For steps to upgrade a ROSA cluster that does not use the AWS Security Token Service (STS), see xref:../upgrading/rosa-upgrading.adoc#rosa-upgrading[Upgrading ROSA clusters].
 ====
 
 include::modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+2]
 include::modules/rosa-upgrading-manual-ocm.adoc[leveloffset=+2]
-include::modules/rosa-upgrading-automatic-ocm.adoc[leveloffset=+2]


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2669. The PR adds a new assembly for ROSA with STS upgrades. A new procedure section is also added about the prerequisites to upgrading ROSA with STS clusters from 4.7 to 4.8.

The preview is [here](https://deploy-preview-37080--osdocs.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts.html).