### PR TITLE
GH#33456 Hide NSX-T component for VMC as it is not available for that platform

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -15,6 +15,28 @@
 // * installing/installing_vmc/installing-vmc-customizations.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
@@ -47,10 +69,11 @@ Installing a cluster on VMware vSphere version 6.7U2 or earlier and virtual hard
 |vSphere 6.5 and later
 |This plug-in creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
+ifndef::vmc[]
 |Optional: Networking (NSX-T)
 |vSphere 6.5U3 or vSphere 6.7U2 and later
 |vSphere 6.5U3 or vSphere 6.7U2+ are required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
-
+endif::vmc[]
 |===
 
 If you use a vSphere version 6.5 instance, consider upgrading to 6.7U3 or 7.0 before
@@ -60,3 +83,25 @@ you install {product-title}.
 ====
 You must ensure that the time on your ESXi hosts is synchronized before you install {product-title}. See link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-8756D419-A878-4AE0-9183-C6D5A91A8FB1.html[Edit Time Configuration for a Host] in the VMware documentation.
 ====
+
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]


### PR DESCRIPTION
Resolves #33456

Previews:
- VMC hiding the NSX-T component in the table: https://deploy-preview-37527--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations.html#installation-vsphere-infrastructure_installing-vmc-customizations
- vSphere displaying the NSX-T component in the table: https://deploy-preview-37527--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned-customizations