### PR TITLE
CNV-11786: version attributes for 4.9

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -13,8 +13,8 @@
 :ProductRelease:
 :ProductVersion:
 :VirtVersion: 4.9
-:KubeVirtVersion: v0.41.0
-:HCOVersion: 4.8.2
+:KubeVirtVersion: v0.44.2
+:HCOVersion: 4.9.0
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
- [CNV-11786](https://issues.redhat.com/browse/CNV-11786)
- Note: I updated the `{VirtVersion}` attribute in https://github.com/openshift/openshift-docs/pull/36774
- CP to 4.9
- Needs SME review: @tiraboschi @stu-gott please take a look; thanks!

Preview builds (TBD):
- `{HCOVersion}` attribute: [example](https://deploy-preview-37118--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components)
- `{KubeVirtVersion}` attribute: [example](https://deploy-preview-37118--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#additional-resources_virt-create-vms_virt-create-vms) (the API reference link)