### PR TITLE
Adds 4.6.48 release notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3347,3 +3347,25 @@ link:https://access.redhat.com/solutions/6409551[{product-title} 4.6.47 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-48"]
+=== RHBA-2021:3829 - {product-title} 4.6.48 bug fix update
+
+Issued: 2021-10-20
+
+{product-title} release 4.6.48 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3829[RHBA-2021:3829] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3828[RHBA-2021:3828] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6438661[{product-title} 4.6.48 container image list]
+
+[id="ocp-4-6-48-features"]
+==== Features
+
+* Kubernetes v1.19.14 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v11913[1.19.14], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v11912[1.19.13], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v11911[1.19.12], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v11910[1.19.11], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1199[1.19.10], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1198[1.19.9], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1197[1.19.8], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1196[1.19.7], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1195[1.19.6], link:https://github.com/kubernetes/kubernetes/blob/release-1.19/CHANGELOG/CHANGELOG-1.19.md#changelog-since-v1194[1.19.5].
+
+
+[id="ocp-4-6-48-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

Preview: https://deploy-preview-37741--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-48

Not to be merged until the erratas are shipped live.