### PR TITLE
TELCODOCS-382 - release note known issues for OCP 4.9.6 z-stream RAN GA release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2056,6 +2056,94 @@ $ oc annotate -n <NAMESPACE> route/<ROUTE-NAME> "haproxy.router.openshift.io/bal
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2015829[*BZ#2015829*])
 
+[id="ocp-4-9-ran-ga-known-issues"]
+* The `oc adm release extract --tools` command fails when an image that is hosted in the local registry is specified. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1823143[*BZ#1823143*])
+
+* On an {product-title} single node configuration, pod creation times are over two times slower when using the real-time kernel (`kernel-rt`) than when using the non-real time kernel. When using `kernel-rt`, the slower pod creation times affect the maximum number of supported pods because recovery time is impacted after a node reboots.
++
+As a workaround, when you use `kernel-rt`, you can improve the recovery time by booting with the `rcupdate.rcu_normal_after_boot=0` kernel argument. This requires a real-time kernel version `kernel-rt-4.18.0-305.16.1.rt7.88.el8_4` or later. This known issue applies to {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1975356[*BZ#1975356*])
+
+* Following an {product-title} single node reboot, all pods are restarted which causes significant load and longer than normal pod creation times. This happens because the Container Network Interface (CNI) is not able to process the `pod add` events quickly enough. The following error message is displayed: `timed out waiting for OVS port binding`. The {product-title} single node instance eventually recovers, though more slowly than expected. This known issue applies to {product-title} version 4.8.15 and later. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1986216[*BZ#1986216*])
+
+* An error occurs during SNO cluster provisioning where `bootkube` tries to use `oc` towards the end of the cluster bootstrap process. The kube API receives a shutdown request and this causes the cluster bootstrap process to fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2010665[*BZ#2010665*])
+
+* Deploying an {product-title} version 4.9 SNO cluster after a successful 4.8 deployment on the same host fails due to a modified boot table entry. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2011306[*BZ#2011306*])
+
+* There is an instability issue with the inbox iavf driver that is evident when a DPDK-based workload is deployed in {product-title} version 4.8.5. The issue is also apparent when a DPDK workload is deployed on a host running RHEL for Real Time 8. The issue occurs in hosts with Intel XXV710 NICs installed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2000180[*BZ#2000180*])
+
+* A clock jump error occurs in the `linuxptp` subsystem that is deployed by the PTP Operator. The reported error message is: `clock jumped backward or running slower than expected!`. The error is encountered in a host with an Intel Columbiaville E810 NIC installed in a {product-title} version 4.8 or 4.9 cluster. The error is likely Intel ice driver related, rather than an error in the `linuxptp` subsystem. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2013478[*BZ#2013478*])
+
+* Sometimes Operator installation fails during zero touch provisioning (ZTP) installation of a DU node. The `InstallPlan` API reports an error. The reported error message is: `Bundle unpacking failed. Reason: DeadlineExceeded`. The error occurs if the Operator installation job exceeds 600 seconds.
++
+As a workaround, re-try the Operator install by running the following `oc` commands for the failed Operator:
++
+. Delete the catalog source:
++
+[source,terminal]
+----
+$ oc -n openshift-marketplace delete catsrc <failed_operator_name>
+----
++
+. Delete the install plan:
++
+[source,terminal]
+----
+$ oc -n <failed_operator_namespace> delete ip <failed_operator_install_plan>
+----
++
+. Delete the subscription and wait for the Operator `CatalogSource` and `Subscription` resources to be re-created by the relevant custom resource policy:
++
+[source,terminal]
+----
+$ oc -n <failed_operator_namespace> delete sub <failed_operator_subscription>
+----
++
+.Expected result
++
+The Operator `InstallPlan` and `ClusterServiceVersion` resources are created and the Operator is installed.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2021456[*BZ#2021456*])
+
+[id="ocp-4-9-ran-ga-known-issues-BZ2021151"]
+* A race condition exists between the SR-IOV Operator and the Machine Config Operator (MCO) which occurs intermittently and manifests itself in different ways during the ZTP installation process for the DU node. The race condition can cause the following errors:
++
+** Sometimes the performance profile configuration is not applied when the ZTP installation process finishes provisioning a DU node. When the ZTP installation process finishes provisioning a DU node, the performance profile configuration is not applied to the node and the `MachineConfigPool` resource becomes stuck in an `Updating` state.
++
+As a workaround, perform the following procedure.
++
+. Get the name of the failed DU node:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME              CONFIG                                   UPDATED   UPDATING   DEGRADED
+control-plane-1   rendered-control-plane-1-90fe2b00c718    False     True       False
+compute-1         rendered-compute-1-31197fc6da09          True      False      False
+----
++
+. Uncordon the failed node, and wait for the `machine-config-daemon` to apply the performance profile. For example:
++
+[source,terminal]
+----
+$ oc adm uncordon compute-compute-1-31197fc6da09
+----
++
+.Expected result
++
+The `machine-config-daemon` applies the performance profile configuration to the node.
+
+** Sometimes, the performance profile configuration does not get applied during DU node configuration. As a workaround, change the sequence of applying the policies on the DU node. Apply the Machine Config Operator (MCO) and the Performance Addon Operator (PAO) policies first and then apply the SR-IOV policies.
+
+** During the policy configuration for the DU node, the reboot can take tens of minutes. No workaround is required in this instance. The system eventually recovers.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2021151[*BZ#2021151*])
+
 [id="ocp-4-9-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-382

Merge to enterprise-4.9

Release note known issues for the following BZs:

* BZ#1823143 - oc adm release extract --command, --tools doesn't pull from localregistry when given a localregistry/image
* BZ#1975356 - Pod creation 2.5x slower with rt-kernel
* BZ#1986216 - SNO: Slow Pod recovery due to "timed out waiting for OVS port binding"
* BZ#2000180 - iavf instability with inbox iavf 4.18.0-305.17.1.rt7.88.el8_4.ocptest.11.x86_64
* BZ#2010665 - Bootkube tries to use oc after cluster bootstrap is done and there is no API
* BZ#2013478 - PTP "clock jumped backward or running slower than expected!" in OpenShift 4.8 environment with Intel E810
* BZ#2011306 - Deploying 4.9 after 4.8 deployment on the same node fails due to modified boot table entry
* BZ#2021456 - operators installation doesn't start during ZTP installation, installplan reports Bundle unpacking failed. Reason: DeadlineExceeded
* BZ#2021151 - Sometimes the DU node does not get the performance profile configuration applied and MachineConfigPool stays stuck in Updating 

Preview: https://deploy-preview-38300--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-ran-ga-known-issues