### PR TITLE
Modularize CSR management text

### DIFF
--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -36,6 +36,7 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -55,6 +55,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -47,10 +47,7 @@ You can view Azure's DNS solution by visiting this xref:installation-azure-creat
 
 include::modules/installation-azure-increasing-limits.adoc[leveloffset=+2]
 
-[id="csr-management-azure_{context}"]
-=== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-azure-permissions.adoc[leveloffset=+2]
 include::modules/installation-azure-service-principal.adoc[leveloffset=+2]

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
@@ -50,10 +50,7 @@ include::modules/installation-azure-stack-hub-network-config.adoc[leveloffset=+2
 
 You can view Azure's DNS solution by visiting this xref:installation-azure-create-dns-zones_{context}[example for creating DNS zones].
 
-[id="csr-management-azure-stack-hub_{context}"]
-=== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-azure-stack-hub-permissions.adoc[leveloffset=+2]
 include::modules/installation-azure-service-principal.adoc[leveloffset=+2]

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -27,6 +27,7 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[Installing a user-provisioned bare metal cluster on a restricted network] for more information about performing a restricted network installation on bare metal infrastructure that you provision.
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -35,6 +35,7 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[Installing a user-provisioned bare metal cluster on a restricted network] for more information about performing a restricted network installation on bare metal infrastructure that you provision.
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -40,6 +40,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -31,18 +31,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 Be sure to also review this site list if you are configuring a proxy.
 ====
 
-[id="csr-management-gcp-vpc"]
-== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.
+include::modules/csr-management.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -26,10 +26,7 @@ The steps for performing a user-provisioned infrastructure installation are prov
 Be sure to also review this site list if you are configuring a proxy.
 ====
 
-[id="csr-management-gcp_{context}"]
-== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.
+include::modules/csr-management.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -31,6 +31,7 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -39,6 +39,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -36,6 +36,7 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra-ibm-z-kvm.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -36,6 +36,7 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -45,6 +45,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra-ibm-z-kvm.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -44,6 +44,7 @@ include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+++ b/installing/installing_platform_agnostic/installing-platform-agnostic.adoc
@@ -27,6 +27,7 @@ Be sure to also review this site list if you are configuring a proxy.
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -42,6 +42,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -30,6 +30,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -33,6 +33,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -45,6 +45,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -37,6 +37,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -36,6 +36,7 @@ include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
 * To update the hardware version for your vSphere nodes, see xref:../../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on nodes running in vSphere].
 
 include::modules/installation-requirements-user-infra.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -10,6 +10,7 @@ In {product-title}, you can add Red Hat Enterprise Linux (RHEL) compute, or work
 include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 [id="additional-resources_adding-rhel-compute"]
 == Additional resources

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -10,6 +10,7 @@ If your {product-title} cluster already includes Red Hat Enterprise Linux (RHEL)
 include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
+include::modules/csr-management.adoc[leveloffset=+2]
 
 [id="additional-resources_more-rhel-compute"]
 == Additional resources

--- a/modules/csr-management.adoc
+++ b/modules/csr-management.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// installing/installing_aws/installing-aws-user-infra.adoc
+// installing/installing_aws/installing-restricted-networks-aws.adoc
+// installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+// installing/installing_azure/installing-azure-user-infra.adoc
+// installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+// installing/installing_bare_metal/installing-bare-metal.adoc
+// installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+// installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// installing/installing_gcp/installing-gcp-user-infra.adoc
+// installing/installing_gcp/installing-restricted-networks-gcp.adoc
+// installing/installing_ibm_power/installing-ibm-power.adoc
+// installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// installing/installing_ibm_z/installing-ibm-z.adoc
+// installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+// installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+// installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+// installing/installing_vmc/installing-vmc-user-infra.adoc
+// installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// installing/installing_vsphere/installing-vsphere.adoc
+// machine_management/adding-rhel-compute.adoc
+// machine_management/more-rhel-compute.adoc
+// post_installation_configuration/node-tasks.adoc
+
+[id="csr-management_{context}"]
+= Certificate signing requests management
+
+Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet serving certificate requests and approving them.

--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -21,19 +21,6 @@ By using the provided CloudFormation templates, you can create stacks of AWS res
 
 Alternatively, you can manually create the components or you can reuse existing infrastructure that meets the cluster requirements. Review the CloudFormation templates for more details about how the components interrelate.
 
-[id="csr-management-aws_{context}"]
-== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.
-
 [id="installation-aws-user-infra-other-infrastructure_{context}"]
 == Other infrastructure components
 

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -181,16 +181,3 @@ The preferred requirements for each cluster virtual machine are:
 |120 GB
 
 |===
-
-[id="csr_management_{context}"]
-== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -374,19 +374,6 @@ On your IBM Power instance, set up:
 
 endif::ibm-power[]
 
-[id="csr_management_{context}"]
-== Managing certificate signing requests
-
-Because your cluster has limited access to automatic machine management when you
-use infrastructure that you provision, you must provide a mechanism for approving
-cluster certificate signing requests (CSRs) after installation. The
-`kube-controller-manager` only approves the kubelet client CSRs. The
-`machine-approver` cannot guarantee the validity of a serving certificate
-that is requested by using kubelet credentials because it cannot confirm that
-the correct machine issued the request. You must determine and implement a
-method of verifying the validity of the kubelet serving certificate requests
-and approving them.
-
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -45,8 +45,3 @@ endif::[]
 * Each system must meet any additional requirements for your system provider. For example, if you installed your cluster on VMware vSphere, your disks must be configured according to its link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[storage guidelines] and the `disk.enableUUID=true` attribute must be set.
 
 * Each system must be able to access the cluster's API endpoints by using DNS-resolvable hostnames. Any network security access control that is in place must allow system access to the cluster's API service endpoints.
-
-[id="csr-management-rhel_{context}"]
-== Certificate signing requests management
-
-Because your cluster has limited access to automatic machine management when you use infrastructure that you provision, you must provide a mechanism for approving cluster certificate signing requests (CSRs) after installation. The `kube-controller-manager` only approves the kubelet client CSRs. The `machine-approver` cannot guarantee the validity of a serving certificate that is requested by using kubelet credentials because it cannot confirm that the correct machine issued the request. You must determine and implement a method of verifying the validity of the kubelet that is serving and approving certificate requests.

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -15,6 +15,7 @@ Understand and work with RHEL compute nodes.
 
 include::modules/rhel-compute-overview.adoc[leveloffset=+2]
 include::modules/rhel-compute-requirements.adoc[leveloffset=+2]
+include::modules/csr-management.adoc[leveloffset=+3]
 
 [id="additional-resources_post-install-node-tasks"]
 == Additional resources


### PR DESCRIPTION
The new module (repurposed existing content) is used 26 times across the installer docs, so I will not list every preview here. Here's a subset of the previews:
- [AWS UPI](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#csr-management_installing-aws-user-infra)
- [Azure UPI](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#csr-management_installing-azure-user-infra)
- [GCP UPI](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#csr-management_installing-gcp-user-infra)
- [Adding more RHEL compute machines](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#csr-management_installing-gcp-user-infra)
- [IBM Power](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#csr-management_installing-ibm-power)
- [IBM Z](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#csr-management_installing-ibm-z)
- [bare metal UPI](https://deploy-preview-38226--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#csr-management_installing-bare-metal)

No QE required; only modularized existing content.