### PR TITLE
BZ:1942662 - Adding firewall URL sections to point 5 instead of 4

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -74,14 +74,10 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |===
 |Cloud |URL | Port |Function
 
-.2+|AWS
+|AWS
 |`*.amazonaws.com`
 |443, 80
 |Required to access AWS services and resources. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
-
-|`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
-|443, 80
-|Required to access AWS services and resources when using strict security requirements. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
 
 .2+|GCP
 |`*.googleapis.com`
@@ -137,7 +133,6 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |443, 80
 |Required for `odo` CLI.
 |===
-+
 Operators require route access to perform health checks. Specifically, the
 authentication and web console Operators connect to two routes to verify that
 the routes work. If you are the cluster administrator and do not want to allow
@@ -148,6 +143,21 @@ the routes work. If you are the cluster administrator and do not want to allow
 that is specified in the `spec.route.hostname` field of the
 `consoles.operator/cluster` object if the field is not empty.
 
+. Allowlist the following URLs for optional third-party content:
++
+[cols="3,2,4",options="header"]
+|===
+|URL | Port | Function
+
+|`registry.connect.redhat.com`
+|443, 80
+|Required for all third-party images and certified operators.
+
+|`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
+|443, 80
+|Required for Sonatype Nexus, F5 Big IP operators.
+|===
++
 . If you use a default Red Hat Network Time Protocol (NTP) server allow the following URLs:
 * `1.rhel.pool.ntp.org`
 * `2.rhel.pool.ntp.org`


### PR DESCRIPTION
For Versions 4.6+ 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1942662

Description: It was recommended to move `oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com` to point 5 instead of point 4

Preview: https://deploy-preview-37792--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall

Ready for QA: @xiuwang 

For Peer Reviewers: Can you please add 'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' 'enterprise-4.10' and 'Peer Review needed'. Thank you!!

Note: Still in progress