### PR TITLE
GH#36067: clarifying domain/appsDomain per GH Issue confusion

### DIFF
--- a/modules/nw-ingress-configuring-application-domain.adoc
+++ b/modules/nw-ingress-configuring-application-domain.adoc
@@ -8,7 +8,7 @@
 
 //OpenShift Dedicated or Amazon RH OpenShift cluster administrator
 
-As a cluster administrator, you can specify an alternative default domain for user-created routes by configuring `appsDomain` field. If you specify an alternative domain, it overrides the default cluster domain for the purpose of determining the default host for a new route.
+As a cluster administrator, you can specify an alternative to the default cluster domain for user-created routes by configuring the `appsDomain` field. The `appsDomain` field is an optional domain for AWS infrastructure to use instead of the default, which is specified in the `domain` field. If you specify an alternative domain, it overrides the default cluster domain for the purpose of determining the default host for a new route.
 
 For example, you can use the DNS domain for your company as the default domain for routes and ingresses for applications running on your cluster.
 
@@ -31,7 +31,7 @@ $ oc edit ingresses.config/cluster -o yaml
 +
 .. Edit the YAML file:
 +
-.Sample `appsDomain` configuration to `apps.acme.io`
+.Sample `appsDomain` configuration to `test.example.com`
 [source,yaml]
 ----
 apiVersion: config.openshift.io/v1
@@ -39,11 +39,13 @@ kind: Ingress
 metadata:
   name: cluster
 spec:
-  domain: apps.<domain_url>
-  appsDomain: apps.acme.io
+  domain: apps.example.com            <1>
+  appsDomain: <test.example.com>      <2>
 ----
+<1> Default domain
+<2> Optional: Domain for AWS infrastructure to use for application routes. Instead of the default prefix, `apps`, you can use an alternative prefix like `test`.
 +
-. Verify that an existing route contains the new domain name by exposing the route and verifying the route domain change:
+. Verify that an existing route contains the domain name specified in the `appsDomain` field by exposing the route and verifying the route domain change:
 //+
 //.. Access the Ingress Controller Operator YAML file:
 //+
@@ -65,11 +67,12 @@ $ oc expose service hello-openshift
 route.route.openshift.io/hello-openshift exposed
 ----
 +
-.. Verify route domain change:
+.Example output:
 +
 [source,terminal]
 ----
 $ oc get routes
 NAME              HOST/PORT                                   PATH   SERVICES          PORT       TERMINATION   WILDCARD
-hello-openshift   hello-openshift-my-project.apps.acme.io          hello-openshift   8080-tcp                 None
+hello-openshift   hello_openshift-<my_project>.test.example.com
+hello-openshift   8080-tcp                 None
 ----


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/36067

For 4.7+ 

Preview: https://deploy-preview-38469--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-ingress-configuring-application-domain_configuring-ingress

Based on this GH Issue, it seems like this topic needed some clarification around the differences between the 2 domains. I incorporated some info from the Config Parameters table https://docs.openshift.com/container-platform/4.9/networking/ingress-operator.html#nw-ingress-controller-configuration-parameters_configuring-ingress

Additionally, I removed the <domain_name> from the `domain` field, as the customer seemed to be confused by why domain appears to be a replaceable value specifically. I can understand because typically the <_> format is used for replaceable values, and this `domain` field is not replaceable since its the default. I instead moved the replaceable value formatting to the `appsDomain' field and added annotations to further clarify the purpose of each field.

@lihongan would you PTAL at my doc fix for this issue?