### PR TITLE
[virt] Adding CNV docs to OKD

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1699,7 +1699,7 @@ Topics:
   - Name: Adding compute machines to bare metal
     File: adding-bare-metal-compute-user-infra
 - Name: Deploying machine health checks
-  File: deploying-machine-health-checks 
+  File: deploying-machine-health-checks
 ---
 Name: Nodes
 Dir: nodes
@@ -1785,7 +1785,7 @@ Topics:
   - Name: Using the Node Tuning Operator
     File: nodes-node-tuning-operator
   - Name: Remediating nodes with the Poison Pill Operator
-    File: eco-poison-pill-operator 
+    File: eco-poison-pill-operator
   - Name: Understanding node rebooting
     File: nodes-nodes-rebooting
   - Name: Freeing node resources using garbage collection
@@ -2781,37 +2781,81 @@ Topics:
   - Name: Removing Jaeger
     File: rhbjaeger-removing
 ---
-Name: OpenShift Virtualization
+Name: Virtualization
 Dir: virt
-Distros: openshift-enterprise
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: About OpenShift Virtualization
   File: about-virt
+  Distros: openshift-enterprise
+- Name: About OKD Virtualization
+  File: about-virt
+  Distros: openshift-origin
 - Name: Start here with OpenShift Virtualization
   File: virt-learn-more-about-openshift-virtualization
+  Distros: openshift-enterprise
+- Name: Start here with OKD Virtualization
+  File: virt-learn-more-about-openshift-virtualization
+  Distros: openshift-origin
 - Name: OpenShift Virtualization release notes
   File: virt-4-8-release-notes
-- Name: Installing OpenShift Virtualization
+  Distros: openshift-enterprise
+- Name: OKD Virtualization release notes
+  File: virt-4-8-release-notes
+  Distros: openshift-origin
+- Name: Installing
   Dir: install
   Topics:
   - Name: Preparing your OpenShift cluster for OpenShift Virtualization
     File: preparing-cluster-for-virt
+    Distros: openshift-enterprise
+  - Name: Preparing your OKD cluster for OKD Virtualization
+    File: preparing-cluster-for-virt
+    Distros: openshift-origin
   - Name: Planning your environment according to OpenShift Virtualization object maximums
     File: virt-planning-environment-object-maximums
+    Distros: openshift-enterprise
+  - Name: Planning your environment according to OKD Virtualization object maximums
+    File: virt-planning-environment-object-maximums
+    Distros: openshift-origin
   - Name: Specifying nodes for OpenShift Virtualization components
     File: virt-specifying-nodes-for-virtualization-components
+    Distros: openshift-enterprise
+  - Name: Specifying nodes for OKD Virtualization components
+    File: virt-specifying-nodes-for-virtualization-components
+    Distros: openshift-origin
   - Name: Installing OpenShift Virtualization using the web console
     File: installing-virt-web
+    Distros: openshift-enterprise
+  - Name: Installing OKD Virtualization using the web console
+    File: installing-virt-web
+    Distros: openshift-origin
   - Name: Installing OpenShift Virtualization using the CLI
     File: installing-virt-cli
+    Distros: openshift-enterprise
+  - Name: Installing OKD Virtualization using the CLI
+    File: installing-virt-cli
+    Distros: openshift-origin
   - Name: Enabling the virtctl client
     File: virt-enabling-virtctl
   - Name: Uninstalling OpenShift Virtualization using the web console
     File: uninstalling-virt-web
+    Distros: openshift-enterprise
+  - Name: Uninstalling OKD Virtualization using the web console
+    File: uninstalling-virt-web
+    Distros: openshift-origin
   - Name: Uninstalling OpenShift Virtualization using the CLI
     File: uninstalling-virt-cli
+    Distros: openshift-enterprise
+  - Name: Uninstalling OKD Virtualization using the CLI
+    File: uninstalling-virt-cli
+    Distros: openshift-origin
 - Name: Upgrading OpenShift Virtualization
   File: upgrading-virt
+  Distros: openshift-enterprise
+- Name: Upgrading OKD Virtualization
+  File: upgrading-virt
+  Distros: openshift-origin
 - Name: Additional security privileges granted for kubevirt-controller and virt-launcher
   File: virt-additional-security-privileges-controller-and-launcher
 - Name: Using the CLI tools
