### PR TITLE
BZ1986562: changing a note for a deprecated feature

### DIFF
--- a/modules/builds-identifying-image-change-triggers.adoc
+++ b/modules/builds-identifying-image-change-triggers.adoc
@@ -74,7 +74,8 @@ Each `BuildTriggerPolicy` has a `type` field and set of pointers fields. Each po
 
 For image change triggers, the value of `type` is `ImageChange`. Then, the `imageChange` field is the pointer to an `ImageChangeTrigger` object, which has the following fields:
 
-* `lastTriggeredImageID`: This field, which is not shown in the example, is deprecated in {product-title} 4.8 and will be ignored in a future release. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
+* `lastTriggeredImageID`: This field, which is not shown in the example, was deprecated in {product-title} 4.8 and is ignored in {product-title} 4.9. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
+
 * `paused`: You can use this field, which is not shown in the example, to temporarily disable this particular image change trigger.
 * `from`: You use this field to reference the `ImageStreamTag` that drives this image change trigger. Its type is the core Kubernetes type, `OwnerReference`.
 

--- a/modules/builds-image-change-trigger-identification.adoc
+++ b/modules/builds-image-change-trigger-identification.adoc
@@ -22,7 +22,7 @@ So for image change triggers, the value of `type` is `ImageChange`.
 
 Then, the `imageChange` field is the pointer to an `ImageChangeTrigger` object. So this will be set. It has the following fields:
 
-* `lastTriggeredImageID`: This field is deprecated in {product-title} 4.8, but is still being set. It will be ignored in a future release. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
+* `lastTriggeredImageID`: This field is deprecated in {product-title} 4.8 but is ignored in {product-title} 4.9. It contains the resolved image reference for the `ImageStreamTag` when the last build was triggered from this `BuildConfig`.
 * `paused`: This field is used to temporarily disable this particular image change trigger.
 * `from`: This field is used to reference the `ImageStreamTag` that drives this image change trigger. Its type is the core Kubernetes type, `OwnerReference`. The `from` field has the following fields of note:
   * `kind`: In this case, the only supported value is `ImageStreamTag`.


### PR DESCRIPTION
Goes with https://bugzilla.redhat.com/show_bug.cgi?id=1986562

This issue was surfaced on the 4.8 -> 4.9 [scrub](https://github.com/openshift/openshift-docs/pull/36974/files#r720336543), and I am pulling it out for a separate check.