### PR TITLE
BZ1986216 and BZ1975356: Slow pod recovery and slow pod creation

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2442,6 +2442,12 @@ For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=18786
 
 * Currently, the prerequisites in the web console quick start cards appear as a paragraph instead of a list. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1905147[*BZ#1905147*])
 
+* On an {product-title} single node configuration, pod creation times are over two times slower when using the real-time kernel (kernel-rt) than when using the non-real-time kernel. When using kernel-rt, the slower creation times impact the maximum number of supported pods because recovery time is impacted after a node reboots. As a workaround when you are using the kernel-rt, you can improve the impacted recovery time by booting with the `rcupdate.rcu_normal_after_boot=0` kernel argument, which requires a real-time kernel version `kernel-rt-4.18.0-305.16.1.rt7.88.el8_4` or later. This known issue applies to the {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975356[*BZ#1975356*])
+
+
+* Following an {product-title} single node reboot, all pods are restarted which causes significant load and longer than normal pod creation times. This happens because the Container Network Interface (CNI) is not able to process the `pod add` events quickly enough. The following error message is displayed: `timed out waiting for OVS port binding`. The {product-title} single node instance eventually recovers, though more slowly than expected. This known issue applies to the {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986216[*BZ#1986216*])
+
+
 [id="ocp-4-8-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
For enterprise 4.8

SME/QE ack in GDoc.

BZ links: 
https://bugzilla.redhat.com/show_bug.cgi?id=1986216
https://bugzilla.redhat.com/show_bug.cgi?id=1975356

Preview (last two bulletpoints): https://deploy-preview-37514--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-known-issues