### PR TITLE
BZ#1889247: Add gcp diskType and diskSizeGB parameter descriptions

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -932,6 +932,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |The name of the existing subnet in your VPC that you want to deploy your compute machines to.
 |The subnet name.
 
+|`platform.gcp.osDisk.diskSizeGB`
+|The size of the disk in gigabytes (GB).
+|Any size between 16 GB and 65536 GB.
+
+|`platform.gcp.osDisk.diskType`
+|The type of disk.
+|Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. The worker nodes can be either type.
+
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for control plane machine disk encryption.
 |The encryption key name.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1889247

OCP Version: 4.6+

Old PR with reviewer feedback: https://github.com/openshift/openshift-docs/pull/37122

Direct doc preview link: https://deploy-preview-37268--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-customizations