### PR TITLE
Makes the release note to add nodes to an existing cluster clearer

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -71,9 +71,9 @@ If you are creating machine configs for day 1 or day 2 operations that use Ignit
 [id="ocp-4-6-additional-steps-to-add-nodes-to-clusters"]
 ==== Additional steps to add nodes to existing clusters
 
-For clusters that have been upgraded to {product-title} 4.6, if you want to add more nodes to your {product-title} cluster by using the latest version of {op-system} boot media, you might need to manually modify your Ignition configuration as part of the process. This is because {product-title} 4.6 introduced changes to the Ignition specification.
+For clusters that have been upgraded to {product-title} 4.6, you can add more nodes to your {product-title} cluster. These instructions are only applicable if you originally installed a cluster prior to {product-title} 4.6 and have since upgraded to 4.6. 
 
-For information about affected clusters and the required steps, see link:https://access.redhat.com/solutions/5514051[Adding new nodes to UPI cluster fails after upgrading to OpenShift 4.6+].
+If you installed a user-provisioned cluster on bare metal or vSphere, you must ensure that your boot media or OVA image matches the version that your cluster was upgraded to. Additionally, your Ignition configuration file must be modified to be spec v3 compatible. For more detailed instructions and an example Ignition config file, see the link:https://access.redhat.com/solutions/5514051[Adding new nodes to UPI cluster fails after upgrading to OpenShift 4.6+] Knowledgebase Solution article.
 
 [id="ocp-4-6-extensions-supported-for-rhcos-mco"]
 ==== Extensions now supported for {op-system} and MCO


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1928303

Preview: https://deploy-preview-37165--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-additional-steps-to-add-nodes-to-clusters

For 4.6 only. 

Pending QA. 