### PR TITLE
[enterprise-4.6] BZ:1889247 add gcp diskType and diskSizeGB params

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -753,6 +753,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |`platform.gcp.computeSubnet`
 |The name of the existing subnet in your VPC that you want to deploy your compute machines to.
 |The subnet name.
+
+|`platform.gcp.osDisk.diskSizeGB`
+|The size of the disk in gigabytes (GB).
+|Any size between 16 GB and 65536 GB.
+
+|`platform.gcp.osDisk.diskType`
+|The type of disk.
+|Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. The worker nodes can be either type.
 |====
 
 endif::gcp[]


### PR DESCRIPTION
Cherrypicked from 169e00e1359dbf147d520fd1a6898d676fe199cf | xref: https://github.com/openshift/openshift-docs/pull/37268