### PR TITLE
TELCODOCS-310: Update the OCP version number in KNI/Telco contents

### DIFF
--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -44,7 +44,7 @@ metadata:
 spec:
   containers:
   - name: dynamic-irq-pod
-    image: "quay.io/openshift-kni/cnf-tests:4.8"
+    image: "quay.io/openshift-kni/cnf-tests:4.9"
     command: ["sleep", "10h"]
     resources:
       requests:

--- a/modules/cnf-installing-the-performance-addon-operator.adoc
+++ b/modules/cnf-installing-the-performance-addon-operator.adoc
@@ -75,7 +75,7 @@ $ oc get packagemanifest performance-addon-operator -n openshift-marketplace -o 
 .Example output
 [source,terminal]
 ----
-4.8
+4.9
 ----
 
 .. Create the following Subscription CR and save the YAML in the `pao-sub.yaml` file:

--- a/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
+++ b/modules/cnf-performing-end-to-end-tests-for-platform-verification.adoc
@@ -68,7 +68,7 @@ You can use the `ROLE_WORKER_CNF` variable to override the worker pool name:
 [source,terminal]
 ----
 $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e
-ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+ROLE_WORKER_CNF=custom-worker-pool registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----
 +
 [NOTE]
@@ -83,7 +83,7 @@ Use this command to run in dry-run mode. This is useful for checking what is in 
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.dryRun -ginkgo.v
 ----
 
 [id="cnf-performing-end-to-end-tests-disconnected-mode_{context}"]
@@ -104,7 +104,7 @@ Run this command from an intermediate machine that has access both to the cluste
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/mirror -registry my.local.registry:5000/ |  oc image mirror -f -
 ----
 
 Then, follow the instructions in the following section about overriding the registry used to fetch the images.
@@ -116,7 +116,7 @@ This is done by setting the `IMAGE_REGISTRY` environment variable:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAGE_REGISTRY="my.local.registry:5000/" -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-mirroring-to-cluster-internal-registry_{context}"]
@@ -213,7 +213,7 @@ echo "{\"auths\": { \"$REGISTRY\": { \"auth\": $TOKEN } }}" > dockerauth.json
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/mirror -registry $REGISTRY/cnftests |  oc image mirror --insecure=true -a=$(pwd)/dockerauth.json -f -
 ----
 
 . Run the tests:
@@ -235,11 +235,11 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 [
     {
         "registry": "public.registry.io:5000",
-        "image": "imageforcnftests:4.8"
+        "image": "imageforcnftests:4.9"
     },
     {
         "registry": "public.registry.io:5000",
-        "image": "imagefordpdk:4.8"
+        "image": "imagefordpdk:4.9"
     }
 ]
 ----
@@ -248,7 +248,7 @@ $ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e IMAG
 +
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/mirror --registry "my.local.registry:5000/" --images "/kubeconfig/images.json" |  oc image mirror -f -
 ----
 
 [id="cnf-performing-end-to-end-tests-running-in-single-node-cluster_{context}"]
@@ -342,7 +342,7 @@ For example, to change the `CNF_TESTS_IMAGE` with a custom registry run the foll
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig -e CNF_TESTS_IMAGE="custom-cnf-tests-image:latests" registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----
 
 [id="cnf-performing-end-to-end-tests-ginko-parameters_{context}"]
@@ -354,7 +354,7 @@ You can use the `-ginkgo.focus` parameter to filter a set of tests:
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="performance|sctp"
 ----
 
 You can run only the latency test using the `-ginkgo.focus` parameter.
@@ -363,7 +363,7 @@ To run only the latency test, you must provide the `-ginkgo.focus` parameter and
 
 [source,terminal]
 ----
-$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
+$ docker run --rm -v $KUBECONFIG:/kubeconfig -e KUBECONFIG=/kubeconfig -e LATENCY_TEST_RUN=true -e LATENCY_TEST_RUNTIME=600 -e OSLAT_MAXIMUM_LATENCY=20 -e PERF_TEST_PROFILE=<performance_profile_name> registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh -ginkgo.focus="\[performance\]\[config\]|\[performance\]\ Latency\ Test"
 ----
 
 [NOTE]
@@ -525,7 +525,7 @@ Assuming the `kubeconfig` file is in the current folder, the command for running
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----
 
 This allows your `kubeconfig` file to be consumed from inside the running container.
@@ -844,7 +844,7 @@ A JUnit-compliant XML is produced by passing the `--junit` parameter together wi
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --junit /path/to/junit
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/junitdest:/path/to/junit -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh --junit /path/to/junit
 ----
 
 [id="cnf-performing-end-to-end-tests-test-failure-report_{context}"]
@@ -854,7 +854,7 @@ A report with information about the cluster state and resources for troubleshoot
 
 [source,terminal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh --report /path/to/report
+$ docker run -v $(pwd)/:/kubeconfig -v $(pwd)/reportdest:/path/to/report -e KUBECONFIG=/kubeconfig/kubeconfig registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh --report /path/to/report
 ----
 
 [id="cnf-performing-end-to-end-tests-podman_{context}"]
@@ -915,5 +915,5 @@ To override the performance profile, the manifest must be mounted inside the con
 
 [source,termal]
 ----
-$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.8 /usr/bin/test-run.sh
+$ docker run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig -e PERFORMANCE_PROFILE_MANIFEST_OVERRIDE=/kubeconfig/manifest.yaml registry.redhat.io/openshift4/cnf-tests-rhel8:v4.9 /usr/bin/test-run.sh
 ----

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -89,7 +89,7 @@ EXTERNAL-IP   OS-IMAGE                                       	KERNEL-VERSION
 CONTAINER-RUNTIME
 cnf-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.22.1
 128.66.135.107   <none>    	        Red Hat Enterprise Linux CoreOS 46.82.202008252340-0 (Ootpa)
-4.18.0-211.rt5.23.el8.x86_64   cri-o://1.22.1-90.rhaos4.8.git4a0ac05.el8-rc.1
+4.18.0-211.rt5.23.el8.x86_64   cri-o://1.22.1-90.rhaos4.9.git4a0ac05.el8-rc.1
 [...]
 ----
 

--- a/modules/cnf-upgrading-performance-addon-operator.adoc
+++ b/modules/cnf-upgrading-performance-addon-operator.adoc
@@ -44,7 +44,7 @@ You can manually upgrade Performance Addon Operator to the next minor version by
 
 . In the *Update channel* pane, click the pencil icon on the right side of the version number to open the *Change Subscription update channel* window.
 
-. Select the next minor version. For example, if you want to upgrade to Performance Addon Operator 4.8, select *4.8*.
+. Select the next minor version. For example, if you want to upgrade to Performance Addon Operator 4.9, select *4.9*.
 
 . Click *Save*.
 
@@ -115,8 +115,8 @@ $ oc get csv
 [source,terminal]
 ----
 VERSION    REPLACES                                         PHASE
-4.8.0      performance-addon-operator.v4.8.0                Installing
-4.7.0                                                       Replacing
+4.9.0      performance-addon-operator.v4.9.0                Installing
+4.8.0                                                       Replacing
 ----
 
 . Run `get csv` again to verify the output:
@@ -130,5 +130,5 @@ VERSION    REPLACES                                         PHASE
 [source,terminal]
 ----
 NAME                                DISPLAY                      VERSION   REPLACES                            PHASE
-performance-addon-operator.v4.8.0   Performance Addon Operator   4.8.0     performance-addon-operator.v4.7.0   Succeeded
+performance-addon-operator.v4.9.0   Performance Addon Operator   4.9.0     performance-addon-operator.v4.8.0   Succeeded
 ----


### PR DESCRIPTION
Applies to Main AND the Enterprise-4.9 branch

Jira: https://issues.redhat.com/browse/TELCODOCS-310

Browse the preview here: https://deploy-preview-37519--osdocs.netlify.app