### PR TITLE
MULTIARCH-1672, 1675: Backport multi-nic to IBM P/Z to OCP 4.6

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -44,7 +44,7 @@ include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.hcpa6/bhslzvs.htm[Bridging a HiperSockets LAN with a z/VM Virtual Switch] in the IBM Knowledge Center.
+* See link:https://www.ibm.com/docs/en/zvm/7.1?topic=networks-bridging-hipersockets-lan-zvm-virtual-switch[Bridging a HiperSockets LAN with a z/VM Virtual Switch] in IBM Documentation.
 
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
@@ -66,6 +66,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+1]
@@ -73,6 +75,8 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+1]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-user-infra-machines-iso.adoc[leveloffset=+1]
+
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
@@ -100,7 +104,7 @@ include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffs
 
 .Additional resources
 
-* See also link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within OpenShift4 nodes without SSH].
+* See link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within OpenShift4 nodes without SSH].
 
 == Next steps
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -51,7 +51,8 @@ include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
 
 .Additional resources
 
-* See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.hcpa6/bhslzvs.htm[Bridging a HiperSockets LAN with a z/VM Virtual Switch] in the IBM Knowledge Center.
+* See link:https://www.ibm.com/docs/en/zvm/7.1?topic=networks-bridging-hipersockets-lan-zvm-virtual-switch[Bridging a HiperSockets LAN with a z/VM Virtual Switch] in IBM Documentation.
+
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
 include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
@@ -72,6 +73,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
 include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
@@ -79,6 +82,8 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 
 include::modules/installation-ibm-z-user-infra-machines-iso.adoc[leveloffset=+1]
+
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+2]
 
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
@@ -108,7 +113,7 @@ include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffs
 
 .Additional resources
 
-* See also link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within {product-title} version 4 nodes without SSH].
+* See link:https://access.redhat.com/solutions/4387261[How to generate SOSREPORT within {product-title} version 4 nodes without SSH].
 
 == Next steps
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -28,6 +28,12 @@
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_power/installing-ibm-power.adoc
+// * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -120,6 +126,24 @@ ifeval::["{context}" == "installing-openstack-installer-restricted"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
 :vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:ibm-power:
 endif::[]
 
 [id="installation-configuration-parameters_{context}"]
@@ -279,6 +303,10 @@ networking:
 The IP address blocks for machines.
 
 If you specify multiple IP address blocks, the blocks must not overlap.
+
+ifdef::ibm-z,ibm-power[]
+If you specify multiple IP kernel arguments, the `machineNetwork.cidr` value must be the CIDR of the primary network.
+endif::ibm-z,ibm-power[]
 |An array of objects. For example:
 
 [source,yaml]
@@ -1038,4 +1066,22 @@ ifeval::["{context}" == "installing-openstack-installer-restricted"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!ibm-power:
 endif::[]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -6,6 +6,30 @@
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:ibm-power:
+:restricted:
+endif::[]
 
 [id="installation-user-infra-machines-static-network_{context}"]
 = Advanced {op-system} installation reference
@@ -52,11 +76,28 @@ nameserver=4.4.4.41
 ----
 
 a|Specify multiple network interfaces by specifying multiple `ip=` entries.
+
 a|
 ----
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
+
+a|Optional: You can configure routes to additional networks by setting an `rd.route=` value. 
+
+If the additional network gateway is different from the primary network gateway, the default gateway must be the primary network gateway.
+a|
+To configure the default gateway: 
+
+----
+ip=::10.10.10.254::::
+----
+
+To configure the route for the additional network:
+
+----
+rd.route=20.20.20.0/24:20.20.20.254:enp2s0
+---- 
 
 a|Disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used.
 a|
@@ -145,6 +186,7 @@ vlan=bond0.100:bond0
 
 |===
 
+ifndef::ibm-z,ibm-power[]
 [discrete]
 == `coreos.inst` boot options for ISO or PXE install
 
@@ -343,3 +385,24 @@ a|`-h`, `--help`
 a|Print help information.
 
 |===
+
+endif::ibm-z,ibm-power[]
+
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-power"]
+:!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
+:!ibm-power:
+endif::[]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.6

Jira:
* https://issues.redhat.com/browse/MULTIARCH-1672
* https://issues.redhat.com/browse/MULTIARCH-1675
This PR backports the mult-nic changes we made for [P/Z in 4.9](https://github.com/openshift/openshift-docs/pull/36250) to 4.6

Related PRs: 
* [backport 4.7](https://github.com/openshift/openshift-docs/pull/38094)
* [backport 4.8](https://github.com/openshift/openshift-docs/pull/38039)

Preview
* Installing a cluster with z/VM on IBM Z and LinuxONE - [Networking and bonding options for ISO installations](https://deploy-preview-38177--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-static-network_installing-ibm-z)


QE review: Micah Abbott
IBM Z: Holger Wolf, IBM P: Mick Tarsel