### PR TITLE
TELCODOCS296 - Updated latest specs for the NHC resource

### DIFF
--- a/modules/eco-node-health-check-operator-about.adoc
+++ b/modules/eco-node-health-check-operator-about.adoc
@@ -22,29 +22,37 @@ metadata:
   namespace: openshift-operators
 spec:
   minHealthy: 51% <1>
-  remediationTemplate: <2>
+  pauseRequests: <2>
+    - <pause-test-cluster> 
+  remediationTemplate: <3>
     apiVersion: poison-pill.medik8s.io/v1alpha1
     name: group-x
     namespace: openshift-operators
     kind: PoisonPillRemediationTemplate
-  selector: <3>
+  selector: <4>
     matchExpressions:
       - key: node-role.kubernetes.io/worker
         operator: Exists
-  unhealthyConditions: <4>
+  unhealthyConditions: <5>
     - type: Ready
       status: "False"
-      duration: 300s <5>
+      duration: 300s <6>
     - type: Ready
       status: Unknown
-      duration: 300s <5>
+      duration: 300s <6>
 ----
 
 <1> Specifies the amount (in percentage) of nodes allowed to be concurrently remediated in the targeted pool. If the number of healthy nodes equals to or exceeds the limit set by `minHealthy`, remediation occurs. The default value is 51%.
-<2> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator. 
-<3> Specifies a `selector` that matches labels or expressions that you want to check. The default value is empty, which selects all nodes.
-<4> Specifies a list of the conditions that determine whether a node is considered unhealthy. 	
-<5> Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the node will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy node.
+<2> Prevents any new remediation from starting, while allowing any ongoing remediations to persist. The default value is empty. However, you can enter an array of strings that identify the cause of pausing the remediation. For example, `pause-test-cluster`.
++
+[NOTE]
+====
+During the upgrade process, nodes in the cluster might become temporarily unavailable and get identified as unhealthy. In the case of worker nodes, when the Operator detects that the cluster is upgrading, it stops remediating new unhealthy nodes to prevent such nodes from rebooting.
+====
+<3> Specifies a remediation template from the remediation provider. For example, from the Poison Pill Operator. 
+<4> Specifies a `selector` that matches labels or expressions that you want to check. The default value is empty, which selects all nodes.
+<5> Specifies a list of the conditions that determine whether a node is considered unhealthy. 	
+<6> Specifies the timeout duration for a node condition. If a condition is met for the duration of the timeout, the node will be remediated. Long timeouts can result in long periods of downtime for a workload on an unhealthy node.
 
 [id="understanding-nhc-operator-workflow_{context}"]
 == Understanding the Node Health Check Operator workflow


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-296: Add latest specs for the NHC resource for the Node Health Check Operator

Applies to OpenShift version 4.9+

Preview link: https://deploy-preview-37531--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-node-health-check-operator.html#about-node-health-check-operator_node-health-check-operator

- SME review completed and acked by @rgolangh 
- Awaiting QE review/ack from @shellymiron 