### PR TITLE
OSDOCS-1781: Document image prune ignoreInvalidImageReferences parameter

### DIFF
--- a/modules/pruning-images-manual.adoc
+++ b/modules/pruning-images-manual.adoc
@@ -201,6 +201,7 @@ You can apply conditions to your manually pruned images.
 * When an image is pruned, all references to the image are removed from all
 image streams that have a reference to the image in `status.tags`.
 * Image layers that are no longer referenced by any images are removed.
+* `ignoreInvalidImageReferences` is enabled by default, and allows the pruner to continue pruning when it cannot parse an image reference of a pod, build, or deployment. If you can guarantee that all objects in your cluster have syntactically correct image references, and want to have confirmation that the image pruner understands every image reference, you can disable `ignoreInvalidImageReferences` by setting it to `false`. This is not recommended for multi-tenant clusters, because a single pod with an invalid reference blocks the pruner.
 
 [NOTE]
 ====
@@ -210,7 +211,7 @@ information that this operation is not allowed.
 
 Separating the removal of {product-title} image API objects and image data from the registry by using `--prune-registry=false`, followed by hard pruning the registry, can narrow timing windows and is safer when compared to trying to prune both through one command. However, timing windows are not completely removed.
 
-For example, you can still create a Pod referencing an image as pruning identifies that image for pruning. You should still keep track of an API object created during the pruning operations that might reference images so that you can mitigate any references to deleted content.
+For example, you can still create a pod referencing an image as pruning identifies that image for pruning. You should still keep track of an API object created during the pruning operations that might reference images so that you can mitigate any references to deleted content.
 
 Re-doing the pruning without the `--prune-registry` option or with `--prune-registry=true` does not lead to pruning the associated storage in the image registry for images previously pruned by `--prune-registry=false`. Any images that were pruned with `--prune-registry=false` can only be deleted from registry storage by hard pruning the registry.
 

--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -6,7 +6,7 @@
 = Automatically pruning images
 
 Images that are no longer required by the system due to age,
-status, or exceed limits are automatically pruned. Cluster administrators can configure the Pruning Custom Resource, or suspend it.
+status, or exceed limits are automatically pruned. Cluster administrators can configure the pruning custom resource (CR), or suspend it.
 
 .Prerequisites
 
@@ -16,7 +16,8 @@ status, or exceed limits are automatically pruned. Cluster administrators can co
 .Procedure
 
 * Verify that the object named `imagepruners.imageregistry.operator.openshift.io/cluster` contains the following `spec` and `status` fields:
-
++
+.Sample image pruner config file
 [source,yaml]
 ----
 spec:
@@ -31,9 +32,10 @@ spec:
   tolerations: [] <9>
   successfulJobsHistoryLimit: 3 <10>
   failedJobsHistoryLimit: 3 <11>
+  ignoreInvalidImageReferences: true <12>
 status:
-  observedGeneration: 2 <12>
-  conditions: <13>
+  observedGeneration: 2 <13>
+  conditions: <14>
   - type: Available
     status: "True"
     lastTransitionTime: 2019-10-09T03:13:45
@@ -50,23 +52,59 @@ status:
     reason: Succeeded
     message: "Most recent image pruning job succeeded."
 ----
