### PR TITLE
CNV-13462: HCO version bump for 2.6.7

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.6
+:HCOVersion: 2.6.7
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- [CNV-13462](https://issues.redhat.com/browse/CNV-13462)
- No CP
- One instance of this attribute is in the `startingCSV` value [here](https://deploy-preview-37089--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components)
- Will merge when both advisories are shipped live 