### PR TITLE
An egress router pod macvlan is created by cluster

### DIFF
--- a/modules/nw-egress-router-pod.adoc
+++ b/modules/nw-egress-router-pod.adoc
@@ -95,7 +95,7 @@ spec:
   - name: egress-router-wait
     image: {egress-pod-image-url}
 ----
-<1> Before starting the `egress-router` container, create a macvlan network interface on the primary network interface and move that interface into the pod network namespace. You must include the quotation marks around the `"true"` value. To create the macvlan interface on a network interface other than the primary one, set the annotation value to the name of that interface. For example, `eth1`.
+<1> The annotation tells {product-title} to create a macvlan network interface on the primary network interface controller (NIC) and move that macvlan interface into the pod's network namespace. You must include the quotation marks around the `"true"` value. To have {product-title} create the macvlan interface on a different NIC interface, set the annotation value to the name of that interface. For example, `eth1`.
 <2> IP address from the physical network that the node is on that is reserved for use by the egress router pod. Optional: You can include the subnet length, the `/24` suffix, so that a proper route to the local subnet is set. If you do not specify a subnet length, then the egress router can access only the host specified with the `EGRESS_GATEWAY` variable and no other hosts on the subnet.
 <3> Same value as the default gateway used by the node.
 <4> External server to direct traffic to. Using this example, connections to the pod are redirected to `203.0.113.25`, with a source IP address of `192.168.12.99`.
@@ -192,7 +192,7 @@ ifdef::dns[]
 endif::dns[]
     ...
 ----
-<1> Before starting the `egress-router` container, create a macvlan network interface on the primary network interface and move that interface into the pod network namespace. You must include the quotation marks around the `"true"` value. To create the macvlan interface on a network interface other than the primary one, set the annotation value to the name of that interface. For example, `eth1`.
+<1> The annotation tells {product-title} to create a macvlan network interface on the primary network interface controller (NIC) and move that macvlan interface into the pod's network namespace. You must include the quotation marks around the `"true"` value. To have {product-title} create the macvlan interface on a different NIC interface, set the annotation value to the name of that interface. For example, `eth1`.
 <2> IP address from the physical network that the node is on that is reserved for use by the egress router pod. Optional: You can include the subnet length, the `/24` suffix, so that a proper route to the local subnet is set. If you do not specify a subnet length, then the egress router can access only the host specified with the `EGRESS_GATEWAY` variable and no other hosts on the subnet.
 <3> Same value as the default gateway used by the node.
 ifdef::http[]


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/issues/36979

Preview: [Egress router pod specification for redirect mode](https://deploy-preview-37407--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-layer3-redirection.html#nw-egress-router-pod_deploying-egress-router-layer3-redirection)
Preview: [Egress router pod specification for HTTP mode](https://deploy-preview-37407--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-http-redirection.html#nw-egress-router-pod_deploying-egress-router-http-redirection)