### PR TITLE
BZ#1962763 conditionalize machine-pool ref in parameter description for RHV only

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -436,7 +436,10 @@ Optional installation configuration parameters are described in the following ta
 
 |`compute`
 |The configuration for the machines that comprise the compute nodes.
-|Array of `MachinePool` objects. For details, see the following "Machine-pool" table.
+|Array of `MachinePool` objects.
+ifdef::rhv[]
+For details, see the "Additional RHV parameters for machine pools" table.
+endif::rhv[]
 
 ifndef::ibm-z,ibm-power[]
 |`compute.architecture`
@@ -479,7 +482,10 @@ accounts for the dramatically decreased machine performance.
 
 |`controlPlane`
 |The configuration for the machines that comprise the control plane.
-|Array of `MachinePool` objects. For details, see the following "Machine-pool" table.
+|Array of `MachinePool` objects.
+ifdef::rhv[]
+For details, see the "Additional RHV parameters for machine pools" table.
+endif::rhv[]
 
 ifndef::ibm-z,ibm-power[]
 |`controlPlane.architecture`


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1962763
enterprise-4.9
enterprise 4.10
can also be ported to any recent versions that are actively used by customers.

Previews: 
AWS - no mention of Machine-pools table - 
https://deploy-preview-37384--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters-optional_installing-aws-customizations
RHV - mention of "Additional RHV parameters for machine pools" table.
https://deploy-preview-37384--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installation-configuration-parameters-optional_installing-rhv-customizations