### PR TITLE
CNV-14244_2: Re-adding Tech Preview include into Hot Plug Disk assembly

### DIFF
--- a/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc
@@ -4,6 +4,7 @@ include::modules/virt-document-attributes.adoc[]
 :context: virt-hot-plugging-virtual-disks
 
 :FeatureName: Hot-plugging virtual disks
+include::modules/technology-preview.adoc[leveloffset=+1]
 
 toc::[]
 


### PR DESCRIPTION
For 4.9 only.

See PR https://github.com/openshift/openshift-docs/pull/36962.

The Tech Preview `include:` was accidentally removed by another writer when working on the 4.9 release.

This PR only re-adds that one `include` statement. No new content otherwise.
