### PR TITLE
BZ#2020414: OSDK `operator-lib` version bump

### DIFF
--- a/modules/osdk-run-proxy.adoc
+++ b/modules/osdk-run-proxy.adoc
@@ -34,7 +34,7 @@ This tutorial uses `HTTP_PROXY` as an example environment variable.
 .Procedure
 ifdef::golang[]
 . Edit the `controllers/memcached_controller.go` file to include the following:
-.. Import the `proxy` package from the link:https://github.com/operator-framework/operator-lib/tree/v0.3.0[`operator-lib`] library:
+.. Import the `proxy` package from the link:https://github.com/operator-framework/operator-lib/releases/tag/v0.7.0[`operator-lib`] library:
 +
 [source,golang]
 ----


### PR DESCRIPTION
4.9+

https://bugzilla.redhat.com/show_bug.cgi?id=2020414

This PR fixes the tagged version of the `operator-lib` library for
OSDK. The proxy features described in the tutorial were added in
`v0.7.0` and not available in `v0.3.0`.

Direct link to docs preview: https://deploy-preview-38445--osdocs.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-tutorial#osdk-run-proxy_osdk-golang-tutorial