### PR TITLE
added notes for 4.7.34 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2929,3 +2929,19 @@ link:https://access.redhat.com/solutions/6395081[{product-title} 4.7.33 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-34"]
+=== RHBA-2021:3824 - {product-title} 4.7.34 bug fix update
+
+Issued: 2021-10-20
+
+{product-title} release 4.7.34 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3824[RHBA-2021:3824] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3822[RHBA-2021:3822] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6427981[{product-title} 4.7.34 container image list]
+
+[id="ocp-4-7-34-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Notes for 4.7.34 release 

- applies to `enterprise-4.7` only
- [Preview link](https://deploy-preview-37691--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-34)