### PR TITLE
BZ#1948730 Add cluster-wide proxy module since now supported for IPI

### DIFF
--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -42,8 +42,7 @@ include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
-// Removing; Proxy not supported for AWS IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -46,8 +46,7 @@ include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
-// Removing; Proxy not supported for AWS IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
 include::modules/nw-operator-cr.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -30,8 +30,7 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
-// Removing; Proxy not supported for Azure IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -35,8 +35,7 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
-// Removing; Proxy not supported for Azure IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -34,8 +34,7 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set]
 
-// Removing; Proxy not supported for GCP IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -41,8 +41,7 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 * xref:../../machine_management/creating_machinesets/creating-machineset-gcp.adoc#machineset-enabling-customer-managed-encryption_creating-machineset-gcp[Enabling customer-managed encryption keys for a machine set]
 
-// Removing; Proxy not supported for GCP IPI for 4.2
-// include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -54,6 +54,7 @@ include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 include::modules/installation-initializing.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
 
 .Additional resources

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -31,6 +31,7 @@ include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
 include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-osp-restricted-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-osp-setting-worker-affinity.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -44,6 +44,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -45,6 +45,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 // Network Operator specific configuration
 
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -44,6 +44,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 // begin network customization
 include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -38,6 +38,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -41,6 +41,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 // begin network customization
 include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -54,6 +54,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]
 include::modules/nw-modifying-operator-install-config.adoc[leveloffset=+1]

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -1,26 +1,54 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_aws/installing_aws-customizations.adoc
+// * installing/installing_aws/installing_aws-network-customizations.adoc
+// * installing/installing_aws/installing_aws-private.adoc
+// * installing/installing_aws/installing_aws-vpc.adoc
 // * installing/installing_aws/installing_aws-china.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+// * installing/installing_aws/installing-restricted-networks-aws.adoc
+// * installing/installing_azure/installing-azure-customizations.adoc
+// * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-private.adoc
+// * installing/installing_azure/installing-azure-vnet.adoc
 // * installing/installing_azure/installing-azure-user-infra.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-customizations.adoc
+// * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
+// * installing/installing_gcp/installing-gcp-vpc.adoc
 // * installing/installing_gcp/installing-gcp-user-infra.adoc
+// * installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
-// * installing/installing_aws/installing-restricted-networks-aws.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+// * installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+// * installing/installing_vmc/installing-vmc-customizations.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * networking/configuring-a-custom-pki.adoc
 // * installing/installing-rhv-restricted-network.adoc
 
@@ -39,10 +67,34 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :vsphere:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:vsphere:
+endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :vmc:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :vmc:
 endif::[]
 
@@ -154,9 +206,33 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :!vsphere:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
+:!vsphere:
+endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :!vmc:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :!vmc:
 endif::[]

--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -7,11 +7,6 @@ toc::[]
 
 Production environments can deny direct access to the internet and instead have an HTTP or HTTPS proxy available. You can configure {product-title} to use a proxy by xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[modifying the Proxy object for existing clusters] or by configuring the proxy settings in the `install-config.yaml` file for new clusters.
 
-[IMPORTANT]
-====
-The cluster-wide proxy is only supported if you used a user-provisioned infrastructure installation or provide your own networking, such as a virtual private cloud or virtual network, for a supported provider.
-====
-
 == Prerequisites
 
 * Review the xref:../installing/install_config/configuring-firewall.adoc#configuring-firewall[sites that your cluster requires access to] and determine whether any of them must bypass the proxy. By default, all cluster system egress traffic is proxied, including calls to the cloud provider API for the cloud that hosts your cluster. System-wide proxy affects system components only, not user workloads. Add sites to the Proxy object's `spec.noProxy` field to bypass the proxy if necessary.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1948730

Added the [Configuring the cluster-wide proxy during installation](https://deploy-preview-37150--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configure-proxy_installing-aws-customizations) module into various (mostly IPI) assemblies, since it's now supported using the installer. Also removed an incorrect note in [Configuring the cluster-wide proxy](https://deploy-preview-37150--osdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html), which stated that UPI was the only supported install type for cluster-wide proxy.