### PR TITLE
SRVCOM-1559: Remove outdated sizing requirements

### DIFF
--- a/modules/serverless-cluster-sizing-req.adoc
+++ b/modules/serverless-cluster-sizing-req.adoc
@@ -1,7 +1,3 @@
-// Module included in the following assemblies:
-//
-// * /serverless/admin_guide/install-serverless-operator.adoc
-
 [id="serverless-cluster-sizing-req_{context}"]
 = Defining cluster size requirements for an {ServerlessProductName} installation
 
@@ -12,11 +8,7 @@ To install and use {ServerlessProductName}, the {product-title} cluster must be 
 The following requirements relate only to the pool of worker machines of the {product-title} cluster. Control plane nodes are not used for general scheduling and are omitted from the requirements.
 ====
 
-The minimum requirement for {ServerlessProductName} is a cluster with 10 CPUs and 40GB memory.
-
-The total size requirements to run {ServerlessProductName} are dependent on the applications deployed. By default, each pod requests approximately 400m of CPU, so the minimum requirements are based on this value.
-
-In the size requirement provided, an application can scale up to 10 replicas. Lowering the actual CPU request of applications can increase the number of possible replicas.
+The total size requirements to run {ServerlessProductName} are dependent on the applications deployed. By default, each pod requests approximately 400m of CPU, so the minimum requirements are based on this value. Lowering the actual CPU request of applications can increase the number of possible replicas.
 
 [NOTE]
 ====

--- a/serverless/admin_guide/install-serverless-operator.adoc
+++ b/serverless/admin_guide/install-serverless-operator.adoc
@@ -15,12 +15,8 @@ This guide walks cluster administrators through installing the {ServerlessOperat
 
 include::modules/serverless-cluster-sizing-req.adoc[leveloffset=+1]
 
-[id="installing-openshift-serverless-advanced-reqs"]
-== Additional requirements for advanced use cases
-
-For more advanced use cases such as logging or metering on {product-title}, you must deploy more resources. Recommended requirements for such use cases are 24 CPUs and 96GB of memory.
-
 If you have high availability (HA) enabled on your cluster, this requires between 0.5 - 1.5 cores and between 200MB - 2GB of memory for each replica of the Knative Serving control plane.
+
 HA is enabled for some Knative Serving components by default. You can disable HA by following the documentation on xref:../../serverless/admin_guide/serverless-ha.adoc#serverless-ha[Configuring high availability replicas on {ServerlessProductName}].
 
 [id="installing-openshift-serverless-scaling-with-machinesets"]


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVCOM-1559

Applies for OCP 4.6+

Direct preview link: https://deploy-preview-37121--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/install-serverless-operator?utm_source=github&utm_campaign=bot_dp