### PR TITLE
Fix ocp_ver in OSDK install URL for 4.9

### DIFF
--- a/modules/osdk-installing-cli-linux-macos.adoc
+++ b/modules/osdk-installing-cli-linux-macos.adoc
@@ -3,7 +3,7 @@
 // * cli_reference/osdk/cli-osdk-install.adoc
 // * operators/operator_sdk/osdk-installing-cli.adoc
 
-:ocp_ver: 4.9
+:ocp_ver: 4.9.0
 :osdk_ver: v1.10.1
 
 [id="osdk-installing-cli-linux-macos_{context}"]


### PR DESCRIPTION
Adjusting for actual live file path.

Preview:

* Link in step 1 of https://deploy-preview-37635--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/osdk/cli-osdk-install.html#osdk-installing-cli-linux-macos_cli-osdk-install