### PR TITLE
Removes worker nodes from oc get nodes command as they will not show …

### DIFF
--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -59,8 +59,6 @@ NAME      STATUS    ROLES   AGE  VERSION
 master-0  Ready     master  63m  v1.22.1
 master-1  Ready     master  63m  v1.22.1
 master-2  Ready     master  64m  v1.22.1
-worker-0  NotReady  worker  76s  v1.22.1
-worker-1  NotReady  worker  70s  v1.22.1
 ----
 +
 The output lists all of the machines that you created.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1910456

Preview: https://deploy-preview-37216--osdocs.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-bare-metal-compute-user-infra.html#installation-approve-csrs_adding-bare-metal-compute-user-infra

Pending QE ack.

For 4.9 only. 