### PR TITLE
[enterprise-4.8] Global terminology fix: network interface card and vNIC

### DIFF
--- a/modules/cnf-cpu-infra-container.adoc
+++ b/modules/cnf-cpu-infra-container.adoc
@@ -8,7 +8,7 @@
 Generic housekeeping and workload tasks use CPUs in a way that may impact latency-sensitive processes. By default, the container runtime uses all online CPUs to run all containers together, which can result in context switches and spikes in latency. Partitioning the CPUs prevents noisy processes from interfering with latency-sensitive processes by separating them from each other. The following table describes how processes run on a CPU after you have tuned the node using the Performance Add-On Operator:
 
 .Process' CPU assignments
-[%header,cols=2*] 
+[%header,cols=2*]
 |===
 |Process type
 |Details
@@ -34,7 +34,7 @@ Generic housekeeping and workload tasks use CPUs in a way that may impact latenc
 
 The exact partitioning pattern to use depends on many factors like hardware, workload characteristics and the expected system load. Some sample use cases are as follows:
 
-* If the latency-sensitive workload uses specific hardware, such as a network interface card (NIC), ensure that the CPUs in the isolated pool are as close as possible to this hardware. At a minimum, you should place the workload in the same Non-Uniform Memory Access (NUMA) node.
+* If the latency-sensitive workload uses specific hardware, such as a network interface controller (NIC), ensure that the CPUs in the isolated pool are as close as possible to this hardware. At a minimum, you should place the workload in the same Non-Uniform Memory Access (NUMA) node.
 
 * The reserved pool is used for handling all interrupts. When depending on system networking, allocate a sufficiently-sized reserve pool to handle all the incoming packet interrupts. In {product-version} and later versions, workloads can optionally be labeled as sensitive.
 
@@ -45,7 +45,7 @@ The decision regarding which specific CPUs should be used for reserved and isola
 The reserved and isolated CPU pools must not overlap and together must span all available cores in the worker node.
 ====
 
-To ensure that housekeeping tasks and workloads do not interfere with each other, specify two groups of CPUs in the `spec` section of the performance profile. 
+To ensure that housekeeping tasks and workloads do not interfere with each other, specify two groups of CPUs in the `spec` section of the performance profile.
 
 * `isolated` - Specifies the CPUs for the application container workloads. These CPUs have the lowest latency. Processes in this group have no interruptions and can, for example, reach much higher DPDK zero packet loss bandwidth.
 
@@ -71,5 +71,5 @@ spec:
     node-role.kubernetes.io/worker: ""
 ----
 <1> Specify which CPUs are for infra containers to perform cluster and operating system housekeeping duties.
-<2> Specify which CPUs are for application containers to run workloads. 
+<2> Specify which CPUs are for application containers to run workloads.
 <3> Optional: Specify a node selector to apply the performance profile to specific nodes.

--- a/modules/cnf-provisioning-deploying-a-distributed-unit-(du)-manually.adoc
+++ b/modules/cnf-provisioning-deploying-a-distributed-unit-(du)-manually.adoc
@@ -33,7 +33,7 @@ Running cell application on COTS hardware requires the following features to be 
 * AVX-512 instruction set (for Flexran and / or FPGA implementation)
 * Additional features depending on the RAN Operator requirements
 
-Accessing hardware acceleration devices and high throughput network interface cards by virtualized software applications
+Accessing hardware acceleration devices and high throughput network interface controllers by virtualized software applications
 requires use of SR-IOV and Passthrough PCI device virtualization.
 
 In addition to the compute and acceleration requirements, DUs operate on multiple internal and external networks.

--- a/modules/cnf-provisioning-deploying-a-distributed-unit-manually.adoc
+++ b/modules/cnf-provisioning-deploying-a-distributed-unit-manually.adoc
@@ -33,7 +33,7 @@ Running cell application on COTS hardware requires the following features to be 
 * AVX-512 instruction set (for Flexran and / or FPGA implementation)
 * Additional features depending on the RAN Operator requirements
 
-Accessing hardware acceleration devices and high throughput network interface cards by virtualized software applications
+Accessing hardware acceleration devices and high throughput network interface controllers by virtualized software applications
 requires use of SR-IOV and Passthrough PCI device virtualization.
 
 In addition to the compute and acceleration requirements, DUs operate on multiple internal and external networks.

