### PR TITLE
[RHACS] Added required FQDNs in Central prereq

### DIFF
--- a/modules/central-requirements.adoc
+++ b/modules/central-requirements.adoc
@@ -19,6 +19,12 @@ recommend using a hostPath volume.
 ====
 * Use Solid-State Drives (SSD) for best performance.
 However, you can use another storage type if you do not have SSDs available.
+* If you use a web proxy or firewall, you must configure bypass rules to allow traffic for the `definitions.stackrox.io` and `collector-modules.stackrox.io` domains and enable {product-title} to trust your web proxy or firewall. Otherwise, updates for vulnerability definitions and kernel support packages will fail.
++
+{product-title} requires access to:
+
+** `definitions.stackrox.io` for downloading updated vulnerability definitions. Vulnerability definition updates allow {product-title} to maintain up-to-date vulnerability data when new vulnerabilities are discovered or additional data sources are added.
+** `collector-modules.stackrox.io` to download updated kernel support packages. Updated Kernel support packages ensure that {product-title} can monitor the latest operating systems and collect data about the network traffic and processes running inside the containers. Without these updates, {product-title} might fail to monitor containers if you add new nodes in your cluster or if you update your nodes' operating system.
 
 [NOTE]
 ====


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2744

- Added FQDNs in Central prerequisites.

Preview: https://openshift-docs-git-osdocs-2744-fix-gnelson.vercel.app/openshift-acs/master/installing/prerequisites.html#central-prerequisites_acs-prerequisites