### PR TITLE
BZ1994630: Updating mentions of VirtualMachineInstance in kind: object of YAML examples to VirtualMachine

### DIFF
--- a/modules/virt-booting-vms-efi-mode.adoc
+++ b/modules/virt-booting-vms-efi-mode.adoc
@@ -5,7 +5,7 @@
 [id="virt-booting-vms-efi-mode_{context}"]
 = Booting virtual machines in EFI mode
 
-You can configure a virtual machine to boot in EFI mode by editing the VM or VMI manifest.
+You can configure a virtual machine to boot in EFI mode by editing the VM manifest.
 
 .Prerequisites
 
@@ -13,17 +13,17 @@ You can configure a virtual machine to boot in EFI mode by editing the VM or VMI
 
 .Procedure
 
-. Create a YAML file that defines a VM object or a Virtual Machine Instance (VMI) object. Use the firmware stanza of the example YAML file:
+. Create a YAML file that defines a VM object. Use the firmware stanza of the example YAML file:
 +
 .Booting in EFI mode with secure boot active
 [source,yaml]
 ----
   apiversion: kubevirt.io/v1
-  kind: VirtualMachineInstance
+  kind: VirtualMachine
   metadata:
     labels:
-      special: vmi-secureboot
-    name: vmi-secureboot
+      special: vm-secureboot
+    name: vm-secureboot
   spec:
     domain:
       devices:

--- a/modules/virt-schedule-cpu-host-model-vms.adoc
+++ b/modules/virt-schedule-cpu-host-model-vms.adoc
@@ -9,17 +9,17 @@ When the CPU model for a virtual machine (VM) is set to `host-model`, the VM inh
 
 .Procedure
 
-* Edit the `domain` spec of your VM configuration file. The following example shows `host-model` being specified for the virtual machine instance (VMI):
+* Edit the `domain` spec of your VM configuration file. The following example shows `host-model` being specified for the virtual machine:
 +
 [source,yaml]
 ----
 apiVersion: kubevirt/v1alpha3
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
-  name: myvmi
+  name: myvm
 spec:
   domain:
     cpu:
       model: host-model <1>
 ----
-<1> The VM or VMI that inherits the CPU model of the node where it is scheduled.
+<1> The VM that inherits the CPU model of the node where it is scheduled.

--- a/modules/virt-schedule-supported-cpu-model-vms.adoc
+++ b/modules/virt-schedule-supported-cpu-model-vms.adoc
@@ -5,21 +5,21 @@
 [id="virt-schedule-supported-cpu-model-vms_{context}"]
 = Scheduling virtual machines with the supported CPU model
 
-You can configure a CPU model for a virtual machine (VM) or a virtual machine instance (VMI) to schedule it on a node where its CPU model is supported.
+You can configure a CPU model for a virtual machine (VM) to schedule it on a node where its CPU model is supported.
 
 .Procedure
 
-* Edit the `domain` spec of your virtual machine configuration file. The following example shows a specific CPU model defined for a VMI:
+* Edit the `domain` spec of your virtual machine configuration file. The following example shows a specific CPU model defined for a VM:
 +
 [source,yaml]
 ----
 apiVersion: kubevirt.io/v1alpha3
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
-  name: myvmi
+  name: myvm
 spec:
   domain:
     cpu:
       model: Conroe <1>
 ----
-<1> CPU model for the VMI.
+<1> CPU model for the VM.

--- a/modules/virt-setting-policy-attributes.adoc
+++ b/modules/virt-setting-policy-attributes.adoc
@@ -9,14 +9,14 @@ You can set a policy attribute and CPU feature for each virtual machine (VM) to 
 
 .Procedure
 
-* Edit the `domain` spec of your VM configuration file. The following example sets the CPU feature and the `require` policy for a virtual machine instance (VMI):
+* Edit the `domain` spec of your VM configuration file. The following example sets the CPU feature and the `require` policy for a virtual machine (VM):
 +
 [source,yaml]
 ----
 apiVersion: v1
 kind: VirtualMachine
 metadata:
-  name: myvmi
+  name: myvm
 spec:
   domain:
     cpu:
@@ -24,5 +24,5 @@ spec:
       - name: apic <1>
         policy: require <2>
 ----
-<1> Name of the CPU feature for the VM or VMI.
-<2> Policy attribute for the VM or VMI.
+<1> Name of the CPU feature for the VM.
+<2> Policy attribute for the VM.

--- a/modules/virt-template-vm-probe-config.adoc
+++ b/modules/virt-template-vm-probe-config.adoc
@@ -2,17 +2,17 @@
 //
 // * virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
 
