### PR TITLE
OKD#224: Add Code of Conduct to OKD.io

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -37,6 +37,9 @@ Topics:
 - Name: Legal notice
   File: legal-notice
   Distros: openshift-enterprise,openshift-online
+- Name: Code of conduct
+  File: okd-code-conduct
+  Distros: openshift-origin
 ---
 Name: What's new?
 Dir: whats_new

--- a/welcome/okd-code-conduct.adoc
+++ b/welcome/okd-code-conduct.adoc
@@ -1,0 +1,84 @@
+[id="okd-code-conduct"]
+= {product-title} code of conduct
+include::modules/common-attributes.adoc[]
+:context: okd-code-conduct
+
+toc::[]
+
+
+Every community can be strengthened by a diverse variety of viewpoints, insights, opinions, skillsets, and skill levels. However, with diversity comes the potential for disagreement and miscommunication. The purpose of this Code of Conduct is to ensure that disagreements and differences of opinion are conducted respectfully and on their own merits, without personal attacks or other behavior that might create an unsafe or unwelcoming environment.
+
+These policies are not designed to be a comprehensive set of Things You Cannot Do. We ask that you treat your fellow community members with respect and courtesy, and in general, Don’t Be A Jerk. This Code of Conduct is meant to be followed in spirit as much as in letter and is not exhaustive.
+
+All {product-title} events and participants therein are governed by this Code of Conduct and anti-harassment policy. We expect organizers to enforce these guidelines throughout all events, and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe environment for our whole community. Specifically, this Code of Conduct covers participation in all {product-title}-related forums and mailing lists, code and documentation contributions, public IRC channels, private correspondence, and public meetings.
+
+{product-title} community members are…
+
+Considerate::
+Contributions of every kind have far-ranging consequences. Just as your work depends on the work of others, decisions you make surrounding your contributions to the {product-title} community affect your fellow community members. You are strongly encouraged to take those consequences into account while making decisions.
+
+Patient::
+Asynchronous communication can come with its own frustrations, even in the most responsive of communities. Please remember that our community is largely built on volunteered time, and that questions, contributions, and requests for support may take some time to receive a response. Repeated “bumps” or “reminders” in rapid succession are not good displays of patience. Additionally, it is considered poor manners to ping a specific person with general questions. Pose your question to the community as a whole, and wait patiently for a response.
+
+Respectful::
+Every community inevitably has disagreements, but remember that it is possible to disagree respectfully and courteously. Disagreements are never an excuse for rudeness, hostility, threatening behavior, abuse (verbal or physical), or personal attacks.
+
+Kind::
+Everyone should feel welcome in the {product-title} community, regardless of their background. Please be courteous, respectful and polite to fellow community members. Do not make or post offensive comments related to skill level, gender, gender identity or expression, sexual orientation, disability, physical appearance, body size, race, or religion. Sexualized images or imagery, real or implied violence, intimidation, oppression, stalking, sustained disruption of activities, publishing the personal information of others without explicit permission to do so, unwanted physical contact, and unwelcome sexual attention are all strictly prohibited. Additionally, you are encouraged not to make assumptions about the background or identity of your fellow community members.
+
+Inquisitive::
+The only stupid question is the one that does not get asked. We encourage our users to ask early and ask often. Rather than asking whether you can ask a question (the answer is always yes!), instead, simply ask your question. You are encouraged to provide as many specifics as possible. Code snippets in the form of Gists or other paste site links are almost always needed in order to get the most helpful answers. Refrain from pasting multiple lines of code directly into the IRC channels - instead use gist.github.com or another paste site to provide code snippets.
+
+Helpful::
+The {product-title} community is committed to being a welcoming environment for all users, regardless of skill level. We were all beginners once upon a time, and our community cannot grow without an environment where new users feel safe and comfortable asking questions. It can become frustrating to answer the same questions repeatedly; however, community members are expected to remain courteous and helpful to all users equally, regardless of skill or knowledge level. Avoid providing responses that prioritize snideness and snark over useful information. At the same time, everyone is expected to read the provided documentation thoroughly. We are happy to answer questions, provide strategic guidance, and suggest effective workflows, but we are not here to do your job for you.
+
+[id="okd-code-conduct-harrassment"]
+== Anti-harassment policy
+
+Harassment includes (but is not limited to) the following behaviors:
+
+* Offensive comments related to gender (including gender expression and identity), age, sexual orientation, disability, physical appearance, body size, race, and religion
+
+* Derogatory terminology including words commonly known to be slurs
+
+* Posting sexualized images or imagery in public spaces
+
+* Deliberate intimidation
+
+* Stalking
+
+* Posting others’ personal information without explicit permission
+
+* Sustained disruption of talks or other events
+
+* Inappropriate physical contact
+
+* Unwelcome sexual attention
+
+Participants asked to stop any harassing behavior are expected to comply immediately. Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Meetup organizing staff and other volunteer organizers should not use sexualized attire or otherwise create a sexualized environment at community events.
+
+In addition to the behaviors outlined above, continuing to behave a certain way after you have been asked to stop also constitutes harassment, even if that behavior is not specifically outlined in this policy. It is considerate and respectful to stop doing something after you have been asked to stop, and all community members are expected to comply with such requests immediately.
+
+[id="okd-code-conduct-violations"]
+== Policy violations
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting codeofconduct@ansible.com, to any channel operator in the community IRC channels, or to the local organizers of an event. Meetup organizers are encouraged to prominently display points of contact for reporting unacceptable behavior at local events.
+
+If a participant engages in harassing behavior, the meetup organizers may take any action they deem appropriate. These actions may include but are not limited to warning the offender, expelling the offender from the event, and barring the offender from future community events.
+
+Organizers will be happy to help participants contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
+
+We expect all participants, organizers, speakers, and attendees to follow these policies at all of our event venues and event-related social events.
+
+The {product-title} Community Code of Conduct is licensed under the Creative Commons Attribution-Share Alike 3.0 license. Our Code of Conduct was adapted from Codes of Conduct of other open source projects, including:
+
+Contributor Covenant
+
+Elastic
+
+The Fedora Project
+
+OpenStack
+
+Puppet Labs
+
+Ubuntu

