### PR TITLE
Issue-37670: Fix egressFirewall API server example

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -55,7 +55,7 @@ spec:
       cidrSelector: <api_server_address_range> <2>
     type: Allow
 # ...
-  - deny:
+  - to:
       cidrSelector: 0.0.0.0/0 <3>
     type: Deny
 ----


### PR DESCRIPTION
Fixes #37670
Applies to 4.6+

Preview: https://deploy-preview-37672--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-firewall.html#nw-egressnetworkpolicy-about_openshift-sdn-egress-firewall