### PR TITLE
CNV-12828: placing redirects to prevent CNV from releasing with OCP

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -134,9 +134,9 @@ AddType text/vtt                            vtt
     # Redirect ROSA version 4 docs to go to non versioned docs
     RewriteRule ^rosa/4/?$ /rosa/welcome/index.html [L,R=301]
     RewriteRule ^rosa/4/(.*)$ /rosa/$1 [NE,R=301]
-    
+
     # this pipeline redirect has to come before the latest kicks in generically
-    RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=302]    
+    RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=302]
 
     # remove aro docs to just the welcome page
     RewriteRule aro/4/(?!welcome)(.*)?$ /container-platform/latest/$1 [L,R=301]
@@ -161,10 +161,10 @@ AddType text/vtt                            vtt
 
     # OSD redirects for new content
     RewriteRule dedicated/4/cloud_infrastructure_access/dedicated-aws-vpn.html dedicated/osd_private_connections/aws-private-connections.html [NE,R=302]
-    
+
     # ROSA STS Creating Cluster to multiple pages - https://github.com/openshift/openshift-docs/pull/36955
     RewriteRule rosa/rosa_getting_started_sts/rosa-sts-creating-cluster\.html rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly.html [NE,R=302]
-        
+
     # ACS welcome page redirect to StackRox docs
     # RewriteRule ^acs/?(.*)$ https://help.stackrox.com/ [NE,R=301]
 
@@ -224,8 +224,8 @@ AddType text/vtt                            vtt
     # NOTE THAT THESE ARE A 302 REDIRECT, not a 301. Replace with 301 at CNV GA
     # send all cnv/ to virt/about-virt.html.
     # send all virt/ to virt/about-virt.html excluding about-virt.html otherwise there is an infinite loop
-    # RewriteRule container-platform/4\.5/virt/(?!about-virt\.html) /container-platform/4.5/virt/about-virt.html [NE,R=302]
-    RewriteRule container-platform/4\.5/cnv/?(.*)$ /container-platform/4.5/virt/about-virt.html [NE,R=301]
+    RewriteRule container-platform/4\.9/virt/(?!about-virt\.html) /container-platform/4.9/virt/about-virt.html [NE,R=302]
+    # RewriteRule container-platform/4\.5/cnv/?(.*)$ /container-platform/4.5/virt/about-virt.html [NE,R=301]
 
     # Serverless Redirects
     RewriteRule container-platform/(4\.5|4\.6)/serverless/knative_eventing/(serverless-subscriptions\.html|serverless-channels\.html|serverless-subscriptions\.html) /container-platform/$1/serverless/event_workflows/serverless-channels.html [NE,R=301]


### PR DESCRIPTION
[CNV-12828](https://issues.redhat.com/browse/CNV-12828)

To be reversed when CNV 4.9 GAs (after merging placeholder reversal)