### PR TITLE
RHDEVDOCS-3387 Rename conscious language module and update includes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 
 For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-openshift-gitops.adoc#understanding-openshift-gitops[Understanding OpenShift GitOps].
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]

--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -18,7 +18,7 @@ toc::[]
 
 For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding OpenShift Pipelines].
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
 include::modules/op-release-notes-1-5.adoc[leveloffset=+1]

--- a/jaeger/rhbjaeger-release-notes.adoc
+++ b/jaeger/rhbjaeger-release-notes.adoc
@@ -9,7 +9,7 @@ toc::[]
 
 include::modules/jaeger-product-overview.adoc[leveloffset=+1]
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 include::modules/support.adoc[leveloffset=+1]
 

--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 OpenShift Logging 5.0, 5.1, and 5.2 run on {product-title} 4.7 and 4.8.
 
-include::modules/con_making-open-source-more-inclusive.adoc[leveloffset=+1]
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Release Notes by version
 

--- a/modules/making-open-source-more-inclusive.adoc
+++ b/modules/making-open-source-more-inclusive.adoc
@@ -1,6 +1,6 @@
 :_module-type: CONCEPT
 
-[id="con_making-open-source-more-inclusive_{context}"]
+[id="making-open-source-more-inclusive_{context}"]
 = Making open source more inclusive
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].


### PR DESCRIPTION
Purpose: This PR is a derivative of https://github.com/openshift/openshift-docs/pull/36814 that renames the file and updates the includes that point to it.

- Aligned team: Dev Tools
- For branches: 4.8+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3387
- Direct link to doc preview: tbd
- All reviews complete. Please merge now.
