### PR TITLE
GH38029: ammendment to note that has incorrect version for 4.10

### DIFF
--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -99,6 +99,11 @@ The minimum TLS version for Ingress Controllers is `1.1`, and the maximum TLS ve
 Ciphers and the minimum TLS version of the configured security profile are reflected in the `TLSProfile` status.
 ====
 
+[IMPORTANT]
+====
+The Ingress Operator converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`.
+====
+
 |`clientTLS`
 |`clientTLS` authenticates client access to the cluster and services; as a result, mutual TLS authentication is enabled. If not set, then client TLS is not enabled.
 

--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -24,11 +24,11 @@ The TLS security profile defines the minimum TLS version and the TLS ciphers for
 
 You can see the ciphers and the minimum TLS version of the configured TLS security profile in the `IngressController` custom resource (CR) under `Status.Tls Profile` and the configured TLS security profile under `Spec.Tls Security Profile`. For the `Custom` TLS security profile, the specific ciphers and minimum TLS version are listed under both parameters.
 
-[IMPORTANT]
+[NOTE]
 ====
-The HAProxy Ingress Controller image does not support TLS `1.3` and because the `Modern` profile requires TLS `1.3`, it is not supported. The Ingress Operator converts the `Modern` profile to `Intermediate`.
+The HAProxy Ingress Controller image supports TLS `1.3` and the `Modern` profile.
 
-The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`, and TLS `1.3` of a `Custom` profile to `1.2`.
+The Ingress Operator also converts the TLS `1.0` of an `Old` or `Custom` profile to `1.1`.
 ====
 
 .Prerequisites


### PR DESCRIPTION
GH Issue: #38029

I had another [PR](https://github.com/openshift/openshift-docs/pull/38049) that was only for 4.9 because in my spastic 🧠 I quickly wanted to fix the version that we just released. Alas, I forgot that 4.10 exists and I need to open against main. So, here it is against main. 