### PR TITLE
[BZ:1845393]: Updates for restoring to a previous cluster

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -7,7 +7,7 @@
 [id="dr-scenario-2-restoring-cluster-state_{context}"]
 = Restoring to a previous cluster state
 
-You can use a saved etcd backup to restore back to a previous cluster state. You use the etcd backup to restore a single control plane host. Then the etcd cluster Operator handles scaling to the remaining control plane hosts.
+You can use a saved etcd backup to restore a previous cluster state or restore a cluster that has lost the majority of control plane hosts.
 
 [IMPORTANT]
 ====
@@ -38,7 +38,7 @@ If you do not complete this step, you will not be able to access the control pla
 +
 This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
 
-. Stop the static pods on all other control plane nodes.
+. Stop the static pods on any other control plane nodes.
 +
 [NOTE]
 ====
@@ -186,6 +186,8 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 
+.. Repeat this step for each lost control plane host that is not the recovery host.
+
 . In a separate terminal window, log in to the cluster as a user with the `cluster-admin` role by using the following command:
 +
 [source,terminal]
@@ -230,7 +232,7 @@ If the output includes multiple revision numbers, such as `2 nodes are at revisi
 +
 In a terminal that has access to the cluster as a `cluster-admin` user, run the following commands.
 
-.. Update the `kubeapiserver`:
+.. Force a new rollout for the Kubernetes API server:
 +
 [source,terminal]
 ----
@@ -255,7 +257,7 @@ AllNodesAtLatestRevision
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
-.. Update the `kubecontrollermanager`:
+.. Force a new rollout for the Kubernetes controller manager:
 +
 [source,terminal]
 ----
@@ -280,7 +282,7 @@ AllNodesAtLatestRevision
 +
 If the output includes multiple revision numbers, such as `2 nodes are at revision 6; 1 nodes are at revision 7`, this means that the update is still in progress. Wait a few minutes and try again.
 
-.. Update the `kubescheduler`:
+.. Force a new rollout for the Kubernetes scheduler:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Preview link: https://deploy-preview-37499--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state

Versions: 4.6+ (BZ lists 4.5+ but we are supporting 4.6 as a minimum supported version)

Referenced PR: https://github.com/openshift/openshift-docs/pull/35328
