### PR TITLE
BZ-2016270- updated correct image url for must-gather

### DIFF
--- a/modules/sandboxed-containers-collecting-data.adoc
+++ b/modules/sandboxed-containers-collecting-data.adoc
@@ -24,4 +24,7 @@ These component logs are collected as long as there is at least one pod running 
 
 To collect {sandboxed-containers-first} data with `must-gather`, you must specify the
 {sandboxed-containers-first} image:
-`--image=registry.redhat.io/openshift-sandboxed-containers-1.1.0/osc-must-gather:1.1.0`.
+[source,terminal]
+----
+--image=registry.redhat.io/openshift-sandboxed-containers-tech-preview/osc-must-gather-rhel8:1.1.0
+----


### PR DESCRIPTION
Bug [2016270](https://bugzilla.redhat.com/show_bug.cgi?id=2016270) - update for 4.9.

Preview link: https://deploy-preview-38093--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/troubleshooting-sandboxed-containers.html

Reviewed and approved by QE @bpradipt 