### PR TITLE
[RHACS] Updated the support page for uploading diagnostic bundle

### DIFF
--- a/configuration/generate-diagnostic-bundle.adoc
+++ b/configuration/generate-diagnostic-bundle.adoc
@@ -13,7 +13,7 @@ You can generate a diagnostic bundle and inspect its data before sending.
 
 [NOTE]
 ====
-The diagnostic bundle is unencrypted, and typically, the size of the bundle is between 100 KB and 1 MB (depending upon the number of clusters in your environment).
+The diagnostic bundle is unencrypted, and depending upon the number of clusters in your environment, the bundle size is between 100 KB and 1 MB.
 Always use an encrypted channel to transfer this data back to Red Hat.
 ====
 

--- a/modules/acs-requirements.adoc
+++ b/modules/acs-requirements.adoc
@@ -40,5 +40,5 @@ Use the `helm version` command to verify the version of Helm you have installed.
 +
 [NOTE]
 ====
-If you are not a Red Hat customer and purchased the Stackrox Kubernetes Security Platform before the acquisition, you can use StackRox’s container registry at `stackrox.io`. Contact mailto:support@stackrox.com[support@stackrox.com] to enable access to the registry.
+If you are not a Red Hat customer and purchased the StackRox Kubernetes Security Platform before the acquisition, you can use StackRox’s container registry at `stackrox.io`. Contact mailto:support@stackrox.com[support@stackrox.com] to enable access to the registry.
 ====

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -6,8 +6,7 @@
 = Submitting a support case
 
 .Prerequisites
-* You have access to the cluster as a user with the `cluster-admin` role.
-* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster.
 * You have a Red Hat Customer Portal account.
 * You have a Red Hat standard or premium subscription.
 
@@ -18,27 +17,6 @@
 . Enter a concise but descriptive problem summary and further details about the symptoms being experienced, as well as your expectations.
 . Review the updated list of suggested Red Hat Knowledgebase solutions for a potential match against the problem that is being reported. The list is refined as you provide more information during the case creation process. If the suggested articles do not address the issue, click *Continue*.
 . Ensure that the account information presented is as expected, and if not, amend accordingly.
-. Check that the autofilled {product-title} Cluster ID is correct. If it is not, manually obtain your cluster ID.
-+
-* To manually obtain your cluster ID using the {product-title} web console:
-.. Navigate to *Home* -> *Dashboards* -> *Overview*.
-.. Find the value in the *Cluster ID* field of the *Details* section.
-+
-* Alternatively, it is possible to open a new support case through the {product-title} web console and have your cluster ID autofilled.
-.. From the toolbar, navigate to *(?) Help* -> *Open Support Case*.
-.. The *Cluster ID* value is autofilled.
-+
-* To obtain your cluster ID using the OpenShift CLI (`oc`), run the following command:
-+
-[source,terminal]
-----
-$ oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}'
-----
-. Complete the following questions where prompted and then click *Continue*:
-+
-* Where are you experiencing the behavior? What environment?
-* When does the behavior occur? Frequency? Repeatedly? At certain times?
-* What information can you provide around time-frames and the business impact?
-. Upload relevant diagnostic data files and click *Continue*. It is recommended to include data gathered using the `oc adm must-gather` command as a starting point, plus any issue-specific data that is not collected by that command.
+. Upload the generated diagnostic bundle and click *Continue*.
 . Input relevant case management details and click *Continue*.
 . Preview the case details and click *Submit*.

--- a/support/getting-support-stackrox.adoc
+++ b/support/getting-support-stackrox.adoc
@@ -10,7 +10,7 @@ This topic provides information about the technical support for the StackRox Kub
 
 [IMPORTANT]
 ====
-* The support-related information listed on this page is only applicable if you are not a Red Hat customer and you purchased the Stackrox Kubernetes Security Platform before the acquisition. Red Hat will honor the StackRox support policy for its duration.
+* The support-related information listed on this page is only applicable if you are not a Red Hat customer and you purchased the StackRox Kubernetes Security Platform before the acquisition. Red Hat will honor the StackRox support policy for its duration.
 * If you are a Red Hat customer, see the following resources:
 ** xref:../support/getting-support.adoc#getting-support[Getting support for {product-title}]
 ** link:https://access.redhat.com/node/5822721[{product-title} Support Policy]

--- a/support/getting-support.adoc
+++ b/support/getting-support.adoc
@@ -10,7 +10,7 @@ This topic provides information about the technical support for {product-title}.
 [IMPORTANT]
 ====
 * The support-related information listed on this page is only applicable if you are a Red Hat customer.
-* If you are not a Red Hat customer, and you purchased the Stackrox Kubernetes Security Platform before the acquisition. Red Hat will honor the StackRox support policy for its duration. For details, see xref:../support/getting-support-stackrox.adoc#getting-support-stackrox[Getting support for StackRox Kubernetes Security Platform].
+* If you are not a Red Hat customer, and you purchased the StackRox Kubernetes Security Platform before the acquisition. Red Hat will honor the StackRox support policy for its duration. For details, see xref:../support/getting-support-stackrox.adoc#getting-support-stackrox[Getting support for StackRox Kubernetes Security Platform].
 ====
 
 
@@ -27,4 +27,19 @@ provide specific details, such as the section name and {product-title} version.
 
 include::modules/support-knowledgebase-about.adoc[leveloffset=+1]
 include::modules/support-knowledgebase-search.adoc[leveloffset=+1]
+
+[id="generating-a-diagnostic-bundle"]
+== Generating a diagnostic bundle
+You can generate a diagnostic bundle and send that data to enable the support team to provide insights into the status and health of Red Hat Advanced Cluster Security for Kubernetes components.
+
+[NOTE]
+====
+The diagnostic bundle is unencrypted, and depending upon the number of clusters in your environment, the bundle size is between 100 KB and 1 MB.
+====
+
+include::modules/generate-diagnostic-bundle-using-acs-portal.adoc[leveloffset=+2]
+
+include::modules/generate-diagnostic-bundle-using-roxctl-cli.adoc[leveloffset=+2]
+
+
 include::modules/support-submitting-a-case.adoc[leveloffset=+1]


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2811

- Removed OpenShift specific information
- Added diagnosting bundle generation steps.

Preview: https://openshift-docs-git-osdocs-2811-fix-gnelson.vercel.app/openshift-acs/master/support/getting-support.html