### PR TITLE
BZ2015218_RN_4.7: Add a deprecation notice for instance_type_id field of machine object for oVirt/RHV

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1099,6 +1099,11 @@ In the table, features are marked with the following statuses:
 |REM
 |REM
 
+|The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+|GA
+|GA
+|DEP
+
 |====
 
 [id="ocp-4-7-deprecated-features"]
@@ -1139,6 +1144,11 @@ Using non-groupfied API resources is deprecated and will be removed in a future 
 ----
 
 When you encounter this message, update your resource file to use the correct value.
+
+[id="ocp-4-7-instance_type_id-operator_rhv"]
+==== The `instance_type_id` installation configuration parameter for {rh-virtualization-first}
+
+The `instance_type_id` installation configuration parameter is deprecated and will be removed in a future release.
 
 [id="ocp-4-7-removed-features"]
 === Removed features


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=12015218.

This applies to:
enterprise-4.7

Added deprecation notice in the Release Notes

Preview:
https://deploy-preview-37876--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes#ocp-4-7-deprecated-features