### PR TITLE
Link only to the OCP mirror site for live PXE image downloads

### DIFF
--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -77,8 +77,6 @@ Replace `bootstrap.ign` with `master.ign` or `worker.ign` in the command to vali
 ifndef::openshift-origin[]
 . Obtain the {op-system} `kernel`,
 `initramfs` and `rootfs` files from the
-link:https://access.redhat.com/downloads/content/290[Product Downloads] page on the Red
-Hat customer portal or the
 link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/[{op-system} image mirror]
 page.
 +


### PR DESCRIPTION
The customer portal page doesn't appear to have them.

cc @miabbott @bobfuru 