### PR TITLE
BZ1903933: Removal of redundant notice

### DIFF
--- a/modules/cnf-upgrading-performance-addon-operator.adoc
+++ b/modules/cnf-upgrading-performance-addon-operator.adoc
@@ -3,11 +3,6 @@
 // * scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.adoc
 //
 
-[IMPORTANT]
-====
-The feature described in this document is for *Developer Preview* purposes and is *not supported* by Red Hat at this time.
-This feature could cause nodes to reboot and not be available.
-====
 
 [id="upgrading-performance-addon-operator_{context}"]
 = Upgrading Performance Addon Operator


### PR DESCRIPTION
Link to preview: https://deploy-preview-37674--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes
Applies to enterprise-4.6.
Link to Jira: https://bugzilla.redhat.com/show_bug.cgi?id=1903933
SME review approved in BZ, waiting on QE.
Removed warning re Developer preview - feature now integrated in product.