### PR TITLE
BZ2006013: add a line which clarifies why additionalbundletrust does not work without proxy

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -162,10 +162,10 @@ ifdef::vsphere,vmc[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere,vmc[]
 <4> If provided, the installation program generates a config map that is named `user-ca-bundle` in
-the `openshift-config` namespace that contains one or more additional CA
-certificates that are required for proxying HTTPS connections. The Cluster Network
-Operator then creates a `trusted-ca-bundle` config map that merges these contents
-with the {op-system-first} trust bundle, and this config map is referenced in the `trustedCA` field of the `Proxy` object. The `additionalTrustBundle` field is required unless
+the `openshift-config` namespace to hold the additional CA
+certificates. If you provide `additionalTrustBundle` and at least one proxy setting, the `Proxy` object is configured to reference the `user-ca-bundle` config map in the `trustedCA` field. The Cluster Network
+Operator then creates a `trusted-ca-bundle` config map that merges the contents specified for the `trustedCA` parameter
+with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless
 the proxy's identity certificate is signed by an authority from the {op-system} trust
 bundle.
 If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=2006013

Requires QE ack from @xltian 