### PR TITLE
Global style fix: s/log into/log in to

### DIFF
--- a/dev_guide/application_lifecycle/promoting_applications.adoc
+++ b/dev_guide/application_lifecycle/promoting_applications.adoc
@@ -628,7 +628,7 @@ $ oc tag <project_for_stage_N>/<imagestream_name_for_stage_N>:<tag_for_stage_N> 
 ----
 
 .. If the registry is not shared, you can leverage the access tokens for each of
-your promotion pipeline registries as you log into both the source and
+your promotion pipeline registries as you log in to both the source and
 destination registries, pulling, tagging, and pushing your application images
 accordingly:
 
@@ -652,7 +652,7 @@ environment:
 $ docker tag <src_env_registry_ip>:<port>/<namespace>/<image name>:<tag> <dest_env_registry_ip>:<port>/<namespace>/<image name>:<tag>
 ----
 
-... Log into the destination staging environment registry:
+... Log in to the destination staging environment registry:
 +
 ----
 $ docker login -u <username> -e <any_email_address> -p <token_value> <dest_env_registry_ip>:<port>

--- a/dev_guide/dev_tutorials/openshift_pipeline.adoc
+++ b/dev_guide/dev_tutorials/openshift_pipeline.adoc
@@ -305,7 +305,7 @@ xref:../../using_images/other_images/jenkins.adoc#jenkins-cross-project-access[C
 Access].
 
 * To add projects to monitor, either:
-** Log into the Jenkins console.
+** Log in to the Jenkins console.
 *** Navigate to *Manage Jenkins*, then *Configure System*.
 *** Update the *Namespace* field under *OpenShift Jenkins Sync*.
 ** Or extend the OpenShift Jenkins image using the

--- a/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_load_balancer.adoc
@@ -53,7 +53,7 @@ Then, perform the following tasks:
 
 To create a load balancer service:
 
-. Log into {product-title}.
+. Log in to {product-title}.
 
 . Load the project where the service you want to expose is located. If the project or service does not exist, see xref:expose-lb-project[Create a Project and Service].
 +

--- a/dev_guide/expose_service/expose_internal_ip_nodeport.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_nodeport.adoc
@@ -44,7 +44,7 @@ include::dev_guide/expose_service/expose_internal_ip_service.adoc[tag=expose-svc
 
 You specify a port number for the nodePort when you create or modify a service. If you didn't manually specify a port, system will allocate one for you.
 
-. Log into the master node.
+. Log in to the master node.
 
 . If the project you want to use does not exist, create a new project for your service:
 +

--- a/dev_guide/expose_service/expose_internal_ip_service.adoc
+++ b/dev_guide/expose_service/expose_internal_ip_service.adoc
@@ -78,7 +78,7 @@ $ oc adm policy add-cluster-role-to-user cluster-admin <username>
 
 The first step in allowing access to a service is to define an external IP address range in the master configuration file:
 
-. Log into  {product-title} as a user with the cluster admin role.
+. Log in to  {product-title} as a user with the cluster admin role.
 +
 ----
 $ oc login
@@ -131,7 +131,7 @@ If the project and service that you want to expose do not exist, first create th
 
 If the project and service already exist, go to the next step: *Expose the Service to Create a Route*.
 
-. Log into {product-title}.
+. Log in to {product-title}.
 
 . Create a new project for your service:
 +
@@ -177,9 +177,9 @@ You must xref:../../cli_reference/basic_cli_operations.adoc#expose[expose the se
 
 To expose the service:
 
-. Log into {product-title}.
+. Log in to {product-title}.
 
-. Log into the project where the service you want to expose is located.
+. Log in to the project where the service you want to expose is located.
 +
 ----
 $ oc project project1
@@ -236,7 +236,7 @@ Then, perform the following tasks:
 
 To assign an external IP address to a service:
 
-. Log into {product-title}.
+. Log in to {product-title}.
 
 . Load the project where the service you want to expose is located. If the project or service does not exist, see xref:create-external-project-service[Create a Project and Service] in the Prerequisites.
 

--- a/dev_guide/managing_images.adoc
+++ b/dev_guide/managing_images.adoc
@@ -530,7 +530,7 @@ as the {product-title} API. To perform a `docker login` against the internal reg
 you can choose any user name and email, but the password must be a valid
 {product-title} token.
 
-To log into the internal registry:
+To log in to the internal registry:
 
 . Log in to {product-title}:
 +

--- a/dev_guide/projects.adoc
+++ b/dev_guide/projects.adoc
@@ -233,7 +233,7 @@ within the project.
  collaborator has confirmed their Red Hat Developers account, you can add them
  to your subscription.
 
- . Each collaborator must sign into
+ . Each collaborator must sign in to
 link:https://developers.redhat.com/[developers.redhat.com] and click on their
 name in the upper-right corner to access their account details. Make note of the
 *Red Hat Login ID* on this page, as it is the user name you will be required to

--- a/getting_started/developers_cli.adoc
+++ b/getting_started/developers_cli.adoc
@@ -188,7 +188,7 @@ To create an application, you must create a new project and specify the location
 of the source. From there, {product-title} begins the build process and creates
 a new deployment.
 
-. Log into {product-title} from the CLI:
+. Log in to {product-title} from the CLI:
 ifndef::openshift-aro[]
 +
 * With username and password:

--- a/getting_started/devpreview_faq.adoc
+++ b/getting_started/devpreview_faq.adoc
@@ -158,7 +158,7 @@ the Internal Registry] for more information.
 
 [[devpreview-checking-current-usage]]
 HOW DO I CHECK MY CURRENT USAGE?::
