### PR TITLE
BZ:1927776 - Adding clarification for regionEndpoint section

### DIFF
--- a/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
+++ b/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
@@ -43,3 +43,12 @@ true, or this parameter is ignored.
 It is optional.
 
 |===
+
+[NOTE]
+====
+When the value of the `regionEndpoint` parameter is configured to a URL of a Rados Gateway, an explicit port must not be specified. For example:
+[source,yaml]
+----
+regionEndpoint: http://rook-ceph-rgw-ocs-storagecluster-cephobjectstore.openshift-storage.svc.cluster.local
+----
+====


### PR DESCRIPTION
For Versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1927776

Preview: https://deploy-preview-38061--osdocs.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.html#registry-operator-configuration-resource-overview-aws-s3_configuring-registry-storage-aws-user-infrastructure

Ready for QA: @yanpzhan 

For Peer Reviews: Can you please add the labels 'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' 'enterprise-4.10' and 'Peer Review needed', Thank you!!