### PR TITLE
RHDEVDOCS-3165 - Reference docs for Cluster Monitoring Operator config map fields

### DIFF
--- a/modules/monitoring-config-map-fields-reference-for-the-cluster-monitoring-operator.adoc
+++ b/modules/monitoring-config-map-fields-reference-for-the-cluster-monitoring-operator.adoc
@@ -1,0 +1,276 @@
+// NOTE: The contents of this file are automatically generated from source code comments.
+// If you wish to make a change or an addition to the content in this document, do so by changing the code comments.
+//
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+[id="monitoring-config-map-fields-reference-for-the-cluster-monitoring-operator_{context}"]
+= Config map fields reference for the Cluster Monitoring Operator
+
+These tables describe fields that you can use in config map objects for the Cluster Monitoring Operator. These fields enable you to do fine-grained configuration of platform monitoring and user workload monitoring.
+
+== ClusterMonitoringConfiguration
+
+
+.PrometheusOperatorConfig	
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.PrometheusK8sConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | false | Tech Preview
+| retention |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+| resources |  | *v1.ResourceRequirements | true | GA
+| externalLabels |  | map[string]string | true | GA
+| volumeClaimTemplate |  | *v12.EmbeddedPersistentVolumeClaim | true | GA
+| remoteWrite |  | []RemoteWriteSpec | true | GA
+| additionalAlertmanagerConfigs |  | []AdditionalAlertmanagerConfig | true | GA
+|===
+
+
+.AlertmanagerMainConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| enabled |  | *bool | true | GA
+| logLevel |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+| resources |  | *v1.ResourceRequirements | true | GA
+| volumeClaimTemplate |  | *monv1.EmbeddedPersistentVolumeClaim | true | GA
+|===
+
+
+.KubeStateMetricsConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.OpenShiftStateMetricsConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.GrafanaConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| enabled |  | *bool | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.HTTPConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| httpProxy |  | string | true | GA
+| httpsProxy |  | string | true | GA
+| noProxy |  | string | true | GA
+|===
+
+
+.TelemeterClientConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| clusterID |  | string | true | GA
+| enabled |  | *bool | true | GA
+| telemeterServerURL |  | string | true | GA
+| token |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.K8sPrometheusAdapter
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.ThanosQuerierConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+| resources |  | *v1.ResourceRequirements | true | GA
+|===
+
+
+.RemoteWriteSpec
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| url | The URL of the endpoint to send samples to. | string | true | GA
+| name | The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer. | string | false | GA
+| remoteTimeout | Timeout for requests to the remote write endpoint. | string | false | GA
+| headers | Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.25.0 and newer. | map[string]string | false | GA
+| writeRelabelConfigs | The list of remote write relabel configurations. | []monv1.RelabelConfig | false | GA
+| basicAuth | BasicAuth for the URL. | *monv1.BasicAuth | false | GA
+| bearerTokenFile | Bearer token for remote write. | string | false | GA
+| tlsConfig | TLS Config to use for remote write. | *monv1.SafeTLSConfig | false | GA
+| proxyUrl | Optional ProxyURL | string | false | GA
+| queueConfig | QueueConfig allows tuning of the remote write queue parameters. | *monv1.QueueConfig | false | GA
+| metadataConfig | MetadataConfig configures the sending of series metadata to remote storage. | *monv1.MetadataConfig | false | GA
+|===
+
+
+.AdditionalAlertmanagerConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| scheme | The URL scheme to use when talking to Alertmanagers. | string | false | GA
+| pathPrefix | Path prefix to add in front of the push endpoint path. | string | false | GA
+| timeout | The timeout used when sending alerts. | *string | false | GA
+| apiVersion | The api version of Alertmanager. | string | true | GA
+| tlsConfig | TLS Config to use for alertmanager connection. | TLSConfig | false | GA
+| bearerToken | Bearer token to use when authenticating to Alertmanager. | *v1.SecretKeySelector | false | GA
+| staticConfigs | List of statically configured Alertmanagers. | []string | false | GA
+|===
+
+
+.TLSConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| ca | The CA cert in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| cert | The client cert in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| key | The client key in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| serverName | Used to verify the hostname for the targets. | string | false | GA
+| insecureSkipVerify | Disable target certificate validation. | bool | true | GA
+|===
+
+
+== UserWorkloadConfiguration
+
+
+.PrometheusOperatorConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+|===
+
+
+.PrometheusRestrictedConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | true | GA
+| retention |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+| resources |  | *v1.ResourceRequirements | true | GA
+| externalLabels |  | map[string]string | true | GA
+| volumeClaimTemplate |  | *v12.EmbeddedPersistentVolumeClaim | true | GA
+| remoteWrite |  | []RemoteWriteSpec | true | GA
+| enforcedSampleLimit |  | *uint64 | true | GA
+| enforcedTargetLimit |  | *uint64 | true | GA
+| additionalAlertmanagerConfigs |  | []AdditionalAlertmanagerConfig | true | GA
+|===
+
+
+.ThanosRulerConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| logLevel |  | string | true | GA
+| nodeSelector |  | map[string]string | true | GA
+| tolerations |  | []v1.Toleration | true | GA
+| resources |  | *v1.ResourceRequirements | true | GA
+| volumeClaimTemplate |  | *v12.EmbeddedPersistentVolumeClaim | true | GA
+| additionalAlertmanagerConfigs |  | []AdditionalAlertmanagerConfig | true | GA
+|===
+
+
+.RemoteWriteSpec
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| url | The URL of the endpoint to send samples to. | string | true | GA
+| name | The name of the remote write queue, must be unique if specified. The name is used in metrics and logging in order to differentiate queues. Only valid in Prometheus versions 2.15.0 and newer. | string | false | GA
+| remoteTimeout | Timeout for requests to the remote write endpoint. | string | false | GA
+| headers | Custom HTTP headers to be sent along with each remote write request. Be aware that headers that are set by Prometheus itself can't be overwritten. Only valid in Prometheus versions 2.25.0 and newer. | map[string]string | false | GA
+| writeRelabelConfigs | The list of remote write relabel configurations. | []monv1.RelabelConfig | false | GA
+| basicAuth | BasicAuth for the URL. | *monv1.BasicAuth | false | GA
+| bearerTokenFile | Bearer token for remote write. | string | false | GA
+| tlsConfig | TLS Config to use for remote write. | *monv1.SafeTLSConfig | false | GA
+| proxyUrl | Optional ProxyURL | string | false | GA
+| queueConfig | QueueConfig allows tuning of the remote write queue parameters. | *monv1.QueueConfig | false | GA
+| metadataConfig | MetadataConfig configures the sending of series metadata to remote storage. | *monv1.MetadataConfig | false | GA
+|===
+
+
+.AdditionalAlertmanagerConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| scheme | The URL scheme to use when talking to Alertmanagers. | string | false | GA
+| pathPrefix | Path prefix to add in front of the push endpoint path. | string | false | GA
+| timeout | The timeout used when sending alerts. | *string | false | GA
+| apiVersion | The api version of Alertmanager. | string | true | GA
+| tlsConfig | TLS Config to use for alertmanager connection. | TLSConfig | false | GA
+| bearerToken | Bearer token to use when authenticating to Alertmanager. | *v1.SecretKeySelector | false | GA
+| staticConfigs | List of statically configured Alertmanagers. | []string | false | GA
+|===
+
+
+.TLSConfig
+[options=”header”]
+|===
+| Field | Description | Scheme | Required | Status
+
+| ca | The CA cert in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| cert | The client cert in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| key | The client key in the Prometheus container to use for the targets. | *v1.SecretKeySelector | false | GA
+| serverName | Used to verify the hostname for the targets. | string | false | GA
+| insecureSkipVerify | Disable target certificate validation. | bool | true | GA
+|===
+
+

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -165,6 +165,9 @@ include::modules/monitoring-disabling-the-local-alertmanager.adoc[leveloffset=+1
 * link:https://prometheus.io/docs/alerting/latest/alertmanager/[Prometheus Alertmanager documentation]
 * xref:../monitoring/managing-alerts.adoc#[Managing alerts]
 
+// Cluster Monitoring Operator config map field reference
+include::modules/monitoring-config-map-fields-reference-for-the-cluster-monitoring-operator.adoc[leveloffset=+1]
+
 == Next steps
 
 * xref:../monitoring/enabling-monitoring-for-user-defined-projects.adoc#enabling-monitoring-for-user-defined-projects[Enabling monitoring for user-defined projects]


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3165
- Direct link to doc preview: http://file.rdu.redhat.com/bburt/RHDEVDOCS-3165-better-docs-for-CMO-configmaps/monitoring/configuring-the-monitoring-stack.html#monitoring-config-map-fields-reference-for-the-cluster-monitoring-operator_configuring-the-monitoring-stack
- SME review: @ tbd
- QE review: @ tbd
- Peer review: @ tbd
- <All reviews complete. Please merge now>