### PR TITLE
Global style fix: s/log into/log in to

### DIFF
--- a/cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc
+++ b/cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc
@@ -12,7 +12,7 @@ To create services from an Operator, you must ensure that the Operator has valid
 the service. If this YAML has placeholder values or sample values, a service cannot start. You can modify the YAML file and start the service with the modified values. To learn how to modify YAML files and start services from it, see xref:../../cli_reference/developer_cli_odo/creating-instances-of-services-managed-by-operators.adoc#creating-services-from-yaml-files_creating-instances-of-services-managed-by-operators[Creating services from YAML files].
 
 == Prerequisites
-* Install the `oc` CLI and log into the cluster.
+* Install the `oc` CLI and log in to the cluster.
 ** Note that the configuration of the cluster determines the services available to you. To access the Operator services, a cluster administrator must install the respective Operator on the cluster first. To learn more, see xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Adding Operators to the cluster].
 * Install the `{odo-title}` CLI.
 

--- a/modules/dedicated-aws-vpc-configuring-routing-tables.adoc
+++ b/modules/dedicated-aws-vpc-configuring-routing-tables.adoc
@@ -30,7 +30,7 @@ Select the private one that has a number of explicitly associated subnets.
 . Click *Save*.
 
 . You must complete the same process with the other VPC's CIDR block:
-.. Log into the Customer AWS Web Console → *VPC Service* → *Route Tables*.
+.. Log in to the Customer AWS Web Console → *VPC Service* → *Route Tables*.
 .. Select the Route Table for your VPC.
 .. Select the *Routes* tab, then *Edit*.
 .. Enter the {product-title} Cluster VPC CIDR block in the *Destination* text box.

--- a/modules/developer-cli-odo-pushing-the-odo-init-image-to-a-mirror-registry.adoc
+++ b/modules/developer-cli-odo-pushing-the-odo-init-image-to-a-mirror-registry.adoc
@@ -27,7 +27,7 @@ $ echo <content_of_additional_ca> | base64 --decode > disconnect-ca.crt
 $ sudo cp ./disconnect-ca.crt /etc/pki/ca-trust/source/anchors/<mirror-registry>.crt
 ----
 
-. Trust a CA in your client platform and log into the {product-title} mirror registry:
+. Trust a CA in your client platform and log in to the {product-title} mirror registry:
 +
 [source,terminal]
 ----
@@ -107,7 +107,7 @@ PS C:\> echo <content_of_additional_ca> | base64 --decode > disconnect-ca.crt
 PS C:\WINDOWS\system32> certutil -addstore -f "ROOT" disconnect-ca.crt
 ----
 
-. Trust a CA in your client platform and log into the {product-title} mirror registry:
+. Trust a CA in your client platform and log in to the {product-title} mirror registry:
 +
 .. Restart Docker using the Docker UI.
 +

--- a/modules/developer-cli-odo-pushing-the-odo-init-image-to-an-internal-registry-directly.adoc
+++ b/modules/developer-cli-odo-pushing-the-odo-init-image-to-an-internal-registry-directly.adoc
@@ -54,7 +54,7 @@ $ echo <tls.crt> | base64 --decode > ca.crt
 $ sudo cp ca.crt  /etc/pki/ca-trust/source/anchors/externalroute.crt && sudo update-ca-trust enable && sudo systemctl daemon-reload && sudo systemctl restart docker
 ----
 
-. Log into the internal registry:
+. Log in to the internal registry:
 +
 [source,terminal]
 ----
@@ -131,7 +131,7 @@ $ echo <tls.crt> | base64 --decode > ca.crt
 $ sudo security add-trusted-cert -d -r trustRoot -k /Library/Keychains/System.keychain ca.crt
 ----
 
-. Log into the internal registry:
+. Log in to the internal registry:
 +
 [source,terminal]
 ----
@@ -208,7 +208,7 @@ PS C:\> echo <tls.crt> | base64 --decode > ca.crt
 PS C:\WINDOWS\system32> certutil -addstore -f "ROOT" ca.crt
 ----
 
-. Log into the internal registry:
+. Log in to the internal registry:
 +
 [source,terminal]
 ----

