### PR TITLE
[RHACS] Version 3.66 Release nodes and image tags

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -33,6 +33,8 @@ Name: Release notes
 Dir: release_notes
 Distros: openshift-acs
 Topics:
+- Name: Red Hat Advanced Cluster Security for Kubernetes 3.66
+  File: 366-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.65
   File: 365-release-notes
 - Name: Red Hat Advanced Cluster Security for Kubernetes 3.64

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -40,10 +40,10 @@ endif::[]
 :mtc-version: 1.4
 :mtc-version-z: 1.4.2
 :ocp: OpenShift Container Platform
-:rhacs-version: 3.65.1
+:rhacs-version: 3.66.0
 :ocp-supported-version: 4.5
-:scanner-version: 2.19.1
-:collector-version: 3.3.1-latest
+:scanner-version: 2.20.0
+:collector-version: 3.4.1-latest
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty
 // Following variables are used in modules/adding-comments.adoc and modules/adding-tags.adoc
@@ -53,4 +53,4 @@ endif::[]
 :capspluralporv: Processes
 // Following variables are required for publishing using PV2
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
-:product-version: 3.65
+:product-version: 3.66

--- a/release_notes/366-release-notes.adoc
+++ b/release_notes/366-release-notes.adoc
@@ -1,0 +1,88 @@
+[id="366-release-notes"]
+= Red Hat Advanced Cluster Security for Kubernetes 3.66
+include::modules/common-attributes.adoc[]
+:context: 366-release-notes
+
+toc::[]
+
+{product-title} (RHACS) 3.66 includes feature enhancements, bug fixes, scale improvements, and other changes.
+
+*Release date:* October 18, 2021
+
+[id="new-features"]
+== New features
+
+[id="scan-deploymentconfig-in-your-cicd-pipeline"]
+=== Scan deployment configurations in your CI pipeline
+You can now identify misconfigurations in your {ocp} deployment configuration files by running the `roxctl deployment check` command in your CI pipeline.
+
+[id="active-component-identification"]
+=== Active component identification
+{product-title} now identifies if a component is in use by a process at runtime and then asserts that component as an active component.
+
+[id="new-configuration-settings-for-operator-and-helm-charts"]
+=== New configuration settings for Operator and Helm charts
+
+* You can now configure tolerations for Central, Scanner, ScannerDB, Sensor, and Admission Controller in {product-title} by using Helm charts and the RHACS Operator.
+
+* You can now disable the automatic administrator password generation for Central by specifying the `adminPasswordGenerationDisabled` as `true` in the RHACS Operator configuration.
+
+[id="important-bug-fixes"]
+== Important bug fixes
+
+* *ROX-7912*: Previously, {product-title} reported the CVE-2019-9893 as both fixable and not fixable. This has been fixed.
+
+* *ROX-7414* and *ROX-5180*: Previously, sometimes Central and Sensor consumed all available memory, and their pods stopped with `OOMKilled` status. The high memory consumption was because of resource-intensive evaluation of roles, bindings, and service accounts. This issue has been fixed.
+
+* *ROX-7978*: Previously, Central crashed sometimes if you sent build-time notifications by using the Syslog protocol. This has been fixed.
+
+* *ROX-8055*: Previously, the downloading of runtime probes failed in IPV6 only environments. This has been fixed.
+
+* *ROX-8093*: Previously, the {product-title} portal would sometimes show an error message under the MITRE ATT&CK section. This has been fixed.
+
+[id="important-system-changes"]
+== Important system changes
+
+* In {product-title} 3.66, Red Hat has deprecated the following default security policies:
+
+** *DockerHub NGINX 1.10*
+** *Shellshock: Multiple CVEs*
+** *Heartbleed: CVE-2014-0160*
+
+* Red Hat has deprecated the Alpine-based images of {product-title}. All images are now based on Red Hat Universal Base Image (UBI).
+
+* The admission controller settings for the RHACS Operator now listen to both `update` and `create` events by default.
+
+* You can no longer delete the default security policies on fresh installations of {product-title} 3.65 or newer. However, if you upgrade from an older version to 3.65 or newer, you can still delete the default security policies.
+
+* In {product-title} 3.66:
+
+** the *Analyst* permission set and role does not contain the `DebugLogs` permission.
+** the *Mount Docker Socket* policy is renamed to *Mount Container Runtime Socket*. This policy also detects if a deployment mounts the CRI-O socket for both Kubernetes and {ocp}.
+** the *Docker CIS 4.4: Ensure images are scanned and rebuilt to include security patches* policy is disabled by default.
+
+* The `roxctl` CLI now supports command-line completion for `bash`, `zsh`, `fish` and PowerShell.
+
+[id="image-versions"]
+== Image versions
+
+|===
+| Image | Description | Current version
+
+| Main
+| Includes Central, Sensor, Admission Controller, and Compliance.
+Also includes `roxctl` for use in continuous integration (CI) systems.
+| registry.redhat.io/rh-acs/main:3.66.0
+
+| Scanner
+| Scans images and nodes.
+| registry.redhat.io/rh-acs/scanner:2.20.0
+
+| Scanner DB
+| Stores image scan results and vulnerability definitions.
+| registry.redhat.io/rh-acs/scanner-db:2.20.0
+
+| Collector
+| Collects runtime activity in Kubernetes or {ocp} clusters.
+| registry.redhat.io/rh-acs/collector:3.4.1-latest
+|===


### PR DESCRIPTION
Includes: 
- Release notes for 3.66
- Updated image tags

Preview: https://openshift-docs-git-366-updates-gnelson.vercel.app/openshift-acs/master/release_notes/366-release-notes.html

**NOTES**:
- This PR is for RHACS docs at https://docs.openshift.com/acs/welcome/index.html
- It doesn't require any special labels or milestones
