### PR TITLE
BZ#2015218: Added deprecation message for instanceTypeID

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1079,6 +1079,10 @@ Additional {rh-virtualization} configuration parameters for machine pools are de
 
 |`<machine-pool>.platform.ovirt.instanceTypeID`
 |Optional. An instance type UUID, such as `00000009-0009-0009-0009-0000000000f1`, which you can get from the `https://<engine-fqdn>/ovirt-engine/api/instancetypes` endpoint.
+[WARNING]
+====
+The `instance_type_id` field is deprecated and will be removed in a future release.
+====
 |String of UUID
 
 |`<machine-pool>.platform.ovirt.osDisk`

--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -83,7 +83,14 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 
 <7> Specify the {rh-virtualization} VM template to use to create the machine.
 
-<8> Optional: Specify the VM instance type. If you include this parameter, you do not need to specify the hardware parameters of the VM including CPU and memory because this parameter overrides all hardware parameters.
+<8> Optional: Specify the VM instance type.
++
+[WARNING]
+====
+The `instance_type_id` field is deprecated and will be removed in a future release.
+====
++
+If you include this parameter, you do not need to specify the hardware parameters of the VM including CPU and memory because this parameter overrides all hardware parameters.
 
 <9> Optional: The CPU field contains the CPU's configuration, including sockets, cores, and threads.
 


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=12015218.

This applies to:
enterprise-4.9
enterprise-4.8
enterprise-4.7

Preview: 
- https://deploy-preview-37745--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-rhv.html#machineset-yaml-rhv_creating-machineset-rhv
- https://deploy-preview-37745--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_rhv/installing-rhv-customizations.html#installation-configuration-parameters-additional-machine_installing-rhv-customizations

Added deprecation notice in the following topics:
modules/installation-configuration-parameters.adoc
modules/machineset-yaml-rhv.adoc