### PR TITLE
modules/nodes-descheduler-profiles: Clarify RemovePodsHavingTooManyRestarts as sum

### DIFF
--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -28,9 +28,9 @@ It enables the following strategies:
 +
 It enables the following strategies:
 +
-* `RemovePodsHavingTooManyRestarts`: removes pods that have been restarted too many times.
+* `RemovePodsHavingTooManyRestarts`: removes pods whose containers have been restarted too many times.
 +
-Pods that are restarted more than 100 times are removed. This includes restarts for Init Containers.
+Pods where the sum of restarts over all containers (including Init Containers) is more than 100.
 
 * `LowNodeUtilization`: finds nodes that are underutilized and evicts pods, if possible, from overutilized nodes in the hope that recreation of evicted pods will be scheduled on these underutilized nodes.
 +


### PR DESCRIPTION
Pods don't restart, although they can be deleted and replaced with new pods.  Containers within pods restart.  Previously it was unclear whether the threshold was "one of my containers has more than 100 restarts" or "summing over all of my containers, there have been more than 100 restarts".  This commit makes it clear that it's the latter, based on [the backing code][1].  For example, a pod with three containers, each with 50 restarts, would be eligible for descheduling.

I'm also not super exited about the "removes pods" language, since as the docs point out elsewhere, some pods are not descheduled (e.g. pods in the `openshift-*` and `kube-system` namespaces).  I'd prefer language like "Considers pods whose containers...".  But that's orthogonal enough that I'm leaving it out for this commit.

[1]: https://github.com/kubernetes-sigs/descheduler/blob/bfd5feaf60a202cecafcf2d30cf171a138c04885/pkg/descheduler/strategies/toomanyrestarts.go#L110-L122