### PR TITLE
OSDOCS-2767: Added a missing link to the additional resources section

### DIFF
--- a/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+++ b/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
@@ -19,4 +19,5 @@ include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 xref:../rosa_getting_started_sts/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]
 
 == Additional resources
+* See xref:../rosa_planning/rosa-limits-scalability.adoc#initial-planning-considerations_rosa-limits-scalability[Intial Planning Considerations] for guidance on worker node count.
 * See xref:../rosa_policy/rosa-policy-process-security.adoc#rosa-policy-sre-access_rosa-policy-process-security[SRE access to all Red Hat OpenShift Service on AWS clusters] for information about how Red Hat site reliability engineering accesses ROSA clusters.


### PR DESCRIPTION
This PR addresses a missing link to the ROSA Getting Started STS documentation.

JIRA: https://issues.redhat.com/browse/OSDOCS-2767

Preview: https://deploy-preview-37698--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-aws-prereqs#additional-resources