### PR TITLE
BZ1860560: modify mirror registry

### DIFF
--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -66,7 +66,7 @@ ifndef::openshift-origin[]
 +
 [source,terminal]
 ----
-$ cat ./pull-secret.text | jq .  > <path>/<pull-secret-file><1>
+$ cat ./pull-secret.text | jq .  > <path>/<pull_secret_file_in_json><1>
 ----
 <1> Specify the path to the folder to store the pull secret in and a name for
 the JSON file that you create.
@@ -139,8 +139,8 @@ The file resembles the following example:
 ----
 {
   "auths": {
-    "<mirror_registry>": {
-      "auth": "<credentials>",
+    "registry.example.com": {
+      "auth": "BGVtbYk3ZHAtqXs=",
       "email": "you@example.com"
     },
     "cloud.openshift.com": {


### PR DESCRIPTION
Applies to 4.6 + versions

[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1860560)

Scope: Modify mirror registry details

[Preview](https://deploy-preview-37898--osdocs.netlify.app/)

@tsze-redhat please review.

