### PR TITLE
BZ2011435 - Document "needVhostNet" & "isRdma" for SriovNetworkNodePolicy

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -22,16 +22,17 @@ spec:
     feature.node.kubernetes.io/network-sriov.capable: "true" <4>
   priority: <priority> <5>
   mtu: <mtu> <6>
-  numVfs: <num> <7>
-  nicSelector: <8>
-    vendor: "<vendor_code>" <9>
-    deviceID: "<device_id>" <10>
-    pfNames: ["<pf_name>", ...] <11>
-    rootDevices: ["<pci_bus_id>", ...] <12>
-    netFilter: "<filter_string>" <13>
-  deviceType: <device_type> <14>
-  isRdma: false <15>
-  linkType: <link_type> <16>
+  needVhostNet: false <7>
+  numVfs: <num> <8>
+  nicSelector: <9>
+    vendor: "<vendor_code>" <10>
+    deviceID: "<device_id>" <11>
+    pfNames: ["<pf_name>", ...] <12>
+    rootDevices: ["<pci_bus_id>", ...] <13>
+    netFilter: "<filter_string>" <14>
+  deviceType: <device_type> <15>
+  isRdma: false <16>
+  linkType: <link_type> <17>
 ----
 <1> The name for the custom resource object.
 
@@ -45,31 +46,35 @@ spec:
 
 <6> Optional: The maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different network interface controller (NIC) models.
 
-<7> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
+<7> Optional: Set `needVhostNet` to `true` to mount the `/dev/vhost-net` device in the pod. This can be use with Data Plane Development Kit (DPDK) to forward traffic to the kernel network stack.
 
-<8> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
+<8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
+
+<9> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 +
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
 
-<9> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
+<10> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
 
-<10> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
+<11> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
 
-<11> Optional: An array of one or more physical function (PF) names for the device.
+<12> Optional: An array of one or more physical function (PF) names for the device.
 
-<12> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
+<13> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
 
-<13> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
+<14> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
 
-<14> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
+<15> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
 +
-For a Mellanox NIC to work in Data Plane Development Kit (DPDK) mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
+For a Mellanox NIC to work in DPDK mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
 
-<15> Optional: Whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
+<16> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
 +
-If the `isRDMA` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
+If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
++
+Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
 
-<16> Optional: The link type for the VFs. You can specify one of the following values: `eth` or `ib`. Specify `eth` for Ethernet or `ib` for InfiniBand. The default value is `eth`.
+<17> Optional: The link type for the VFs. You can specify one of the following values: `eth` or `ib`. Specify `eth` for Ethernet or `ib` for InfiniBand. The default value is `eth`.
 +
 When `linkType` is set to `ib`, `isRdma` is automatically set to `true` by the SR-IOV Network Operator webhook. When `linkType` is set to `ib`, `deviceType` should not be set to `vfio-pci`.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2011430
https://bugzilla.redhat.com/show_bug.cgi?id=2011435

This work is for main, enterprise-4.9, enterprise-4.10

Preview: 

https://deploy-preview-37234--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#nw-sriov-networknodepolicy-object_configuring-sriov-device