### PR TITLE
BZ2018486: Remove ipsec row for IBM Z 

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -25,6 +25,18 @@ endif::[]
 ifeval::["{context}" == "post-install-network-configuration"]
 :post-install-network-configuration:
 endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:ibm-z:
+endif::[]
 
 [id="nw-operator-cr_{context}"]
 = Cluster Network Operator configuration
@@ -254,7 +266,7 @@ ifdef::operator[]
 The UDP port for the Geneve overlay network.
 endif::operator[]
 
-
+ifndef::ibm-z[]
 |`ipsecConfig`
 |`object`
 |
@@ -264,6 +276,7 @@ endif::operator[]
 ifdef::operator[]
 If the field is present, IPsec is enabled for the cluster.
 endif::operator[]
+endif::ibm-z[]
 
 |`policyAuditConfig`
 |`object`
@@ -283,7 +296,7 @@ endif::operator[]
 
 |`maxFileSize`
 |integer
-|The maximum size for the audit log in bytes. The default value is `50000000` or 50MB.
+|The maximum size for the audit log in bytes. The default value is `50000000` or 50 MB.
 
 |`destination`
 |string
@@ -314,7 +327,9 @@ defaultNetwork:
   ovnKubernetesConfig:
     mtu: 1400
     genevePort: 6081
+ifndef::ibm-z[]
     ipsecConfig: {}
+endif::ibm-z[]
 ----
 
 [discrete]
@@ -393,4 +408,16 @@ endif::[]
 
 ifdef::post-install-network-configuration[]
 :!post-install-network-configuration:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-ibm-z-kvm"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
+:!ibm-z:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
+:!ibm-z:
 endif::[]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.8, 4.9, 4.10

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2018486

Preview https://deploy-preview-38382--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#nw-operator-cr-cno-object_installing-ibm-z

QE review: Tom Dale