### PR TITLE
Update k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc

### DIFF
--- a/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
+++ b/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
@@ -18,7 +18,7 @@ You must install the Kubernetes NMState Operator from the web console while logg
 
 . Click on *Install* to open the *Install Operator* window.
 
-. Under *Installed Namespace*, ensure the namespace is `openshift-nmstate`. If `openshift-nmstate` does not exist in the combo box, click on *Create Namespace* and enter `openshift-nmstate` in the *Name* field of the dialog box and press *Create*.
+. Under *Installed Namespace*, ensure the namespace is `openshift-nmstate`. If `openshift-nmstate` does not exist in the combo box, click on *Create Project* and enter `openshift-nmstate` in the *Name* field of the dialog box and press *Create*.
 
 . Click *Install* to install the Operator.
 


### PR DESCRIPTION
As of openshift/console#9890 the dropdown shows 'Create Project' instead of 'Create Namespace' when creating a namespace during installation of the operator in an OpenShift cluster.

4.8.x:
![image](https://user-images.githubusercontent.com/10140713/138460014-f3f88fa4-b942-415f-9811-5add24f612dd.png)


4.9.0:
![image](https://user-images.githubusercontent.com/10140713/138459651-5b1446f3-a9ab-43ae-9804-003bfc19aa5b.png)
