### PR TITLE
BZ1913087: Added note that IPI installation method is the only supported method

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -8,6 +8,11 @@ toc::[]
 In {product-title} {product-version}, you can install a cluster on
 {rh-openstack-first} in a restricted network by creating an internal mirror of the installation release content.
 
+[NOTE]
+====
+Installing in a restricted network is supported only for installer-provisioned installations.
+====
+
 .Prerequisites
 
 * xref:../../installing/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[Create a registry on your mirror host]


### PR DESCRIPTION
CP to 4.6

https://bugzilla.redhat.com/show_bug.cgi?id=1913087

Updated the intro of **Installing a cluster on OpenStack in a restricted network** to include a note that the IPI installation method is the only supported installation method when installing in a restricted network.

Doc preview: https://deploy-preview-37430--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-restricted.html
