### PR TITLE
GH#27862 Put must gather audit logs back

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -11,14 +11,48 @@
 [id="about-must-gather_{context}"]
 = About the must-gather tool
 
-The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues, such as:
+The `oc adm must-gather` CLI command collects the information from your cluster that is most likely needed for debugging issues, including:
 
 * Resource definitions
-* Audit logs
 * Service logs
 
-You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product.
+By default, the `oc adm must-gather` command uses the default plug-in image and writes into `./must-gather.local`.
 
-When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
+Alternatively, you can collect specific information by running the command with the appropriate arguments as described in the following sections: 
 
+* To collect data related to one or more specific features, use the `--image` argument with an image, as listed in a following section. 
++
+For example:
++
+[source,terminal]
+----
+$ oc adm must-gather  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v4.9.0
+----
+
+* To collect the audit logs, use the `-- /usr/bin/gather_audit_logs` argument, as described in a following section.
++
+For example:
++
+[source,terminal]
+----
+$ oc adm must-gather -- /usr/bin/gather_audit_logs
+----
++
+[NOTE]
+====
+Audit logs are not collected as part of the default set of information to reduce the size of the files. 
+====
+
+When you run `oc adm must-gather`, a new pod with a random name is created in a new project on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in the current working directory.
+
+For example:
+
+[source,terminal]
+----
+NAMESPACE                      NAME                 READY   STATUS      RESTARTS      AGE
+...
+openshift-must-gather-5drcj    must-gather-bklx4    2/2     Running     0             72s
+openshift-must-gather-5drcj    must-gather-s8sdh    2/2     Running     0             72s
+...
+----
 // todo: table or ref module listing available images?

--- a/modules/gathering-data-audit-logs.adoc
+++ b/modules/gathering-data-audit-logs.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-collecting-virt-data.adoc
+// * support/gathering-cluster-data.adoc
+
+ifeval::["{context}" == "gathering-cluster-data"]
+:support:
+endif::[]
+ifeval::["{context}" == "audit-log-view"]
+:viewing:
+endif::[]
+
+[id="gathering-data-audit-logs_{context}"]
+= Gathering audit logs
+
+ifdef::support[]
+You can gather audit logs, which are a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system. You can gather audit logs for:
+
+* etcd server
+* Kubernetes API server
+* OpenShift OAuth API server
+* OpenShift API server
+
+endif::support[]
+ifdef::viewing[]
+You can use the must-gather tool to collect the audit logs for debugging your cluster, which you can review or send to Red Hat Support.
+endif::viewing[]
+
+.Procedure
+
+. Run the `oc adm must-gather` command with the `-- /usr/bin/gather_audit_logs` flag:
++
+[source,terminal]
+----
+$ oc adm must-gather -- /usr/bin/gather_audit_logs
+----
+
+. Create a compressed file from the `must-gather` directory that was just created in your working directory. For example, on a computer that uses a Linux operating system, run the following command:
++
+[source,terminal]
+----
+$ tar cvaf must-gather.tar.gz must-gather.local.472290403699006248 <1>
+----
+<1> Replace `must-gather-local.472290403699006248` with the actual directory name.
+
+. Attach the compressed file to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
+
+
+ifeval::["{context}" == "gathering-cluster-data"]
+:!support:
+endif::[]
+ifeval::["{context}" == "audit-log-view"]
+:!viewing:
+endif::[]

--- a/security/audit-log-view.adoc
+++ b/security/audit-log-view.adoc
@@ -16,9 +16,13 @@ include::modules/nodes-nodes-audit-log-basic-viewing.adoc[leveloffset=+1]
 // Filtering audit logs
 include::modules/security-audit-log-filtering.adoc[leveloffset=+1]
 
+// Gathering audit logs
+include::modules/gathering-data-audit-logs.adoc[leveloffset=+1]
+
 [id="viewing-audit-logs-additional-resources"]
 == Additional resources
 
+* xref:../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[Must-gather tool]
 * link:https://github.com/kubernetes/apiserver/blob/master/pkg/apis/audit/v1/types.go#L72[API audit log event structure]
 * xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[Configuring the audit log policy]
 * xref:../logging/cluster-logging-external.adoc#cluster-logging-external[Forwarding logs to third party systems]

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -21,10 +21,13 @@ It is recommended to provide:
 include::modules/about-must-gather.adoc[leveloffset=+1]
 
 // Gathering data about your cluster for Red Hat Support
-include::modules/support-gather-data.adoc[leveloffset=+1]
+include::modules/support-gather-data.adoc[leveloffset=+2]
 
 // Gathering data about specific features
-include::modules/gathering-data-specific-features.adoc[leveloffset=+1]
+include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
+
+// Gathering audit logs
+include::modules/gathering-data-audit-logs.adoc[leveloffset=+2]
 
 // Obtain your cluster identifier
 include::modules/support-get-cluster-id.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/27862

Audit logs are no longer collected by default to reduce the size of the log bundle, this was suppressed via [this commit](https://github.com/openshift/must-gather/commit/7b3fff50ac06fa3dd288aaf55679d46a53db8a84#diff-bad6eb3f5953b7f47f014fd8b04a48470c1d64d94bbd29566af842f0b60c909c).

If needed, the audit logs can be gathered again on the following manner:

$ oc adm must-gather -- /usr/bin/gather_audit_logs

Previews: 
New text and organization in [About the must-gather tool](https://deploy-preview-38415--osdocs.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#about-must-gather_gathering-cluster-data)
New section on [Gathering audit logs](https://deploy-preview-38415--osdocs.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-audit-logs_gathering-cluster-data). 
Same section in the [Viewing Audit Logs assembly](https://deploy-preview-38415--osdocs.netlify.app/openshift-enterprise/latest/security/audit-log-view.html#gathering-data-audit-logs_audit-log-view) with `ifevals` comments to change the intro paragraph.