### PR TITLE
GH#37995: Remove incorrect `delete-emptydir-data` flag

### DIFF
--- a/modules/nodes-nodes-rebooting-gracefully.adoc
+++ b/modules/nodes-nodes-rebooting-gracefully.adoc
@@ -22,7 +22,7 @@ $ oc adm cordon <node1>
 +
 [source,terminal]
 ----
-$ oc adm drain <node1> --ignore-daemonsets --delete-emptydir-data
+$ oc adm drain <node1> --ignore-daemonsets --delete-local-data
 ----
 +
 . Access the node in debug mode:


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/37995

Preview: [Rebooting a node gracefully](https://deploy-preview-38142--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-rebooting.html#nodes-nodes-rebooting-gracefully_nodes-nodes-rebooting)