### PR TITLE
typo fix for BZ2011435

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -46,7 +46,7 @@ spec:
 
 <6> Optional: The maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different network interface controller (NIC) models.
 
-<7> Optional: Set `needVhostNet` to `true` to mount the `/dev/vhost-net` device in the pod. This can be use with Data Plane Development Kit (DPDK) to forward traffic to the kernel network stack.
+<7> Optional: Set `needVhostNet` to `true` to mount the `/dev/vhost-net` device in the pod. Use the mounted `/dev/vhost-net` device with Data Plane Development Kit (DPDK) to forward traffic to the kernel network stack.
 
 <8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 


### PR DESCRIPTION
Typo fix for https://bugzilla.redhat.com/show_bug.cgi?id=2011435.

Merge to enterprise-4.9, enterprise-4.10, main.

https://deploy-preview-37319--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#nw-sriov-networknodepolicy-object_configuring-sriov-device