### PR TITLE
BZ1971700: Add a section to expose default registry

### DIFF
--- a/modules/registry-exposing-default-registry-manually.adoc
+++ b/modules/registry-exposing-default-registry-manually.adoc
@@ -1,0 +1,51 @@
+[id="registry-exposing-default-registry-manually_{context}"]
+= Exposing a default registry manually
+
+Instead of logging in to the default {product-title} registry from within the cluster, you can gain external access to it by exposing it with a route. This external access enables you to log in to the registry from outside the cluster using the route address and to tag and push images to an existing project by using the route host.
+
+.Prerequisites:
+
+* The following prerequisites are automatically performed:
+** Deploy the Registry Operator.
+** Deploy the Ingress Operator.
+
+.Procedure
+
+You can expose the route by using the `defaultRoute` parameter in the `configs.imageregistry.operator.openshift.io` resource.
+
+To expose the registry using the `defaultRoute`:
+
+. Set `defaultRoute` to `true`:
++
+[source,terminal]
+----
+$ oc patch configs.imageregistry.operator.openshift.io/cluster --patch '{"spec":{"defaultRoute":true}}' --type=merge
+----
++
+. Get the default registry route:
++
+[source,terminal]
+----
+$ HOST=$(oc get route default-route -n openshift-image-registry --template='{{ .spec.host }}')
+----
+
+. Get the certificate of the Ingress Operator:
++
+[source,terminal]
+----
+$ oc get secret -n openshift-ingress  router-certs-default -o go-template='{{index .data "tls.crt"}}' | base64 -d | sudo tee /etc/pki/ca-trust/source/anchors/${HOST}.crt  > /dev/null
+----
+
+. Enable the cluster's default certificate to trust the route using the following commands:
++
+[source,terminal]
+----
+$ sudo update-ca-trust enable
+----
+
+. Log in with podman using the default route:
++
+[source,terminal]
+----
+$ sudo podman login -u kubeadmin -p $(oc whoami -t) $HOST
+----

--- a/registry/securing-exposing-registry.adoc
+++ b/registry/securing-exposing-registry.adoc
@@ -10,4 +10,5 @@ so that it serves traffic through TLS. Unlike previous versions of
 {product-title}, the registry is not exposed outside of the cluster at the time
 of installation.
 
+include::modules/registry-exposing-default-registry-manually.adoc[leveloffset=+1]
 include::modules/registry-exposing-secure-registry-manually.adoc[leveloffset=+1]


### PR DESCRIPTION
The existing section only mentions how to get a certificate of custom routes,
added a section to get a certificate for default registry routes.
Fixes: [BZ1971700](https://bugzilla.redhat.com/show_bug.cgi?id=1971700)
OCP version: 4.7+ versions
Preview: [link](https://deploy-preview-37577--osdocs.netlify.app/openshift-enterprise/latest/registry/securing-exposing-registry.html#registry-exposing-default-registry-manually_securing-exposing-registry)
QA contact: @xiuwang 