### PR TITLE
BZ1974251: include a note for the fix of unexpected node reboots upon CA rotation in 4.6

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -57,7 +57,7 @@ spec:
       cidrSelector: <api_server_address_range> <2>
     type: Allow
 # ...
-  - deny:
+  - to:
       cidrSelector: 0.0.0.0/0 <3>
     type: Deny
 ----

--- a/modules/troubleshooting-disabling-autoreboot-mco.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco.adoc
@@ -14,5 +14,6 @@ To avoid unwanted disruptions, you can modify the machine config pool (MCP) to p
 Pausing an MCP prevents the MCO from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires, and the MCO attempts to renew the certificate automatically, the new certificate is created but not applied across the nodes in the paused MCP. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
 
 New CA certificates are generated at 292 days from the installation date and removed at 365 days from that date. To determine the next automatic CA certificate rotation, see the link:https://access.redhat.com/articles/5651701[Understand CA cert auto renewal in Red Hat OpenShift 4].
-====
 
+The rotation of a `kube-apiserver-to-kubelet-signer` CA does not cause unexpected node reboots in {product-title} versions 4.7 and above.
+====


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1974251

[Docs preview](https://deploy-preview-37743--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues)

Requires QE ack from @wangke19 