### PR TITLE
Removing port option from 'oc create route'

### DIFF
--- a/modules/migration-creating-registry-route-for-dim.adoc
+++ b/modules/migration-creating-registry-route-for-dim.adoc
@@ -25,7 +25,7 @@ ifdef::advanced-migration-options-3-4[]
 +
 [source,terminal]
 ----
-$ oc create route passthrough --service=docker-registry --port=5000 -n default
+$ oc create route passthrough --service=docker-registry -n default
 ----
 endif::[]
 
@@ -33,5 +33,5 @@ endif::[]
 +
 [source,terminal]
 ----
-$ oc create route passthrough --service=image-registry --port=5000 -n openshift-image-registry
+$ oc create route passthrough --service=image-registry -n openshift-image-registry
 ----


### PR DESCRIPTION
No Jira/BZ number

Removing port 5000 option in the "oc create route" command for source cluster because service is specified, so 5000 is the default.

4.6+

Previews: 
OCP 3: https://deploy-preview-37374--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/advanced-migration-options-3-4.html#migration-creating-registry-route-for-dim_advanced-migration-options-3-4

OCP 4: https://deploy-preview-37374--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/advanced-migration-options-mtc.html#migration-creating-registry-route-for-dim_advanced-migration-options-mtc

QE approved. Peer review required.