-[id="virt-template-vmi-probe-config_{context}"]
-= Template: Virtual machine instance configuration file for defining health checks
+[id="virt-template-vm-probe-config_{context}"]
+= Template: Virtual machine configuration file for defining health checks
 
 [source,yaml]
 ----
 apiVersion: kubevirt.io/v1alpha3
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
   labels:
-    special: vmi-fedora
-  name: vmi-fedora
+    special: vm-fedora
+  name: vm-fedora
 spec:
   domain:
     devices:

--- a/modules/virt-template-vm-pxe-config.adoc
+++ b/modules/virt-template-vm-pxe-config.adoc
@@ -2,18 +2,18 @@
 //
 // * virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
 
-[id="virt-pxe-vmi-template_{context}"]
-= Template: Virtual machine instance configuration file for PXE booting
+[id="virt-pxe-vm-template_{context}"]
+= Template: Virtual machine configuration file for PXE booting
 
 [source,yaml]
 ----
 apiVersion: kubevirt.io/v1alpha3
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
   creationTimestamp: null
   labels:
-    special: vmi-pxe-boot
-  name: vmi-pxe-boot
+    special: vm-pxe-boot
+  name: vm-pxe-boot
 spec:
   domain:
     devices:

--- a/modules/virt-template-windows-vm.adoc
+++ b/modules/virt-template-windows-vm.adoc
@@ -2,17 +2,17 @@
 //
 // * virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
 
-[id="virt-template-windows-vmi_{context}"]
-= Template: Windows virtual machine instance configuration file
+[id="virt-template-windows-vm_{context}"]
+= Template: Windows virtual machine configuration file
 
 [source,yaml]
 ----
 apiVersion: kubevirt.io/v1alpha3
-kind: VirtualMachineInstance
+kind: VirtualMachine
 metadata:
   labels:
-    special: vmi-windows
-  name: vmi-windows
+    special: vm-windows
+  name: vm-windows
 spec:
   domain:
     clock:

--- a/virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
+++ b/virt/logging_events_monitoring/virt-monitoring-vm-health.adoc
@@ -11,7 +11,7 @@ include::modules/virt-about-readiness-liveness-probes.adoc[leveloffset=+1]
 include::modules/virt-define-http-readiness-probe.adoc[leveloffset=+1]
 include::modules/virt-define-tcp-readiness-probe.adoc[leveloffset=+1]
 include::modules/virt-define-http-liveness-probe.adoc[leveloffset=+1]
-include::modules/virt-template-vmi-probe-config.adoc[leveloffset=+1]
+include::modules/virt-template-vm-probe-config.adoc[leveloffset=+1]
 
 [id="additional-resources_monitoring-vm-health"]
 == Additional resources

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.adoc
@@ -21,4 +21,4 @@ include::modules/virt-networking-glossary.adoc[leveloffset=+1]
 
 include::modules/virt-pxe-booting-with-mac-address.adoc[leveloffset=+1]
 
-include::modules/virt-template-vmi-pxe-config.adoc[leveloffset=+1]
+include::modules/virt-template-vm-pxe-config.adoc[leveloffset=+1]

--- a/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc
@@ -9,4 +9,4 @@ toc::[]
 You can boot a virtual machine (VM) in Extensible Firmware Interface (EFI) mode.
 
 include::modules/virt-about-efi-mode-for-vms.adoc[leveloffset=+1]
-include::modules/virt-booting-efi-mode.adoc[leveloffset=+1]
+include::modules/virt-booting-vms-efi-mode.adoc[leveloffset=+1]

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -28,7 +28,7 @@ include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 
 include::modules/virt-template-vm-config.adoc[leveloffset=+2]
 
-include::modules/virt-template-windows-vmi.adoc[leveloffset=+2]
+include::modules/virt-template-windows-vm.adoc[leveloffset=+2]
 
 include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset=+1]
 .Additional resources


### PR DESCRIPTION
This PR addresses Bug 1994630 ( https://bugzilla.redhat.com/show_bug.cgi?id=1994630 ) and it's associated JIRA story [CNV-13648](https://issues.redhat.com/browse/CNV-13648) ( https://issues.redhat.com/browse/CNV-13648 ).

The bug is about modifying mentions of VirtualMachineInstance in the "kind:" object of a handful of YAML examples, replacing it with VirtualMachine.

CP: 4.9

Preview: 

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.html#virt-booting-vms-efi-mode_virt-efi-mode-for-vms

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.html#virt-schedule-cpu-host-model-vms_virt-schedule-vms

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-schedule-vms.html#virt-schedule-supported-cpu-model-vms_virt-schedule-vms

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-monitoring-vm-health.html#virt-template-vmi-probe-config_virt-monitoring-vm-health

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pxe-booting.html#virt-pxe-vmi-template_pxe-booting

https://deploy-preview-37086--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-template-windows-vmi_virt-using-the-default-pod-network-with-virt