### PR TITLE
RHDEVDOCS-3260 Changed triggers API version to v1beta1

### DIFF
--- a/modules/op-about-pipelinerun.adoc
+++ b/modules/op-about-pipelinerun.adoc
@@ -3,13 +3,13 @@
 // *openshift_pipelines/op-creating-applications-with-cicd-pipelines.adoc
 
 [id="about-pipelinerun_{context}"]
-= PipelineRun
+= Pipeline run
 
-A _PipelineRun_ is the running instance of a Pipeline. It instantiates a Pipeline for execution with specific inputs, outputs, and execution parameters on a cluster. A corresponding TaskRun is created for each Task automatically in the PipelineRun.
+A _pipeline run_ is the running instance of a pipeline. It instantiates a pipeline for execution with specific inputs, outputs, and execution parameters on a cluster. A corresponding task run is created for each task automatically in the pipeline run.
 
-All the Tasks in the Pipeline are executed in the defined sequence until all Tasks are successful or a Task fails. The `status` field tracks and stores the progress of each TaskRun in the PipelineRun for monitoring and auditing purpose.
+All the tasks in the pipeline are executed in the defined sequence until all tasks are successful or a task fails. The `status` field tracks and stores the progress of each task run in the pipeline run for monitoring and auditing purpose.
 
-The following example shows a PipelineRun to run the `build-and-deploy` Pipeline  with relevant resources and parameters:
+The following example runs the `build-and-deploy` pipeline with relevant resources and parameters:
 [source,yaml]
 ----
 apiVersion: tekton.dev/v1beta1 <1>
@@ -36,9 +36,9 @@ spec:
           requests:
             storage: 500Mi
 ----
-<1> PipelineRun API version `v1beta1`.
+<1> Pipeline run API version `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `PipelineRun`.
-<3> Unique name to identify this PipelineRun.
-<4> Name of the Pipeline to be run. In this example, `build-and-deploy`.
-<5> Specifies the list of parameters required to run the Pipeline.
-<6> Workspace used by the PipelineRun.
+<3> Unique name to identify this pipeline run.
+<4> Name of the pipeline to be run. In this example, `build-and-deploy`.
+<5> Specifies the list of parameters required to run the pipeline.
+<6> Workspace used by the pipeline run.

--- a/modules/op-about-triggers.adoc
+++ b/modules/op-about-triggers.adoc
@@ -18,7 +18,7 @@ The following example shows a code snippet of the `TriggerBinding` resource, whi
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1 <1>
+apiVersion: triggers.tekton.dev/v1beta1 <1>
 kind: TriggerBinding <2>
 metadata:
   name: vote-app <3>
@@ -32,7 +32,7 @@ spec:
     value: $(body.head_commit.id)
 ----
 +
-<1> The API version of the `TriggerBinding` resource. In this example, `v1alpha1`.
+<1> The API version of the `TriggerBinding` resource. In this example, `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `TriggerBinding`.
 <3> Unique name to identify the `TriggerBinding` resource.
 <4> List of parameters which will be extracted from the received event payload and passed to the `TriggerTemplate` resource. In this example, the Git repository URL, name, and revision are extracted from the body of the event payload.
@@ -44,7 +44,7 @@ The following example shows a code snippet of a `TriggerTemplate` resource, whic
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1 <1>
+apiVersion: triggers.tekton.dev/v1beta1 <1>
 kind: TriggerTemplate <2>
 metadata:
   name: vote-app <3>
@@ -87,13 +87,13 @@ spec:
               storage: 500Mi
 ----
 +
