### PR TITLE
ISSUE-36166: Remove duplicated content

### DIFF
--- a/modules/osdk-golang-generate-crd.adoc
+++ b/modules/osdk-golang-generate-crd.adoc
@@ -17,19 +17,3 @@ $ make manifests
 ----
 +
 This Makefile target invokes the `controller-gen` utility to generate the CRD manifests in the `config/crd/bases/cache.example.com_memcacheds.yaml` file.
-
-[id="osdk-golang-generate-crd-validation_{context}"]
-== About OpenAPI validation
-
-OpenAPIv3 schemas are added to CRD manifests in the `spec.validation` block when the manifests are generated. This validation block allows Kubernetes to validate the properties in a Memcached custom resource (CR) when it is created or updated.
-
-Markers, or annotations, are available to configure validations for your API. These markers always have a `+kubebuilder:validation` prefix.
-
-.Additional resources
-
-* For more details on the usage of markers in API code, see the following Kubebuilder documentation:
-** link:https://book.kubebuilder.io/reference/generating-crd.html[CRD generation]
-** link:https://book.kubebuilder.io/reference/markers.html[Markers]
-** link:https://book.kubebuilder.io/reference/markers/crd-validation.html[List of OpenAPIv3 validation markers]
-
-* For more details about OpenAPIv3 validation schemas in CRDs, see the link:https://kubernetes.io/docs/tasks/extend-kubernetes/custom-resources/custom-resource-definitions/#specifying-a-structural-schema[Kubernetes documentation].


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/36166
Applies to 4.7+
Preview Link:  https://deploy-preview-37477--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial#osdk-golang-generate-crd-validation_osdk-golang-tutorial (Previously, there was a duplicated section right below this content and it's been removed to have 1 section of the same content). 