### PR TITLE
GH#38021:Fix ClusterResourceOverride examples

### DIFF
--- a/modules/nodes-cluster-resource-configure.adoc
+++ b/modules/nodes-cluster-resource-configure.adoc
@@ -26,11 +26,13 @@ To modify cluster-level overcommit:
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
 metadata:
--   name: cluster
+    name: cluster
 spec:
-   memoryRequestToLimitPercent: 50 <1>
-   cpuRequestToLimitPercent: 25 <2>
-   limitCPUToMemoryPercent: 200 <3>
+  podResourceOverride:
+    spec:
+      memoryRequestToLimitPercent: 50 <1>
+      cpuRequestToLimitPercent: 25 <2>
+      limitCPUToMemoryPercent: 200 <3>
 ----
 <1> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
 <2> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
@@ -44,11 +46,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
 
-....
+ ...
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true" <1>
 
-....
+ ...
 ----
 <1> Add this label to each project.

--- a/modules/nodes-cluster-resource-override.adoc
+++ b/modules/nodes-cluster-resource-override.adoc
@@ -18,11 +18,13 @@ following example:
 apiVersion: operator.autoscaling.openshift.io/v1
 kind: ClusterResourceOverride
 metadata:
--   name: cluster <1>
+    name: cluster <1>
 spec:
-   memoryRequestToLimitPercent: 50 <2>
-   cpuRequestToLimitPercent: 25 <3>
-   limitCPUToMemoryPercent: 200 <4>
+  podResourceOverride:
+    spec:
+      memoryRequestToLimitPercent: 50 <2>
+      cpuRequestToLimitPercent: 25 <3>
+      limitCPUToMemoryPercent: 200 <4>
 ----
 <1> The name must be `cluster`.
 <2> Optional. If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit, between 1-100. The default is 50.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/38021

Previews:
[Cluster-level overcommit using the Cluster Resource Override Operator](https://deploy-preview-38138--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override_nodes-cluster-overcommit)[
Configuring cluster-level overcommit](https://deploy-preview-38138--osdocs.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-configure_nodes-cluster-overcommit)