### PR TITLE
Fix Knative blog link on Serverless Release Notes page

### DIFF
--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -12,7 +12,7 @@ For an overview of {ServerlessProductName} functionality, see xref:../serverless
 ====
 {ServerlessProductName} is based on the open source Knative project.
 
-For details about the latest Knative component releases, see the link:https://knative.dev/blog/releases[Knative releases blog].
+For details about the latest Knative component releases, see the link:https://knative.dev/blog/[Knative blog].
 ====
 
 include::modules/serverless-api-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
See https://docs.openshift.com/container-platform/4.8/serverless/serverless-release-notes.html

The Knative blog doesn't contain a "Releases" filter page (anymore?) and shows a 404 page instead. Just changed the link to the complete Knative blog instead.