### PR TITLE
[enterprise-4.6] Bug 1926260: Document restrictions on naming of data FS mount unit

### DIFF
--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -35,51 +35,6 @@ Because `/var` must be in place before a fresh installation of {op-system-first}
 If you follow the steps to create a separate `/var` partition in this procedure, it is not necessary to create the Kubernetes manifest and Ignition config files again as described later in this section.
 ====
 
-.Prerequisites
-
-* If container storage is on the root partition, ensure that this root partition is mounted with the `pquota` option by including `rootflags=pquota` in the GRUB command line.
-
-* If the container storage is on a partition that is mounted by `/etc/fstab`, ensure that the following mount option is included in the `/etc/fstab` file:
-+
-[source,terminal]
-----
-/dev/sdb1      /var           xfs defaults,pquota 0 0
-----
-
-* If the container storage is on a partition that is mounted by `systemd`, ensure that the `MachineConfig` object includes the following mount option as in this example:
-+
-[source,yaml]
-----
-spec:
-  config:
-    ignition:
-      version: 3.1.0
-    storage:
-      disks:
-        - device: /dev/sdb
-          partitions:
-            - label: var
-              sizeMiB: 240000
-              startMiB: 0
-      filesystems:
-        - device: /dev/disk/by-partlabel/var
-          format: xfs
-          path: /var
-    systemd:
-      units:
-        - contents: |
-            [Unit]
-            Before=local-fs.target
-            [Mount]
-            Where=/var
-            What=/dev/disk/by-partlabel/var
-            Options=defaults,pquota
-            [Install]
-            WantedBy=local-fs.target
-          enabled: true
-          name: var.mount
-----
-
 .Procedure
 
 . Create a directory to hold the {product-title} installation files:
@@ -124,8 +79,7 @@ $ ls $HOME/clusterconfig/openshift/
 ...
 ----
 
-. Create a `MachineConfig` object and add it to a file in the `openshift` directory. For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This attaches storage to a separate `/var` directory.
-
+. Create a `MachineConfig` object and add it to a file in the `openshift` directory. For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
 [source,yaml]
 ----
@@ -143,29 +97,38 @@ spec:
       disks:
       - device: /dev/<device_name> <1>
         partitions:
-        - sizeMiB: <partition_size>
+        - label: var
           startMiB: <partition_start_offset> <2>
-          label: var
+          sizeMiB: <partition_size> <3>
       filesystems:
-        - path: /var
-          device: /dev/disk/by-partlabel/var
+        - device: /dev/disk/by-partlabel/var
+          path: /var
           format: xfs
     systemd:
       units:
-        - name: var.mount
+        - name: var.mount <4>
           enabled: true
           contents: |
             [Unit]
             Before=local-fs.target
             [Mount]
-            Where=/var
             What=/dev/disk/by-partlabel/var
+            Where=/var
+            Options=defaults,prjquota <5>
             [Install]
             WantedBy=local-fs.target
 ----
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 MiB (Mebibytes) is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+<3> The size of the data partition in mebibytes.
+<4> The name of the mount unit must match the directory specified in the `Where=` directive. For example, for a filesystem mounted on `/var/lib/containers`, the unit must be named `var-lib-containers.mount`.
+<5> The `prjquota` mount option must be enabled for filesystems used for container storage.
++
+[NOTE]
+====
+When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
+====
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -48,51 +48,6 @@ Because `/var` must be in place before a fresh installation of
 by creating a machine config that is inserted during the `openshift-install`
 preparation phases of an {product-title} installation.
 
-.Prerequisites
-
-* If container storage is on the root partition, ensure that this root partition is mounted with the `pquota` option by including `rootflags=pquota` in the GRUB command line.
-
-* If the container storage is on a partition that is mounted by `/etc/fstab`, ensure that the following mount option is included in the `/etc/fstab` file:
-+
-[source,terminal]
-----
-/dev/sdb1      /var           xfs defaults,pquota 0 0
-----
-
-* If the container storage is on a partition that is mounted by `systemd`, ensure that the `MachineConfig` object includes the following mount option as in this example:
-+
-[source,yaml]
-----
-spec:
-  config:
-    ignition:
-      version: 3.1.0
-    storage:
-      disks:
-        - device: /dev/sdb
-          partitions:
-            - label: var
-              sizeMiB: 240000
-              startMiB: 0
-      filesystems:
-        - device: /dev/disk/by-partlabel/var
-          format: xfs
-          path: /var
-    systemd:
-      units:
-        - contents: |
-            [Unit]
-            Before=local-fs.target
-            [Mount]
-            Where=/var
-            What=/dev/disk/by-partlabel/var
-            Options=defaults,pquota
-            [Install]
-            WantedBy=local-fs.target
-          enabled: true
-          name: var.mount
-----
-
 .Procedure
 
 . Create a directory to hold the {product-title} installation files:
