### PR TITLE
BZ2010913: Updated note about bare metal cloud providers

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -13,10 +13,18 @@ xref:../../installing/installing_bare_metal/preparing-to-install-on-bare-metal.a
 +
 [NOTE]
 ====
-* {VirtProductName} only supports {op-system} worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
-
-* Infrastructure solutions offered by bare metal cloud providers are not supported.
+{VirtProductName} only supports {op-system} worker nodes. RHEL 7 or RHEL 8 nodes are not supported.
 ====
+
+* You can install {VirtProductName} on Amazon Web Services (AWS) bare metal instances. Bare metal instances offered by other cloud providers are not supported.
++
+--
+ifdef::openshift-enterprise[]
+:FeatureName: Installing OpenShift Virtualization on AWS bare metal instances
+include::modules/technology-preview.adoc[leveloffset=+2]
+endif::[]
+--
+
 
 * Additionally, there are two options to maintain high availability (HA) of virtual machines:
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2010913

Reopened the bug to accomodate last minute change request by the CNV leads. 

For 4.9, support for AWS bare metal nodes is Technology Preview. Updated note to reflect this.

Preview: https://deploy-preview-38260--osdocs.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt