### PR TITLE
adds notes for 4.8.17

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2780,3 +2780,19 @@ link:https://access.redhat.com/solutions/6417501[{product-title} 4.8.15 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-17"]
+=== RHBA-2021:3927 - {product-title} 4.8.17 bug fix and security update
+
+Issued: 2021-10-27
+
+{product-title} release 4.8.17 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3927[RHBA-2021:3927] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3926[RHSA-2021:3926] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6455311[{product-title} 4.8.17 container image list]
+
+[id="ocp-4-8-17-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.8.17 release

- Applies to `enterprise-4.8` only
- [Preview link](https://deploy-preview-37998--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-17)