### PR TITLE
MON-1841 4.9 Monitoring Release Notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -647,6 +647,77 @@ In {product-title} 4.7, _Cluster Logging_ became _Red Hat OpenShift Logging_. Fo
 [id="ocp-4-9-monitoring"]
 === Monitoring
 
+The monitoring stack for this release includes the following new and modified features.
+
+==== Monitoring stack components and dependencies
+
+Updates to versions of monitoring stack components and dependencies include the following:
+
+* Prometheus to 2.29.2
+* The Prometheus Operator to 0.49.0
+* The Prometheus Adapter to 0.9.0
+* Alertmanager to 0.22.2
+* Thanos to 0.22.0
+
+==== Alerting rules
+
+* *New*
+** `HighlyAvailableWorkloadIncorrectlySpread` informs you about a potential problem when two instances of a highly available monitoring component are running on the same node and have persistent volumes attached.
+** `NodeFileDescriptorLimit` triggers an alert when a node kernel is running out of available file descriptors. A warning level alert fires at greater than 70% usage, and a critical level alert fires at greater than 90% usage.
+** `PrometheusLabelLimitHit` detects when a target exceeds the defined label limits.
+** `PrometheusTargetSyncFailure` detects when Prometheus fails to synchronize targets.
+** All critical alerting rules contain links to runbooks.
+* *Enhanced*
+** `AlertmanagerReceiversNotConfigured` and `KubePodCrashLooping` now contain fewer false positives.
+** `KubeCPUOvercommit` and `KubeMemoryOvercommit` are now more robust in non-homogeneous environments.
+** The `for` duration setting of the `NodeFilesystemAlmostOutOfSpace` alerting rule has changed from one hour to 30 minutes so that the system more quickly detects when disk space runs low.
+** `KubeDeploymentReplicasMismatch` now fires as expected. In previous versions, this alert did not fire.
+**  The following alerts now contain a `namespace` label:
+*** `AlertmanagerReceiversNotConfigured`
+*** `KubeClientErrors`
+*** `KubeCPUOvercommit`
+*** `KubeletDown`
+*** `KubeMemoryOvercommit`
+*** `MultipleContainersOOMKilled`
+*** `ThanosQueryGrpcClientErrorRate`
+*** `ThanosQueryGrpcServerErrorRate`
+*** `ThanosQueryHighDNSFailures`
+*** `ThanosQueryHttpRequestQueryErrorRateHigh`
+*** `ThanosQueryHttpRequestQueryRangeErrorRateHigh`
+*** `ThanosSidecarPrometheusDown`
+*** `Watchdog`
+
+[NOTE]
+=====
+Red Hat does not guarantee backward compatibility for metrics, recording rules, or alerting rules.
+=====
+
+==== Alertmanager
+
+* You can add and configure additional external Alertmanagers for both platform and user-defined project monitoring stacks.
+* You can disable the local Alertmanager instance.
+
+==== Prometheus
+
+* You can enable and configure remote write storage for both platform monitoring and user-defined projects in Prometheus. This feature enables you to send ingested metrics to long-term storage.
+* To reduce the overall memory consumption of Prometheus, the following cAdvisor metrics with both an empty `pod` and `namespace` label have been dropped: 
+** `container_fs_.*`
+** `container_spec_.*`
+** `container_blkio_device_usage_total`
+** `container_file_descriptors`
+** `container_sockets`
+** `container_threads_max`
+** `container_threads`
+** `container_start_time_seconds`
+** `container_last_seen`
+* When persistent storage is not configured for platform monitoring, upgrades and cluster disruptions can lead to data loss.  A warning message has been added to the `Degraded` condition when the system detects that persistent storage is not configured for platform monitoring. 
+* You can exclude individual user-defined projects from the `openshift-user-workload-monitoring` project by adding the `openshift.io/user-monitoring: "false"` label to them.
+* You can configure an `enforcedTargetLimit` parameter for the `openshift-user-workload-monitoring` project to set an overall limit on the number of targets scraped.
+
+==== Grafana
+
+Because running the default Grafana dashboard can take resources from user workloads, you can disable the Grafana dashboard deployment.
+
 [id="ocp-4-9-metering"]
 === Metering
 
@@ -1773,6 +1844,11 @@ sh-4.4$ bash -x /var/lib/haproxy/reload-haproxy
 Alternatively, you can annotate the route to force a reload.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
 
 * This release contains a known issue. If you customize the hostname and certificate of the OpenShift OAuth route, Jenkins no longer trusts the OAuth server endpoint. As a result, users cannot log in to the Jenkins console if they rely on the OpenShift OAuth integration to manage identity and access. A workaround is not available at this time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1991448[*BZ#1991448*])
+
+* Because certain high cardinality monitoring metrics were inadvertently dropped, the following container performance input and output metrics are not available in this release: `pod`, `qos`, and `System`.
++
+No workaround exists for this issue. To track these metrics for production workloads, do not upgrade to the initial 4.9 release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008120[*BZ#2008120*])
+
 
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
- Purpose: OpenShift 4.9 Release Notes for Monitoring stack
- Aligned team: Dev Tools
- For branches: 4.9 ONLY
- Jira: https://issues.redhat.com/browse/MON-1841
- Direct link to doc previews: 
- - New and enhanced features: https://deploy-preview-37264--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-monitoring.
- - Known issues: https://deploy-preview-37264--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-known-issues
- SME review: @simonpasquier (approved)
- QE review: @juzhao (approved) and @lihongyan1
- Peer review: @missmesss and @jc-berger (approved)
- All reviews complete. Please merge now