### PR TITLE
added notes for 4.7.34 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2893,7 +2893,7 @@ link:https://access.redhat.com/solutions/6362042[{product-title} 4.7.32 containe
 [id="ocp-4-7-32-features"]
 ==== Features
 
-* Kubernetes v1.20.10 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#v12010[v1.20.10], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1209[v1.20.9], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1208[v1.20.8], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1207[v1.20.7], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1206[v1.20.6], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1205[v1.20.5], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1204[v1.20.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1203[v1.20.3], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1202[v1.20.2], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1201[v1.20.1], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1200[v1.20.0].
+* Kubernetes 1.20.10 is now available. More information can be found in the following changelogs: link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#v12010[1.20.10], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1209[1.20.9], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1208[1.20.8], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1207[1.20.7], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1206[1.20.6], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1205[1.20.5], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1204[1.20.4], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1203[1.20.3], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1202[1.20.2], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1201[1.20.1], link:https://github.com/kubernetes/kubernetes/blob/release-1.20/CHANGELOG/CHANGELOG-1.20.md#changelog-since-v1200[1.20.0].
 
 [id="ocp-4-7-32-bug-fixes"]
 ==== Bug fixes
@@ -2926,6 +2926,22 @@ link:https://access.redhat.com/solutions/6395081[{product-title} 4.7.33 containe
 * Previously, there was an unchecked index operation `--max-components` argument. With this update, a check was implemented to ensure components do not request a value for an index that is out of range. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2004194[*BZ#2004194*])
 
 [id="ocp-4-7-33-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-7-34"]
+=== RHBA-2021:3824 - {product-title} 4.7.34 bug fix update
+
+Issued: 2021-10-20
+
+{product-title} release 4.7.34 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3824[RHBA-2021:3824] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:3822[RHBA-2021:3822] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6427981[{product-title} 4.7.34 container image list]
+
+[id="ocp-4-7-34-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.7.34 

- applies to `enterprise-4.7` only
- [Preview link](https://deploy-preview-37760--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-34)
- [Preview link for the removed 'v'](https://deploy-preview-37760--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-32)

*Note: This is a new PR for the same changes. [This PR](https://github.com/openshift/openshift-docs/pull/37691) did not have a feature branch checked out. Opening this one to fix.