### PR TITLE
SRVCOM-1501: Add Serverless 1.18.0 release notes

### DIFF
--- a/modules/interacting-serverless-apps-http2-gRPC.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC.adoc
@@ -13,6 +13,22 @@ These routes also do not support gRPC because gRPC is transported by HTTP2.
 If you use these protocols in your application, you must call the application using the ingress gateway directly.
 To do this you must find the ingress gateway's public address and the application's specific host.
 
+// FIXME: Uncomment for Serverless 1.19.0
+// [IMPORTANT]
+// ====
+// This method needs to expose Kourier Gateway using the `LoadBalancer` service type. You can configure this by adding the following YAML to your `KnativeServing` custom resource definition (CRD):
+
+// [source,yaml]
+// ----
+// ...
+// spec:
+//   ingress:
+//     kourier:
+//       service-type: LoadBalancer
+// ...
+// ----
+// ====
+
 .Procedure
 
 . Find the application host. See the instructions in _Verifying your serverless application deployment_.

--- a/modules/serverless-rn-1-14-0.adoc
+++ b/modules/serverless-rn-1-14-0.adoc
@@ -28,6 +28,6 @@ Only the `v1beta1` version of the APIs for `KafkaChannel` and `KafkaSource` obje
 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
-As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
 +
 For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-15-0.adoc
+++ b/modules/serverless-rn-1-15-0.adoc
@@ -21,6 +21,6 @@ The `serving.knative.dev/visibility` label, which was previously used to create 
 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
-As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
 +
 For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-16-0.adoc
+++ b/modules/serverless-rn-1-16-0.adoc
@@ -119,12 +119,12 @@ spec:
      targetPort: 8081
 ----
 
-* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there is a delay when you create the first new service after the `KnativeServing` custom resource definition (CRD) becomes `Ready`.
+* If you have 1000 Knative services on a cluster, and then perform a reinstall or upgrade of Knative Serving, there is a delay when you create the first new service after the `KnativeServing` custom resource (CR) becomes `Ready`.
 +
 The `3scale-kourier-control` service reconciles all previously existing Knative services before processing the creation of a new service, which causes the new service to spend approximately 800 seconds in an `IngressNotConfigured` or `Unknown` state before the state updates to `Ready`.
 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
-As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
 +
 For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].

--- a/modules/serverless-rn-1-17-0.adoc
+++ b/modules/serverless-rn-1-17-0.adoc
@@ -12,7 +12,7 @@
 * The `kn func` CLI plug-in now uses `func` 0.17.0.
 * In the upcoming {ServerlessProductName} 1.19.0 release, the URL scheme of external routes will default to HTTPS for enhanced security.
 +
-If you do not want this change to apply for your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource definition (CRD):
+If you do not want this change to apply for your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource (CR):
 +
 [source,yaml]
 ----
