### PR TITLE
enterprise-4.9: OSDOCS-1837 removing notes that were only for 4.6-4.8

### DIFF
--- a/modules/tls-profiles-understanding.adoc
+++ b/modules/tls-profiles-understanding.adoc
@@ -42,7 +42,6 @@ The `Modern` profile requires a minimum TLS version of 1.3.
 ====
 Use caution when using a `Custom` profile, because invalid configurations can cause problems.
 ====
-
 |===
 
 [NOTE]


### PR DESCRIPTION
Cherry Picked from 87b047a | xref:  #37265