### PR TITLE
TELCODOCS-258: Release notes for TELCODOCS-258

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -113,6 +113,20 @@ For more information, see xref:../updating/updating-cluster-prepare.adoc#updatin
 
 {product-title} 4.9 supports etcd 3.5. Before you upgrade the cluster, verify that a valid etcd backup exists. An etcd backup ensures that the cluster can be restored if an upgrade failure occurs. In {product-title} 4.9, etcd upgrades are automatic. Depending on the cluster’s transition state to version 4.9, an etcd backup might be available. However, verifying that a backup exists before the cluster upgrade starts is recommended.
 
+[id="ocp-4-9-installation-ibm-cloud"]
+==== Installing a cluster on IBM Cloud using installer-provisioned infrastructure
+
+{product-title} 4.9 introduces support for installing a cluster on IBM Cloud&#174; using installer-provisioned infrastructure. The procedure is nearly identical to installer-provisioned infrastructure on bare metal with these differences:
+
+* Installer-provisioned installation of {product-title} 4.9 on IBM Cloud requires the `provisioning` network, IPMI, and PXE boot. Red Hat does not support deployment with Redfish and virtual media on IBM Cloud.
+* You must create and configure public and private VLANs on the IBM Cloud.
+* IBM Cloud nodes must be available before starting the installation process. So you must create the IBM Cloud nodes first.
+* You must prepare the provisioner node.
+* You must install and configure a DHCP server on the public `baremetal` network.
+* You must configure the `install-config.yaml` file so that each node points to the BMC using IPMI, and sets the IPMI privilege level to `OPERATOR.`
+
+See xref:../installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc[Deploying installer-provisioned clusters on IBM Cloud] for details.
+
 [id="ocp-4-9-web-console"]
 === Web console
 


### PR DESCRIPTION
Provides release notes for [TELCODOCS-258](https://issues.redhat.com/browse/TELCODOCS-258). 

Fixes: [TELCODOCS-258](https://issues.redhat.com/browse/TELCODOCS-258)

Release Version: 4.9

Preview URL: https://deploy-preview-37204--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-installation-ibm-cloud

Signed-off-by: John Wilkins <jowilkin@redhat.com>