### PR TITLE
SRVOCF-365: Document the -r <repository> option of the `kn func create` command

### DIFF
--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -3,7 +3,7 @@
 
 You can create a basic serverless function using the `kn` CLI.
 
-You can specify the path, runtime, and template as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
+You can specify the path, runtime, template, and repository with the template as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
 
 .Procedure
 
@@ -11,7 +11,7 @@ You can specify the path, runtime, and template as flags on the command line, or
 +
 [source,terminal]
 ----
-$ kn func create <path> -l <runtime> -t <template>
+$ kn func create -r <repository> -l <runtime> -t <template> <path>
 ----
 ** Supported runtimes include `node`, `go`, `python`, `quarkus`, and `typescript`.
 ** Supported templates include `http` and `events`.
@@ -29,5 +29,23 @@ Project path:  /home/user/demo/examplefunc
 Function name: examplefunc
 Runtime:       typescript
 Template:      events
+Writing events to /home/user/demo/examplefunc
+----
++
+** Alternatively, you can specify a repository that contains a custom template.
++
+.Example command
+[source,terminal]
+----
+$ kn func create -r https://github.com/boson-project/templates/ -l node -t hello-world examplefunc
+----
++
+.Example output
+[source,terminal]
+----
+Project path:  /home/user/demo/examplefunc
+Function name: examplefunc
+Runtime:       node
+Template:      hello-world
 Writing events to /home/user/demo/examplefunc
 ----


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVOCF-365
Docs preview: https://deploy-preview-37675--osdocs.netlify.app/openshift-enterprise/latest/serverless/cli_tools/kn-func-ref.html#serverless-create-func-kn_kn-func-ref