@@ -118,9 +73,7 @@ $ ls $HOME/clusterconfig/openshift/
 ----
 
 . Create a `MachineConfig` object and add it to a file in the `openshift` directory.
-For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This attaches storage to a separate `/var`
-directory.
-
+For example, name the file `98-var-partition.yaml`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
 [source,yaml]
 ----
@@ -138,29 +91,38 @@ spec:
       disks:
       - device: /dev/<device_name> <1>
         partitions:
-        - sizeMiB: <partition_size>
+        - label: var
           startMiB: <partition_start_offset> <2>
-          label: var
+          sizeMiB: <partition_size> <3>
       filesystems:
-        - path: /var
-          device: /dev/disk/by-partlabel/var
+        - device: /dev/disk/by-partlabel/var
+          path: /var
           format: xfs
     systemd:
       units:
-        - name: var.mount
+        - name: var.mount <4>
           enabled: true
           contents: |
             [Unit]
             Before=local-fs.target
             [Mount]
-            Where=/var
             What=/dev/disk/by-partlabel/var
+            Where=/var
+            Options=defaults,prjquota <5>
             [Install]
             WantedBy=local-fs.target
 ----
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+<3> The size of the data partition in mebibytes.
+<4> The name of the mount unit must match the directory specified in the `Where=` directive. For example, for a filesystem mounted on `/var/lib/containers`, the unit must be named `var-lib-containers.mount`.
+<5> The `prjquota` mount option must be enabled for filesystems used for container storage.
++
+[NOTE]
+====
+When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
+====
 
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and `openshift` subdirectories:
 +

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -126,9 +126,7 @@ $ ls $HOME/clusterconfig/openshift/
 . Create a `MachineConfig` object and add it to a file in the `openshift` directory.
 For example, name the file `98-var-partition.yaml`,
 change the disk device name to the name of the storage device on the `worker` systems,
-and set the storage size as appropriate. This attaches storage to a separate `/var`
-directory.
-
+and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
 [source,yaml]
 ----
@@ -146,34 +144,39 @@ spec:
       disks:
       - device: /dev/<device_name> <1>
         partitions:
-        - sizeMiB: <partition_size>
+        - label: var
           startMiB: <partition_start_offset> <2>
-          label: var
+          sizeMiB: <partition_size> <3>
       filesystems:
-        - path: /var
-          device: /dev/disk/by-partlabel/var
+        - device: /dev/disk/by-partlabel/var
+          path: /var
           format: xfs
     systemd:
       units:
-        - name: var.mount
+        - name: var.mount <4>
           enabled: true
           contents: |
             [Unit]
             Before=local-fs.target
             [Mount]
-            Where=/var
             What=/dev/disk/by-partlabel/var
+            Where=/var
+            Options=defaults,prjquota <5>
             [Install]
             WantedBy=local-fs.target
 ----
 +
 <1> The storage device name of the disk that you want to partition.
 <2> When adding a data partition to the boot disk, a minimum value of 25000 mebibytes is recommended. The root file system is automatically resized to fill all available space up to the specified offset. If no value is specified, or if the specified value is smaller than the recommended minimum, the resulting root file system will be too small, and future reinstalls of {op-system} might overwrite the beginning of the data partition.
+<3> The size of the data partition in mebibytes.
+<4> The name of the mount unit must match the directory specified in the `Where=` directive. For example, for a filesystem mounted on `/var/lib/containers`, the unit must be named `var-lib-containers.mount`.
+<5> The `prjquota` mount option must be enabled for filesystems used for container storage.
 +
 [NOTE]
 ====
 When creating a separate `/var` partition, you cannot use different instance types for worker nodes, if the different instance types do not have the same device name.
 ====
+
 . Run `openshift-install` again to create Ignition configs from a set of files in the `manifest` and
 `openshift` subdirectories:
 +


### PR DESCRIPTION
Cherry-pick of ad2b75d9197d15de9ba6ff8a062b0fcb0fd50111 | xref: https://github.com/openshift/openshift-docs/pull/37959

----

Users were customizing the example config and failing to rename the
mount unit to match the new mountpoint, causing the mount to fail.
Document the unit naming requirements.

In the process, revert and redo commit 7068e5ae.  The original commit
has a few issues:

- It adds a long Prerequisites section which almost entirely duplicates
the config in the Procedure section, with the lines in a different order,
solely to add the pquota mount option.  This doesn't narratively make
sense as a prerequisite.

- It references mounting filesystems via /etc/fstab, which we don't
generally document or recommend.

- It references adding rootflags=pquota if container storage is kept on
the root filesystem, in order to mount the root filesystem with the
prjquota option.  This a) isn't relevant to adding a /var mountpoint and
b) is the default.

- It removes the note about configs encoding a dependency on the device
node name for the disk containing additional partitions, which is still
the case at present.

We do need the prjquota option for container storage, but we can document
that fact much more concisely.