--- a/modules/installing-rhv-accessing-ocp-web-console.adoc
+++ b/modules/installing-rhv-accessing-ocp-web-console.adoc
@@ -6,7 +6,7 @@
 [id="installing-rhv-accessing-ocp-web-console_{context}"]
 = Accessing the {product-title} web console on {rh-virtualization}
 
-After the {product-title} cluster initializes, you can log into the {product-title} web console.
+After the {product-title} cluster initializes, you can log in to the {product-title} web console.
 
 .Procedure
 . Optional: In the {rh-virtualization-first} Administration Portal, open *Compute* -> *Cluster*.

--- a/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm.adoc
@@ -51,7 +51,7 @@ $ systemctl status libvirtd
            ├─ 9850 /usr/sbin/libvirtd
 ----
 +
-If the bootstrap VM is operational, log into it.
+If the bootstrap VM is operational, log in to it.
 
 . Use the `virsh console` command to find the IP address of the bootstrap VM:
 +

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -8,7 +8,7 @@
 [id="logging-in-by-using-the-web-console_{context}"]
 = Logging in to the cluster by using the web console
 
-The `kubeadmin` user exists by default after an {product-title} installation. You can log into your cluster as the `kubeadmin` user by using the {product-title} web console.
+The `kubeadmin` user exists by default after an {product-title} installation. You can log in to your cluster as the `kubeadmin` user by using the {product-title} web console.
 
 .Prerequisites
 

--- a/modules/logging-into-a-cluster-after-installation.adoc
+++ b/modules/logging-into-a-cluster-after-installation.adoc
@@ -5,6 +5,6 @@
 [id="logging-into-a-cluster-after-installation_{context}"]
 = Logging into a cluster after an installation
 
-After an installation, the `kubeadmin` user exists by default. You can log into your cluster as the `kubeadmin` user by using the CLI or the {product-title} web console.
+After an installation, the `kubeadmin` user exists by default. You can log in to your cluster as the `kubeadmin` user by using the CLI or the {product-title} web console.
 
 

--- a/modules/machine-delete.adoc
+++ b/modules/machine-delete.adoc
@@ -12,7 +12,7 @@ You can delete a specific machine.
 
 * Install an {product-title} cluster.
 * Install the OpenShift CLI (`oc`).
-* Log into `oc` as a user with `cluster-admin` permission.
+* Log in to `oc` as a user with `cluster-admin` permission.
 
 .Procedure
 

--- a/modules/ossm-access-grafana.adoc
+++ b/modules/ossm-access-grafana.adoc
@@ -17,4 +17,4 @@ Grafana is an analytics tool that you can use to view, query, and analyze your s
 
 . Click the link in the *Location* column for the *Grafana* row.
 
-. Log into the Grafana console with your {product-title} credentials.
+. Log in to the Grafana console with your {product-title} credentials.

--- a/modules/ossm-access-prometheus.adoc
+++ b/modules/ossm-access-prometheus.adoc
@@ -17,4 +17,4 @@ Prometheus is a monitoring and alerting tool that you can use to collect multi-d
 
 . Click the link in the *Location* column for the *Prometheus* row.
 
-. Log into the Prometheus console with your {product-title} credentials.
+. Log in to the Prometheus console with your {product-title} credentials.

--- a/modules/update-oc-configmap-signature-verification.adoc
+++ b/modules/update-oc-configmap-signature-verification.adoc
@@ -15,7 +15,7 @@ Before you update your cluster, you must manually create a config map that conta
 
 . Obtain the image signature for the version that you are upgrading to from either link:https://mirror.openshift.com/pub/openshift-v4/signatures/openshift/release[mirror.openshift.com] or link:https://storage.googleapis.com/openshift-release/official/signatures[Google Cloud Storage (GCS)].
 
-. Use `oc` command-line interface (CLI) to log into the cluster that you are upgrading.
+. Use `oc` command-line interface (CLI) to log in to the cluster that you are upgrading.
 
 . Apply the mirrored release image signature config map to the connected cluster:
 +


### PR DESCRIPTION
Changed all instances of "log into" to "log in to", for reasons of good sense and the IBM Style Guide.

See also #38180

Applies to 4.6+