### PR TITLE
OSDOCS-2654: Added a missing name flag to the rosa CLI commands.

### DIFF
--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -16,14 +16,14 @@ Labels are assigned as key=value pairs. Each key must be unique to the object it
 +
 [source,terminal]
 ----
-$ rosa create machinepool --cluster=<cluster-name> <machinepool_ID> --replicas=<number-nodes> --labels=<key=pair>
+$ rosa create machinepool --cluster=<cluster-name> --name=<machinepool_ID> --replicas=<number-nodes> --labels=<key=pair>
 ----
 +
 This example shows how to use labels to assign a database workload to a group of worker nodes, and creates 2 replica worker nodes that you can manage as one unit:
 +
 [source,terminal]
 ----
-$ rosa create machinepool --cluster=mycluster db-nodes-mp --replicas=2 --labels=app=db,tier=backend
+$ rosa create machinepool --cluster=mycluster --name=db-nodes-mp --replicas=2 --labels=app=db,tier=backend
 ----
 +
 .Example output


### PR DESCRIPTION
This PR adds the missing `--name=` flag to two rosa CLI commands. Without this flag, the commands failed.

JIRA: https://issues.redhat.com/browse/OSDOCS-2654

Preview: https://deploy-preview-37409--osdocs.netlify.app/openshift-rosa/latest/nodes/rosa-managing-worker-nodes#rosa-adding-node-labels_rosa-managing-worker-nodes