### PR TITLE
fixes links to go to the correct place in RNs

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2263,7 +2263,7 @@ link:https://access.redhat.com/solutions/5857851[{product-title} 4.7.1 container
 [id="ocp-4-7-1-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-2"]
 === RHBA-2021:0749 - {product-title} 4.7.2 bug fix update
@@ -2279,7 +2279,7 @@ link:https://access.redhat.com/solutions/5873362[{product-title} 4.7.2 container
 [id="ocp-4-7-2-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-3"]
 === RHBA-2021:0821 - {product-title} 4.7.3 bug fix update
@@ -2295,7 +2295,7 @@ link:https://access.redhat.com/solutions/5894521[{product-title} 4.7.3 container
 [id="ocp-4-7-3-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-4"]
 === RHSA-2021:0957 - {product-title} 4.7.4 bug fix and security update
@@ -2311,7 +2311,7 @@ link:https://access.redhat.com/solutions/5906541[{product-title} 4.7.4 container
 [id="ocp-4-7-4-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-5"]
 === RHSA-2021:1005 - {product-title} 4.7.5 bug fix and security update
@@ -2356,7 +2356,7 @@ If results return `Permission denied`, iptables or your kernal might need upgrad
 [id="ocp-4-7-5-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-6"]
 === RHBA-2021:1075 - {product-title} 4.7.6 bug fix update
@@ -2396,7 +2396,7 @@ This update adds new capabilities to the cluster API provider BareMetal (CAPBM) 
 [id="ocp-4-7-6-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-7"]
 === RHBA-2021:1149 - {product-title} 4.7.7 bug fix and security update
@@ -2424,7 +2424,7 @@ Now, the OpenShift build image and associated pod mount all entitlement-related 
 [id="ocp-4-7-7-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-8"]
 === RHSA-2021:1225 - {product-title} 4.7.8 bug fix and security update
@@ -2440,7 +2440,7 @@ link:https://access.redhat.com/solutions/5982961[{product-title} 4.7.8 container
 [id="ocp-4-7-8-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-9"]
 === RHBA-2021:1365 - {product-title} 4.7.9 bug fix and security update
@@ -2462,7 +2462,7 @@ link:https://access.redhat.com/solutions/6001181[{product-title} 4.7.9 container
 [id="ocp-4-7-9-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-11"]
 === RHBA-2021:1550 - {product-title} 4.7.11 bug fix and security update
@@ -2541,7 +2541,7 @@ In an upcoming release of {product-title}, OAuth tokens that do not include a SH
 [id="ocp-4-7-11-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-12"]
 === RHSA-2021:1561 - {product-title} 4.7.12 bug fix and security update
@@ -2557,7 +2557,7 @@ link:https://access.redhat.com/solutions/6067301[{product-title} 4.7.12 containe
 [id="ocp-4-7-12-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-13"]
 === RHSA-2021:2121 - {product-title} 4.7.13 bug fix and security update
@@ -2578,7 +2578,7 @@ link:https://access.redhat.com/solutions/6078781[{product-title} 4.7.13 containe
 [id="ocp-4-7-13-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-16"]
 === RHSA-2021:2286 - {product-title} 4.7.16 bug fix and security update
@@ -2619,7 +2619,7 @@ With this update, users can now collect the `virt_platform` metric. The `virt_pl
 [id="ocp-4-7-16-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 
 [id="ocp-4-7-18"]
@@ -2664,7 +2664,7 @@ In this update, Telemetry includes a new `openshift:build_by_strategy:sum` gauge
 [id="ocp-4-7-18-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-19"]
 === RHBA-2021:2554 - {product-title} 4.7.19 bug fix and security update
@@ -2689,7 +2689,7 @@ link:https://access.redhat.com/solutions/6163712[{product-title} 4.7.19 containe
 [id="ocp-4-7-19-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-21"]
 === RHBA-2021:2762 - {product-title} 4.7.21 bug fix and security update
@@ -2720,7 +2720,7 @@ With this update, `aws-sdk-go` is bumped to v1.38.35, which supports new Amazon 
 [id="ocp-4-7-21-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-22"]
 === RHBA-2021:2903 - {product-title} 4.7.22 bug fix update
@@ -2744,7 +2744,7 @@ With this update, installation in the Amazon Web Services (AWS) `ap-northeast-3`
 [id="ocp-4-7-22-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-23"]
 === RHSA-2021:2977 - {product-title} 4.7.23 bug fix and security update
@@ -2760,7 +2760,7 @@ link:https://access.redhat.com/solutions/6246671[{product-title} 4.7.23 containe
 [id="ocp-4-7-23-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-24"]
 === RHBA-2021:3032 - {product-title} 4.7.24 bug fix update
@@ -2785,7 +2785,7 @@ link:https://access.redhat.com/solutions/6258591[{product-title} 4.7.24 containe
 [id="ocp-4-7-24-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-28"]
 === RHSA-2021:3262 - {product-title} 4.7.28 bug fix and security update
@@ -2812,7 +2812,7 @@ link:https://access.redhat.com/solutions/6284521[{product-title} 4.7.28 containe
 [id="ocp-4-7-28-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-29"]
 === RHSA-2021:3303 - {product-title} 4.7.29 bug fix and security update
@@ -2835,7 +2835,7 @@ Previously, the workaround was to remove and recreate these policies. With this 
 [id="ocp-4-7-29-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-30"]
 === RHBA-2021:3422 - {product-title} 4.7.30 bug fix update
@@ -2851,7 +2851,7 @@ link:https://access.redhat.com/solutions/6327721[{product-title} 4.7.30 containe
 [id="ocp-4-7-30-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-31"]
 === RHBA-2021:3510 - {product-title} 4.7.31 bug fix update
@@ -2875,7 +2875,7 @@ The minimum storage required to install an {product-title} cluster has decreased
 [id="ocp-4-7-31-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
 
 [id="ocp-4-7-32"]
 === RHBA-2021:3636 - {product-title} 4.7.32 bug fix and security update
@@ -2901,4 +2901,4 @@ link:https://access.redhat.com/solutions/6362042[{product-title} 4.7.32 containe
 [id="ocp-4-7-32-upgrading"]
 ==== Upgrading
 
-To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-service-overview_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Applies to `enterprise-4.7` only
[Preview link](https://deploy-preview-37364--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-asynchronous-errata-updates) (This is a link to the Asynchronous Eratta updates since it is fixing a link in almost all of the .z-stream entries)