### PR TITLE
BZ2013929 - Corrected rekey directory

### DIFF
--- a/modules/nbde-backing-up-server-keys.adoc
+++ b/modules/nbde-backing-up-server-keys.adoc
@@ -9,4 +9,4 @@ The Tang server, by default, stores its keys in the `/usr/libexec/tangd-keygen` 
 
 .Procedure
 
-* Back up the contents of the `/usr/libexec/tangd-keygen` directory.
+* Copy the backup key from the `/var/db/tang` directory to the temp directory from which you can restore the key.

--- a/modules/nbde-recovering-server-keys.adoc
+++ b/modules/nbde-recovering-server-keys.adoc
@@ -9,6 +9,6 @@ You can recover the keys for a Tang server by accessing the keys from a backup.
 
 .Procedure
 
-* Restore the contents of the `/usr/libexec/tangd-keygen` directory from backup while the Tang server is offline.
+* Restore the key from your backup folder to the `/var/db/tang/` directory.
 +
 When the Tang server starts up, it advertises and uses these restored keys.


### PR DESCRIPTION
For OCP 4.9 

See https://bugzilla.redhat.com/show_bug.cgi?id=2013929 for additional details.

Preview: https://deploy-preview-37601--osdocs.netlify.app/openshift-enterprise/latest/security/network_bound_disk_encryption/nbde-managing-encryption-keys

Signed off by Stephen Smith stesmith@redhat.com