@@ -2902,6 +2946,10 @@ Topics:
     Topics:
     - Name: Using the default pod network with OpenShift Virtualization
       File: virt-using-the-default-pod-network-with-virt
+      Distros: openshift-enterprise
+    - Name: Using the default pod network with OKD Virtualization
+      File: virt-using-the-default-pod-network-with-virt
+      Distros: openshift-origin
     - Name: Attaching a virtual machine to multiple networks
       File: virt-attaching-vm-multiple-networks
     - Name: Configuring IP addresses for virtual machines
@@ -3044,6 +3092,10 @@ Topics:
     File: virt-prometheus-queries
   - Name: Collecting OpenShift Virtualization data for Red Hat Support
     File: virt-collecting-virt-data
+    Distros: openshift-enterprise
+  - Name: Collecting OKD Virtualization data for community report
+    File: virt-collecting-virt-data
+    Distros: openshift-origin
 ---
 # OpenShift Serverless
 Name: Serverless

--- a/modules/virt-about-node-maintenance.adoc
+++ b/modules/virt-about-node-maintenance.adoc
@@ -15,7 +15,7 @@ Virtual machine instances without an eviction strategy are shut down. Virtual ma
 Virtual machines must have a persistent volume claim (PVC) with a shared `ReadWriteMany` (RWX) access mode to be live migrated.
 ====
 
-When installed as part of OpenShift Virtualization, Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.
+When installed as part of {VirtProductName}, Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.
 
 [NOTE]
 ====

--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -31,3 +31,12 @@
 :Install_BookName: Installing OpenShift Virtualization
 :Using_BookName: Using OpenShift Virtualization
 :RN_BookName: OpenShift Virtualization release notes
+
+// OKD branding
+ifdef::openshift-origin[]
+:product-title: OKD
+:VirtProductName: OKD Virtualization
+:Install_BookName: Installing OKD Virtualization
+:Using_BookName: Using OKD Virtualization
+:RN_BookName: OKD Virtualization release notes
+endif::[]

--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -1,6 +1,7 @@
 [id="about-sriov"]
 = About Single Root I/O Virtualization (SR-IOV) hardware networks
 include::modules/common-attributes.adoc[]
+include::modules/virt-document-attributes.adoc[]
 :context: about-sriov
 
 toc::[]
@@ -65,6 +66,6 @@ include::modules/nw-sriov-huge-pages.adoc[leveloffset=+2]
 * xref:../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sriov-operator[Installing the SR-IOV Network Operator]
 * Optional: xref:../../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]
 * xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device]
-* If you use OpenShift Virtualization: xref:../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[Configuring an SR-IOV network device for virtual machines]
+* If you use {VirtProductName}: xref:../../virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc#virt-configuring-sriov-device-for-vms[Configuring an SR-IOV network device for virtual machines]
 * xref:../../networking/hardware_networks/configuring-sriov-net-attach.adoc#configuring-sriov-net-attach[Configuring an SR-IOV network attachment]
 * xref:../../networking/hardware_networks/add-pod.adoc#add-pod[Adding a pod to an SR-IOV additional network]

--- a/virt/install/installing-virt-cli.adoc
+++ b/virt/install/installing-virt-cli.adoc
@@ -1,6 +1,6 @@
+include::modules/virt-document-attributes.adoc[]
 [id="installing-virt-cli"]
 = Installing {VirtProductName} using the CLI
-include::modules/virt-document-attributes.adoc[]
 :context: installing-virt-cli
 
 toc::[]

--- a/virt/install/installing-virt-web.adoc
+++ b/virt/install/installing-virt-web.adoc
@@ -1,6 +1,6 @@
+include::modules/virt-document-attributes.adoc[]
 [id="installing-virt-web"]
 = Installing {VirtProductName} using the web console
-include::modules/virt-document-attributes.adoc[]
 :context: installing-virt-web
 
 toc::[]

--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -1,6 +1,6 @@
+include::modules/virt-document-attributes.adoc[]
 [id="preparing-cluster-for-virt"]
 = Configuring your cluster for {VirtProductName}
-include::modules/virt-document-attributes.adoc[]
 :context: preparing-cluster-for-virt
 
 toc::[]

