### PR TITLE
CNV-14394: Fixing Broken URL on Start Here with OpenShift Virtualization page

### DIFF
--- a/virt/virt-learn-more-about-openshift-virtualization.adoc
+++ b/virt/virt-learn-more-about-openshift-virtualization.adoc
@@ -19,7 +19,7 @@ Use the following tables to find content to help you learn about and use {VirtPr
 | xref:../virt/node_network/virt-updating-node-network-config.adoc#virt-updating-node-network-config[Updating your node network configuration]
 | xref:../virt/logging_events_monitoring/virt-collecting-virt-data.adoc#virt-collecting-virt-data[Getting Support]
 
-| xref:../welcome/learn_more_about_openshift.adoc#learn_more_about_openshift[Learn more about {product-title}]
+| link:https://access.redhat.com/documentation/en-us/openshift_container_platform/[Learn more about {product-title}]
 | xref:../virt/virtual_machines/virtual_disks/virt-features-for-storage.adoc#virt-features-for-storage[Plan storage for virtual machine disks]
 | xref:../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]
 |


### PR DESCRIPTION
For 4.8, 4.9, and 4.10.

Jira: https://issues.redhat.com/browse/CNV-14394

Tagging @ctomasko for Code Review.

Direct doc preview link: https://deploy-preview-37596--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-learn-more-about-openshift-virtualization