### PR TITLE
[okd][virt] commenting out RNs in topic map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -789,7 +789,7 @@ Topics:
   - Name: Troubleshooting the Compliance Operator
     File: compliance-operator-troubleshooting
   - Name: Uninstalling the Compliance Operator
-    File: compliance-operator-uninstallation  
+    File: compliance-operator-uninstallation
   - Name: Using the oc-compliance plug-in
     File: oc-compliance-plug-in-using
 - Name: File Integrity Operator
@@ -2847,9 +2847,9 @@ Topics:
 - Name: OpenShift Virtualization release notes
   File: virt-4-8-release-notes
   Distros: openshift-enterprise
-- Name: OKD Virtualization release notes
-  File: virt-4-8-release-notes
-  Distros: openshift-origin
+#- Name: OKD Virtualization release notes
+#  File: virt-4-8-release-notes
+#  Distros: openshift-origin
 - Name: Installing
   Dir: install
   Topics:


### PR DESCRIPTION
- No associated bug/issue
- The CNV release notes have a lot of support implications etc. that are not relevant/potentially misleading for OKD. Commenting out instead of removing in case we want to do something with OKD release notes in the future.
- cherrypick to enterprise-4.9 and 4.10
- preview (or lack thereof): http://file.rdu.redhat.com/pousley/102121/okd-remove-rns/welcome/index.html

attn @fabiand 