--- a/welcome/okd-code-conduct.adoc
+++ b/welcome/okd-code-conduct.adoc
@@ -6,33 +6,37 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 
-Every community can be strengthened by a diverse variety of viewpoints, insights, opinions, skillsets, and skill levels. However, with diversity comes the potential for disagreement and miscommunication. The purpose of this Code of Conduct is to ensure that disagreements and differences of opinion are conducted respectfully and on their own merits, without personal attacks or other behavior that might create an unsafe or unwelcoming environment.
+Every community can be strengthened by a diverse variety of viewpoints, insights, opinions, skill sets, and skill levels. However, with diversity comes the potential for disagreement and miscommunication. The purpose of this Code of Conduct is to ensure that disagreements and differences of opinion are conducted respectfully and on their own merits, without personal attacks or other behavior that might create an unsafe or unwelcoming environment.
 
-These policies are not designed to be a comprehensive set of things you cannot do. We ask that you treat your fellow community members with respect and courtesy, and in general, Don’t Be A Jerk. This Code of Conduct is meant to be followed in spirit as much as in letter and is not exhaustive.
+These policies are not designed to be a comprehensive set of things you cannot do. We ask that you treat your fellow community members with respect and courtesy. This Code of Conduct should be followed in spirit as much as in letter and is not exhaustive.
 
-All {product-title} events and community members are governed by this Code of Conduct and anti-harassment policy. We expect <WHO> to enforce these guidelines throughout all events, and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe environment for our whole community. For the purposes of this Code of Conduct, the term _events_ refers to any in-person or on-line gathering, e-mail thread, chat room, code and documentation contribution, or any situation where {product-title} community members are invited to gather and communicate. A _community member_ is anyone who particiaptes in contributing or maintaining the {product-title} project.  
+All {product-title} events and community members are governed by this Code of Conduct and anti-harassment policy. We expect <WHO> to enforce these guidelines throughout all events, and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe environment for our whole community. 
 
-{product-title} community members are:
+For the purposes of this Code of Conduct: 
 
