### PR TITLE
BZ-1952538: virtctl command options

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -9,11 +9,25 @@ The `virtctl` client is a command-line utility for managing {VirtProductName}
 resources. The following table contains the `virtctl` commands used throughout
 the {VirtProductName} documentation.
 
-To view a list of options that you can use with a command, run it with the `-h` or `--help` flag. For example:
+To view a list of `virtctl` commands, run the following command:
+
+[source,terminal]
+----
+$ virtctl help
+----
+
+To view a list of options that you can use with a specific command, run it with the `-h` or `--help` flag. For example:
 
 [source,terminal]
 ----
 $ virtctl image-upload -h
+----
+
+To view a list of global command options that you can use with any command including the `virtctl` command, run the following command:
+
+[source,terminal]
+----
+$ virtctl options
 ----
 
 .`virtctl` client commands


### PR DESCRIPTION
This PR is associated with https://bugzilla.redhat.com/show_bug.cgi?id=1952583.
The content for virtctl was expanded to additional details for viewing the virtctl command options. 