### PR TITLE
Fix typos to unify the style

### DIFF
--- a/modules/adding-custom-notification-banners.adoc
+++ b/modules/adding-custom-notification-banners.adoc
@@ -33,4 +33,4 @@ spec:
 ----
 <1> Valid location settings are `BannerTop`, `BannerBottom`, and `BannerTopBottom`.
 
-. Click the *Create* button to apply your changes.
+. Click *Create* to apply your changes.

--- a/modules/builds-strategy-secrets-web-console.adoc
+++ b/modules/builds-strategy-secrets-web-console.adoc
@@ -20,7 +20,7 @@ repository.
 
 . On the build configuration editor page or in the `create app from builder image` page of the web console, set the *Source Secret*.
 
-. Click the *Save* button.
+. Click *Save*.
 
 
 //[NOTE]

--- a/modules/creating-custom-links.adoc
+++ b/modules/creating-custom-links.adoc
@@ -83,4 +83,4 @@ spec:
     imageURL: https://via.placeholder.com/24
 ----
 
-. Click the *Save* button to apply your changes.
+. Click *Save* to apply your changes.

--- a/modules/dedicated-aws-vpc-initiating-peering.adoc
+++ b/modules/dedicated-aws-vpc-initiating-peering.adoc
@@ -27,8 +27,7 @@ with the procedure.
 
 . Log in to the Web Console for the OSD AWS Account and navigate to the
 *VPC Dashboard* in the region where the cluster is being hosted.
-. Go to the *Peering Connections* page and click the *Create Peering Connection*
-button.
+. Go to the *Peering Connections* page and click *Create Peering Connection*.
 . Verify the details of the account you are logged in to and the details of the
 account and VPC you are connecting to:
 .. *Peering connection name tag*: Set a descriptive name for the VPC Peering Connection.

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -74,8 +74,7 @@ the *Status* column for any errors or failures.
 .. Click the installed *Red Hat OpenShift Logging* Operator.
 
 .. Under the *Details* tab, in the *Provided APIs* section, in the
-*Cluster Logging* box, click *Create Instance* . Select the *YAML View*
-radio button and paste the following YAML definition into the window
+*Cluster Logging* box, click *Create Instance* . Select *YAML View* and paste the following YAML definition into the window
 that displays.
 +
 .Cluster Logging custom resource (CR)

--- a/modules/dedicated-managing-dedicated-administrators.adoc
+++ b/modules/dedicated-managing-dedicated-administrators.adoc
@@ -12,9 +12,9 @@ link:https://console.redhat.com/openshift[{cloud-redhat-com}] site.
 [id="dedicated-administrators-adding-user_{context}"]
 == Adding a user
 . Navigate to the *Cluster Details* page and *Access Control* tab.
-. Click the *Add user* button.  (first user only)
+. Click *Add user*.  (first user only)
 . Enter the user name and select the group (*dedicated-admins*)
-. Click the *Add* button.
+. Click *Add*.
 
 [id="dedicated-administrators-removing-user_{context}"]
 == Removing a user

--- a/modules/dedicated-scaling-your-cluster.adoc
+++ b/modules/dedicated-scaling-your-cluster.adoc
@@ -10,7 +10,7 @@ To scale your {product-title} cluster:
 . From link:https://console.redhat.com/openshift[console.redhat.com/openshift], click
  on the cluster you want to resize.
 
-. Click the *Actions* button, then *Scale Cluster*.
+. Click *Actions*, then *Scale Cluster*.
 
 . Select how many compute nodes are required, then click *Apply*.
 

--- a/modules/developer-cli-odo-installing-odo-on-windows.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-windows.adoc
@@ -19,7 +19,7 @@ The following example demonstrates how to set up a path variable. Your binaries 
 . Create a folder at `C:\go-bin`.
 . Right click *Start* and click *Control Panel*.
 . Select *System and Security* and then click *System*.
-. From the menu on the left, select the *Advanced systems settings* and click the *Environment Variables* button at the bottom.
+. From the menu on the left, select the *Advanced systems settings* and click *Environment Variables* at the bottom.
 . Select *Path* from the *Variable* section and click *Edit*.
 . Click *New* and type `C:\go-bin` into the field or click *Browse* and select the directory, and click *OK*.
 

--- a/modules/gitops-configuring-the-groups-claim.adoc
+++ b/modules/gitops-configuring-the-groups-claim.adoc
@@ -15,7 +15,7 @@ Protocol:: `openid-connect`
 Display On Content Scope:: `On`
 Include to Token Scope:: `On`
 
