### PR TITLE
RHDEVDOCS-2664: Add ODC docs for domain mapping

### DIFF
--- a/modules/serverless-access-custom-domain.adoc
+++ b/modules/serverless-access-custom-domain.adoc
@@ -1,24 +1,22 @@
 // Module included in the following assemblies:
 //
-// * serverless/networking/serverless-ossm-custom-domains.adoc
+// * serverless/knative_serving/serverless-custom-domains.adoc
 
 [id="serverless-access-custom-domain_{context}"]
 = Accessing a service using your custom domain
 
 .Procedure
 
-. Access the custom domain by using the `Host` header in a `curl` request. For example:
+* Access the custom domain by using the `Host` header in a `curl` request. For example:
 +
-
+.Example command
 [source,terminal]
 ----
 $ curl -H "Host: custom-ksvc-domain.example.com" http://<ip_address>
 ----
-
 +
 where `<ip_address>` is the IP address that the {product-title} ingress router is exposed to.
 +
-
 .Example output
 [source,terminal]
 ----

--- a/modules/serverless-domain-mapping-odc-admin.adoc
+++ b/modules/serverless-domain-mapping-odc-admin.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * serverless/knative_serving/serverless-custom-domains.adoc
+
+[id="serverless-domain-mapping-odc-admin_{context}"]
+= Mapping a custom domain to a service by using the Administrator perspective
+
+If you have cluster administrator permissions, you can create a `DomainMapping` custom resource (CR) by using the *Administrator* perspective in the {product-title} web console.
+
+.Prerequisites
+
+* You have logged in to the web console.
+* You are in the *Administrator* perspective.
+* You have installed the {ServerlessOperatorName}.
+* You have installed Knative Serving.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have created a Knative service and control a custom domain that you want to map to that service.
++
+[NOTE]
+====
+Your custom domain must point to the IP address of the {product-title} cluster.
+====
+
+.Procedure
+
+. Navigate to *CustomResourceDefinitions* and use the search box to find the *DomainMapping* custom resource definition (CRD).
+
+. Click the *DomainMapping* CRD, then navigate to the *Instances* tab.
+
+. Click *Create DomainMapping*.
+
+. Modify the YAML for the `DomainMapping` CR so that it includes the following information for your instance:
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1alpha1
+kind: DomainMapping
+metadata:
+ name: <domain_name> <1>
+ namespace: <namespace> <2>
+spec:
+ ref:
+   name: <target_name> <3>
+   kind: <target_type> <4>
+   apiVersion: serving.knative.dev/v1
+----
+<1> The custom domain name that you want to map to the target CR.
+<2> The namespace of both the `DomainMapping` CR and the target CR.
+<3> The name of the target CR to map to the custom domain.
+<4> The type of CR being mapped to the custom domain.
++
+.Example domain mapping to a Knative service
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1alpha1
+kind: DomainMapping
+metadata:
+ name: custom-ksvc-domain.example.com
+ namespace: default
+spec:
+ ref:
+   name: example-service
+   kind: Service
+   apiVersion: serving.knative.dev/v1
+----
+
+.Verification
+
+* Access the custom domain by using a `curl` request. For example:
++
+.Example command
+[source,terminal]
+----
+$ curl custom-ksvc-domain.example.com
+----
++
+.Example output
+[source,terminal]
+----
+Hello OpenShift!
+----

--- a/modules/serverless-domain-mapping-odc-developer.adoc
+++ b/modules/serverless-domain-mapping-odc-developer.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * serverless/knative_serving/serverless-custom-domains.adoc
+
+[id="serverless-domain-mapping-odc-developer_{context}"]
+= Mapping a custom domain to a service by using the Developer perspective
+
+You can use the *Developer* perspective of the {product-title} web console to map a `DomainMapping` custom resource (CR) to a Knative service.
+
+.Prerequisites
+
+* You have logged in to the web console.
+* You are in the *Developer* perspective.
+* The {ServerlessOperatorName} and Knative Serving are installed on your cluster. This must be completed by a cluster administrator.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have created a Knative service and control a custom domain that you want to map to that service.
++
+[NOTE]
+====
+Your custom domain must point to the IP address of the {product-title} cluster.
+====
+
+.Procedure
+
+. Navigate to the *Topology* page.
+
+. Right-click on the service that you want to map to a domain, and select the *Edit* option that contains the service name. For example, if the service is named `example-service`, select the *Edit example-service* option.
+
+. In the *Advanced options* section, click *Show advanced Routing options*.
+.. If the domain mapping CR that you want to map to the service already exists, you can select it from the *Domain mapping* drop-down.
+.. If you want to create a new domain mapping CR, type the domain name into the box, and select the *Create* option. For example, if you type in `example.com`, the *Create* option is *Create "example.com"*.
+
+. Click *Save* to save the changes to your service.
+
+.Verification
+
+. Navigate to the *Topology* page.
+
+. Click on the service that you have created.
+
+. In the *Resources* tab of the service information window, you can see the domain you have mapped to the service listed under *Domain mappings*.

--- a/serverless/security/serverless-custom-domains.adoc
+++ b/serverless/security/serverless-custom-domains.adoc
@@ -14,6 +14,16 @@ You can customize the domain for your Knative service by mapping a custom domain
 include::modules/serverless-create-domain-mapping.adoc[leveloffset=+1]
 include::modules/serverless-create-domain-mapping-kn.adoc[leveloffset=+1]
 
+// Using the web console
+
+[id="serverless-custom-domains-odc"]
+== Creating a custom domain mapping by using the web console
+
+You can use the *Administrator* or *Developer* perspective of the {product-title} web console to create a custom domain mapping for a Knative service.
+
+include::modules/serverless-domain-mapping-odc-admin.adoc[leveloffset=+2]
+include::modules/serverless-domain-mapping-odc-developer.adoc[leveloffset=+2]
+
 [id="serverless-custom-domains-private-services"]
 == Configuring custom domains for private Knative services
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHDEVDOCS-2664

Applies for OCP 4.9+

Direct preview link: https://deploy-preview-37708--osdocs.netlify.app/openshift-enterprise/latest/serverless/security/serverless-custom-domains.html#serverless-custom-domains-odc