### PR TITLE
BZ1899491: adding an admonition to cautiously use LocalVolumeSet

### DIFF
--- a/modules/persistent-storage-local-discovery.adoc
+++ b/modules/persistent-storage-local-discovery.adoc
@@ -16,6 +16,11 @@ For more information about the support scope of Red Hat Technology Preview featu
 
 Use the following procedure to automatically discover local devices, and to automatically provision local volumes for selected devices.
 
+[WARNING]
+====
+Use the `LocalVolumeSet` object with caution. When you automatically provision persistent volumes (PVs) from local disks, the local PVs might claim all devices that match. If you are using a `LocalVolumeSet` object, make sure the Local Storage Operator is the only entity managing local devices on the node.
+====
+
 .Prerequisites
 * You have cluster administrator permissions.
 


### PR DESCRIPTION
Applies to 4.6+ versions

[Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1899491l)

Added an admonition for users to exercise caution when using `LocalVolumeSet` for automatic provisioning of PVs.

[Preview](https://deploy-preview-37974--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-local)


@gnufied @duanwei33  please review .
