### PR TITLE
OSDOCS-2909: Removing admin ack docs for 4.10

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -472,14 +472,6 @@ Topics:
   File: understanding-the-update-service
 - Name: Installing and configuring the OpenShift Update Service
   File: installing-update-service
-# TODO: Remove below assembly for 4.10:
-- Name: Preparing to update to OpenShift Container Platform 4.10
-  File: updating-cluster-prepare
-  Distros: openshift-enterprise
-# TODO: Remove below assembly for 4.10:
-- Name: Preparing to update to OKD 4.9
-  File: updating-cluster-prepare
-  Distros: openshift-origin
 - Name: Updating a cluster between minor versions
   File: updating-cluster-between-minor
 - Name: Updating a cluster within a minor version from the web console

--- a/updating/updating-cluster-between-minor.adoc
+++ b/updating/updating-cluster-between-minor.adoc
@@ -29,9 +29,6 @@ $ oc adm upgrade --force
 * Ensure that all machine config pools (MCPs) are running and not paused. Nodes associated with a paused MCP are skipped during the update process. You can pause the MCPs if you are performing a canary rollout update strategy.
 * If your cluster uses manually maintained credentials, ensure that the Cloud Credential Operator (CCO) is in an upgradeable state. For more information, see _Upgrading clusters with manually maintained credentials_ for xref:../installing/installing_aws/manually-creating-iam.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-aws[AWS], xref:../installing/installing_azure/manually-creating-iam-azure.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-azure[Azure], or xref:../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-maintained-credentials-upgrade_manually-creating-iam-gcp[GCP].
 * If your cluster uses manually maintained credentials with the AWS Secure Token Service (STS), obtain a copy of the `ccoctl` utility from the release image being upgraded to and use it to process any updated credentials. For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-upgrading[_Upgrading an OpenShift Container Platform cluster configured for manual mode with STS_].
-* Review the list of APIs that were removed in Kubernetes 1.22, migrate any affected components to use the new API version, and provide the administrator acknowledgment. For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.9].
-+
-// TODO: Currently, this ^ admin ack is only applicable for 4.9 and should be removed for 4.10+
 
 [IMPORTANT]
 ====

--- a/updating/updating-cluster-prepare.adoc
+++ b/updating/updating-cluster-prepare.adoc
@@ -5,6 +5,8 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+// NOTE: This assembly and included modules are currently not used, but are being kept becuase it might be needed again for Kubernetes 1.25/OCP 4.12 (when more Kubernetes APIs are being removed).
+
 {product-title} 4.9 uses Kubernetes 1.22, which removed a significant number of deprecated `v1beta1` APIs.
 
 {product-title} 4.8.14 introduced a requirement that an administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.8 to 4.9. This is to help prevent issues after upgrading to {product-title} 4.9, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2909

Preview: https://deploy-preview-38446--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-the-update-service.html
^ (Just preview that the docs are no longer there)