### PR TITLE
BZ1994507: HPP backing directory must not be in root

### DIFF
--- a/modules/virt-about-hostpath-provisioner.adoc
+++ b/modules/virt-about-hostpath-provisioner.adoc
@@ -13,7 +13,7 @@ When you install the {VirtProductName} Operator, the hostpath provisioner Operat
 is automatically installed. To use it, you must:
 
 * Configure SELinux:
-** If you use Red Hat Enterprise Linux CoreOS 8 workers, you must create a `MachineConfig`
+** If you use {op-system-first} 8 workers, you must create a `MachineConfig`
 object on each node.
 ** Otherwise, apply the SELinux label `container_file_t` to the persistent volume (PV) backing
 directory on each node.

--- a/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
+++ b/modules/virt-configuring-selinux-hpp-on-rhcos8.adoc
@@ -3,16 +3,18 @@
 // * virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
 
 [id="virt-configuring-selinux-hpp-on-rhcos8_{context}"]
-= Configuring SELinux for the hostpath provisioner on Red Hat Enterprise Linux CoreOS 8
+= Configuring SELinux for the hostpath provisioner on {op-system-first} 8
 
-You must configure SELinux before you create the `HostPathProvisioner` custom
-resource. To configure SELinux on Red Hat Enterprise Linux CoreOS 8 workers, you
-must create a `MachineConfig` object on each node.
+You must configure SELinux before you create the `HostPathProvisioner` custom resource. To configure SELinux on {op-system-first} 8 workers, you must create a `MachineConfig` object on each node.
 
 .Prerequisites
 
-* Create a backing directory on each node for the persistent volumes (PVs)
-that the hostpath provisioner creates.
+* Create a backing directory on each node for the persistent volumes (PVs) that the hostpath provisioner creates.
++
+[IMPORTANT]
+====
+The backing directory must not be located in the filesystem's root directory because the `/` partition is read-only on {op-system}. For example, you can use `/var/<directory_name>` but not `/<directory_name>`.
+====
 
 
 .Procedure
@@ -25,8 +27,7 @@ that the hostpath provisioner creates.
 $ touch machineconfig.yaml
 ----
 
-. Edit the file, ensuring that you include the directory where you want the
-hostpath provisioner to create PVs. For example:
+. Edit the file, ensuring that you include the directory where you want the hostpath provisioner to create PVs. For example:
 +
 
 [source,yaml]
@@ -49,14 +50,14 @@ spec:
             Before=kubelet.service
 
             [Service]
-            ExecStart=/usr/bin/chcon -Rt container_file_t <path/to/backing/directory> <1>
+            ExecStart=/usr/bin/chcon -Rt container_file_t <backing_directory_path> <1>
 
             [Install]
             WantedBy=multi-user.target
           enabled: true
           name: hostpath-provisioner.service
 ----
-<1> Specify the backing directory where you want the provisioner to create PVs.
+<1> Specify the backing directory where you want the provisioner to create PVs. This directory must not be located in the filesystem's root directory (`/`).
 
 . Create the `MachineConfig` object:
 +

--- a/modules/virt-creating-storage-class.adoc
+++ b/modules/virt-creating-storage-class.adoc
@@ -48,7 +48,7 @@ do not specify a value, the storage class defaults to `Delete`.
 binding occur. Specify `WaitForFirstConsumer` to delay the binding and provisioning
 of a PV until after a pod that uses the persistent volume claim (PVC)
 is created. This ensures that the PV meets the pod's scheduling requirements.
-
++
 [NOTE]
 ====
 Virtual machines use data volumes that are based on local PVs. Local PVs are bound to specific nodes. While the disk image is prepared for consumption by the virtual machine, it is possible that the virtual machine cannot be scheduled to the node where the local storage PV was previously pinned.
@@ -63,6 +63,6 @@ To solve this problem, use the Kubernetes pod scheduler to bind the PVC to a PV 
 $ oc create -f storageclass.yaml
 ----
 
-.Additional information
+.Additional resources
 
-* link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage Classes]
+* link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage classes]

--- a/modules/virt-using-hostpath-provisioner.adoc
+++ b/modules/virt-using-hostpath-provisioner.adoc
@@ -5,26 +5,27 @@
 [id="virt-using-hostpath-provisioner_{context}"]
 = Using the hostpath provisioner to enable local storage
 