@@ -45,8 +45,13 @@ Ensure that you are using the latest `kn` CLI version for your {ServerlessProduc
 
 * If you create a new subscription for a Kafka channel, or a new Kafka source, there might be a delay in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reports a ready status.
 +
-As a result, messages that are sent during the time which the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
+As a result, messages that are sent during the time when the data plane is not reporting a ready status might not be delivered to the subscriber or sink.
 +
 For more information about this issue and possible workarounds, see link:https://access.redhat.com/articles/6343981[Knowledge Article #6343981].
 
 * The Camel-K 1.4 release is not compatible with {ServerlessProductName} version 1.17.0. This is because Camel-K 1.4 uses APIs that were removed in Knative version 0.23.0. There is currently no workaround available for this issue. If you need to use Camel-K 1.4 with {ServerlessProductName}, do not upgrade to {ServerlessProductName} version 1.17.0.
++
+[NOTE]
+====
+The issue has been fixed, and Camel-K version 1.4.1 is compatible with {ServerlessProductName} 1.17.0.
+====

--- a/modules/serverless-rn-1-18-0.adoc
+++ b/modules/serverless-rn-1-18-0.adoc
@@ -1,0 +1,77 @@
+[id="serverless-rn-1-18-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.18.0
+
+[id="new-features-1-18-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.24.0.
+* {ServerlessProductName} now uses Knative Eventing 0.24.0.
+* {ServerlessProductName} now uses Kourier 0.24.0.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.24.0.
+* {ServerlessProductName} now uses Knative Kafka 0.24.7.
+* The `kn func` CLI plug-in now uses `func` 0.18.0.
+* In the upcoming {ServerlessProductName} 1.19.0 release, the URL scheme of external routes will default to HTTPS for enhanced security.
++
+If you do not want this change to apply for your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource (CR):
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      defaultExternalScheme: "http"
+...
+----
++
+If you want the change to apply in 1.18.0 already, add the following YAML:
++
+[source,yaml]
+----
+...
+spec:
+  config:
+    network:
+      defaultExternalScheme: "https"
+...
+----
+
+* In the upcoming {ServerlessProductName} 1.19.0 release, the default service type by which the Kourier Gateway is exposed will be `ClusterIP` and not `LoadBalancer`.
++
+If you do not want this change to apply to your workloads, you can override the default setting before upgrading to 1.19.0, by adding the following YAML to your `KnativeServing` custom resource (CR):
++
+[source,yaml]
+----
+...
+spec:
+  ingress:
+    kourier:
+      service-type: LoadBalancer
+...
+----
+
+* You can now use `emptyDir` volumes with {ServerlessProductName}. See the {ServerlessProductName} documentation about Knative Serving for details.
+
+* Rust templates are now available when you create a function using `kn func`.
+
+[id="fixed-issues-1-18-0_{context}"]
+== Fixed issues
+
+* The prior 1.4 version of Camel-K was not compatible with {ServerlessProductName} 1.17.0. The issue in Camel-K has been fixed, and Camel-K version 1.4.1 can be used with {ServerlessProductName} 1.17.0.
+
+* Previously, if you created a new subscription for a Kafka channel, or a new Kafka source, a delay was possible in the Kafka data plane becoming ready to dispatch messages after the newly created subscription or sink reported a ready status.
++
+As a result, messages that were sent during the time when the data plane was not reporting a ready status, might not have been delivered to the subscriber or sink.
++
+In {ServerlessProductName} 1.18.0, the issue is fixed and the initial messages are no longer lost. For more information about the issue, see link:https://access.redhat.com/articles/6343981[Knowledgebase Article #6343981].
+
+[id="known-issues-1-18-0_{context}"]
+== Known issues
+
+* Older versions of the Knative `kn` CLI might use older versions of the Knative Serving and Knative Eventing APIs. For example, version 0.23.2 of the `kn` CLI uses the `v1alpha1` API version.
++
+On the other hand, newer releases of {ServerlessProductName} might no longer support older API versions. For example, {ServerlessProductName} 1.18.0 no longer supports version `v1alpha1` of the `kafkasources.sources.knative.dev` API.
++
+Consequently, using an older version of the Knative `kn` CLI with a newer {ServerlessProductName} might produce an error because the `kn` cannot find the outdated API. For example, version 0.23.2 of the `kn` CLI does not work with {ServerlessProductName} 1.18.0.
++
+To avoid issues, use the latest `kn` CLI version available for your {ServerlessProductName} release. For {ServerlessProductName} 1.18.0, use Knative `kn` CLI 0.24.0.

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -18,6 +18,7 @@ For details about the latest Knative component releases, see the link:https://kn
 include::modules/serverless-api-versions.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-18-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-17-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-16-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-15-0.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVCOM-1501
Docs preview:
* The release notes for 1.18.0 https://deploy-preview-37574--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-18-0_serverless-release-notes
* An added sentence regarding Camel-K to the 1.17.0 notes (the very last sentence in 1.17.0 notes) https://deploy-preview-37574--osdocs.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#known-issues-1-17-0_serverless-release-notes
* Additional note regarding the LoadBalancer service type https://deploy-preview-37574--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-applications.html#interacting-serverless-apps-http2-gRPC_serverless-applications