### PR TITLE
[enterprise-4.8] BZ 2009796: Modifications to dual-stack networking module

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -6,7 +6,7 @@
 
 = Modifying the `install-config.yaml` file for dual-stack network (optional)
 
-To deploy an {product-title} cluster with dual-stack networking, make the following changes to the `install-config.yaml` file.
+To deploy an {product-title} cluster with dual-stack networking, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
 
 [source,yaml]
 ----
@@ -23,22 +23,7 @@ serviceNetwork:
 - fd03::/112
 ----
 
-NOTE: In the above snippet, the network settings must match the settings for the cluster's network environment. The `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings must have two CIDR entries each. The first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
-
 [IMPORTANT]
 ====
-The IPv4 entries must go *before* the IPv6 entries.
+The API VIP IP address and the Ingress VIP address must be of the primary IP address family when using dual-stack networking. Currently, Red Hat does not support dual-stack VIPs or dual-stack networking with IPv6 as the primary IP address family. However, Red Hat does support dual-stack networking with IPv4 as the primary IP address family. Therefore, the IPv4 entries must go *before* the IPv6 entries.
 ====
-
-ifeval::[{product-version} < 4.8]
-To deploy an {product-title} cluster with dual-stack, create an additional manifest to enable the `FeatureGate` with the following contents:
-[source,yaml]
-----
-apiVersion: config.openshift.io/v1
-kind: FeatureGate
-metadata:
-  name: cluster
-spec:
-  featureSet: IPv6DualStackNoUpgrade
-----
-endif::[]


### PR DESCRIPTION
Modifications to dual-stack networking module for added clarity on dual-stack and VIPs. We support API VIP and Ingress VIP on IPv4, but not IPv6.

See https://bugzilla.redhat.com/show_bug.cgi?id=2009796 for details.

Release: 4.8

Signed-off-by: John Wilkins <jowilkin@redhat.com>