### PR TITLE
BZ1989948: Added Important paragraph - applicable only to enterprise 4.8

### DIFF
--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -12,6 +12,11 @@ You can create an index image using the `opm` CLI.
 * `opm` version 1.12.3+
 * `podman` version 1.9.3+
 * A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -43,6 +43,11 @@ endif::[]
 * `opm` version 1.12.3+
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
++
+[IMPORTANT]
+====
+The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
+====
 
 .Procedure
 


### PR DESCRIPTION
This pull request is linked to #36594.

Added Important paragraph, which is required for sections containing Docker v2-2.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1989948#

OCP Version: **applicable 4.8 only**

Direct Doc Preview Links:
https://deploy-preview-37970--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-index-image_olm-managing-custom-catalogs

https://deploy-preview-37970--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-pruning-index-image_olm-managing-custom-catalogs