### PR TITLE
BZ1983992: Rearranges TOC for clarity on secrets for 4.6

### DIFF
--- a/builds/creating-build-inputs.adoc
+++ b/builds/creating-build-inputs.adoc
@@ -51,6 +51,12 @@ include::modules/builds-binary-source.adoc[leveloffset=+1]
 
 include::modules/builds-input-secrets-configmaps.adoc[leveloffset=+1]
 
+include::modules/builds-secrets-overview.adoc[leveloffset=+2]
+
+include::modules/builds-creating-secrets.adoc[leveloffset=+2]
+
+include::modules/builds-using-secrets.adoc[leveloffset=+2]
+
 include::modules/builds-adding-input-secrets-configmaps.adoc[leveloffset=+2]
 
 include::modules/builds-source-to-image.adoc[leveloffset=+2]
@@ -72,11 +78,9 @@ include::modules/builds-using-build-fields-as-environment-variables.adoc[levelof
 
 include::modules/builds-using-secrets-as-environment-variables.adoc[leveloffset=+2]
 
-include::modules/builds-secrets-overview.adoc[leveloffset=+1]
+.Additional resources
 
-include::modules/builds-creating-secrets.adoc[leveloffset=+2]
-
-include::modules/builds-using-secrets.adoc[leveloffset=+3]
+* xref:../builds/creating-build-inputs.adoc#builds-input-secrets-configmaps_creating-build-inputs[Input secrets and config maps]
 
 include::modules/builds-service-serving-certificate-secrets.adoc[leveloffset=+1]
 

--- a/modules/builds-using-secrets-as-environment-variables.adoc
+++ b/modules/builds-using-secrets-as-environment-variables.adoc
@@ -7,6 +7,11 @@
 
 You can make key values from secrets available as environment variables using the `valueFrom` syntax.
 
+[IMPORTANT]
+====
+This method shows the secrets as plain text in the output of the build pod console. To avoid this, use input secrets and config maps instead. 
+====
+
 .Procedure
 
 * To use a secret as an environment variable, set the `valueFrom` syntax:


### PR DESCRIPTION
[BZ1983992](https://bugzilla.redhat.com/show_bug.cgi?id=1983992)

- Applies to `enterprise-4.6` only
- [Preview link](https://deploy-preview-37828--osdocs.netlify.app/openshift-enterprise/latest/builds/creating-build-inputs.html)