### PR TITLE
CNV-14662: Adding admonitions about container disk limits 

### DIFF
--- a/modules/virt-preparing-container-disk-for-vms.adoc
+++ b/modules/virt-preparing-container-disk-for-vms.adoc
@@ -7,6 +7,13 @@
 
 You must build a container disk with a virtual machine image and push it to a container registry before it can used with a virtual machine. You can then either import the container disk into a PVC using a data volume and attach it to a virtual machine, or you can attach the container disk directly to a virtual machine as an ephemeral `containerDisk` volume.
 
+The size of a disk image inside a container disk is limited by the maximum layer size of the registry where the container disk is hosted.
+
+[NOTE]
+====
+For link:https://access.redhat.com/documentation/en-us/red_hat_quay/[Red Hat Quay], you can change the maximum layer size by editing the YAML configuration file that is created when Red Hat Quay is first deployed.
+====
+
 .Prerequisites
 
 * Install `podman` if it is not already installed.

--- a/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
@@ -7,6 +7,14 @@ toc::[]
 
 You can build a virtual machine image into a container disk and store it in your container registry. You can then import the container disk into persistent storage for a virtual machine or attach it directly to the virtual machine for ephemeral storage.
 
+[IMPORTANT]
+====
+If you use large container disks, I/O traffic might increase, impacting worker nodes. This can lead to unavailable nodes. You can resolve this by:
+
+* xref:../../../applications/pruning-objects.adoc#pruning-deployments_pruning-objects[Pruning `DeploymentConfig` objects]
+* xref:../../../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring[Configuring garbage collection]
+====
+
 include::modules/virt-about-container-disks.adoc[leveloffset=+1]
 include::modules/virt-preparing-container-disk-for-vms.adoc[leveloffset=+1]
 
@@ -17,6 +25,5 @@ include::modules/virt-disabling-tls-for-registry.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../../virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc#virt-importing-virtual-machine-images-datavolumes[Import the container disk into persistent storage for a virtual machine].
-
 * xref:../../../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[Create a virtual machine] that uses
 a `containerDisk` volume for ephemeral storage.


### PR DESCRIPTION
For 4.6, 4.7, 4.8, 4.9, 4.10

Jira: https://issues.redhat.com/browse/CNV-14662
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2018281

See PR: https://github.com/openshift/openshift-docs/pull/32695 for @fabiand's original request.

Tagging @fabiand for code review
Tagging Oded Ramaz in Jira to assign a QE resource.

Direct doc preview link: https://deploy-preview-38474--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms#virt-preparing-container-disk-for-vms_virt-using-container-disks-with-vms