-To check your project's current resource usage, you can log into the web console
+To check your project's current resource usage, you can log in to the web console
 and view them from the *Settings* tab of your project's *Overview*, or use the
 following CLI command:
 

--- a/getting_started/topics/configuring_AWS_VPC.adoc
+++ b/getting_started/topics/configuring_AWS_VPC.adoc
@@ -8,7 +8,7 @@ If a virtual private cloud (VPC) peering connection was requested, the VPC
 peering request is initiated from the Red Hat OpenShift AWS account. First,
 accept the peering request , and then configure the Route Tables:
 
-. Log into your AWS Web Console.
+. Log in to your AWS Web Console.
 . Select the Route Table for your VPC (*VPC* → *Route Tables*).
 . Select the *Routes* tab.
 . Click *Edit*.

--- a/install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc
+++ b/install_config/advanced_ldap_configuration/sssd_for_ldap_failover.adoc
@@ -240,13 +240,13 @@ username:*:12345:12345:Example User:/home/username:/usr/bin/bash
 ----
 ====
 
-. Attempt to log into the VM as an LDAP user and confirm that the authentication
+. Attempt to log in to the VM as an LDAP user and confirm that the authentication
 is properly set up. This can be done via the local console or a remote service
 such as SSH.
 
 [NOTE]
 ====
-If you do not want LDAP users to be able to log into this machine, it is
+If you do not want LDAP users to be able to log in to this machine, it is
 recommended to modify *_/etc/pam.d/system-auth_* and
 *_/etc/pam.d/password-auth_* to remove the lines containing *pam_sss.so*.
 ====

--- a/install_config/aggregate_logging.adoc
+++ b/install_config/aggregate_logging.adoc
@@ -2054,7 +2054,7 @@ monitoring container and pod logs allows administrator users (`cluster-admin` or
 
 Kibana Visualize exists inside the Elasticsearch and ES-OPS
 pod, and must be run inside those pods. To load dashboards and other Kibana UI
-objects, you must first log into Kibana as the user you want to add the
+objects, you must first log in to Kibana as the user you want to add the
 dashboards to, then log out. This will create the necessary per-user
 configuration that the next step relies on. Then, run:
 

--- a/install_config/imagestreams_templates.adoc
+++ b/install_config/imagestreams_templates.adoc
@@ -127,7 +127,7 @@ Before you consider performing the tasks in this topic, confirm if these image
 streams and templates are already registered in your {product-title} cluster by
 doing one of the following:
 
-* Log into the web console and click *Add to Project*.
+* Log in to the web console and click *Add to Project*.
 * List them for the *openshift* project using the CLI:
 +
 ----
@@ -198,7 +198,7 @@ IMAGESTREAMDIR="/usr/share/ansible/openshift-ansible/roles/openshift_examples/fi
     DBTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/ppc64le/db-templates"; \
     QSTEMPLATES="/usr/share/ansible/openshift-ansible/roles/openshift_examples/files/examples/ppc64le/quickstart-templates"
 ----
-    
+
 endif::[]
 
 [[creating-image-streams-for-openshift-images]]
@@ -396,7 +396,7 @@ endif::[]
 == What's Next?
 
 With these artifacts created, developers can now
-xref:../dev_guide/authentication.adoc#dev-guide-authentication[log into the web console]
+xref:../dev_guide/authentication.adoc#dev-guide-authentication[log in to the web console]
 and follow the flow for
 xref:../dev_guide/templates.adoc#creating-from-templates-using-the-web-console[creating from a template].
 Any of the database or application templates can be selected

--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1765,7 +1765,7 @@ For example:
 
 *Redirect master log to a file*
 
-To redirect the output of master log into a file, run the following command:
+To redirect the output of master log in to a file, run the following command:
 
 ----
 master-logs api api 2> file

--- a/install_config/registry/accessing_registry.adoc
+++ b/install_config/registry/accessing_registry.adoc
@@ -50,7 +50,7 @@ container:
 # oc describe pod <pod_name>
 ----
 
-. Log into the desired node:
+. Log in to the desired node:
 +
 ----
 # ssh node.example.com

--- a/install_config/topics/ocp_osp_provisioning.adoc
+++ b/install_config/topics/ocp_osp_provisioning.adoc
@@ -299,7 +299,7 @@ $ openstack security group rule delete REMOTE_GROUP_ID
 |openshift_openstack_dns_nameservers | IP of DNS nameservers
 |openshift_openstack_public_hostname_suffix | Adds a suffix to the node hostname in the DNS record for both public and private
 |openshift_openstack_nsupdate_zone | Zone to be updated with OCP instance IPs
-|openshift_openstack_keypair_name | Keypair name used to log into OCP instances
+|openshift_openstack_keypair_name | Keypair name used to log in to OCP instances
 |openshift_openstack_external_network_name| OpenStack public network name
 |openshift_openstack_default_image_name | OpenStack image used for OCP instances
 |openshift_openstack_num_masters | Number of master nodes to deploy

--- a/install_config/topics/sssd_for_ldap_failover_configure_sssd.adoc
+++ b/install_config/topics/sssd_for_ldap_failover_configure_sssd.adoc
@@ -10,7 +10,7 @@ Module included in the following assemblies:
 = Configuring SSSD for LDAP failover
 Complete these steps on the remote basic authentication server.
 
-You can configure the SSSD to retrieve attributes, such as email addresses and 
+You can configure the SSSD to retrieve attributes, such as email addresses and
 display names, and pass them to {product-title} to display in the web interface.
 In the following steps, you configure the SSSD to provide email addresses to
 {product-title}:
@@ -42,7 +42,7 @@ For more advanced cases, see the
 https://access.redhat.com/documentation/en-US/Red_Hat_Enterprise_Linux/7/html/System-Level_Authentication_Guide/authconfig-ldap.html[System-Level Authentication Guide]
 
 . To use SSSD to manage failover situations for LDAP, add more entries to the
- *_/etc/sssd/sssd.conf_* file on the *ldap_uri* line. Systems that are 
+ *_/etc/sssd/sssd.conf_* file on the *ldap_uri* line. Systems that are
 enrolled with FreeIPA can automatically handle failover by using DNS SRV records.
 
 . Modify the *[domain/DOMAINNAME]* section of the *_/etc/sssd/sssd.conf_* file
@@ -64,7 +64,7 @@ contains only the domain name listed in the *[domain/DOMAINNAME]* section.
 domains = example.com
 ----
 
-. Grant Apache permission to retrieve the email attribute. Add the following 
+. Grant Apache permission to retrieve the email attribute. Add the following
 lines to the *[ifp]* section of the *_/etc/sssd/sssd.conf_* file:
 +
 ----
@@ -94,7 +94,7 @@ your domain:
     /org/freedesktop/sssd/infopipe org.freedesktop.sssd.infopipe.GetUserAttr \
     string:username \ <1>
     array:string:mail <2>
-    
+
 method return time=1528091855.672691 sender=:1.2787 -> destination=:1.2795 serial=13 reply_serial=2
    array [
       dict entry(
@@ -108,19 +108,19 @@ method return time=1528091855.672691 sender=:1.2787 -> destination=:1.2795 seria
 <1> Provide a user name in your LDAP solution.
 <2> Specify the attribute that you configured.
 
-. Attempt to log into the VM as an LDAP user and confirm that you can log in
+. Attempt to log in to the VM as an LDAP user and confirm that you can log in
 using LDAP credentials. You can use either the local console or a remote service
 like SSH to log in.
 
 [IMPORTANT]
 ====
-By default, all users can log into the remote basic authentication server by using
+By default, all users can log in to the remote basic authentication server by using
 their LDAP credentials. You can change this behavior:
 
 * If you use IPA joined systems,
 link:https://www.freeipa.org/page/Howto/HBAC_and_allow_all[configure host-based access control].
 * If you use Active Directory joined systems, use a
 link:https://docs.pagure.org/SSSD.sssd/design_pages/active_directory_gpo_integration.html[group policy object].
-* For other cases, see the 
+* For other cases, see the
 link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/system-level_authentication_guide/sssd[SSSD configuration] documentation.
 ====

--- a/modules/cnv_accessing_vmi_ssh.adoc
+++ b/modules/cnv_accessing_vmi_ssh.adoc
@@ -1,22 +1,22 @@
 [[accessvmissh]]
 === Accessing a virtual machine instance via SSH
 
-You can use SSH to access a virtual machine, but first you must expose port 
+You can use SSH to access a virtual machine, but first you must expose port
 22 on the VM.
 
-The `virtctl expose` command forwards a virtual machine instance port to a node 
-port and creates a service for enabled access. The following example creates 
-the *fedora-vm-ssh* service which forwards port 22 of the `<fedora-vm>` virtual 
+The `virtctl expose` command forwards a virtual machine instance port to a node
+port and creates a service for enabled access. The following example creates
+the *fedora-vm-ssh* service which forwards port 22 of the `<fedora-vm>` virtual
 machine to a port on the node:
 
 .Prerequisites
 * The virtual machine instance you want to access must be running.
 
 .Procedure
-. Run the following command to create the *fedora-vm-ssh* service: 
+. Run the following command to create the *fedora-vm-ssh* service:
 +
 ----
-$ virtctl expose vm <fedora-vm> --port=20022 --target-port=22 --name=fedora-vm-ssh --type=NodePort 
+$ virtctl expose vm <fedora-vm> --port=20022 --target-port=22 --name=fedora-vm-ssh --type=NodePort
 ----
 
 . Check the service to find out which port the service acquired:
@@ -27,7 +27,7 @@ NAME            TYPE       CLUSTER-IP     EXTERNAL-IP   PORT(S)           AGE
 fedora-vm-ssh   NodePort   127.0.0.1      <none>        20022:32551/TCP   6s
 ----
 
-. Log into the virtual machine instance via SSH, using the `ipAddress` of the 
+. Log in to the virtual machine instance via SSH, using the `ipAddress` of the
 node and the port that you found in Step 2:
 +
 ----

--- a/modules/cnv_install_1_4.adoc
+++ b/modules/cnv_install_1_4.adoc
@@ -33,7 +33,7 @@ that can be modified to match your configuration.
 $ yum install kubevirt-ansible
 ----
 
-. Log into the {product-title} cluster as an admin user:
+. Log in to the {product-title} cluster as an admin user:
 +
 ----
 $ oc login -u system:admin

--- a/modules/cnv_uninstall_1_4.adoc
+++ b/modules/cnv_uninstall_1_4.adoc
@@ -18,7 +18,7 @@ This procedure uninstalls the following components:
 
 .Procedure
 
-. Log into the {product-title} cluster as an admin user:
+. Log in to the {product-title} cluster as an admin user:
 +
 ----
 $ oc login -u system:admin

--- a/modules/crio_trouble.adoc
+++ b/modules/crio_trouble.adoc
@@ -54,7 +54,7 @@ OPTIONS:
 ```
 
 == Checking CRI-O's general health
-Log into a node in your {product-title} cluster that is running CRI-O and
+Log in to a node in your {product-title} cluster that is running CRI-O and
 run the following commands to check the general health of the CRI-O container engine:
 
 Check that the CRI-O related packages are installed. That includes the

--- a/release_notes/ocp_3_5_release_notes.adoc
+++ b/release_notes/ocp_3_5_release_notes.adoc
@@ -1297,7 +1297,7 @@ Previously, the user would need to reload the browser if an update error
 occurred.
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1388493[*BZ#1388493*])
 
-* On the web console *About* page, the user can copy the CLI code to log into
+* On the web console *About* page, the user can copy the CLI code to log in to
 {product-title} using the current session token. The token is now permanently hidden
 and the web console now appends the user token if the user copies the CLI
 example using the *Copy to Clipboard* button.

--- a/release_notes/ose_3_2_release_notes.adoc
+++ b/release_notes/ose_3_2_release_notes.adoc
@@ -435,7 +435,7 @@ NAME      DOCKER REPO                     TAGS     UPDATED
 mysql     172.30.1.5:5000/default/redis   local    Less than a second ago
 ----
 +
-Log into your local container image registry, then pull the image from the integrated
+Log in to your local container image registry, then pull the image from the integrated
 registry:
 +
 ----

--- a/servicemesh-install/topics/install.adoc
+++ b/servicemesh-install/topics/install.adoc
@@ -24,7 +24,7 @@ Starting with {ProductName} {ProductVersion}, you must install the Jaeger Operat
 === Installing the Jaeger Operator
 You must install the Jaeger Operator for the {ProductName} Operator to install the control plane.
 
-. Log into the {product-title} as a cluster administrator.
+. Log in to the {product-title} as a cluster administrator.
 
 . Run the following commands to install the Jaeger Operator:
 +
@@ -41,7 +41,7 @@ $ oc create -n observability -f https://raw.githubusercontent.com/jaegertracing/
 === Installing the Kiali Operator
 You must install the Kiali Operator for the {ProductName} Operator to install the control plane.
 
-. Log into the {product-title} as a cluster administrator.
+. Log in to the {product-title} as a cluster administrator.
 
 . Run the following command to install the Kiali Operator:
 +
@@ -57,7 +57,7 @@ $ bash <(curl -L https://git.io/getLatestKialiOperator) --operator-image-version
 You must install the Jaeger Operator and the Kiali Operator before you install the {ProductName} Operator.
 ====
 
-. Log into the {product-title} as a cluster administrator.
+. Log in to the {product-title} as a cluster administrator.
 
 . If the `istio-operator` and `istio-system` namespaces do not exist, run these commands to create the namespaces:
 +
@@ -77,7 +77,7 @@ $ oc apply -n istio-operator -f https://raw.githubusercontent.com/Maistra/istio-
 [[verifying-operator-installation]]
 == Verifying the Operator installation
 
-. Log into the {product-title} as a cluster administrator.
+. Log in to the {product-title} as a cluster administrator.
 
 . Run this command to verify that the Operator is installed correctly.
 +

--- a/using_images/db_images/mongodb.adoc
+++ b/using_images/db_images/mongodb.adoc
@@ -488,7 +488,7 @@ $ oc rsh mongodb-0
 sh-4.2$
 ----
 
-* Log into a MongoDB instance:
+* Log in to a MongoDB instance:
 +
 [source,bash]
 ----


### PR DESCRIPTION
Changed all instances of "log into" to "log in to", for reasons of good sense and the IBM Style Guide.

See also: #38179 

Applies only to `enterprise-3.11`
