### PR TITLE
RHDEVDOCS-3411- added release notes for 1.3.0

### DIFF
--- a/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
+++ b/cicd/gitops/configuring-sso-for-argo-cd-on-openshift.adoc
@@ -8,11 +8,6 @@ toc::[]
 
 After the {gitops-title} Operator is installed, Argo CD automatically creates a user with `admin` permissions. To manage multiple users, Argo CD allows cluster administrators to configure SSO.
 
-[NOTE]
-====
-Bundled Dex OIDC provider is not supported.
-====
-
 .Prerequisites
 * Red Hat SSO is installed on the cluster.
 

--- a/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+++ b/cicd/gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
@@ -14,6 +14,8 @@ With Red Hat OpenShift GitOps, you can configure Argo CD to recursively sync the
 
 include::modules/logging-in-to-the-argo-cd-instance-by-using-your-openshift-credentials.adoc[leveloffset=+1]
 
+include::modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc[leveloffset=+1]
+
 include::modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc[leveloffset=+1]
 
 include::modules/gitops-creating-an-application-by-using-the-oc-tool.adoc[leveloffset=+1]

--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -19,7 +19,11 @@ For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-open
 
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
+
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-2.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-3-0.adoc
+++ b/modules/gitops-release-notes-1-3-0.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3_{context}"]
+= Release notes for {gitops-title} 1.3
+
+{gitops-title} 1.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="new-features-1-3_{context}"]
+== New features
+In addition to the fixes and stability improvements, the following sections highlight what is new in {gitops-title} 1.3.0:
+
+* For a fresh install of v1.3.0, Dex is automatically configured. You can log into the default Argo CD instance in the `openshift-gitops` namespace using the OpenShift or `kubeadmin` credentials.  As an admin you can disable the Dex installation after the Operator is installed which will remove the Dex deployment from the `openshift-gitops` namespace.
+* The default Argo CD instance installed by the  Operator as well as accompanying controllers can now run on the infrastructure nodes of the cluster by setting a simple configuration toggle.
+* Internal communications in Argo CD can now be secured using the TLS and the OpenShift cluster certificates. The Argo CD routes can now leverage the OpenShift cluster certificates in addition to using external certificate managers such as the cert-manager.
+* Use the improved *environment details* view in the *Developer* perspective of the console 4.9 to gain insights into the GitOps environments.
+* You can now access custom health checks in Argo CD for `DeploymentConfig` resources, `Route` resources, and Operators installed using OLM.
+* The GitOps Operator now conforms to the naming conventions recommended by the latest Operator-SDK:
+** The prefix `gitops-operator-` is added to all resources
+** Service account is renamed to `gitops-operator-controller-manager`
+
+
+[id="fixed-issues-1-3_{context}"]
+== Fixed issues
+The following issues were resolved in the current release:
+
+* Previously, if you set up a new namespace to be managed by a new instance of Argo CD, it would immediately be **Out Of Sync** due to the new roles and bindings that the Operator creates to manage that new namespace. This behavior is fixed.  link:https://issues.redhat.com/browse/GITOPS-1384[GITOPS-1384]
+
+[id="known-issues-1-3_{context}"]
+== Known issues
+
+* While migrating from the Dex authentication provider to the Keycloak provider, you may experience login issues with Keycloak. link:https://issues.redhat.com/browse/GITOPS-1450[GITOPS-1450]
++
+To prevent the above issue, when migrating, uninstall Dex by removing the `.spec.dex` section found in the Argo CD custom resource. Allow a few minutes for Dex to uninstall completely, and then proceed to install Keycloak by adding `.spec.sso.provider: keycloak` to the Argo CD custom resource.
++
+As a workaround, uninstall Keycloak by removing `.spec.sso.provider: keycloak` and then re-install.

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+=== Compatibility and support matrix
+
+Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
+
+In the table, features are marked with the following statuses:
+
+* *TP*: _Technology Preview_
+* *GA*: _General Availability_
+
+|===
+|*OpenShift GitOps* 6+|*Component Versions*|*OpenShift Versions*|*Support status*
+
+|*Version*|*kam*|*Helm*|*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*||
+|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.7-4.9|GA
+|1.2.0|0.0.38|3.5.0|3.9.4|2.0.5|0.1.0|N/A|4.8|GA
+|1.1.0|0.0.32|3.5.0|3.9.4|2.0.0|N/A|N/A|4.7|GA
+|===

--- a/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
+++ b/modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assembly:
+//
+// * gitops/configuring_argo_cd_to_recursively_sync_a_git_repository_with_your_application/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+
+[id="run-argo-cd-instance-on-cluster_{context}"]
+
+= Running the Argo CD instance at the cluster-level
+
+The default Argo CD instance and the accompanying controllers, installed by the {gitops-title} Operator, can now run on the infrastructure nodes of the cluster by setting a simple configuration toggle.
+
+[discrete]
+.Procedure
+. Label the existing nodes:
++
+[source,terminal]
+----
+$ oc label node <node-name> node-role.kubernetes.io/infra=""
+----
++
+. Optional: If required, you can also apply taints and isolate the workloads on infrastructure nodes and prevent other workloads from scheduling on these nodes:
++
+[source,terminal]
+----
+$ oc adm taint nodes -l node-role.kubernetes.io/infra
+infra=reserved:NoSchedule infra=reserved:NoExecute
+----
+. Add the `runOnInfra` toggle in the `GitOpsService` custom resource:
++
+[source,yaml]
+----
+apiVersion: pipelines.openshift.io/v1alpha1
+kind: GitopsService
+metadata:
+  name: cluster
+spec:
+  runOnInfra: true
+----
+. Optional: If taints have been added to the nodes, then add `tolerations` to the `GitOpsService` custom resource, for example:
++
+[source,yaml]
+----
+  spec:
+    runOnInfra: true
+    tolerations:
+    - effect: NoSchedule
+      key: infra
+      value: reserved
+    - effect: NoExecute
+      key: infra
+      value: reserved
+----
+. Verify that the workloads in the `openshift-gitops` namespace are now scheduled on the infrastructure nodes by viewing *Pods* -> *Pod details* for any pod in the console UI.
+
+[NOTE]
+====
+Any `nodeSelectors` and `tolerations` manually added to the default Argo CD custom resource are overwritten by the toggle and `tolerations` in the `GitOpsService` custom resource.
+====


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: [RHDEVDOCS-3411](https://issues.redhat.com/browse/RHDEVDOCS-3411) GitOps Release Notes, Known Issues and Bug Fixes for 1.3
 https://issues.redhat.com/browse/RHDEVDOCS-3411
Preview pages: https://deploy-preview-37968--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-3_gitops-release-notes
SME+QE review: @reginapizza 
Peer-review:  @Preeticp 