### PR TITLE
OSDOCS-2721 Changed book title of hardware enablement

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2059,11 +2059,11 @@ Topics:
   File: ztp-deploying-disconnected
   Distros: openshift-origin,openshift-enterprise
 ---
-Name: Hardware enablement
+Name: Specialized hardware and driver enablement
 Dir: hardware_enablement
 Distros: openshift-origin,openshift-enterprise
 Topics:
-- Name: About hardware enablement
+- Name: About specialized hardware and driver enablement
   File: about-hardware-enablement
 - Name: Driver Toolkit
   File: psap-driver-toolkit

--- a/hardware_enablement/about-hardware-enablement.adoc
+++ b/hardware_enablement/about-hardware-enablement.adoc
@@ -1,5 +1,5 @@
 [id="about-hardware-enablement"]
-= About hardware enablement
+= About specialized hardware and driver enablement
 include::modules/common-attributes.adoc[]
 :context: about-hardware-enablement
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2721

Direct link to the change:
https://deploy-preview-37187--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/about-hardware-enablement.html

Affects 4.9+