### PR TITLE
Adds notes for 4.7.33 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2219,6 +2219,8 @@ As a result, the oVirt CSI Driver Operator no longer continually restarts. (link
 
 * Currently, a Kubernetes port collision issue can cause a breakdown in pod-to-pod communication, even after pods are redeployed. For detailed information and a workaround, see the Red Hat Knowledge Base solution link:https://access.redhat.com/solutions/5940711[Port collisions between pod and cluster IPs on OpenShift 4 with OVN-Kubernetes]. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939676[*BZ#1939676*], link:https://bugzilla.redhat.com/show_bug.cgi?id=1939045[*BZ#1939045*])
 
+* In {product-title} 4.7, pod limits and requests do not appear in the web console. This feature cannot be implemented in this release without introducing a breaking change to monitoring.  This feature is fixed in {product-title} 4.8 release. For detailed information, see the Red Hat Knowledge Base solution link:https://access.redhat.com/solutions/6394861[{product-title} 4.7 console no longer displays request or limit lines on CPU and Memory usage charts] (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975147[*BZ#1975147*])
+
 [id="ocp-4-7-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
@@ -2899,6 +2901,31 @@ link:https://access.redhat.com/solutions/6362042[{product-title} 4.7.32 containe
 * Previously, a cluster was not fully operational when deployed on {rh-openstack} with the combination of a proxy and a custom CA certificate. This was due to the HTTP transport connection to {rh-openstack} endpoints using a custom CA certificate that was missing the proxy settings. With this update, the proxy settings to the HTTP transport are now used when connecting with a custom CA certificate. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2000551[*BZ#2000551*])
 
 [id="ocp-4-7-32-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-33"]
+=== RHBA-2021:3686 - {product-title} 4.7.33 bug fix update
+
+Issued: 2021-10-12
+
+{product-title} release 4.7.33 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3686[RHBA-2021:3686] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3685[RHBA-2021:3685] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6395081[{product-title} 4.7.33 container image list]
+
+[id="ocp-4-7-33-bug-fixes"]
+==== Bug fixes
+
+* Previously, there were incorrect tolerations for `handler` pods causing them not to deploy on nodes with taints. With this update, the correct toleration is set on `handler` pods and they are deployed on all nodes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1970127[*BZ#1970127*])
+
+* Previously, the `NetworkManager-wait-online.service` timed out too early which prevented a connection to be established before `coreos-installer` could fetch the `Ignition` config. With this update, the `NetworkManager-wait-online.service` timeout has been increased to its default upstream value and no longer fails to fetch `Ignition` config. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1983774[*BZ#1983774*])
+
+* Previously, there was an unchecked index operation `--max-components` argument. With this update, a check was implemented to ensure components do not request a value for an index that is out of range. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004194[*BZ#2004194*])
+
+[id="ocp-4-7-33-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Release notes for 4.7.33 

- Applies to `enterprise-4.7` only
- [Preview link](https://deploy-preview-37256--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-7-33)