### PR TITLE
BZ1974296: The hpa documentation should describe how to configure a hpa with Deployment and ReplicaSet

### DIFF
--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -64,3 +64,54 @@ Use the {product-title} web console to check the memory behavior of your applica
 and ensure that your application meets these requirements before using
 memory-based autoscaling.
 ====
+
+The following example shows autoscaling for the `image-registry` `DeploymentConfig` object. The initial deployment requires 3 pods. The HPA object increased that minimum to 5 and will increase the pods up to 7 if CPU usage on the pods reaches 75%:
+
+[source,terminal]
+----
+$ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
+----
+
+.Example output
+[source,terminal]
+----
+horizontalpodautoscaler.autoscaling/image-registry autoscaled
+----
+
+.Sample HPA for the `image-registry` `DeploymentConfig` object with `minReplicas` set to 3
+[source,yaml]
+----
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: image-registry
+  namespace: default
+spec:
+  maxReplicas: 7
+  minReplicas: 3
+  scaleTargetRef:
+    apiVersion: apps.openshift.io/v1
+    kind: DeploymentConfig
+    name: image-registry
+  targetCPUUtilizationPercentage: 75
+status:
+  currentReplicas: 5
+  desiredReplicas: 0
+----
+
+
+. View the new state of the deployment:
++
+[source,terminal]
+----
+$ oc get dc image-registry
+----
++
+There are now 5 pods in the deployment:
++
+.Example output
+[source,terminal]
+----
+NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
+image-registry   1          5         5         config
+----

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -6,8 +6,7 @@
 
 = Creating a horizontal pod autoscaler for CPU utilization by using the CLI
 
-You can create a horizontal pod autoscaler (HPA) for an existing `DeploymentConfig` or `ReplicationController` object
-that automatically scales the pods associated with that object to maintain the CPU usage you specify.
+You can create a horizontal pod autoscaler (HPA) for an existing `Deployment`, `DeploymentConfig`, `ReplicaSet`, `ReplicationController`, or `StatefulSet` object that automatically scales the pods associated with that object to maintain the CPU usage you specify.
 
 The HPA increases and decreases the number of replicas between the minimum and maximum numbers to maintain the specified CPU utilization across all pods.
 
@@ -56,37 +55,29 @@ To create a horizontal pod autoscaler for CPU utilization:
 
 . Perform one of the following one of the following:
 
-** To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing `DeploymentConfig` object:
+** To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing object:
 +
 [source,terminal]
 ----
-$ oc autoscale dc/<dc-name> \// <1>
+$ oc autoscale <object_type>/<name> \// <1>
   --min <number> \// <2>
   --max <number> \// <3>
   --cpu-percent=<percent> <4>
 ----
 +
-<1> Specify the name of the `DeploymentConfig` object. The object must exist.
+<1> Specify the type and name of the object to autoscale. The object must exist and be a `Deployment`, `DeploymentConfig`/`dc`, `ReplicaSet`/`rs`, `ReplicationController`/`rc`, or `StatefulSet`.
 <2> Optionally, specify the minimum number of replicas when scaling down.
 <3> Specify the maximum number of replicas when scaling up.
 <4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU. If not specified or negative, a default autoscaling policy is used.
-
-** To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing replication controller:
++
+For example, the following command shows autoscaling for the `image-registry` `DeploymentConfig` object. The initial deployment requires 3 pods. The HPA object increased that minimum to 5 and will increase the pods up to 7 if CPU usage on the pods reaches 75%:
 +
 [source,terminal]
 ----
-$ oc autoscale rc/<rc-name> <1>
-  --min <number> \// <2>
-  --max <number> \// <3>
-  --cpu-percent=<percent> <4>
+$ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
 ----
-+
-<1> Specify the name of the replication controller. The object must exist.
-<2> Specify the minimum number of replicas when scaling down.
-<3> Specify the maximum number of replicas when scaling up.
-<4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU. If not specified or negative, a default autoscaling policy is used.
 
-** To scale for a specific CPU value, create a YAML file similar to the following for an existing `DeploymentConfig` object or replication controller:
+** To scale for a specific CPU value, create a YAML file similar to the following for an existing object:
 +
 .. Create a YAML file similar to the following:
 +
@@ -100,7 +91,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: v1 <3>
-    kind: ReplicationController <4>
+    kind: ReplicaSet <4>
     name: example <5>
   minReplicas: 1 <6>
   maxReplicas: 10 <7>
