### PR TITLE
BZ#1986701 Remove erroneous text describing cluster proxy

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -103,10 +103,7 @@ additionalTrustBundle: | <4>
 ----
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
 URL scheme must be `http`. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpProxy` value.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. If
-this field is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections.
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpsProxy` value.
+<2> A proxy URL to use for creating HTTPS connections outside the cluster. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpsProxy` value.
 <3> A comma-separated list of destination domain names, IP addresses, or
 other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
 ifdef::vsphere,vmc[]

--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -103,9 +103,7 @@ spec:
 --
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
 URL scheme must be `http`.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. If
-this is not specified, then `httpProxy` is used for both HTTP and HTTPS
-connections.
+<2> A proxy URL to use for creating HTTPS connections outside the cluster.
 <3> A comma-separated list of destination domain names, domains, IP addresses or
 other network CIDRs to exclude proxying.
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1986701

Previews:
- https://deploy-preview-37245--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-configure-proxy_installing-aws-user-infra
- https://deploy-preview-37245--osdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html#nw-proxy-configure-object_config-cluster-wide-proxy