### PR TITLE
BZ2013088: Added known issue to the 4.9 RN

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1976,6 +1976,9 @@ No workaround exists for this issue. To track these metrics for production workl
 * When IP multicast relay is enabled on a logical router that contains distributed gateway ports, multicast traffic is not forwarded correctly on the distributed gateway port. The result is broken IP multicast functionality in OVN-Kubernetes.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2010374[*BZ#2010374*])
 
+* In the *Administrator* perspective of the web console, a page that is supposed to display a list of nodes is rendered before the list of nodes is available, which causes the page to become unresponsive. There is no workaround, but this issue will be addressed in a future release.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2013088[*BZ#2013088*])
+
 * Operator Lifecycle Manager (OLM) uses a combination of timestamp checks and obsolete API calls, which do not work for `skipRange` upgrades, to determine if it is necessary to perform an upgrade for a particular subscription. For Operators that use the `skipRange` upgrade, there is a delay in the upgrade process that can take up to 15 minutes to resolve and can potentially be blocked for even longer.
 +
 As a workaround, cluster administrators can delete the `catalog-operator` pod in the `openshift-operator-lifecycle-manager` namespace. This causes the pod to be automatically recreated, which causes the `skipRange` upgrade to trigger. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002276[*BZ#2002276*])


### PR DESCRIPTION
Added known issue for https://bugzilla.redhat.com/show_bug.cgi?id=2013088

Applies only to `enterprise-4.9

Needs:
* SME review @yaacov 
* QE review @yapei 

Direct preview (scroll up a bit!): https://deploy-preview-37576--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-asynchronous-errata-updates