### PR TITLE
Fix for BZ 1989929

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
@@ -3,57 +3,17 @@
 include::modules/common-attributes.adoc[]
 :context: ipi-install
 
-ifdef::watermark[]
-[IMPORTANT]
-====
-The Bare Metal IPI images and code described in this document are for *Developer Preview* purposes and are *not supported* by Red Hat at this time.
-====
-endif::[]
-
 Installer-provisioned installation provides support for installing {product-title} on bare metal nodes. This guide provides a methodology to achieving a successful installation.
 
 During installer-provisioned installation on bare metal, the installer on the bare metal node labeled as `provisioner` creates a bootstrap virtual machine (VM). The role of the bootstrap VM is to assist in the process of deploying an {product-title} cluster. The bootstrap VM connects to the `baremetal` network and to the `provisioning` network, if present, via the network bridges.
 
-ifeval::[{product-version} >= 4.6]
 image::71_OpenShift_4.6_Baremetal_IPI_Deployment_1020_1.svg[Deployment phase one]
-endif::[]
 
-ifeval::[{product-version} == 4.5]
-image::4.5-71_OpenShift_Baremetal_IPI_Depoyment_0320_1.png[Deployment phase one]
-endif::[]
+When the installation of OpenShift control plane nodes is complete and fully operational, the installer destroys the bootstrap VM automatically and moves the virtual IP addresses (VIPs) to the control plane nodes.
 
-ifeval::[{product-version} < 4.5]
-image::4.4-71_OpenShift_Baremetal_IPI_Depoyment_0320_1.png[Deployment phase one]
-endif::[]
-
-When the installation of OpenShift control plane nodes is complete and fully operational, the installer destroys the bootstrap VM automatically and moves the virtual IP addresses (VIPs) to
-ifeval::[{product-version} >= 4.8]
-the control plane nodes.
-endif::[]
-ifeval::[{product-version} <= 4.7]
-the appropriate nodes. The API VIP moves to the control plane nodes and the Ingress VIP moves to the worker nodes.
-endif::[]
-
-
-
-ifeval::[{product-version} >= 4.8]
 image::161_OpenShift_Baremetal_IPI_Deployment_updates_0521.svg[Deployment phase two]
-endif::[]
 
-ifeval::[{product-version} >= 4.6]
-ifeval::[{product-version} <= 4.7]
-image::71_OpenShift_4.6_Baremetal_IPI_Deployment_1020_2.svg[Deployment phase two]
-endif::[]
-endif::[]
-
-ifeval::[{product-version} == 4.5]
-The API VIPs move into the control plane nodes and the Ingress VIP services applications that reside within the worker nodes.
-
-image::4.5-71_OpenShift_Baremetal_IPI_Depoyment_0320_2.png[Deployment phase two]
-endif::[]
-
-ifeval::[{product-version} < 4.5]
-The API and DNS VIPs move into the control plane nodes and the Ingress VIP services applications that reside within the worker nodes.
-
-image::4.4-71_OpenShift_Baremetal_IPI_Depoyment_0320_2.png[Deployment phase two]
-endif::[]
+[IMPORTANT]
+====
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. 
+====

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -89,9 +89,7 @@ controlPlane:
 |
 |Replicas sets the number of control plane (master) nodes included as part of the {product-title} cluster.
 
-ifeval::[{product-version} >= 4.4]
 a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the `provisioning` network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
