### PR TITLE
BZ1977949: Add verify Ignition step

### DIFF
--- a/modules/installation-user-infra-machines-iso.adoc
+++ b/modules/installation-user-infra-machines-iso.adoc
@@ -132,6 +132,15 @@ Be sure that the installation is successful on each node before commencing with 
 
 . After {op-system} installs, the system reboots. During the system reboot, it applies the Ignition config file that you specified.
 
+. Check the console output to verify that Ignition ran.
++
+.Example command
+[source,terminal]
+----
+Ignition: ran on 2022/03/14 14:48:33 UTC (this boot)
+Ignition: user-provided config was applied
+----
+
 . Continue to create the other machines for your cluster.
 +
 [IMPORTANT]

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -192,6 +192,15 @@ Be sure that the installation is successful on each node before commencing with 
 
 . After {op-system} installs, the system reboots. During reboot, the system applies the Ignition config file that you specified.
 
+. Check the console output to verify that Ignition ran.
++
+.Example command
+[source,terminal]
+----
+Ignition: ran on 2022/03/14 14:48:33 UTC (this boot)
+Ignition: user-provided config was applied
+----
+
 . Continue to create the machines for your cluster.
 +
 [IMPORTANT]

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -139,7 +139,14 @@ $ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 .. Complete the configuration and power on the VM.
-
+.. Check the console output to verify that Ignition ran.
++
+.Example command
+[source,terminal]
+----
+Ignition: ran on 2022/03/14 14:48:33 UTC (this boot)
+Ignition: user-provided config was applied
+----
 . Create the rest of the machines for your cluster by following the preceding steps for each machine.
 +
 [IMPORTANT]


### PR DESCRIPTION
Adds step to check console output to verify that Ignition was run
This enhancement is available in OCP 4.10+. 
This PR is essentially a clone of https://github.com/openshift/openshift-docs/pull/37535.

Related bug: https://bugzilla.redhat.com/show_bug.cgi?id=1977949
Related CoreOS PR: https://github.com/openshift/os/pull/658

vSphere preview link (step 6j): https://deploy-preview-37793--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere
BM ISO preview link (step 10): https://deploy-preview-37793--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-iso_installing-bare-metal
BM PXE preview link (step 9): https://deploy-preview-37793--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-pxe_installing-bare-metal