### PR TITLE
BZ 1989929: Using IPMI and PXE requires the provisioning network

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-overview.adoc
@@ -26,7 +26,7 @@ ifeval::[{product-version} < 4.5]
 image::4.4-71_OpenShift_Baremetal_IPI_Depoyment_0320_1.png[Deployment phase one]
 endif::[]
 
-When the installation of OpenShift control plane nodes is complete and fully operational, the installer destroys the bootstrap VM automatically and moves the virtual IP addresses (VIPs) to
+When the installation of {product-title} control plane nodes is complete and fully operational, the installer destroys the bootstrap VM automatically and moves the virtual IP addresses (VIPs) to
 ifeval::[{product-version} >= 4.8]
 the control plane nodes.
 endif::[]
@@ -57,3 +57,8 @@ The API and DNS VIPs move into the control plane nodes and the Ingress VIP servi
 
 image::4.4-71_OpenShift_Baremetal_IPI_Depoyment_0320_2.png[Deployment phase two]
 endif::[]
+
+[IMPORTANT]
+====
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.
+====

--- a/modules/ipi-install-bmc-addressing.adoc
+++ b/modules/ipi-install-bmc-addressing.adoc
@@ -5,9 +5,10 @@
 
 = BMC addressing
 
-Most vendors support BMC addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
+Most vendors support Baseboard Management Controller (BMC) addressing with the Intelligent Platform Management Interface (IPMI). IPMI does not encrypt communications. It is suitable for use within a data center over a secured or dedicated management network. Check with your vendor to see if they support Redfish network boot. Redfish delivers simple and secure management for converged, hybrid IT and the Software Defined Data Center (SDDC). Redfish is human readable and machine capable, and leverages common internet and web services standards to expose information directly to the modern tool chain. If your hardware does not support Redfish network boot, use IPMI.
 
-.IPMI
+[discrete]
+== IPMI
 
 Hosts using IPMI use the `ipmi://<out-of-band-ip>:<port>` address format, which defaults to port `623` if not specified. The following example demonstrates an IPMI configuration within the `install-config.yaml` file.
 
@@ -24,8 +25,13 @@ platform:
           password: <password>
 ----
 
+[IMPORTANT]
+====
+The `provisioning` network is required when PXE booting using IPMI for BMC addressing. It is not possible to PXE boot hosts without a `provisioning` network. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+====
 
-.Redfish network boot
+[discrete]
+== Redfish network boot
 
 To enable Redfish, use `redfish://` or `redfish+http://` to disable TLS. The installer requires both the hostname or the IP address and the path to the system ID. The following example demonstrates a Redfish configuration within the `install-config.yaml` file.
 

--- a/modules/ipi-install-configuring-nodes.adoc
+++ b/modules/ipi-install-configuring-nodes.adoc
@@ -5,7 +5,8 @@
 [id="configuring-nodes_{context}"]
 = Configuring nodes
 
-.Configuring nodes when using the `provisioning` network
+[discrete]
+== Configuring nodes when using the `provisioning` network
 
 Each node in the cluster requires the following configuration for proper installation.
 
@@ -16,10 +17,11 @@ A mismatch between nodes will cause an installation failure.
 
 While the cluster nodes can contain more than two NICs, the installation process only focuses on the first two NICs:
 
+[options="header"]
 |===
 |NIC |Network |VLAN
-| NIC1 | `provisioning` | <provisioning-vlan>
-| NIC2 | `baremetal` | <baremetal-vlan>
+| NIC1 | `provisioning` | <provisioning_vlan>
+| NIC2 | `baremetal` | <baremetal_vlan>
 |===
 
 NIC1 is a non-routable network (`provisioning`) that is only used for the installation of the {product-title} cluster.
@@ -27,7 +29,7 @@ NIC1 is a non-routable network (`provisioning`) that is only used for the instal
 ifndef::openshift-origin[The {op-system-base-full} 8.x installation process on the provisioner node might vary. To install {op-system-base-full} 8.x using a local Satellite server or a PXE server, PXE-enable NIC2.]
 ifdef::openshift-origin[The {op-system-first} installation process on the provisioner node might vary. To install {op-system} using a local Satellite server or a PXE server, PXE-enable NIC2.]
 
-
+[options="header"]
 |===
 |PXE |Boot order
 | NIC1 PXE-enabled `provisioning` network | 1
@@ -41,6 +43,7 @@ Ensure PXE is disabled on all other NICs.
 
 Configure the control plane and worker nodes as follows:
 
+[options="header"]
 |===
 |PXE | Boot order
 | NIC1 PXE-enabled (provisioning network) | 1
@@ -48,22 +51,29 @@ Configure the control plane and worker nodes as follows:
 
 ifeval::[{product-version} > 4.3]
 
-.Configuring nodes without the `provisioning` network
+[discrete]
+== Configuring nodes without the `provisioning` network
 
 The installation process requires one NIC:
 
+[options="header"]
 |===
 |NIC |Network |VLAN
-| NICx | `baremetal` | <baremetal-vlan>
+| NICx | `baremetal` | <baremetal_vlan>
 |===
 
 NICx is a routable network (`baremetal`) that is used for the installation of the {product-title} cluster, and routable to the internet.
 
+[IMPORTANT]
+====
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.
+====
 endif::[]
 
 ifeval::[{product-version} > 4.6]
 [id="configuring-nodes-for-secure-boot_{context}"]
-.Configuring nodes for Secure Boot manually
+[discrete]
+== Configuring nodes for Secure Boot manually
 
 Secure Boot prevents a node from booting unless it verifies the node is using only trusted software, such as UEFI firmware drivers, EFI applications, and the operating system.
 

--- a/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc
@@ -33,6 +33,12 @@ platform:
   baremetal:
     apiVIP: <apiVIP>
     ingressVIP: <ingress/wildcard VIP>
-    provisioningNetwork: "Disabled"
+    provisioningNetwork: "Disabled" <1>
 ----
+<1> Add the `provisioningNetwork` configuration setting, if needed, and set it to `Disabled`.
+
+[IMPORTANT]
+====
+The `provisioning` network is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`. See "Redfish virtual media for HPE iLO" in the "BMC addressing for HPE iLO" section or "Redfish virtual media for Dell iDRAC" in the "BMC addressing for Dell iDRAC" section for additional details.
+====
 endif::[]

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -7,31 +7,31 @@
 
 Installer-provisioned installation of {product-title} involves several network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
 
-.Configuring NICs
+[discrete]
+== Configuring NICs
 
 {product-title} deploys with two networks:
 
 - `provisioning`: The `provisioning` network is an optional non-routable network used for provisioning the underlying operating system on each node that is a part of the {product-title} cluster. The network interface for the `provisioning` network on each cluster node must have the BIOS or UEFI configured to PXE boot.
 +
-In {product-title} versions 4.6 through 4.8, the `provisioningNetworkInterface` configuration setting specifies the `provisioning` network NIC. In {product-title} 4.9 and later releases, you can specify the `provisioning` network NIC with the `bootMACAddress` configuration setting.
+The `provisioningNetworkInterface` configuration setting specifies the `provisioning` network NIC name on the control plane nodes, which must be identical on the control plane nodes. The `bootMACAddress` configuration setting provides a means to specify a particular NIC on each node for the `provisioning` network.
++
+The `provisioning` network is optional, but it is required for PXE booting. If you deploy without a `provisioning` network, you must use a virtual media BMC addressing option such as `redfish-virtualmedia` or `idrac-virtualmedia`.
 
-- `baremetal`: The `baremetal` network is a routable network.
-+
-In {product-title} 4.3, when deploying using the `provisioning` network, the second NIC on each node, such as `eth1` or `eno2`, must interface with the `baremetal` network.
-+
-In {product-title} 4.4 and later releases, you can use any NIC to interface with the `baremetal` network, provided it is the same NIC order across worker and control plane nodes when using the `provisioningNetworkInterface` configuration setting. In {product-title} 4.9 and later releases, you can use any NIC, provided it is not the NIC associated to the `bootMACAddress` configuration setting for the `provisioning` network when using the `bootMACAddress` configuration setting instead of the `provisioningNetworkInterface` setting.
+- `baremetal`: The `baremetal` network is a routable network. You can use any NIC to interface with the `baremetal` network provided the NIC is not configured to use the `provisioning` network.
 
 [IMPORTANT]
 ====
 When using a VLAN, each NIC must be on a separate VLAN corresponding to the appropriate network.
 ====
 
-.Configuring the DNS server
+[discrete]
+== Configuring the DNS server
 
 Clients access the {product-title} cluster nodes over the `baremetal` network. A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
 
 ----
-<cluster-name>.<domain-name>
+<cluster_name>.<domain>
 ----
 
 For example:
@@ -41,11 +41,11 @@ test-cluster.example.com
 ----
 
 ifeval::[{product-version}>4.7]
-{product-title} 4.8 and later releases include functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. After the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
+{product-title} includes functionality that uses cluster membership information to generate A/AAAA records. This resolves the node names to their IP addresses. After the nodes are registered with the API, the cluster can disperse node information without using CoreDNS-mDNS. This eliminates the network traffic associated with multicast DNS.
 
 [IMPORTANT]
 ====
-You must create a DNS entry for the `api.<cluster-name>.<domain>` domain name on the external DNS because removing CoreDNS causes the local entry to disappear. Failure to create a DNS record for the `api.<cluster-name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
+You must create a DNS entry for the `api.<cluster_name>.<domain>` domain name on the external DNS because removing CoreDNS causes the local entry to disappear. Failure to create a DNS record for the `api.<cluster_name>.<domain>` domain name in the external DNS server precludes worker nodes from joining the cluster.
 ====
 endif::[]
 
