### PR TITLE
Issue-36224: Add Allow value option to insecureEdgeTerminationPolicy

### DIFF
--- a/modules/nw-ingress-creating-a-passthrough-route.adoc
+++ b/modules/nw-ingress-creating-a-passthrough-route.adoc
@@ -42,7 +42,8 @@ spec:
 ----
 <1> The name of the object, which is limited to 63 characters.
 <2> The `*termination*` field is set to `passthrough`. This is the only required `tls` field.
-<3> Optional `insecureEdgeTerminationPolicy`. The only valid values are `None`, `Redirect`, or empty for disabled.
+<3> Optional `insecureEdgeTerminationPolicy`. The only valid values are `Allow`, `None`, `Redirect`, or empty for disabled.
+
 +
 The destination pod is responsible for serving certificates for the
 traffic at the endpoint. This is currently the only method that can support requiring client certificates, also known as two-way authentication.


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/36224

Preview: https://deploy-preview-38166--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/secured-routes.html#nw-ingress-creating-a-passthrough-route_secured-routes