### PR TITLE
BZ-2010982: Updated yaml file with correct details for 4.9

### DIFF
--- a/modules/sandboxed-containers-installing-operator-cli.adoc
+++ b/modules/sandboxed-containers-installing-operator-cli.adoc
@@ -33,29 +33,29 @@ metadata:
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
-  name: openshift-sandboxed-containers-kataconfig-group
+  name: openshift-sandboxed-containers-operator
   namespace: openshift-sandboxed-containers-operator
 spec:
   targetNamespaces:
-    - openshift-sandboxed-containers
+  - openshift-sandboxed-containers-operator
 ---
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: sandboxed-containers-operatorhub
+  name: openshift-sandboxed-containers-operator
   namespace: openshift-sandboxed-containers-operator
 spec:
+  channel: "preview-1.1"
+  installPlanApproval: Automatic
+  name: sandboxed-containers-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-  name: sandboxed-containers-kataconfig
-  startingCSV: openshift-sandboxed-containers-kataconfig.v1.0.0
-  channel: "preview-1.0"
-  approval: "Automatic"
+  startingCSV: sandboxed-containers-operator.v1.1.0
 ----
 +
 [NOTE]
 ====
-Using the *preview-1.0* channel ensures that you install the version of {sandboxed-containers-first} that is compatible with your {product-title} version.
+Using the *preview-1.1* channel ensures that you install the version of {sandboxed-containers-first} that is compatible with your {product-title} version.
 ====
 
 . Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects for {sandboxed-containers-first}:


### PR DESCRIPTION
[Bugzilla 2010982](https://bugzilla.redhat.com/show_bug.cgi) - changes apply to OpenShift Docs 4.9:

Preview link: https://deploy-preview-37173--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads?utm_source=github&utm_campaign=bot_dp#sandboxed-containers-installing-operator-cli_deploying-sandboxed-containers

Reviewed and approved by QE.