### PR TITLE
OSDOCS-2387 MCO supports upgrades-in-place for single-node OpenShift

### DIFF
--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -7,4 +7,4 @@
 
 An installation of {product-title} on a single node is a specialized installation. The primary use case is for edge computing workloads, including small physical footprints, intermittent connectivity, portable clouds, and 5G radio access networks (RAN) close to a base station. An installation on a single node supports autonomous workloads.
 
-The major trade off with an installation on a single node is the lack of high availability. Currently, Red Hat does not support upgrading {product-title} when installed on a single node. Upgrades and some configuration changes require re-installation.
+The major trade off with an installation on a single node is the lack of high availability.

--- a/modules/updating-sno.adoc
+++ b/modules/updating-sno.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-cli.adoc
+// * updating/updating-cluster.adoc
+
+[id="update-single-node-openshift_{context}"]
+= About updating single node {product-title}
+
+You can update, or upgrade, a single-node {product-title} cluster by using either the console or CLI. 
+
+However, note the following limitations: 
+
+* The prerequisite to pause the `MachineHealthCheck` resources is not required because there is no other node to perform the health check.
+
+* Restoring a single-node {product-title} cluster using an etcd backup is not officially supported. However, it is good practice to perform the etcd backup in case your upgrade fails. If your control plane is healthy, you might be able to restore your cluster to a previous state by using the backup.  
+
+* Updating a single-node {product-title} cluster requires downtime and can include an automatic reboot. The amount of downtime depends on the update payload, as described in the following scenarios: 
+
+** If the update payload contains an operating system update, which requires a reboot, the downtime is significant and impacts cluster management and user workloads. 
+
+** If the update contains machine configuration changes that do not require a reboot, the downtime is less, and the impact on the cluster management and user workloads is lessened. In this case, the node draining step is skipped with single-node {product-title} because there is no other node in the cluster to reschedule the workloads to.
+ 
+** If the update payload does not contain an operating system update or machine configuration changes, a short API outage occurs and resolves quickly. 
+
+[IMPORTANT]
+====
+There are conditions, such as bugs in an updated package, that can cause the single node to not restart after a reboot. In this case, the update does not rollback automatically. 
+====

--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -56,6 +56,12 @@ If you want to use the canary rollout update process, see xref:../updating/updat
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 
+include::modules/updating-sno.adoc[leveloffset=+1]
+
+.Additional resources
+
+* For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.html#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+
 include::modules/update-upgrading-web.adoc[leveloffset=+1]
 
 include::modules/update-changing-update-server-web.adoc[leveloffset=+1]

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -38,6 +38,11 @@ include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 
+include::modules/updating-sno.adoc[leveloffset=+1]
+
+.Additional resources
+
+For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.html#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
 include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 
 include::modules/update-changing-update-server-cli.adoc[leveloffset=+1]

--- a/updating/updating-cluster.adoc
+++ b/updating/updating-cluster.adoc
@@ -30,6 +30,12 @@ include::modules/update-service-overview.adoc[leveloffset=+1]
 
 include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
+include::modules/updating-sno.adoc[leveloffset=+1]
+
+.Additional resources
+
+For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.html#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+
 include::modules/update-changing-update-server-web.adoc[leveloffset=+1]
 
 include::modules/update-upgrading-web.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/37239

Previews: 
* New module in the _Between minor versions_ assembly: https://deploy-preview-37584--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-between-minor.html#updating-single-node-openshift-container-platform
* New module in the _Within minor versions_ console assembly: https://deploy-preview-37584--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster.html#updating-single-node-openshift-container-platform
* New module in the _Within minor versions_ CLI assembly: https://deploy-preview-37584--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#updating-single-node-openshift-container-platform