### PR TITLE
Update nw-networkpolicy-about.adoc

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -39,7 +39,7 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: deny-by-default
 spec:
-  podSelector:
+  podSelector: {}
   ingress: []
 ----
 
@@ -75,7 +75,7 @@ apiVersion: networking.k8s.io/v1
 metadata:
   name: allow-same-namespace
 spec:
-  podSelector:
+  podSelector: {}
   ingress:
   - from:
     - podSelector: {}


### PR DESCRIPTION
Fixes for #37011 

The file that is updated is [nw-networkpolicy-about.adoc](https://github.com/openshift/openshift-docs/blob/main/modules/nw-networkpolicy-about.adoc).
Added the {} after the podSelector: field., without these it was leading the error such as :
```
$ oc create -f ns.yaml --validate --dry-run=client
error: error validating "ns.yaml": error validating data: ValidationError(NetworkPolicy.spec.podSelector): unknown field "ingress" in io.k8s.apimachinery.pkg.apis.meta.v1.LabelSelector; if you choose to ignore these errors, turn validation off with --validate=false

```
