### PR TITLE
GH#32985: Fix rsync examples

### DIFF
--- a/modules/nodes-containers-copying-files-procedure.adoc
+++ b/modules/nodes-containers-copying-files-procedure.adoc
@@ -36,21 +36,14 @@ use with the `oc rsync` command.
 +
 [source,terminal]
 ----
-$ oc rsync <local-dir> <pod-name>:/<remote-dir>
+$ oc rsync <local-dir> <pod-name>:/<remote-dir> -c <container-name>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc rsync /home/user/source devpod1234:/src
-----
-+
-.Example output
-[source,terminal]
-----
-WARNING: cannot use rsync: rsync not available in container
-status.txt
+$ oc rsync /home/user/source devpod1234:/src -c user-container
 ----
 
 * To copy a pod directory to a local directory:
@@ -64,6 +57,4 @@ $ oc rsync devpod1234:/src /home/user/source
 [source,terminal]
 ----
 $ oc rsync devpod1234:/src/status.txt /home/user/
-WARNING: cannot use rsync: rsync not available in container
-status.txt
 ----


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/32985

Rsync example, remove warning and add correct example with -c option

Preview: https://deploy-preview-38276--osdocs.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-copying-files#nodes-containers-copying-files-procedure_nodes-containers-copying-files