### PR TITLE
[virt] Fixing VM yaml examples

### DIFF
--- a/modules/virt-booting-vms-efi-mode.adoc
+++ b/modules/virt-booting-vms-efi-mode.adoc
@@ -18,28 +18,33 @@ You can configure a virtual machine to boot in EFI mode by editing the VM manife
 .Booting in EFI mode with secure boot active
 [source,yaml]
 ----
-  apiversion: kubevirt.io/v1
-  kind: VirtualMachine
-  metadata:
-    labels:
-      special: vm-secureboot
-    name: vm-secureboot
-  spec:
-    domain:
-      devices:
-        disks:
-        - disk:
-            bus: virtio
-          name: containerdisk
-      features:
-        acpi: {}
-        smm:
-          enabled: true <1>
-      firmware:
-        bootloader:
-          efi:
-            secureBoot: true <2>
-...
+apiversion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    special: vm-secureboot
+  name: vm-secureboot
+spec:
+  template:
+    metadata:
+      labels:
+        special: vm-secureboot
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+        features:
+          acpi: {}
+          smm:
+            enabled: true <1>
+        firmware:
+          bootloader:
+            efi:
+              secureBoot: true <2>
+#...
 ----
 <1> {VirtProductName} requires System Management Mode (`SMM`) to be enabled for Secure Boot in EFI mode to occur.
 <2> {VirtProductName} supports a VM with or without Secure Boot when using EFI mode. If Secure Boot is enabled, then EFI mode is required. However, EFI mode can be enabled without using Secure Boot.

--- a/modules/virt-schedule-cpu-host-model-vms.adoc
+++ b/modules/virt-schedule-cpu-host-model-vms.adoc
@@ -18,8 +18,10 @@ kind: VirtualMachine
 metadata:
   name: myvm
 spec:
-  domain:
-    cpu:
-      model: host-model <1>
+  template:
+    spec:
+      domain:
+        cpu:
+          model: host-model <1>
 ----
 <1> The VM that inherits the CPU model of the node where it is scheduled.

--- a/modules/virt-schedule-supported-cpu-model-vms.adoc
+++ b/modules/virt-schedule-supported-cpu-model-vms.adoc
@@ -18,8 +18,10 @@ kind: VirtualMachine
 metadata:
   name: myvm
 spec:
-  domain:
-    cpu:
-      model: Conroe <1>
+  template:
+    spec:
+      domain:
+        cpu:
+          model: Conroe <1>
 ----
 <1> CPU model for the VM.

--- a/modules/virt-setting-policy-attributes.adoc
+++ b/modules/virt-setting-policy-attributes.adoc
@@ -18,11 +18,13 @@ kind: VirtualMachine
 metadata:
   name: myvm
 spec:
-  domain:
-    cpu:
-      features:
-      - name: apic <1>
-        policy: require <2>
+  template:
+    spec:
+      domain:
+        cpu:
+          features:
+            - name: apic <1>
+              policy: require <2>
 ----
 <1> Name of the CPU feature for the VM.
 <2> Policy attribute for the VM.

--- a/modules/virt-template-vm-probe-config.adoc
+++ b/modules/virt-template-vm-probe-config.adoc
@@ -14,39 +14,44 @@ metadata:
     special: vm-fedora
   name: vm-fedora
 spec:
-  domain:
-    devices:
-      disks:
-      - disk:
-          bus: virtio
-        name: containerdisk
-      - disk:
-          bus: virtio
+  template:
+    metadata:
+      labels:
+        special: vm-fedora
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 1024M
+      readinessProbe:
+        httpGet:
+          port: 1500
+        initialDelaySeconds: 120
+        periodSeconds: 20
+        timeoutSeconds: 10
+        failureThreshold: 3
+        successThreshold: 3
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: kubevirt/fedora-cloud-registry-disk-demo
+      - cloudInitNoCloud:
+          userData: |-
+            #cloud-config
+            password: fedora
+            chpasswd: { expire: False }
+            bootcmd:
+              - setenforce 0
+              - dnf install -y nmap-ncat
+              - systemd-run --unit=httpserver nc -klp 1500 -e '/usr/bin/echo -e HTTP/1.1 200 OK\\n\\nHello World!'
         name: cloudinitdisk
-    resources:
-      requests:
-        memory: 1024M
-  readinessProbe:
-    httpGet:
-      port: 1500
-    initialDelaySeconds: 120
-    periodSeconds: 20
-    timeoutSeconds: 10
-    failureThreshold: 3
-    successThreshold: 3
-  terminationGracePeriodSeconds: 0
-  volumes:
-  - name: containerdisk
-    containerDisk:
-      image: kubevirt/fedora-cloud-registry-disk-demo
-  - cloudInitNoCloud:
-      userData: |-
-        #cloud-config
-        password: fedora
-        chpasswd: { expire: False }
-        bootcmd:
-          - setenforce 0
-          - dnf install -y nmap-ncat
-          - systemd-run --unit=httpserver nc -klp 1500 -e '/usr/bin/echo -e HTTP/1.1 200 OK\\n\\nHello World!'
-    name: cloudinitdisk
 ----

