### PR TITLE
 OSDOCS-2527: Post-installation configuration overview

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -438,6 +438,8 @@ Name: Post-installation configuration
 Dir: post_installation_configuration
 Distros: openshift-origin,openshift-enterprise
 Topics:
+- Name: Post-installation configuration overview
+  File: index
 - Name: Configuring a private cluster
   Distros: openshift-enterprise,openshift-origin
   File: configuring-private-cluster

--- a/post_installation_configuration/index.adoc
+++ b/post_installation_configuration/index.adoc
@@ -1,0 +1,76 @@
+[id="post-install-configuration-overview"]
+= Post-installation configuration overview
+include::modules/common-attributes.adoc[]
+:context: post-installation-configuration-overview
+
+toc::[]
+
+After installing {product-title}, a cluster administrator can configure and customize the following components:
+
+* Machine
+* Cluster
+* Node
+* Network
+* Storage
+* Users
+* Alerts and notifications
+
+[id="post-install-tasks"]
+== Performing post-installation configuration tasks
+
+Cluster administrators can perform the following post-installation configuration tasks:
+
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#post-install-machine-configuration-tasks[Configure operating system features]:
+Machine Config Operator (MCO) manages `MachineConfig` objects. By using MCO, you can perform the following on an {product-title} cluster:
+
+** Configure nodes by using `MachineConfig` objects
+** Configure MCO-related custom resources
+
+* xref:../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[Configure cluster features]:
+As a cluster administrator, you can modify the configuration resources of the major features of an {product-title} cluster. These features include:
+
+** Image registry
+** Networking configuration
+** Image build behavior
+** Identity provider
+** The etcd configuration
+** Machine set creation to handle the workloads
+** Cloud provider credential management
+
+* xref:../post_installation_configuration/configuring-private-cluster.adoc#configuring-private-cluster[Configure cluster components to be private]:
+By default, the installation program provisions {product-title} by using a publicly accessible DNS and endpoints. If you want your cluster to be accessible from within an internal network only, configure the following components to be private:
+
+** DNS
+** Ingress Controller
+** API server
+
+* xref:../post_installation_configuration/node-tasks.adoc#post-install-node-tasks[Perform node operations]:
+By default, {product-title} uses {op-system-first} compute machines.
+As a cluster administrator, you can perform the following operations with the machines in your {product-title} cluster:
+
+** Add and remove compute machines
+** Add and remove taints and tolerations to the nodes
+** Configure the maximum number of pods per node
+** Enable Device Manager
+
+* xref:../post_installation_configuration/network-configuration.adoc#post-install-network-configuration[Configure network]:
+After installing {product-title}, as a cluster administrator, you can configure the following:
+
+** Ingress cluster traffic
+** Node port service range
+** Network policy
+** Enabling the cluster-wide proxy
+
+* xref:../post_installation_configuration/storage-configuration.adoc#post-install-storage-configuration[Configure storage]:
+By default, containers operate using ephemeral storage or transient local storage. The ephemeral storage has a lifetime limitation, so you must configure persistent storage to store the data for a long time.
+You can configure storage by using one of the following methods:
+
+** *Dynamic provisioning*: You can dynamically provision storage on demand by defining and creating storage classes that control different levels of storage, including storage access.
+
+** *Static provisioning*: Cluster administrators can use Kubernetes persistent volumes to make existing storage available to a cluster by supporting various device configurations and mount options.
+
+* xref:../post_installation_configuration/preparing-for-users.adoc#post-install-preparing-for-users[Configure users]:
+OAuth access tokens allow users to authenticate themselves to the API. As a cluster administrator, you can configure OAuth to specify an identity provider, use role-based access control to define and apply permissions to users, and install an Operator from OperatorHub.
+
+* xref:../post_installation_configuration/configuring-alert-notifications.adoc#configuring-alert-notifications[Manage alerts and notifications]:
+As a cluster administrator, you can view firing alerts by default from the Alerting UI of the web console. You can also configure {product-title} to send alert notifications to external systems so that you learn about important issues with your cluster.


### PR DESCRIPTION
- The overview page for Post-installation configuration
-  OCP version: 4.6+
-  The post-installation book consists of many components as mentioned below
- [Jirra issue](https://issues.redhat.com/browse/OSDOCS-2527)
- Preview link : https://deploy-preview-37237--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/index.html
- QE contacts: Looking forward to the suggestions!
**Network**: @lihongan @zhaozhanqi @anuragthehatter  Kindly review the `Configuring cluster components to private` and `Configuring network` bullet points. 
**Authentication**: @yaoli-redhat Kindly review the `Configuring users` bullet point.
**Monitoring**: @lihongyan1 Kindly review the `Managing alerts and notifications` bullet point.
**MCO**: @rioliu-rh , @sergiordlr Kindly review the `Configuring operating system features` and `Performing machine operations` bullet points.
**Storage**: @duanwei33 Kindly review the `Configuring storage` bullet point. 