### PR TITLE
Removing the attribute to hard code the version

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -71,7 +71,7 @@ See xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-use
 [id="ocp-4-9-upgrade-pause-mhc"]
 ==== Pausing machine health checks before updating the cluster
 
-During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} {product-version} introduces the `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster.
+During the upgrade process, nodes in the cluster might become temporarily unavailable. In the case of worker nodes, the machine health check might identify such nodes as unhealthy and reboot them. To avoid rebooting such nodes, {product-title} 4.9 introduces the `cluster.x-k8s.io/paused=""` annotation to let you pause the `MachineHealthCheck` resources before updating the cluster.
 
 For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing_updating-cluster-cli[Pausing a MachineHealthCheck resource].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-291: Minor fix for the RN for pausing the machine health check. @bobfuru suggested that I hard code the version in place of using the attribute, which I agree. 

Release note for OpenShift 4.9

Preview: https://deploy-preview-37106--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-upgrade-pause-mhc