### PR TITLE
BZ2015218_RN_4.8: Add a deprecation notice for instance_type_id field of machine object for oVirt/RHV

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1281,6 +1281,11 @@ In the table, features are marked with the following statuses:
 |TP
 |REM
 
+|The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+|GA
+|DEP
+|DEP
+
 |====
 
 
@@ -1317,6 +1322,12 @@ Therefore, update scripts and jobs that inspect `buildConfig.spec.triggers[i].im
 This release deprecates the Jenkins Operator, which was a Technology Preview feature. A future version of {product-title} will remove the Jenkins Operator from OperatorHub in the {product-title} web console interface. Then, upgrades for the Jenkins Operator will no longer be available, and the Operator will not be supported.
 
 Customers can continue to deploy Jenkins on {product-title} using the templates provided by the Samples Operator.
+
+[id="ocp-4-8-instance_type_id-operator_rhv"]
+==== The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+
+The `instance_type_id` installation configuration parameter
+ is deprecated and will be removed in a future release.
 
 [id="ocp-4-8-removed-features"]
 === Removed features


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=12015218.

This applies to:
enterprise-4.8

Added deprecation notice in the Release Notes

Preview:
https://deploy-preview-37874--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-deprecated-features