### PR TITLE
OTA-472: Reorganizing upgrade section

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -115,8 +115,8 @@ function selectVersion(currentVersion) {
 
   // main file to edit is the file path after the version to the html at
   // the end.
-  // Example: https://docs.openshift.com/container-platform/4.4/updating/updating-cluster-between-minor.html
-  // file path is updating/updating-cluster-between-minor.adoc
+  // Example: https://docs.openshift.com/container-platform/4.4/updating/updating-cluster-within-minor.html
+  // file path is updating/updating-cluster-within-minor.adoc
 
   mainFileToEdit =
     window.location.pathname.substring(

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -470,6 +470,8 @@ Topics:
   File: understanding-the-update-service
 - Name: Installing and configuring the OpenShift Update Service
   File: installing-update-service
+- Name: Understanding upgrade channels
+  File: understanding-upgrade-channels-release
 # TODO: Remove below assembly for 4.10:
 - Name: Preparing to update to OpenShift Container Platform 4.10
   File: updating-cluster-prepare
@@ -478,11 +480,9 @@ Topics:
 - Name: Preparing to update to OKD 4.9
   File: updating-cluster-prepare
   Distros: openshift-origin
-- Name: Updating a cluster between minor versions
-  File: updating-cluster-between-minor
-- Name: Updating a cluster within a minor version from the web console
-  File: updating-cluster
-- Name: Updating a cluster within a minor version by using the CLI
+- Name: Updating a cluster within a minor version using the web console
+  File: updating-cluster-within-minor
+- Name: Updating a cluster within a minor version using the CLI
   File: updating-cluster-cli
 - Name: Performing update using canary rollout strategy
   File: update-using-custom-machine-config-pools

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -37,4 +37,4 @@ include::modules/ipi-install-verifying-static-ip-address-configuration.adoc[leve
 
 .Additional resources
 
-* See xref:../../updating/updating-cluster-between-minor.adoc#understanding-upgrade-channels_updating-cluster-between-minor[{product-title} upgrade channels and releases] for an explanation of the different release channels.
+* See xref:../../updating/updating-cluster-within-minor.adoc#understanding-upgrade-channels_updating-cluster-within-minor[{product-title} upgrade channels and releases] for an explanation of the different release channels.

--- a/installing/validating-an-installation.adoc
+++ b/installing/validating-an-installation.adoc
@@ -22,9 +22,9 @@ include::modules/getting-cluster-version-status-and-update-details.adoc[leveloff
 
 * See xref:../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-operator-issues[Troubleshooting Operator issues] for information about investigating issues with Operators.
 
-* See xref:../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[Updating a cluster between minor versions] for more information on updating your cluster.
+* See xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster between minor versions] for more information on updating your cluster.
 
-* See xref:../updating/updating-cluster-between-minor.adoc#understanding-upgrade-channels_updating-cluster-between-minor[OpenShift Container Platform upgrade channels and releases] for an overview about upgrade release channels.
+* See xref:../updating/updating-cluster-within-minor.adoc#understanding-upgrade-channels_updating-cluster-within-minor[OpenShift Container Platform upgrade channels and releases] for an overview about upgrade release channels.
 
 //Querying the status of the cluster nodes by using the CLI
 include::modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc[leveloffset=+1]

--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -66,7 +66,7 @@ For more information, see xref:../architecture/architecture-installation.adoc#in
 
 In {product-title} 3.11, you upgraded your cluster by running Ansible playbooks. In {product-title} {product-version}, the cluster manages its own updates, including updates to {op-system-first} on cluster nodes. You can easily upgrade your cluster by using the web console or by using the `oc adm upgrade` command from the OpenShift CLI and the Operators will automatically upgrade themselves. If your {product-title} {product-version} cluster has {op-system-base} worker machines, then you will still need to run an Ansible playbook to upgrade those worker machines.
 
-For more information, see xref:../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[Updating clusters].
+For more information, see xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating clusters].
 
 [id="migration-considerations"]
 == Migration considerations

--- a/modules/machine-health-checks-pausing.adoc
+++ b/modules/machine-health-checks-pausing.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 
 // * updating/updating-cluster-cli.adoc
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 // * updating/updating-restricted-network-cluster.adoc
 
 [id="machine-health-checks-pausing_{context}"]
@@ -66,4 +66,3 @@ Resume the machine health checks after updating the cluster. To resume the check
 $ oc -n openshift-machine-api annotate mhc <mhc-name> cluster.x-k8s.io/paused-
 ----
 ====
-

--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * updating/updating-cluster.adoc
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 // * updating/updating-cluster-cli.adoc
 // * updating/updating-cluster-rhel-compute.adoc
 // * updating/updating-disconnected-cluster.adoc
@@ -80,7 +80,7 @@ ifndef::openshift-origin[]
 
 In addition to the stable channel, all even-numbered minor versions of {product-title} offer an link:https://access.redhat.com/support/policy/updates/openshift#ocp4_phases[Extended Update Support] (EUS). These EUS versions extend the Full and Maintenance support phases for customers with Standard and Premium Subscriptions to 18 months.
 
-Although there is no difference between `stable-4.y` and `eus-4.y` channels until {product-title} 4.y transitions to the EUS phase, you can switch to the `eus-4.y` channel as soon as it becomes available. 
+Although there is no difference between `stable-4.y` and `eus-4.y` channels until {product-title} 4.y transitions to the EUS phase, you can switch to the `eus-4.y` channel as soon as it becomes available.
 
 When upgrades to the next EUS channel are offered, you can switch to the next EUS channel and upgrade until you have reached the next EUS version.
 

--- a/modules/unmanaged-operators.adoc
+++ b/modules/unmanaged-operators.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * architecture/architecture-installation.adoc
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 
 [id="unmanaged-operators_{context}"]
 = Support policy for unmanaged Operators

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/architecture-installation.adoc
 // * architecture/control-plane.adoc
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 // * updating/updating-cluster-cli.adoc
 // * updating/updating-cluster-rhel-compute.adoc
 // * updating/updating-cluster.adoc
@@ -44,4 +44,3 @@ If you use {op-system-base-full} machines as workers, the MCO does not update th
 With the specification for the new version applied to the old kubelet, the {op-system-base} machine cannot return to the `Ready` state. You cannot complete the update until the machines are available. However, the maximum number of unavailable nodes is set to ensure that normal cluster operations can continue with that number of machines out of service.
 
 The OpenShift Update Service is composed of an Operator and one or more application instances.
-

--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
 // * updating/updating-cluster.adoc
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 
 ifeval::["{context}" == "updating-cluster"]
 :within:
 endif::[]
-ifeval::["{context}" == "updating-cluster-between-minor"]
+ifeval::["{context}" == "updating-cluster-within-minor"]
 :between:
 endif::[]
 ifeval::["{context}" == "updating-cluster-rhel-compute"]
@@ -25,7 +25,7 @@ link:https://access.redhat.com/downloads/content/290[in the errata section] of t
 .Prerequisites
 
 * Have access to the web console as a user with `admin` privileges.
-* Pause all `MachineHealthCheck` resources. 
+* Pause all `MachineHealthCheck` resources.
 
 .Procedure
 

--- a/modules/update-using-custom-machine-config-pools-canary.adoc
+++ b/modules/update-using-custom-machine-config-pools-canary.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-between-minor.adoc
+// * updating/updating-cluster-within-minor.adoc
 
 [id="update-using-custom-machine-config-pools-canary_{context}"]
 = Performing a canary rollout update
@@ -12,9 +12,9 @@ In some specific use cases, you might want a more controlled update process wher
 
 The rolling update process is *not* a typical update workflow. With larger clusters, it can be a time-consuming process that requires you execute multiple commands. This complexity can result in errors that can affect the entire cluster.  It is recommended that you carefully consider whether your organization wants to use a rolling update and carefully plan the implementation of the process before you start.
 
-The rolling update process described in this topic involves: 
+The rolling update process described in this topic involves:
 
-* Creating one or more custom machine config pools (MCPs). 
+* Creating one or more custom machine config pools (MCPs).
 * Labeling each node that you do not want to  update immediately to move those nodes to the custom MCPs.
 * Pausing those custom MCPs, which prevents updates to those nodes.
 * Performing the cluster update.
@@ -26,7 +26,7 @@ The rolling update process described in this topic involves:
 
 [NOTE]
 ====
-Pausing an MCP prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatically renew the certificate, the new certificate is created but not applied across the nodes in the respective machine config pool. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.  
+Pausing an MCP prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatically renew the certificate, the new certificate is created but not applied across the nodes in the respective machine config pool. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
 ====
 
-//link that follows is in the assembly: updating-cluster-between-minor
+//link that follows is in the assembly: updating-cluster-within-minor

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -142,7 +142,7 @@ You use these resources to retrieve information about the cluster. Some configur
 |`version`
 |In {product-title} {product-version}, you must not customize the `ClusterVersion`
 resource for production clusters. Instead, follow the process to
-xref:../updating/updating-cluster.adoc#updating-cluster[update a cluster].
+xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[update a cluster].
 
 |`dns.config.openshift.io`
 |`cluster`

--- a/security/container_security/security-hosts-vms.adoc
+++ b/security/container_security/security-hosts-vms.adoc
@@ -28,7 +28,7 @@ ifndef::openshift-origin[]
 endif::[]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[Disk encryption]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Chrony time service]
-* xref:../../updating/updating-cluster-between-minor.adoc#update-service-overview_updating-cluster-between-minor[{product-title} cluster updates]
+* xref:../../updating/updating-cluster-within-minor.adoc#update-service-overview_updating-cluster-within-minor[{product-title} cluster updates]
 
 // Virtualization versus containers
 include::modules/security-hosts-vms-vs-containers.adoc[leveloffset=+1]

--- a/support/remote_health_monitoring/about-remote-health-monitoring.adoc
+++ b/support/remote_health_monitoring/about-remote-health-monitoring.adoc
@@ -13,7 +13,7 @@ A cluster that reports data to Red Hat through Telemetry and the Insights Operat
 
 The *Insights Operator* gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce insights about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators on link:https://console.redhat.com/openshift[console.redhat.com/openshift].
 
-More information is provided in this document about these two processes. 
+More information is provided in this document about these two processes.
 
 .Telemetry and Insights Operator benefits
 
@@ -37,7 +37,7 @@ include::modules/telemetry-about-telemetry.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See the xref:../../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[{product-title} update documentation] for more information about updating or upgrading a cluster.
+* See the xref:../../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[{product-title} update documentation] for more information about updating or upgrading a cluster.
 
 include::modules/telemetry-what-information-is-collected.adoc[leveloffset=+2]
 
@@ -80,11 +80,11 @@ As further described in the preceding sections of this document, Red Hat collect
 
 .Collection safeguards
 
-Red Hat employs technical and organizational measures designed to protect the telemetry and configuration data. 
+Red Hat employs technical and organizational measures designed to protect the telemetry and configuration data.
 
 .Sharing
 
-Red Hat may share the data collected through Telemetry and the Insights Operator internally within Red Hat to improve your user experience. Red Hat may share telemetry and configuration data with its business partners in an aggregated form that does not identify customers to help the partners better understand their markets and their customers’ use of Red Hat offerings or to ensure the successful integration of products jointly supported by those partners. 
+Red Hat may share the data collected through Telemetry and the Insights Operator internally within Red Hat to improve your user experience. Red Hat may share telemetry and configuration data with its business partners in an aggregated form that does not identify customers to help the partners better understand their markets and their customers’ use of Red Hat offerings or to ensure the successful integration of products jointly supported by those partners.
 
 .Third party service providers
 

--- a/updating/installing-update-service.adoc
+++ b/updating/installing-update-service.adoc
@@ -16,8 +16,6 @@ To provide a similar upgrade experience in a restricted network, you can install
 
 The following sections describe how to provide over-the-air updates for your disconnected cluster and its underlying operating system.
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
-
 [id="update-service-prereqs"]
 == Prerequisites
 

--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -1,0 +1,32 @@
+[id="understanding-upgrade-channels"]
+= Understanding upgrade channels and releases
+include::modules/common-attributes.adoc[]
+:context: understanding-upgrade-channels-releases
+
+toc::[]
+
+In {product-title} 4.1, Red Hat introduced the concept of channels for recommending the appropriate release versions for cluster upgrades. By controlling the pace of upgrades, these upgrade channels allow you to choose an upgrade strategy. Upgrade channels are tied to a minor version of {product-title}. For instance, {product-title} 4.8 upgrade channels recommend upgrades to 4.8 and upgrades within 4.8. They also recommend upgrades within 4.7 and from 4.7 to 4.8, to allow clusters on 4.7 to eventually upgrade to 4.8. They do not recommend upgrades to 4.9 or later releases. This strategy ensures that administrators explicitly decide to upgrade to the next minor version of {product-title}.
+
+Upgrade channels control only release selection and do not impact the version of the cluster that you install; the `openshift-install` binary file for a specific version of {product-title} always installs that version.
+
+ifndef::openshift-origin[]
+
+{product-title} {product-version} offers the following upgrade channels:
+
+* `candidate-{product-version}`
+* `fast-{product-version}`
+* `stable-{product-version}`
+* `eus-4.6` (only available when running 4.6)
+
+If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
+
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+
+{product-title} {product-version} offers the following upgrade channel:
+
+* `stable-4`
+
+endif::openshift-origin[]
+
+include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]

