### PR TITLE
BZ1962929: documentation for increasing the AWS master flavor size

### DIFF
--- a/modules/increasing-aws-flavor-size.adoc
+++ b/modules/increasing-aws-flavor-size.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+
+[id="increasing-aws-flavor-size_{context}"]
+=  Increasing the flavor size of the Amazon Web Services (AWS) master instances
+
+When you have overloaded AWS master nodes in a cluster and the master nodes require more resources, you can increase the flavor size of the master instances.
+[NOTE]
+====
+It is recommended to backup etcd before increasing the flavor size of the AWS master instances.
+====
+
+.Prerequisites
+
+* You have an IPI (installer-provisioned infrastructure) or UPI (user-provisioned infrastructure) cluster on AWS.
+
+
+.Procedure
+
+. Open the AWS console, fetch the master instances.
+
+. Stop one master instance.
+
+. Select the stopped instance, and click *Actions* -> *Instance Settings* -> *Change instance type*.
+
+. Change the instance to a larger type, ensuring that the type is the same base as the previous selection, and apply changes. For example, you can change `m5.xlarge` to `m5.2xlarge` or `m5.4xlarge`.
+
+. Backup the instance, and repeat the steps for the next master instance.

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -20,6 +20,11 @@ include::modules/modify-unavailable-workers.adoc[leveloffset=+1]
 
 include::modules/master-node-sizing.adoc[leveloffset=+1]
 
+include::modules/increasing-aws-flavor-size.adoc[leveloffset=+2]
+
+.Additional resources
+* xref:../backup_and_restore/backing-up-etcd.adoc#backing-up-etcd[Backing up etcd]
+
 include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 
 include::modules/etcd-defrag.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1962929

[Doc preview](https://deploy-preview-37639--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices)

Requires QE approval from @duanwei33 