### PR TITLE
BZ1986962: Modifying worker node VM CPU requirements to be more agnostic

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -39,7 +39,7 @@ Without an external monitoring system or a qualified human monitoring node healt
 
 * When using a disconnected cluster on a restricted network, you must xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[configure proxy support in Operator Lifecycle Manager] to access the Red Hat-provided OperatorHub. Using a proxy allows the cluster to fetch the {VirtProductName} Operator.
 
-* If your cluster uses worker nodes from multiple CPU vendors, live migration failures can occur. For example, a virtual machine with an AMD CPU might attempt to live-migrate to a node with an Intel CPU and likely fail migration. To avoid this, label nodes with a vendor-specific label, such as `Vendor=Intel` or `Vendor=AMD`, and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
+* If your cluster uses worker nodes with different CPUs, live migration failures can occur because different CPUs have different capacities. To avoid such failures, use CPUs with appropriate capacity for each node and set node affinity on your virtual machines to ensure successful migration. See xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity[Configuring a required node affinity rule] for more information.
 
 * All CPUs must be supported by Red Hat Enterprise Linux 8 and meet the following requirements:
 


### PR DESCRIPTION
This PR addresses Bug 1986962 (https://bugzilla.redhat.com/show_bug.cgi?id=1986962) mirrored in JIRA story CNV-13237 (https://issues.redhat.com/browse/CNV-13237)

The bug is about modifying the CPU requirements for worker node VMs to not mention specific vendors, making them more agnostic in the process

CP: 4.9, 4.10

Preview: Bullet starting with "If your cluster uses worker nodes with different CPUs" in https://deploy-preview-37582--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt