### PR TITLE
BZ190696: Add warning about protracted boot time with no feedback

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -33,3 +33,8 @@ For Dell servers, ensure the {product-title} cluster nodes have AutoAttach Enabl
 ====
 The installer will not initiate installation on a node if the node firmware is below the foregoing versions when installing with virtual media.
 ====
+
+[WARNING]
+====
+Boot times can take up to 10 minutes without any indication of progress. Do not cancel the installation or restart during this period because this could require troubleshooting on the next installation.
+====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1960696

Added Warning: Boot times are protracted without any indication of progress. Do not assume the boot is stuck, or abort or reboot during this installation.

Merge to enterprise-4.8.

Browse to preview: https://deploy-preview-37233--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites?utm_source=github&utm_campaign=bot_dp#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites 

SME feedback: The new wording is better IMHO. This way the deploying person(s) won't way for hours/days to start debugging.
Thanks! (Full details in the BZ)