### PR TITLE
Removing Remote Worker Nodes from OKD

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1875,7 +1875,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
 - Name: Remote worker nodes on the network edge
   Dir: edge
-  Distros: openshift-enterprise,openshift-origin
+  Distros: openshift-enterprise
   Topics:
   - Name: Using remote worker node at the network edge
     File: nodes-edge-remote-workers


### PR DESCRIPTION
The [Using remote worker nodes at the network edge](https://docs.okd.io/4.8/nodes/edge/nodes-edge-remote-workers.html) assembly is not appropriate for OKD. Removing.

Preview with topic removed: http://file.rdu.redhat.com/~mburke/odk-remove-remote-workers/nodes/clusters/nodes-containers-events.html