### PR TITLE
OSDOCS-2481: Added a note that limits cloud infrastructure access

### DIFF
--- a/modules/enable-aws-access.adoc
+++ b/modules/enable-aws-access.adoc
@@ -7,6 +7,12 @@
 [id="enable-aws-access"]
 = Understanding AWS cloud infrastructure access
 
+[NOTE]
+====
+AWS cloud infrastructure access does not apply to the Customer Cloud Subscription (CCS) infrastructure type that is chosen when you create a cluster because CCS clusters are deployed onto your account.
+====
+
+
 {AWS} infrastructure access permits link:https://access.redhat.com/node/3610411[Customer Portal Organization Administrators] and cluster owners to enable AWS Identity and Access Management (IAM) users to have federated access to the AWS Management Console for their {product-title} cluster. AWS access can be granted for customer AWS users, and private cluster access can be implemented to suit the needs of your {product-title} environment.
 
 . Get started with configuring AWS infrastructure access for your {product-title} cluster. By creating an AWS user and account and providing that user with access to the {product-title} AWS account.


### PR DESCRIPTION
This PR adds a small note that only non-CCS users will have cloud infrastructure access.

JIRA: https://issues.redhat.com/browse/OSDOCS-2481

Preview: https://deploy-preview-37453--osdocs.netlify.app/openshift-dedicated/latest/osd_private_connections/aws-private-connections#enable-aws-access