### PR TITLE
OSDOCS-2454: AWS EFS TP-> GA

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -17,7 +17,7 @@ The following table describes the CSI drivers that are installed with {product-t
 |CSI driver  |CSI volume snapshots  |CSI cloning  |CSI resize
 
 |AWS EBS | ✅ | - | ✅
-|AWS EFS (Tech Preview) | - | - | -
+|AWS EFS | - | - | -
 |Google Cloud Platform (GCP) persistent disk (PD)| ✅ | - | ✅
 |Microsoft Azure Disk | ✅ | ✅ | ✅
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -10,9 +10,6 @@ toc::[]
 
 {product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic File Service (EFS).
 
-:FeatureName: AWS EFS Driver Operator
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
 
 After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
@@ -20,7 +17,7 @@ After installing the AWS EFS CSI Driver Operator, {product-title} installs the A
 * The _AWS EFS CSI Driver Operator_, after being installed, does not create a storage class by default to use to create persistent volume claims (PVCs). However, you can manually create the AWS EFS `StorageClass`.
 The AWS EFS CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on-demand, eliminating the need for cluster administrators to pre-provision storage.
 
-* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs. The AWS EFS CSI driver must be manually installed.
+* The _AWS EFS CSI driver_ enables you to create and mount AWS EFS PVs. 
 
 [NOTE]
 ====


### PR DESCRIPTION
4.10+

Move AWS EFS from TP to GA status.

**Preview**: https://deploy-preview-37976--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html

https://deploy-preview-37976--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

**PTAL**: @jsafrane @chao007 