### PR TITLE
Fixed spelling mistake in RN

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -43,9 +43,9 @@ As part of that effort, with this release the following changes are in place:
 * We have begun to progressively replace the terminology of "master" with "control plane". You will notice throughout the documentation that we use both terms, with "master" in parenthesis. For example "... the control plane node (also known as the master node)". In a future release, we will update this to be "the control plane node".
 
 [id="ocp-4-8-add-on-support-status"]
-== {product-title} layered and dependant component support and compatibility
+== {product-title} layered and dependent component support and compatibility
 
-The scope of support for layered and dependant components of {product-title} changes independently of the {product-title} version. To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
+The scope of support for layered and dependent components of {product-title} changes independently of the {product-title} version. To determine the current support status and compatibility for an add-on, refer to its release notes. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat OpenShift Container Platform Life Cycle Policy].
 
 [id="ocp-4-8-new-features-and-enhancements"]
 == New features and enhancements


### PR DESCRIPTION
Changed "dependant" to "dependent".

Applies only to `enterprise-4.8`
Preview here: https://deploy-preview-38302--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-add-on-support-status