### PR TITLE
OSDK fixup: Updating Golang proxy tutorial code example 

### DIFF
--- a/modules/osdk-run-proxy.adoc
+++ b/modules/osdk-run-proxy.adoc
@@ -17,7 +17,7 @@ endif::[]
 [id="osdk-run-proxy_{context}"]
 = Enabling proxy support
 
-To support proxied clusters, your Operator must inspect the environment for the following standard proxy variables and pass the values to Operands:
+Operator authors can develop Operators that support network proxies. Cluster administrators configure proxy support for the environment variables that are handled by Operator Lifecycle Manager (OLM). To support proxied clusters, your Operator must inspect the environment for the following standard proxy variables and pass the values to Operands:
 
 * `HTTP_PROXY`
 * `HTTPS_PROXY`
@@ -33,11 +33,21 @@ This tutorial uses `HTTP_PROXY` as an example environment variable.
 
 .Procedure
 ifdef::golang[]
-. Add the `proxy.ReadProxyVarsFromEnv` helper function to the reconcile loop in the `controllers/memcached_controller.go` file and append the results to the Operand environments:
+. Edit the `controllers/memcached_controller.go` file to include the following:
+.. Import the `proxy` package from the link:https://github.com/operator-framework/operator-lib/tree/v0.3.0[`operator-lib`] library:
 +
 [source,golang]
 ----
-...
+import (
+  ...
+   "github.com/operator-framework/operator-lib/proxy"
+)
+----
+
+.. Add the `proxy.ReadProxyVarsFromEnv` helper function to the reconcile loop and append the results to the Operand environments:
++
+[source,golang]
+----
 for i, container := range dep.Spec.Template.Spec.Containers {
 		dep.Spec.Template.Spec.Containers[i].Env = append(container.Env, proxy.ReadProxyVarsFromEnv()...)
 }


### PR DESCRIPTION
Release: 4.9
https://issues.redhat.com/browse/OSDOCS-2211

This adds the necessary `proxy` package from the OSDK `operator-lib` to #36738.

Docs preview: https://deploy-preview-37095--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial#osdk-run-proxy_osdk-golang-tutorial