### PR TITLE
BZ 1897312: Incorporating Steve Hardy's comments regarding worker node count.

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
-:product-version: 4.8
 
 [id="node-requirements_{context}"'"]
 = Node requirements
@@ -12,13 +11,7 @@ Installer-provisioned installation involves a number of hardware node requiremen
 
 * *Similar nodes:* Red Hat recommends nodes have an identical configuration per role. That is, Red Hat recommends nodes be the same brand and model with the same CPU, memory, and storage configuration.
 
-ifeval::[{product-version} < 4.5]
-* *Intelligent Platform Management Interface (IPMI):* Installer-provisioned installation requires IPMI enabled on each node.
-endif::[]
-
-ifeval::[{product-version} > 4.4]
 * *Baseboard Management Controller:* The `provisioner` node must be able to access the baseboard management controller (BMC) of each {product-title} cluster node. You may use IPMI, Redfish, or a proprietary protocol.
-endif::[]
 
 ifndef::openshift-origin[]
 * *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
@@ -31,21 +24,19 @@ endif::[]
 
 * *Provisioner node:* Installer-provisioned installation requires one `provisioner` node.
 
-* *Control plane:* Installer-provisioned installation requires three control plane nodes for high availability.
+* *Control plane:* Installer-provisioned installation requires three control plane nodes for high availability. You can deploy an {product-title} cluster with only three control plane nodes, making the control plane nodes schedulable as worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
 
-* *Worker nodes:* While not required, a typical production cluster has one or more worker nodes. Smaller clusters are more resource efficient for administrators and developers during development, production, and testing.
+* *Worker nodes:* While not required, a typical production cluster has two or more worker nodes.
++
+[IMPORTANT]
+====
+Do not deploy a cluster with only one worker node, because the cluster will deploy with routers and ingress traffic in a degraded state.
+====
 
 * *Network interfaces:* Each node must have at least one 10GB network interface for the routable `baremetal` network. Each node must have one 10GB network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration. Network interface names must follow the same naming convention across all nodes. For example, the first NIC name on a node, such as `eth0` or `eno1`, must be the same name on all of the other nodes. The same principle applies to the remaining NICs on each node.
 
-ifeval::[{product-version} > 4.3]
 * *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
-endif::[]
 
-ifeval::[{product-version} == 4.7]
-* *Secure Boot:* Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications, and the operating system. To deploy an {product-title} cluster with Secure Boot, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot only when installer-provisioned installations use Red Fish Virtual Media. Red Hat does not support Secure Boot with self-generated keys.
-endif::[]
-
-ifeval::[{product-version} > 4.7]
 * *Secure Boot:* Many production scenarios require nodes with Secure Boot enabled to verify the node only boots with trusted software, such as UEFI firmware drivers, EFI applications, and the operating system. You may deploy with Secure Boot manually or managed.
 +
 . *Manually:* To deploy an {product-title} cluster with Secure Boot manually, you must enable UEFI boot mode and Secure Boot on each control plane node and each worker node. Red Hat supports Secure Boot with manually enabled UEFI and Secure Boot only when installer-provisioned installations use Redfish virtual media. See "Configuring nodes for Secure Boot manually" in the "Configuring nodes" section for additional details.
@@ -56,4 +47,3 @@ ifeval::[{product-version} > 4.7]
 ====
 Red Hat does not support Secure Boot with self-generated keys.
 ====
-endif::[]


### PR DESCRIPTION
Worker node counts should be 0 or 2+, but not 1. We can also deploy a cluster with three control plane nodes. 

See https://bugzilla.redhat.com/show_bug.cgi?id=1897312 for additional details.

Release: 4.9, 4.8

Preview URL: https://deploy-preview-37810--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#node-requirements_ipi-install-prerequisites

Signed-off-by: John Wilkins <jowilkin@redhat.com>