### PR TITLE
[RHACS] SAML 2.0 Docs need reminder to setup additional rules

### DIFF
--- a/modules/configure-saml-identity-provider.adoc
+++ b/modules/configure-saml-identity-provider.adoc
@@ -48,3 +48,8 @@ The *Test Login* page opens in a new browser tab.
 ** On success, {product-title} shows the `User ID` and `User Attributes` the identity provider sent for the credentials you have used to log in.
 ** On failure, {product-title} shows a message describing why the identity provider's response could not be processed.
 . Close the *Test Login* browser tab.
++
+[NOTE]
+====
+Even if the response indicates successful authentication, you might need to create additional access rules based on the user metadata from your identity provider.
+====


### PR DESCRIPTION
Added a note that further configuration is required depending upon the IDP.

Preview: https://openshift-docs-git-saml-step-clarify-gnelson.vercel.app/openshift-acs/master/operating/manage-user-access/configure-okta-identity-cloud.html#configure-saml-identity-provider_configure-okta-identity-cloud

NOTES:

- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
