### PR TITLE
added command and rephrased proc steps like run

### DIFF
--- a/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
+++ b/modules/create-a-kubeletconfig-crd-to-edit-kubelet-parameters.adoc
@@ -17,14 +17,14 @@ As the fields in the `kubeletConfig` object are passed directly to the kubelet f
 
 .Procedure
 
-. Run:
+. View the available machine configuration objects that you can select:
 +
 [source,terminal]
 ----
 $ oc get machineconfig
 ----
 +
-This provides a list of the available machine configuration objects you can select. By default, the two kubelet-related configs are `01-master-kubelet` and `01-worker-kubelet`.
+By default, the two kubelet-related configs are `01-master-kubelet` and `01-worker-kubelet`.
 
 . To check the current value of max pods per node, run:
 +
@@ -88,14 +88,21 @@ spec:
     kubeAPIQPS: <QPS>
 ----
 
-.. Run:
+.. Update the machine config pool for workers with the label:
++
+[source,terminal]
+----
+$ oc label machineconfigpool worker custom-kubelet=large-pods
+----
+
+.. Create the `KubeletConfig` object:
 +
 [source,terminal]
 ----
 $ oc create -f change-maxPods-cr.yaml
 ----
 
-.. Run:
+.. Verify that the `KubeletConfig` object is created:
 +
 [source,terminal]
 ----
@@ -130,14 +137,16 @@ cluster, it can take a long time for the configuration change to be reflected.
 At any time, you can adjust the number of machines that are updating to speed up
 the process.
 
-. Run:
+. Edit the `worker` machine config pool:
 +
+[source,terminal]
 ----
 $ oc edit machineconfigpool worker
 ----
 
 . Set `maxUnavailable` to the desired value.
 +
+[source,yaml]
 ----
 spec:
   maxUnavailable: <node_count>


### PR DESCRIPTION
This applies to only `enterprise-4.6` .
[https://bugzilla.redhat.com/show_bug.cgi?id=1912719](url)

Added a command and rephrased procedure steps that say `Run`. 
Steps should be more descriptive and in line with 4.7/4.8 currently.

Preview:[https://deploy-preview-37188--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html](url)
@jianzhangbjz please review