### PR TITLE
BZ1900525: Removed warning for moving workload not allowed

### DIFF
--- a/machine_management/creating-infrastructure-machinesets.adoc
+++ b/machine_management/creating-infrastructure-machinesets.adoc
@@ -9,11 +9,6 @@ include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
 You can create a machine set to host only infrastructure components. You apply specific Kubernetes labels to these machines and then update the infrastructure components to run on only those machines. These infrastructure nodes are not counted toward the total number of subscriptions that are required to run the environment.
 
-[IMPORTANT]
-====
-Unlike earlier versions of {product-title}, you cannot move the infrastructure components to the control plane machines. To move the components, you must create a new machine set.
-====
-
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
 [id="creating-infrastructure-machinesets-production"]


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1900525

Target releases: 4.7, 4.8, 4.9, 4.10

Preview link: https://deploy-preview-37666--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets

@sunzhaohua2 - Kindly help with the QE review.