### PR TITLE
BZ:1908066 - Updating image build guidelines

### DIFF
--- a/modules/images-create-guide-openshift.adoc
+++ b/modules/images-create-guide-openshift.adoc
@@ -40,7 +40,7 @@ Because the container user is always a member of the root group, the container u
 ====
 Care must be taken when altering the directories and file permissions of sensitive areas of a container, which is no different than to a normal system.
 
-If applied to sensitive areas, such as `/etc/passwd`, this can allow the modification of such files by unintended users potentially exposing the container or host. CRI-O supports the insertion of random user IDs into the container's `/etc/passwd`, so changing permissions is never required.
+If applied to sensitive areas, such as `/etc/passwd`, this can allow the modification of such files by unintended users potentially exposing the container or host. CRI-O supports the insertion of arbitrary user IDs into the container's `/etc/passwd`, so changing permissions is never required.
 ====
 
 In addition, the processes running in the container must not listen on privileged ports, ports below 1024, since they are not running as a privileged user.
@@ -48,7 +48,7 @@ In addition, the processes running in the container must not listen on privilege
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [IMPORTANT]
 ====
-If your S2I image does not include a `USER` declaration with a numeric user, your builds fail by default. To allow images that use either named users or the root `0` user to build in {product-title}, you can add the project's builder service account, `system:serviceaccount:<your-project>:builder`, to the `privileged` security context constraint (SCC). Alternatively, you can allow all images to run as any user.
+If your S2I image does not include a `USER` declaration with a numeric user, your builds fail by default. To allow images that use either named users or the root `0` user to build in {product-title}, you can add the project's builder service account, `system:serviceaccount:<your-project>:builder`, to the `anyuid` security context constraint (SCC). Alternatively, you can allow all images to run as any user.
 ====
 endif::[]
 


### PR DESCRIPTION
Version 4.6x 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1908066

Comments: Changing some wording in the 'warning' section, and changed the SCC in the 'important' section from `privileged` to `anyuid`

Preview: https://deploy-preview-38266--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/create-images.html#images-create-guide-openshift_create-images

Ready for QA: @xiuwang 

For Peer Reviewers: Labels needed  'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8', 'enterprise-4.9', 'enterprise-4.10', and 'Peer Review needed'. Thank you!!