### PR TITLE
RHDEVDOCS-3427: Updates for Serverless Deployments on ODC

### DIFF
--- a/modules/odc-importing-codebase-from-git-to-create-application.adoc
+++ b/modules/odc-importing-codebase-from-git-to-create-application.adoc
@@ -37,15 +37,18 @@ The resource name must be unique in a namespace. Modify the resource name if you
 
 * *Deployment*, to create an application in plain Kubernetes style.
 * *Deployment Config*, to create an {product-title} style application.
-* *Knative Service*, to create a microservice.
+* *Serverless Deployment*, to create a Knative service.
 
 +
 [NOTE]
 ====
-The *Knative Service* option is displayed in the *Import from git* form only if the *Serverless Operator* is installed in your cluster. For further details refer to documentation on installing OpenShift Serverless.
+The *Serverless Deployment* option is displayed in the *Import from git* form only if the {ServerlessOperatorName} is installed in your cluster. For further details, refer to the {ServerlessProductName} documentation.
 ====
+
 . In the *Pipelines* section, select *Add Pipeline*, and then click *Show Pipeline Visualization* to see the pipeline for the application.
+
 . In the *Advanced Options* section, the *Create a route to the application* is selected by default so that you can access your application using a publicly available URL. You can clear the check box if you do not want to expose your application on a public route.
+
 . Optional: You can use the following advanced options to further customize your application:
 
 Routing::
@@ -56,6 +59,13 @@ Click the *Routing* link to:
 * Secure your route by selecting the *Secure Route* check box. Select the required TLS termination type and set a policy for insecure traffic from the respective drop-down lists.
 +
 For serverless applications, the Knative service manages all the routing options above. However, you can customize the target port for traffic, if required. If the target port is not specified, the default port of `8080` is used.
+
+Domain mapping::
+If you are creating a *Serverless Deployment*, you can add a custom domain mapping to the Knative service during creation.
++
+* In the *Advanced options* section, click *Show advanced Routing options*.
+** If the domain mapping CR that you want to map to the service already exists, you can select it from the *Domain mapping* drop-down menu.
+** If you want to create a new domain mapping CR, type the domain name into the box, and select the *Create* option. For example, if you type in `example.com`, the *Create* option is *Create "example.com"*.
 
 Health Checks::
 Click the *Health Checks* link to add Readiness, Liveness, and Startup probes to your application. All the probes have prepopulated default data; you can add the probes with the default data or customize it as required.


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/RHDEVDOCS-3427

Applies for OCP 4.9+

Direct preview link: https://deploy-preview-37990--osdocs.netlify.app/openshift-enterprise/latest/applications/creating_applications/odc-creating-applications-using-developer-perspective#odc-importing-codebase-from-git-to-create-application_odc-creating-applications-using-developer-perspective