### PR TITLE
[enterprise-4.8] OSDOCS-2711 Add known issue and info for projected volumes and Windows pods

### DIFF
--- a/modules/nodes-containers-projected-volumes-about.adoc
+++ b/modules/nodes-containers-projected-volumes-about.adoc
@@ -12,6 +12,13 @@ so that I can synthesize a single directory with various sources of information;
 * populate a single volume with the keys from multiple secrets, config maps, and with downward API information,
 explicitly specifying paths for each item, so that I can have full control over the contents of that volume.
 
+[IMPORTANT]
+====
+When the `RunAsUser` permission is set in the security context of a Linux-based pod, the projected files have the correct permissions set, including container user ownership. However, when the Windows equivalent `RunAsUsername` permission is set in a Windows pod, the kubelet is unable to correctly set ownership on the files in the projected volume.
+
+Therefore, the `RunAsUsername` permission set in the security context of a Windows pod is not honored for Windows projected volumes running in {product-title}.
+====
+
 The following general scenarios show how you can use projected volumes.
 
 *Config map, secrets, Downward API.*::
@@ -93,7 +100,6 @@ spec:
 ====
 If there are multiple containers in the pod, each container needs a `volumeMounts` section, but only one `volumes` section is needed.
 ====
-
 
 .Pod with multiple secrets with a non-default permission mode set
 

--- a/windows_containers/windows-containers-release-notes-3-x.adoc
+++ b/windows_containers/windows-containers-release-notes-3-x.adoc
@@ -55,6 +55,33 @@ For more information on how to configure BYOH Windows instances, see xref:../win
 
 * When installing a BYOH Windows instance using a DNS name entry in the config map, the WMCO configures the instance twice before marking it as a `Ready` node. This will be fixed in a future release of the WMCO. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005360[**BZ#2005360**])
 
+* When the `RunAsUser` permission is set in the security context of a Linux-based pod, the projected files have the correct permissions set, including container user ownership. However, when the Windows equivalent `RunAsUsername` permission is set in a Windows pod, the kubelet is prevented from setting correct ownership on the files in the projected volume. This problem can get exacerbated when used in conjunction with a xref:../storage/persistent_storage/persistent-storage-hostpath.adoc#persistent-storage-using-hostpath[hostPath volume] where best practices are not followed. For example, giving a pod access to the `C:\var\lib\kubelet\pods\` folder results in that pod being able to access service account tokens from other pods.
++
+By default, the projected files will have the following ownership, as shown in this example Windows projected volume file:
++
+[source,posh]
+----
+Path   : Microsoft.PowerShell.Core\FileSystem::C:\var\run\secrets\kubernetes.io\serviceaccount\..2021_08_31_22_22_18.318230061\ca.crt
+Owner  : BUILTIN\Administrators
+Group  : NT AUTHORITY\SYSTEM
+Access : NT AUTHORITY\SYSTEM Allow  FullControl
+         BUILTIN\Administrators Allow  FullControl
+         BUILTIN\Users Allow  ReadAndExecute, Synchronize
+Audit  :
+Sddl   : O:BAG:SYD:AI(A;ID;FA;;;SY)(A;ID;FA;;;BA)(A;ID;0x1200a9;;;BU)
+----
++
+This indicates all administrator users, like someone with the `ContainerAdministrator` role, have read, write, and execute access, while non-administrator users have read and execute access.
++
+[IMPORTANT]
+====
+{product-title} applies the `RunAsUser` security context to all pods irrespective of its operating system. This means Windows pods automatically have the `RunAsUser` permission applied to its security context. 
+====
++
+In addition, if a Windows pod is created with a projected volume with the default `RunAsUser` permission set, the pod gets stuck in the `ContainerCreating` phase.
++
+To handle these issues, {product-title} forces the file permission handling in projected service account volumes set in the security context of the pod to not be honored for projected volumes on Windows. Note that this behavior for Windows pods is how file permission handling used to work for all pod types prior to {product-title} 4.7. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1971745[**BZ#1971745**])
+
 [id="wmco-3-0-0"]
 == Release notes for Red Hat Windows Machine Config Operator 3.0.0
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2711

This will be manually backported for OCP 4.7.

Previews:
- [Known issue](https://deploy-preview-37811--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-3-x.html#wmco-3-1-0-known-issues)
- [Admonition](https://deploy-preview-37811--osdocs.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-projected-volumes.html#nodes-containers-projected-volumes-about_nodes-containers-projected-volumes)