### PR TITLE
Add additional explanation why an upgrade is not available in the upgrade service

### DIFF
--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -23,7 +23,7 @@ To allow the OpenShift Update Service to provide only compatible updates, a rele
 
 [IMPORTANT]
 ====
-The OpenShift Update Service displays all valid updates. Do not force an update to a version that the OpenShift Update Service does not display.
+The OpenShift Update Service displays all recommended updates for your current cluster.  If an upgrade path is not recommended by the OpenShift Update Service, it might be because of a known issue with the update or the target release.
 ====
 
 ////


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2723

Direct link to changes - It is the first IMPORTANT note in the section.
https://deploy-preview-37230--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-the-update-service.html#update-service-overview_understanding-the-update-service

Affects versions: 4.6+