@@ -115,9 +106,10 @@ spec:
 <1> Use the `autoscaling/v2beta2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
-* For a replication controller, use `v1`,
-* For a `DeploymentConfig` object, use `apps.openshift.io/v1`.
-<4> Specify the kind of object to scale, either `ReplicationController` or `DeploymentConfig`.
+* For a `ReplicationController`, use `v1`.
+* For a `DeploymentConfig`, use `apps.openshift.io/v1`.
+* For a `Deployment`, `ReplicaSet`, `Statefulset` object, use `apps/v1`.
+<4> Specify the type of object. The object must be a `Deployment`, `DeploymentConfig`/`dc`, `ReplicaSet`/`rs`, `ReplicationController`/`rc`, or `StatefulSet`.
 <5> Specify the name of the object to scale. The object must exist.
 <6> Specify the minimum number of replicas when scaling down.
 <7> Specify the maximum number of replicas when scaling up.
@@ -147,81 +139,3 @@ NAME            REFERENCE                       TARGETS         MINPODS   MAXPOD
 cpu-autoscale   ReplicationController/example   173m/500m       1         10        1          20m
 ----
 
-For example, the following command creates a horizontal pod autoscaler that maintains between 3 and 7 replicas of the pods that are controlled by the `image-registry` `DeploymentConfig` object to maintain an average CPU utilization of 75% across all pods.
-
-[source,terminal]
-----
-$ oc autoscale dc/image-registry --min 3 --max 7 --cpu-percent=75
-----
-
-.Example output
-[source,terminal]
-----
-horizontalpodautoscaler.autoscaling/image-registry autoscaled
-----
-
-.Sample HPA for the `image-registry` `DeploymentConfig` object with `minReplicas` set to 3
-[source,yaml]
-----
-apiVersion: autoscaling/v1
-kind: HorizontalPodAutoscaler
-metadata:
-  name: image-registry
-  namespace: default
-spec:
-  maxReplicas: 7
-  minReplicas: 3
-  scaleTargetRef:
-    apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
-    name: image-registry
-  targetCPUUtilizationPercentage: 75
-status:
-  currentReplicas: 5
-  desiredReplicas: 0
-----
-
-The following example shows autoscaling for the `image-registry` `DeploymentConfig` object. The initial deployment requires 3 pods. The HPA object increased that minimum to 5 and will increase the pods up to 7 if CPU usage on the pods reaches 75%:
-
-. View the current state of the `image-registry` deployment:
-+
-[source,terminal]
-----
-$ oc get dc image-registry
-----
-+
-.Example output
-[source,terminal]
-----
-NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
-image-registry   1          3         3         config
-----
-
-. Autoscale the `image-registry` `DeploymentConfig` object:
-+
-[source,terminal]
-----
-$ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
-----
-+
-.Example output
-[source,terminal]
-----
-horizontalpodautoscaler.autoscaling/image-registry autoscaled
-----
-
-. View the new state of the deployment:
-+
-[source,terminal]
-----
-$ oc get dc image-registry
-----
-+
-There are now 5 pods in the deployment:
-+
-.Example output
-[source,terminal]
-----
-NAME             REVISION   DESIRED   CURRENT   TRIGGERED BY
-image-registry   1          5         5         config
-----

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -58,7 +58,7 @@ To create a horizontal pod autoscaler for memory utilization:
 
 . Create a YAML file for one of the following:
 
-** To scale for a specific memory value, create a `HorizontalPodAutoscaler` object similar to the following for an existing `DeploymentConfig` object or replication controller:
+** To scale for a specific memory value, create a `HorizontalPodAutoscaler` object similar to the following for an existing `ReplicationController` object or replication controller:
 +
 .Example output
 [source,yaml,options="nowrap"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1974296

Previews:
_The following example shows autoscaling for the `image-registry`_
https://deploy-preview-37231--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling?utm_source=github&utm_campaign=bot_dp#supported-metrics

_Creating a horizontal pod autoscaler for CPU utilization by using the CLI_
https://deploy-preview-37231--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling?utm_source=github&utm_campaign=bot_dp#nodes-pods-autoscaling-creating-cpu_nodes-pods-autoscaling

_To scale for a specific memory value:_
https://deploy-preview-37231--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling?utm_source=github&utm_campaign=bot_dp#nodes-pods-autoscaling-creating-memory_nodes-pods-autoscaling