### PR TITLE
[vsphere] add storage profile update privilege

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -53,6 +53,7 @@ An additional role is required if the installation program is to create a vSpher
 `InventoryService.Tagging.EditCategory`
 `InventoryService.Tagging.EditTag`
 `Sessions.ValidateSession`
+`StorageProfile.Update`
 `StorageProfile.View`
 
 |vSphere vCenter Cluster


### PR DESCRIPTION
4.10 CI testing revealed an additional required privilege on the vCenter role for the vmware-vsphere CSI driver. The intent of this PR is to add the privilege to the docs for 4.9/4.10.

required here: https://github.com/openshift/vmware-vsphere-csi-driver-operator/blob/0e66c4af75609334bf29eced4ea46e5cc51f6ee1/pkg/operator/storageclasscontroller/vmware.go#L270

cc: @bergerhoffer @jcpowermac 