### PR TITLE
OSDOCS2597: include nodes overview for 4.7

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1560,6 +1560,8 @@ Name: Nodes
 Dir: nodes
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: Overview of nodes
+  File: index
 - Name: Working with pods
   Dir: pods
   Topics:

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -1,0 +1,129 @@
+[id="overview-of-nodes"]
+= Overview of nodes
+include::modules/common-attributes.adoc[]
+:context: overview-of-nodes
+
+toc::[]
+
+// TODO: Need some help with an intro blurb
+
+[id="nodes-overview"]
+== About nodes
+
+A node is a virtual or bare-metal machine in a Kubernetes cluster. Worker nodes host your application containers, grouped as pods. The control plane nodes run services that are required to control the Kubernetes cluster. In {product-title}, the control plane nodes contain more than just the Kubernetes services for managing the {product-title} cluster.
+
+Having stable and healthy nodes in a cluster is fundamental to the smooth functioning of your hosted application.
+In {product-title}, you can access, manage, and monitor a node through the `Node` object representing the node.
+Using the OpenShift CLI (`oc`) or the web console, you can perform the following operations on a node.
+
+[discrete]
+=== Read operations
+
+The read operations allow an administrator or a developer to get information about nodes in an {product-title} cluster.
+
+* xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing_nodes-nodes-viewing[List all the nodes in a cluster].
+* Get information about a node, such as memory and CPU usage, health, status, and age.
+* xref:../nodes/nodes/nodes-nodes-viewing.adoc#nodes-nodes-viewing-listing-pods_nodes-nodes-viewing[List pods running on a node].
+
+[discrete]
+=== Management operations
+
+As an administrator, you can easily manage a node in an {product-title} cluster
+through several tasks:
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Add or update node labels]. A label is a key-value pair applied to a `Node` object. You can control the scheduling of pods using labels.
+* Change node configuration using a custom resource definition (CRD), or the `kubeletConfig` object.
+* Configure nodes to allow or disallow the scheduling of pods. Healthy worker nodes with a `Ready` status allow pod placement by default while the control plane nodes do not; you can change this default behavior by xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[configuring the worker nodes to be unschedulable] and xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-master-schedulable_nodes-nodes-working[the control plane nodes to be schedulable].
+* xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring[Allocate resources for nodes] using the `system-reserved` setting. You can allow {product-title} to automatically determine the optimal `system-reserved` CPU and memory resources for your nodes, or you can manually determine and set the best resources for your nodes.
+* xref:../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods-about_nodes-nodes-jobs[Configure the number of pods that can run on a node] based on the number of processor cores on the node, a hard limit, or both.
+* Reboot a node gracefully using xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-affinity_nodes-nodes-rebooting[pod anti-affinity].
+* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes[Delete a node from a cluster] by scaling down the cluster using a machine set. To delete a node from a bare-metal cluster, you must first drain all pods on the node and then manually delete the node.
+
+[discrete]
+=== Enhancement operations
+
+{product-title} allows you to do more than just access and manage nodes; as an administrator, you can perform the following tasks on nodes to make the cluster more efficient, application-friendly, and to provide a better environment for your developers.
+
+* Manage node-level tuning for high-performance applications that require some level of kernel tuning by xref:../nodes/nodes/nodes-node-tuning-operator.adoc#nodes-node-tuning-operator[using the Node Tuning Operator].
+* xref:../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[Run background tasks on nodes automatically with daemon sets]. You can create and use daemon sets to create shared storage, run a logging pod on every node, or deploy a monitoring agent on all nodes.
+* xref:../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection[Free node resources using garbage collection]. You can ensure that your nodes are running efficiently by removing terminated containers and the images not referenced by any running pods.
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-kernel-arguments_nodes-nodes-working[Add kernel arguments to a set of nodes].
+* Configure an {product-title} cluster to have worker nodes at the network edge (remote worker nodes). For information on the challenges of having remote worker nodes in an {product-title} cluster and some recommended approaches for managing pods on a remote worker node, see xref:../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers[Using remote worker nodes at the network edge].
+
+
+[id="pods-overview"]
+== About pods
+
+A pod is one or more containers deployed together on a node. As a cluster administrator, you can define a pod, assign it to run on a healthy node that is ready for scheduling, and manage. A pod runs as long as the containers are running. You cannot change a pod once it is defined and is running. Some operations you can perform when working with pods are:
+
+[discrete]
+=== Read operations
+
+As an administrator, you can get information about pods in a project through the following tasks:
+
+* xref:../nodes/pods/nodes-pods-viewing.adoc#nodes-pods-viewing-project_nodes-pods-viewing[List pods associated with a project], including information such as the number of replicas and restarts, current status, and age.
+* xref:../nodes/pods/nodes-pods-viewing.adoc#nodes-pods-viewing-usage_nodes-pods-viewing[View pod usage statistics] such as CPU, memory, and storage consumption.
+
+[discrete]
+=== Management operations
+
+The following list of tasks provides an overview of how an administrator can manage pods in an {product-title} cluster.
+
+* Control scheduling of pods using the advanced scheduling features available in {product-title}:
+** Node-to-pod binding rules such as xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity-example-affinity_nodes-scheduler-pod-affinity[pod affinity], xref:../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[node affinity], and xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-anti-affinity-configuring_nodes-scheduler-pod-affinity[anti-affinity].
+** xref:../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Node labels and selectors].
+** xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Taints and tolerations].
+** xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Pod topology spread constraints].
+** xref:../nodes/scheduling/nodes-custom-scheduler.adoc#nodes-custom-scheduler[Custom schedulers].
+* xref:../nodes/scheduling/nodes-descheduler.adoc#nodes-descheduler[Configure the descheduler to evict pods] based on specific strategies so that the scheduler reschedules the pods to more appropriate nodes.
+* xref:../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-restart_nodes-pods-configuring[Configure how pods behave after a restart using pod controllers and restart policies].
+* xref:../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-bandwidth_nodes-pods-configuring[Limit both egress and ingress traffic on a pod].
+* xref:../nodes/containers/nodes-containers-volumes.adoc#nodes-containers-volumes[Add and remove volumes to and from any object that has a pod template]. A volume is a mounted file system available to all the containers in a pod. Container storage is ephemeral; you can use volumes to persist container data.
+
+[discrete]
+=== Enhancement operations
+
+You can work with pods more easily and efficiently with the help of various tools and features available in {product-title}. The following operations involve using those tools and features to better manage pods.
+
+
+[cols="2,1,2"]
+|===
+|Operation |User |More information
+
+|Create and use a horizontal pod autoscaler.
+|Developer
+|You can use a horizontal pod autoscaler to specify the minimum and the maximum number of pods you want to run, as well as the CPU utilization or memory utilization your pods should target. Using a horizontal pod autoscaler, you can xref:../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling[automatically scale pods].
+
+|xref:../nodes/pods/nodes-pods-vertical-autoscaler.adoc#nodes-pods-vpa[Install and use a vertical pod autoscaler].
+|Administrator and developer
+|As an administrator, use a vertical pod autoscaler to better use cluster resources by monitoring the resources and the resource requirements of workloads.
+
+As a developer, use a vertical pod autoscaler to ensure your pods stay up during periods of high demand by scheduling pods to nodes that have enough resources for each pod.
+
+|Provide access to external resources using device plug-ins.
+|Administrator
+|A xref:../nodes/pods/nodes-pods-plugins.adoc#nodes-pods-device[device plug-in] is a gRPC service running on nodes (external to the kubelet), which manages specific hardware resources. You can xref:../nodes/pods/nodes-pods-plugins.adoc#methods-for-deploying-a-device-plug-in[deploy a device plug-in] to provide a consistent and portable solution to consume hardware devices across clusters.
+
+|Provide sensitive data to pods xref:../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[using the `Secret` object].
+|Administrator
+|Some applications need sensitive information, such as passwords and usernames. You can use the `Secret` object to provide such information to an application pod.
+
+
+|===
+
+[id="containers-overview"]
+== About containers
+
+A container is the basic unit of an {product-title} application, which comprises the application code packaged along with its dependencies, libraries, and binaries. Containers provide consistency across environments and multiple deployment targets: physical servers, virtual machines (VMs), and private or public cloud.
+
+Linux container technologies are lightweight mechanisms for isolating running processes and limiting access to only designated resources.
+As an administrator, You can perform various tasks on a Linux container, such as:
+
+* xref:../nodes/containers/nodes-containers-copying-files.adoc#nodes-containers-copying-files[Copy files to and from a container].
+* xref:../nodes/containers/nodes-containers-downward-api.adoc#nodes-containers-downward-api[Allow containers to consume API objects].
+* xref:../nodes/containers/nodes-containers-remote-commands.adoc#nodes-containers-remote-commands[Execute remote commands in a container].
+* xref:../nodes/containers/nodes-containers-port-forwarding.adoc#nodes-containers-port-forwarding[Use port forwarding to access applications in a container].
+
+{product-title} provides specialized containers called xref:../nodes/containers/nodes-containers-init.adoc#nodes-containers-init[Init containers]. Init containers run before application containers and can contain utilities or setup scripts not present in an application image. You can use an Init container to perform tasks before the rest of a pod is deployed.
+
+Apart from performing specific tasks on nodes, pods, and containers, you can work with the overall {product-title} cluster to keep the cluster efficient and the application pods highly available.

--- a/nodes/pods/nodes-pods-vertical-autoscaler.adoc
+++ b/nodes/pods/nodes-pods-vertical-autoscaler.adoc
@@ -1,6 +1,6 @@
-[id="nodes-pods-vpa"]
 :context: nodes-pods-vertical-autoscaler
-= Automatically adjust pod resource levels with the vertical pod autoscaler 
+[id="nodes-pods-vpa"]
+= Automatically adjust pod resource levels with the vertical pod autoscaler
 include::modules/common-attributes.adoc[]
 
 toc::[]
@@ -10,8 +10,8 @@ toc::[]
 The {product-title} Vertical Pod Autoscaler Operator (VPA) automatically reviews the historic and current CPU and memory resources for containers in pods and can update the resource limits and requests based on the usage values it learns. The VPA uses individual custom resources (CR) to update all of the pods associated with a workload object, such as a `Deployment`, `DeploymentConfig`, `StatefulSet`, `Job`, `DaemonSet`, `ReplicaSet`, or `ReplicationController`, in a project.
 
 The VPA helps you to understand the optimal CPU and memory usage for your pods and can automatically maintain pod resources through the pod lifecycle.
- 
-:FeatureName: vertical pod autoscaler 
+
+:FeatureName: vertical pod autoscaler
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 // The following include statements pull in the module files that comprise
@@ -29,5 +29,3 @@ include::modules/nodes-pods-vertical-autoscaler-using-about.adoc[leveloffset=+1]
 include::modules/nodes-pods-vertical-autoscaler-configuring.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-vertical-autoscaler-uninstall.adoc[leveloffset=+1]
-
-


### PR DESCRIPTION
Applies to 4.6

[OSDOCS2597](https://issues.redhat.com/browse/OSDOCS-2597)

[Docs preview](https://deploy-preview-37702--osdocs.netlify.app/openshift-enterprise/latest/nodes/index.html)

This PR is a backport of [#37368](https://github.com/openshift/openshift-docs/pull/37368)

Requires ack from @rphillips