### PR TITLE
OSDOCS-2734: Add release note announcing image registy uses Azure Blob Storage for Azure Stack Hub clusters

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -544,6 +544,16 @@ For more information, see xref:../storage/persistent_storage/persistent-storage-
 
 {product-title} 4.9 adds resizing capability to the oVirt CSI Driver, which allows users to increase the size of their existing persistent volume claims (PVCs). Prior to this feature, users had to create new PVCs with the increased size, and move all of the content from the old persistent volume (PV) to the new PV, which could result in data loss. Now, users can edit the existing PVC and the oVirt CSI Driver will resize the underlying oVirt disk.
 
+[id="ocp-4-9-registry"]
+=== Registry
+
+[id="ocp-4-9-registry-azure-storage"]
+==== Image Registry uses Azure Blob Storage on Azure Stack Hub installations
+
+In {product-title} 4.9, the integrated Image Registry uses Azure Blob Storage for clusters installed on Microsoft Azure Stack Hub using user-provisioned infrastructure.
+
+See xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[Installing a cluster on Azure Stack Hub using ARM templates] for details.
+
 [id="ocp-4-9-olm"]
 === Operator lifecycle
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2734

Related to https://github.com/openshift/openshift-docs/issues/33497.

Preview: https://deploy-preview-37420--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-registry-azure-storage