### PR TITLE
Fix backup / recovery rehearsal language

### DIFF
--- a/modules/rosa-policy-incident.adoc
+++ b/modules/rosa-policy-incident.adoc
@@ -73,7 +73,7 @@ All {product-title} clusters are backed up using AWS snapshots. Notably, this do
 
 |===
 
-- The SRE rehearses recovery processes quarterly.
+- Red Hat rehearses recovery processes periodically.
 - Red Hat does not commit to any Recovery Point Objective (RPO) or Recovery Time Objective (RTO).
 - Customers are responsible for taking regular backups of their data.
 - Backups performed by the SRE are taken as a precautionary measure only. They are stored in the same region as the cluster.


### PR DESCRIPTION
Red Hat currently rehearses recovery procedures annually. Docs previously mentioned "quarterly" rehearsals. Making this more generic to "periodically" so that if policies / procedures change, these docs don't become inaccurate. Customers who are sensitive to this information will want to see current Compliance audit reports anyways, which detail Red Hat's recovery rehearsal practices as reviewed by an accredited 3rd party.