### PR TITLE
OSDOCS-2682: Add public cloud support for Egress IPs

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/openshift_sdn/assigning-egress-ips.adoc
-// * networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc
+// * networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
 
 ifeval::["{context}" == "egress-ips"]
 :openshift-sdn:
@@ -10,7 +10,6 @@ ifeval::["{context}" == "configuring-egress-ips-ovn"]
 :ovn:
 endif::[]
 
-ifdef::ovn[]
 [id="nw-egress-ips-about_{context}"]
 = Egress IP address architectural design and implementation
 
@@ -19,17 +18,21 @@ The {product-title} egress IP address functionality allows you to ensure that th
 For example, you might have a pod that periodically queries a database that is hosted on a server outside of your cluster. To enforce access requirements for the server, a packet filtering device is configured to allow traffic only from specific IP addresses.
 To ensure that you can reliably allow access to the server from only that specific pod, you can configure a specific egress IP address for the pod that makes the requests to the server.
 
+An egress IP address assigned to a namespace is different from an egress router, which is used to send traffic to specific destinations.
+
+ifdef::openshift-sdn[]
 An egress IP address is implemented as an additional IP address on the primary network interface of a node and must be in the same subnet as the primary IP address of the node. The additional IP address must not be assigned to any other node in the cluster.
+endif::openshift-sdn[]
+
+[IMPORTANT]
+====
+Egress IP addresses must not be configured in any Linux network configuration files, such as `ifcfg-eth0`.
+====
 
 [id="nw-egress-ips-platform-support_{context}"]
 == Platform support
 
 Support for the egress IP address functionality on various platforms is summarized in the following table:
-
-[IMPORTANT]
-====
-The egress IP address implementation is not compatible with Amazon Web Services (AWS), Azure Cloud, or any other public cloud platform incompatible with the automatic layer 2 network manipulation required by the egress IP feature.
-====
 
 [cols="1,1",options="header"]
 |===
@@ -37,12 +40,114 @@ The egress IP address implementation is not compatible with Amazon Web Services 
 | Platform | Supported
 
 | Bare metal | Yes
-| vSphere | Yes
+| VMWare vSphere | Yes
 | {rh-openstack-first} | No
-| Public cloud | No
+| Amazon Web Services (AWS) | Yes
+| Google Cloud Platform (GCP) | Yes
+| Microsoft Azure | Yes
 
 |===
 
