### PR TITLE
Adds a batch of Storage bug doc text and one Storage enhancement

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -494,6 +494,11 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 For more information, see xref:../storage/persistent_storage/persistent-storage-local.adoc#persistent-storage-local[Persistent storage using local volumes].
 
+[id="ocp-4-9-ovirt-csi-driver-enhancement"]
+==== oVirt CSI driver resizing feature is now available  
+
+{product-title} 4.9 adds resizing capability to the oVirt CSI Driver, which allows users to increase the size of their existing persistent volume claims (PVCs). Prior to this feature, users had to create new PVCs with the increased size, and move all of the content from the old persistent volume (PV) to the new PV, which could result in data loss. Now, users can edit the existing PVC and the oVirt CSI Driver will resize the underlying oVirt disk. 
+
 [id="ocp-4-9-registry"]
 === Registry
 
@@ -1381,6 +1386,16 @@ conditions:
 * Previously, you could delete `LocalVolumeSets` with in-use PVs, which required manual clean up. This fix ensures that all released PVs are cleaned automatically. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1862429[*BZ#1862429*])
 
 * Previously, the `oc get volumesnapshotcontent` command did not display the namespace for a volume snapshot, which meant that the volume snapshot was not uniquely identified. This command now displays the namespace for the volume snapshot. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965263[*BZ#1965263*])
+
+* Previously, the Manila CSI Operator used a custom transport when communicating with a {rh-openstack-first} endpoint that used self-signed certificates. Because this custom transport did not consume the proxy environment variables, the Manila CSI Operator would fail to communicate with Manila. This update ensures that the custom transport consumes the proxy environment variables. As a result, the Manila CSI Operator now works with proxy and custom CA certificates. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960152[*BZ#1960152*])
+
+* Previously, the Cinder CSI Driver Operator was not using the configured proxy to connect to the {rh-openstack-first} API, which could cause the installation to fail. With this update, an annotation is included in the Cinder CSI Driver Operator deployment that ensures proxy environment variables are set on the container. As a result, the installation no longer fails. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985391[*BZ#1985391*])
+
+* The frequency at which the Local Storage Operator inspects newly added block devices has been changed from 5 seconds to 60 seconds to decrease its CPU consumption. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1994035[*BZ#1994035*])
+
+* Previously, communication failure with the Manila CSI Operator would degrade the cluster. With this update, failed communication with the Manila CSI Operator endpoint results in a non-fatal error. As a result, the Manila CSI Operator gets disabled instead of degrading the cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001958[*BZ#2001958*])
+
+* Previously, the Local Storage Operator deleted orphaned persistent volumes (PVs) with a 10 second delay, and the delay was cumulative. When several persistent volume claims (PVCs) were deleted at the same time, it could take several minutes or hours to get their PVs deleted. Consequently, corresponding local disks were not available for new PVCs for several hours. With this fix, the 10 second delay is removed. As a result, PVs are detected and corresponding local disks are made available for new PVCs sooner. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007684[*BZ#2007684*])
 
 [discrete]
 [id="ocp-4-9-web-console-admin-perspective-bug-fixes"]


### PR DESCRIPTION
4.9 Storage bug doc text. There is one enhancement here, and multiple bug fixes. 

Preview:

Bug Fixes: https://deploy-preview-37361--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-bug-fixes

Enhancement: https://deploy-preview-37361--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-9-ovirt-csi-driver-enhancement

To be merged to 4.9 upon approval. 