+* An _event_ is any in-person or on-line gathering, e-mail thread, chat room, code or documentation contribution, or any situation where {product-title} community members are invited to gather and communicate. 
+
+* A _community member_ is anyone who attends {product-title} events and/or participates in contributing or maintaining the {product-title} project. {product-title} community members are:
++
 Considerate::
-Contributions of every kind have far-ranging consequences. Just as your work depends on the work of others, decisions you make surrounding your contributions to the {product-title} community affect your fellow community members. You are strongly encouraged to take those consequences into account while making decisions.
-
+Contributions of every kind have far-ranging consequences. Just as your work depends on the work of others, decisions you make surrounding your contributions to the {product-title} community affect your fellow community members. You are strongly encouraged to take those consequences into account while making decisions. Additionally, pinging a specific person with general questions is inconsiderate to that person. Always pose general question to the community as a whole.
++
 Patient::
-Asynchronous communication can come with its own frustrations, even in the most responsive of communities. Please remember that our community is largely built on volunteered time. It might take some time to receive a response to questions, contributions, and requests for support. Repeated _bumps_ or _reminders_ in rapid succession are not good displays of patience. Additionally, it is considered poor manners to ping a specific person with general questions. Pose your question to the community as a whole, and wait patiently for a response.
-
+Asynchronous communication can come with its own frustrations, even in the most responsive of communities. Please remember that our community is largely built on volunteered time. It might take some time to receive a response to questions, contributions, and requests for support. Repeated _bumps_ or _reminders_ in rapid succession are not good displays of patience. Always wait patiently for a response.
++
 Respectful::
-Every community inevitably has disagreements, but remember that it is possible to disagree respectfully and courteously. Disagreements are never an excuse for rudeness, hostility, threatening behavior, abuse (verbal or physical), or personal attacks.
-
+Every community inevitably has disagreements, but disagreements are never an excuse for rudeness, hostility, threatening behavior, abuse (verbal or physical), or personal attacks. Always remember that it is possible to disagree respectfully and courteously.
++
 Kind::
-Everyone should feel welcome in the {product-title} community, regardless of their background. Please be courteous, respectful and polite to fellow community members. You are expected to follow the xref:okd-code-conduct-harrassment[Anti-harassment policy]. Additionally, you are encouraged not to make assumptions about the background or identity of your fellow community members.
-
+Everyone should feel welcome in the {product-title} community, regardless of background. Please be courteous, respectful and polite to fellow community members. Additionally, you are encouraged not to make assumptions about the background or identity of your fellow community members. Always follow the xref:okd-code-conduct-harassment[Anti-harassment policy].
++
 Inquisitive::
-The only stupid question is the one that does not get asked. We encourage our users to ask early and ask often. Rather than asking whether you can ask a question (the answer is always yes!), instead, simply ask your question. You are encouraged to provide as many specifics as possible. Code snippets in the form of Gists or other paste site links are almost always needed in order to get the most helpful answers. Refrain from pasting multiple lines of code directly into the Google Group channel or emails. Instead use gist.github.com or another paste site to provide code snippets.
-
+We encourage {product-title} community members to _ask early and ask often_. Rather than asking whether you can ask a question (the answer is always yes!), simply ask your question. You are encouraged to provide as many specifics as possible. Code snippets in the form of Gists or other paste site links are almost always needed in order to get the most helpful answers. Refrain from pasting multiple lines of code directly into the Google Group channel or emails. Instead use gist.github.com or another paste site to provide code snippets. Always remember that the only stupid question is the one that does not get asked.
++
 Helpful::
