### PR TITLE
BZ#2011502: ovn-k supports one default gateway

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies:
 //
+// * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
@@ -11,29 +12,35 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
+// * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_gcp/installing-gcp-customizations.adoc
-// * installing/installing_gcp/installing-gcp-private.adoc
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
+// * installing/installing_gcp/installing-gcp-private.adoc
 // * installing/installing_gcp/installing-gcp-vpc.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
-// * installing/installing_openstack/installing-openstack-installer-custom.adoc
-// * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
-// * installing/installing_openstack/installing-openstack-user.adoc
-// * installing/installing_openstack/installing-openstack-user-kuryr.adoc
-// * installing/installing_rhv/installing-rhv-customizations.adoc
-// * installing/installing_vmc/installing-vmc-customizations.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations.adoc
-// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
-// * installing/installing_ibm_z/installing-ibm-z.adoc
-// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
-// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
-// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_openstack/installing-openstack-installer-custom.adoc
+// * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+// * installing/installing_openstack/installing-openstack-installer-restricted.adoc
+// * installing/installing_openstack/installing-openstack-installer-sr-iov.adoc
+// * installing/installing_openstack/installing-openstack-user-kuryr.adoc
+// * installing/installing_openstack/installing-openstack-user-sr-iov-kuryr.adoc
+// * installing/installing_openstack/installing-openstack-user-sr-iov.adoc
+// * installing/installing_openstack/installing-openstack-user.adoc
+// * installing/installing_rhv/installing-rhv-customizations.adoc
+// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
+// * installing/installing_vmc/installing-vmc-customizations.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -263,8 +270,12 @@ If you use the OVN-Kubernetes cluster network provider, both IPv4 and IPv6 addre
 
 If you use the OpenShift SDN cluster network provider, only the IPv4 address family is supported.
 
-If you configure your cluster to use both IP address families, you must specify IPv4 and IPv6 addresses in the same order for all network configuration parameters. For example, in the following configuration IPv4 addresses are listed before IPv6 addresses.
+If you configure your cluster to use both IP address families, review the following requirements:
 
+* Both IP families must use the same network interface for the default gateway.
+
+* You must specify IPv4 and IPv6 addresses in the same order for all network configuration parameters. For example, in the following configuration IPv4 addresses are listed before IPv6 addresses.
++
 [source,yaml]
 ----
 networking:
@@ -1377,3 +1388,4 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
 endif::[]
+

--- a/modules/nw-ovn-kuberentes-limitations.adoc
+++ b/modules/nw-ovn-kuberentes-limitations.adoc
@@ -5,8 +5,23 @@
 [id="nw-ovn-kubernetes-limitations_{context}"]
 = OVN-Kubernetes limitations
 
-The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has a limitation that is related to traffic policies.
-The network provider does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
+The OVN-Kubernetes Container Network Interface (CNI) cluster network provider has the following limitations:
+
+* OVN-Kubernetes does not support setting the external traffic policy or internal traffic policy for a Kubernetes service to `local`.
 The default value, `cluster`, is supported for both parameters.
 This limitation can affect you when you add a service of type `LoadBalancer`, `NodePort`, or add a service with an external IP.
+
+// The foll limitation is also recorded in the installation section.
+* For clusters configured for dual-stack networking, both IPv4 and IPv6 traffic must use the same network interface as the default gateway.
+If this requirement is not met, pods on the host in the `ovnkube-node` daemon set enter the `CrashLoopBackOff` state.
+If you display a pod with a command like `oc get pod -n openshift-ovn-kubernetes -l app=ovnkube-node -o yaml`, the `status` field contains more than one message about the default gateway, as shown in the following output:
++
+[source,terminal]
+----
+I1006 16:09:50.985852   60651 helper_linux.go:73] Found default gateway interface br-ex 192.168.127.1
+I1006 16:09:50.985923   60651 helper_linux.go:73] Found default gateway interface ens4 fe80::5054:ff:febe:bcd4
+F1006 16:09:50.985939   60651 ovnkube.go:130] multiple gateway interfaces detected: br-ex ens4
+----
++
+The only resolution is to reconfigure the host networking so that both IP families use the same network interface for the default gateway.
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2011502

-----
Added a second bullet to [OVN-Kubernetes limitations](https://deploy-preview-38035--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-limitations_about-ovn-kubernetes) to state that both IP families must use the same iface is a limitation.

For installation doc, the [Network configuration parameters](https://deploy-preview-38035--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters-network_installing-bare-metal) heading already had a mention of dual-stack networking, so I added the "Both IP families must use the same network interface for the default gateway." bullet.

That update to the installation section affects a plurality of installation-related pages--there's a lot of repetition:

* Bare metal: [link](https://deploy-preview-38035--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters-network_installing-bare-metal) (same destination as the preceding link)

* Bare metal w/ network customizations: [link](https://deploy-preview-38035--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-configuration-parameters-network_installing-bare-metal-network-customizations)

* Bare metal w/ restricted network: [link](https://deploy-preview-38035--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-configuration-parameters-network_installing-restricted-networks-bare-metal)