### PR TITLE
BZ#1889248: Add gcp licenses parameter description

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -909,7 +909,7 @@ ifdef::gcp[]
 Additional GCP configuration parameters are described in the following table:
 
 .Additional GCP parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^1,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
@@ -937,6 +937,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |`platform.gcp.computeSubnet`
 |The name of the existing subnet in your VPC that you want to deploy your compute machines to.
 |The subnet name.
+
+|`platform.gcp.licenses`
+|A list of license URLs that must be applied to the compute images.
+[IMPORTANT]
+====
+The `licenses` parameter is a deprecated field and nested virtualization is enabled by default. It is not recommended to use this field.
+====
+|Any license available with the link:https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list[license API], such as the license to enable link:https://cloud.google.com/compute/docs/instances/nested-virtualization/overview[nested virtualization]. You cannot use this parameter with a mechanism that generates pre-built images. Using a license URL forces the installer to copy the source image before use.
 
 |`platform.gcp.osDisk.diskSizeGB`
 |The size of the disk in gigabytes (GB).


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1889248

OCP version: 4.6+

Direct doc preview link: https://deploy-preview-37422--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-additional-gcp_installing-gcp-customizations