### PR TITLE
BZ1859396: Fixed out-of-date oc expose command

### DIFF
--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -75,7 +75,13 @@ ifdef::nodeport[]
 +
 [source,terminal]
 ----
-$ oc expose dc nodejs-ex --type=NodePort --name=nodejs-ex-ingress
+$ oc expose service nodejs-ex  --type=NodePort --name=nodejs-ex-nodeport --generator="service/v2"
+----
++
+.Example output
+[source,terminal]
+----
+service/nodejs-ex-nodeport exposed
 ----
 
 . Optional: To confirm the service is available with a node port exposed, enter the following command:


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1859396

Applies to 4.6+

Preview link: https://deploy-preview-38343--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport#nw-exposing-service_configuring-ingress-cluster-traffic-nodeport
