### PR TITLE
BZ1989948: Added Important paragraph - applicable only to enterprise 4.7

### DIFF
--- a/modules/olm-building-operator-catalog-image.adoc
+++ b/modules/olm-building-operator-catalog-image.adoc
@@ -14,11 +14,16 @@ endif::[]
 
 Cluster administrators can build a custom Operator catalog image based on the Package Manifest Format to be used by Operator Lifecycle Manager (OLM). The catalog image can be pushed to a container image registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]. For a cluster on a restricted network, this registry can be a registry that the cluster has network access to, such as a mirror registry created during a restricted network cluster installation.
 
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
+
 For this example, the procedure assumes use of a mirror registry that has access to both your network and the Internet.
 
 [NOTE]
 ====
-Only the Linux version of the `oc` client can be used for this procedure, because the Windows and macOS versions do not provide the `oc adm catalog build` command. 
+Only the Linux version of the `oc` client can be used for this procedure, because the Windows and macOS versions do not provide the `oc adm catalog build` command.
 ====
 
 .Prerequisites

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -12,6 +12,11 @@ You can create an index image using the `opm` CLI.
 * `opm` version 1.12.3+
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 

--- a/modules/olm-mirroring-package-manifest-catalog.adoc
+++ b/modules/olm-mirroring-package-manifest-catalog.adoc
@@ -14,6 +14,11 @@ Cluster administrators can mirror a custom Operator catalog image based on the P
 * `oc` version 4.3.5+
 * `podman` version 1.9.3+
 * Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 * If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +
 [source,terminal]

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -43,6 +43,11 @@ endif::[]
 * `opm` version 1.12.3+
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 

--- a/modules/olm-testing-operator-catalog-image.adoc
+++ b/modules/olm-testing-operator-catalog-image.adoc
@@ -13,6 +13,11 @@ You can validate Operator catalog image content by running it as a container and
 * `podman` version 1.9.3+
 * `oc` version 4.3.5+
 * Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 * link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
 
 .Procedure

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -27,6 +27,11 @@ Only the Linux version of the `oc` client can be used for this procedure, becaus
 * `oc` version 4.3.5+ Linux client
 * `podman` version 1.9.3+
 * Access to mirror registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 * OperatorHub configured to use custom catalog images
 * If you are working with private registries, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +


### PR DESCRIPTION
This pull request is linked to #36594.

Added Important paragraph, which is required for sections containing Docker v2-2.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1989948#

OCP Version: **applicable 4.7 only**

Direct Doc Preview Links:
https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-index-image_olm-managing-custom-catalogs

https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-pruning-index-image_olm-managing-custom-catalogs

https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-building-operator-catalog-image_olm-managing-custom-catalogs

https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-mirroring-package-manifest-catalog_olm-managing-custom-catalogs

https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-updating-operator-catalog-image_olm-managing-custom-catalogs

https://deploy-preview-37969--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-testing-operator-catalog-image_olm-managing-custom-catalogs