### PR TITLE
RHDEVDOCS - 3311 Steps added to modify the spring petclininc under verifying argo cd

### DIFF
--- a/modules/gitops-verifying-argo-cd-self-healing-behavior.adoc
+++ b/modules/gitops-verifying-argo-cd-self-healing-behavior.adoc
@@ -23,6 +23,17 @@ You can test and observe the self-healing behavior in Argo CD.
 
 . Modify the Spring PetClinic deployment and commit the changes to the `app/` directory of the Git repository. Argo CD will automatically deploy the changes to the cluster.
 
+.. Fork the link:https://github.com/redhat-developer/openshift-gitops-getting-started[OpenShift GitOps getting started repository].
+
+.. In the `deployment.yaml` file, change the `failureThreshold` value to `5`.
+
+.. In the deployment cluster, run the following command to verify the changed value of the `failureThreshold` field:
++
+[source,terminal]
+----
+$ oc edit deployment spring-petclinic -n spring-petclinic
+----
+
 . Test the self-healing behavior by modifying the deployment on the cluster and scaling it up to two pods while watching the application in the {product-title} web console.
 +
 .. Run the following command to modify the deployment:


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: [RHDEVDOCS-3311](https://issues.redhat.com/browse/RHDEVDOCS-3311) Verifying Argo CD self behavior steps not clear - https://issues.redhat.com/browse/RHDEVDOCS-3311
Preview pages: https://deploy-preview-37608--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/deploying-a-spring-boot-application-with-argo-cd#verifying-argo-cd-self-healing-behavior_deploying-a-spring-boot-application-with-argo-cd
SME+QE review: @iam-veeramalla  
Peer-review: @Preeticp