### PR TITLE
4.9 Release note: PORTENABLE-52 OSDK bundle validate removed Kube APIs

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -586,7 +586,26 @@ For more information, see xref:../operators/operator_sdk/osdk-ha-sno.adoc#osdk-h
 
 [id="ocp-4-9-osdk-proxy-support"]
 ==== Operator support for network proxies
+
 Operator authors can now develop Operators that support network proxies. Operators with proxy support inspect the Operator deployment for environment variables and pass the variables on to the required Operands. Cluster administrators configure proxy support for the environment variables that are handled by Operator Lifecycle Manager (OLM). For more information, see the Operator SDK tutorials for developing Operators using xref:../operators/operator_sdk/golang/osdk-golang-tutorial.adoc#osdk-run-proxy[Go], xref:../operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc#osdk-run-proxy[Ansible], and xref:../operators/operator_sdk/helm/osdk-helm-tutorial.adoc#osdk-run-proxy[Helm].
+
+[id="ocp-4-9-osdk-k8s-api-bundle-validate"]
+==== Validating bundle manifests for APIs removed from Kubernetes 1.22
+
+You can now check bundle manifests for APIs removed from Kubernetes 1.22 by using the Operator Framework suite of tests with the `bundle validate` subcommand.
+
+For example:
+
+[source,terminal]
+----
+$ operator-sdk bundle validate .<bundle_dir_or_image> \
+  --select-optional suite=operatorframework \
+  --optional-values=k8s-version=1.22
+----
+
+If your bundle manifest includes APIs removed from Kubernetes 1.22, the command displays a warning message. The warning message indicates which APIs you need to migrate and links to the Kubernetes API migration guide.
+
+See the xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-removed-kube-1-22-apis[table of beta APIs removed from Kubernetes 1.22] and the xref:../operators/operator_sdk/osdk-cli-ref.adoc#osdk-cli-ref-bundle-validate[Operator SDK CLI reference] for more information.
 
 [id="ocp-4-9-builds"]
 === Builds


### PR DESCRIPTION
4.9 Release note

This release note documents the OSDK feature [PORTENABLE-52](https://issues.redhat.com/browse/PORTENABLE-52), which checks bundle manifests for APIs removed in Kubernetes 1.22.

Docs preview link: https://deploy-preview-37411--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-osdk-k8s-api-bundle-validate