### PR TITLE
BZ:1923942 - Improving image registry mirroring documentation

### DIFF
--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -38,7 +38,7 @@ requested from the source repository.
 
 [NOTE]
 ====
-You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project. 
+You can only configure global pull secrets for clusters that have an `ImageContentSourcePolicy` object. You cannot add a pull secret to a project.
 ====
 
 .Prerequisites
@@ -80,9 +80,13 @@ spec:
   - mirrors:
     - example.com/example/ubi-minimal
     source: registry.access.redhat.com/ubi8/ubi-minimal
+  - mirrors:
+    - mirror.example.com/redhat
+    source: registry.redhat.io/openshift4 <3>
 ----
 <1> Indicates the name of the image registry and repository.
 <2> Indicates the registry and repository containing the content that is mirrored.
+<3> You can configure a namespace inside a registry to use any image in that namespace. If you use a registry domain as a source, the `ImageContentSourcePolicy` resource is applied to all repositories from the registry.
 
 . Create the new `ImageContentSourcePolicy` object:
 +


### PR DESCRIPTION
For Versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1923942[BZ#1923942]

Description: Customer wanted to be able use any image in a registry, not just a specific one. Added clarification that it is possible to configure a namespace inside a registry to use any image in that namespace. 

Preview: https://deploy-preview-37206--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-registry-mirror_image-configuration

Ready for QA: @xiuwang 

For Peer reviewers: Labels needed 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' and 'Peer Review needed'. Thank you!! 