### PR TITLE
GH#37176:Duplication of wording in nodes-edge-remote-workers.adoc

### DIFF
--- a/modules/nodes-edge-remote-workers-network.adoc
+++ b/modules/nodes-edge-remote-workers-network.adoc
@@ -11,8 +11,6 @@ All nodes send heartbeats to the Kubernetes Controller Manager Operator (kube co
 
 If the kube controller loses contact with a node after a configured period, the node controller on the control plane updates the node health to `Unhealthy` and marks the node `Ready` condition as `Unknown`. In response, the scheduler stops scheduling pods to that node. The on-premise node controller adds a `node.kubernetes.io/unreachable` taint with a `NoExecute` effect to the node and schedules pods on the node for eviction after five minutes, by default.  
 
-On that node, the kubelet adds a `node.kubernetes.io/unreachable` taint with a `NoExecute` effect to the node and begins to evict pods on the node after five minutes, by default. 
-
 If a workload controller, such as a `Deployment` object or `StatefulSet` object, is directing traffic to pods on the unhealthy node and other nodes can reach the cluster, {product-title} routes the traffic away from the pods on the node. Nodes that cannot reach the cluster do not get updated with the new traffic routing. As a result, the workloads on those nodes might continue to attempt to reach the unhealthy node.
 
 You can mitigate the effects of connection loss by: 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/37176

Preview: https://deploy-preview-37320--osdocs.netlify.app/openshift-enterprise/latest/nodes/edge/nodes-edge-remote-workers.html#nodes-edge-remote-workers-network_nodes-edge-remote-workers