### PR TITLE
Added notes for release 4.8.18

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2767,7 +2767,7 @@ To upgrade an existing {product-title} 4.8 cluster to this latest release, see x
 
 Issued: 2021-10-19
 
-{product-title} release 4.8.15, which contains security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3821[RHBA-2021:3821] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3820[RHSA-2021:3820] advisory.
+{product-title} release 4.8.15, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3821[RHBA-2021:3821] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3820[RHSA-2021:3820] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
@@ -2797,13 +2797,34 @@ To upgrade an existing {product-title} 4.8 cluster to this latest release, see x
 
 Issued: 2021-10-27
 
-{product-title} release 4.8.17 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3927[RHBA-2021:3927] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3926[RHSA-2021:3926] advisory.
+{product-title} release 4.8.17, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:3927[RHBA-2021:3927] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:3926[RHSA-2021:3926] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 
 link:https://access.redhat.com/solutions/6455311[{product-title} 4.8.17 container image list]
 
 [id="ocp-4-8-17-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-18"]
+=== RHBA-2021:4020 - {product-title} 4.8.18 bug fix update
+
+Issued: 2021-11-02
+
+{product-title} release 4.8.18 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4020[RHBA-2021:4020] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4019[RHBA-2021:4019] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6469021[{product-title} 4.8.18 container image list]
+
+[id="ocp-4-8-18-bug-fixes"]
+==== Bug fixes
+
+* With the deprecation of the `lastTriggeredImageID` field for build configs, the image change trigger controller stopped checking the ID field prior to initiating builds. Consequently, if a build config was created and had an image change trigger start while the cluster was running {product-title} 4.7 or earlier, it continuously tried to trigger builds. With this update, these unnecessary attempts to trigger builds no longer occur. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2006793[*BZ#2006793*])
+
+[id="ocp-4-8-18-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.8.18, scheduled for publication on 2 November 2021.

* Applies only to `enterprise-4.8`
* There's only one bug, a clone, and the doc text for its 4.9 incarnation was already reviewed in #38224 
* Preview: https://deploy-preview-38239--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-18