### PR TITLE
Added notes for release 4.8.15

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2698,7 +2698,7 @@ link:https://access.redhat.com/solutions/6363171[{product-title} 4.8.13 containe
 [id="ocp-4-8-13-features"]
 ==== Features
 
-* Kubernetes 1.21.4 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1213[1.21.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1212[1.21.3], and link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1211[1.21.2]. 
+* Kubernetes 1.21.4 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1213[1.21.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1212[1.21.3], and link:https://github.com/kubernetes/kubernetes/blob/release-1.21/CHANGELOG/CHANGELOG-1.21.md#changelog-since-v1211[1.21.2].
 
 [id="ocp-4-8-13-bug-fixes"]
 ==== Bug fixes
@@ -2741,6 +2741,36 @@ For more information on the list of removed Kubernetes APIs, tips for how to eva
 * Previously, when using IPv6 DHCP, node interface addresses might be leased with a `/128` prefix. Consequently, OVN-Kubernetes uses the same prefix to infer the node's network and routes any other address traffic, including traffic to other cluster nodes, through the gateway. With this update, OVN-Kubernetes inspects the node's routing table and checks for the wider routing entry for the node's interface address and uses that prefix to infer the node's network. As a result, traffic to other cluster nodes is no longer routed through the gateway. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1994624[*BZ#1994624*])
 
 [id="ocp-4-8-14-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-15"]
+=== RHBA-2021:3821 - {product-title} 4.8.15 bug fix and security update
+
+Issued: 2021-10-19
+
+{product-title} release 4.8.15, which contains security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3821[RHBA-2021:3821] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3820[RHSA-2021:3820] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6417501[{product-title} 4.8.15 container image list]
+
+[id="ocp-4-8-15-known-issues"]
+==== Known issues
+
+* On an {product-title} single node configuration, pod creation times are over two times slower when using the real-time kernel (kernel-rt) than when using the non-real-time kernel. When using kernel-rt, the slower creation times impact the maximum number of supported pods because recovery time is impacted after a node reboots. As a workaround when you are using the kernel-rt, you can improve the impacted recovery time by booting with the `rcupdate.rcu_normal_after_boot=0` kernel argument, which requires a real-time kernel version `kernel-rt-4.18.0-305.16.1.rt7.88.el8_4` or later. This known issue applies to the {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975356[*BZ#1975356*])
+
+* Following an {product-title} single node reboot, all pods are restarted which causes significant load and longer than normal pod creation times. This happens because the Container Network Interface (CNI) is not able to process the `pod add` events quickly enough. The following error message is displayed: `timed out waiting for OVS port binding`. The {product-title} single node instance eventually recovers, though more slowly than expected. This known issue applies to the {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986216[*BZ#1986216*])
+
+[id="ocp-4-8-15-bug-fixes"]
+==== Bug fixes
+
+* Previously, when the Local Storage Operator was deleting orphaned persistent volumes (PVs), it would delete a PV and then wait 10 seconds before deleting the next one. In environments where many PVs needed to be deleted, these 10-second wait periods caused unnecessary delays, and new persistent volume claims took too long. This bug fix removes the 10-second wait period. New persistent volume claims are processed in a timely manner. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008088[*BZ#2008088*])
+
+* Previously, when the configuration settings for a bare metal deployment included a value for `provisioningHostIP` even when `provisioningNetwork` was disabled, the Metal3 pod would start with a provisioning IP address that was not maintained. Ironic took this provisioning IP address when it started, and would fail when the address stopped working. With this bug fix, the system ignores `provisioningHostIP` when `provisioningNetwork` is disabled. Ironic starts with a properly configured external IP address. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975711[*BZ#1975711*])
+
+[id="ocp-4-8-15-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for OCP 4.8.15

Applies only to `enterprise-4.8`

The Known issues subsection contains BZs that are to be repeated in the general Known issues section. Those BZs have already been reviewed here: https://github.com/openshift/openshift-docs/pull/37514

Preview: https://deploy-preview-37671--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-15