### PR TITLE
OSDOCS-2639 - Adding opt-in region recommendations

### DIFF
--- a/modules/rosa-requirements-deploying-in-opt-in-regions.adoc
+++ b/modules/rosa-requirements-deploying-in-opt-in-regions.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+
+[id="rosa-requirements-deploying-in-opt-in-regions_{context}"]
+= Requirements for deploying a cluster in an opt-in region
+
+An AWS opt-in region is a region that is not enabled by default. If you want to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS) in an opt-in region, you must meet the following requirements:
+
+* The region must be enabled in your AWS account. For more information about enabling opt-in regions, see link:https://docs.aws.amazon.com/general/latest/gr/rande-manage.html[Managing AWS Regions] in the AWS documentation.
+* The security token version in your AWS account must be set to version 2. You cannot use version 1 security tokens for opt-in regions.
++
+[IMPORTANT]
+====
+Updating to security token version 2 can impact the systems that store the tokens, due to the increased token length. For more information, see link:https://docs.aws.amazon.com/cli/latest/reference/iam/set-security-token-service-preferences.html[the AWS documentation on setting STS preferences].
+====

--- a/modules/rosa-setting-the-aws-security-token-version.adoc
+++ b/modules/rosa-setting-the-aws-security-token-version.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+
+[id="rosa-setting-the-aws-security-token-version_{context}"]
+= Setting the AWS security token version
+
+If you want to create a {product-title} (ROSA) cluster with the AWS Security Token Service (STS) in an AWS opt-in region, you must set the security token version to version 2 in your AWS account.
+
+.Prerequisites
+
+* You have installed and configured the latest AWS CLI on your installation host.
+
+.Procedure
+
+. List the ID of the AWS account that is defined in your AWS CLI configuration:
++
+[source,terminal]
+----
+$ aws sts get-caller-identity --query Account --output json
+----
++
+Ensure that the output matches the ID of the relevant AWS account.
+
+. List the security token version that is set in your AWS account:
++
+[source,terminal]
+----
+$ aws iam get-account-summary --query SummaryMap.GlobalEndpointTokenVersion --output json
+----
++
+.Example output
++
+[source,terminal]
+----
+1
+----
+
+. To update the security token version to version 2 for all regions in your AWS account, run the following command:
++
+[source,terminal]
+----
+$ aws iam set-security-token-service-preferences --global-endpoint-token-version v2Token
+----
++
+[IMPORTANT]
+====
+Updating to security token version 2 can impact the systems that store the tokens, due to the increased token length. For more information, see link:https://docs.aws.amazon.com/cli/latest/reference/iam/set-security-token-service-preferences.html[the AWS documentation on setting STS preferences].
+====

--- a/modules/rosa-sts-aws-requirements.adoc
+++ b/modules/rosa-sts-aws-requirements.adoc
@@ -1,7 +1,11 @@
+// Module included in the following assemblies:
+//
+// * rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+
 [id="rosa-sts-customer-requirements_{context}"]
 = Customer requirements when using STS for deployment
 
-The following prerequisites must be complete before you deploy {product-title} (ROSA) clusters using STS.
+The following prerequisites must be complete before you deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS).
 
 [id="rosa-account_{context}"]
 == Account

--- a/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+++ b/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
@@ -12,6 +12,8 @@ Ensure that the following AWS prerequisites are met before installing ROSA with 
 
 include::modules/rosa-aws-understand.adoc[leveloffset=+1]
 include::modules/rosa-sts-aws-requirements.adoc[leveloffset=+1]
+include::modules/rosa-requirements-deploying-in-opt-in-regions.adoc[leveloffset=+1]
+include::modules/rosa-setting-the-aws-security-token-version.adoc[leveloffset=+2]
 include::modules/rosa-sts-aws-iam.adoc[leveloffset=+1]
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This relates to https://issues.redhat.com/browse/OSDOCS-2639. The PR adds a section about the requirements for deploying a ROSA cluster with STS in an AWS opt-in region.

The preview is [here](https://deploy-preview-37759--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-aws-prereqs#rosa-requirements-deploying-in-opt-in-regions_rosa-sts-aws-prerequisites).