### PR TITLE
[WIP] BZ1975701: Clarify static IP workaround for Tang encryption on vSphere

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -154,12 +154,36 @@ When the `Do you wish to trust these keys? [ynYN]` prompt displays, type `Y`.
 {op-system-base} 8 provides Clevis version 15, which uses the SHA-1 hash algorithm to generate thumbprints. Some other distributions provide Clevis version 17 or later, which use the SHA-256 hash algorithm for thumbprints. You must use a Clevis version that uses SHA-1 to create the thumbprint, to prevent Clevis binding issues when you install {op-system-first} on your {product-title} cluster nodes.
 ====
 
-.. If the nodes are configured with static IP addressing, use the `coreos-installer` `--append-karg` option when installing {op-system} nodes to set the IP address of the installed system. Append the `ip=` and other arguments needed for your network.
+.. If the nodes are configured with static IP addressing:
+
+... Use the `coreos-installer` `--append-karg` option when installing {op-system} nodes to set the IP address of the installed system. Append the `ip=` and other arguments needed for your network.
 +
 [IMPORTANT]
 ====
 Some methods for configuring static IPs do not affect the initramfs after the first boot and will not work with Tang encryption. These include the `coreos-installer` `--copy-network` option, as well as adding `ip=` arguments to the kernel command line of the live ISO or PXE image during installation. Incorrect static IP configuration causes the second boot of the node to fail.
 ====
+
+... When Tang disk encryption is enabled on a cluster on VMware vSphere with user-provisioned infrastructure, add the following `rd.neednet=1` kernel argument to retain a static IP configuration after the second reboot:
++
+[source,terminal]
+----
+kernelArguments:
+  - rd.neednet=1
+  - ip=10.10.10.10::10.10.10.1:255.255.255.0::ens192:none:8.8.8.8 <1>
+----
++
+<1> You can use a short bash script to populate the `ip=` string, as shown in the following example:
++
+[source,bash]
+----
+ip='10.10.10.10'
+gateway='10.10.10.1'
+netmask='255.255.255.0'
+hostname=''
+interface='ens192'
+nameserver='8.8.8.8'
+echo "ip=${ip}::${gateway}:${netmask}:${hostname}:${interface}:none:${nameserver}"
+----
 
 . On your installation node, change to the directory that contains the installation program and generate the Kubernetes manifests for the cluster:
 +


### PR DESCRIPTION
[BZ1975701](https://bugzilla.redhat.com/show_bug.cgi?id=1975701)
As mentioned in https://github.com/openshift/openshift-docs/issues/33497#issuecomment-939259707 and documented in 4.9 Release Notes (https://github.com/openshift/openshift-docs/pull/37356), this adds a workaround that avoids a Tang server switching from static IP addressing to DHCP on second boot on a vSphere UPI.

Impacts 4.8+ docs. (Updates [Configuring disk encryption and mirroring](https://docs.openshift.com/container-platform/4.8/installing/install_config/installing-customizing.html#installation-special-config-storage-procedure_installing-customizing), step `2.d`.)

Preview link (adds step `2.d.ii`): https://deploy-preview-37362--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing?utm_source=github&utm_campaign=bot_dp#installation-special-config-storage-procedure_installing-customizing