### PR TITLE
Updated builds-source-input-satellite-config.adoc corrected repo-file for sample repository configuration.

### DIFF
--- a/modules/builds-source-input-satellite-config.adoc
+++ b/modules/builds-source-input-satellite-config.adoc
@@ -16,13 +16,13 @@ Builds that use Red Hat Satellite to install content must provide appropriate co
 [source,terminal]
 ----
 [test-<name>]
- name=test-<number>
- baseurl = https://satellite.../content/dist/rhel/server/7/7Server/x86_64/os
- enabled=1
- gpgcheck=0
- sslverify=0
- sslclientkey = /etc/pki/entitlement/...-key.pem
- sslclientcert = /etc/pki/entitlement/....pem
+name=test-<number>
+baseurl = https://satellite.../content/dist/rhel/server/7/7Server/x86_64/os
+enabled=1
+gpgcheck=0
+sslverify=0
+sslclientkey = /etc/pki/entitlement/...-key.pem
+sslclientcert = /etc/pki/entitlement/....pem
 ----
 
 .Procedure


### PR DESCRIPTION
Hello Team,
In official documentation for CICD [Running builds with Red Hat Satellite subscriptions](https://docs.openshift.com/container-platform/4.8/cicd/builds/running-entitled-builds.html#builds-source-input-satellite-config_running-entitled-builds) -> Prerequisites steps for -> Sample repository configuration -> the repo file having issues and corrected that via removing spaces at the beginning of the lines.

The above commit resolve -> https://github.com/openshift/openshift-docs/issues/38018 issue. 
@vikram-redhat 