--- a/modules/virt-template-vm-pxe-config.adoc
+++ b/modules/virt-template-vm-pxe-config.adoc
@@ -15,43 +15,48 @@ metadata:
     special: vm-pxe-boot
   name: vm-pxe-boot
 spec:
-  domain:
-    devices:
-      disks:
-      - disk:
-          bus: virtio
-        name: containerdisk
-        bootOrder: 2
-      - disk:
-          bus: virtio
-        name: cloudinitdisk
-      interfaces:
-      - masquerade: {}
-        name: default
-      - bridge: {}
+  template:
+    metadata:
+      labels:
+        special: vm-pxe-boot
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+            bootOrder: 2
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+          interfaces:
+          - masquerade: {}
+            name: default
+          - bridge: {}
+            name: pxe-net
+            macAddress: de:00:00:00:00:de
+            bootOrder: 1
+        machine:
+          type: ""
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: default
+        pod: {}
+      - multus:
+          networkName: pxe-net-conf
         name: pxe-net
-        macAddress: de:00:00:00:00:de
-        bootOrder: 1
-    machine:
-      type: ""
-    resources:
-      requests:
-        memory: 1024M
-  networks:
-  - name: default
-    pod: {}
-  - multus:
-      networkName: pxe-net-conf
-    name: pxe-net
-  terminationGracePeriodSeconds: 0
-  volumes:
-  - name: containerdisk
-    containerDisk:
-      image: kubevirt/fedora-cloud-container-disk-demo
-  - cloudInitNoCloud:
-      userData: |
-        #!/bin/bash
-        echo "fedora" | passwd fedora --stdin
-    name: cloudinitdisk
-status: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: containerdisk
+        containerDisk:
+          image: kubevirt/fedora-cloud-container-disk-demo
+      - cloudInitNoCloud:
+          userData: |
+            #!/bin/bash
+            echo "fedora" | passwd fedora --stdin
+        name: cloudinitdisk
+    status: {}
 ----

--- a/modules/virt-template-windows-vm.adoc
+++ b/modules/virt-template-windows-vm.adoc
@@ -14,49 +14,54 @@ metadata:
     special: vm-windows
   name: vm-windows
 spec:
-  domain:
-    clock:
-      timer:
-        hpet:
-          present: false
-        hyperv: {}
-        pit:
-          tickPolicy: delay
-        rtc:
-          tickPolicy: catchup
-      utc: {}
-    cpu:
-      cores: 2
-    devices:
-      disks:
-      - disk:
-          bus: sata
-        name: pvcdisk
-      interfaces:
-      - masquerade: {}
-        model: e1000
-        name: default
-    features:
-      acpi: {}
-      apic: {}
-      hyperv:
-        relaxed: {}
-        spinlocks:
-          spinlocks: 8191
-        vapic: {}
-    firmware:
-      uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
-    machine:
-      type: q35
-    resources:
-      requests:
-        memory: 2Gi
-  networks:
-  - name: default
-    pod: {}
-  terminationGracePeriodSeconds: 0
-  volumes:
-  - name: pvcdisk
-    persistentVolumeClaim:
-      claimName: disk-windows
+  template:
+    metadata:
+      labels:
+        special: vm-windows
+    spec:
+      domain:
+        clock:
+          timer:
+            hpet:
+              present: false
+            hyperv: {}
+            pit:
+              tickPolicy: delay
+            rtc:
+              tickPolicy: catchup
+          utc: {}
+        cpu:
+          cores: 2
+        devices:
+          disks:
+          - disk:
+              bus: sata
+            name: pvcdisk
+          interfaces:
+          - masquerade: {}
+            model: e1000
+            name: default
+        features:
+          acpi: {}
+          apic: {}
+          hyperv:
+            relaxed: {}
+            spinlocks:
+              spinlocks: 8191
+            vapic: {}
+        firmware:
+          uuid: 5d307ca9-b3ef-428c-8861-06e72d69f223
+        machine:
+          type: q35
+        resources:
+          requests:
+            memory: 2Gi
+      networks:
+      - name: default
+        pod: {}
+      terminationGracePeriodSeconds: 0
+      volumes:
+      - name: pvcdisk
+        persistentVolumeClaim:
+          claimName: disk-windows
 ----


### PR DESCRIPTION
- enterprise-4.9 and 4.10
- fixing examples after @stu-gott raised an issue with me directly (no bug/jira)
- fixes errors introduced in https://github.com/openshift/openshift-docs/pull/37086/files
- [preview build example](https://deploy-preview-37591--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-template-windows-vm_virt-using-the-default-pod-network-with-virt)
- approved by Ruth Netser and Israel Pinto via email