### PR TITLE
BZ-1990953: Only the first container can use SR-IOV network attachment

### DIFF
--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -30,6 +30,8 @@ ifdef::sriov[]
 [NOTE]
 =====
 If a network attachment is managed by the SR-IOV Network Operator, the SR-IOV Network Resource Injector adds the `resource` field to the `Pod` object automatically.
+
+Only the first container in your pod is configured for access to your SR-IOV additional network. If you have multiple containers defined in your `Pod` object, you must ensure that the container that requires access to your SR-IOV additional network is defined first. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1990953[BZ#1990953].
 =====
 
 ifdef::bz[]

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -29,9 +29,11 @@ The pod must be in the same namespace as the additional network.
 ifdef::sriov[]
 [NOTE]
 =====
-If a network attachment is managed by the SR-IOV Network Operator, the SR-IOV Network Resource Injector adds the `resource` field to the `Pod` object automatically.
+If a network attachment is managed by the SR-IOV Network Operator, the SR-IOV Network Resource Injector adds the `resource` field to the first container in a pod automatically.
 
-Only the first container in your pod is configured for access to your SR-IOV additional network. If you have multiple containers defined in your `Pod` object, you must ensure that the container that requires access to your SR-IOV additional network is defined first. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1990953[BZ#1990953].
+If you are using an Intel network interface controller (NIC) in Data Plane Development Kit (DPDK) mode, only the first container in your pod is configured to access the NIC. Your SR-IOV additional network is configured for DPDK mode if the `deviceType` is set to `vfio-pci` in the `SriovNetworkNodePolicy` object.
+
+You can workaround this issue by either ensuring that the container that needs access to the NIC is the first container defined in the `Pod` object or by disabling the Network Resource Injector. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1990953[BZ#1990953].
 =====
 
 ifdef::bz[]

--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -37,7 +37,7 @@ SR-IOV Network Operator webhook::
 A dynamic admission controller webhook that validates the Operator custom resource and sets appropriate default values for unset fields.
 
 SR-IOV Network resources injector::
-A dynamic admission controller webhook that provides functionality for patching Kubernetes pod specifications with requests and limits for custom network resources such as SR-IOV VFs.
+A dynamic admission controller webhook that provides functionality for patching Kubernetes pod specifications with requests and limits for custom network resources such as SR-IOV VFs. The SR-IOV network resources injector adds the `resource` field to only the first container in a pod automatically.
 
 SR-IOV network device plug-in::
 A device plug-in that discovers, advertises, and allocates SR-IOV network virtual function (VF) resources. Device plug-ins are used in Kubernetes to enable the use of limited resources, typically in physical devices. Device plug-ins give the Kubernetes scheduler awareness of resource availability, so that the scheduler can schedule pods on nodes with sufficient resources.


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1990953

cc @zshi-redhat 