### PR TITLE
BZ-2010700: Updated module to note that Secure Boot requires Redfish.

### DIFF
--- a/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
@@ -5,7 +5,7 @@
 
 = Configuring managed Secure Boot in the `install-config.yaml` file (optional)
 
-To enable managed Secure Boot, add the `bootMode` configuration setting to each node:
+You can enable managed Secure Boot when deploying an installer-provisioned cluster using Redfish BMC addressing, such as `redfish`, `redfish-virtualmedia`, or `idrac-virtualmedia`. To enable managed Secure Boot, add the `bootMode` configuration setting to each node:
 
 [source,yaml]
 .Example
@@ -14,18 +14,25 @@ hosts:
   - name: openshift-master-0
     role: master
     bmc:
-      address: ipmi://<out-of-band-ip>
+      address: redfish://<out_of_band_ip> <1>
       username: <user>
       password: <password>
-    bootMACAddress: <NIC1-mac-address>
+    bootMACAddress: <NIC1_mac_address>
     rootDeviceHints:
      deviceName: "/dev/sda"
-    bootMode: UEFISecureBoot <1>
+    bootMode: UEFISecureBoot <2>
 ----
 
-<1> The `bootMode` setting is `UEFI` by default. Change it to `UEFISecureBoot` to enable managed Secure Boot.
+<1> Ensure the `bmc.address` setting uses `redfish`, `redfish-virtualmedia`, or `idrac-virtualmedia` as the protocol. See "BMC addressing for HPE iLO" or "BMC addressing for Dell iDRAC" for additional details.
+
+<2> The `bootMode` setting is `UEFI` by default. Change it to `UEFISecureBoot` to enable managed Secure Boot.
 
 [NOTE]
 ====
 See "Configuring nodes" in the "Prerequisites" to ensure the nodes can support managed Secure Boot. If the nodes do not support managed Secure Boot, see "Configuring nodes for Secure Boot manually" in the "Configuring nodes" section. Configuring Secure Boot manually requires Redfish virtual media.
+====
+
+[NOTE]
+====
+Red Hat does not support Secure Boot with IPMI, because IPMI does not provide Secure Boot management facilities.
 ====


### PR DESCRIPTION
Updated module to note that Secure Boot requires Redfish.

See https://bugzilla.redhat.com/show_bug.cgi?id=2010700 for additional details.

Release: 4.8 and 4.9

Preview URL: N/A. Modified assembly to remove conditional text in another PR. Avoiding the otherwise inevitable merge conflict.

Signed-off-by: John Wilkins <jowilkin@redhat.com>