--- a/updating/update-using-custom-machine-config-pools.adoc
+++ b/updating/update-using-custom-machine-config-pools.adoc
@@ -1,5 +1,5 @@
 [id="update-using-custom-machine-config-pools"]
-= Performing a canary rollout update 
+= Performing a canary rollout update
 include::modules/common-attributes.adoc[]
 :context: update-using-custom-machine-config-pools
 
@@ -7,7 +7,7 @@ toc::[]
 
 
 
-There might be some scenarios where you want a more controlled rollout of an update to the worker nodes in order to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, then update the remaining nodes. This is commonly referred to as a _canary_ update. Or, you might also want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time. 
+There might be some scenarios where you want a more controlled rollout of an update to the worker nodes in order to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, then update the remaining nodes. This is commonly referred to as a _canary_ update. Or, you might also want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time.
 
 In these scenarios, you can create multiple custom machine config pools (MCPs) to prevent certain worker nodes from updating when you update the cluster. After the rest of the cluster is updated, you can update those worker nodes in batches at appropriate times.
 
@@ -27,7 +27,7 @@ This scenario has not been tested and might result in an undefined cluster state
 
 [IMPORTANT]
 ====
-Pausing a machine config pool prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatially renew the certificate, the new certificate is created but not applied across the nodes in the respective machine config pool. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.  
+Pausing a machine config pool prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatially renew the certificate, the new certificate is created but not applied across the nodes in the respective machine config pool. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
 ====
 
 [id="update-using-custom-machine-config-pools-about-mcp_{context}"]
