### PR TITLE
BZ1986216: Slow Pod recovery due to "timed out waiting for OVS port binding"

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1982,6 +1982,8 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 
 * Currently, when launching {op-system-base-full} 8 on Google Cloud Platform with FIPS mode enabled, {op-system-base} 8 fails to download metadata when trying to install packages from the Red Hat Update Infrastructure (RHUI). As a temporary workaround, you can disable RHUI repositories and use Red Hat Subscription Management to get content. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2001464[*BZ#2001464*]), (link:https://bugzilla.redhat.com/show_bug.cgi?id=1997516[*BZ#1997516*]).
 
+* Following an {product-title} single node reboot, all pods are restarted which causes significant load and longer than normal pod creation times. This happens because the Container Network Interface (CNI) is not able to process the `pod add` events quickly enough. The following error message is displayed: `timed out waiting for OVS port binding`. The {product-title} single node instance eventually recovers, just slower than expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986216[*BZ#1986216*])
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
For enterprise 4.9

SME/QE ack in GDoc.

BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=1986216

Preview: https://deploy-preview-37513--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-known-issues