### PR TITLE
BZ2013911: correct webUI navigation step for mco

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
@@ -5,7 +5,7 @@
 [id="troubleshooting-disabling-autoreboot-mco-console_{context}"]
 = Disabling the Machine Config Operator from automatically rebooting by using the console
 
-To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can use the {product-title} web console to modify the machine config pool (MCP) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process. 
+To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can use the {product-title} web console to modify the machine config pool (MCP) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process.
 
 [NOTE]
 ====
@@ -20,21 +20,21 @@ New CA certificates are generated at 292 days from the installation date and rem
 
 .Procedure
 
-To pause or unpause automatic MCO update rebooting: 
+To pause or unpause automatic MCO update rebooting:
 
 * Pause the autoreboot process:
 
 . Log in to the {product-title} web console as a user with the `cluster-admin` role.
 
-. Click *Compute* -> *Machine Config Pools*.
+. Click *Compute* -> *MachineConfigPools*.
 
-. On the *Machine Config Pools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
+. On the *MachineConfigPools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
 
 . On the *master* or *worker* page, click *YAML*.
 
 . In the YAML, update the `spec.paused` field to `true`.
 +
-.Sample MachineConfigPool object 
+.Sample MachineConfigPool object
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -46,9 +46,9 @@ spec:
 ----
 <1> Update the `spec.paused` field to `true` to pause rebooting.
 
-. To verify that the MCP is paused, return to the *Machine Config Pools* page.
+. To verify that the MCP is paused, return to the *MachineConfigPools* page.
 +
-On the *Machine Config Pools* page, the *Paused* column reports *True* for the MCP you modified.
+On the *MachineConfigPools* page, the *Paused* column reports *True* for the MCP you modified.
 +
 If the MCP has pending changes while paused, the *Updated* column is *False* and *Updating* is *False*. When *Updated* is *True* and *Updating* is *False*, there are no pending changes.
 +
@@ -57,19 +57,19 @@ If the MCP has pending changes while paused, the *Updated* column is *False* and
 If there are pending changes (where both the *Updated* and *Updating* columns are *False*), it is recommended to schedule a maintenance window for a reboot as early as possible. Use the following steps for unpausing the autoreboot process to apply the changes that were queued since the last reboot.
 ====
 
-* Unpause the autoreboot process: 
+* Unpause the autoreboot process:
 
 . Log in to the {product-title} web console as a user with the `cluster-admin` role.
 
-. Click *Compute* -> *Machine Config Pools*.
+. Click *Compute* -> *MachineConfigPools*.
 
-. On the *Machine Config Pools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
+. On the *MachineConfigPools* page, click either *master* or *worker*, depending upon which nodes you want to pause rebooting for.
 
 . On the *master* or *worker* page, click *YAML*.
 
 . In the YAML, update the `spec.paused` field to `false`.
 +
-.Sample MachineConfigPool object 
+.Sample MachineConfigPool object
 [source,yaml]
 ----
 apiVersion: machineconfiguration.openshift.io/v1
@@ -86,9 +86,8 @@ spec:
 By unpausing an MCP, the MCO applies all paused changes reboots {op-system-first} as needed.
 ====
 
-. To verify that the MCP is paused, return to the *Machine Config Pools* page.
+. To verify that the MCP is paused, return to the *MachineConfigPools* page.
 +
-On the *Machine Config Pools* page, the *Paused* column reports *False* for the MCP you modified.
+On the *MachineConfigPools* page, the *Paused* column reports *False* for the MCP you modified.
 +
 If the MCP is applying any pending changes, the *Updated* column is *False* and the *Updating* column is *True*. When *Updated* is *True* and *Updating* is *False*, there are no further changes being made.
-


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=2013911

[Docs preview](https://deploy-preview-38020--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco-console_troubleshooting-operator-issues)

Requires QE ack from @rioliu-rh 