### PR TITLE
Update templates-writing-parameters.adoc

### DIFF
--- a/modules/templates-writing-parameters.adoc
+++ b/modules/templates-writing-parameters.adoc
@@ -9,11 +9,11 @@ Parameters allow a value to be supplied by you or generated when the template is
 
 * As a string value by placing values in the form `${PARAMETER_NAME}` in any string field in the template.
 
-* As a JSON or YAML value by placing values in the form `${PARAMETER_NAME}` in place of any field in the template.
+* As a JSON or YAML value by placing values in the form `${{PARAMETER_NAME}}` in place of any field in the template.
 
 When using the `${PARAMETER_NAME}` syntax, multiple parameter references can be combined in a single field and the reference can be embedded within fixed data, such as `"http://${PARAMETER_1}${PARAMETER_2}"`. Both parameter values are substituted and the resulting value is a quoted string.
 
-When using the `${PARAMETER_NAME}` syntax only a single parameter reference is allowed and leading and trailing characters are not permitted. The resulting value is unquoted unless, after substitution is performed, the result is not a valid JSON object. If the result is not a valid JSON value, the resulting value is quoted and treated as a standard string.
+When using the `${{PARAMETER_NAME}}` syntax only a single parameter reference is allowed and leading and trailing characters are not permitted. The resulting value is unquoted unless, after substitution is performed, the result is not a valid JSON object. If the result is not a valid JSON value, the resulting value is quoted and treated as a standard string.
 
 A single parameter can be referenced multiple times within a template and it can be referenced using both substitution syntaxes within a single template.
 


### PR DESCRIPTION
Fixes for #36813 .
The unintentionally changed {{PARAMETER_NAME}} is changed back to its original form.