### PR TITLE
OSDOCS cont improvement CCO updates: multiple tickets and a BZ for STS content

### DIFF
--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -27,6 +27,10 @@ include::modules/installation-azure-permissions.adoc[leveloffset=+1]
 
 include::modules/installation-azure-service-principal.adoc[leveloffset=+1]
 
+.Additional resources
+
+* For more information about CCO modes, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator-modes[About the Cloud Credential Operator].
+
 include::modules/installation-azure-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -54,6 +54,11 @@ Because your cluster has limited access to automatic machine management when you
 
 include::modules/installation-azure-permissions.adoc[leveloffset=+2]
 include::modules/installation-azure-service-principal.adoc[leveloffset=+2]
+
+.Additional resources
+
+* For more information about CCO modes, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator-modes[About the Cloud Credential Operator].
+
 include::modules/installation-azure-regions.adoc[leveloffset=+2]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-account.adoc
@@ -20,6 +20,10 @@ include::modules/installation-azure-stack-hub-permissions.adoc[leveloffset=+1]
 
 include::modules/installation-azure-service-principal.adoc[leveloffset=+1]
 
+.Additional resources
+
+* For more information about CCO modes, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator-modes[About the Cloud Credential Operator].
+
 [id="next-steps_installing-azure-stack-hub-account"]
 == Next steps
 

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
@@ -58,6 +58,10 @@ Because your cluster has limited access to automatic machine management when you
 include::modules/installation-azure-stack-hub-permissions.adoc[leveloffset=+2]
 include::modules/installation-azure-service-principal.adoc[leveloffset=+2]
 
+.Additional resources
+
+* For more information about CCO modes, see xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator-modes[About the Cloud Credential Operator].
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -24,6 +24,11 @@ The `ccoctl` is a Linux binary that must run in a Linux environment.
 ----
 $ CCO_IMAGE=$(oc adm release info --image-for='cloud-credential-operator' $RELEASE_IMAGE)
 ----
++
+[NOTE]
+====
+Ensure that the architecture of the `$RELEASE_IMAGE` matches the architecture of the environment in which you will use the `ccoctl` tool.
+====
 
 . Extract the `ccoctl` binary from the CCO container image within the {product-title} release image:
 +

--- a/modules/installation-azure-service-principal.adoc
+++ b/modules/installation-azure-service-principal.adoc
@@ -209,7 +209,7 @@ ifndef::ash[]
 ** To operate the CCO in _passthrough mode_, the app registration service principal does not require additional API permissions.
 --
 +
-For more information about CCO modes, see the *Cloud Credential Operator* entry in the *Red Hat Operators reference* content.
+For more information about CCO modes, see "About the Cloud Credential Operator" in the "Managing cloud provider credentials" section of the _Authentication and authorization_ guide.
 +
 [NOTE]
 ====

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -30,6 +30,8 @@ administrator-level credential secret in the cluster `kube-system` namespace.
 ----
 $ openshift-install create install-config --dir=<installation_directory>
 ----
++
+where `<installation_directory>` is the directory in which the installation program creates files.
 
 . Edit the `install-config.yaml` configuration file so that it contains the `credentialsMode` parameter set to `Manual`.
 +
@@ -50,10 +52,8 @@ compute:
 +
 [source,terminal]
 ----
-$ openshift-install create manifests --dir=<installation_directory> <1>
+$ openshift-install create manifests --dir=<installation_directory>
 ----
-<1> For `<installation_directory>`, specify the directory name to store the
-files that the installation program creates.
 
 . From the directory that contains the installation program, obtain details of the {product-title} release image that your `openshift-install` binary is built to use:
 +
@@ -172,5 +172,5 @@ $ openshift-install create cluster --dir=<installation_directory>
 +
 [IMPORTANT]
 ====
-Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state. For details, see the _Upgrading clusters with manually maintained credentials_ section of the installation content for your cloud provider.
+Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state. For details, see the "Upgrading clusters with manually maintained credentials" section of the installation content for your cloud provider.
 ====

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -21,7 +21,7 @@ Before upgrading a cluster with manually maintained credentials, you must create
 
 . Extract and examine the `CredentialsRequest` custom resource for the new release.
 +
-The _Manually creating IAM_ section of the installation content for your cloud provider explains how to obtain and use the credentials required for your cloud.
+The "Manually creating IAM" section of the installation content for your cloud provider explains how to obtain and use the credentials required for your cloud.
 
 . Update the manually maintained credentials on your cluster:
 

--- a/modules/sts-mode-installing-manual-run-installer.adoc
+++ b/modules/sts-mode-installing-manual-run-installer.adoc
@@ -7,16 +7,33 @@
 
 .Prerequisites
 
-* Create the `install-config.yaml` file for your installation.
+* Obtain the {product-title} release image.
 
 .Procedure
 
-. From the installation directory that contains your `install-config.yaml` file, configure the  Cloud Credential Operator (CCO) to run in manual mode:
+. Change to the directory that contains the installation program and create the `install-config.yaml` file:
 +
 [source,terminal]
 ----
-$ echo “credentialsMode: Manual” >> install-config.yaml
+$ openshift-install create install-config --dir=<installation_directory>
 ----
++
+where `<installation_directory>` is the directory in which the installation program creates files.
+
+. Edit the `install-config.yaml` configuration file so that it contains the `credentialsMode` parameter set to `Manual`.
++
+.Example `install-config.yaml` configuration file
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: cluster1.example.com
+credentialsMode: Manual <1>
+compute:
+- architecture: amd64
+  hyperthreading: Enabled
+...
+----
+<1> This line is added to set the `credentialsMode` parameter to `Manual`.
 
 . Create the required {product-title} installation manifests:
 +


### PR DESCRIPTION
Addresses:
- [OSDOCS-2649](https://issues.redhat.com/browse/OSDOCS-2649)
- [OSDOCS-2702](https://issues.redhat.com/browse/OSDOCS-2702)
- [BZ#2015855](https://bugzilla.redhat.com/show_bug.cgi?id=2015855)

Applies to 4.7+ branches

Previews:
- [OSDOCS-2649](https://issues.redhat.com/browse/OSDOCS-2649): **Fix outdated refs to CCO content**
[Creating a service principal](https://deploy-preview-37882--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-service-principal_installing-azure-account) (step 6 and _Additional resources_ under module)
Module is reused and _Additional resources_ reproduced for other Azure install procs.
- [OSDOCS-2702](https://issues.redhat.com/browse/OSDOCS-2702): **Clarify install-config.yaml steps for AWS STS**
[Running the installer](https://deploy-preview-37882--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#sts-mode-installing-manual-run-installer_sts-mode-upgrading) (_Prerequisites_ and steps 1-2)
[Manually create IAM](https://deploy-preview-37882--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws) (steps 1 and 3, tidied up to match same steps in _Running the installer_)
- BZ#2015855: **Add a note about downloading ccoctl for different architecture**
[Configuring the Cloud Credential Operator utility](https://deploy-preview-37882--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts) (step 1)