-The {product-title} community is committed to being a welcoming environment for all users, regardless of skill level. We were all beginners once upon a time, and our community cannot grow without an environment where new users feel safe and comfortable asking questions. It can become frustrating to answer the same questions repeatedly; however, community members are expected to remain courteous and helpful to all users equally, regardless of skill or knowledge level. Avoid providing responses that prioritize snideness and snark over useful information. At the same time, everyone is expected to read the provided documentation thoroughly. We are happy to answer questions, provide strategic guidance, and suggest effective workflows, but we are not here to do your job for you.
+The {product-title} community is committed to being a welcoming environment for all users, regardless of skill level. Our community cannot grow without an environment where new users feel safe and comfortable asking questions. It can become frustrating to answer the same questions repeatedly; however, community members are expected to remain courteous and helpful to all users equally, regardless of skill or knowledge level. At the same time, everyone is expected to read the provided documentation thoroughly. We are happy to answer questions, provide strategic guidance, and suggest effective workflows, but we are not here to do your job for you. Always remember we were all beginners once upon a time,
 
-[id="okd-code-conduct-harrassment"]
+[id="okd-code-conduct-harassment"]
 == Anti-harassment policy
 
 Harassment includes (but is not limited to) the following behaviors:
@@ -41,7 +45,7 @@ Harassment includes (but is not limited to) the following behaviors:
 
 * Derogatory terminology including words commonly known to be slurs
 
-* Posting sexualized images or imagery in public spaces
+* Posting sexual images or imagery in public spaces
 
 * Deliberate intimidation
 
@@ -55,17 +59,17 @@ Harassment includes (but is not limited to) the following behaviors:
 
 * Unwelcome sexual attention
 
-Community members asked to stop any harassing behavior are expected to comply immediately. In particular, community members should not use sexualized images, activities, or other material. Community members should not use sexualized attire or otherwise create a sexualized environment at community events.
+Community members asked to stop any harassing behavior are expected to comply immediately. In particular, community members should not use sexual images, activities, or other material. Community members should not use sexual attire or otherwise create a sexualized environment at community events.
 
-In addition to the behaviors outlined above, continuing to behave a certain way after you have been asked to stop also constitutes harassment, even if that behavior is not specifically outlined in this policy. It is considerate and respectful to stop doing something after you have been asked to stop, and all community members are expected to comply with such requests immediately.
+In addition to the behaviors outlined above, continuing to behave in a certain way after you have been asked to stop also constitutes harassment, even if that behavior is not specifically outlined in this policy. It is considerate and respectful to stop doing something after you have been asked to stop, and all community members are expected to comply with such requests immediately.
 
 [id="okd-code-conduct-violations"]
 == Policy violations
 Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting <EMAIL/CONTACT REQUIRED>.
 
-If a community member engages in harassing behavior, <WHO> may take any action deemed appropriate. These actions may include but are not limited to warning the offender, expelling the offender from the event, and barring the offender from participating in the community.
+If a community member engages in harassing behavior, <WHO> may take any action deemed appropriate. These actions may include but are not limited to warning the offender and expelling the offender from an event. <WHO> might determine that the offender should be barred from participating in the community.
 
-<WHO> will be happy to help community members contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
+<WHO> will be happy to help community members contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of an event. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and in-person.
 
 We expect all community members to follow these policies during all of our events.
 

--- a/welcome/okd-code-conduct.adoc
+++ b/welcome/okd-code-conduct.adoc
@@ -65,7 +65,7 @@ Instances of abusive, harassing, or otherwise unacceptable behavior may be repor
 
 If a community member engages in harassing behavior, <WHO> may take any action deemed appropriate. These actions may include but are not limited to warning the offender, expelling the offender from the event, and barring the offender from participating in the community.
 
-<WHO> will be happy to help participants contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
+<WHO> will be happy to help community members contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
 
 We expect all community members to follow these policies during all of our events.
 

--- a/welcome/okd-code-conduct.adoc
+++ b/welcome/okd-code-conduct.adoc
@@ -1,5 +1,5 @@
 [id="okd-code-conduct"]
-= {product-title} code of conduct
+= {product-title} Code of Conduct
 include::modules/common-attributes.adoc[]
 :context: okd-code-conduct
 
@@ -8,26 +8,26 @@ toc::[]
 
 Every community can be strengthened by a diverse variety of viewpoints, insights, opinions, skillsets, and skill levels. However, with diversity comes the potential for disagreement and miscommunication. The purpose of this Code of Conduct is to ensure that disagreements and differences of opinion are conducted respectfully and on their own merits, without personal attacks or other behavior that might create an unsafe or unwelcoming environment.
 
