### PR TITLE
Put 1.18.0 CR docs live

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1744,7 +1744,7 @@ Name: Nodes
 Dir: nodes
 Distros: openshift-enterprise,openshift-origin
 Topics:
-- Name: Overview of nodes 
+- Name: Overview of nodes
   File: index
 - Name: Working with pods
   Dir: pods
@@ -3181,9 +3181,8 @@ Topics:
     # Serving
   - Name: Creating Knative Serving components in the Administrator perspective
     File: serverless-cluster-admin-serving
-#  - Name: Configuring the Knative Serving custom resource
-#    File: knative-serving-CR-config
-# Uncomment at 1.18.0 release
+  - Name: Configuring the Knative Serving custom resource
+    File: knative-serving-CR-config
     # Monitoring
   - Name: Monitoring serverless components
     File: serverless-admin-monitoring


### PR DESCRIPTION
No Jira, follows up on https://github.com/openshift/openshift-docs/pull/35924 to make docs live for Serverless 1.18.0 release.

Direct preview link: https://deploy-preview-37775--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config

Applies for OCP 4.6+