### PR TITLE
Removes https:// from console.redhat.com/api/ingress 

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -63,7 +63,7 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |443, 80
 |Required for Telemetry
 
-|`https://console.redhat.com/api/ingress`
+|`console.redhat.com/api/ingress`
 |443, 80
 |Required for Telemetry and for `insights-operator`
 |===


### PR DESCRIPTION
GH issue: https://github.com/openshift/openshift-docs/issues/38171

Preview: https://deploy-preview-38277--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall

For 4.6+

Pending QE ack. 

@gpei please review for accuracy :) 