-. Click the *Save* button and navigate to `groups` -> *Mappers*.
+. Click *Save* and navigate to `groups` -> *Mappers*.
 
 . Add a new token mapper with the following values:
 Name:: `groups`

--- a/modules/gitops-creating-a-new-client-in-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-in-keycloak.adoc
@@ -7,7 +7,7 @@
 
 .Procedure
 
-. Log in to your Keycloak server, select the realm you want to use, navigate to the *Clients* page, and then click the *Create* button in the upper-right section of the screen.
+. Log in to your Keycloak server, select the realm you want to use, navigate to the *Clients* page, and then click *Create* in the upper-right section of the screen.
 
 . Specify the following values:
 Client ID:: `argocd`

--- a/modules/installing-gitops-operator-in-web-console.adoc
+++ b/modules/installing-gitops-operator-in-web-console.adoc
@@ -20,7 +20,7 @@ If you have already installed the Community version of the Argo CD Operator, rem
 
 . Open the *Administrator* perspective of the web console and navigate to *Operators* → *OperatorHub* in the menu on the left.
 
-. Search for `OpenShift GitOps`, click the *{gitops-title}* tile, and then click the *Install* button.
+. Search for `OpenShift GitOps`, click the *{gitops-title}* tile, and then click *Install*.
 +
 {gitops-title} will be installed in all namespaces of the cluster.
 

--- a/modules/monitoring-running-metrics-queries.adoc
+++ b/modules/monitoring-running-metrics-queries.adoc
@@ -15,8 +15,8 @@ You begin working with metrics by entering one or several Prometheus Query Langu
 * To show all available metrics and PromQL functions, click *Insert Metric at Cursor*.
 . For multiple queries, click *Add Query*.
 . For deleting queries, click {kebab} for the query, then select *Delete query*.
-. For keeping but not running a query, click the *Disable query* button.
-. After you finish creating queries, click the *Run Queries* button. The metrics from the queries are visualized on the plot. If a query is invalid, the UI shows an error message.
+. For keeping but not running a query, click *Disable query*.
+. After you finish creating queries, click *Run Queries*. The metrics from the queries are visualized on the plot. If a query is invalid, the UI shows an error message.
 +
 [NOTE]
 ====

--- a/modules/odc-monitoring-your-project-metrics.adoc
+++ b/modules/odc-monitoring-your-project-metrics.adoc
@@ -42,7 +42,7 @@ image::odc_project_alerts.png[]
 +
 ** Use the *Filter* list to filter the alerts by their *Alert State* and *Severity*.
 
-** Click on an alert to go to the details page for that alert. In the *Alerts Details* page, you can click the *View Metrics* button to see the metrics for the alert.
+** Click on an alert to go to the details page for that alert. In the *Alerts Details* page, you can click *View Metrics* to see the metrics for the alert.
 
 ** Use the *Notifications* toggle adjoining an alert rule to silence all the alerts for that rule, and then select the duration for which the alerts will be silenced from the *Silence for* list.
 You must have the permissions to edit alerts to see the *Notifications* toggle.

--- a/modules/odc-splitting-traffic-between-revisions-using-developer-perspective.adoc
+++ b/modules/odc-splitting-traffic-between-revisions-using-developer-perspective.adoc
@@ -17,7 +17,7 @@ image::odc-serverless-app.png[]
 
 . Click the service, indicated by the *S* icon at the top of the side panel, to see an overview of the service details.
 . Click the *YAML* tab and modify the service configuration in the YAML editor, and click *Save*. For example, change the `timeoutseconds` from 300 to 301 . This change in the configuration triggers a new revision. In the *Topology* view, the latest revision is displayed and the *Resources* tab for the service now displays the two revisions.
-. In the *Resources* tab, click the btn:[Set Traffic Distribution] button to see the traffic distribution dialog box:
+. In the *Resources* tab, click btn:[Set Traffic Distribution] to see the traffic distribution dialog box:
 .. Add the split traffic percentage portion for the two revisions in the *Splits* field.
 .. Add tags to create custom URLs for the two revisions.
 .. Click *Save* to see two nodes representing the two revisions in the Topology view.

--- a/modules/ossm-tutorial-jaeger-generating-traces.adoc
+++ b/modules/ossm-tutorial-jaeger-generating-traces.adoc
@@ -46,6 +46,6 @@ echo $JAEGER_URL
 
 . Log in using the same user name and password as you use to access the {product-title} console.
 