--- a/modules/cnf-reducing-netqueues-using-pao.adoc
+++ b/modules/cnf-reducing-netqueues-using-pao.adoc
@@ -5,7 +5,7 @@
 [id="reducing-nic-queues-using-the-performance-addon-operator_{context}"]
 = Reducing NIC queues using the Performance Addon Operator
 
-The Performance Addon Operator allows you to adjust the Network Interface Card (NIC) queue count for each network device by configuring the performance profile. Device network queues allows the distribution of packets among different physical queues and each queue gets a separate thread for packet processing.
+The Performance Addon Operator allows you to adjust the network interface controller (NIC) queue count for each network device by configuring the performance profile. Device network queues allows the distribution of packets among different physical queues and each queue gets a separate thread for packet processing.
 
 In real-time or low latency systems, all the unnecessary interrupt request lines (IRQs) pinned to the isolated CPUs must be moved to reserved or housekeeping CPUs.
 

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -326,7 +326,7 @@ On your IBM Power instance, set up:
 === Network for the PowerVM guest virtual machines
 
 * Virtualized by the Virtual I/O Server using Shared Ethernet Adapter
-* Virtualized by the Virtual I/O Server using IBM VNIC
+* Virtualized by the Virtual I/O Server using IBM vNIC
 
 [discrete]
 === Storage / main memory
@@ -363,7 +363,7 @@ On your IBM Power instance, set up:
 === Network for the PowerVM guest virtual machines
 
 * Virtualized by the Virtual I/O Server using Shared Ethernet Adapter
-* Virtualized by the Virtual I/O Server using IBM VNIC
+* Virtualized by the Virtual I/O Server using IBM vNIC
 
 [discrete]
 === Storage / main memory

--- a/modules/nw-egress-router-about.adoc
+++ b/modules/nw-egress-router-about.adoc
@@ -100,7 +100,7 @@ $ openstack port set --allowed-address \
 
 {rh-virtualization-first}::
 
-If you are using link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/administration_guide/sect-virtual_network_interface_cards#Explanation_of_Settings_in_the_VM_Interface_Profile_Window[{rh-virtualization}], you must select *No Network Filter* for the Virtual Network Interface Card (vNIC).
+If you are using link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/administration_guide/sect-virtual_network_interface_cards#Explanation_of_Settings_in_the_VM_Interface_Profile_Window[{rh-virtualization}], you must select *No Network Filter* for the Virtual network interface controller (vNIC).
 
 VMware vSphere::
 

--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -68,7 +68,7 @@ Only SR-IOV network devices on selected nodes are configured. The SR-IOV
 Container Network Interface (CNI) plug-in and device plug-in are deployed only on selected nodes.
 <5> Optional: Specify an integer value between `0` and `99`. A smaller number gets higher priority, so a priority of `10` is higher than a priority of `99`. The default value is `99`.
 <6> Optional: Specify a value for the maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different NIC models.
