### PR TITLE
BZ#1913242 Add link to compatibility matrix in the RHV install prerequisites

### DIFF
--- a/installing/installing_rhv/installing-rhv-customizations.adoc
+++ b/installing/installing_rhv/installing-rhv-customizations.adoc
@@ -30,6 +30,7 @@ This installation program is available for Linux and macOS only.
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization-first}].
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 

--- a/installing/installing_rhv/installing-rhv-default.adoc
+++ b/installing/installing_rhv/installing-rhv-default.adoc
@@ -23,6 +23,7 @@ This installation program is available for Linux and macOS only.
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization-first}].
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 

--- a/installing/installing_rhv/installing-rhv-user-infra.adoc
+++ b/installing/installing_rhv/installing-rhv-user-infra.adoc
@@ -18,7 +18,7 @@ The following items are required to install an {product-title} cluster on a {rh-
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
-* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization}].
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization-first}].
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_rhv/preparing-to-install-on-rhv.adoc
+++ b/installing/installing_rhv/preparing-to-install-on-rhv.adoc
@@ -1,5 +1,5 @@
 [id="preparing-to-install-on-rhv"]
-= Preparing to install on RHV
+= Preparing to install on {rh-virtualization-first}
 include::modules/common-attributes.adoc[]
 :context: preparing-to-install-on-rhv
 
@@ -9,6 +9,7 @@ toc::[]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have a supported combination of versions in the link:https://access.redhat.com/articles/5485861[Support Matrix for {product-title} on {rh-virtualization-first}].
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 
 [id="choosing-an-method-to-install-ocp-on-rhv"]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1913242
enterprise-4.9
could also be back-ported to enterprise-4.8 or to any recent version that customers are actively using

added link for [compatibility matrix](https://access.redhat.com/articles/5485861) in the Prerequisites for chapters:
[Preparing to Install on RHV](https://deploy-preview-37288--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/preparing-to-install-on-rhv.html)
[Installing a cluster on RHV with customizations](https://docs.openshift.com/container-platform/4.7/installing/installing_rhv/installing-rhv-customizations.html) 
[Installing a Cluster quickly on RHV](https://docs.openshift.com/container-platform/4.7/installing/installing_rhv/installing-rhv-default.html#prerequisites)