### PR TITLE
RHDEVDOCS-3421 - TLSSecurityProfile setting for cluster monitoring

### DIFF
--- a/modules/monitoring-default-monitoring-components.adoc
+++ b/modules/monitoring-default-monitoring-components.adoc
@@ -49,3 +49,9 @@ By default, the {product-title} {product-version} monitoring stack includes thes
 |===
 
 All of the components in the monitoring stack are monitored by the stack and are automatically updated when {product-title} is updated.
+
+[NOTE]
+====
+All components of the monitoring stack use the TLS security profile settings that are centrally configured by a cluster administrator.
+If you configure a monitoring stack component that uses TLS security settings, the component uses the TLS security profile settings that already exist in the `tlsSecurityProfile` field in the global {product-title} `apiservers.config.openshift.io/cluster` resource. 
+====

--- a/monitoring/understanding-the-monitoring-stack.adoc
+++ b/monitoring/understanding-the-monitoring-stack.adoc
@@ -19,6 +19,7 @@ include::modules/monitoring-targets-for-user-defined-projects.adoc[leveloffset=+
 
 * xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#granting-users-permission-to-monitor-user-defined-projects_enabling-monitoring-for-user-defined-projects[Granting users permission to monitor user-defined projects]
+* xref:../security/tls-security-profiles.adoc#tls-security-profiles[Configuring TLS security profiles]
 
 == Next steps
 


### PR DESCRIPTION
 Aligned team: Dev Tools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3421
- Direct link to doc preview: https://deploy-preview-38267--osdocs.netlify.app/openshift-enterprise/latest/monitoring/understanding-the-monitoring-stack.html#default-monitoring-components_understanding-the-monitoring-stack
- SME review: @jan--f 
- QE review: @juzhao 
- Peer review: @abrennan89 
- <All reviews complete. Please merge now>