### PR TITLE
Update nmstate.io apis of NMS and NNCP from v1beta1 to v1

### DIFF
--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -16,7 +16,7 @@ By default, the manifest applies to all nodes in the cluster. To add the interfa
 +
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: <br1-eth1-policy> <1>

--- a/modules/virt-example-bond-nncp.adoc
+++ b/modules/virt-example-bond-nncp.adoc
@@ -25,7 +25,7 @@ It includes samples values that you must replace with your own information.
 
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: bond0-eth1-eth2-policy <1>

--- a/modules/virt-example-bridge-nncp.adoc
+++ b/modules/virt-example-bridge-nncp.adoc
@@ -14,7 +14,7 @@ It includes samples values that you must replace with your own information.
 
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: br1-eth1-policy <1>

--- a/modules/virt-example-ethernet-nncp.adoc
+++ b/modules/virt-example-ethernet-nncp.adoc
@@ -13,7 +13,7 @@ It includes sample values that you must replace with your own information.
 
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: eth1-policy <1>

--- a/modules/virt-example-vlan-nncp.adoc
+++ b/modules/virt-example-vlan-nncp.adoc
@@ -14,7 +14,7 @@ It includes samples values that you must replace with your own information.
 
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: vlan-eth1-policy <1>

--- a/modules/virt-removing-interface-from-nodes.adoc
+++ b/modules/virt-removing-interface-from-nodes.adoc
@@ -25,7 +25,7 @@ Similarly, removing an interface does not delete the policy.
 +
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: <br1-eth1-policy> <1>

--- a/modules/virt-troubleshooting-incorrect-policy-config.adoc
+++ b/modules/virt-troubleshooting-incorrect-policy-config.adoc
@@ -19,7 +19,7 @@ To find the error, investigate the available NMState resources. You can then upd
 +
 [source,yaml]
 ----
-apiVersion: nmstate.io/v1beta1
+apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
   name: ens01-bridge-testfail


### PR DESCRIPTION
We have updated the API versions of nmstate.io `NMState` and `NodeNetworkConfigurationPolicy` to v1 in https://github.com/nmstate/kubernetes-nmstate/pull/857 so the docs must be adjusted as well.

OCP target version: 4.10

/hold until the changes from https://github.com/nmstate/kubernetes-nmstate/pull/857 got merged into downstreams

- https://issues.redhat.com/browse/SDN-2215