### PR TITLE
BZ2004741: update configuration of proxy protocol on ingress router pods in host network

### DIFF
--- a/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
+++ b/modules/nw-ingress-controller-configuration-proxy-protocol.adoc
@@ -36,7 +36,7 @@ $ oc -n openshift-ingress-operator edit ingresscontroller/default
     endpointPublishingStrategy:
       hostNetwork:
         protocol: PROXY
-      type: NodePortService
+      type: HostNetwork
 ----
 * If your Ingress Controller uses the NodePortService endpoint publishing strategy type, set the `spec.endpointPublishingStrategy.nodePort.protocol` subfield to `PROXY`:
 +


### PR DESCRIPTION
Applies to 4.8+

https://bugzilla.redhat.com/show_bug.cgi?id=2004741

[Doc preview](https://deploy-preview-37441--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-controller-configuration-proxy-protocol_configuring-ingress)

Requires QE ack from @zhaozhanqi 