### PR TITLE
GitHub:37721 - Added port 443 req for vSphere IPI and UPI installs

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -19,6 +19,8 @@ In {product-title} {product-version}, you can install a cluster on VMware vSpher
 Because the installation media is on the mirror host, you can use that computer to complete all installation steps.
 ====
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide the ReadWriteMany access mode.
+* The {product-title} installer requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -25,6 +25,8 @@ Because the installation media is on the mirror host, you can use that computer 
 ====
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
+* Completing the installation requires that you upload the {op-system-first} OVA on vSphere hosts. The machine from which you complete this process requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall and plan to use the Telemetry service, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured the firewall to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -13,6 +13,8 @@ VMware vSphere instance by using installer-provisioned infrastructure. To custom
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide `ReadWriteMany` access modes.
+* The {product-title} installer requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -16,6 +16,8 @@ You must set most of the network configuration parameters during installation, a
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
+* The {product-title} installer requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, confirm with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -14,6 +14,8 @@ VMware vSphere instance by using installer-provisioned infrastructure.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide
 `ReadWriteMany` access modes.
+* The {product-title} installer requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -24,6 +24,8 @@ The steps for performing a user-provisioned infrastructure installation are prov
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* Completing the installation requires that you upload the {op-system-first} OVA on vSphere hosts. The machine from which you complete this process requires access to port 443 on the vCenter and ESXi hosts. Verify that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -18,6 +18,8 @@ The steps for performing a user-provisioned infrastructure installation are prov
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
 * You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
 * You provisioned xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] for your cluster. To deploy a private image registry, your storage must provide `ReadWriteMany` access modes.
+* Completing the installation requires that you upload the {op-system-first} OVA on vSphere hosts. The machine from which you complete this process requires access to port 443 on the vCenter and ESXi hosts. You verified that port 443 is accessible.
+* If you use a firewall, you confirmed with the administrator that port 443 is accessible. Control plane nodes must be able to reach vCenter and ESXi hosts on port 443 for the installation to succeed.
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 +
 [NOTE]


### PR DESCRIPTION
CP to 4.6, 4.7, 4.8, 4.9, and 4.10

https://github.com/openshift/openshift-docs/issues/37721

Prerequisites for IPI installation topics where updated with the following info:

- The OpenShift installer requires access to port 443 on the vCenter and ESXi hosts.
- If a firewall is in use, that the control-plane nodes must be able to reach vCenter and ESXi hosts on port 443.

Doc preview

- [Installing a cluster on vSphere](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#prerequisites).
- [Installing a cluster on vSphere with customizations](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#prerequisites)
- [Installing a cluster on vSphere with network customizations](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#prerequisites)
- [Installing a cluster on vSphere in a restricted network](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.html#prerequisites_installing-restricted-networks-installer-provisioned-vsphere)

Updated prerequisites to list that port 443 access is required to complete the installation for both IPI and UPI installs:

Prerequisites for UPI installation topics where updated with the following info:

- The machine from which you complete the installation process requires access to port 443 on the vCenter and ESXi hosts.
- If a firewall is in use, that the control-plane nodes must be able to reach vCenter and ESXi hosts on port 443.

Doc preview

- [Installing a cluster on vSphere with user-provisioned infrastructure](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#prerequisites)
- [Installing a cluster on vSphere with network customizations](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations.html#prerequisites)
- [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure](https://deploy-preview-37873--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#prerequisites)