### PR TITLE
BZ 2009796: IPI BM Dual-stack must use IPv4 as the primary IP family

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
@@ -8,13 +8,9 @@ include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[l
 
 include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+1]
 
-ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+1]
-endif::[]
 
-ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+1]
 
@@ -24,21 +20,15 @@ include::modules/ipi-install-bmc-addressing-for-dell-idrac.adoc[leveloffset=+1]
 
 include::modules/ipi-install-bmc-addressing-for-hpe-ilo.adoc[leveloffset=+1]
 
-ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc[leveloffset=+1]
-endif::[]
 
 include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
 
 include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+1]
 
-ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc[leveloffset=+1]
-endif::[]
 
-ifeval::[{product-version} > 4.7]
 include::modules/ipi-install-configure-network-components-to-run-on-the-control-plane.adoc[leveloffset=+1]
-endif::[]
 
 ifeval::[{product-version} > 4.8]
 include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+1]

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -6,7 +6,7 @@
 
 = Modifying the `install-config.yaml` file for dual-stack network (optional)
 
-To deploy an {product-title} cluster with dual-stack networking, make the following changes to the `install-config.yaml` file.
+To deploy an {product-title} cluster with dual-stack networking, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
 
 [source,yaml]
 ----
@@ -23,22 +23,7 @@ serviceNetwork:
 - fd03::/112
 ----
 
-NOTE: In the above snippet, the network settings must match the settings for the cluster's network environment. The `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings must have two CIDR entries each. The first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
-
 [IMPORTANT]
 ====
-The IPv4 entries must go *before* the IPv6 entries.
+The API VIP IP address and the Ingress VIP address must be of the primary IP address family when using dual-stack networking. Currently, Red Hat does not support dual-stack VIPs or dual-stack networking with IPv6 as the primary IP address family. However, Red Hat does support dual-stack networking with IPv4 as the primary IP address family. Therefore, the IPv4 entries must go *before* the IPv6 entries.
 ====
-
-ifeval::[{product-version} < 4.8]
-To deploy an {product-title} cluster with dual-stack, create an additional manifest to enable the `FeatureGate` with the following contents:
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: IPv6DualStackNoUpgrade
-----
-endif::[]


### PR DESCRIPTION
Edited the module to make the IPv4 requirement prominent and note that IPv6 is not supported as the primary IP family.

See https://bugzilla.redhat.com/show_bug.cgi?id=2009796 for details.

Preview URL: https://deploy-preview-37424--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#modifying-install-config-for-dual-stack-network_ipi-install-configuration-files

Releases: 4.8 and 4.9

Signed-off-by: John Wilkins <jowilkin@redhat.com>