### PR TITLE
[RHDEVDOCS-3208] ODC Release Notes, Bug Fixes for 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1436,6 +1436,10 @@ conditions:
 [id="ocp-4-9-web-console-developer-perspective-bug-fixes"]
 ==== Web console (Developer perspective)
 
+* Previously, kamelets of type `sink` were shown in the catalog for event sources along with source kamelets. In the current release, the catalog for event sources displays only kamelets of type `source`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971544[*BZ#1971544*])
+
+* Previously, the log file contained information in a single line without any line breaks. In the current release, the log file contains the expected line breaks with additional line breaks around log headers. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985080[*BZ#1985080*])
+
 [id="ocp-4-9-technology-preview"]
 == Technology Preview features
 


### PR DESCRIPTION
**Purpose**:
* Release notes for Openshift 4.9
* Bug fixes update for Web Console (Developer Perspective)

**PR information**:
* Aligned team: Dev Tools
* For branches: OpenShift 4.9
* JIRA: https://issues.redhat.com/browse/RHDEVDOCS-3208
* Direct link to doc preview: https://deploy-preview-37236--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-bug-fixes
* SME Review: @invincibleJai @andrewballantyne 
* QE Review: @karthikjeeyar 
* Peer Review: @missmesss @bburt-rh 