### PR TITLE
OSDOCS-2711 Information on project volume permission issues for Windows pods

### DIFF
--- a/modules/nodes-containers-projected-volumes-about.adoc
+++ b/modules/nodes-containers-projected-volumes-about.adoc
@@ -178,4 +178,34 @@ Consider the following situations related to the volume file paths.
 (this is true for resources that are updated after pod creation as well).
 
 *Collisions when One Path is Explicit and the Other is Automatically Projected*:: In the event that there is a collision due to a user specified path matching data that is automatically projected,
-the latter resource will overwrite anything preceding it as before
+the latter resource will overwrite anything preceding it as before.
+
+[id="file-permission-handling-for-windows-pods_{context}"]
+== File permission handling for Windows pods
+
+When the `RunAsUser` permission is set in the security context of a Linux-based pod, the projected files have the correct permissions set, including container user ownership. However, this is not the case for Windows pods. When the Windows equivalent `RunAsUsername` permission is set, the kubelet is prevented from setting correct ownership on the files in the projected volume. This is due to differences in the way user accounts are managed in Windows. Windows stores and manages local user and group accounts in a database file called Security Account Manager (SAM). This database is not shared between the Windows container host and the running containers.
+
+[NOTE]
+====
+{product-title} applies the `RunAsUser` security context to all pods irrespective of its operating system. This means Windows pods automatically have the `RunAsUser` permission applied to its security context.
+====
+
+This problem can get exacerbated when used in conjunction with a hostPath volume where best practices are not followed. For example, giving a pod access to the `C:\var\lib\kubelet\pods\` folder results in that pod being able to access service account tokens from other pods.
+
+By default, the projected files will have the following ownership, as shown for an example Windows projected volume file:
+
+[source,posh]
+----
+Path   : Microsoft.PowerShell.Core\FileSystem::C:\var\run\secrets\kubernetes.io\serviceaccount\..2021_08_31_22_22_18.318230061\ca.crt
+Owner  : BUILTIN\Administrators
+Group  : NT AUTHORITY\SYSTEM
+Access : NT AUTHORITY\SYSTEM Allow  FullControl
+         BUILTIN\Administrators Allow  FullControl
+         BUILTIN\Users Allow  ReadAndExecute, Synchronize
+Audit  :
+Sddl   : O:BAG:SYD:AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)
+----
+
+This indicates all administrator users, like someone with the `ContainerAdministrator` role, have read, write, and execute access, while non-administrator users have read and execute access.
+
+Creating a Windows pod with the `RunAsUser` and `RunAsUsername` permissions in its security context with a projected volume results in the pod being stuck in the `ContainerCreating` phase. To handle this scenario, {product-title} forces the file permission handling in projected service account volumes set in the security context of the pod to not be honored for projected volumes on Windows. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971745[BZ#1971745]). Note that this behavior for Windows pods is how file permission handling used to work for all pod types prior to {product-title} 4.7.

--- a/nodes/containers/nodes-containers-projected-volumes.adoc
+++ b/nodes/containers/nodes-containers-projected-volumes.adoc
@@ -32,6 +32,8 @@ All sources are required to be in the same namespace as the pod.
 
 include::modules/nodes-containers-projected-volumes-about.adoc[leveloffset=+1]
 
+.Additional resources
+
+* For best practices on using hostPath volumes, see xref:../../storage/persistent_storage/persistent-storage-hostpath.adoc#persistent-storage-using-hostpath[Persistent storage using hostPath].
+
 include::modules/nodes-containers-projected-volumes-creating.adoc[leveloffset=+1]
-
-


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2711

Preview: https://deploy-preview-37587--osdocs.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-projected-volumes.html#file-permission-handling-for-windows-pods_nodes-containers-projected-volumes