### PR TITLE
SRVKE-940: Add note about at least once delivery for Kafka

### DIFF
--- a/serverless/knative_eventing/serverless-kafka.adoc
+++ b/serverless/knative_eventing/serverless-kafka.adoc
@@ -6,13 +6,22 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can use the `KafkaChannel` channel type and `KafkaSource` event source with {ServerlessProductName}.
-To do this, you must install the Knative Kafka components, and configure the integration between {ServerlessProductName} and a supported link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/index[Red Hat AMQ Streams] cluster.
+You can use the `KafkaChannel` channel type and `KafkaSource` event source with {ServerlessProductName}. To do this, you must install the Knative Kafka components, and configure the integration between {ServerlessProductName} and a supported link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.6/html/amq_streams_on_openshift_overview/index[Red Hat AMQ Streams] cluster.
 
 [NOTE]
 ====
 Knative Kafka is not currently supported for IBM Z and IBM Power Systems.
 ====
+
+[id="serverless-kafka-delivery-retries"]
+== Event delivery and retries
+
+Using Kafka components in your event-driven architecture provides "at least once" guarantees for event delivery. This means that operations are retried until a return code value is received. However, while this makes your application more resilient to lost events, it might result in duplicate events being sent.
+
+For the Kafka event source, there is a fixed number of retries for event delivery by default. For Kafka channels, retries are only performed if they are configured in the Kafka channel `Delivery` spec.
+
+[id="install-serverless-kafka"]
+== Installing Knative Kafka
 
 The {ServerlessOperatorName} provides the Knative Kafka API that can be used to create a `KnativeKafka` custom resource:
 
@@ -36,7 +45,7 @@ spec:
 <3> Enables developers to use the `KafkaSource` event source type in the cluster.
 
 // Install Kafka
-include::modules/serverless-install-kafka-odc.adoc[leveloffset=+1]
+include::modules/serverless-install-kafka-odc.adoc[leveloffset=+2]
 
 [id="serverless-kafka-channel-link"]
 == Using Kafka channels


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKE-940

Applies for OCP 4.6+

Direct preview link: https://deploy-preview-38259--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_eventing/serverless-kafka.html