### PR TITLE
OSDOCS-2759: Added note and x-ref for network policy through the web console

### DIFF
--- a/modules/nw-networkpolicy-create.adoc
+++ b/modules/nw-networkpolicy-create.adoc
@@ -156,3 +156,10 @@ ifdef::multi[]
 endif::multi[]
 :!name:
 :!role:
+
+[NOTE]
+====
+If you log in with a user with the `cluster-admin` role in the console, then you
+have a choice of creating a network policy in any namespace in the cluster
+directly from the YAML view or from a form in the web console. 
+====

--- a/networking/network_policy/creating-network-policy.adoc
+++ b/networking/network_policy/creating-network-policy.adoc
@@ -10,3 +10,6 @@ As a user with the `admin` role, you can create a network policy for a namespace
 include::modules/nw-networkpolicy-create.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-object.adoc[leveloffset=+1]
+== Additional resources
+
+* xref:../../web_console/web-console.adoc[Accessing the web console]


### PR DESCRIPTION
For Version 4.9+

[issues.redhat.com/browse/OSDOCS-2759](issues.redhat.com/browse/OSDOCS-2759)
[issues.redhat.com/browse/NETOBSERV-1](issues.redhat.com/browse/NETOBSERV-1)

Direct link to doc preview: https://deploy-preview-37634--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html

Ready for:
SME: @jotak 
QA:  @jechen0648 