-<1> `schedule`: `CronJob` formatted schedule. This is an optional field, default is daily at midnight.
-<2> `suspend`: If set to `true`, the `CronJob` running pruning is suspended. This is an optional field, default is `false`. The initial value on new clusters is `false`.
-<3> `keepTagRevisions`: The number of revisions per tag to keep. This is an optional field, default is `3`. The initial value is `3`.
-<4> `keepYoungerThanDuration`: Retain images younger than this duration. This is an optional field. If a value is not specified, either `keepYoungerThan` or the default value `60m` (60 minutes) is used.
-<5> `keepYoungerThan`: Deprecated. The same as `keepYoungerThanDuration`, but the duration is specified as an integer in nanoseconds. This is an optional field. When `keepYoungerThanDuration` is set, this field is ignored.
-<6> `resources`: Standard Pod resource requests and limits. This is an optional field.
-<7> `affinity`: Standard Pod affinity. This is an optional field.
-<8> `nodeSelector`: Standard Pod node selector. This is an optional field.
-<9> `tolerations`: Standard Pod tolerations. This is an optional field.
-<10> `successfulJobsHistoryLimit`: The maximum number of successful jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
-<11> `failedJobsHistoryLimit`: The maximum number of failed jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
-<12> `observedGeneration`: The generation observed by the Operator.
-<13> `conditions`: The standard condition objects with the following types:
-* `Available`: Indicates if the pruning job has been created. Reasons can be Ready or Error.
-* `Scheduled`: Indicates if the next pruning job has been scheduled. Reasons can be Scheduled, Suspended, or Error.
-* `Failed`: Indicates if the most recent pruning job failed.
+<1> Optional. `CronJob` formatted `schedule`. The default setting is daily at midnight.
+<2> Optional. If `suspend` is set to `true`, the `CronJob` running pruning is suspended. The `suspend` field is set to `false` by default. The initial value on new clusters is `false`.
+<3> Optional. `keepTagRevisions` is the number of revisions per tag to keep. The  default value is `3`. The initial value is `3`.
+<4> Optional. `keepYoungerThanDuration` retains images younger than this duration. If a value is not specified, either `keepYoungerThan` or the default value `60m` (60 minutes) is used.
+<5> Optional. `keepYoungerThan` is the same as `keepYoungerThanDuration`, but the duration is specified as an integer in nanoseconds. When `keepYoungerThanDuration` is set, this field is ignored. `keepYoungerThan` is deprecated.
+<6> Optional. `resources` are the standard pod resource requests and limits.
+<7> Optional. `affinity` is the standard pod affinity.
+<8> Optional. `nodeSelector` is the standard pod node selector.
+<9> Optional. `tolerations` is the standard pod tolerations.
+<10> Optional. `successfulJobsHistoryLimit` is the maximum number of successful jobs to retain. The value must be  set to `>= 1` to ensure metrics are reported. The default is `3`. The initial value is `3`.
+<11> Optional. `failedJobsHistoryLimit`: The maximum number of failed jobs to retain. Must be `>= 1` to ensure metrics are reported. This is an optional field, default is `3`. The initial value is `3`.
+<12> Optional. `ignoreInvalidImageReferences` indicates whether the pruner can ignore errors while parsing image references. The default value is `true`.
+<13> Optional. `observedGeneration` is the generation observed by the Operator.
+<14> Optional. `conditions`: The standard condition objects with the following types:
 
+- `Available`: Indicates if the pruning job has been created. Reasons can be `AsExpected` or `Error`.
+- `Scheduled`: Indicates if the next pruning job has been scheduled. Reasons can be `Scheduled` or `Suspended`.
+- `Failed`: Indicates if the most recent pruning job failed.
++
+.Sample image pruner config file with `Degraded` status conditions for `logLevel` and `status`
+[source,yaml]
+----
+spec:
+  failedJobsHistoryLimit: 3
+  ignoreInvalidImageReferences: true
+  keepTagRevisions: 3
+  logLevel: Normal
+  schedule: ""
+  successfulJobsHistoryLimit: 3
+  suspend: false
+status:
+  conditions:
+  - lastTransitionTime: "2021-10-15T03:50:13Z"
+    message: Pruner CronJob has been created
+    reason: AsExpected
+    status: "True"
+    type: Available
+  - lastTransitionTime: "2021-10-15T03:43:17Z"
+    message: Pruner completed successfully
+    reason: Complete
+    status: "False"
+    type: Failed
+  - lastTransitionTime: "2021-10-15T03:43:17Z"
+    message: The pruner job has been scheduled
+    reason: Scheduled
+    status: "True"
+    type: Scheduled
+  - lastTransitionTime: "2021-10-15T03:50:13Z"
+    reason: AsExpected
+    status: "False"
+    type: Degraded
+  observedGeneration: 1
+----
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1781

Preview build: https://deploy-preview-37229--osdocs.netlify.app/openshift-enterprise/latest/applications/pruning-objects?utm_source=github&utm_campaign=bot_dp#pruning-images_pruning-objects