### PR TITLE
OSDOCS-2709: Added troubleshooting information for ELB failures.

### DIFF
--- a/modules/rosa-troubleshooting-deployment.adoc
+++ b/modules/rosa-troubleshooting-deployment.adoc
@@ -40,3 +40,21 @@ $ rosa init --delete-stack
 ----
 $ rosa init
 ----
+
+== Elastic load balancer (ELB) `AccessDenied` error
+
+In AWS accounts that have never created a load balancer, it is possible that the service role for the Elastic load balancer (ELB) might not exist yet. You may receive the following error:
+
+[source,terminal]
+----
+Error: Error creating network Load Balancer: AccessDenied: User: arn:aws:sts::xxxxxxxxxxxx:assumed-role/ManagedOpenShift-Installer-Role/xxxxxxxxxxxxxxxxxxx is not authorized to perform: iam:CreateServiceLinkedRole on resource: arn:aws:iam::xxxxxxxxxxxx:role/aws-service-role/elasticloadbalancing.amazonaws.com/AWSServiceRoleForElasticLoadBalancing"
+----
+
+To resolve this issue, ensure that the role exists on your AWS account. If not, create this role with the following command:
+
+[source,terminal]
+----
+aws iam get-role --role-name "AWSServiceRoleForElasticLoadBalancing" || aws iam create-service-linked-role --aws-service-name "elasticloadbalancing.amazonaws.com"
+----
+
+This command only needs to be executed once per account.


### PR DESCRIPTION
This PR adds information to set up a role should Elastic load balancers (ELB) fail with an `AccessDenied` error.

JIRA: https://issues.redhat.com/browse/OSDOCS-2709

Preview: https://deploy-preview-38472--osdocs.netlify.app/openshift-rosa/latest/rosa_support/rosa-troubleshooting-deployments#elastic-load-balancer-elb-accessdenied-error