### PR TITLE
PR38413: fix get packagemanifest command for SRO

### DIFF
--- a/modules/psap-special-resource-operator-installing-using-cli.adoc
+++ b/modules/psap-special-resource-operator-installing-using-cli.adoc
@@ -63,7 +63,7 @@ $ oc create -f sro-operatorgroup.yaml
 +
 [source,terminal]
 ----
-$ oc get packagemanifest special-resource-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
+$ oc get packagemanifest openshift-special-resource-operator -n openshift-marketplace -o jsonpath='{.status.defaultChannel}'
 ----
 +
 .Example output


### PR DESCRIPTION
Based on this PR: https://github.com/openshift/openshift-docs/issues/38413
Applies to 4.9+
Direct link to change:
https://deploy-preview-38434--osdocs.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-special-resource-operator#installing-the-special-resource-operator-using-cli_special-resource-operator