### PR TITLE
[enterprise-4.7]BZ:1922741 - adding alternative to grpcurl command

### DIFF
--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -39,8 +39,8 @@ ifeval::["{context}" != "olm-managing-custom-catalogs"]
 * Workstation with unrestricted network access
 endif::[]
 * `podman` version 1.9.3+
-* link:https://github.com/fullstorydev/grpcurl[`grpcurl`]
-* `opm` version 1.12.3+
+* link:https://github.com/fullstorydev/grpcurl[`grpcurl`] (third-party command-line tool)
+* `opm` version 1.18.0+
 * Access to a registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
 


### PR DESCRIPTION
Conflicts: 
modules/olm-pruning-index-image.adoc

Manual cherry-pick of: https://github.com/openshift/openshift-docs/pull/37875