### PR TITLE
BZ:1922741 - Adding alternative to grpcurl command

### DIFF
--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -39,7 +39,7 @@ ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
 endif::[]
 * `podman` version 1.9.3+
-* link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
+* link:https://github.com/fullstorydev/grpcurl[`grpcurl`] (third-party command-line tool)
 * `opm` version 1.18.0+
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]


### PR DESCRIPTION
For versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1922741

Preview: https://deploy-preview-37875--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-pruning-index-image_olm-restricted-networks

Ready for QA: @jianzhangbjz 

For Peer Reviewers: Labels needed 'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' 'enterprise-4.10' and 'Peer Review needed', Thank you!!