-endif::[]
 
 
 | `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration.
@@ -105,13 +103,6 @@ default name resolves correctly.
 
 | `ingressVIP` | `test.apps.<clustername.clusterdomain>` | The VIP to use for ingress traffic.
 
-ifeval::[{product-version} < 4.5]
-Provide this setting or pre-configure it in the DNS so that the default name resolves correctly.
-|`dnsVIP` | | The VIP to use for internal DNS communication.
-
-This setting has no default and must always be provided.
-endif::[]
-
 |===
 
 
@@ -121,15 +112,6 @@ endif::[]
 |Parameters
 |Default
 |Description
-
-
-ifeval::[{product-version} > 4.3]
-ifeval::[{product-version} < 4.6]
-|`provisioningDHCPExternal`
-| `false`
-|Defines if the installer uses an external DHCP or the provisioner node DHCP.
-endif::[]
-endif::[]
 
 |`provisioningDHCPRange`
 |`172.22.0.10,172.22.0.100`
@@ -145,15 +127,7 @@ a|`provisioningNetworkCIDR`
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the `provisioning` subnet. For example, `172.22.0.2`
-ifeval::[{product-version} >= 4.5]
-or `2620:52:0:1307::2`
-endif::[]
-.
-
-ifeval::[{product-version} == 4.6]
-Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
-endif::[]
+|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the `provisioning` subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
 
 | `externalBridge`
 | `baremetal`
@@ -170,13 +144,7 @@ endif::[]
 | `bootstrapOSImage`
 |
 | A URL to override the default operating system image for the bootstrap node. The URL must contain a SHA-256 hash of the image. For example:
-`https://mirror.openshift.com/rhcos-<version>-qemu.qcow2.gz?sha256=<uncompressed_sha256>`
-ifdef::upstream[]
-ifeval::[{product-version} >= 4.5]
- or  `http://[2620:52:0:1307::1]/rhcos-<version>-qemu.x86_64.qcow2.gz?sha256=<uncompressed_sha256>`
-endif::[]
-endif::[]
-.
+`https://mirror.openshift.com/rhcos-<version>-qemu.qcow2.gz?sha256=<uncompressed_sha256>`.
 
 | `clusterOSImage`
 |
@@ -189,19 +157,10 @@ endif::[]
 
 `Disabled`: Set this parameter to `Disabled` to disable the requirement for a `provisioning` network. When set to `Disabled`, you must only use virtual media based provisioning, or bring up the cluster using the assisted installer. If `Disabled` and using power management, BMCs must be accessible from the `baremetal` network. If `Disabled`, you must provide two IP addresses on the `baremetal` network that are used for the provisioning services.
 
-ifeval::[{product-version} >= 4.6]
 `Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
 `Unmanaged`: Set this parameter to `Unmanaged` to enable the provisioning network but take care of manual configuration of DHCP. Virtual media provisioning is recommended but PXE is still available if required.
-endif::[]
 
-ifeval::[{product-version} == 4.6]
-| `provisioningHostIP`
-|
-| Set this parameter to an available IP address on the `baremetal` network when the `provisioningNetwork` configuration setting is set to `Disabled`.
-endif::[]
-
-ifeval::[{product-version} > 4.4]
 | `httpProxy`
 |
 | Set this parameter to the appropriate HTTP proxy used within your environment.
@@ -213,15 +172,15 @@ ifeval::[{product-version} > 4.4]
 | `noProxy`
 |
 | Set this parameter to the appropriate list of exclusions for proxy usage within your environment.
-endif::[]
 
 |===
 
-.Hosts
+[discrete]
+== Hosts
 
 The `hosts` parameter is a list of separate bare metal assets used to build the cluster.
 
-[options="header"]
+[width="100%", cols="3,2,5",  options="header"]
 .Hosts
 |===
 |Name |Default |Description
@@ -244,9 +203,4 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 |
 | The MAC address of the NIC that the host uses for the `provisioning` network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
 
-ifeval::[{product-version} < 4.6]
-| `hardwareProfile`
-| `default`
-| This parameter exposes the device name that the installer attempts to deploy the {product-title} cluster for the control plane and worker nodes. The value defaults to `default` for control plane nodes and `unknown` for worker nodes. The list of profiles includes: `default`, `libvirt`, `dell`, `dell-raid`, and `openstack`. The `default` parameter attempts to install on `/dev/sda` of the {product-title} cluster nodes.
-endif::[]
 |===

--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -23,8 +23,9 @@ platform:
 
 For Dell hardware, Red Hat supports integrated Dell Remote Access Controller (iDRAC) virtual media, Redfish network boot, and IPMI.
 
-.BMC address formats for Dell iDRAC
-[frame="topbot",options="header"]
+[discrete]
+== BMC address formats for Dell iDRAC
+[width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format
 |iDRAC virtual media| `idrac-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/System.Embedded.1`
@@ -39,18 +40,10 @@ Use `idrac-virtualmedia` as the protocol for Redfish virtual media. `redfish-vir
 
 See the following sections for additional details.
 
-.Redfish virtual media for Dell iDRAC
+[discrete]
+== Redfish virtual media for Dell iDRAC
 
 For Redfish virtual media on Dell servers, use `idrac-virtualmedia://` in the `address` setting. Using `redfish-virtualmedia://` will not work.
-
-ifeval::[{product-version} >= 4.6]
-ifeval::[{product-version} < 4.7]
-[NOTE]
-====
-Redfish virtual media on Dell servers has a known issue in {product-title} 4.6, which will be resolved in a future release.
-====
-endif::[]
-endif::[]
 
 The following example demonstrates using iDRAC virtual media within the  `install-config.yaml` file.
 
@@ -94,7 +87,8 @@ Use `idrac-virtualmedia://` as the protocol for Redfish virtual media. Using `re
 ====
 
 
-.Redfish network boot for iDRAC
+[discrete]
+== Redfish network boot for iDRAC
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable transport layer security (TLS). The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 

--- a/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
@@ -24,7 +24,7 @@ platform:
 For Fujitsu hardware, Red Hat supports integrated Remote Management Controller (iRMC) and IPMI.
 
 .BMC address formats for Fujitsu iRMC
-[frame="topbot",options="header"]
+[options="header"]
 |====
 |Protocol|Address Format
 |iRMC| `irmc://<out-of-band-ip>`

--- a/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
+++ b/modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc
@@ -24,7 +24,7 @@ platform:
 For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Redfish network boot, and IPMI.
 
 .BMC address formats for HPE iLO
-[frame="topbot",options="header"]
+[width="100%", cols="1,3", options="header"]
 |====
 |Protocol|Address Format
 |Redfish virtual media| `redfish-virtualmedia://<out-of-band-ip>/redfish/v1/Systems/1`
@@ -34,7 +34,8 @@ For HPE integrated Lights Out (iLO), Red Hat supports Redfish virtual media, Red
 
 See the following sections for additional details.
 
-.Redfish virtual media for HPE iLO
+[discrete]
+== Redfish virtual media for HPE iLO
 
 To enable Redfish virtual media for HPE servers, use `redfish-virtualmedia://` in the `address` setting. The following example demonstrates using Redfish virtual media within the `install-config.yaml` file.
 
@@ -73,7 +74,8 @@ Redfish virtual media is not supported on 9th generation systems running iLO4, b
 ====
 
 
-.Redfish network boot for HPE iLO
+[discrete]
+== Redfish network boot for HPE iLO
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -5,9 +5,10 @@
 
 = BMC addressing
 
-Most vendors support BMC addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
+Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
 
