### PR TITLE
SRVKS-789: Move steps for enabling Serving metrics despite Service Mesh & mTLS

### DIFF
--- a/modules/serverless-ossm-enabling-serving-metrics.adoc
+++ b/modules/serverless-ossm-enabling-serving-metrics.adoc
@@ -1,0 +1,59 @@
+[id="serverless-ossm-enabling-serving-metrics_{context}"]
+= Enabling Knative Serving metrics when using Service Mesh with mTLS
+
+If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default, because Service Mesh prevents Prometheus from scraping metrics. This section shows how to enable Knative Serving metrics when using Service Mesh and mTLS.
+
+.Prerequisites
+
+* You have installed the {ServerlessOperatorName} on your {product-title} cluster.
+* You have installed {ProductName} with the mTLS functionality enabled.
+* You have installed Knative Serving.
+
+.Procedure
+
+. Specify `prometheus` as the `metrics.backend-destination` in the `observability` spec of the Knative Serving custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    observability:
+      metrics.backend-destination: "prometheus"
+----
++
+This step prevents metrics from being disabled by default.
+
+. Apply the following network policy to allow traffic from the Prometheus namespace:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-openshift-monitoring-ns
+  namespace: knative-serving
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: "openshift-monitoring"
+  podSelector: {}
+----
+
+. Modify and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
++
+[source,yaml]
+----
+spec:
+  proxy:
+    networking:
+      trafficControl:
+        inbound:
+          excludedPorts:
+          - 8444
+----

--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -26,59 +26,7 @@ WARNING: found multiple channel heads: [amqstreams.v1.7.2 amqstreams.v1.6.2], pl
 +
 You can fix this issue by uninstalling the AMQ Streams Operator before installing or upgrading the {ServerlessOperatorName}. You can then reinstall the AMQ Streams Operator.
 
-// Added note about the following to admin and dev metrics assemblies - remove these if the issue gets resolved.
-* If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
-+
-If you want to enable Knative Serving metrics for use with Service Mesh and mTLS, you must complete the following steps:
-
-.. Specify `prometheus` as the `metrics.backend-destination` in the `observability` spec of the Knative Serving custom resource (CR):
-+
-[source,yaml]
-----
-apiVersion: operator.knative.dev/v1alpha1
-kind: KnativeServing
-metadata:
-  name: knative-serving
-spec:
-  config:
-    observability:
-      metrics.backend-destination: "prometheus"
-----
-+
-This step prevents metrics from being disabled by default.
-
-.. Apply the following network policy to allow traffic from the Prometheus namespace:
-+
-[source,yaml]
-----
-apiVersion: networking.k8s.io/v1
-kind: NetworkPolicy
-metadata:
-  name: allow-from-openshift-monitoring-ns
-  namespace: knative-serving
-spec:
-  ingress:
-  - from:
-    - namespaceSelector:
-        matchLabels:
-          name: "openshift-monitoring"
-  podSelector: {}
-  policyTypes:
-  - Ingress
-----
-
-.. Modify and reapply the default Service Mesh control plane in the `istio-system` namespace, so that it includes the following spec:
-+
-[source,yaml]
-----
-spec:
-  proxy:
-    networking:
-      trafficControl:
-        inbound:
-          excludedPorts:
-          - 8444
-----
+* If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics. For instructions on enabling Knative Serving metrics for use with Service Mesh and mTLS, see the "Integrating Service Mesh with OpenShift Serverless" section of the Serverless documentation.
 
 * If you deploy Service Mesh CRs with the Istio ingress enabled, you might see the following warning in the `istio-ingressgateway` pod:
 +

--- a/serverless/admin_guide/serverless-admin-metrics.adoc
+++ b/serverless/admin_guide/serverless-admin-metrics.adoc
@@ -18,7 +18,7 @@ Metrics enable cluster administrators to monitor how {ServerlessProductName} clu
 ====
 If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
 
-For information about resolving this issue, see the xref:../../serverless/serverless-release-notes.adoc#serverless-rn-1-16-0_serverless-release-notes[Serverless 1.16.0 release notes].
+For information about resolving this issue, see xref:../../serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Integrating Service Mesh with OpenShift Serverless].
 ====
 
 // Common metrics

--- a/serverless/admin_guide/serverless-ossm-setup.adoc
+++ b/serverless/admin_guide/serverless-ossm-setup.adoc
@@ -32,6 +32,7 @@ If you want to use any domain name, including those which are not subdomains of 
 
 include::modules/serverlesss-ossm-external-certs.adoc[leveloffset=+2]
 include::modules/serverless-ossm-setup.adoc[leveloffset=+2]
+include::modules/serverless-ossm-enabling-serving-metrics.adoc[leveloffset=+2]
 
 // With kourier
 include::modules/serverless-ossm-setup-with-kourier.adoc[leveloffset=+1]

--- a/serverless/knative_serving/serverless-serving-metrics.adoc
+++ b/serverless/knative_serving/serverless-serving-metrics.adoc
@@ -17,7 +17,7 @@ Metrics enable developers to monitor how Knative services are performing.
 ====
 If Service Mesh is enabled with mTLS, metrics for Knative Serving are disabled by default because Service Mesh prevents Prometheus from scraping metrics.
 
-For information about resolving this issue, see the xref:../../serverless/serverless-release-notes.adoc#serverless-rn-1-16-0_serverless-release-notes[Serverless 1.16.0 release notes].
+For information about resolving this issue, see xref:../../serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup[Integrating Service Mesh with OpenShift Serverless].
 ====
 
 include::modules/serverless-queue-proxy-metrics.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVKS-789
Docs preview:
* Moved section https://deploy-preview-37573--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-ossm-setup.html#serverless-ossm-enabling-serving-metrics_serverless-ossm-setup
* Reference to the section from a warning https://deploy-preview-37573--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-admin-metrics.html
* Another reference to the section from a warning https://deploy-preview-37573--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-serving-metrics.html
* Shortened release note, from which the information has been moved https://deploy-preview-37573--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-16-0_serverless-release-notes