-These policies are not designed to be a comprehensive set of Things You Cannot Do. We ask that you treat your fellow community members with respect and courtesy, and in general, Don’t Be A Jerk. This Code of Conduct is meant to be followed in spirit as much as in letter and is not exhaustive.
+These policies are not designed to be a comprehensive set of things you cannot do. We ask that you treat your fellow community members with respect and courtesy, and in general, Don’t Be A Jerk. This Code of Conduct is meant to be followed in spirit as much as in letter and is not exhaustive.
 
-All {product-title} events and participants therein are governed by this Code of Conduct and anti-harassment policy. We expect organizers to enforce these guidelines throughout all events, and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe environment for our whole community. Specifically, this Code of Conduct covers participation in all {product-title}-related forums and mailing lists, code and documentation contributions, public IRC channels, private correspondence, and public meetings.
+All {product-title} events and community members are governed by this Code of Conduct and anti-harassment policy. We expect <WHO> to enforce these guidelines throughout all events, and we expect attendees, speakers, sponsors, and volunteers to help ensure a safe environment for our whole community. For the purposes of this Code of Conduct, the term _events_ refers to any in-person or on-line gathering, e-mail thread, chat room, code and documentation contribution, or any situation where {product-title} community members are invited to gather and communicate. A _community member_ is anyone who particiaptes in contributing or maintaining the {product-title} project.  
 
-{product-title} community members are…
+{product-title} community members are:
 
 Considerate::
 Contributions of every kind have far-ranging consequences. Just as your work depends on the work of others, decisions you make surrounding your contributions to the {product-title} community affect your fellow community members. You are strongly encouraged to take those consequences into account while making decisions.
 
 Patient::
-Asynchronous communication can come with its own frustrations, even in the most responsive of communities. Please remember that our community is largely built on volunteered time, and that questions, contributions, and requests for support may take some time to receive a response. Repeated “bumps” or “reminders” in rapid succession are not good displays of patience. Additionally, it is considered poor manners to ping a specific person with general questions. Pose your question to the community as a whole, and wait patiently for a response.
+Asynchronous communication can come with its own frustrations, even in the most responsive of communities. Please remember that our community is largely built on volunteered time. It might take some time to receive a response to questions, contributions, and requests for support. Repeated _bumps_ or _reminders_ in rapid succession are not good displays of patience. Additionally, it is considered poor manners to ping a specific person with general questions. Pose your question to the community as a whole, and wait patiently for a response.
 
 Respectful::
 Every community inevitably has disagreements, but remember that it is possible to disagree respectfully and courteously. Disagreements are never an excuse for rudeness, hostility, threatening behavior, abuse (verbal or physical), or personal attacks.
 
 Kind::
-Everyone should feel welcome in the {product-title} community, regardless of their background. Please be courteous, respectful and polite to fellow community members. Do not make or post offensive comments related to skill level, gender, gender identity or expression, sexual orientation, disability, physical appearance, body size, race, or religion. Sexualized images or imagery, real or implied violence, intimidation, oppression, stalking, sustained disruption of activities, publishing the personal information of others without explicit permission to do so, unwanted physical contact, and unwelcome sexual attention are all strictly prohibited. Additionally, you are encouraged not to make assumptions about the background or identity of your fellow community members.
+Everyone should feel welcome in the {product-title} community, regardless of their background. Please be courteous, respectful and polite to fellow community members. You are expected to follow the xref:okd-code-conduct-harrassment[Anti-harassment policy]. Additionally, you are encouraged not to make assumptions about the background or identity of your fellow community members.
 
 Inquisitive::
