### PR TITLE
multipath: add `rw` karg for day1 multipathing

### DIFF
--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -43,7 +43,8 @@ $ mpathconf --enable && systemctl start multipathd.service
 ----
 $ coreos-installer install /dev/mapper/mpatha \ <1>
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root
+--append-karg root=/dev/disk/by-label/dm-mpath-root \
+--append-karg rw
 ----
 <1> Indicates the path of the single multipathed device.
 +
@@ -53,7 +54,8 @@ $ coreos-installer install /dev/mapper/mpatha \ <1>
 ----
 $ coreos-installer install /dev/disk/by-id/wwn-<wwn_ID> \ <1>
 --append-karg rd.multipath=default \
---append-karg root=/dev/disk/by-label/dm-mpath-root
+--append-karg root=/dev/disk/by-label/dm-mpath-root \
+--append-karg rw
 ----
 <1> Indicates the WWN ID of the target multipathed device. For example, `0xx194e957fcedb4841`.
 +


### PR DESCRIPTION
Normally, RHCOS automatically adds `rw` to the kernel cmdline after the
first boot. But it won't do this if there's already a `root` karg
specified. So while it's not necessary for day-2 multipath, for day-1 we
do need to explicitly add it.

Related: rhbz#2011776