### PR TITLE
CNV-14317: Adding annotation recommending RBD Block mode PVCs with OCS

### DIFF
--- a/modules/virt-creating-storage-class.adoc
+++ b/modules/virt-creating-storage-class.adoc
@@ -6,7 +6,15 @@
 = Creating a storage class
 
 When you create a storage class, you set parameters that affect the
-dynamic provisioning of persistent volumes (PVs) that belong to that storage class. +
+dynamic provisioning of persistent volumes (PVs) that belong to that storage class.
+
+[IMPORTANT]
+====
+When using {VirtProductName} with {product-title} Container Storage, specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. With virtual machine disks, RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
+
+To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and `VolumeMode: Block`.
+====
+
 [NOTE]
 ====
 You cannot update a `StorageClass` object's parameters after you create it.

--- a/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc
@@ -7,6 +7,13 @@ toc::[]
 
 When you create a data volume, the Containerized Data Interface (CDI) creates a persistent volume claim (PVC) and populates the PVC with your data. You can create a data volume as either a standalone resource or by using a `dataVolumeTemplate` resource in a virtual machine specification. You create a data volume by using either the PVC API or storage APIs.
 
+[IMPORTANT]
+====
+When using {VirtProductName} with {product-title} Container Storage, specify RBD block mode persistent volume claims (PVCs) when creating virtual machine disks. With virtual machine disks, RBD block mode volumes are more efficient and provide better performance than Ceph FS or RBD filesystem-mode PVCs.
+
+To specify RBD block mode PVCs, use the 'ocs-storagecluster-ceph-rbd' storage class and `VolumeMode: Block`.
+====
+
 [TIP]
 ====
 Whenever possible, use the storage API to optimize space allocation and maximize performance.


### PR DESCRIPTION
For 4.6, 4.7, 4.8, 4.9, and 4.10.

Jira: https://issues.redhat.com/browse/CNV-14317

@aglitke please Code Review.
@demilyc please QE Review.

Direct Doc preview link: https://deploy-preview-37492--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms#virt-creating-storage-class_virt-configuring-local-storage-for-vms

NOTE: As the "Creating Data Volumes" assembly did not exist in 4.6 or 4.7, I created the following PRs to manually pick the Storage Class module contents to 4.6 and 4.7, as the picks in this PR failed for 4.6 and 4.7. Copying @adellape who worked with me on this.

https://github.com/openshift/openshift-docs/pull/37829
https://github.com/openshift/openshift-docs/pull/37830