### PR TITLE
Fix ver in opm install URL for 4.9

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -15,7 +15,7 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Procedure
 
-. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-{product-version}/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.9.0/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
 
 . Unpack the archive.
 


### PR DESCRIPTION
Adjusting for actual live file path (the expected `latest-4.9` does not currently exist).

Preview:

* Link in step 1 of https://deploy-preview-37638--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-install.html#olm-installing-opm_cli-opm-install