### PR TITLE
PR37292: Fix two SRO YAML examples

### DIFF
--- a/modules/psap-special-resource-operator-installing-using-cli.adoc
+++ b/modules/psap-special-resource-operator-installing-using-cli.adoc
@@ -80,12 +80,12 @@ $ oc get packagemanifest special-resource-operator -n openshift-marketplace -o j
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: special-resource-operator
+  name: openshift-special-resource-operator
   namespace: openshift-special-resource-operator
 spec:
   channel: "4.9" <1>
   installPlanApproval: Automatic
-  name: special-resource-operator
+  name: openshift-special-resource-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
 ----

--- a/modules/psap-special-resource-operator-using-configmaps.adoc
+++ b/modules/psap-special-resource-operator-using-configmaps.adoc
@@ -131,6 +131,7 @@ metadata:
     specialresource.openshift.io/state: "driver-container"
     specialresource.openshift.io/driver-container-vendor: simple-kmod
     specialresource.openshift.io/kernel-affine: "true"
+    specialresource.openshift.io/from-configmap: "true"
 spec:
   updateStrategy:
     type: OnDelete


### PR DESCRIPTION
Based on this PR: https://github.com/openshift/openshift-docs/issues/37292
Applies to 4.9+
Direct links to changes:

https://deploy-preview-38265--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator#installing-the-special-resource-operator-using-cli_special-resource-operator

https://deploy-preview-38265--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator#deploy-simple-kmod-using-configmap-chart