-<7> Specify the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel Network Interface Card (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
+<7> Specify the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 <8> The `nicSelector` mapping selects the Ethernet device for the Operator to configure. You do not need to specify values for all the parameters. It is recommended to identify the Ethernet adapter with enough precision to minimize the possibility of selecting an Ethernet device unintentionally.
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`.
 If you specify both `pfNames` and `rootDevices` at the same time, ensure that they point to an identical device.

--- a/modules/optimizing-mtu-networking.adoc
+++ b/modules/optimizing-mtu-networking.adoc
@@ -5,7 +5,7 @@
 [id="optimizing-mtu_{context}"]
 = Optimizing the MTU for your network
 
-There are two important maximum transmission units (MTUs): the network interface card (NIC) MTU and the cluster network MTU.
+There are two important maximum transmission units (MTUs): the network interface controller (NIC) MTU and the cluster network MTU.
 
 The NIC MTU is only configured at the time of {product-title} installation. The MTU must be less than or equal to the maximum supported value of the NIC of your network. If you are optimizing for throughput, choose the largest possible value. If you are optimizing for lowest latency, choose a lower value.
 

--- a/modules/virt-add-boot-order-web.adoc
+++ b/modules/virt-add-boot-order-web.adoc
@@ -20,7 +20,7 @@ Add items to a boot order list by using the web console.
 
 . Click the pencil icon that is located on the right side of *Boot Order*. If a YAML configuration does not exist, or if this is the first time that you are creating a boot order list, the following message displays: *No resource selected. VM will attempt to boot from disks by order of appearance in YAML file.*
 
-. Click *Add Source* and select a bootable disk or network interface card (NIC) for the virtual machine.
+. Click *Add Source* and select a bootable disk or network interface controller (NIC) for the virtual machine.
 
 . Add any additional disks or NICs to the boot order list.
 

--- a/modules/virt-creating-vm-wizard-web.adoc
+++ b/modules/virt-creating-vm-wizard-web.adoc
@@ -9,7 +9,7 @@ The web console features a wizard that guides you through the process of selecti
 
 You can select a template from the list of preconfigured templates, review the settings, and create a virtual machine in the *Create virtual machine from template* wizard. If you choose to customize your virtual machine, the wizard guides you through the *General*, *Networking*, *Storage*, *Advanced*, and *Review* steps. All required fields displayed by the wizard are marked by a ++*++.
 
-Create Network interface cards (NICs) and storage disks later and attach them to virtual machines.
+Create network interface controllers (NICs) and storage disks later and attach them to virtual machines.
 
 .Procedure
 

--- a/modules/virt-edit-boot-order-yaml-web.adoc
+++ b/modules/virt-edit-boot-order-yaml-web.adoc
@@ -17,7 +17,7 @@ Edit the boot order list in a YAML configuration file by using the CLI.
 $ oc edit vm example
 ----
 
-. Edit the YAML file and modify the values for the boot order associated with a disk or network interface card (NIC). For example:
+. Edit the YAML file and modify the values for the boot order associated with a disk or network interface controller (NIC). For example:
 
 +
 [source,yaml]
@@ -40,7 +40,7 @@ interfaces:
     name: default
 ----
 <1> The boot order value specified for the disk.
-<2> The boot order value specified for the network interface card.
+<2> The boot order value specified for the network interface controller.
 
 . Save the YAML file.
 

--- a/modules/virt-networking-wizard-fields-web.adoc
+++ b/modules/virt-networking-wizard-fields-web.adoc
@@ -13,10 +13,10 @@
 |Name | Description
 
 |Name
-|Name for the network interface card.
+|Name for the network interface controller.
 
 |Model
-|Indicates the model of the network interface card. Supported values are *e1000e* and *virtio*.
+|Indicates the model of the network interface controller. Supported values are *e1000e* and *virtio*.
 
 |Network
 |List of available network attachment definitions.
@@ -25,5 +25,5 @@
 |List of available binding methods. For the default pod network, `masquerade` is the only recommended binding method. For secondary networks, use the `bridge` binding method. The `masquerade` method is not supported for non-default networks. Select `SR-IOV` if you configured an SR-IOV network device and defined that network in the namespace.
 
 |MAC Address
-|MAC address for the network interface card. If a MAC address is not specified, one is assigned automatically.
+|MAC address for the network interface controller. If a MAC address is not specified, one is assigned automatically.
 |===

--- a/scalability_and_performance/optimizing-networking.adoc
+++ b/scalability_and_performance/optimizing-networking.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface cards (NIC) offloads, multi-queue, and ethtool settings.
+The xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface controllers (NIC) offloads, multi-queue, and ethtool settings.
 
 xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] uses Geneve (Generic Network Virtualization Encapsulation) instead of VXLAN as the tunnel protocol.
 

--- a/virt/virtual_machines/virt-edit-boot-order.adoc
+++ b/virt/virtual_machines/virt-edit-boot-order.adoc
@@ -9,7 +9,7 @@ You can update the values for a boot order list by using the web console or the 
 
 With *Boot Order* in the *Virtual Machine Overview* page, you can:
 
-* Select a disk or network interface card (NIC) and add it to the boot order list.
+* Select a disk or network interface controller (NIC) and add it to the boot order list.
 * Edit the order of the disks or NICs in the boot order list.
 * Remove a disk or NIC from the boot order list, and return it back to the inventory of bootable sources.
 

--- a/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
+++ b/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
@@ -5,7 +5,7 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-You can view the IP address for a network interface card (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
+You can view the IP address for a network interface controller (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
 
 include::modules/virt-viewing-vmi-ip-cli.adoc[leveloffset=+1]
 include::modules/virt-viewing-vmi-ip-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry Picked from  d11a586bcf7aa5ca9dc372ee52da422e10261d94 xref: https://github.com/openshift/openshift-docs/pull/37506