### PR TITLE
Bz1963254: New RN - UEFI and secure boot

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -61,6 +61,9 @@ The SVVP Certification applies to:
 //CNV-14246
 * You can now use the `virtctl guestfs` command xref:../virt/virt-using-the-cli-tools.html#virt-creating-pvc-with-virtctl-guestfs_virt-using-the-cli-tools[to maintain, repair, and debug virtual machine disks].
 
+//BZ-1963254 UEFI without Secure Boot
+* You can now boot xref:../virt/virtual_machines/advanced_vm_management/virt-efi-mode-for-vms.adoc#virt-efi-mode-for-vms[Extensible Firmware Interface (EFI) virtual machines] that have `secureboot` disabled.
+
 [id="virt-4-9-quick-starts"]
 === Quick starts
 
@@ -131,8 +134,6 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 == Known issues
 
 //New known issues should go below here.
-
-//BZ-1963254 UEFI without Secure Boot
 
 //BZ-2007397
 * If you hot-plug a virtual disk and then force delete the `virt-launcher` pod, you might lose data. This is due to a race condition that can cause the VM disk's contents to be wiped from the persistent volume. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007397[*BZ#2007397*])


### PR DESCRIPTION
Previously a bug, now and added feature RN
Re: BZ1963254 https://bugzilla.redhat.com/show_bug.cgi?id=1963254
For 4.9 release notes

Preview: https://deploy-preview-37399--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-9-release-notes.html