### PR TITLE
BZ1977949: Add the instruction to check ignition run time

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -131,6 +131,14 @@ $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 .. Complete the configuration and power on the VM.
+.. Check the console output to verify that Ignition was run.
++
+.Example command
+[source,terminal]
+----
+Ignition: ran on 2021/10/14 14:48:33 UTC (this boot)
+Ignition: user-provided config was applied
+----
 
 . Create the rest of the machines for your cluster by following the preceding steps for each machine.
 +


### PR DESCRIPTION
Added an instruction to check the console output to know at what time the ignition ran.
OCP version: 4.10.0
BZ197794 : https://bugzilla.redhat.com/show_bug.cgi?id=1977949
QA contact: @mike-nguyen         
Preview: https://deploy-preview-37535--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere
