### PR TITLE
Add documentation for RAID feature

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -53,6 +53,8 @@ ifeval::[{product-version} > 4.8]
 include::modules/ipi-install-configuring-bios-for-worker-node.adoc[leveloffset=+2]
 endif::[]
 
+include::modules/ipi-install-configuring-raid-for-worker-node.adoc[leveloffset=+2]
+
 include::modules/ipi-install-creating-a-disconnected-registry.adoc[leveloffset=+1]
 
 include::modules/ipi-install-deploying-routers-on-worker-nodes.adoc[leveloffset=+1]

--- a/modules/ipi-install-configuring-raid-for-worker-node.adoc
+++ b/modules/ipi-install-configuring-raid-for-worker-node.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal_ipi/ipi-install-configuration-files.adoc
+[id="configuring-raid-for-worker-node_{context}"]
+= Configuring RAID for worker node
+
+The following procedure configures RAID (Redundant Array of Independent Disks) for the worker node during the installation process.
+
+[NOTE]
+====
+. Only servers with BMC (Baseboard Management Controller) type `irmc` are supported. Other types of servers are currently not supported.
+. If you want to configure hardware RAID for the server, make sure the server has a RAID controller.
+====
+
+.Procedure
+. Create manifests.
+. Modify the BMH (Bare Metal Host) file corresponding to the worker:
++
+[source,terminal]
+----
+$ vim clusterconfigs/openshift/99_openshift-cluster-api_hosts-3.yaml
+----
++
+[NOTE]
+====
+Because servers with BMC type `irmc` do not support software RAID, the following RAID configuration uses hardware RAID as an example.
+====
++
+.. If you added specific RAID configuration to the spec, this causes the worker node to delete the original RAID configuration in the `preparing` phase and perform a specified configuration on the RAID. For example:
++
+[source,yaml]
+----
+spec:
+  raid:
+    hardwareRAIDVolumes:
+    - level: "0"
+      name: "sda"
+      numberOfPhysicalDisks: 1
+      rotational: true
+      sizeGibibytes: 0
+----
+<1> `level` is a required field, and the others are optional fields.
++
+.. If you added an empty RAID configuration to the spec, this empty configuration causes the worker node to delete the original RAID configuration during the `preparing` phase, but does not perform a new configuration. For example:
++
+[source,yaml]
+----
+spec:
+  raid:
+    hardwareRAIDVolumes: []
+----
++
+.. If you do not add a `raid` field in the spec, the original RAID configuration is not deleted, and no new configuration will be performed.
+. Create cluster.


### PR DESCRIPTION
In OCP4.10, the feature of configuring the RAID of the worker node in the process of IPI has been added.
Add corresponding documents for detailed description.

Signed-off-by: Zhou Hao <zhouhao@fujitsu.com>