### PR TITLE
[virt] Removed CNV integration with Service Mesh RN

### DIFF
--- a/virt/virt-4-9-release-notes.adoc
+++ b/virt/virt-4-9-release-notes.adoc
@@ -41,8 +41,10 @@ Red Hat is committed to replacing problematic language in our code, documentatio
 == New and changed features
 //CNV-8875 OLM and stable channels
 
-//CNV-8577 OpenShift Service Mesh
+//CNV-8577 OpenShift Service Mesh: Commenting out the RN because the feature will now be available in 4.10
+////
 * {VirtProductName} is now integrated with OpenShift Service Mesh. You can xref:../virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.adoc#virt-connecting-vm-to-service-mesh[connect virtual machines to a service mesh] to monitor, visualize, and control traffic between pods that run virtual machine workloads on the default pod network with IPv4.
+////
 
 //CNV-12858
 * {VirtProductName} is certified in Microsoft’s Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.


### PR DESCRIPTION
The feature associated with this RN has been moved to 4.10

Commented out the RN in the 4.9 file; to be carried over to 4.10.