--- a/virt/install/uninstalling-virt-cli.adoc
+++ b/virt/install/uninstalling-virt-cli.adoc
@@ -1,6 +1,6 @@
 [id="uninstalling-virt-cli"]
-= Uninstalling {VirtProductName} using the CLI
 include::modules/virt-document-attributes.adoc[]
+= Uninstalling {VirtProductName} using the CLI
 :context: uninstalling-virt-cli
 
 toc::[]

--- a/virt/install/uninstalling-virt-web.adoc
+++ b/virt/install/uninstalling-virt-web.adoc
@@ -1,6 +1,6 @@
 [id="uninstalling-virt-web"]
-= Uninstalling {VirtProductName} using the web console
 include::modules/virt-document-attributes.adoc[]
+= Uninstalling {VirtProductName} using the web console
 :context: uninstalling-virt-web
 
 toc::[]

--- a/virt/install/virt-planning-environment-object-maximums.adoc
+++ b/virt/install/virt-planning-environment-object-maximums.adoc
@@ -1,6 +1,6 @@
 [id="virt-planning-environment-object-maximums"]
-= Planning your environment according to {VirtProductName} object maximums
 include::modules/virt-document-attributes.adoc[]
+= Planning your environment according to {VirtProductName} object maximums
 :context: virt-planning-environment-object-maximums
 
 toc::[]

--- a/virt/install/virt-specifying-nodes-for-virtualization-components.adoc
+++ b/virt/install/virt-specifying-nodes-for-virtualization-components.adoc
@@ -1,6 +1,6 @@
+include::modules/virt-document-attributes.adoc[]
 [id="virt-specifying-nodes-for-virtualization-components"]
 = Specifying nodes for {VirtProductName} components
-include::modules/virt-document-attributes.adoc[]
 include::modules/common-attributes.adoc[]
 :context: virt-specifying-nodes-for-virtualization-components
 

--- a/virt/logging_events_monitoring/virt-collecting-virt-data.adoc
+++ b/virt/logging_events_monitoring/virt-collecting-virt-data.adoc
@@ -1,6 +1,6 @@
+include::modules/virt-document-attributes.adoc[]
 [id="virt-collecting-virt-data"]
 = Collecting {VirtProductName} data for Red Hat Support
-include::modules/virt-document-attributes.adoc[]
 :context: virt-collecting-virt-data
 
 toc::[]

--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -1,7 +1,7 @@
 [id="upgrading-virt"]
-= Upgrading {VirtProductName}
 include::modules/virt-document-attributes.adoc[]
 include::modules/common-attributes.adoc[]
+= Upgrading {VirtProductName}
 :context: upgrading-virt
 
 toc::[]

--- a/virt/virt-4-8-release-notes.adoc
+++ b/virt/virt-4-8-release-notes.adoc
@@ -1,6 +1,6 @@
 [id="virt-4-8-release-notes"]
-= {RN_BookName}
 include::modules/virt-document-attributes.adoc[]
+= {RN_BookName}
 :context: virt-4-8-release-notes
 toc::[]
 

--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -1,6 +1,6 @@
 [id="virt-learn-more-about-openshift-virtualization"]
-= Start here with {VirtProductName}
 include::modules/virt-document-attributes.adoc[]
+= Start here with {VirtProductName}
 :context: virt-learn-more-about-openshift-virtualization
 
 toc::[]


### PR DESCRIPTION
- This PR adds the CNV docs to the openshift-origin distro and changes the top-level ToC label to "Virtualization" to avoid "OpenShift" appearing in OKD (or vice versa). Similarly, the "Installing OpenShift Virtualization" ToC label is now "Installing" (which matches OpenShift).
- There is now an ifdef statement in the virt-document-attributes file so that `{VirtProductName}` renders as "OKD Virtualization" in the openshift-origin distro.
- Most changes originate from this PR by @sandrobonazzola: https://github.com/openshift/openshift-docs/pull/36612

- CP to enterprise-4.9
- QE approved; needs peer review
- Note: Netlify does not do an openshift-origin preview build. You can view the changes pertaining to openshift-enterprise [here](https://deploy-preview-37215--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html). I uploaded a preview build for the OKD changes, which you can view here: http://file.rdu.redhat.com/pousley/101221/okd-virt-docs/welcome/