### PR TITLE
Bug 2011855: [vsphere] add privilege for vmware-vsphere csi driver

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -72,6 +72,7 @@ An additional role is required if the installation program is to create a vSpher
 `Datastore.AllocateSpace`
 `Datastore.Browse`
 `Datastore.FileManagement`
+`InventoryService.Tagging.ObjectAttachable`
 
 |vSphere Port Group
 |Always


### PR DESCRIPTION
4.10 CI testing revealed an additional required privilege on the datastore for the vmware-vsphere CSI driver.  The intent of this PR is to add the privilege to the docs for 4.9/4.10.  

cc: @gnufied @jcpowermac 

required here: https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/0e66c4af75609334bf29eced4ea46e5cc51f6ee1/pkg/operator/storageclasscontroller/vmware.go#L226

failing test example:
Operator degraded (VSphereCSIDriverOperatorCR_VMwareVSphereDriverStorageClassController_SyncError): VSphereCSIDriverOperatorCRDegraded: VMwareVSphereDriverStorageClassControllerDegraded: error creating or applying tag ci-op-iqmx58wm-b00e2-8mmxb: POST https://ibmvcenter.vmc-ci.devcluster.openshift.com/rest/com/vmware/cis/tagging/tag-association/id:urn:vmomi:InventoryServiceTag:5b0ca3c1-4e1f-47eb-b265-c85f5dadd9a1:GLOBAL?~action=attach: 403 Forbidden