### PR TITLE
MULTIARCH-1670, 1673: Backport multi-nic to IBM P/Z to OCP 4.8

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -43,6 +43,8 @@ include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
+* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 .Additional resources
@@ -78,6 +80,8 @@ include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-user-infra-machines-iso.adoc[leveloffset=+1]
+
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -51,6 +51,8 @@ include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
+* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
 .Additional resources
@@ -86,6 +88,8 @@ include::modules/nw-operator-cr.adoc[leveloffset=+1]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-user-infra-machines-iso.adoc[leveloffset=+1]
+
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -387,6 +387,10 @@ endif::bare[]
 The IP address blocks for machines.
 
 If you specify multiple IP address blocks, the blocks must not overlap.
+
+ifdef::ibm-z,ibm-power[]
+If you specify multiple IP kernel arguments, the `machineNetwork.cidr` value must be the CIDR of the primary network.
+endif::ibm-z,ibm-power[]
 |An array of objects. For example:
 
 [source,yaml]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -6,6 +6,32 @@
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:ibm-power:
+:restricted:
+endif::[]
 
 [id="installation-user-infra-machines-static-network_{context}"]
 = Advanced {op-system} installation reference
@@ -56,11 +82,28 @@ nameserver=4.4.4.41
 ----
 
 a|Specify multiple network interfaces by specifying multiple `ip=` entries.
+
 a|
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
+
+a|Optional: You can configure routes to additional networks by setting an `rd.route=` value. 
+
+If the additional network gateway is different from the primary network gateway, the default gateway must be the primary network gateway.
+a|
+To configure the default gateway: 
+
+----
+ip=::10.10.10.254::::
+----
+
+To configure the route for the additional network:
+
+----
+rd.route=20.20.20.0/24:20.20.20.254:enp2s0
+---- 
 
 a|Disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used. In the example, the `enp1s0` interface has a static networking configuration and DHCP is disabled for `enp2s0`, which is not used.
 a|
@@ -149,7 +192,7 @@ vlan=bond0.100:bond0
 ----
 
 |===
-
+ifndef::ibm-z,ibm-power[]
 [id="installation-user-infra-machines-coreos-installer-options_{context}"]
 == `coreos-installer` options for ISO installations
 
@@ -351,3 +394,24 @@ a|`ignition.config.url`
 
 a|Optional: The URL of the Ignition config for the live boot. For example, this can be used to customize how `coreos-installer` is invoked, or to run code before or after the installation. This is different from `coreos.inst.ignition_url`, which is the Ignition config for the installed system.
 |===
+
+endif::ibm-z,ibm-power[]
+
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!ibm-power:
+endif::[]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.8

Jira:
* https://issues.redhat.com/browse/MULTIARCH-1670
* https://issues.redhat.com/browse/MULTIARCH-1673

This PR backports the mult-nic changes we made for [P/Z in 4.9](https://github.com/openshift/openshift-docs/pull/36250) to 4.8

Related PRs: 
* [backport 4.6](https://github.com/openshift/openshift-docs/pull/38177)
* [backport 4.7](https://github.com/openshift/openshift-docs/pull/38094)

Preview
* Installing a cluster with z/VM on IBM Z and LinuxONE - [Networking and bonding options for ISO installations](https://deploy-preview-38039--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-routing-bonding_installing-ibm-z)

Same for Power and restricted installation on P and Z


QE review: Micah Abbott
IBM Z: Holger Wolf, IBM P: Mike Tarsel