### PR TITLE
RN-TELCODOCS-358: New release notes for sandboxed containers 4.9

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1932,6 +1932,8 @@ Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-enterprise
 Topics:
+- Name: OpenShift sandboxed containers release notes
+  File: sandboxed-containers-4.9-release-notes
 - Name: Understanding OpenShift sandboxed containers
   File: understanding-sandboxed-containers
 - Name: Deploying OpenShift sandboxed containers workloads

--- a/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
+++ b/sandboxed_containers/deploying-sandboxed-container-workloads.adoc
@@ -38,7 +38,7 @@ include::modules/sandboxed-containers-selecting-nodes.adoc[leveloffset=+3]
 include::modules/sandboxed-containers-scheduling-workloads.adoc[leveloffset=+3]
 include::modules/sandboxed-containers-viewing-workloads-from-cli.adoc[leveloffset=+2]
 
-[id="{context}_additional-resources"]
+[id="deploying-sandboxed-containers-workloads_additional-resources"]
 == Additional resources
 
 * The {sandboxed-containers-operator} is supported in a restricted network environment. For more information, xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].

--- a/sandboxed_containers/sandboxed-containers-4.9-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.9-release-notes.adoc
@@ -1,0 +1,83 @@
+[id="sandboxed-containers-4-9-release-notes"]
+= {sandboxed-containers-first} {product-version} release notes
+include::modules/common-attributes.adoc[]
+:context: sandboxed-containers-release-notes
+
+toc::[]
+
+[id="ocp-4-9-about-this-release"]
+== About this release
+
+These release notes track the development of {sandboxed-containers-first} in Red Hat {product-title}.
+
+This product is currently in Technology Preview. {sandboxed-containers-first} is not intended for production use. For more information, see the Red Hat Customer Portal link:https://access.redhat.com/support/offerings/techpreview[support scope] for features in Technology Preview.
+
+[id="sandboxed-containers-4-9-new-features-and-enhancements"]
+== New features and enhancements
+
+[id="fips-compatability-rn"]
+=== FIPS compatibility
+
+FIPS mode is now automatically enabled for {sandboxed-containers-first}. {sandboxed-containers-first} deployed on an {product-title} cluster installed in FIPS mode will not taint the cluster's FIPS support. For more information, see xref:../sandboxed_containers/understanding-sandboxed-containers.adoc#security-compliance-nist_understanding-sandboxed-containers[Understanding compliance and risk management].
+
+[id="collect-resources-with-must-gather-rn"]
+=== Collect resources with must-gather
+
+The {sandboxed-containers-operator} now includes a must-gather image, allowing you to collect custom resources and log files specific to this Operator and the underlying runtime components for diagnostic purposes. For more information, see xref:../sandboxed_containers/troubleshooting-sandboxed-containers.adoc#troubleshooting-sandboxed-containers[Collecting {sandboxed-containers-first} data for Red Hat Support].
+
+[id="sandboxed-containers-disconnected-environments-rn"]
+=== Disconnected environments
+
+You can now install the {sandboxed-containers-operator} in a disconnected environment. For more information, see the xref:../sandboxed_containers/deploying-sandboxed-container-workloads.adoc#deploying-sandboxed-containers-workloads_additional-resources[Additional resources for Deploying {sandboxed-containers-first} workloads].
+
+[id="sandboxed-containers-4-9-bug-fixes"]
+== Bug fixes
+
+* Previously, when running Fedora on {sandboxed-containers-first}, some packages required file access permission changes that {product-title} did not grant to containers by default. With this release, these permissions are granted by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915377[*BZ#1915377*])
+
+* Previously, adding a value to `kataConfgPoolSelector` in the {product-title} web console populated `scheduling.nodeSelector` with an empty value. As a result, pods that used a `RuntimeClass` object with the value of `kata` could be scheduled to nodes without the Kata Containers runtime installed. With this release, only nodes labeled with the same label as defined in `kataConfgPoolSelector` will install the Kata Containers runtime. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019384[*BZ#2019384*])
+
+* Previously, the {sandboxed-containers-operator} details page on Operator Hub was missing fields. In this release, these fields are no longer missing. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019383[*BZ#2019383*])
+
+* Previously, creating multiple `KataConfig` custom resources resulted in a silent failure, with no error from the {product-title} web console notifying the user that creating more than one custom resource failed. With this release, the user receives an error when trying to create multiple custom resources. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019381[*BZ#2019381*])
+
+* Previously, there were instances where the Operator Hub in the {product-title} web console did not display icons for an Operator. With this release, icons are always displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019380[*BZ#9019380*])
+
+[id="sandboxed-containers-4-9-known-issues"]
+== Known issues
+
+* If you are using {sandboxed-containers-first}, you cannot use the `hostPath` volume in a {product-title} cluster to mount a file or directory from the host node’s file system into your pod. As an alternative, you can use local persistent volumes. See xref:../storage/persistent_storage/persistent-storage-local.adoc[Persistent storage using local volumes] for more information. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
+
+[id="sandboxed-containers-4-9-asynchronous-errata-updates"]
+== Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {sandboxed-containers-first} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} 1.1.0.
+
+[id="sandboxed-containers-1-1-0"]
+=== RHEA-2021:3941 - {sandboxed-containers-first} 1.1.0 image release, bug fix,and enhancement advisory
+
+Issued: 2021-10-21
+
+{sandboxed-containers-first} release 1.1.0 is now available. This advisory contains an update for {sandboxed-containers-first} with enhancements and bug fixes.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/RHEA-2021:3941[RHEA-2021:3941] advisory.
+//
+//#link:https://access.redhat.com/errata/product/290/ver=4.9/rhel---8/x86_64/RHEA-2021:3941[]
+//
+//[id="sandboxed-containers-1-0-2"]
+//=== RHBA-2021:3751 - {sandboxed-containers-first} 1.0.2 bug fix advisory
+//
+//Issued: 2021-10-07
+//
+//{sandboxed-containers-first} release 1.0.2 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+//
+//The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/product/290/ver=4.8/rhel---8/x86_64/RHBA-2021:3751[RHBA-2021:3751] advisory.

--- a/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
+++ b/sandboxed_containers/troubleshooting-sandboxed-containers.adoc
@@ -21,6 +21,6 @@ include::modules/about-must-gather.adoc[leveloffset=+1]
 
 include::modules/sandboxed-containers-collecting-data.adoc[leveloffset=+1]
 
-[id="{context}_additional-resources"]
+[id="troubleshooting-sandboxed-containers_additional-resources"]
 == Additional resources
 * For more information about gathering data for support, see xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster].


### PR DESCRIPTION
New release notes document for sandboxed containers 4.9.

Preview link: https://deploy-preview-37510--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-4.9-release-notes.html

Acked by PM, SME, QE, peer reviewed, and went through change management process.