### PR TITLE
CNV14246: Adding release note about virtctl guestfs command

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -57,6 +57,9 @@ High-performance virtual machine templates are now available for xref:virt-guest
 //CNV-8875
 * If your {VirtProductName} Operator subscription used any update channel other than *stable*, it is now automatically subscribed to the *stable* channel. This single update channel delivers z-stream and minor version updates and ensures that your {VirtProductName} and {product-title} versions are compatible.
 
+//CNV-14246
+* You can now use the `virtctl guestfs` command xref:../virt/virt-using-the-cli-tools.html#virt-creating-pvc-with-virtctl-guestfs_virt-using-the-cli-tools[to maintain, repair, and debug virtual machine disks].
+
 [id="virt-4-9-quick-starts"]
 === Quick starts
 


### PR DESCRIPTION
This PR addresses JIRA story [CNV-14246](https://issues.redhat.com/browse/CNV-14246) ( https://issues.redhat.com/browse/CNV-14246 ).

The story is a release note about the new virtctl guest command

CP: 4.9

Preview: Bullet starting with "You can now use a new virtctl guestfs" in https://deploy-preview-37211--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-9-new