### PR TITLE
OSSMDOC-429: Small edits to service mesh release notes

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -24,7 +24,7 @@ Module included in the following assemblies:
 |Component |Version
 
 |Istio
-|1.9.6
+|1.9.8
 
 |Envoy Proxy
 |1.17.1
@@ -38,7 +38,7 @@ Module included in the following assemblies:
 
 == New features and enhancements {ProductName} 2.1
 
-This release of {ProductName} adds support for Istio 1.9.6, Envoy Proxy 1.17.1, Jaeger 1.24.1, and Kiali 1.36.5 on {product-title} 4.6 EUS, 4.7, 4.8, and 4.9.
+This release of {ProductName} adds support for Istio 1.9.8, Envoy Proxy 1.17.1, Jaeger 1.24.1, and Kiali 1.36.5 on {product-title} 4.6 EUS, 4.7, 4.8, and 4.9.
 
 In addition, this release has the following new features and enhancements:
 
@@ -77,7 +77,6 @@ With Mixer now officially removed, OpenShift Service Mesh 2.1 does not support t
 * Virtual Machine integration is not yet supported
 * Kubernetes Gateway API is not yet supported
 * Remote fetch and load of WebAssembly HTTP filters are not yet supported
-* Smart DNS Proxying is not yet supported
 * Custom CA Integration using the Kubernetes CSR API is not yet supported
 * Request Classification for monitoring traffic is a tech preview feature
 * Integration with external authorization systems via Authorization policy’s CUSTOM action is a tech preview feature
@@ -91,7 +90,7 @@ The amount of time {ProductName} uses to prune old resources at the end of every
 
 Kiali 1.36 includes the following features and enhancements:
 
-* {ProductShortName} service mesh troubleshooting functionality
+* {ProductShortName} troubleshooting functionality
 ** Control plane and gateway monitoring
 ** Proxy sync statuses
 ** Envoy configuration views


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 
- Jira: https://issues.redhat.com/browse/OSSMDOC-429
- Direct link to doc preview: https://deploy-preview-38435--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#istio-1-9-support
- SME review: @longmuir
- QE review: @yxun
- Peer review: @ 	tbd
- Cherry pick to 4.6, 4.7, 4.8, 4.9, and 4.10