+[IMPORTANT]
+====
+The assignment of egress IP addresses to control plane nodes with the EgressIP feature is not supported on a cluster provisioned on Amazon Web Services (AWS). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2039656[*BZ#2039656*])
+====
+
+[id="nw-egress-ips-public-cloud-platform-considerations_{context}"]
+== Public cloud platform considerations
+
+For clusters provisioned on public cloud infrastructure, there is a constraint on the absolute number of assignable IP addresses per node. The maximum number of assignable IP addresses per node, or the _IP capacity_, can be described in the following formula:
+
+[source,text]
+----
+IP capacity = public cloud default capacity - sum(current IP assignments)
+----
+
+While the Egress IPs capability manages the IP address capacity per node, it is important to plan for this constraint in your deployments. For example, for a cluster installed on bare-metal infrastructure with 8 nodes you can configure 150 egress IP addresses. However, if a public cloud provider limits IP address capacity to 10 IP addresses per node, the total number of assignable IP addresses is only 80. To achieve the same IP address capacity in this example cloud provider, you would need to allocate 7 additional nodes.
+
+To confirm the IP capacity and subnets for any node in your public cloud environment, you can enter the `oc get node <node_name> -o yaml` command. The `cloud.network.openshift.io/egress-ipconfig` annotation includes capacity and subnet information for the node.
+
+The annotation value is an array with a single object with fields that provide the following information for the primary network interface:
+
+* `interface`: Specifies the interface ID on AWS and Azure and the interface name on GCP.
+* `ifaddr`: Specifies the subnet mask for one or both IP address families.
+* `capacity`: Specifies the IP address capacity for the node. On AWS, the IP address capacity is provided per IP address family. On Azure and GCP, the IP address capacity includes both IPv4 and IPv6 addresses.
+
+The following examples illustrate the annotation from nodes on several public cloud providers. The annotations are indented for readability.
+
+.Example `cloud.network.openshift.io/egress-ipconfig` annotation on AWS
+[source,yaml]
+----
+cloud.network.openshift.io/egress-ipconfig: [
+  {
+    "interface":"eni-078d267045138e436",
+    "ifaddr":{"ipv4":"10.0.128.0/18"},
+    "capacity":{"ipv4":14,"ipv6":15}
+  }
+]
+----
+
+.Example `cloud.network.openshift.io/egress-ipconfig` annotation on GCP
+[source,yaml]
+----
+cloud.network.openshift.io/egress-ipconfig: [
+  {
+    "interface":"nic0",
+    "ifaddr":{"ipv4":"10.0.128.0/18"},
+    "capacity":{"ip":14}
+  }
+]
+----
+
+The following sections describe the IP address capacity for supported public cloud environments for use in your capacity calculation.
+
+[id="nw-egress-ips-capacity-aws_{context}"]
+=== Amazon Web Services (AWS) IP address capacity limits
+
+On AWS, constraints on IP address assignments depend on the instance type configured. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI[IP addresses per network interface per instance type]
+
+[id="nw-egress-ips-capacity-gcp_{context}"]
+=== Google Cloud Platform (GCP) IP address capacity limits
+
+On GCP, the networking model implements additional node IP addresses through IP address aliasing, rather than IP address assignments. However, IP address capacity maps directly to IP aliasing capacity.
+
+The following capacity limits exist for IP aliasing assignment:
+
+- Per node, the maximum number of IP aliases, both IPv4 and IPv6, is 10.
+- Per VPC, the maximum number of IP aliases is unspecified, but {product-title} scalability testing reveals the maximum to be approximately 15,000.
+
+For more information, see link:https://cloud.google.com/vpc/docs/quota#per_instance[Per instance] quotas and link:https://cloud.google.com/vpc/docs/alias-ip[Alias IP ranges overview].
+
+[id="nw-egress-ips-capacity-azure_{context}"]
+=== Microsoft Azure IP address capacity limits
+
+On Azure, the following capacity limits exist for IP address assignment:
+
+- Per NIC, the maximum number of assignable IP addresses, for both IPv4 and IPv6, is 256.
+- Per virtual network, the maximum number of assigned IP addresses cannot exceed 65,536.
+
+For more information, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits].
+
+ifdef::openshift-sdn[]
+[id="nw-egress-ips-limitations_{context}"]
+== Limitations
+
+The following limitations apply when using egress IP addresses with the OpenShift SDN cluster network provider:
+
+- You cannot use manually assigned and automatically assigned egress IP addresses on the same nodes.
+- If you manually assign egress IP addresses from an IP address range, you must not make that range available for automatic IP assignment.
+- You cannot share egress IP addresses across multiple namespaces using the OpenShift SDN egress IP address implementation.
+
+If you need to share IP addresses across namespaces, the OVN-Kubernetes cluster network provider egress IP address implementation allows you to span IP addresses across multiple namespaces.
+
+[NOTE]
+====
+If you use OpenShift SDN in multitenant mode, you cannot use egress IP addresses with any namespace that is joined to another namespace by the projects that are associated with them.
+For example, if `project1` and `project2` are joined by running the `oc adm pod-network join-projects --to=project1 project2` command, neither project can use an egress IP address. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1645577[BZ#1645577].
+====
+endif::openshift-sdn[]
+
+ifdef::ovn[]
 [id="nw-egress-ips-considerations_{context}"]
 == Assignment of egress IPs to pods
 
@@ -142,23 +247,10 @@ For the configuration in the previous example, {product-title} assigns both egre
 endif::ovn[]
 
 ifdef::openshift-sdn[]
-[id="nw-egress-ips-about_{context}"]
-= Egress IP address assignment for project egress traffic
+[id="automatic-manual-assignment-approaches"]
+== IP address assignment approaches
 
-By configuring an egress IP address for a project, all outgoing external connections from the specified project will share the same, fixed source IP address.
-External resources can recognize traffic from a particular project based on the egress IP address.
-An egress IP address assigned to a project is different from the egress router, which is used to send traffic to specific destinations.
-
-Egress IP addresses are implemented as additional IP addresses on the primary network interface of the node and must be in the same subnet as the node's primary IP address.
-
-[IMPORTANT]
-====
-Egress IP addresses must not be configured in any Linux network configuration files, such as `ifcfg-eth0`.
-
-Allowing additional IP addresses on the primary network interface might require extra configuration when using some cloud or VM solutions.
-====
-
-You can assign egress IP addresses to namespaces by setting the `egressIPs` parameter of the `NetNamespace` object. After an egress IP is associated with a project, OpenShift SDN allows you to assign egress IPs to hosts in two ways:
+You can assign egress IP addresses to namespaces by setting the `egressIPs` parameter of the `NetNamespace` object. After an egress IP address is associated with a project, OpenShift SDN allows you to assign egress IP addresses to hosts in two ways:
 
 * In the _automatically assigned_ approach, an egress IP address range is assigned to a node.
 * In the _manually assigned_ approach, a list of one or more egress IP address is assigned to a node.
@@ -170,26 +262,8 @@ High availability of nodes is automatic.
 If a node that hosts an egress IP address is unreachable and there are nodes that are able to host that egress IP address, then the egress IP address will move to a new node.
 When the unreachable node comes back online, the egress IP address automatically moves to balance egress IP addresses across nodes.
 
-[IMPORTANT]
-====
-The following limitations apply when using egress IP addresses with the OpenShift SDN cluster network provider:
-
-- You cannot use manually assigned and automatically assigned egress IP addresses on the same nodes.
-- If you manually assign egress IP addresses from an IP address range, you must not make that range available for automatic IP assignment.
-- You cannot share egress IP addresses across multiple namespaces using the OpenShift SDN egress IP address implementation.
-ifeval::["{product-version}" >= "4.6"]
-If you need to share IP addresses across namespaces, the OVN-Kubernetes cluster network provider egress IP address implementation allows you to span IP addresses across multiple namespaces.
-endif::[]
-====
-
-[NOTE]
-====
-If you use OpenShift SDN in multitenant mode, you cannot use egress IP addresses with any namespace that is joined to another namespace by the projects that are associated with them.
-For example, if `project1` and `project2` are joined by running the `oc adm pod-network join-projects --to=project1 project2` command, neither project can use an egress IP address. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1645577[BZ#1645577].
-====
-
 [id="considerations-automatic-egress-ips"]
-== Considerations when using automatically assigned egress IP addresses
+=== Considerations when using automatically assigned egress IP addresses
 
 When using the automatic assignment approach for egress IP addresses the following considerations apply:
 
@@ -203,9 +277,14 @@ If the node hosting the namespace's egress IP address is unreachable, {product-t
 The automatic assignment approach works best for clusters installed in environments with flexibility in associating additional IP addresses with nodes.
 
 [id="considerations-manual-egress-ips"]
-== Considerations when using manually assigned egress IP addresses
+=== Considerations when using manually assigned egress IP addresses
 
-This approach is recommended for clusters installed in public cloud environments, where there can be limitations on associating additional IP addresses with nodes.
+This approach allows you to control which nodes can host an egress IP address.
+
+[NOTE]
+====
+If your cluster is installed on public cloud infrastructure, you must ensure that each node that you assign egress IP addresses to has sufficient spare capacity to host the IP addresses. For more information, see "Platform considerations" in a previous section.
+====
 
 When using the manual assignment approach for egress IP addresses the following considerations apply:
 

--- a/modules/nw-egress-ips-static.adoc
+++ b/modules/nw-egress-ips-static.adoc
@@ -49,9 +49,11 @@ To provide high availability, set the `egressIPs` value to two or more IP addres
 Because OpenShift SDN manages the `NetNamespace` object, you can make changes only by modifying the existing `NetNamespace` object. Do not create a new `NetNamespace` object.
 ====
 
-. Manually assign the egress IP to the node hosts. Set the `egressIPs` parameter
-on the `HostSubnet` object on the node host. Using the following JSON, include
-as many IP addresses as you want to assign to that node host:
+. Manually assign the egress IP address to the node hosts.
++
+If your cluster is installed on public cloud infrastructure, you must confirm that the node has available IP address capacity.
++
+Set the `egressIPs` parameter on the `HostSubnet` object on the node host. Using the following JSON, include as many IP addresses as you want to assign to that node host:
 +
 [source,terminal]
 ----

--- a/networking/openshift_sdn/assigning-egress-ips.adoc
+++ b/networking/openshift_sdn/assigning-egress-ips.adoc
@@ -1,3 +1,4 @@
+:_content-type: ASSEMBLY
 [id="assigning-egress-ips"]
 = Configuring egress IPs for a project
 include::modules/common-attributes.adoc[]
@@ -5,10 +6,16 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure the OpenShift SDN default Container Network Interface (CNI) network provider to assign one or more egress IP addresses to a project.
+[role="_abstract"]
+As a cluster administrator, you can configure the OpenShift SDN Container Network Interface (CNI) cluster network provider to assign one or more egress IP addresses to a project.
 
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-automatic.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-static.adoc[leveloffset=+1]
+
+[id="{context}-additional-resources"]
+== Additional resources
+
+* If you are configuring manual egress IP address assignment, see xref:../../networking/openshift_sdn/assigning-egress-ips.adoc#nw-egress-ips-public-cloud-platform-considerations_egress-ips[Platform considerations] for information about IP capacity planning.

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure the OVN-Kubernetes default Container Network Interface (CNI) network provider to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
+As a cluster administrator, you can configure the OVN-Kubernetes Container Network Interface (CNI) cluster network provider to assign one or more egress IP addresses to a namespace, or to specific pods in a namespace.
 
 include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Add public cloud support for Egress IPs
    
- https://issues.redhat.com/browse/OSDOCS-2682
    
This adds documentation regarding support for public clouds by the
Egress IPs feature for both OVN-Kubernetes and OpenShift SDN.

Previews:
- [Configuring egress IPs for a project](https://deploy-preview-38448--osdocs.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/assigning-egress-ips.html) (OpenShift SDN)
- [Configuring an egress IP address](https://deploy-preview-38448--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html) (OVN-Kubernetes)

TODO
- Add abstract
- Add module types
- Squash

~Questions:~
~- For OpenShift SDN and manual assignment, what happens if a node does _not_ have spare IP capacity? Is there any error or does egress IPs silently fail, and if so, what are the consequences?~
~- Unrelated, but should we include any platform limitations for bare metal, vSphere, or OSP?~