### PR TITLE
Adds 4.8.14 RNs as well as a note on admin ack when upgrading to 4.9

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2477,7 +2477,7 @@ link:https://access.redhat.com/solutions/6221811[{product-title} 4.8.3 container
 [id="ocp-4-8-3-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-4"]
 === RHSA-2021:2983 - {product-title} 4.8.4 security and bug fix update
@@ -2513,7 +2513,7 @@ link:https://access.redhat.com/solutions/6246811[{product-title} 4.8.4 container
 [id="ocp-4-8-4-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1972478[*BZ#1972478*])
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 
 [id="ocp-4-8-5"]
@@ -2546,7 +2546,7 @@ A new enhancement adds egress IP address support to the {product-title} 4.8 Anon
 [id="ocp-4-8-5-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-9"]
 === RHBA-2021:3247 - {product-title} 4.8.9 security and bug fix update
@@ -2605,7 +2605,7 @@ Previously, the workaround was to remove and recreate these policies. With this 
 [id="ocp-4-8-9-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-10"]
 === RHBA-2021:3299 - {product-title} 4.8.10 bug fix update
@@ -2621,7 +2621,7 @@ link:https://access.redhat.com/solutions/6308491[{product-title} 4.8.10 containe
 [id="ocp-4-8-10-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-11"]
 === RHBA-2021:3429 - {product-title} 4.8.11 bug fix update
@@ -2642,7 +2642,7 @@ link:https://access.redhat.com/solutions/6324771[{product-title} 4.8.11 containe
 [id="ocp-4-8-11-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-12"]
 === RHBA-2021:3511 - {product-title} 4.8.12 bug fix update
@@ -2673,7 +2673,7 @@ The minimum storage required to install an {product-title} cluster has decreased
 [id="ocp-4-8-12-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-8-13"]
 === RHBA-2021:3632 - {product-title} 4.8.13 bug fix and security update
@@ -2689,7 +2689,7 @@ link:https://access.redhat.com/solutions/6363171[{product-title} 4.8.13 containe
 [id="ocp-4-8-13-features"]
 ==== Features
 
-* Kubernetes v1.21.4 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1213[1.21.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1212[1.21.3], and link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1211[1.21.2]. 
+* Kubernetes 1.21.4 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1213[1.21.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1212[1.21.3], and link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1211[1.21.2]. 
 
 [id="ocp-4-8-13-bug-fixes"]
 ==== Bug fixes
@@ -2700,4 +2700,38 @@ link:https://access.redhat.com/solutions/6363171[{product-title} 4.8.13 containe
 [id="ocp-4-8-13-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-14"]
+=== RHBA-2021:3682 - {product-title} 4.8.14 bug fix update
+
+Issued: 2021-10-11
+
+{product-title} release 4.8.14 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3682[RHBA-2021:3682] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6395061[{product-title} 4.8.14 container image list]
+
+[id="ocp-4-8-14-preparing-upgrade-next-release"]
+==== Preparing to upgrade to the next {product-title} release
+
+{product-title} 4.8.14 introduces a check that impacts upgrading to the next {product-title} release, which is currently planned to be {product-title} 4.9. This is because Kubernetes 1.22, which {product-title} 4.9 is expected to use, removed a link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-22[significant number of deprecated `v1beta1` APIs].
+
+This check requires an administrator to provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by the cluster. Administrators must evaluate their cluster for any removed APIs in use and migrate them to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.
+
+All clusters require this administrator acknowledgment before they can be upgraded to {product-title} 4.9.
+
+For more information on the list of removed Kubernetes APIs, tips for how to evaluate your cluster for removed APIs in use, and how to provide the administrator acknowledgment, see link:https://access.redhat.com/articles/6329921[Preparing to upgrade to OpenShift Container Platform 4.9].
+
+[id="ocp-4-8-14-bug-fixes"]
+==== Bug fixes
+
+* Previously, when `provisioningHostIP` was set, it was being assigned to the Metal3 pod even in cases where the provisioning network was disabled. This no longer happens. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975711[*BZ#1975711*])
+
+* Previously, when using IPv6 DHCP, node interface addresses might be leased with a `/128` prefix. Consequently, OVN-Kubernetes uses the same prefix to infer the node's network and routes any other address traffic, including traffic to other cluster nodes, through the gateway. With this update, OVN-Kubernetes inspects the node's routing table and checks for the wider routing entry for the node's interface address and uses that prefix to infer the node's network. As a result, traffic to other cluster nodes is no longer routed through the gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1994624[*BZ#1994624*])
+
+[id="ocp-4-8-14-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

Preview:  https://deploy-preview-37257--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-8-14

RNs for 4.8.14. 

To be merged 10-11. 