### PR TITLE
OSDOCS-2414 - Adding BYO KMS key steps

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -5,7 +5,7 @@
 [id="rosa-sts-creating-cluster-customizations_{context}"]
 = Creating a cluster with STS using customizations
 
-When you create an OpenShift cluster that uses the AWS Security Token Service (STS), you can customize your installation interactively. When you run `rosa create cluster --interactive` at cluster creation time, you are presented with a series of interactive prompts that enable you to customize your deployment. For more information, see _Interactive cluster creation mode reference_.
+When you create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you can customize your installation interactively. When you run `rosa create cluster --interactive` at cluster creation time, you are presented with a series of interactive prompts that enable you to customize your deployment. For more information, see _Interactive cluster creation mode reference_.
 
 There are two `rosa` CLI modes for deploying a cluster with STS:
 
@@ -28,6 +28,7 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Share
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
 * You have installed and configured the latest AWS, ROSA, and `oc` CLIs on your installation host.
+* If you are using a customer-managed AWS Key Management Service (KMS) key for encryption, you have created a symmetric KMS key and you have the key ID and Amazon Resource Name (ARN). For more information about creating AWS KMS keys, see link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html[the AWS documenation].
 
 .Procedure
 
@@ -35,7 +36,7 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Share
 +
 [NOTE]
 ====
-The account-wide roles and policies are specific to an OpenShift version, for example OpenShift 4.8. If you are using multiple cluster versions in one account, you can optionally specify a version-specific prefix for the Amazon Resource Names (ARNs) by using `--prefix <prefix_name>`. With the prefix, you can easily identify the roles and policies for each cluster version. If you do not specify a prefix, the `ManagedOpenShift` prefix is implied.
+The account-wide roles and policies are specific to an OpenShift version, for example OpenShift 4.8. If you are using multiple cluster versions in one account, you can optionally specify a version-specific prefix for the ARNs by using `--prefix <prefix_name>`. With the prefix, you can easily identify the roles and policies for each cluster version. If you do not specify a prefix, the `ManagedOpenShift` prefix is implied.
 ====
 +
 .. Generate the IAM policy JSON files in the current working directory and output the `aws` CLI commands for review:
@@ -49,6 +50,58 @@ $ rosa create account-roles --mode manual <1>
 You can optionally specify an OpenShift minor release, for example `4.8`, by using the `--version` option. The latest stable version is assumed if the option is not included. The account-wide roles and policies are specific to an OpenShift minor release version and are backward compatible.
 +
 .. After review, run the `aws` commands manually to create the roles and policies. Alternatively, you can run the preceding command using `--mode auto` to run the `aws` commands immediately.
+
+. (Optional) If you are using your own AWS KMS key to encrypt the control plane data volumes and the persistent volumes (PVs) for your applications, add the ARN for the account-wide installer role to your KMS key policy.
+.. Save the key policy for your KMS key to a file on your local machine. The following example saves the output to `kms-key-policy.json` in the current working directory:
++
+[source,terminal]
+----
+$ aws kms get-key-policy --key-id <key_id_or_arn> --policy-name default --output text > kms-key-policy.json <1>
+----
+<1> Replace `<key_id_or_arn>` with the ID or ARN of your KMS key.
++
+.. Add the ARN for the account-wide installer role that you created in the preceding step to the `Statement.Principal.AWS` section in the file. In the following example, the ARN for the default `ManagedOpenShift-Installer-Role` role is added:
++
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Id": "key-default-1",
+  "Statement": [
+    {
+      "Sid": "Enable IAM User Permissions",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": [
+          "arn:aws:iam::<aws_account_id>:root",
+          "arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role" <1>
+        ]
+      },
+      "Action": "kms:*",
+      "Resource": "*"
+    }
+  ]
+}
+----
+<1> You must specify the ARN for the account-wide role that will be used when you create the ROSA cluster. The ARNs listed in the section must be comma-separated.
++
+[NOTE]
+====
+If you specify a prefix when you create the account-wide role, it is included in the role name in place of `ManagedOpenShift`.
+====
++
+.. Apply the changes to your KMS key policy:
++
+[source,terminal]
+----
+$ aws kms put-key-policy --key-id <key_id_or_arn> \ <1>
+    --policy file://kms-key-policy.json \ <2>
+    --policy-name default
+----
+<1> Replace `<key_id_or_arn>` with the ID or ARN of your KMS key.
+<2> You must include the `file://` prefix when referencing a key policy in a local file.
++
+You can reference the ARN of your KMS key when you create the cluster in the next step.
 
 . Create a cluster with STS using custom installation options. You can use the `--interactive` mode to interactively specify custom settings:
 +
@@ -74,7 +127,7 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
 ? Install into an existing VPC (optional): No
-? Enable Customer Managed key (optional): No
+? Enable Customer Managed key (optional): No <4>
 ? Compute nodes instance type (optional): 
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
@@ -85,7 +138,7 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <4>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <5>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
@@ -95,7 +148,8 @@ I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_n
 <1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.8.9`.
 <2> If more than one matching set of account-wide roles are available in your account for a cluster version, an interactive list of options is provided.
 <3> Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<4> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<4> Enable this option if you are using your own AWS KMS key to encrypt the control plane data volumes and the PVs for your applications. Specify the ARN for the KMS key that you added the account-wide role ARN to in the preceding step.
+<5> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 +
 [NOTE]
 ====


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2414. The PR adds steps to use your own AWS Key Management Service (KMS) keys when creating a ROSA cluster that uses the AWS Security Token Service (STS).

The preview is [here](https://deploy-preview-37611--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations_rosa-sts-creating-a-cluster-with-customizations).