@@ -35,7 +35,7 @@ Pausing a machine config pool prevents the Machine Config Operator from applying
 
 In {product-title}, nodes are not considered individually. Nodes are grouped into machine config pools (MCP). There are two MCPs in a default {product-title} cluster: one for the control plane nodes and one for the worker nodes. An {product-title} update affects all MCPs concurrently.
 
-During the update, the Machine Config Operator (MCO) drains and cordons all nodes within a MCP up to the specified `maxUnavailable` number of nodes (if specified), by default `1`. Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable. After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot. 
+During the update, the Machine Config Operator (MCO) drains and cordons all nodes within a MCP up to the specified `maxUnavailable` number of nodes (if specified), by default `1`. Draining and cordoning a node deschedules all pods on the node and marks the node as unschedulable. After the node is drained, the Machine Config Daemon applies a new machine configuration, which can include updating the operating system (OS). Updating the OS requires the host to reboot.
 
 To prevent specific nodes from being updated, and thus, not drained, cordoned, and updated, you can create custom MCPs. Then, pause those MCPs to ensure that the nodes associated with those MCPs are not updated. The MCO does not update any paused MCPs. You can create one or more custom MCPs, which can give you more control over the sequence in which you update those nodes. After you update the nodes in the first MCP, you can verify the application compatibility, and then update the rest of the nodes gradually to the new version.
 
