### PR TITLE
Fix the placement of NHC Operator in the side navigation

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1815,10 +1815,10 @@ Topics:
     File: nodes-node-tuning-operator
   - Name: Remediating nodes with the Poison Pill Operator
     File: eco-poison-pill-operator
-  - Name: Understanding node rebooting
-    File: nodes-nodes-rebooting
   - Name: Deploying node health checks by using the Node Health Check Operator
     File: eco-node-health-check-operator
+  - Name: Understanding node rebooting
+    File: nodes-nodes-rebooting
   - Name: Freeing node resources using garbage collection
     File: nodes-nodes-garbage-collection
   - Name: Allocating resources for nodes


### PR DESCRIPTION
[TELCODOCS-296](https://issues.redhat.com/browse/TELCODOCS-296) Placing the Node Health Check Operator assembly right after the Poison Pill Operator assembly as these are related.
This change was implemented and merged in https://github.com/openshift/openshift-docs/pull/37253. However, it did not reflect in the WIP doc site for 4.9 (possibly to to a merge conflict that might have rejected this change)

Applies to OpenShift 4.9

Preview link: https://deploy-preview-37490--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-node-health-check-operator.html