### PR TITLE
[PR 37696]: Change specific reference  to a generic z-stream release

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
@@ -15,7 +15,7 @@ installation, otherwise the backup will contain expired certificates. It is also
 recommended to take etcd backups during non-peak usage hours, as it is a
 blocking action.
 
-Be sure to take an etcd backup after you upgrade your cluster. This is important because when you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.7.2 cluster must use an etcd backup that was taken from 4.7.2.
+Be sure to take an etcd backup after you upgrade your cluster. This is important because when you restore your cluster, you must use an etcd backup that was taken from the same z-stream release. For example, an {product-title} 4.y.z cluster must use an etcd backup that was taken from 4.y.z.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Referencing PR: https://github.com/openshift/openshift-docs/issues/37696
Releases: 4.9  (CP to 4.8 and 4.10)
Preview link:  https://deploy-preview-37877--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html

Synopsis: The current content references 4.7.2 and must be updated for each release. This PR changes the reference to 4.y.z