### PR TITLE
Adds two networking bug doc text

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1233,6 +1233,10 @@ Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].im
 
 * Previously, the Cluster Network Operator (CNO) deployed a service monitor for the `network-check-source` service to get discovered by Prometheus without correct annotations and role-based access control (RBAC). As a result, the service and its metrics never populated in Prometheus. Now, the correct annotations and RBAC are added to the namespace of `network-check-source` service. Now, metrics of service `network-check-source` get scraped by Prometheus.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1986061[*BZ#1986061*])
 
+* Previously, when using IPv6 DHCP, node interface addresses might be leased with a `/128` prefix. Consequently, OVN-Kubernetes uses the same prefix to infer the node's network and routes any other address traffic, including traffic to other cluster nodes, through the gateway. With this update, OVN-Kubernetes inspects the node's routing table and checks for the wider routing entry for the node's interface address and uses that prefix to infer the node's network. As a result, traffic to other cluster nodes is no longer routed through the gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1994624[*BZ#1994624*])
+
+* Previously, when a cluster used the OVN-Kubernetes Container Network Interface provider, attempting to add an egress router with IPv6 address failed. With the fix, support for IPv6 is added to the egress router CNI plug-in and adding adding egress routers succeeds.   (link:https://bugzilla.redhat.com/show_bug.cgi?id=1989688[*BZ#1989688*])
+
 [discrete]
 [id="ocp-4-9-node-bug-fixes"]
 ==== Node


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-37363--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-bug-fixes

Can be merged upon approval. 