### PR TITLE
RHDEVDOCS-3371 Tracker: 2002368 - samples should not go degraded when…

### DIFF
--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -51,6 +51,12 @@ Certain circumstances result in the Cluster Samples Operator bootstrapping itsel
 
 * If the Cluster Samples Operator cannot reach link:https://registry.redhat.io[registry.redhat.io] after three minutes on initial start-up after a clean installation.
 * If the Cluster Samples Operator detects it is on an IPv6 network.
+* If the xref:../openshift_images/image-configuration.html#images-configuration-parameters_image-configuration[Image configuration resources] settings prevent the creation of image streams with the default image registry or the image registry specified by the xref:../openshift_images/configuring-samples-operator.html#samples-operator-configuration_configuring-samples-operator[`samplesRegistry` setting].
+
+[NOTE]
+====
+For {product-title}, the default image registry is `registry.redhat.io`. For OKD, the default image registry is `registry.access.redhat.com` or `quay.io`.
+====
 
 However, if the Cluster Samples Operator also detects an {product-title} global proxy is configured, it bypasses those checks.
 


### PR DESCRIPTION
… image allowedRegistries blocks imagestream creation

- Aligned team: Dev Tools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3371
- Direct link to doc preview: https://deploy-preview-37372--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/configuring-samples-operator?utm_source=github&utm_campaign=bot_dp#samples-operator-bootstrapped
- SME review: @gabemontero 
- QE review: @jitendar-singh 
- Peer review: @ 	tbd
- <All reviews complete. Please merge now>