### PR TITLE
search: add ACS versioning

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -198,7 +198,7 @@
     'openshift-enterprise': ['docs_cp', version],
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
-    'openshift-acs' : ['docs_acs']
+    'openshift-acs' : ['docs_acs', version]
   };
 
   // only OSD v3 docs have the version variable specified


### PR DESCRIPTION
With the recently introduced ACS docs versioning, the existing `version` variable should be passed to the search in order to filter the relevant results only.

@vikram-redhat, please have a look and cherry pick as needed.