### PR TITLE
[enterprise-4.7] GH#34497: [OKD] RHCOS image download link instead of FCOS image link

### DIFF
--- a/modules/installation-rhv-specifying-rhcos-image-settings.adoc
+++ b/modules/installation-rhv-specifying-rhcos-image-settings.adoc
@@ -13,6 +13,7 @@ Update the {op-system-first} image settings of the `inventory.yml` file. Later, 
 
 .Procedure
 
+ifndef::openshift-origin[]
 . Locate the {op-system} image download page for the version of {product-title} you are installing, such as link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/latest/[Index of /pub/openshift-v4/dependencies/rhcos/latest/latest].
 
 . From that download page, copy the URL of an OpenStack `qcow2` image, such as `\https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/latest/rhcos-openstack.x86_64.qcow2.gz`.
@@ -24,3 +25,17 @@ Update the {op-system-first} image settings of the `inventory.yml` file. Later, 
 rhcos:
   "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/latest/rhcos-openstack.x86_64.qcow2.gz"
 ----
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+. Locate the {op-system} image download page, such as link:https://getfedora.org/coreos/download?tab=cloud_operators&stream=stable[Download Fedora CoreOS].
+
+. From that download page, copy the URL of an OpenStack `qcow2` image, such as `\https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz`.
+
+. Edit the `inventory.yml` playbook you downloaded earlier. In it, replace the `rhcos` stanza and paste the URL as the value for `image_url`. For example:
++
+[source,yaml]
+----
+rhcos:
+  image_url: "https://builds.coreos.fedoraproject.org/prod/streams/stable/builds/34.20210611.3.0/x86_64/fedora-coreos-34.20210611.3.0-openstack.x86_64.qcow2.xz"
+----
+endif::openshift-origin[]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/34516