### PR TITLE
Fix all missing gcp attribute closures

### DIFF
--- a/modules/admin-credentials-root-secret-formats.adoc
+++ b/modules/admin-credentials-root-secret-formats.adoc
@@ -102,3 +102,13 @@ stringData:
   service_account.json: <ServiceAccount>
 ----
 endif::google-cloud-platform[]
+
+ifeval::["{context}" == "manually-creating-iam-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-gcp"]
+:!google-cloud-platform:
+endif::[]

--- a/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
+++ b/modules/alternatives-to-storing-admin-secrets-in-kube-system.adoc
@@ -52,3 +52,13 @@ If you prefer not to store an administrator-level credential secret in the clust
 
 Using manual mode allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. You can also use this mode if your environment does not have connectivity to the cloud provider public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade. You must also manually supply credentials for every component that requests them.
 endif::azure[]
+
+ifeval::["{context}" == "manually-creating-iam-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-gcp"]
+:!google-cloud-platform:
+endif::[]

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -64,3 +64,10 @@ directory to delete the cluster.
 
 . Optional: Delete the `<installation_directory>` directory and the
 {product-title} installation program.
+
+ifeval::["{context}" == "uninstalling-cluster-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "uninstalling-cluster-gcp"]
+:!gcp:
+endif::[]

--- a/modules/machineset-creating-non-guaranteed-instances.adoc
+++ b/modules/machineset-creating-non-guaranteed-instances.adoc
@@ -71,3 +71,13 @@ providerSpec:
 If `preemptible` is set to `true`, the machine is labelled as an `interruptable-instance` after the instance is launched.
 
 endif::gcp[]
+
+ifeval::["{context}" == "creating-machineset-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "creating-machineset-gcp"]
+:!gcp:
+endif::[]

--- a/modules/machineset-non-guaranteed-instance.adoc
+++ b/modules/machineset-non-guaranteed-instance.adoc
@@ -71,3 +71,13 @@ Interruptions can occur when using preemptible VM instances for the following re
 
 When GCP terminates an instance, a termination handler running on the preemptible VM instance node deletes the machine resource. To satisfy the machine set `replicas` quantity, the machine set creates a machine that requests a preemptible VM instance.
 endif::gcp[]
+
+ifeval::["{context}" == "creating-machineset-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "creating-machineset-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "creating-machineset-gcp"]
+:!gcp:
+endif::[]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -174,3 +174,13 @@ $ openshift-install create cluster --dir=<installation_directory>
 ====
 Before upgrading a cluster that uses manually maintained credentials, you must ensure that the CCO is in an upgradeable state. For details, see the _Upgrading clusters with manually maintained credentials_ section of the installation content for your cloud provider.
 ====
+
+ifeval::["{context}" == "manually-creating-iam-aws"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "manually-creating-iam-gcp"]
+:!google-cloud-platform:
+endif::[]


### PR DESCRIPTION
GCP previews for these attribute endings:

- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#admin-credentials-root-secret-formats_manually-creating-iam-gcp
- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#alternatives-to-storing-admin-secrets-in-kube-system_manually-creating-iam-gcp
- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html
- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-non-guaranteed-instance_creating-machineset-gcp
- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-creating-non-guaranteed-instance_creating-machineset-gcp
- https://deploy-preview-37885--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#manually-create-iam_manually-creating-iam-gcp