### PR TITLE
BZ-2020416: IPv6 is not supported for user-provisioned clusters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -72,17 +72,23 @@ ifeval::["{context}" == "installing-gcp-customizations"]
 :gcp:
 endif::[]
 // OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-ifeval::["{context}" == "installing-bare-metal"]
-:bare:
-endif::[]
+// But only for installer-provisioned
+// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
+//ifeval::["{context}" == "installing-bare-metal"]
+//:bare:
+//endif::[]
 // OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-ifeval::["{context}" == "installing-bare-metal-network-customizations"]
-:bare:
-endif::[]
+// But only for installer-provisioned
+// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
+//ifeval::["{context}" == "installing-bare-metal-network-customizations"]
+//:bare:
+//endif::[]
 // OSDOCS-1640 - IPv4/IPv6 dual-stack bare metal only
-ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
-:bare:
-endif::[]
+// But only for installer-provisioned
+// https://bugzilla.redhat.com/show_bug.cgi?id=2020416
+//ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
+//:bare:
+//endif::[]
 ifeval::["{context}" == "installing-gcp-private"]
 :gcp:
 endif::[]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=2020416

Preview (no mention of IPv6): https://deploy-preview-38463--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-configuration-parameters-network_installing-bare-metal