### PR TITLE
OSDOCS-1837: removing notes that were only for 4.6-4.8

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -99,12 +99,6 @@ The minimum TLS version for Ingress Controllers is `1.1`, and the maximum TLS ve
 Ciphers and the minimum TLS version of the configured security profile are reflected in the `TLSProfile` status.
 ====
 
-[IMPORTANT]
-====
-{product-title} router enables Red Hat-distributed OpenSSL default set of TLS `1.3` cipher suites, which uses TLS_AES_128_CCM_SHA256, TLS_CHACHA20_POLY1305_SHA256, TLS_AES_256_GCM_SHA384, and TLS_AES_128_GCM_SHA256.
-Your cluster might accept TLS `1.3` connections and cipher suites, even though TLS `1.3` is unsupported in {product-title} 4.6, 4.7, and 4.8.
-====
-
 |`clientTLS`
 |`clientTLS` authenticates client access to the cluster and services; as a result, mutual TLS authentication is enabled. If not set, then client TLS is not enabled.
 

--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -47,10 +47,6 @@ In {product-title} 4.6, 4.7, and 4.8, the `Modern` profile is unsupported. If se
 ====
 Use caution when using a `Custom` profile, because invalid configurations can cause problems.
 ====
-[NOTE]
-====
-{product-title} router enables Red Hat-distributed OpenSSL default set of TLS `1.3` cipher suites. Your cluster might accept TLS `1.3` connections and cipher suites, even though TLS `1.3` is unsupported in {product-title} 4.6, 4.7, and 4.8.
-====
 |===
 
 [NOTE]


### PR DESCRIPTION
I needed to remove notes that got added to 4.9 when I created a PR against upstream/main for content that was only meant for 4.6-4.8 (#37087). 