### PR TITLE
BZ#1982108 Missing GCP end attribute

### DIFF
--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -269,6 +269,9 @@ endif::[]
 ifeval::["{context}" == "installing-gcp-vpc"]
 :!gcp:
 endif::[]
+ifeval::["{context}" == "installing-restricted-networks-gcp-installer-provisioned"]
+:!gcp:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!user-infra:
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1982108

Preview: https://deploy-preview-37600--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-default.html#ssh-agent-using_installing-rhv-default