### PR TITLE
JIRA-OSDOCS2735: Updated the default setting of preferred cluster privacy

### DIFF
--- a/modules/create-aws-cluster.adoc
+++ b/modules/create-aws-cluster.adoc
@@ -63,7 +63,7 @@ Revoking these credentials in AWS will result in a loss of access to any cluster
 
 .... Host Prefix: /23
 
-... Select your preferred cluster privacy. *Private* is selected by default.
+... Select your preferred cluster privacy. *Public* is selected by default.
 
 +
 [IMPORTANT]


### PR DESCRIPTION
This PR is to address JIRA: https://issues.redhat.com/browse/OSDOCS-2735
Topic: https://deploy-preview-38404--osdocs.netlify.app/openshift-dedicated/latest/osd_cluster_create/creating-your-cluster#create-aws-cluster_creating-your-cluster
Exact section: Section "Creating a cluster on AWS" > Procedure > Step 10, pt. iii > Changed the default setting of preferred cluster privacy from "Private" to "Public"
