### PR TITLE
4.9 RNs near-GA cleanup

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -13,7 +13,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update k8s link once there is a version-specific URL for the Kubernetes release
-{product-title} (link:https://access.redhat.com/errata/RHSA-2021:2438[RHSA-2021:2438]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md[Kubernetes 1.22] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2021:3759[RHSA-2021:3759]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md[Kubernetes 1.22] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 //Red Hat did not publicly release {product-title} 4.9.0 as the GA version and, instead, is releasing {product-title} 4.9.TBD as the GA version.
 
@@ -28,13 +28,13 @@ You must use {op-system} machines for the control plane, and you can use either 
 //{product-title} 4.6 is an Extended Update Support (EUS) release. More information on Red Hat OpenShift EUS is available in link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[OpenShift Life Cycle] and link:https://access.redhat.com/support/policy/updates/openshift-eus[OpenShift EUS Overview].
 
 //TODO: The line below is not true for 4.9 but should be used when it is next appropriate. Revisit in October 2022 timeframe.
-//With the release of {product-title} 4.9, version 4.6 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+//With the release of {product-title} 4.9, version 4.6 is now end of life. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 
 [id="ocp-4-9-add-on-support-status"]
-== {product-title} layered and dependant component support and compatibility
+== {product-title} layered and dependent component support and compatibility
 
-The scope of support for layered and dependant components of {product-title} changes independently of the {product-title} version. To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+The scope of support for layered and dependent components of {product-title} changes independently of the {product-title} version. To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 [id="ocp-4-9-new-features-and-enhancements"]
 == New features and enhancements
@@ -68,7 +68,7 @@ During the upgrade process, nodes in the cluster might become temporarily unavai
 
 For more information, see xref:../updating/updating-cluster-cli.adoc#machine-health-checks-pausing_updating-cluster-cli[Pausing a MachineHealthCheck resource].
 
-[id=ocp-4.9-azure-cidr]
+[id=ocp-4-9-azure-cidr]
 ==== Increased size of Azure subnets within the machine CIDR
 The {product-title} installation program for Microsoft Azure now creates subnets as large as possible within the machine CIDR. This lets the cluster use a machine CIDR that is appropriately sized to accommodate the number of nodes in the cluster.
 
@@ -544,9 +544,6 @@ For more information, see xref:../storage/persistent_storage/persistent-storage-
 
 {product-title} 4.9 adds resizing capability to the oVirt CSI Driver, which allows users to increase the size of their existing persistent volume claims (PVCs). Prior to this feature, users had to create new PVCs with the increased size, and move all of the content from the old persistent volume (PV) to the new PV, which could result in data loss. Now, users can edit the existing PVC and the oVirt CSI Driver will resize the underlying oVirt disk.
 
-[id="ocp-4-9-registry"]
-=== Registry
-
 [id="ocp-4-9-olm"]
 === Operator lifecycle
 
@@ -843,20 +840,13 @@ edge sites with declarative configurations of bare metal equipment at remote sit
 ZTP uses the GitOps deployment set of practices for infrastructure deployment. GitOps achieves
 these tasks using declarative specifications stored in Git repositories, such as YAML files and other defined patterns, to provide a framework for deploying the infrastructure. The declarative output is leveraged by the Open Cluster Manager (OCM) for multisite deployment. For more information, see xref:../scalability_and_performance/ztp-deploying-disconnected.html#provisioning-edge-sites-at-scale_ztp-deploying-disconnected[Provisioning edge sites at scale].
 
-
-[id="ocp-4-9-backup-and-restore"]
-=== Backup and restore
-
-[id="ocp-4-9-dev-exp"]
-=== Developer experience
-
 [id="ocp-4-9-insights-operator"]
 === Insights Operator
 
 [id="ocp-4-9-insights-operator-sca"]
-==== Importing RHEL Simple Content Access certificates (Technology Preview)
+==== Importing {op-system-base} Simple Content Access certificates (Technology Preview)
 
-In {product-title} 4.9, Insights Operator can import RHEL Simple Content Access (SCA) certificates from {cloud-redhat-com}.
+In {product-title} 4.9, Insights Operator can import {op-system-base} Simple Content Access (SCA) certificates from {cloud-redhat-com}.
 
 For more information, see xref:../support/remote_health_monitoring/insights-operator-simple-access.adoc[_Importing RHEL Simple Content Access certificates with Insights Operator_].
 
@@ -882,13 +872,10 @@ With this release, installations on Microsoft Azure Stack Hub can be performed b
 
 For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc[Using manual mode].
 
-[id="ocp-4-9-sandboxed-containers"]
-=== {sandboxed-containers-first}
-
 [id="ocp-4-9-notable-technical-changes"]
 == Notable technical changes
 
-{product-title} 4.9 introduces the following notable technical changes.
+{product-title} {product-version} introduces the following notable technical changes.
 
 // Note: use [discrete] for these sub-headings.
 
@@ -1050,7 +1037,7 @@ In the table, features are marked with the following statuses:
 |DEP
 |DEP
 
-|Bring your own RHEL 7 compute machines
+|Bring your own {op-system-base} 7 compute machines
 |DEP
 |DEP
 |DEP
@@ -1092,9 +1079,9 @@ The default xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs
 
 [id="ocp-4-9-vsphere-and-virtual-hardware-version-deprecations"]
 ==== vSphere 6.7 Update 2 and earlier cluster installation and virtual hardware version 13 are now deprecated
-Installing a cluster on VMware vSphere version 6.7 Update 2 or earlier and virtual hardware version 13 is now deprecated. Support for these versions will end in a future version of {product-title}. 
+Installing a cluster on VMware vSphere version 6.7 Update 2 or earlier and virtual hardware version 13 is now deprecated. Support for these versions will end in a future version of {product-title}.
 
-Hardware version 15 is now the default for vSphere virtual machines in {product-title}. Hardware version 15 will be the only supported version in a future version of {product-title}. 
+Hardware version 15 is now the default for vSphere virtual machines in {product-title}. Hardware version 15 will be the only supported version in a future version of {product-title}.
 
 [id="ocp-4-9-removed-features"]
 === Removed features
@@ -1214,7 +1201,7 @@ The deprecated `v1beta1` API for the descheduler has been removed in {product-ti
 The deprecated `dhclient` binary has been removed from {op-system}. Starting with {product-title} 4.6, {op-system} switched to using `NetworkManager` in the `initramfs` to configure networking during early boot. Use the `NetworkManager` internal DHCP client for networking configuration instead. See link:https://bugzilla.redhat.com/show_bug.cgi?id=1908462[*BZ#1908462*] for more information.
 
 [id="ocp-4-9-builds-lasttriggeredimageid-parameter"]
-==== Cease updating the `lastTriggeredImageID` field and ignore it
+==== Cease updating the lastTriggeredImageID field and ignore it
 
 The current release stops updating the `buildConfig.spec.triggers[i].imageChange.lastTriggeredImageID` field when the `ImageStreamTag` referenced by `buildConfig.spec.triggers[i].imageChage` points to a new image. Instead, this release updates the `buildConfig.status.imageChangeTriggers[i].lastTriggeredImageID` field.
 
@@ -1241,10 +1228,6 @@ Support for using `v1` without a group for `apiVersion` for {product-title} reso
 
 * Previously, the CA for API server client certificates was rotated early in the lifetime of a cluster, which prevented the Authentication Operator from creating a certificate signing request (CSR) because a previous CSR with the same name still existed. The Kubernetes API server was unable to authenticate itself to the OAuth API server when sending `TokenReview` requests, which caused authentication to fail. Generated names are now used when creating CSRs by the Authentication Operator, so an early rotation of the CA for API server client certificates no longer causes authentication failures.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1978193[*BZ#1978193*])
-
-[discrete]
-[id="ocp-4-9-assisted-installer-bug-fixes"]
-==== Assisted installer
 
 [discrete]
 [id="ocp-4-9-bare-metal-hardware-bug-fixes"]
@@ -1274,11 +1257,9 @@ Support for using `v1` without a group for `apiVersion` for {product-title} reso
 
 * In {product-title} and later, the fix for bug link:https://bugzilla.redhat.com/show_bug.cgi?id=1884270[BZ#1884270] incorrectly pruned SSH protocol URLs in an attempt to provide SCP-styled URL capabilities. This error caused the `oc new-build` command not to pick an automatic source clone secret: the build could not use the `build.openshift.io/sbuild.openshift.io/source-secret-match-uri-1ource-secret-match-uri-1` annotation to map SSH keys with the associated secrets, and therefore could not perform git cloning. This update reverts the changes from BZ#1884270 so that builds can use the annotation and perform git cloning.
 
-* Before this update, various allowed and block registry configuration options of the cluster image configuration could block the Cluster Samples Operator from creating image streams. When that happened, the samples operator marked itself as `degraded`, which impacted the general OpenShift Container Platform install and upgrade status.
+* Before this update, various allowed and block registry configuration options of the cluster image configuration could block the Cluster Samples Operator from creating image streams. When that happened, the samples operator marked itself as `degraded`, which impacted the general {product-title} install and upgrade status.
 +
 The Cluster Samples Operator can bootstrap itself as `removed` in a variety of circumstances. With this update, these circumstances include when the xref:../openshift_images/image-configuration.html#images-configuration-parameters_image-configuration[image controller configuration parameters] prevent the creation of image streams by using the default image registry or by using the image registry specified by the xref:../openshift_images/configuring-samples-operator.html#samples-operator-configuration_configuring-samples-operator[`samplesRegistry` setting]. The Operator status also indicates when the cluster image configuration prevents the creation of the sample image streams.
-
-
 
 [discrete]
 [id="ocp-4-9-cloud-compute-bug-fixes"]
@@ -1315,10 +1296,6 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986540[*BZ#1986540*])
 
 [discrete]
-[id="ocp-4-9-cloud-credential-operator-bug-fixes"]
-==== Cloud Credential Operator
-
-[discrete]
 [id="ocp-4-9-cluster-version-operator-bug-fixes"]
 ==== Cluster Version Operator
 
@@ -1332,22 +1309,10 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004568[*BZ#2004568*])
 
 [discrete]
-[id="ocp-4-9-compliance-operator-bug-fixes"]
-==== Compliance Operator
-
-[discrete]
 [id="ocp-4-9-console-storage-bug-fixes"]
 ==== Console Storage Plug-in
 
 * Previously, when working with Ceph storage, the Console Storage Plug-in unnecessarily included a redundant use of a namespace parameter. This bug had no customer-visible impact; however, the plug-in has been updated to avoid the redundant use of the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1982682[*BZ#1982682*])
-
-[discrete]
-[id="ocp-4-9-dns-bug-fixes"]
-==== DNS
-
-[discrete]
-[id="ocp-4-9-etcd-bug-fixes"]
-==== etcd
 
 [discrete]
 [id="ocp-4-9-image-registry-bug-fixes"]
@@ -1358,14 +1323,6 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 
 * The `spec.managementState` in `configs.imageregistry` is set to `Removed`, which caused the image pruner pod to generate warnings about deprecated CronJob in `v1.21` and later, and that `batch/v1` should be used. This fix updates `batch/v1beta1` with `batch/v1` in {product-title} `oc`. Now, warnings about the deprecated CronJob in image pruner pods no longer appear.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1976112[*BZ#1976112*])
-
-[discrete]
-[id="ocp-4-9-image-streams-bug-fixes"]
-==== Image Streams
-
-[discrete]
-[id="ocp-4-9-insights-operator-bug-fixes"]
-==== Insights Operator
 
 [discrete]
 [id="ocp-4-9-installer-bug-fixes"]
@@ -1401,14 +1358,6 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971624[*BZ#1971624*])
 
 [discrete]
-[id="ocp-4-9-machine-config-operator-bug-fixes"]
-==== Machine Config Operator
-
-[discrete]
-[id="ocp-4-9-monitoring-bug-fixes"]
-==== Monitoring
-
-[discrete]
 [id="ocp-4-9-networking-bug-fixes"]
 ==== Networking
 
@@ -1422,7 +1371,7 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 
 * Previously, `ovnkube-trace` required iproute to be installed in the source and/or destination pod because it needed to detect the interfaces `link` index. This causes `ovnkube-trace` to fail on pods if there is no iproute installed. Now, you can get the `link` index from `/sys/class/net/<interface>/iflink` instead of iproute. As a result, `ovnkube-trace` no longer requires iproute to be installed in source and destination pods. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1978137[*BZ#1978137*])
 
-* Previously, the Cluster Network Operator (CNO) deployed a service monitor for the `network-check-source` service to get discovered by Prometheus without correct annotations and role-based access control (RBAC). As a result, the service and its metrics never populated in Prometheus. Now, the correct annotations and RBAC are added to the namespace of `network-check-source` service. Now, metrics of service `network-check-source` get scraped by Prometheus.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1986061[*BZ#1986061*])
+* Previously, the Cluster Network Operator (CNO) deployed a service monitor for the `network-check-source` service to get discovered by Prometheus without correct annotations and role-based access control (RBAC). As a result, the service and its metrics never populated in Prometheus. Now, the correct annotations and RBAC are added to the namespace of `network-check-source` service. Now, metrics of service `network-check-source` get scraped by Prometheus. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986061[*BZ#1986061*])
 
 * Previously, when using IPv6 DHCP, node interface addresses might be leased with a `/128` prefix. Consequently, OVN-Kubernetes uses the same prefix to infer the node's network and routes any other address traffic, including traffic to other cluster nodes, through the gateway. With this update, OVN-Kubernetes inspects the node's routing table and checks for the wider routing entry for the node's interface address and uses that prefix to infer the node's network. As a result, traffic to other cluster nodes is no longer routed through the gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1980135[*BZ#1980135*])
 
@@ -1443,10 +1392,6 @@ The Cluster Samples Operator can bootstrap itself as `removed` in a variety of c
 
 * Previously, a bug in CRI-O caused CRI-O to leak a child PID of a process it created. As a result, if under load, systemd could create a significant number of zombie processes. This could lead to node failure if the node ran out of PIDs. CRI-O was fixed to prevent the leakage. As a result, these zombie processes are no longer being created.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2003197[*BZ#2003197*])
-
-[discrete]
-[id="ocp-4-9-oauth-api-server-bug-fixes"]
-==== OAuth API server
 
 [discrete]
 [id="ocp-4-9-openshift-cli-bug-fixes"]
@@ -1521,10 +1466,6 @@ conditions:
 * Previously, the z-stream version of a cluster was used in Operator compatibility calculations. As a result, micro releases of {product-title} were blocked. This update fixes the issue by ignoring cluster z-stream versions in Operator compatibility comparisons. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1993286[*BZ#1993286*])
 
 [discrete]
-[id="ocp-4-9-operator-sdk-bug-fixes"]
-==== Operator SDK
-
-[discrete]
 [id="ocp-4-9-openshift-api-server-bug-fixes"]
 ==== OpenShift API server
 
@@ -1538,16 +1479,12 @@ conditions:
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1939788[*BZ#1939788*])
 
 [discrete]
-[id="ocp-4-9-performance-addon-operator-bug-fixes"]
-==== Performance Addon Operator
-
-[discrete]
 [id="ocp-4-9-rhcos-bug-fixes"]
 ==== {op-system-first}
 
 * Previously, systemd was unable to read environment files in `/etc/kubernetes`. The SELinux policy caused this and as a result, the kubelet did not start. The policy has been modified. The kubelet starts and the environment files are read. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1969998[*BZ#1969998*])
 
-* In an s390x Kernel Virtual Machine (KVM) with an ECKD DASD attached, the DASD would appear to be a regular virtio storage device but would become inaccessible if the VTOC was removed. As a result, you could not use DASD as a virtio block device when installing {op-system-first} on the KVM. The `coreos-installer` program has been updated so that it now installs RHCOS with a VTOC-format partition table when the installation destination is a virtio storage device such as an ECKD DASD attached to a KVM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960485[*BZ#1960485*])
+* In an s390x Kernel Virtual Machine (KVM) with an ECKD DASD attached, the DASD would appear to be a regular virtio storage device but would become inaccessible if the VTOC was removed. As a result, you could not use DASD as a virtio block device when installing {op-system-first} on the KVM. The `coreos-installer` program has been updated so that it now installs {op-system-first} with a VTOC-format partition table when the installation destination is a virtio storage device such as an ECKD DASD attached to a KVM. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1960485[*BZ#1960485*])
 
 * Previously, the `NetworkManager-wait-online-service` timed out too early, which prevented establishing a connection before the `coreos-installer` program could start. Consequently, if the network took too long to start, the `coreos-installer` program failed to fetch the Ignition config. With this update, the `NetworkManager-wait-online-service` timeout has been increased to its default upstream value. As a result, the `coreos-installer` program no longer fails to fetch the Ignition config. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1967483[*BZ#1967483*])
 
@@ -1564,10 +1501,6 @@ conditions:
 ==== Samples
 
 * Previously, the lack of a connection timeout led to lengthy delays. This occurred when the Cluster Samples Operator, with `managementState` set to `Removed`, tested the connection to `registry.redhat.io`. With the addition of a connection timeout, the delay is eliminated. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990140[*BZ#1990140*])
-
-[discrete]
-[id="ocp-4-9-service-ca-bug-fixes"]
-==== Service CA
 
 [discrete]
 [id="ocp-4-9-storage-bug-fixes"]
@@ -1975,7 +1908,7 @@ Alternatively, you can annotate the route to force a reload. (link:https://bugzi
 
 * Installations on {rh-openstack-first} with Kuryr will not work if configured with a cluster-wide proxy when the cluster-wide proxy is required to access {rh-openstack} APIs. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1985486[*BZ#1985486*])
 
-* Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*].
+* Due to a race condition, the {rh-openstack-first} cloud provider might not start properly. Consequently, LoadBalancer services might never get an `EXTERNAL-IP` set. As a temporary workaround, you can restart the kube-controller-manager pods using the procedure described in (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004542[*BZ#2004542*]).
 
 * The SR-IOV network configuration daemon pod will cordon the node and mark it as unschedulable. It will use the add or delete `SriovNetworkNodePolicy` custom resource (CR) before waiting for the `syncStatus` of the CR to change to `Succeeded`. As a temporary workaround, before adding or deleting a `SriovNetworkNodePolicy` CR, make sure the `syncStatus` of the `SriovNetworkNodeState` CRs is in the `Succeeded` state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002508[*BZ#2002508*])
 
@@ -1993,7 +1926,7 @@ $ oc -n openshift-ingress rsh router-default-6647d984d8-q7b58
 sh-4.4$ bash -x /var/lib/haproxy/reload-haproxy
 ----
 +
-Alternatively, you can annotate the route to force a reload.(link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
+Alternatively, you can annotate the route to force a reload. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990020[*BZ#1990020*])
 
 * This release contains a known issue. If you customize the hostname and certificate of the OpenShift OAuth route, Jenkins no longer trusts the OAuth server endpoint. As a result, users cannot log in to the Jenkins console if they rely on the OpenShift OAuth integration to manage identity and access. A workaround is not available at this time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1991448[*BZ#1991448*])
 
@@ -2038,7 +1971,7 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 * Operators must list any related images for Operator Lifecycle Manager (OLM) to run from a local source. Presently, if the `relatedImages` parameter of the `ClusterServiceVersion` (CSV) object is not defined, `opm render` does not populate the related images. This is planned to be fixed in a later release.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2000379[*BZ#2000379*])
 
-* Previously, Open vSwitch (OVS) ran in a container on each OpenShift Container Platform cluster node and the node exporter agent collected OVS CPU and memory metrics from the nodes. Now, OVS runs on the cluster nodes as systemd units and the metrics are not collected. This is planned to be fixed in a later release. OVS packet metrics are still collected.
+* Previously, Open vSwitch (OVS) ran in a container on each {product-title} cluster node and the node exporter agent collected OVS CPU and memory metrics from the nodes. Now, OVS runs on the cluster nodes as systemd units and the metrics are not collected. This is planned to be fixed in a later release. OVS packet metrics are still collected.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2002868[*BZ#2002868*])
 
 * The flag that is used to hide or show the *Storage* -> *Overview* page in the {product-title} web console is misconfigured. As a result, the overview page is not visible after deploying a cluster that includes OpenShift Cluster Storage. This is planned to be fixed in a later release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013132[*BZ#2013132*])
@@ -2046,7 +1979,7 @@ As a workaround, cluster administrators can delete the `catalog-operator` pod in
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
-Security, bug fix, and enhancement updates for {product-title} 4.9 are released as asynchronous errata through the Red Hat Network. All {product-title} 4.9 errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+Security, bug fix, and enhancement updates for {product-title} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
 
 Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
 
@@ -2055,7 +1988,7 @@ Red Hat Customer Portal users can enable errata notifications in the account set
 Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
-This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} 4.9. Versioned asynchronous releases, for example with the form {product-title} 4.9.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Several little changes to clean this up for GA.

- [Advisory number update](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-about-this-release) (external link won't work until GA)
- Replaced several written out product names and instances of `4.9` with attributes (throughout file)
- [Changed `dependant` to `dependent`](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-add-on-support-status) (the misspelling is on the page it links to, but better to be spelled correctly)
- Removed a `.` from [an ID](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-azure-cidr)
- Removed all unused section headings under [New features](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-new-features-and-enhancements) and [Bug fixes](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-bug-fixes)
- Removed formatting from a [title](https://deploy-preview-37595--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-builds-lasttriggeredimageid-parameter)
- Fixed a couple link formatting items (throughout file)