### PR TITLE
BZ2015218_RN: Add a deprecation notice for instance_type_id field of machine object for oVirt/RHV

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1081,6 +1081,11 @@ In the table, features are marked with the following statuses:
 |GA
 |DEP
 
+|The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+|DEP
+|DEP
+|DEP
+
 |====
 
 [id="ocp-4-9-deprecated-features"]
@@ -1101,6 +1106,11 @@ The default xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs
 Installing a cluster on VMware vSphere version 6.7 Update 2 or earlier and virtual hardware version 13 is now deprecated. Support for these versions will end in a future version of {product-title}.
 
 Hardware version 15 is now the default for vSphere virtual machines in {product-title}. Hardware version 15 will be the only supported version in a future version of {product-title}.
+
+==== The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+
+The `instance_type_id` installation configuration parameter
+ is deprecated and will be removed in a future release.
 
 [id="ocp-4-9-removed-features"]
 === Removed features


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=12015218.

This applies to:
enterprise-4.9

Added deprecation notice in the Release Notes

Preview:
https://deploy-preview-37871--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-deprecated-features
