### PR TITLE
adds notes for 4.9.4 release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1953,7 +1953,7 @@ Alternatively, you can annotate the route to force a reload. (link:https://bugzi
 +
 No workaround exists for this issue. To track these metrics for production workloads, do not upgrade to the initial 4.9 release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2008120[*BZ#2008120*])
 
-* The Special Resource Operator (SRO) might fail to install on Google Cloud Platform due to a software-defined network policy. As a result, the simple-kmod pod is not created. This will be fixed in a future {product-title} release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1996916[*BZ#1996916*])
+* The Special Resource Operator (SRO) might fail to install on Google Cloud Platform due to a software-defined network policy. As a result, the simple-kmod pod is not created. This is fixed in {product-title} xref:../release_notes/ocp-4-9-release-notes.adoc#ocp-4-9-4[4.9.4] release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1996916[*BZ#1996916*])
 
 * In {product-title} 4.9, a user with cluster role cannot scale a deployment or deployment config using the console if they do not have edit rights to the deployment or deployment config. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1886888[*BZ#1886888*])
 
@@ -2027,3 +2027,29 @@ Issued: 2021-10-18
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6415591[{product-title} 4.9.0 container image list]
+
+[id="ocp-4-9-4"]
+=== RHBA-2021:3935 - {product-title} 4.9.4 bug fix and security update
+
+Issued: 2021-10-26
+
+{product-title} release 4.9.4 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3935[RHBA-2021:3935] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3934[RHSA-2021:3934] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6446131[{product-title} 4.9.4 container image list]
+
+[id="ocp-4-9-4-enhancements"]
+==== Enhancements
+
+A new conditional gatherer has been implemented for the `SamplesImagestreamImportFailing` alert, which collects logs and image streams of the `openshift-cluster-samples-operator` namespace when fired. The additional data gathering allows for more insight into problems when pulling image streams from an external registry. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1966153[*BZ#1966153*])
+
+[id="ocp-4-9-4-bug-fixes"]
+==== Bug fixes
+
+* Previously, the *Nodes* page rendered before the list of nodes became available. With this update, the *Nodes* page renders correctly when the node list is available. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013088[*BZ#2013088*])
+
+[id="ocp-4-9-4-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.9.4 release 

- applies to `enterprise-4.9` only 
- [Preview link](https://deploy-preview-37881--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-2)