-<1> The API version of the `TriggerTemplate` resource. In this example, `v1alpha1`.
+<1> The API version of the `TriggerTemplate` resource. In this example, `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `TriggerTemplate`.
 <3> Unique name to identify the `TriggerTemplate` resource.
 <4> Parameters supplied by the `TriggerBinding` resource.
 <5> List of templates that specify the way resources must be created using the parameters received through the `TriggerBinding` or `EventListener` resources.
 
-* The `Trigger` resource combines the `TriggerBinding` and `TriggerTemplate` resources, and optionally, the `interceptors` event processor. 
+* The `Trigger` resource combines the `TriggerBinding` and `TriggerTemplate` resources, and optionally, the `interceptors` event processor.
 +
 Interceptors process all the events for a specific platform that runs before the `TriggerBinding` resource.  You can use interceptors to filter the payload, verify events, define and test trigger conditions, and implement other useful processing. Interceptors use secret for event verification. After the event data passes through an interceptor, it then goes to the trigger before you pass the payload data to the trigger binding. You can also use an interceptor to modify the behavior of the associated trigger referenced in the `EventListener` specification.
 //image::op-triggers.png[]
@@ -102,7 +102,7 @@ The following example shows a code snippet of a `Trigger` resource, named `vote-
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1 <1>
+apiVersion: triggers.tekton.dev/v1beta1 <1>
 kind: Trigger <2>
 metadata:
   name: vote-trigger <3>
@@ -112,11 +112,11 @@ spec:
     - ref:
         name: "github" <5>
       params: <6>
-        - name: "secretRef" 
+        - name: "secretRef"
           value:
             secretName: github-secret
             secretKey: secretToken
-        - name: "eventTypes" 
+        - name: "eventTypes"
           value: ["push"]
   bindings:
     - ref: vote-app <7>
@@ -132,7 +132,7 @@ stringData:
   secretToken: "1234567"
 ----
 +
-<1> The API version of the `Trigger` resource. In this example, `v1alpha1`.
+<1> The API version of the `Trigger` resource. In this example, `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `Trigger`.
 <3> Unique name to identify the `Trigger` resource.
 <4> Service account name to be used.
@@ -148,7 +148,7 @@ The following example shows an `EventListener` resource, which references the `T
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1 <1>
+apiVersion: triggers.tekton.dev/v1beta1 <1>
 kind: EventListener <2>
 metadata:
   name: vote-app <3>
@@ -158,7 +158,7 @@ spec:
     - triggerRef: vote-trigger <5>
 ----
 +
-<1> The API version of the `EventListener` resource. In this example, `v1alpha1`.
+<1> The API version of the `EventListener` resource. In this example, `v1beta1`.
 <2> Specifies the type of Kubernetes object. In this example, `EventListener`.
 <3> Unique name to identify the `EventListener` resource.
 <4> Service account name to be used.

--- a/modules/op-adding-triggers.adoc
+++ b/modules/op-adding-triggers.adoc
@@ -13,7 +13,7 @@ Triggers enable pipelines to respond to external GitHub events, such as push eve
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
   name: vote-app
@@ -45,7 +45,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: vote-app
@@ -108,7 +108,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: Trigger
 metadata:
   name: vote-trigger
@@ -138,7 +138,7 @@ $ oc create -f https://raw.githubusercontent.com/openshift/pipelines-tutorial/{p
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: vote-app
@@ -153,7 +153,7 @@ Alternatively, if you have not defined a trigger custom resource, add the bindin
 +
 [source,yaml]
 ----
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: EventListener
 metadata:
   name: vote-app

--- a/modules/pipelines-document-attributes.adoc
+++ b/modules/pipelines-document-attributes.adoc
@@ -9,4 +9,4 @@
 //
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: Pipelines
-:pipelines-ver: pipelines-1.5
+:pipelines-ver: pipelines-1.6


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [RHDEVDOCS-3260 Update docs for Triggers going Beta](https://issues.redhat.com/browse/RHDEVDOCS-3260)
- **Preview pages**: 
  - [Understanding OpenShift Pipelines > Triggers](https://deploy-preview-37744--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/understanding-openshift-pipelines.html#about-triggers_understanding-openshift-pipelines)
  - [Creating CI/CD solutions... > Adding triggers](https://deploy-preview-37744--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/creating-applications-with-cicd-pipelines.html#adding-triggers_creating-applications-with-cicd-pipelines)
- **SME review**: @savitaashture 
- **Peer-review**: @bburt-rh 