### PR TITLE
Document how to create openshift-nmstate namespace.

### DIFF
--- a/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
+++ b/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
@@ -18,7 +18,7 @@ You must install the Kubernetes NMState Operator from the web console while logg
 
 . Click on *Install* to open the *Install Operator* window.
 
-. Under *Installed Namespace*, ensure the namespace is `openshift-nmstate`. If `openshift-nmstate` does not exist in the combo box, click on *Create Namespace* and enter `openshift-nmstate` in the *Name* field of the dialog box and press *Create*.
+. Under *Installed Namespace*, ensure the namespace is `openshift-nmstate`. If `openshift-nmstate` does not exist in the combo box, it will have to be created from *Administration* -> *Namespaces* before this operator can be installed. Go to *Administration* -> *Namespaces*, click on *Create Namespace* and enter `openshift-nmstate` in the *Name* field of the dialog box and press *Create*. Then restart this installation procedure. Now the `openshift-nmstate` should be available when you get to this step.
 
 . Click *Install* to install the Operator.
 


### PR DESCRIPTION
This updates the documentation to instruct how to create the
openshift-nmstate namespace outside of the kubernetes-nmstate-operator
installer.