### PR TITLE
Updates the table to remove that Manila CSI supports clone and resize

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -23,7 +23,7 @@ The following table describes the CSI drivers that are installed with {product-t
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅
 |OpenShift Container Storage | ✅ | ✅ | ✅
-|OpenStack Manila | ✅ | ✅ | ✅
+|OpenStack Manila | ✅ | - | -
 |Red Hat Virtualization (oVirt) | - | - | ✅
 |VMware vSphere (Tech Preview) | - | - | -
 |===


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1944598
GH Issue: https://github.com/openshift/openshift-docs/issues/37606

Preview: https://deploy-preview-37707--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

Applies to 4.6+

@duanwei33 please review. 