### PR TITLE
Shutdown workers/infra node first & then master master

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -37,11 +37,16 @@ $ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-s
 ----
 <1> To ensure that the cluster can restart gracefully, plan to restart it on or before the specified date. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
 
-. Shut down all of the nodes in the cluster. You can do this from your cloud provider's web console, or run the following loop:
+. Shut down all of the worker/infra nodes first and then the master nodes in the cluster. You can do this from your cloud provider's web console, or run the following loop:
 +
 [source,terminal]
 ----
-$ for node in $(oc get nodes -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
+$ for node in $(oc get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
+----
++
+[source,terminal]
+----
+$ for node in $(oc get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done
 ----
 +
 .Example output


### PR DESCRIPTION
**Background:**
As we know oc debug node command depends on the OpenShift control plane to work. It uses the same tunneling technology that allows opening a shell prompt inside a
running pod (see the oc rsh command later in this section). The oc debug node command is not based on the SSH or RSH protocols.

**Problem description:**
If we have large cluster with 6-8 worker nodes, It is observed that if we gracefully shutdown the all nodes then masters stopped working in the middle of shutting down so lower worker nodes are still working.  As soon as we stopped the master/control-plane nodes with above script there will be no api-server available, so it won't allow to start/schedule the debug node pod on the rest of the worker/infra node. And the few worker/infra nodes remains in running state.

**Solution:**
We should first stop the worker nodes & then master/control-plane nodes.

First, following command added to identify the non master nodes & then with oc debug node gracefull shutdown the worker/infra nodes.
`$ for node in $(oc get node --selector='!node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done`

And then below command added to identify the master nodes & then with oc debug node gracefull shutdown the master nodes.

`$ for node in $(oc get node --selector='node-role.kubernetes.io/master' -o jsonpath='{.items[*].metadata.name}'); do oc debug node/${node} -- chroot /host shutdown -h 1; done`