### PR TITLE
BZ1989948: Added Important paragraph - applicable only to enterprise 4.9

### DIFF
--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -19,6 +19,11 @@ You can create a catalog image that uses the plain text _file-based catalog_ for
 * `opm` version 1.18.0+
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -12,6 +12,11 @@ You can create an index image based on the SQLite database format by using the `
 * `opm` version 1.18.0+
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -43,6 +43,11 @@ endif::[]
 * `opm` version 1.18.0+
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 


### PR DESCRIPTION
This pull request is linked to #36594.

Added Important paragraph, which is required for sections containing Docker v2-2.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1989948#

OCP Version: **applicable 4.9 only**

Direct Doc Preview Links:
https://deploy-preview-37906--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-fb-catalog-image_olm-managing-custom-catalogs

https://deploy-preview-37906--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-index-image_olm-managing-custom-catalogs

https://deploy-preview-37906--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-pruning-index-image_olm-managing-custom-catalogs