### PR TITLE
Updated the placement of the NHC Operator in the topic map file

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1793,10 +1793,10 @@ Topics:
     File: nodes-node-tuning-operator
   - Name: Remediating nodes with the Poison Pill Operator
     File: eco-poison-pill-operator
-  - Name: Understanding node rebooting
-    File: nodes-nodes-rebooting
   - Name: Deploying node health checks by using the Node Health Check Operator
     File: eco-node-health-check-operator
+  - Name: Understanding node rebooting
+    File: nodes-nodes-rebooting
   - Name: Freeing node resources using garbage collection
     File: nodes-nodes-garbage-collection
   - Name: Allocating resources for nodes


### PR DESCRIPTION
[TELCODOCS-296](https://issues.redhat.com/browse/TELCODOCS-296) Placing the Node Health Check Operator assembly right after the Poison Pill Operator assembly as these are related.

Applies to OpenShift 4.9