### PR TITLE
BZ2010913: Added note about bare metal cloud providers

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -1,3 +1,4 @@
+include::modules/common-attributes.adoc[]
 include::modules/virt-document-attributes.adoc[]
 [id="preparing-cluster-for-virt"]
 = Configuring your cluster for {VirtProductName}
@@ -8,11 +9,13 @@ toc::[]
 Before you install {VirtProductName}, ensure that your {product-title} cluster meets the following requirements:
 
 * Your cluster must be installed on
-xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[bare metal] infrastructure with Red Hat Enterprise Linux CoreOS (RHCOS) workers. You can use any installation method including user-provisioned, installer-provisioned, or assisted installer to deploy your cluster.
-
+xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#installing-bare-metal[on-premise bare metal] infrastructure with {op-system-first} workers. You can use any installation method including user-provisioned, installer-provisioned, or assisted installer to deploy your cluster.
++
 [NOTE]
 ====
-{VirtProductName} only supports RHCOS worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
+* {VirtProductName} only supports {op-system} worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
+
+* Infrastructure solutions offered by bare metal cloud providers are not supported.
 ====
 
 * Additionally, there are two options to maintain high availability (HA) of virtual machines:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2010913

Changed an xref and added a note in the `Configuring your cluster for OpenShift Virtualization` assembly that bare metal cloud service providers are not supported.

CP to 4.8, 4.9, 4.10

Preview build: https://deploy-preview-37643--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt