### PR TITLE
BZ1975701: Clarify static IP workaround for Tang encryption on vSphere

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2010,6 +2010,65 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 
 * When MetalLB is run in layer 2 mode with the OVN-Kubernetes Container Network Interface network provider, instead of a single node with a speaker pod responding to an ARP or NDP request, every node in the cluster responds to the request. The unexpected number of ARP responses might resemble an ARP-spoofing attack. Although the experience is different than designed, traffic is routed to the service as long as no software on the hosts or subnet is configured to block ARP. This bug is fixed in a future {product-title} release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1987445[*BZ#1987445*])
 
+* When Tang disk encryption is enabled on a cluster on VMware vSphere with user-provisioned infrastructure using a static IP address, the network changes to DHCP after the second reboot. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975701[*BZ#1975701*])
++
+As a workaround for when the live ISO and `coreos-installer` command are not used, you can use Ignition to lay down a systemd service unit. This unit runs on first boot and executes `rpm-ostree kargs` to append the `"ip="` kernel argument for subsequent boots.
++
+[NOTE]
+====
+Only apply this workaround on Tang-enabled nodes because Tang can be applied on separate control plane and worker nodes.
+====
++
+.Procedure
++
+. To configure a worker node, copy your `worker.ign` file into your current working directory.
+. Create a Butane config YAML file, for example, `worker_1.bu`, that uses Ignition to set up network kernel arguments and to lay down a systemd service during the first boot. The following example configures a worker node:
++
+[source,yaml]
+----
+variant: rhcos
+version: 0.1.0
+ignition:
+  config:
+    merge:
+    - local: worker.ign
+systemd:
+  units:
+  - name: static-ip-karg.service
+    enabled: true
+    contents: |
+        [Unit]
+        Description=Append karg via oneshot
+        ConditionPathExists=/run/ostree-booted
+        ConditionPathExists=!/var/lib/%N.stamp
+        Before=machine-config-daemon-firstboot.service
+        After=boot-complete.target
+
+        [Service]
+        ExecStart=/usr/bin/rpm-ostree kargs --append=rd.neednet=1 --append=ip=192.168.140.20::192.168.140.1:255.255.255.0:worker0.cluster2.openshift.lan:enp1s0:none --append=nameserver=192.168.140.1
+        ExecStart=/bin/touch /var/lib/%N.stamp
+        Type=oneshot
+        RemainAfterExit=yes
+
+        [Install]
+        WantedBy=multi-user.target
+----
++
+. Write the `worker_1.bu` Butane file to the `worker_1.ign` Ignition file by running the following command:
++
+[source,terminal]
+----
+$ cat worker_1.bu | butane --strict --pretty --files-dir=./ > worker_1.ign
+----
++
+. Generate a new node Ignition file that merges the systemd unit to the existing node Ignition file by running the following Butane command:
++
+[source,terminal]
+----
+$ butane -d=./ --output=worker_1.ign worker_1.bu
+----
+
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[BZ1975701](https://bugzilla.redhat.com/show_bug.cgi?id=1975701)
Adds a Known Issue to the OCP 4.9 Release Notes including a verified workaround located here: https://docs.google.com/document/d/1rnAutjuxzUAauqOZwc8Iccl7SSZVWGJXH5VJL08YvTU/edit?usp=sharing
@jinyunma PTAL for QE ack.
Cc: @dustymabe and @miabbott for awareness

**Preview link:** https://deploy-preview-37500--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-known-issues