### PR TITLE
BZ1897420: Detail about ipmi cipher requirements for BM hardware - 4.7

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -20,10 +20,12 @@ ifeval::[{product-version} > 4.4]
 endif::[]
 
 ifndef::openshift-origin[]
-* *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
+* *Latest generation:* Nodes must be of the most recent generation. Because the installer-provisioned installation relies on BMC protocols, the hardware must support IPMI cipher suite 17.
+Additionally, {op-system-base} 8 ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system-base} 8 for the `provisioner` node and {op-system} 8 for the control plane and worker nodes.
 endif::[]
 ifdef::openshift-origin[]
-* *Latest generation:* Nodes must be of the most recent generation. Installer-provisioned installation relies on BMC protocols, which must be compatible across nodes. Additionally, {op-system-first} ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system} for the `provisioner` node and {op-system} for the control plane and worker nodes.
+* *Latest generation:* Nodes must be of the most recent generation. Because the installer-provisioned installation relies on BMC protocols, the hardware must support IPMI cipher suite 17.
+Additionally, {op-system-first} ships with the most recent drivers for RAID controllers. Ensure that the nodes are recent enough to support {op-system} for the `provisioner` node and {op-system} for the control plane and worker nodes.
 endif::[]
 
 * *Registry node:* (Optional) If setting up a disconnected mirrored registry, it is recommended the registry reside in its own node.


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1897420

Release: 4.7

Fix for 4.6 - #39098

Preview link: https://deploy-preview-38301--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#node-requirements_ipi-install-prerequisites