### PR TITLE
BZ2016697: Added the spacing for parameters apiVersion and kind in the yaml file

### DIFF
--- a/modules/persistent-kubelet-log-level-configuration.adoc
+++ b/modules/persistent-kubelet-log-level-configuration.adoc
@@ -7,8 +7,8 @@
 +
 [source,yaml]
 ----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: MachineConfig
+ apiVersion: machineconfiguration.openshift.io/v1
+ kind: MachineConfig
  metadata:
    labels:
      machineconfiguration.openshift.io/role: master


### PR DESCRIPTION
Applicable to 4.6+ versions

[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2016697)

Fixed indentations/spacing in the yaml file for parameters` apiVersion` and `kind`.

[Preview](https://deploy-preview-37960--osdocs.netlify.app/openshift-enterprise/latest/rest_api/editing-kubelet-log-level-verbosity.html)
@sunilcio  please review.