### PR TITLE
Removes worker nodes from example output because they would not show …

### DIFF
--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -50,8 +50,6 @@ NAME      STATUS    ROLES   AGE  VERSION
 master-0  Ready     master  63m  v1.19.0
 master-1  Ready     master  63m  v1.19.0
 master-2  Ready     master  64m  v1.19.0
-worker-0  NotReady  worker  76s  v1.19.0
-worker-1  NotReady  worker  70s  v1.19.0
 ----
 +
 The output lists all of the machines that you created.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910456

Preview: https://deploy-preview-37213--osdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html#installation-approve-csrs_adding-bare-metal-compute-user-infra

For 4.6

Pending QE ack. 

