### PR TITLE
BZ2010739: Make correction to the Gt selector operator

### DIFF
--- a/modules/virt-example-node-placement-affinity-hyperconverged-cr.adoc
+++ b/modules/virt-example-node-placement-affinity-hyperconverged-cr.adoc
@@ -42,7 +42,7 @@ spec:
             preference:
               matchExpressions:
               - key: example.io/num-cpus
-                operator: gt
+                operator: Gt
                 values:
                 - 8
 ----


### PR DESCRIPTION
This PR is associated with https://bugzilla.redhat.com/show_bug.cgi?id=2010739. The selector operator was corrected as noted in the defect.

The Gt operator was changed to gt in this node example:
https://deploy-preview-38216--osdocs.netlify.app/openshift-enterprise/latest/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-affinity-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components

This PR applies to CNV 4.8 and 4.9 releases.