-The only stupid question is the one that does not get asked. We encourage our users to ask early and ask often. Rather than asking whether you can ask a question (the answer is always yes!), instead, simply ask your question. You are encouraged to provide as many specifics as possible. Code snippets in the form of Gists or other paste site links are almost always needed in order to get the most helpful answers. Refrain from pasting multiple lines of code directly into the IRC channels - instead use gist.github.com or another paste site to provide code snippets.
+The only stupid question is the one that does not get asked. We encourage our users to ask early and ask often. Rather than asking whether you can ask a question (the answer is always yes!), instead, simply ask your question. You are encouraged to provide as many specifics as possible. Code snippets in the form of Gists or other paste site links are almost always needed in order to get the most helpful answers. Refrain from pasting multiple lines of code directly into the Google Group channel or emails. Instead use gist.github.com or another paste site to provide code snippets.
 
 Helpful::
 The {product-title} community is committed to being a welcoming environment for all users, regardless of skill level. We were all beginners once upon a time, and our community cannot grow without an environment where new users feel safe and comfortable asking questions. It can become frustrating to answer the same questions repeatedly; however, community members are expected to remain courteous and helpful to all users equally, regardless of skill or knowledge level. Avoid providing responses that prioritize snideness and snark over useful information. At the same time, everyone is expected to read the provided documentation thoroughly. We are happy to answer questions, provide strategic guidance, and suggest effective workflows, but we are not here to do your job for you.
@@ -55,21 +55,23 @@ Harassment includes (but is not limited to) the following behaviors:
 
 * Unwelcome sexual attention
 
-Participants asked to stop any harassing behavior are expected to comply immediately. Sponsors are also subject to the anti-harassment policy. In particular, sponsors should not use sexualized images, activities, or other material. Meetup organizing staff and other volunteer organizers should not use sexualized attire or otherwise create a sexualized environment at community events.
+Community members asked to stop any harassing behavior are expected to comply immediately. In particular, community members should not use sexualized images, activities, or other material. Community members should not use sexualized attire or otherwise create a sexualized environment at community events.
 
 In addition to the behaviors outlined above, continuing to behave a certain way after you have been asked to stop also constitutes harassment, even if that behavior is not specifically outlined in this policy. It is considerate and respectful to stop doing something after you have been asked to stop, and all community members are expected to comply with such requests immediately.
 
 [id="okd-code-conduct-violations"]
 == Policy violations
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting codeofconduct@ansible.com, to any channel operator in the community IRC channels, or to the local organizers of an event. Meetup organizers are encouraged to prominently display points of contact for reporting unacceptable behavior at local events.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting <EMAIL/CONTACT REQUIRED>.
 
-If a participant engages in harassing behavior, the meetup organizers may take any action they deem appropriate. These actions may include but are not limited to warning the offender, expelling the offender from the event, and barring the offender from future community events.
+If a community member engages in harassing behavior, <WHO> may take any action deemed appropriate. These actions may include but are not limited to warning the offender, expelling the offender from the event, and barring the offender from participating in the community.
 
-Organizers will be happy to help participants contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
+<WHO> will be happy to help participants contact security or local law enforcement, provide escorts to an alternate location, or otherwise assist those experiencing harassment to feel safe for the duration of the meetup. We value the safety and well-being of our community members and want everyone to feel welcome at our events, both online and offline.
 
-We expect all participants, organizers, speakers, and attendees to follow these policies at all of our event venues and event-related social events.
+We expect all community members to follow these policies during all of our events.
 
 The {product-title} Community Code of Conduct is licensed under the Creative Commons Attribution-Share Alike 3.0 license. Our Code of Conduct was adapted from Codes of Conduct of other open source projects, including:
+
+Ansible
 
 Contributor Covenant
 


### PR DESCRIPTION
I have made a first pass at customizing the Ansible CoC from the file referenced in Diane's issue: https://github.com/openshift-cs/okd.io/issues/224 

* I changed the concept of _events_ to mean anytime the group communicates (see the wording in the current PR). The Ansible CoC seems to be more aimed at scheduled in-person gatherings than the online meetings and communications that we generally engage in. 
* I removed the concept of _organizer and participant_ as, from the meetings I have attended, it feels like everyone is a peer, rather than people in separate roles.  However, this leaves open the role of who will enforce policy violations and deem punishments for violations, places maked with <WHO> in the current PR. 
* We need a mechanism to report violations.

Please feel free to make further comments.  

Red Hat internal preview: http://file.rdu.redhat.com/~mburke/okd-code-conduct/welcome/okd-code-conduct.html