### PR TITLE
[enterprise-4.7] GH#33456 Hide NSX-T component for VMC as it is not available for that platform

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -15,6 +15,28 @@
 // * installing/installing_vmc/installing-vmc-customizations.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations.adoc
 
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
@@ -28,10 +50,11 @@ You must install the {product-title} cluster on a VMware vSphere version 6 or 7 
 |vSphere 6.5 and later with HW version 13
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
+ifndef::vmc[]
 |Networking (NSX-T)
 |vSphere 6.5U3 or vSphere 6.7U2 and later
 |vSphere 6.5U3 or vSphere 6.7U2+ are required for {product-title}. VMware's NSX Container Plug-in (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
-
+endif::vmc[]
 
 |Storage with in-tree drivers
 |vSphere 6.5 and later
@@ -51,3 +74,25 @@ You must ensure that the time on your ESXi hosts is synchronized before you inst
 ====
 Virtual machines (VMs) configured to use virtual hardware version 14 or greater might result in a failed installation. It is recommended to configure VMs with virtual hardware version 13. This is a known issue that is being addressed in link:https://bugzilla.redhat.com/show_bug.cgi?id=1935539[BZ#1935539].
 ====
+
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]


### PR DESCRIPTION
Manual cherrypick of #37527