### PR TITLE
Revert OSDOCS-1922: Operand deletion from the web console

### DIFF
--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -19,23 +19,17 @@ endif::[]
 
 .Procedure
 
-. From the *Operators* → *Installed Operators* page, scroll or enter a keyword into the *Filter by name* field to find the Operator you want. Then, click on it.
+. Navigate to the *Operators* → *Installed Operators* page.
+
+. Scroll or enter a keyword into the *Filter by name* field to find the Operator that you want to remove. Then, click on it.
 
 . On the right side of the *Operator Details* page, select *Uninstall Operator* from the *Actions* drop-down menu.
 +
-An *Uninstall Operator?* dialog box opens, listing the Operands associated with the Operator.
+An *Uninstall Operator?* dialog box is displayed.
+
+. Select *Uninstall* to remove the Operator, Operator deployments, and pods. Following this action, the Operator stops running and no longer receives updates.
 +
-. Choose one of the following options for the *Delete all operand instances for this Operator* checkbox:
-
-* To remove Operands managed by the Operator automatically, including custom resources (CRs), select the checkbox.
-* To keep the Operands in place or remove them manually later, leave the checkbox clear.
-. Select *Uninstall* to remove the Operator, any Operator deployments, and pods. This Operator stops running and no longer receives updates.
-
-.Verification
-
-- If you choose to remove Operands managed by the Operator automatically, the *Uninstall Operator?* dialog box confirms if the uninstall process is a success. If there are errors, the dialog lists the Operands that you need to delete manually.
-
 [NOTE]
 ====
-Dashboards and navigation items enabled by the web console and off-cluster resources that continue to run might need manual clean up.
+This action does not remove resources managed by the Operator, including custom resource definitions (CRDs) and custom resources (CRs). Dashboards and navigation items enabled by the web console and off-cluster resources that continue to run might need manual clean up. To remove these after uninstalling the Operator, you might need to manually delete the Operator CRDs.
 ====


### PR DESCRIPTION
Release: enterprise-4.9

BZ2013384 was merged into the 4.9 payload, and as a result the feature to allow Operand deletion from the web console does not work. This PR removes the changes made in #36673 and #36232, which both referenced the new feature.

Docs preview: https://deploy-preview-37483--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster#olm-deleting-operators-from-a-cluster-using-web-console_olm-deleting-operators-from-a-cluster

References:
- [OSDOCS-1922](https://issues.redhat.com/browse/OSDOCS-1922)
- #36673, #36232, and #36760
- https://bugzilla.redhat.com/show_bug.cgi?id=2013384