-. In the left pane of the Jaeger dashboard, from the *Service* menu, select *productpage.bookinfo* and click the *Find Traces* button at the bottom of the pane. A list of traces is displayed.
+. In the left pane of the Jaeger dashboard, from the *Service* menu, select *productpage.bookinfo* and click *Find Traces* at the bottom of the pane. A list of traces is displayed.
 
 . Click one of the traces in the list to open a detailed view of that trace.  If you click the first one in the list, which is the most recent trace, you see the details that correspond to the latest refresh of the `/productpage`.

--- a/modules/ossm-tutorial-prometheus-querying-metrics.adoc
+++ b/modules/ossm-tutorial-prometheus-querying-metrics.adoc
@@ -50,7 +50,7 @@ $ export PROMETHEUS_URL=$(oc get route -n istio-system prometheus -o jsonpath='{
 +
 image::ossm-prometheus-home-screen.png[]
 +
-. In the *Expression* field, enter `istio_request_duration_seconds_count`, and click the `Execute` button. You will see a screen similar to the following figure:
+. In the *Expression* field, enter `istio_request_duration_seconds_count`, and click `Execute`. You will see a screen similar to the following figure:
 +
 image::ossm-prometheus-metrics.png[]
 +

--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -13,7 +13,7 @@
 
 . Click *Knative Eventing* in the list of *Provided APIs* for the {ServerlessOperatorName} to go to the *Knative Eventing* tab.
 
-. Click the *Create Knative Eventing* button.
+. Click *Create Knative Eventing*.
 
 . In the *Create Knative Eventing* page, you can choose to configure the `KnativeEventing` object by using either the default form provided, or by editing the YAML.
 

--- a/modules/serverless-install-serving-web-console.adoc
+++ b/modules/serverless-install-serving-web-console.adoc
@@ -13,7 +13,7 @@
 
 . Click *Knative Serving* in the list of *Provided APIs* for the {ServerlessOperatorName} to go to the *Knative Serving* tab.
 
-. Click the *Create Knative Serving* button.
+. Click *Create Knative Serving*.
 
 . In the *Create Knative Serving* page, you can install Knative Serving using the default settings by clicking *Create*.
 +

--- a/modules/viewing-a-project-using-the-web-console.adoc
+++ b/modules/viewing-a-project-using-the-web-console.adoc
@@ -11,4 +11,4 @@
 
 . Select a project to view.
 +
-On this page, click the *Workloads* button to see workloads in the project.
+On this page, click *Workloads* to see workloads in the project.

--- a/modules/virt-about-vm-console-sessions.adoc
+++ b/modules/virt-about-vm-console-sessions.adoc
@@ -14,7 +14,7 @@ the *VNC Console* drop-down list and selecting *Serial Console*.
 
 Console sessions remain active in the background unless they are disconnected. To ensure that only one console session is open at a time, click the *Disconnect before switching* check box before switching consoles.
 
-You can open the active console session in a detached window by clicking the *Open Console in New Window* button or by clicking *Actions* -> *Open Console*.
+You can open the active console session in a detached window by clicking *Open Console in New Window* or by clicking *Actions* -> *Open Console*.
 
 .Options for the *VNC Console*
 * Send key combinations to the virtual machine by clicking *Send Key*.

--- a/modules/virt-removing-secret-configmap-service-account-vm.adoc
+++ b/modules/virt-removing-secret-configmap-service-account-vm.adoc
@@ -23,7 +23,7 @@ that is attached to a virtual machine.
 
 . Click the *Environment* tab.
 
-. Find the item that you want to delete in the list, and click the *Remove* button {delete} on the right side of the item.
+. Find the item that you want to delete in the list, and click *Remove* {delete} on the right side of the item.
 
 . Click *Save*.
 

--- a/modules/virt-vm-creating-nic-web.adoc
+++ b/modules/virt-vm-creating-nic-web.adoc
@@ -16,4 +16,4 @@ Create and attach additional NICs to a virtual machine from the web console.
 . Click *Add Network Interface* to create a new slot in the list.
 . Use the *Network* drop-down list to select the network attachment definition for the additional network.
 . Fill in the *Name*, *Model*, *Type*, and *MAC Address* for the new NIC.
-. Click the *Add* button to save and attach the NIC to the virtual machine.
+. Click *Add* to save and attach the NIC to the virtual machine.


### PR DESCRIPTION
@vikram-redhat There are some typos on button which not follow up the same style(confirmed with @Preeticp [here](https://github.com/openshift/openshift-docs/pull/35481#pullrequestreview-791445235)), minimum version that the change applies to should be 4.6 in my opinion, could you arrange someone to review them? Thanks.