### PR TITLE
Fix build on OpenShift

### DIFF
--- a/.s2i/bin/assemble
+++ b/.s2i/bin/assemble
@@ -24,8 +24,8 @@ echo "---> Fetching remote branches"
 # it's necessary to enforce a * ref so that all branches are referenced
 sed -i 's%fetch = +refs.*%fetch = +refs/heads/*:refs/remotes/origin/*%' .git/config
 git fetch --all --quiet
-for remote in $(git branch -r | egrep -v "(>|$(git rev-parse --abbrev-ref HEAD))$|master$"); do git checkout --force --track $remote; done
-git checkout master
+for remote in $(git branch -r | egrep -v "(>|$(git rev-parse --abbrev-ref HEAD))$|main$"); do git checkout --force --track $remote; done
+git checkout main
 
 # Fixes incompatible character encodings: US-ASCII and UTF-8 error
 export LANG="en_US.UTF-8"
@@ -39,7 +39,7 @@ asciibinder package --site=commercial
 
 mkdir commercial_package
 mv _package/commercial commercial_package
-git checkout master
+git checkout main
 mkdir commercial_package/commercial/httpd-cfg
 mv .s2i/httpd-cfg/01-commercial.conf commercial_package/commercial/httpd-cfg
 mv 404-commercial.html commercial_package/commercial/404.html
@@ -63,8 +63,8 @@ else
     rmdir minishift
 fi
 
-# checking back into master before resuming the packaging of the community content
-git checkout master
+# checking back into main before resuming the packaging of the community content
+git checkout main
 
 echo "---> AsciiBinder packaging community content ..."
 # Package assets for community site only, with Minishift content
@@ -73,7 +73,7 @@ asciibinder package --site=community
 
 mkdir community_package
 mv _package/community community_package
-git checkout master
+git checkout main
 mkdir community_package/community/httpd-cfg
 mv .s2i/httpd-cfg/01-community.conf community_package/community/httpd-cfg
 mv 404-community.html community_package/community/404.html

--- a/asciibinder-template.yml
+++ b/asciibinder-template.yml
@@ -65,29 +65,6 @@ objects:
       labels:
         app: "${NAME}"
 
-  - kind: "ImageStream"
-    apiVersion: "v1"
-    metadata:
-      name: "httpd-24-rhel7"
-      annotations:
-        description: "Upstream httpd 2.4 s2i image"
-      labels:
-        app: "${NAME}"
-    spec:
-      lookupPolicy:
-        local: false
-      tags:
-      - annotations: null
-        from:
-          kind: "DockerImage"
-          name: "registry.access.redhat.com/rhscl/httpd-24-rhel7"
-        generation: 0
-        importPolicy:
-          scheduled: true
-        name: "latest"
-        referencePolicy:
-          type: "Source"
-
   - kind: "BuildConfig"
     apiVersion: "v1"
     metadata:
@@ -110,7 +87,7 @@ objects:
           from:
             kind: "ImageStreamTag"
             namespace: "${NAMESPACE}"
-            name: "ruby:2.3"
+            name: "ruby:2.5-ubi8"
       output:
         to:
           kind: "ImageStreamTag"
@@ -146,7 +123,8 @@ objects:
         sourceStrategy:
           from:
             kind: "ImageStreamTag"
-            name: "httpd-24-rhel7:latest"
+            namespace: "${NAMESPACE}"
+            name: "httpd:2.4"
       output:
         to:
           kind: "ImageStreamTag"


### PR DESCRIPTION
This PR fixes the ability to build and deploy the docs on an OpenShift cluster. I made the following updates:

- Switch ruby from 2.3 (which doesn't exist in OCP4 by default anymore) to the 2.5 image stream tag
- Remove the httpd ImageStream from the asciibinder template and use the default one in the openshift namespace
- Update S2I to use the "main" git branch instead of the old "master" git branch which doesn't exist anymore.

After testing these changes I get a successful build:

```
oc get pods
NAME                            READY   STATUS      RESTARTS   AGE
commercial-docs-1-bnwsd         1/1     Running     0          31m
commercial-docs-1-deploy        0/1     Completed   0          31m
final-commercial-docs-2-build   0/1     Completed   0          49m
stg1-commercial-docs-1-build    0/1     Completed   0          78m
```