### PR TITLE
[virt] Removed CNV integration with service mesh assembly

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2989,8 +2989,9 @@ Topics:
       File: virt-configuring-sriov-device-for-vms
     - Name: Configuring certificate rotation
       File: virt-configuring-certificate-rotation
-    - Name: Connecting virtual machines to a service mesh
-      File: virt-connecting-vm-to-service-mesh
+      # TODO: Add the assembly back for 4.10
+#    - Name: Connecting virtual machines to a service mesh
+#      File: virt-connecting-vm-to-service-mesh
     - Name: Defining an SR-IOV network
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network


### PR DESCRIPTION
This PR comments out the `virt-connecting-vm-to-service-mesh` assembly in `_topic_map.yml` to remove the content from the 4.9 docs

The [epic](https://issues.redhat.com/browse/CNV-4999) for this feature has been moved to 4.10
