### PR TITLE
[WIP] BZ1975701: Add Tang workaround for vSphere to rel notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1770,9 +1770,33 @@ $ oc -n openshift-ingress rsh router-default-6647d984d8-q7b58
 sh-4.4$ bash -x /var/lib/haproxy/reload-haproxy
 ----
 +
-Alternatively, you can annotate the route to force a reload.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
+Alternatively, you can annotate the route to force a reload. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
 
 * This release contains a known issue. If you customize the hostname and certificate of the OpenShift OAuth route, Jenkins no longer trusts the OAuth server endpoint. As a result, users cannot log in to the Jenkins console if they rely on the OpenShift OAuth integration to manage identity and access. A workaround is not available at this time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1991448[*BZ#1991448*])
+
+* When Tang disk encryption is enabled on a cluster on VMware vSphere with user-provisioned infrastructure using a static IP address, the network changes to DHCP after the second reboot. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975701[*BZ#1975701*])
++
+As a workaround, add the following `rd.neednet=1` kernel argument to retain a static IP configuration:
++
+[source,terminal]
+----
+kernelArguments:
+  - rd.neednet=1
+  - ip=10.10.10.10::10.10.10.1:255.255.255.0::ens192:none:8.8.8.8 <1>
+----
++
+<1> You can use a short bash script to populate the `ip=` string, as shown in the following example:
++
+[source,bash]
+----
+ip='10.10.10.10'
+gateway='10.10.10.1'
+netmask='255.255.255.0'
+hostname=''
+interface='ens192'
+nameserver='8.8.8.8'
+echo "ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver}"
+----
 
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
[BZ1975701](https://bugzilla.redhat.com/show_bug.cgi?id=1975701)
As mentioned in https://github.com/openshift/openshift-docs/issues/33497#issuecomment-939259707, this adds a known issue and documented workaround to be added to the OCP 4.9 release notes. I will look at adding the workaround to the [Encrypting and mirroring disks during installation](https://docs.openshift.com/container-platform/4.8/installing/install_config/installing-customizing.html#installation-special-config-storage_installing-customizing) doc in a separate PR.

Preview link (last bullet):  https://deploy-preview-37356--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-known-issues