### PR TITLE
Adds 4.6.47 release notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -71,7 +71,7 @@ If you are creating machine configs for day 1 or day 2 operations that use Ignit
 [id="ocp-4-6-additional-steps-to-add-nodes-to-clusters"]
 ==== Additional steps to add nodes to existing clusters
 
-For clusters that have been upgraded to {product-title} 4.6, you can add more nodes to your {product-title} cluster. These instructions are only applicable if you originally installed a cluster prior to {product-title} 4.6 and have since upgraded to 4.6. 
+For clusters that have been upgraded to {product-title} 4.6, you can add more nodes to your {product-title} cluster. These instructions are only applicable if you originally installed a cluster prior to {product-title} 4.6 and have since upgraded to 4.6.
 
 If you installed a user-provisioned cluster on bare metal or vSphere, you must ensure that your boot media or OVA image matches the version that your cluster was upgraded to. Additionally, your Ignition configuration file must be modified to be spec v3 compatible. For more detailed instructions and an example Ignition config file, see the link:https://access.redhat.com/solutions/5514051[Adding new nodes to UPI cluster fails after upgrading to OpenShift 4.6+] Knowledgebase Solution article.
 
@@ -3322,6 +3322,28 @@ Space precluded documenting all of the container images for this release in the 
 link:https://access.redhat.com/solutions/6364411[{product-title} 4.6.46 container image list]
 
 [id="ocp-4-6-46-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-47"]
+=== RHBA-2021:3737 - {product-title} 4.6.47 bug fix update
+
+Issued: 2021-10-13
+
+{product-title} release 4.6.47 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3737[RHBA-2021:3737] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6409551[{product-title} 4.6.47 container image list]
+
+[id="ocp-4-6-47-bug-fixes"]
+==== Bug fixes
+
+* Previously, the HTTP transport to connect to {rh-openstack-first} endpoints using a custom CA certificate was missing the proxy settings. Consequently, the cluster was not fully operational when deployed on {rh-openstack}. This update passes the proxy settings to the HTTP transport when connecting with a custom CA certificate. As a result, all cluster components work as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002752[*BZ#2002752*])
+
+
+[id="ocp-4-6-47-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ

Preview: https://deploy-preview-37370--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes?utm_source=github&utm_campaign=bot_dp#ocp-4-6-47

Not to be merged until 10-13.