-.IPMI
+[discrete]
+== IPMI
 
 Hosts using IPMI use the `ipmi://<out-of-band-ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
 
@@ -24,8 +25,13 @@ platform:
           password: <password>
 ----
 
+[IMPORTANT]
+====
+The `provisioning` network is required when PXE booting using IPMI for BMC addressing. It is not possible to PXE boot hosts without a `provisioning` network. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+====
 
-.Redfish network boot
+[discrete]
+== Redfish network boot
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 

--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -5,7 +5,8 @@
 [id="configuring-nodes_{context}"]
 = Configuring nodes
 
-.Configuring nodes when using the `provisioning` network
+[discrete]
+== Configuring nodes when using the `provisioning` network
 
 Each node in the cluster requires the following configuration for proper installation.
 
@@ -16,18 +17,19 @@ A mismatch between nodes will cause an installation failure.
 
 While the cluster nodes can contain more than two NICs, the installation process only focuses on the first two NICs:
 
+[options="header"]
 |===
 |NIC |Network |VLAN
-| NIC1 | `provisioning` | <provisioning-vlan>
-| NIC2 | `baremetal` | <baremetal-vlan>
+| NIC1 | `provisioning` | `<provisioning_vlan>`
+| NIC2 | `baremetal` | `<baremetal_vlan>`
 |===
 
-NIC1 is a non-routable network (`provisioning`) that is only used for the installation of the {product-title} cluster.
+In the foregoing example, NIC1 is a non-routable network (`provisioning`) that is only used for the installation of the {product-title} cluster.
 
 ifndef::openshift-origin[The {op-system-base-full} 8.x installation process on the provisioner node might vary. To install {op-system-base-full} 8.x using a local Satellite server or a PXE server, PXE-enable NIC2.]
 ifdef::openshift-origin[The {op-system-first} installation process on the provisioner node might vary. To install {op-system} using a local Satellite server or a PXE server, PXE-enable NIC2.]
 
-
+[options="header"]
 |===
 |PXE |Boot order
 | NIC1 PXE-enabled `provisioning` network | 1
@@ -41,29 +43,33 @@ Ensure PXE is disabled on all other NICs.
 
 Configure the control plane and worker nodes as follows:
 
+[options="header"]
 |===
 |PXE | Boot order
 | NIC1 PXE-enabled (provisioning network) | 1
 |===
 
-ifeval::[{product-version} > 4.3]
-
-.Configuring nodes without the `provisioning` network
+[discrete]
+== Configuring nodes without the `provisioning` network
 
 The installation process requires one NIC:
 
+[options="header"]
 |===
 |NIC |Network |VLAN
-| NICx | `baremetal` | <baremetal-vlan>
+| NICx | `baremetal` | `<baremetal_vlan>`
 |===
 
 NICx is a routable network (`baremetal`) that is used for the installation of the {product-title} cluster, and routable to the internet.
 
-endif::[]
+[IMPORTANT]
+====
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.
+====
 
-ifeval::[{product-version} > 4.6]
 [id="configuring-nodes-for-secure-boot_{context}"]
-.Configuring nodes for Secure Boot manually
+[discrete]
+== Configuring nodes for Secure Boot manually
 
 Secure Boot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications, and the operating system.
 
@@ -82,4 +88,3 @@ To enable Secure Boot manually, refer to the hardware guide for the node and exe
 ====
 Red Hat does not support Secure Boot with self-generated keys.
 ====
-endif::[]

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -8,31 +8,18 @@
 
 To deploy an {product-title} cluster without a `provisioning` network, make the following changes to the `install-config.yaml` file.
 
-ifeval::[{product-version} == 4.6]
 [source,yaml]
 ----
 platform:
   baremetal:
-    apiVIP: <apiVIP>
-    ingressVIP: <ingress/wildcard VIP>
-    provisioningNetwork: "Disabled"
-    provisioningHostIP: <baremetal_network_IP1>
-    bootstrapProvisioningIP: <baremetal_network_IP2>
+    apiVIP: <api_VIP>
+    ingressVIP: <ingress_VIP>
+    provisioningNetwork: "Disabled" <1>
 ----
 
-[NOTE]
-====
-Requires providing two IP addresses from the `baremetal` network for the `provisioningHostIP` and `bootstrapProvisioningIP` configuration settings, and removing the `provisioningBridge` and `provisioningNetworkCIDR` configuration settings.
-====
-endif::[]
+<1> Add the `provisioningNetwork` configuration setting, if needed, and set it to `Disabled`.
 
-ifeval::[{product-version} >= 4.7]
-[source,yaml]
-----
-platform:
-  baremetal:
-    apiVIP: <apiVIP>
-    ingressVIP: <ingress/wildcard VIP>
-    provisioningNetwork: "Disabled"
-----
-endif::[]
+[IMPORTANT]
+====
+The `provisioning` network is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+====

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -7,31 +7,31 @@
 
 Installer-provisioned installation of {product-title} involves several network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
 
-.Configuring NICs
+[discrete]
+== Configuring NICs
 
 {product-title} deploys with two networks:
 
 - `provisioning`: The `provisioning` network is an optional non-routable network used for provisioning the underlying operating system on each node that is a part of the {product-title} cluster. The network interface for the `provisioning` network on each cluster node must have the BIOS or UEFI configured to PXE boot.
 +
-In {product-title} versions 4.6 through 4.8, the `provisioningNetworkInterface` configuration setting specifies the `provisioning` network NIC. In {product-title} 4.9 and later releases, you can specify the `provisioning` network NIC with the `bootMACAddress` configuration setting.
+The `provisioningNetworkInterface` configuration setting specifies the `provisioning` network NIC name on the control plane nodes, which must be identical on the control plane nodes. The `bootMACAddress` configuration setting provides a means to specify a particular NIC on each node for the `provisioning` network.
++
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.
 
-- `baremetal`: The `baremetal` network is a routable network.
-+
-In {product-title} 4.3, when deploying using the `provisioning` network, the second NIC on each node, such as `eth1` or `eno2`, must interface with the `baremetal` network.
-+
-In {product-title} 4.4 and later releases, you can use any NIC to interface with the `baremetal` network, provided it is the same NIC order across worker and control plane nodes when using the `provisioningNetworkInterface` configuration setting. In {product-title} 4.9 and later releases, you can use any NIC, provided it is not the NIC associated to the `bootMACAddress` configuration setting for the `provisioning` network when using the `bootMACAddress` configuration setting instead of the `provisioningNetworkInterface` setting.
+- `baremetal`: The `baremetal` network is a routable network. You can use any NIC to interface with the `baremetal` network provided the NIC is not configured to use the `provisioning` network.
 
 [IMPORTANT]
 ====
 When using a VLAN, each NIC must be on a separate VLAN corresponding to the appropriate network.
 ====
 
-.Configuring the DNS server
+[discrete]
+== Configuring the DNS server
 
 Clients access the {product-title} cluster nodes over the `baremetal` network. A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
 
 ----
-<cluster-name>.<domain-name>
+<cluster_name>.<domain>
 ----
 
 For example:
@@ -40,93 +40,64 @@ For example:
 test-cluster.example.com
 ----
 
-ifeval::[{product-version}>4.7]
-{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. After the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
+{product-title} includes functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. After the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
 
 [IMPORTANT]
 ====
-You must create a DNS entry for the `api.<cluster-name>.<domain>` domain name on the external DNS because removing CoreDNS causes the local entry to disappear. Failure to create a DNS record for the `api.<cluster-name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
+You must create a DNS entry for the `api.<cluster_name>.<domain>` domain name on the external DNS because removing CoreDNS causes the local entry to disappear. Failure to create a DNS record for the `api.<cluster_name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
 ====
-endif::[]
 
-ifdef::upstream[]
-For assistance in configuring the DNS server, check xref:ipi-install-upstream-appendix[Appendix] section for:
-
-- xref:creating-dns-records-on-a-dns-server-option1_{context}[Creating DNS Records with Bind (Option 1)]
-- xref:creating-dns-records-using-dnsmasq-option2_{context}[Creating DNS Records with dnsmasq (Option 2)]
-
-endif::[]
-
-.Dynamic Host Configuration Protocol (DHCP) requirements
+[discrete]
+== Dynamic Host Configuration Protocol (DHCP) requirements
 
 By default, installer-provisioned installation deploys `ironic-dnsmasq` with DHCP enabled for the `provisioning` network. No other DHCP servers should be running on the `provisioning` network when the `provisioningNetwork` configuration setting is set to `managed`, which is the default value. If you have a DHCP server running on the `provisioning` network, you must set the `provisioningNetwork` configuration setting to `unmanaged` in the `install-config.yaml` file.
 
 Network administrators must reserve IP addresses for each node in the {product-title} cluster for the `baremetal` network on an external DHCP server.
 
-.Reserving IP addresses for nodes with the DHCP server
+[discrete]
+== Reserving IP addresses for nodes with the DHCP server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
 
-ifeval::[{product-version} > 4.5]
 . Two virtual IP addresses.
-endif::[]
-ifeval::[{product-version} <= 4.5]
-. Three virtual IP addresses
-endif::[]
 +
 - One IP address for the API endpoint
 - One IP address for the wildcard ingress endpoint
-ifeval::[{product-version} <= 4.5]
-- One IP address for the name server
-endif::[]
-
++
 . One IP address for the provisioner node.
 . One IP address for each control plane (master) node.
 . One IP address for each worker node, if applicable.
 
-ifeval::[{product-version} > 4.6]
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
 Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To use static IP addresses in the {product-title} cluster, reserve the IP addresses with an infinite lease. During deployment, the installer will reconfigure the NICs from DHCP assigned addresses to static IP addresses. NICs with DHCP leases that are not infinite will remain configured to use DHCP.
 ====
-endif::[]
 
-ifeval::[{product-version} > 4.7]
 [IMPORTANT]
 .Networking between external load balancers and control plane nodes
 ====
 External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
 ====
-endif::[]
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
-[width="100%", cols="3,5e,2e", frame="topbot",options="header"]
+[width="100%", cols="3,5,2", options="header"]
 |=====
 | Usage | Host Name | IP
-| API | api.<cluster-name>.<domain> | <ip>
-| Ingress LB (apps) |  *.apps.<cluster-name>.<domain>  | <ip>
-ifeval::[{product-version} <= 4.5]
-| Nameserver | ns1.<cluster-name>.<domain> | <ip>
-endif::[]
-| Provisioner node | provisioner.<cluster-name>.<domain> | <ip>
-| Master-0 | openshift-master-0.<cluster-name>.<domain> | <ip>
-| Master-1 | openshift-master-1.<cluster-name>-.<domain> | <ip>
-| Master-2 | openshift-master-2.<cluster-name>.<domain> | <ip>
-| Worker-0 | openshift-worker-0.<cluster-name>.<domain> | <ip>
-| Worker-1 | openshift-worker-1.<cluster-name>.<domain> | <ip>
-| Worker-n | openshift-worker-n.<cluster-name>.<domain> | <ip>
+| API | `api.<cluster_name>.<domain>` | `<ip>`
+| Ingress LB (apps) |  `*.apps.<cluster_name>.<domain>`  | `<ip>`
+| Provisioner node | `provisioner.<cluster_name>.<domain>` | `<ip>`
+| Master-0 | `openshift-master-0.<cluster_name>.<domain>` | `<ip>`
+| Master-1 | `openshift-master-1.<cluster_name>-.<domain>` | `<ip>`
+| Master-2 | `openshift-master-2.<cluster_name>.<domain>` | `<ip>`
+| Worker-0 | `openshift-worker-0.<cluster_name>.<domain>` | `<ip>`
+| Worker-1 | `openshift-worker-1.<cluster_name>.<domain>` | `<ip>`
+| Worker-n | `openshift-worker-n.<cluster_name>.<domain>` | `<ip>`
 |=====
 
-ifdef::upstream[]
-For assistance in configuring the DHCP server, check xref:ipi-install-upstream-appendix[Appendix] section for:
-
-- xref:creating-dhcp-reservations-option1_{context}[Creating DHCP reservations with dhcpd (Option 1)]
-- xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
-endif::[]
-
-.Network Time Protocol (NTP)
+[discrete]
+== Network Time Protocol (NTP)
 
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
 
@@ -137,25 +108,8 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 
 You may reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
-ifeval::[{product-version} == 4.6]
-.Additional requirements with no provisioning network
-
-All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
-
-- Setting an available IP address from the `baremetal` network to the `bootstrapProvisioningIP` configuration setting within the `install-config.yaml` configuration file.
-
-- Setting an available IP address from the `baremetal` network to the `provisioningHostIP` configuration setting within the `install-config.yaml` configuration file.
-
-- Deploying the {product-title} cluster using RedFish Virtual Media/iDRAC Virtual Media.
-
-[NOTE]
-====
-Configuring additional IP addresses for `bootstrapProvisioningIP` and `provisioningHostIP` is not required when using a `provisioning` network.
-====
-endif::[]
-
-ifeval::[{product-version} > 4.6]
-.State-driven network configuration requirements (Technology Preview)
+[discrete]
+== State-driven network configuration requirements (Technology Preview)
 
 {product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
 
@@ -165,4 +119,3 @@ Configuration must occur before scheduling pods.
 ====
 
 State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
-endif::[]


### PR DESCRIPTION
Adds an admonishment that IPMI requires the provisioning network. Disabling the provisioning network necessitates using a BMC addressing option with virtual media.

See https://bugzilla.redhat.com/show_bug.cgi?id=1989929 for additional details.

Preview URL: https://deploy-preview-37365--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow?utm_source=github&utm_campaign=bot_dp#bmc-addressing_ipi-install-configuration-files  https://deploy-preview-37365--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow?utm_source=github&utm_campaign=bot_dp#modifying-install-config-for-no-provisioning-network_ipi-install-configuration-files

For release(s): 4.8, 4.9
Signed-off-by: John Wilkins <jowilkin@redhat.com>
