### PR TITLE
[enterprise-4.6] Global terminology fix: network interface card and vNIC

### DIFF
--- a/modules/nw-egress-router-about.adoc
+++ b/modules/nw-egress-router-about.adoc
@@ -59,7 +59,7 @@ $ openstack port set --allowed-address \
 
 {rh-virtualization-first}::
 
-If you are using link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/administration_guide/sect-virtual_network_interface_cards#Explanation_of_Settings_in_the_VM_Interface_Profile_Window[{rh-virtualization}], you must select *No Network Filter* for the Virtual Network Interface Card (vNIC).
+If you are using link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html/administration_guide/sect-virtual_network_interface_cards#Explanation_of_Settings_in_the_VM_Interface_Profile_Window[{rh-virtualization}], you must select *No Network Filter* for the Virtual network interface controller (vNIC).
 
 VMware vSphere::
 

--- a/modules/nw-sriov-configuring-device.adoc
+++ b/modules/nw-sriov-configuring-device.adoc
@@ -68,7 +68,7 @@ Only SR-IOV network devices on selected nodes are configured. The SR-IOV
 Container Network Interface (CNI) plug-in and device plug-in are deployed only on selected nodes.
 <5> Optional: Specify an integer value between `0` and `99`. A smaller number gets higher priority, so a priority of `10` is higher than a priority of `99`. The default value is `99`.
 <6> Optional: Specify a value for the maximum transmission unit (MTU) of the virtual function. The maximum MTU value can vary for different NIC models.
-<7> Specify the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel Network Interface Card (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
+<7> Specify the number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 <8> The `nicSelector` mapping selects the Ethernet device for the Operator to configure. You do not need to specify values for all the parameters. It is recommended to identify the Ethernet adapter with enough precision to minimize the possibility of selecting an Ethernet device unintentionally.
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`.
 If you specify both `pfNames` and `rootDevices` at the same time, ensure that they point to an identical device.

--- a/modules/optimizing-mtu-networking.adoc
+++ b/modules/optimizing-mtu-networking.adoc
@@ -5,7 +5,7 @@
 [id="optimizing-mtu_{context}"]
 = Optimizing the MTU for your network
 
-There are two important maximum transmission units (MTUs): the network interface card (NIC) MTU and the cluster network MTU.
+There are two important maximum transmission units (MTUs): the network interface controller (NIC) MTU and the cluster network MTU.
 
 The NIC MTU is only configured at the time of {product-title} installation. The MTU must be less than or equal to the maximum supported value of the NIC of your network. If you are optimizing for throughput, choose the largest possible value. If you are optimizing for lowest latency, choose a lower value.
 

--- a/modules/virt-add-boot-order-web.adoc
+++ b/modules/virt-add-boot-order-web.adoc
@@ -20,7 +20,7 @@ Add items to a boot order list by using the web console.
 
 . Click the pencil icon that is located on the right side of *Boot Order*. If a YAML configuration does not exist, or if this is the first time that you are creating a boot order list, the following message displays: *No resource selected. VM will attempt to boot from disks by order of appearance in YAML file.*
 
-. Click *Add Source* and select a bootable disk or network interface card (NIC) for the virtual machine.
+. Click *Add Source* and select a bootable disk or network interface controller (NIC) for the virtual machine.
 
 . Add any additional disks or NICs to the boot order list.
 

--- a/modules/virt-creating-vm-wizard-web.adoc
+++ b/modules/virt-creating-vm-wizard-web.adoc
@@ -7,7 +7,7 @@
 
 The web console features an interactive wizard that guides you through *General*, *Networking*, *Storage*, *Advanced*, and *Review* steps to simplify the process of creating virtual machines. All required fields are marked by a `*`. When the required fields are completed, you can review and create your virtual machine.
 
-Network interface cards (NICs) and storage disks can be created and attached to virtual machines after they have been created.
+Network interface controllers (NICs) and storage disks can be created and attached to virtual machines after they have been created.
 
 .*Bootable Disk*
 

--- a/modules/virt-edit-boot-order-yaml-web.adoc
+++ b/modules/virt-edit-boot-order-yaml-web.adoc
@@ -17,7 +17,7 @@ Edit the boot order list in a YAML configuration file by using the CLI.
 $ oc edit vm example
 ----
 
-. Edit the YAML file and modify the values for the boot order associated with a disk or network interface card (NIC). For example:
+. Edit the YAML file and modify the values for the boot order associated with a disk or network interface controller (NIC). For example:
 
 +
 [source,yaml]
@@ -40,7 +40,7 @@ interfaces:
     name: default
 ----
 <1> The boot order value specified for the disk.
-<2> The boot order value specified for the network interface card.
+<2> The boot order value specified for the network interface controller.
 
 . Save the YAML file.
 

--- a/modules/virt-networking-wizard-fields-web.adoc
+++ b/modules/virt-networking-wizard-fields-web.adoc
@@ -13,10 +13,10 @@
 |Name | Description
 
 |Name
-|Name for the network interface card.
+|Name for the network interface controller.
 
 |Model
-|Indicates the model of the network interface card. Supported values are *e1000e* and *virtio*.
+|Indicates the model of the network interface controller. Supported values are *e1000e* and *virtio*.
 
 |Network
 |List of available network attachment definitions.
@@ -28,5 +28,5 @@ binding method. The `masquerade` method is not supported for non-default
 networks.
 
 |MAC Address
-|MAC address for the network interface card. If a MAC address is not specified, an ephemeral address is generated for the session.
+|MAC address for the network interface controller. If a MAC address is not specified, one is assigned automatically.
 |===

--- a/scalability_and_performance/optimizing-networking.adoc
+++ b/scalability_and_performance/optimizing-networking.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-The xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface cards (NIC) offloads, multi-queue, and ethtool settings.
+The xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface controllers (NIC) offloads, multi-queue, and ethtool settings.
 
 xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] uses Geneve (Generic Network Virtualization Encapsulation) instead of VXLAN as the tunnel protocol.
 

--- a/virt/virtual_machines/virt-edit-boot-order.adoc
+++ b/virt/virtual_machines/virt-edit-boot-order.adoc
@@ -9,7 +9,7 @@ You can update the values for a boot order list by using the web console or the 
 
 With *Boot Order* in the *Virtual Machine Overview* page, you can:
 
-* Select a disk or network interface card (NIC) and add it to the boot order list.
+* Select a disk or network interface controller (NIC) and add it to the boot order list.
 * Edit the order of the disks or NICs in the boot order list.
 * Remove a disk or NIC from the boot order list, and return it back to the inventory of bootable sources.
 

--- a/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
+++ b/virt/virtual_machines/vm_networking/virt-viewing-ip-of-vm-nic.adoc
@@ -5,7 +5,7 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-You can view the IP address for a network interface card (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
+You can view the IP address for a network interface controller (NIC) by using the web console or the `oc` client. The xref:../../../virt/virtual_machines/virt-installing-qemu-guest-agent.adoc#virt-installing-qemu-guest-agent[QEMU guest agent] displays additional information about the virtual machine's secondary networks.
 
 include::modules/virt-viewing-vmi-ip-cli.adoc[leveloffset=+1]
 include::modules/virt-viewing-vmi-ip-web.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry Picked from d11a586bcf7aa5ca9dc372ee52da422e10261d94 xref: https://github.com/openshift/openshift-docs/pull/37506