### PR TITLE
[enterprise-4.9] Add link to ShiftStack cloud provider item in RNs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -403,8 +403,8 @@ For more information, see xref:../networking/dns-operator.adoc#nw-dns-operator-m
 
 For clusters that run on {rh-openstack}, you can now configure Octavia for load balancing as a cloud provider option.
 
-// TODO: Link when doc is merged.
-// For more information, see xref:../
+For more information, see xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installation-osp-setting-cloud-provider-options_installing-openstack-installer-custom[Setting cloud provider options].
+
 [id="ocp-4-9-nw-tls-profile"]
 ==== Support added for TLS 1.3 and the Modern profile
 


### PR DESCRIPTION
This PR adds a link to a relevant docs example for a release note item.

Context: #36088 

Preview: https://deploy-preview-37285--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-networking-openshift-on-openstack-cloud-provider-options