### PR TITLE
RHDEVDOCS-3244 Notes on deprecation of HOME and workingDir in steps

### DIFF
--- a/modules/op-about-tasks.adoc
+++ b/modules/op-about-tasks.adoc
@@ -5,11 +5,11 @@
 [id="about-tasks_{context}"]
 = Tasks
 
-_Tasks_ are the building blocks of a Pipeline and consists of sequentially executed steps. It is essentially a function of inputs and outputs. A Task can run individually or as a part of the pipeline. Tasks are reusable and can be used in multiple Pipelines. 
+_Tasks_ are the building blocks of a pipeline and consists of sequentially executed steps. It is essentially a function of inputs and outputs. A task can run individually or as a part of the pipeline. Tasks are reusable and can be used in multiple Pipelines.
 
-_Steps_ are a series of commands that are sequentially executed by the Task and achieve a specific goal, such as building an image. Every Task runs as a pod, and each Step runs as a container within that pod. Because Steps run within the same pod, they can access the same volumes for caching files, config maps, and secrets.
+_Steps_ are a series of commands that are sequentially executed by the task and achieve a specific goal, such as building an image. Every task runs as a pod, and each step runs as a container within that pod. Because steps run within the same pod, they can access the same volumes for caching files, config maps, and secrets.
 
-The following example shows the `apply-manifests` Task.
+The following example shows the `apply-manifests` task.
 
 [source,yaml]
 ----
@@ -36,9 +36,27 @@ spec: <4>
           oc apply -f $(params.manifest_dir)
           echo -----------------------------------
 ----
-<1> The Task API version, `v1beta1`.
+<1> The task API version, `v1beta1`.
 <2> The type of Kubernetes object, `Task`.
-<3> The unique name of this Task.
-<4> The list of parameters and Steps in the Task and the workspace used by the Task.
+<3> The unique name of this task.
+<4> The list of parameters and steps in the task and the workspace used by the task.
 
-This Task starts the pod and runs a container inside that pod using the specified image to run the specified commands.
+This task starts the pod and runs a container inside that pod using the specified image to run the specified commands.
+
+[NOTE]
+====
+Starting with {pipelines-shortname} 1.6, the following defaults from the step YAML file are removed:
+
+* The `HOME` environment variable does not default to the `/tekton/home` directory
+* The `workingDir` field does not default to the `/workspace` directory
+
+Instead, the container for the step defines the `HOME` environment variable and the `workingDir` field. However, you can override the default values by specifying the custom values in the YAML file for the step.
+
+As a temporary measure, to maintain backward compatibility with the older {pipelines-shortname} versions, you can set the following fields in the `TektonConfig` custom resource definition to `false`:
+```
+spec:
+  pipeline:
+    disable-working-directory-overwrite: false
+    disable-home-env-overwrite: false
+```
+====

--- a/modules/pipelines-document-attributes.adoc
+++ b/modules/pipelines-document-attributes.adoc
@@ -9,4 +9,4 @@
 //
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: Pipelines
-:pipelines-ver: pipelines-1.5
+:pipelines-ver: pipelines-1.6


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [RHDEVDOCS-3244 Document deprecation `HOME=/tekton/home` and `workingDir=/workspace` in steps](https://issues.redhat.com/browse/RHDEVDOCS-3244)
- **Preview pages**: See the note at the bottom of the section [Understanding OpenShift Pipelines > Tasks](https://deploy-preview-38476--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/understanding-openshift-pipelines.html#about-tasks_understanding-openshift-pipelines)
- **SME review**: @sm43 
- **Peer-review**: @Preeticp 