@@ -46,7 +46,7 @@ To ensure the stability of the control plane, creating a custom MCP from the con
 
 You should give careful consideration to the number of MCPs you create and the number of nodes in each MCP, based on your workload deployment topology. For example, If you need to fit updates into specific maintenance windows, you need to know how many nodes that {product-title} can update within a window. This number is dependent on your unique cluster and workload characteristics.
 
-Also, you need to consider how much extra capacity you have available in your cluster. For example, in the case where your applications fail to work as expected on the updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes. You need to consider how much extra capacity you have available in order to determine the number of custom MCPs you need and how many nodes are in each MCP. For example, if you use two custom MCPs and 50% of your nodes are in each pool, you need to determine if running 50% of your nodes would provide sufficient quality-of-service (QoS) for your applications. 
+Also, you need to consider how much extra capacity you have available in your cluster. For example, in the case where your applications fail to work as expected on the updated nodes, you can cordon and drain those nodes in the pool, which moves the application pods to other nodes. You need to consider how much extra capacity you have available in order to determine the number of custom MCPs you need and how many nodes are in each MCP. For example, if you use two custom MCPs and 50% of your nodes are in each pool, you need to determine if running 50% of your nodes would provide sufficient quality-of-service (QoS) for your applications.
 
 You can use this update process with all documented {product-title} update processes. However, the process does not work with {op-system-base-full} machines, which are updated using Ansible playbooks.
 
