### PR TITLE
BZ1975701: Known issue for Tang on vSphere

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2021,6 +2021,8 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 
 * When MetalLB is run in layer 2 mode with the OVN-Kubernetes Container Network Interface network provider, instead of a single node with a speaker pod responding to an ARP or NDP request, every node in the cluster responds to the request. The unexpected number of ARP responses might resemble an ARP-spoofing attack. Although the experience is different than designed, traffic is routed to the service as long as no software on the hosts or subnet is configured to block ARP. This bug is fixed in a future {product-title} release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1987445[*BZ#1987445*])
 
+* When Tang disk encryption and a static IP address configuration are applied on a VMWare vSphere user-provisioned infrastructure cluster, the nodes fail to boot properly after they are initially provisioned. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975701[*BZ#1975701*])
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[BZ1975701](https://bugzilla.redhat.com/show_bug.cgi?id=1975701) - documents known issue as described in https://github.com/openshift/openshift-docs/issues/33497#issuecomment-939259707. Note that the related workaround requires a Support Exception and is therefore not included in this PR.

Replaces https://github.com/openshift/openshift-docs/pull/37500.

For 4.9 Release Notes

**Preview link:** https://deploy-preview-37558--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-known-issues