### PR TITLE
Console Release Notes for 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -139,6 +139,21 @@ See xref:../installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc
 ==== Accessing node logs from the Node page
 With this update, administrators now have the ability to access node logs from the *Node* page. To review the node logs, you can switch between individual log files and journal log units by clicking the *Logs* tab.
 
+[id="ocp-4-9-cluster-utilization-by-node-type"]
+==== Break down cluster utilization by node type
+
+You now have the ability to filter by node type in the *Cluster utilization* card on the cluster dashboard. Additional node types will appear in the list when created.
+
+[id="ocp-4-9-user-preferences"]
+==== User preferences
+
+This update adds a *User Preferences* page for customizing settings, such as default project, perspective, and topology view.
+
+[id="ocp-4-9-hide-system-projects-from-project-list"]
+==== Hide default projects from project list
+
+With this update, you can hide `default projects` from the *Projects* dropdown in the web console masthead. You can still toggle to show `default projects` before you search and filter.
+
 [id="ocp-4-9-ibm-z"]
 === IBM Z and LinuxONE
 
@@ -549,12 +564,6 @@ File-based catalogs are the latest iteration of the catalog format in Operator L
 For more information about the file-based catalog specification, see xref:../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format].
 
 For instructions about creating file-based catalogs by using the `opm` CLI, see xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-fb-catalog-image_olm-managing-custom-catalogs[Managing custom catalogs].
-
-[id="ocp-4-9-olm-operand-deletion"]
-==== Removing Operands when uninstalling an Operator using the web console
-
-When you uninstall an Operator by using the web console, you can now remove Operands managed by the Operator automatically, including custom resources (CRs). For more information, see
-xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster using the web console].
 
 [id="ocp-4-9-olm-admin-error-reporting"]
 ==== Enhanced error reporting for cluster administrators


### PR DESCRIPTION
Adds in release notes from the "What's new in OpenShift 4.9" presentation 

- Applies to `enterprise-4.9` only
- [Preview link](https://deploy-preview-37413--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-web-console)