### PR TITLE
RHDEVDOCS- 3300-Change Application stages to Openshift GitOps

### DIFF
--- a/modules/logging-in-to-the-argo-cd-instance-by-using-your-openshift-credentials.adoc
+++ b/modules/logging-in-to-the-argo-cd-instance-by-using-your-openshift-credentials.adoc
@@ -14,7 +14,7 @@ Red Hat OpenShift GitOps Operator automatically creates a ready-to-use Argo CD i
 .Procedure
 
 . In the *Administrator* perspective of the web console, navigate to *Operators* -> *Installed Operators* to verify that the Red Hat OpenShift GitOps Operator is installed.
-. Navigate to the {rh-app-icon} menu -> *Application Stages* -> *Argo CD*. The login page of the Argo CD UI is displayed in a new window.
+. Navigate to the {rh-app-icon} menu -> *OpenShift GitOps* -> *Cluster Argo CD*. The login page of the Argo CD UI is displayed in a new window.
 . Obtain the password for the Argo CD instance:
 .. Navigate to the *Developer* perspective of the web console. A list of available projects is displayed.
 .. Navigate to the `openshift-gitops` project.


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: [RHDEVDOCS-3300](https://issues.redhat.com/browse/RHDEVDOCS-3300) Change Application stages to Openshift GitOps - https://issues.redhat.com/browse/RHDEVDOCS-3300
Preview pages: https://deploy-preview-37607--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html#logging-in-to-the-argo-cd-instance-by-using-your-openshift-credentials_configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations
SME+QE review: Preeti
Peer-review: @Preeticp