### PR TITLE
GH#35319: Added unit in the VM memory overhead equation

### DIFF
--- a/modules/virt-cluster-resource-requirements.adoc
+++ b/modules/virt-cluster-resource-requirements.adoc
@@ -35,7 +35,7 @@ Additionally, {VirtProductName} environment resources require a total of 2179 Mi
 
 ----
 Memory overhead per virtual machine ≈ (1.002 * requested memory) + 146 MiB  \
-                + 8 * (number of vCPUs) \ <1>
+                + 8 MiB * (number of vCPUs) \ <1>
              + 16 MiB * (number of graphics devices) <2>
 ----
 


### PR DESCRIPTION
Fixes #35319

Added unit `MiB` after the number `8` in the VM memory overhead equation

CP to 4.7, 4.8, 4.9, 4.10

Preview: https://deploy-preview-37723--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#memory-overhead_preparing-cluster-for-virt