### PR TITLE
[BZ2013204] Kuryr: Add note on Service.spec.sessionAffinity

### DIFF
--- a/modules/installation-osp-kuryr-known-limitations.adoc
+++ b/modules/installation-osp-kuryr-known-limitations.adoc
@@ -19,6 +19,8 @@ Using {product-title} with Kuryr SDN has several limitations that apply to all v
 
 * If the subnet on which machines are created is not connected to a router, or if the subnet is connected, but the router has no external gateway set, Kuryr cannot create floating IPs for `Service` objects with type `LoadBalancer`.
 
+* Configuring the `sessionAffinity=ClientIP` property on `Service` objects does not have an effect. Kuryr does not support this setting.
+
 [discrete]
 [id="openstack-version-limitations_{context}"]
 == {rh-openstack} version limitations


### PR DESCRIPTION
The aforementioned option is not supported by Kuryr (due to OVN Octavia
limitations), so this commit explicitly lists it on "Known limitations
of installing with Kuryr" page.