### PR TITLE
update OCS version in links

### DIFF
--- a/modules/migration-configuring-mcg.adoc
+++ b/modules/migration-configuring-mcg.adoc
@@ -20,7 +20,7 @@ endif::[]
 
 .Procedure
 
-. Deploy OpenShift Container Storage by using the appropriate link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/[OpenShift Container Storage deployment guide].
-. Obtain the S3 endpoint, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` by running the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html-single/managing_hybrid_and_multicloud_resources/index#accessing-the-Multicloud-object-gateway-from-the-terminal_rhocs[`describe` command] on the `NooBaa` custom resource.
+. Deploy OpenShift Container Storage by using the appropriate link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.8/[OpenShift Container Storage deployment guide].
+. Obtain the S3 endpoint, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` by running the link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.8/html-single/managing_hybrid_and_multicloud_resources/index#accessing-the-Multicloud-object-gateway-from-the-terminal_rhocs[`describe` command] on the `NooBaa` custom resource.
 +
 These values are required in order to add MCG as a replication repository to the {mtc-short} web console.


### PR DESCRIPTION
No Jira number.

Updated OCS version number in two links.

4.8+

Preview: https://deploy-preview-38417--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html#migration-configuring-mcg_installing-mtc

Ready for peer review. No QE required.