### PR TITLE
4.9 Rel Notes Known issues

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1204,6 +1204,9 @@ Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].im
 * When using `boot-from-volume` image, creating a new instance leaks volumes if the machine controller is rebooted. This caused the previously created volume to never be cleaned up. This fix ensures that the volume created previously is either pruned or reused.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1983612[*BZ#1983612*])
 
+* Previously, the {rh-virtualization-first} provider ignored NICs with `br-ex` names for machines. Since a network type of `OVNKubernetes` creates a NIC with a `br-ex` name, this resulted in the machine never getting an IP address on OVN-Kubernetes. With this fix, it is now possible to install {product-title} on {rh-virtualization} with network set to `OVNKubernetes`.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1984481[*BZ#1984481*])
+
 * Previously, when deployed on {rh-openstack-first} with a combination of proxy and custom CA certificate, a cluster would not become fully operational. This fix passes the proxy settings to the HTTP transport used when connecting with a custom CA certificate, ensuring that all cluster components work as expected.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986540[*BZ#1986540*])
 
@@ -1884,12 +1887,27 @@ Alternatively, you can annotate the route to force a reload.(link:https://bugzil
 +
 No workaround exists for this issue. To track these metrics for production workloads, do not upgrade to the initial 4.9 release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008120[*BZ#2008120*])
 
-
 * The Special Resource Operator (SRO) might fail to install on Google Cloud Platform due to a software-defined network policy. As a result, the simple-kmod pod is not created. This will be fixed in a future {product-title} release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1996916[*BZ#1996916*])
 
 * In {product-title} 4.9, a user with cluster role cannot scale a deployment or deployment config using the console if they do not have edit rights to the deployment or deployment config. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1886888[*BZ#1886888*])
 
 * In {product-title} 4.9, when minimal or no data exists in the *Developer Console*, most of the monitoring charts or graphs (for example, CPU consumption, memory usage, and bandwidth) show a range of -1 to 1. However, none of these values can ever go below zero, so the negative values are incorrect. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904106[*BZ#1904106*])
+
+* Occasionally, a pod may report an `error killing pod` status. If this occurs, delete the pod and recreate it.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1997476[*BZ#1997476*])
+
+* Intermittently, pods can hang in the `ContainerCreating` state and time out while waiting for Open vSwitch (OVS) port binding. The reported event is `failed to configure pod interface: timed out waiting for OVS port binding`. This issue can occur when many pods are created for the OVN-Kubernetes plug-in.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2005598[*BZ#2005598*])
+
+* After rebooting the egress node, the `lr-policy-list` contains errors, such as duplicate records or missed internal IP addresses. The expected result is that the `lr-policy-list` has the same records as before rebooting the egress node. As a workaround, you can restart the `ovn-kubemaster` pods.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1995887[*BZ#1995887*])
+
+* When IP multicast relay is enabled on a logical router that contains distributed gateway ports, multicast traffic is not forwarded correctly on the distributed gateway port. The result is broken IP multicast functionality in OVN-Kubernetes.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2010374[*BZ#2010374*])
+
+* Operator Lifecycle Manager (OLM) uses a combination of timestamp checks and obsolete API calls, which do not work for `skipRange` upgrades, to determine if it is necessary to perform an upgrade for a particular subscription. For Operators that use the `skipRange` upgrade, there is a delay in the upgrade process that can take up to 15 minutes to resolve and can potentially be blocked for even longer.
++
+As a workaround, cluster administrators can delete the `catalog-operator` pod in the `openshift-operator-lifecycle-manager` namespace. This causes the pod to be automatically recreated, which causes the `skipRange` upgrade to trigger. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002276[*BZ#2002276*])
 
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
First batch of known issues (and one bug fix) for 4.9 rel notes

Mostly from #33497

Previews:
[Bugfix](https://deploy-preview-37434--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-cloud-compute-bug-fixes)
[Known issues](https://deploy-preview-37434--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-known-issues) (last four bullets)