### PR TITLE
OSDOCS-2656: Adding section about Uninstalling the Compliance Operator

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -786,6 +786,8 @@ Topics:
     File: compliance-operator-advanced
   - Name: Troubleshooting the Compliance Operator
     File: compliance-operator-troubleshooting
+  - Name: Uninstalling the Compliance Operator
+    File: compliance-operator-uninstallation  
   - Name: Using the oc-compliance plug-in
     File: oc-compliance-plug-in-using
 - Name: File Integrity Operator

--- a/modules/compliance-operator-uninstall.adoc
+++ b/modules/compliance-operator-uninstall.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// security/compliance_operator/compliance-operator-uninstallation.adoc
+
+[id="compliance-operator-uninstall_{context}"]
+= Uninstalling the OpenShift Compliance Operator from {product-title}
+
+To remove the Compliance Operator, you must first delete the Compliance Operator custom resource definitions (CRDs). After the CRDs are removed, you can then remove the Operator and its namespace by deleting the *openshift-compliance* project.
+
+.Prerequisites
+
+* Access to an {product-title} cluster using an account with `cluster-admin` permissions.
+* The OpenShift Compliance Operator must be installed.
+
+.Procedure
+
+To remove the Compliance Operator by using the {product-title} web console:
+
+. Remove CRDs that were installed by the Compliance Operator:
+
+.. Switch to the *Administration* -> *CustomResourceDefinitions* page.
+
+.. Search for `compliance.openshift.io` in the *Name* field.
+
+.. Click the Options menu {kebab} next to each of the following CRDs, and select *Delete Custom Resource Definition*:
+
+* `ComplianceCheckResult` 
+* `ComplianceRemediation`
+* `ComplianceScan`
+* `ComplianceSuite`
+* `ProfileBundle`
+* `Profile`
+* `Rule`
+* `ScanSettingBinding`
+* `ScanSetting`
+* `TailoredProfile`
+* `Variable`
++
+. Remove the OpenShift Compliance project:
+
+.. Switch to the *Home* -> *Projects* page.
+
+.. Click the Options menu {kebab} next to the *openshift-compliance* project, and select *Delete Project*.
+
+.. Confirm the deletion by typing `openshift-compliance` in the dialog box, and click *Delete*.
+
+
+

--- a/security/compliance_operator/compliance-operator-uninstallation.adoc
+++ b/security/compliance_operator/compliance-operator-uninstallation.adoc
@@ -1,0 +1,10 @@
+[id="compliance-operator-uninstallation_{context}"]
+= Uninstalling the Compliance Operator
+include::modules/common-attributes.adoc[]
+:context: compliance-operator-uninstallation
+
+toc::[]
+
+You can remove the OpenShift Compliance Operator from your cluster by using the {product-title} web console.
+
+include::modules/compliance-operator-uninstall.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2656
Related to: https://bugzilla.redhat.com/show_bug.cgi?id=2005387

Direct link to new section: 
https://deploy-preview-37650--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-uninstallation

Affected version(s): 4.6+