### PR TITLE
SDN-1387: SR-IOV operator fields for single node

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -21,11 +21,57 @@ The `default` CR contains the SR-IOV Network Operator configuration for your clu
 To change the operator configuration, you must modify this CR.
 =====
 
-The `SriovOperatorConfig` object provides several fields for configuring the operator:
+[id="nw-sriov-operator-cr_{context}"]
+== SR-IOV Network Operator config custom resource
 
-* `enableInjector` allows project administrators to enable or disable the Network Resources Injector daemon set.
-* `enableOperatorWebhook` allows project administrators to enable or disable the Operator Admission Controller webhook daemon set.
-* `configDaemonNodeSelector` allows project administrators to schedule the SR-IOV Network Config Daemon on selected nodes.
+The fields for the `sriovoperatorconfig` custom resource are described in the following table:
+
+.SR-IOV Network Operator config custom resource
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|Specifies the name of the SR-IOV Network Operator instance.
+The default value is `default`.
+Do not set a different value.
+
+|`metadata.namespace`
+|`string`
+|Specifies the namespace of the SR-IOV Network Operator instance.
+The default value is `openshift-sriov-network-operator`.
+Do not set a different value.
+
+|`spec.configDaemonNodeSelector`
+|`string`
+|Specifies the node selection to control scheduling the SR-IOV Network Config Daemon on selected nodes.
+By default, this field is not set and the Operator deploys the SR-IOV Network Config daemon set on worker nodes.
+
+|`spec.disableDrain`
+|`boolean`
+|Specifies whether to disable the node draining process or enable the node draining process when you apply a new policy to configure the NIC on a node.
+Setting this field to `true` facilitates software development and installing {product-title} on a single node. By default, this field is not set.
+
+For single node clusters, set this field to `true` after installing the Operator. This field must remain set to `true`.
+
+|`spec.enableInjector`
+|`boolean`
+|Specifies whether to enable or disable the Network Resources Injector daemon set.
+By default, this field is set to `true`.
+
+|`spec.enableOperatorWebhook`
+|`boolean`
+|Specifies whether to enable or disable the Operator Admission Controller webhook daemon set.
+By default, this field is set to `true`.
+
+|`spec.logLevel`
+|`integer`
+|Specifies the log verbosity level of the Operator.
+Set to `0` to show only the basic logs. Set to `2` to show all the available logs.
+By default, this field is set to `2`.
+
+|====
 
 [id="about-network-resource-injector_{context}"]
 == About the Network Resources Injector
@@ -208,3 +254,51 @@ spec:
     <node_label>
 ----
 ====
+
+[id="configure-sr-iov-operator-single-node_{context}"]
+== Configuring the SR-IOV Network Operator for single node installations
+
+By default, the SR-IOV Network Operator drains workloads from a node before every policy change.
+The Operator performs this action to ensure that there no workloads using the virtual functions before the reconfiguration.
+
+For installations on a single node, there are no other nodes to receive the workloads.
+As a result, the Operator must be configured not to drain the workloads from the single node.
+
+[IMPORTANT]
+====
+After performing the following procedure to disable draining workloads, you must remove any workload that uses an SR-IOV network interface before you change any SR-IOV network node policy.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* You must have installed the SR-IOV Network Operator.
+
+.Procedure
+
+- To set the `disableDrain` field to `true`, enter the following command:
++
+[source,terminal]
+----
+$ oc patch sriovoperatorconfig default --type=merge \
+  -n openshift-sriov-network-operator \
+  --patch '{ "spec": { "disableDrain": true } }'
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to update the Operator:
+
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  disableDrain: true
+----
+====
+


### PR DESCRIPTION
Single node installations set the `spec.disableDrain` field to
true. The field must remain set to true for that specialized
installation.

----

The [fields for the Operator](https://deploy-preview-37555--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator#nw-sriov-operator-cr_configuring-sriov-operator) in a table.

A [short procedure](https://deploy-preview-37555--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator#configure-sr-iov-operator-single-node_configuring-sriov-operator) (like the other Operator configuration procedures) shows how to set the `disableDrain` field and has a short explanation to describe why.
