### PR TITLE
OSDOCS-1837: Adding note for 4.6-4.8 TLS 1.3 considerations

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -101,9 +101,8 @@ Ciphers and the minimum TLS version of the configured security profile are refle
 
 [IMPORTANT]
 ====
-The Ingress Controller supports using TLS `1.3` and the `Modern` profile in HAProxy.
-
-The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`.
+{product-title} router enables Red Hat-distributed OpenSSL default set of TLS `1.3` cipher suites, which uses TLS_AES_128_CCM_SHA256, TLS_CHACHA20_POLY1305_SHA256, TLS_AES_256_GCM_SHA384, and TLS_AES_128_GCM_SHA256.
+Your cluster might accept TLS `1.3` connections and cipher suites, even though TLS `1.3` is unsupported in {product-title} 4.6, 4.7, and 4.8.
 ====
 
 |`clientTLS`

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * security/tls-security-profiles.adoc
+// * networking/ingress-operator.adoc
 
 [id="tls-profiles-understanding_{context}"]
 = Understanding TLS security profiles
@@ -34,6 +35,10 @@ The `Intermediate` profile requires a minimum TLS version of 1.2.
 |This profile is intended for use with modern clients that have no need for backwards compatibility. This profile is based on the link:https://wiki.mozilla.org/Security/Server_Side_TLS#Modern_compatibility[Modern compatibility] recommended configuration.
 
 The `Modern` profile requires a minimum TLS version of 1.3.
+[NOTE]
+====
+In {product-title} 4.6, 4.7, and 4.8, the `Modern` profile is unsupported. If selected, the `Intermediate` profile is enabled.
+====
 
 |`Custom`
 |This profile allows you to define the TLS version and ciphers to use.
@@ -42,7 +47,10 @@ The `Modern` profile requires a minimum TLS version of 1.3.
 ====
 Use caution when using a `Custom` profile, because invalid configurations can cause problems.
 ====
-
+[NOTE]
+====
+{product-title} router enables Red Hat-distributed OpenSSL default set of TLS `1.3` cipher suites. Your cluster might accept TLS `1.3` connections and cipher suites, even though TLS `1.3` is unsupported in {product-title} 4.6, 4.7, and 4.8.
+====
 |===
 
 [NOTE]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1837

For 4.6-4.8 an additional note is needed in lieu of Red Hat OpenSSL now supporting TLSv1.3 

TLSSecurityProfile note: https://deploy-preview-37087--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator?utm_source=github&utm_campaign=bot_dp#nw-ingress-controller-configuration-parameters_configuring-ingress