-To deploy the hostpath provisioner and enable your virtual machines to use local
-storage, first create a `HostPathProvisioner` custom resource.
+To deploy the hostpath provisioner and enable your virtual machines to use local storage, first create a `HostPathProvisioner` custom resource.
 
 .Prerequisites
 
-* Create a backing directory on each node for the persistent volumes (PVs)
-that the hostpath provisioner creates.
+* Create a backing directory on each node for the persistent volumes (PVs) that the hostpath provisioner creates.
++
+[IMPORTANT]
+====
+The backing directory must not be located in the filesystem's root directory because the `/` partition is read-only on {op-system-first}. For example, you can use `/var/<directory_name>` but not `/<directory_name>`.
+====
 
-* Apply the SELinux context `container_file_t` to the PV
-backing directory on each node. For example:
+* Apply the SELinux context `container_file_t` to the PV backing directory on each node. For example:
 +
 [source,terminal]
 ----
-$ sudo chcon -t container_file_t -R </path/to/backing/directory>
+$ sudo chcon -t container_file_t -R <backing_directory_path>
 ----
 +
 [NOTE]
 ====
-If you use Red Hat Enterprise Linux CoreOS 8 workers, you must configure SELinux
-by using a `MachineConfig` manifest instead.
+If you use {op-system-first} 8 workers, you must configure SELinux by using a `MachineConfig` manifest instead.
 ====
 
 .Procedure
@@ -36,8 +37,7 @@ by using a `MachineConfig` manifest instead.
 $ touch hostpathprovisioner_cr.yaml
 ----
 
-. Edit the file, ensuring that the `spec.pathConfig.path` value is the directory
-where you want the hostpath provisioner to create PVs. For example:
+. Edit the file, ensuring that the `spec.pathConfig.path` value is the directory where you want the hostpath provisioner to create PVs. For example:
 +
 [source,yaml]
 ----
@@ -48,20 +48,17 @@ metadata:
 spec:
   imagePullPolicy: IfNotPresent
   pathConfig:
-    path: "</path/to/backing/directory>" <1>
+    path: "<backing_directory_path>" <1>
     useNamingPrefix: false <2>
   workload: <3>
 ----
-<1> Specify the backing directory where you want the provisioner to create PVs.
-<2> Change this value to `true` if you want to use the name of the persistent volume claim (PVC)
-that is bound to the created PV as the prefix of the directory name.
+<1> Specify the backing directory where you want the provisioner to create PVs. This directory must not be located in the filesystem's root directory (`/`).
+<2> Change this value to `true` if you want to use the name of the persistent volume claim (PVC) that is bound to the created PV as the prefix of the directory name.
 <3> Optional: You can use the `spec.workload` field to configure node placement rules for the hostpath provisioner.
 +
 [NOTE]
 ====
-If you did not create the backing directory, the provisioner attempts to create
-it for you. If you did not apply the `container_file_t` SELinux context, this can cause
-`Permission denied` errors.
+If you did not create the backing directory, the provisioner attempts to create it for you. If you did not apply the `container_file_t` SELinux context, this can cause `Permission denied` errors.
 ====
 
 . Create the custom resource in the `openshift-cnv` namespace:

--- a/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
@@ -1,5 +1,6 @@
 [id="virt-configuring-local-storage-for-vms"]
 = Configuring local storage for virtual machines
+include::modules/common-attributes.adoc[]
 include::modules/virt-document-attributes.adoc[]
 :context: virt-configuring-local-storage-for-vms
 
@@ -14,8 +15,7 @@ include::modules/virt-configuring-selinux-hpp-on-rhcos8.adoc[leveloffset=+1]
 
 include::modules/virt-using-hostpath-provisioner.adoc[leveloffset=+1]
 
-[id="virt-local-storage-resources"]
-=== Additional resources
+.Additional resources
 * xref:../../../virt/install/virt-specifying-nodes-for-virtualization-components.adoc#virt-specifying-nodes-for-virtualization-components[Specifying nodes for virtualization components]
 
 include::modules/virt-creating-storage-class.adoc[leveloffset=+1]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=1994507
- Adding warnings and notes to indicate that the HPP backing directory must not be in root. Also removing hard wraps while I'm here. Finally, I noticed a numbering syntax issue in the storage class file so I am fixing that as well.
- Edit: Also subbing in `{op-system-first}` and `{op-system}` for "Red Hat Enterprise Linux CoreOS" to make these files OKD-friendly.
- CP to enterprise-4.6, 4.7, 4.8, 4.9, 4.10 
- Preview build: https://deploy-preview-37887--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms