### PR TITLE
[virt] Removing xref prefix from commented-out xref

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -13,10 +13,10 @@ include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 [id="configuring-workload-updates_upgrading-virt"]
 == Configuring automatic workload updates
 
-// Uncomment this in 4.10
+// Uncomment this in 4.10 and replace prefix
 //[NOTE]
 //====
-//Automatic workload updates are enabled by default in {VirtProductName} {VirtVersion}. You can opt out by following a xref:../virt/upgrading-virt.adoc#virt-opting-out-workload-updates_upgrading-virt[workaround to disable this feature] before you upgrade to {VirtVersion}.
+//Automatic workload updates are enabled by default in {VirtProductName} {VirtVersion}. You can opt out by following a ../virt/upgrading-virt.adoc#virt-opting-out-workload-updates_upgrading-virt[workaround to disable this feature] before you upgrade to {VirtVersion}.
 //====
 
 // Remove TP module in 4.10


### PR DESCRIPTION
- removing the "xref" prefix from an xref that I commented out to prevent build errors
- no bug/jira
- CP to 4.9 only (already fixed in 4.10)