@@ -59,8 +59,7 @@ include::modules/update-using-custom-machine-config-pools-pause.adoc[leveloffset
 
 When the MCPs enter ready state, you can peform the cluster update. See one of the following update methods, as appropriate for your cluster:
 
-* xref:../updating/updating-cluster-between-minor.adoc#update-upgrading-web_updating-cluster-between-minor[Updating a cluster between minor versions]
-* xref:../updating/updating-cluster.adoc#update-upgrading-web_updating-cluster[Updating a cluster within a minor version from the web console]
+* xref:../updating/updating-cluster-within-minor.adoc#update-upgrading-web_updating-cluster-within-minor[Updating a cluster between minor versions]
 * xref:../updating/updating-cluster-cli.adoc#update-upgrading-cli_updating-cluster-cli[Updating a cluster within a minor version by using the CLI]
 
 After the update is complete, you can start to unpause the MCPs one-by-one.
@@ -68,5 +67,3 @@ After the update is complete, you can start to unpause the MCPs one-by-one.
 include::modules/update-using-custom-machine-config-pools-unpause.adoc[leveloffset=+1]
 
 include::modules/update-using-custom-machine-config-pools-mcp-remove.adoc[leveloffset=+1]
-
-

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -29,12 +29,13 @@ Using the `unsupportedConfigOverrides` section to modify the configuration of an
 If you are running cluster monitoring with an attached PVC for Prometheus, you might experience OOM kills during cluster upgrade. When persistent storage is in use for Prometheus, Prometheus memory usage doubles during cluster upgrade and for several hours after upgrade is complete. To avoid the OOM kill issue, allow worker nodes with double the size of memory that was available prior to the upgrade. For example, if you are running monitoring on the minimum recommended nodes, which is 2 cores with 8 GB of RAM, increase memory to 16 GB. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1925061[BZ#1925061].
 ====
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../architecture/architecture-installation.adoc#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators]
 
-include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
+include::modules/update-using-custom-machine-config-pools-canary.adoc[leveloffset=+1]
+
+If you want to use the canary rollout update process, see xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update].
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 

--- a/updating/updating-cluster-rhel-compute.adoc
+++ b/updating/updating-cluster-rhel-compute.adoc
@@ -22,12 +22,9 @@ See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permis
 If you are running cluster monitoring with an attached PVC for Prometheus, you might experience OOM kills during cluster upgrade. When persistent storage is in use for Prometheus, Prometheus memory usage doubles during cluster upgrade and for several hours after upgrade is complete. To avoid the OOM kill issue, allow worker nodes with double the size of memory that was available prior to the upgrade. For example, if you are running monitoring on the minimum recommended nodes, which is 2 cores with 8 GB of RAM, increase memory to 16 GB. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1925061[BZ#1925061].
 ====
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../architecture/architecture-installation.adoc#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators]
-
-include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
 include::modules/update-upgrading-web.adoc[leveloffset=+1]
 

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -1,7 +1,7 @@
-[id="updating-cluster-between-minor"]
-= Updating a cluster between minor versions
+[id="updating-cluster-within-minor"]
+= Updating a cluster within a minor version using the web console
 include::modules/common-attributes.adoc[]
-:context: updating-cluster-between-minor
+:context: updating-cluster-within-minor
 
 toc::[]
 
@@ -43,12 +43,9 @@ Using the `unsupportedConfigOverrides` section to modify the configuration of an
 If you are running cluster monitoring with an attached PVC for Prometheus, you might experience OOM kills during cluster upgrade. When persistent storage is in use for Prometheus, Prometheus memory usage doubles during cluster upgrade and for several hours after upgrade is complete. To avoid the OOM kill issue, allow worker nodes with double the size of memory that was available prior to the upgrade. For example, if you are running monitoring on the minimum recommended nodes, which is 2 cores with 8 GB of RAM, increase memory to 16 GB. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1925061[BZ#1925061].
 ====
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../architecture/architecture-installation.adoc#unmanaged-operators_architecture-installation[Support policy for unmanaged Operators]
-
-include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]
 
 include::modules/update-using-custom-machine-config-pools-canary.adoc[leveloffset=+1]
 

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -222,7 +222,7 @@ endif::[]
 - **xref:../scalability_and_performance/scaling-cluster-monitoring-operator.adoc#scaling-cluster-monitoring-operator[Scale] and xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[tune] clusters**: Set cluster limits, tune nodes, scale cluster monitoring, and optimize networking, storage, and routes for your environment.
 
 - **Update a cluster**:
-Use the Cluster Version Operator (CVO) to upgrade your {product-title} cluster. If an update is available from the OpenShift Update Service (OSUS), you apply that cluster update from either the {product-title} xref:../updating/updating-cluster.adoc#updating-cluster[web console] or the xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[OpenShift CLI] (`oc`).
+Use the Cluster Version Operator (CVO) to upgrade your {product-title} cluster. If an update is available from the OpenShift Update Service (OSUS), you apply that cluster update from either the {product-title} xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[web console] or the xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[OpenShift CLI] (`oc`).
 
 ////
 There is a separate process for

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -68,7 +68,7 @@ Use the following sections to find content to help you learn about and use {prod
 |
 
 |
-| xref:../updating/updating-cluster-between-minor.adoc#updating-cluster-between-minor[Updating a cluster]
+| xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster]
 |
 |
 

--- a/whats_new/new-features.adoc
+++ b/whats_new/new-features.adoc
@@ -59,7 +59,7 @@ Easy, over-the-air upgrades for asynchronous z-stream releases of
 OpenShift v4 is available. Cluster administrators can upgrade using the
 *Cluster Settings* tab in the web console.
 See
-xref:../updating/updating-cluster.adoc#updating-cluster[Updating a cluster]
+xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster]
 for more information.
 
 [id="ocp-operator-hub"]


### PR DESCRIPTION
Applies to 4.6+
JIRA Link: https://issues.redhat.com/browse/OTA-472
QE ack received on original PR (#36015). SME ack needed.
Preview Link: [Understanding upgrade channels and releases](https://deploy-preview-37996--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html)
The remaining sections have been updated to remove the redundancy.