### PR TITLE
[enterprise-4.6] BZ-1903943: low latency cpu partitioning chapter lacks info

### DIFF
--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+:_content-type: PROCEDURE
+[id="cnf-restricting-cpu-infra-container_{context}"]
+:_context: cnf-master
+= Restricting CPUs for infra and application containers
+
+Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Performance Addon Operator:
+
+.Process' CPU assignments
+[%header,cols=2*] 
+|===
+|Process type
+|Details
+
+|Burstable and best-effort pods
+|Runs on any CPU except where low latency workload is running
+
+|Infrastructure pods
+|Runs on any CPU except where low latency workload is running
+
+|Interrupts
+|Redirects to reserved CPUs (optional in {product-title} {product-version} and later)
+
+|Kernel processes
+|Pins to reserved CPUs
+
+|Latency-sensitive workload pods
+|Pins to a specific set of exclusive CPUs from the isolated pool
+
+|OS processes/systemd services
+|Pins to reserved CPUs
+|===
+
+The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
+
+* If the latency-sensitive workload uses specific hardware, such as a network interface card (NIC), ensure that the CPUs in the isolated pool are as close as possible to this hardware. At a minimum, you should place the workload in the same Non-Uniform Memory Access (NUMA) node.
+* The reserved pool is used for handling all interrupts. When depending on system networking, allocate a sufficiently-sized reserve pool to handle all the incoming packet interrupts. In {product-version} and later versions, workloads can optionally be labeled as sensitive.
+The decision regarding which specific CPUs should be used for reserved and isolated partitions requires detailed analysis and measurements. Factors like NUMA affinity of devices and memory play a role. The selection also depends on the workload architecture and the specific use case.
+
+[IMPORTANT]
+====
+The reserved and isolated CPU pools must not overlap and together must span all available cores in the worker node.
+====
+
+To ensure that housekeeping tasks and workloads do not interfere with each other, specify two groups of CPUs in the `spec` section of the performance profile.
+
+* `isolated` - Specifies the CPUs for the application container workloads. Workloads running on these CPUs experience the lowest latency as well as zero interruptions and can, for example, reach high zero packet loss bandwidth.
+* `reserved` - Specifies the CPUs for the cluster and operating system housekeeping duties. Threads in the `reserved` group are often busy. Do not run latency-sensitive applications in the `reserved` group. Latency-sensitive applications run in the `isolated` group.
+.Procedure
+
+. Create a performance profile appropriate for the environment's hardware and topology.
+
+. Add the `reserved` and `isolated` parameters with the CPUs you want reserved and isolated for the infra and application containers:
++
+[source,yaml]
+----
+﻿apiVersion: performance.openshift.io/v2
+kind: PerformanceProfile
+metadata:
+  name: infra-cpus
+spec:
+  cpu:
+    reserved: "0-4,9" <1>
+    isolated: "5-8" <2>
+  nodeSelector: <3>
+    node-role.kubernetes.io/worker: ""
+----
+<1> Specify which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
+<2> Specify which CPUs are for application containers to run workloads. 
+<3> Specify a node selector to apply the performance profile to specific nodes.

--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -2,7 +2,6 @@
 // Epic CNF-78 (4.4)
 // Epic CNF-422 (4.5)
 // scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
-
 :_content-type: PROCEDURE
 [id="cnf-tuning-nodes-for-low-latency-via-performanceprofile_{context}"]
 = Tuning nodes for low latency with the performance profile
@@ -51,14 +50,3 @@ spec:
 
 <1> Valid values are `true` or `false`. Setting the `true` value installs the real-time kernel on the node.
 <2> Use this field to configure the topology manager policy. Valid values are `none` (default), `best-effort`, `restricted`, and `single-numa-node`. For more information, see link:https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/#topology-manager-policies[Topology Manager Policies].
-
-[id="cnf-partitioning-the-cpus_{context}"]
-== Partitioning the CPUs
-
-You can reserve cores, or threads, for operating system housekeeping tasks from a single NUMA node and put your workloads on another NUMA node. The reason for this is that the housekeeping processes might be using the CPUs in a way that would impact latency sensitive processes running on those same CPUs. Keeping your workloads on a separate NUMA node prevents the processes from interfering with each other. Additionally, each NUMA node has its own memory bus that is not shared.
-
-Specify two groups of CPUs in the `spec` section:
-
-* `isolated` - Has the lowest latency. Processes in this group have no interruptions and so can, for example, reach much higher DPDK zero packet loss bandwidth.
-
-* `reserved` - The housekeeping CPUs. Threads in the reserved group tend to be very busy, so latency-sensitive applications should be run in the isolated group. See link:https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/#create-a-pod-that-gets-assigned-a-qos-class-of-guaranteed[Create a pod that gets assigned a QoS class of `Guaranteed`].

--- a/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
+++ b/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
@@ -18,6 +18,8 @@ include::modules/cnf-configuring-huge-pages.adoc[leveloffset=+1]
 
 include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+1]
 
+include::modules/cnf-cpu-infra-container.adoc[leveloffset=+1]
+
 include::modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc[leveloffset=+1]
 
 include::modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc[leveloffset=+1]


### PR DESCRIPTION
BZ-1903943: Added multiple partitioning methods

Fixes: BZ-1903943

See https://bugzilla.redhat.com/show_bug.cgi?id=1903943 for additional details.

Preview URL: https://deploy-preview-41100--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes

For release: 4.6 (See PR 41100 for 4.7 and PR [36682](https://github.com/openshift/openshift-docs/pull/36682) for 4.8+)

Signed-off-by: Katie Tothill ktothill@redhat.com