### PR TITLE
RHDEVDOCS-3164 Build release notes, Known Issues and Bug Fixes for 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -564,6 +564,14 @@ For more information, see xref:../operators/operator_sdk/osdk-ha-sno.adoc#osdk-h
 [id="ocp-4-9-builds"]
 === Builds
 
+As a developer using OpenShift for builds, with this update, you can use the following new capabilities:
+
+* You can mount build volumes to give running builds access to information that you do not want to persist in the output container image. Build volumes can provide sensitive information, such as repository credentials, which the build environment or configuration only needs at build-time. Build volumes are different from build inputs, whose data can persist in the output container image.
+//For more information, see xref:TBD[Using Build Volumes]
+
+* You can configure image changes to trigger builds based on information recorded in the BuildConfig status. This way, you can use `ImageChange` triggers with builds in a GitOps workflow.
+//For more information, see xref:TBD[Using ImageChanges to trigger builds]
+
 [id="ocp-4-9-images"]
 === Images
 
@@ -876,12 +884,12 @@ In the table, features are marked with the following statuses:
 |`lastTriggeredImageID` field in the `BuildConfig` spec for Builds
 |GA
 |DEP
-|
+|REM
 
 |Jenkins Operator
 |TP
 |DEP
-|
+|DEP
 
 |HPA custom metrics adapter based on Prometheus
 |TP
@@ -1025,6 +1033,17 @@ The deprecated `v1beta1` API for the descheduler has been removed in {product-ti
 
 The deprecated `dhclient` binary has been removed from {op-system}. Starting with {product-title} 4.6, {op-system} switched to using `NetworkManager` in the `initramfs` to configure networking during early boot. Use the `NetworkManager` internal DHCP client for networking configuration instead. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1908462[*BZ#1908462*] for more information.
 
+[id="ocp-4-9-builds-lasttriggeredimageid-parameter"]
+==== Cease updating the `lastTriggeredImageID` field and ignore it
+
+The current release stops updating the `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` field when the `ImageStreamTag` referenced by `buildConfig.spec.triggers[i].imageChage` points to a new image. Instead, this release updates the `buildConfig.status.imageChangeTriggers[i].lastTriggeredImageID` field.
+
+Additionally, the Build Image Change Trigger controller ignores the `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` field.
+
+Now, the Build Image Change Trigger controller starts a build based on the `buildConfig.status.imageChangeTriggers[i].lastTriggeredImageID` field and how it compares to the image ID now referenced by the `ImageStreamTag` referenced in the `buildConfig.spec.triggers[i].imageChange`.
+
+Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` accordingly. (link:https://issues.redhat.com/browse/BUILD-190[*BUILD-190*])
+
 [id="ocp-4-9-bug-fixes"]
 == Bug fixes
 
@@ -1049,6 +1068,8 @@ The deprecated `dhclient` binary has been removed from {op-system}. Starting wit
 [discrete]
 [id="ocp-4-9-builds-bug-fixes"]
 ==== Builds
+
+* In {product-title} and later, the fix for bug link:https://bugzilla.redhat.com/show_bug.cgi?id=1884270[BZ#1884270] incorrectly pruned SSH protocol URLs in an attempt to provide SCP-styled URL capabilities. This error caused the `oc new-build` command not to pick an automatic source clone secret: the build could not use the `build.openshift.io/sbuild.openshift.io/source-secret-match-uri-1ource-secret-match-uri-1` annotation to map SSH keys with the associated secrets, and therefore could not perform git cloning. This update reverts the changes from BZ#1884270 so that builds can use the annotation and perform git cloning.
 
 [discrete]
 [id="ocp-4-9-cloud-compute-bug-fixes"]
@@ -1745,6 +1766,8 @@ sh-4.4$ bash -x /var/lib/haproxy/reload-haproxy
 ----
 +
 Alternatively, you can annotate the route to force a reload.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
+
+* This release contains a known issue. If you customize the hostname and certificate of the OpenShift OAuth route, Jenkins will no longer trust the OAuth server endpoint. As a result, users cannot log into the Jenkins console if they rely on the OpenShift OAuth integration to manage identity and access.
 
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-4.9 release notes
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3164
- Direct link to doc preview: https://deploy-preview-37160--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-builds
- SME review: @adambkaplan 
- QE review: @gabemontero
- Peer review: @bburt-rh 
- All reviews complete. Ready to merge.
