### PR TITLE
OSDOCS-2816: Fixed an instance type that was m5.xlarge to m5.2xlarge.

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -15,7 +15,7 @@ AWS EC2 instances are required for deploying the control plane and data plane fu
 
 Instance types can vary for control plane and infrastructure nodes, depending on the worker node count. At a minimum, the following EC2 instances will be deployed:
 
-- Three `m5.xlarge` control plane nodes
+- Three `m5.2xlarge` control plane nodes
 - Two `r5.xlarge` infrastructure nodes
 - Two `m5.xlarge` customizable worker nodes
 


### PR DESCRIPTION
Fixed a typo with the AWS instance types.

JIRA: https://issues.redhat.com/browse/OSDOCS-2816

Preview: https://deploy-preview-37942--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#rosa-ec2-instances_prerequisites