### PR TITLE
Adding guidance to not use jq back into the guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -934,6 +934,20 @@ spec:
 +
 Do not use `[...]`, `<snip>`, or any other variant.
 
+* Do not use `jq` in commands (unless it is truly required), because this requires users to install the `jq` tool. Oftentimes, the same or similar result can be accomplished using `jsonpath` for `oc` commands.
++
+For example, this command that uses `jq`:
++
+----
+$ oc get clusterversion -o json|jq ".items[0].spec"
+----
++
+can be updated to use `jsonpath` instead:
++
+----
+$ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'
+----
+
 === Inline code or commands
 Do NOT show full commands or command syntax inline within a sentence. The next section covers how to show commands and command syntax.
 


### PR DESCRIPTION
Looks like the guidance on avoiding `jq` accidentally got removed from the guidelines. Adding it back in with some additional details.

Preview: https://github.com/openshift/openshift-docs/blob/b424a7eab752a670eb46f5c1a377d6f5122cfab5/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output

For reference this was the original guidance:

```
[WARNING]
====
Do not provide examples which use `jq`. Examples should use a templating engine that is provided with oc, like `jsonpath`. See (https://bugzilla.redhat.com/show_bug.cgi?id=1764726#c6) for more information. 
====
```