@@ -57,13 +57,15 @@ For assistance in configuring the DNS server, check xref:ipi-install-upstream-ap
 
 endif::[]
 
-.Dynamic Host Configuration Protocol (DHCP) requirements
+[discrete]
+== Dynamic Host Configuration Protocol (DHCP) requirements
 
 By default, installer-provisioned installation deploys `ironic-dnsmasq` with DHCP enabled for the `provisioning` network. No other DHCP servers should be running on the `provisioning` network when the `provisioningNetwork` configuration setting is set to `managed`, which is the default value. If you have a DHCP server running on the `provisioning` network, you must set the `provisioningNetwork` configuration setting to `unmanaged` in the `install-config.yaml` file.
 
 Network administrators must reserve IP addresses for each node in the {product-title} cluster for the `baremetal` network on an external DHCP server.
 
-.Reserving IP addresses for nodes with the DHCP server
+[discrete]
+== Reserving IP addresses for nodes with the DHCP server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
 
@@ -102,21 +104,21 @@ endif::[]
 
 The following table provides an exemplary embodiment of fully qualified domain names. The API and Nameserver addresses begin with canonical name extensions. The hostnames of the control plane and worker nodes are exemplary, so you can use any host naming convention you prefer.
 
-[width="100%", cols="3,5e,2e", frame="topbot",options="header"]
+[width="100%", cols="3,5,2", options="header"]
 |=====
 | Usage | Host Name | IP
-| API | api.<cluster-name>.<domain> | <ip>
-| Ingress LB (apps) |  *.apps.<cluster-name>.<domain>  | <ip>
+| API | `api.<cluster_name>.<domain>` | `<ip>`
+| Ingress LB (apps) |  `*.apps.<cluster_name>.<domain>`  | `<ip>`
 ifeval::[{product-version} <= 4.5]
-| Nameserver | ns1.<cluster-name>.<domain> | <ip>
+| Nameserver | `ns1.<cluster_name>.<domain>` | `<ip>`
 endif::[]
-| Provisioner node | provisioner.<cluster-name>.<domain> | <ip>
-| Master-0 | openshift-master-0.<cluster-name>.<domain> | <ip>
-| Master-1 | openshift-master-1.<cluster-name>-.<domain> | <ip>
-| Master-2 | openshift-master-2.<cluster-name>.<domain> | <ip>
-| Worker-0 | openshift-worker-0.<cluster-name>.<domain> | <ip>
-| Worker-1 | openshift-worker-1.<cluster-name>.<domain> | <ip>
-| Worker-n | openshift-worker-n.<cluster-name>.<domain> | <ip>
+| Provisioner node | `provisioner.<cluster_name>.<domain>` | `<ip>`
+| Master-0 | `openshift-master-0.<cluster_name>.<domain>` | `<ip>`
+| Master-1 | `openshift-master-1.<cluster_name>-.<domain>` | `<ip>`
+| Master-2 | `openshift-master-2.<cluster_name>.<domain>` | `<ip>`
+| Worker-0 | `openshift-worker-0.<cluster_name>.<domain>` | `<ip>`
+| Worker-1 | `openshift-worker-1.<cluster_name>.<domain>` | `<ip>`
+| Worker-n | `openshift-worker-n.<cluster_name>.<domain>` | `<ip>`
 |=====
 
 ifdef::upstream[]
@@ -126,7 +128,8 @@ For assistance in configuring the DHCP server, check xref:ipi-install-upstream-a
 - xref:creating-dhcp-reservations-using-dnsmasq-option2_{context}[Creating DHCP reservations with dnsmasq (Option 2)]
 endif::[]
 
-.Network Time Protocol (NTP)
+[discrete]
+== Network Time Protocol (NTP)
 
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
 
@@ -138,7 +141,8 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 You may reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
 ifeval::[{product-version} == 4.6]
-.Additional requirements with no provisioning network
+[discrete]
+== Additional requirements with no provisioning network
 
 All installer-provisioned installations require a `baremetal` network. The `baremetal` network is a routable network used for external network access to the outside world. In addition to the IP address supplied to the {product-title} cluster node, installations without a `provisioning` network require the following:
 
@@ -155,7 +159,8 @@ Configuring additional IP addresses for `bootstrapProvisioningIP` and `provision
 endif::[]
 
 ifeval::[{product-version} > 4.6]
-.State-driven network configuration requirements (Technology Preview)
+[discrete]
+== State-driven network configuration requirements (Technology Preview)
 
 {product-title} supports additional post-installation state-driven network configuration on the secondary network interfaces of cluster nodes using `kubernetes-nmstate`. For example, system administrators might configure a secondary network interface on cluster nodes after installation for a storage network.
 


### PR DESCRIPTION
Adds commentary that using IPMI and PXE booting requires the provisinning network. When deploying without the provisioning network, use Redfish with virtual media.

See https://bugzilla.redhat.com/show_bug.cgi?id=1989929 for details.

Release: 4.8

Signed-off-by: John Wilkins <jowilkin@redhat.com>