### PR TITLE
Added notes for release 4.8.19

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2828,3 +2828,19 @@ link:https://access.redhat.com/solutions/6469021[{product-title} 4.8.18 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-8-19"]
+=== RHBA-2021:4109 - {product-title} 4.8.19 bug fix update
+
+Issued: 2021-11-11
+
+{product-title} release 4.8.19 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4109[RHBA-2021:4109] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4108[RHBA-2021:4108] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6487101[{product-title} 4.8.19 container image list]
+
+[id="ocp-4-8-19-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.8.19.

Applies only to `enterprise-4.8`

Preview: https://deploy-preview-38470--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-19