### PR TITLE
RHDEVDOCS-3329 - Release Notes for OpenShift Logging 5.3

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -1,25 +1,66 @@
 [id="cluster-logging-release-notes"]
-= Release notes for Red Hat OpenShift Logging 5.2
+= Release notes for Red Hat OpenShift Logging 5.3
 include::modules/common-attributes.adoc[]
 :context: cluster-logging-release-notes-v5x
 
 toc::[]
 
-[id="openshift-logging-supported-versions"]
-== Supported versions
-
-.{product-title} version support for Red Hat OpenShift Logging (RHOL)
-[options="header"]
-|====
-|        |4.7          |4.8          |4.9
-|RHOL 5.0|X            |X            |
-|RHOL 5.1|X            |X            |
-|RHOL 5.2|X            |X            |X
-|====
-
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
+[id="cluster-logging-supported-versions"]
+== Supported Versions
+include::modules/cluster-logging-supported-versions.adoc[leveloffset=+1]
+
 // Release Notes by version
+[id="cluster-logging-release-notes-5-3-0"]
+== OpenShift Logging 5.3.0
+The following advisories are available for OpenShift Logging 5.3.x:
+
+[id="openshift-logging-5-3-0-new-features-and-enhancements"]
+=== New features and enhancements
+* With this update, authorization requirements for Log Forwarding have been relaxed. Outputs may now be configured with SASL, username/password, or TLS.
+
+[id="openshift-logging-5-3-0-bug-fixes"]
+=== Bug fixes
+* Before this update, application logs were not correctly configured to forward to the proper Cloudwatch stream with multi-line error detection enabled. (link:https://issues.redhat.com/browse/LOG-1939[LOG-1939])
+
+* Before this update, a name change of the deployed collector in the 5.3 release caused the alert 'fluentnodedown' to generate. (link:https://issues.redhat.com/browse/LOG-1918[LOG-1918])
+
+* Before this update, a regression introduced in a prior release configuration caused the collector to flush its buffered messages before shutdown, creating a delay the termination and restart of collector Pods. With this update, fluentd no longer flushes buffers at shutdown, resolving the issue. (link:https://issues.redhat.com/browse/LOG-1735[LOG-1735])
+
+* Before this update, a regression introduced in a prior release intentionally disabled JSON message parsing. With this update, a log entry's "level" value is set based on: a parsed JSON message that has a "level" field or by applying a regex against the message field to extract a match. (link:https://issues.redhat.com/browse/LOG-1199[LOG-1199])
+
+[id="openshift-logging-5-3-0-known-issues"]
+=== Known issues
+* If you forward logs to an external Elasticsearch server and then change a configured value in the pipeline secret, such as the username and password, the Fluentd forwarder loads the new secret but uses the old value to connect to an external Elasticsearch server. This issue happens because the Red Hat OpenShift Logging Operator does not currently monitor secrets for content changes. (link:https://issues.redhat.com/browse/LOG-1652[LOG-1652])
++
+As a workaround, if you change the secret, you can force the Fluentd pods to redeploy by entering:
++
+[source,terminal]
+----
+$ oc delete pod -l component=fluentd
+----
+
+[id="openshift-logging-5-3-0-deprecated-removed-features"]
+== Deprecated and removed features
+Some features available in previous releases have been deprecated or removed.
+
+Deprecated functionality is still included in OpenShift Logging and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+[id="openshift-logging-5-3-0-legacy-forwarding"]
+=== Forwarding logs using the legacy Fluentd and legacy syslog methods have been removed
+
+In OpenShift Logging 5.3, the legacy methods of forwarding logs to Syslog and Fluentd are removed. Bug fixes and support are provided through the end of the OpenShift Logging 5.2 life cycle. After which, no new feature enhancements are made.
+
+Instead, use the following non-legacy methods:
+
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-log-forward-fluentd_cluster-logging-external[Forwarding logs using the Fluentd forward protocol]
+* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-log-forward-syslog_cluster-logging-external[Forwarding logs using the syslog protocol]
+
+[id="openshift-logging-5-3-0-legacy-forwarding-config"]
+=== Configuration mechanisms for legacy forwarding methods have been removed
+
+In OpenShift Logging 5.3, the legacy configuration mechanism for log forwarding is removed: You cannot forward logs using the legacy Fluentd method and legacy Syslog method. Use the standard log forwarding methods instead.
 
 [id="cluster-logging-release-notes-5-2-0"]
 == OpenShift Logging 5.2.0
@@ -104,7 +145,7 @@ As a workaround, if you change the secret, you can force the Fluentd pods to red
 +
 [source,terminal]
 ----
-$ oc delete pod -l component=fluentd
+$ oc delete pod -l component=collector
 ----
 
 [id="openshift-logging-5-2-0-deprecated-removed-features"]

--- a/modules/cluster-logging-supported-versions.adoc
+++ b/modules/cluster-logging-supported-versions.adoc
@@ -1,0 +1,10 @@
+
+.{product-title} version support for Red Hat OpenShift Logging (RHOL)
+[options="header"]
+|====
+|OpenShift       |4.7          |4.8          |4.9
+|RHOL 5.0|X            |X            |
+|RHOL 5.1|X            |X            |
+|RHOL 5.2|X            |X            |X
+|RHOL 5.3|             |             |X
+|====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: main, enterprise-4.9
- https://issues.redhat.com/browse/RHDEVDOCS-3329
- Direct link to doc preview: https://deploy-preview-38137--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes
- SME review: @alanconway
- QE review: @anpingli 
- Peer review: @bburt-rh @jc-berger  
- Please merge
