### PR TITLE
OSDOCS--2572: Machine management overview page

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -1694,6 +1694,8 @@ Name: Machine management
 Dir: machine_management
 Distros: openshift-origin,openshift-enterprise
 Topics:
+- Name: Overview of machine management
+  File: index
 - Name: Creating machine sets
   Dir: creating_machinesets
   Distros: openshift-origin,openshift-enterprise

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -1,0 +1,63 @@
+[id="overview-of-machine-management"]
+= Overview of machine management
+include::modules/common-attributes.adoc[]
+:context: overview-of-machine-management
+
+toc::[]
+
+You can use machine management to flexibly work with underlying infrastructure like Amazon Web Services (AWS), Azure, Google Cloud Platform (GCP), OpenStack, Red Hat Virtualization (RHV), and vSphere to manage the {product-title} cluster.
+You can control the cluster, and also perform auto-scaling, that is, scaling up and down the cluster based on specific workload policies.
+
+The {product-title} cluster can horizontally scale up and down, when the load increases or decreases.
+It is important to have a cluster that adapts to changing workloads.
+
+Machine management is implemented as a xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Custom Resource Definition](CRD).
+A CRD object defines a new unique object `Kind` in the cluster and enables the Kubernetes API server to handle it's entire lifecycle.
+
+The Machine API Operator provisions the following resources:
+
+* MachineSet
+* Machine
+* Cluster Autoscaler
+* Machine Autoscaler
+* Machine Health Checks
+
+[discrete]
+== What you can do with machine sets
+
+As a cluster administrator you can:
+
+. Create a machine set on:
+** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS]
+** xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure]
+** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP]
+** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[OpenStack]
+** xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#creating-machineset-rhv[RHV]
+** xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[vSphere]
+
+. xref:../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scale a machine set] by adding or removing a machine from the machine set.
+. xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modify a machine set] through the MachineSet YAML configuration file.
+. xref:../machine_management/deleting-machine.adoc#deleting-machine[Delete] a machine.
+. xref:../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Create infrastructure machine sets].
+. Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically fix damaged machines in a machine pool.
+
+[discrete]
+== Autoscaler
+
+The autoscaler ensures that your cluster is flexible to changing workloads.
+To xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[autoscale] your {product-title} cluster, you must first deploy a cluster autoscaler, and then deploy a machine autoscaler for each machine set.
+The cluster autoscaler increases and decreases the size of the cluster based on deployment needs.
+The machine autoscaler adjusts the number of machines in the machine sets that you deploy in your {product-title} cluster.
+
+[discrete]
+== User-provisioned infrastructure
+User-provisioned infrastructure is an environment, where the user deploys infrastructure that is compute, network, and storage resources, that hosts the {product-title}.
+You can xref:../machine_management//user_infra/adding-compute-user-infra-general.adoc#adding-compute-user-infra-general[add compute machines] to a cluster on user-provisioned infrastructure either as part of or after the installation process.
+
+[discrete]
+== What you can do with RHEL compute machines
+
+As a cluster administrator, you can:
+
+** xref:../machine_management/adding-rhel-compute.adoc#adding-rhel-compute[Add Red Hat Enterprise Linux (RHEL) compute machines], also known as worker machines, to a user-provisioned infrastructure cluster or an installation-provisioned infrastructure cluster.
+** xref:../machine_management/more-rhel-compute.adoc#more-rhel-compute[Add more Red Hat Enterprise Linux (RHEL) compute machines] to an existing cluster.


### PR DESCRIPTION
Applies to 4.6+ versions

Create an overview page for machine management.

[OSDOCS-2572](https://issues.redhat.com/browse/OSDOCS-2572)   

[Preview](https://deploy-preview-38127--osdocs.netlify.app/openshift-enterprise/latest/machine_management/index.html)

@sunzhaohua2  please review .

