### PR TITLE
BZ1986542: Updated example prometheus queries

### DIFF
--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -30,7 +30,7 @@ To query the vCPU metric, the `schedstats=enable` kernel argument must first be 
 .Example vCPU wait time query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_vcpu_wait_seconds[6m]), 0.1))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period.
 
@@ -48,7 +48,7 @@ Returns the total amount of traffic transmitted (in bytes) on the virtual machin
 .Example network traffic query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_network_receive_bytes_total[6m]), 0.1)) + sum by (name, namespace) (round(irate(kubevirt_vmi_network_transmit_bytes_total[6m]) , 0.1))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_network_receive_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_network_transmit_bytes_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs transmitting the most network traffic at every given moment over a six-minute time period.
 
@@ -69,8 +69,7 @@ Returns the total amount of storage writes (in bytes) of the virtual machine's s
 .Example storage-related traffic query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_storage_read_traffic_bytes_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]), 0.1))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_traffic_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_write_traffic_bytes_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs performing the most storage traffic at every given moment over a six-minute time period.
 
@@ -88,8 +87,7 @@ Returns the amount of read I/O operations the virtual machine is performing per 
 .Example I/O performance query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_read_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_storage_iops_write_total[6m]) , 0.1))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_read_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_write_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs performing the most I/O operations per second at every given moment over a six-minute time period.
 
@@ -107,8 +105,7 @@ Returns the total amount (in bytes) of memory the virtual guest is swapping out.
 .Example memory swapping query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[6m]), 0.1))
-+ sum by (name, namespace) (round(irate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]), 0.1))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1986542

Replaced existing prometheus queries with the example queries provided in the BZ that do not have the `round` function.

CP to 4.8, 4.9, 4.10

Preview build: https://deploy-preview-37657--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-prometheus-queries.html#virt-querying-metrics_virt-prometheus-queries