### PR TITLE
CNV14262: Adding release note about VMs booting in EFI mode no longer requiring SecureBoot

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -63,6 +63,9 @@ The SVVP Certification applies to:
 //CNV-14246
 * You can now use the `virtctl guestfs` command xref:../virt/virt-using-the-cli-tools.html#virt-creating-pvc-with-virtctl-guestfs_virt-using-the-cli-tools[to maintain, repair, and debug virtual machine disks].
 
+//CNV-14262
+* You can now xref:../virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.html#virt-booting-vms-efi-mode_virt-efi-mode-for-vms[boot virtual machines with EFI mode] without mandatory Secure Boot.
+
 [id="virt-4-9-quick-starts"]
 === Quick starts
 


### PR DESCRIPTION
This PR addresses JIRA story [CNV-14262](https://issues.redhat.com/browse/CNV-14262) ( https://issues.redhat.com/browse/CNV-14262 ).

The story is a release note about VMs booting in EFI mode no longer requiring SecureBoot.

CP: 4.9

Preview: Bullet starting with "You can now boot VMs with EFI mode" in https://deploy-preview-37212--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#virt-4-9-new