### PR TITLE
BZ#1889247: change diskSizeGB to new recommendation

### DIFF
--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -48,7 +48,7 @@ controlPlane: <2> <3>
       - us-central1-c
       osDisk:
         diskType: pd-ssd
-        diskSizeGB: 256
+        diskSizeGB: 1024
         encryptionKey: <5>
           kmsKey:
             name: worker-key


### PR DESCRIPTION
SMEs have a new recommendation for the disk size of primary nodes

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1889247

OCP version: 4.6+

Current 4.9 doc: https://docs.openshift.com/container-platform/4.9/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations

Direct doc preview link: https://deploy-preview-37836--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations