### PR TITLE
BZ1886864: Updated operator-sdk working with bundle images

### DIFF
--- a/modules/osdk-building-bundle-image.adoc
+++ b/modules/osdk-building-bundle-image.adoc
@@ -16,50 +16,62 @@ You can build, push, and validate an Operator bundle image using the Operator SD
 
 .Procedure
 
-. From your Operator project directory, build the bundle image using the Operator SDK:
-+
-[source,terminal]
-----
-$ operator-sdk bundle create \
-    <registry>/<namespace>/<bundle_image_name>:<tag> \//<1>
-    -b podman <2>
-----
-<1> The image tag that you want the bundle image to have.
-<2> The CLI tool to use for building the container image, either `docker` (default), `podman`, or `buildah`. This example uses `podman`.
-+
-[NOTE]
-====
-If your local manifests are not located in the default `<project_root>/deploy/olm-catalog/<bundle_name>/manifests`, specify the location with the `--directory` flag.
-====
+. Run the following `make` commands in your Operator project directory to build and push your Operator image. Modify the `IMG` argument in the following steps to reference a repository that you have access to. You can obtain an account for storing containers at repository sites such as Quay.io.
 
-. Log in to the registry where you want to push the bundle image. For example:
+.. Build the image:
 +
 [source,terminal]
 ----
-$ podman login <registry>
+$ make docker-build IMG=<registry>/<user>/<operator_image_name>:<tag>
 ----
 
-. Push the bundle image to the registry:
+.. Push the image to a repository:
 +
 [source,terminal]
 ----
-$ podman push <registry>/<namespace>/<bundle_image_name>:<tag>
+$ make docker-push IMG=<registry>/<user>/<operator_image_name>:<tag>
 ----
 
-. Validate the bundle image in the remote registry:
+. Update your `Makefile` by setting the `IMG` URL to your Operator image name and tag that you pushed:
 +
 [source,terminal]
 ----
-$ operator-sdk bundle validate \
-    <registry>/<namespace>/<bundle_image_name>:<tag> \
-    -b podman
+$ # Image URL to use all building/pushing image targets
+IMG ?= <registry>/<user>/<operator_image_name>:<tag>
 ----
 +
-.Example output
+This value is used for subsequent operations.
+
+. Create your Operator bundle manifest by running the `make bundle` command, which invokes several commands, including the Operator SDK `generate bundle` and `bundle validate` subcommands:
++
 [source,terminal]
 ----
-INFO[0000] Unpacked image layers                                 bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0000] running podman pull                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0002] running podman save                                   bundle-dir=/tmp/bundle-041168359 container-tool=podman
-INFO[0002] All validation tests have completed successfully      bundle-dir=/tmp/bundle-041168359 container-tool=podman
+$ make bundle
+----
++
+Bundle manifests for an Operator describe how to display, create, and manage an application. The `make bundle` command creates the following files and directories in your Operator project:
++
+--
+* A bundle manifests directory named `bundle/manifests` that contains a `ClusterServiceVersion` object
+* A bundle metadata directory named `bundle/metadata`
+* All custom resource definitions (CRDs) in a `config/crd` directory
+* A Dockerfile `bundle.Dockerfile`
+--
++
+These files are then automatically validated by using `operator-sdk bundle validate` to ensure the on-disk bundle representation is correct.
+
+. Build and push your bundle image by running the following commands. OLM consumes Operator bundles using an index image, which reference one or more bundle images.
+
+.. Build the bundle image. Set `BUNDLE_IMG` with the details for the registry, user namespace, and image tag where you intend to push the image:
++
+[source,terminal]
+----
+$ make bundle-build BUNDLE_IMG=<registry>/<user>/<bundle_image_name>:<tag>
+----
+
+.. Push the bundle image:
++
+[source,terminal]
+----
+$ docker push <registry>/<user>/<bundle_image_name>:<tag>
 ----


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1886864

Preview Link: https://deploy-preview-37177--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-working-bundle-images?utm_source=github&utm_campaign=bot_dp

@emmajiafan - Kindly review the fix