### PR TITLE
Add back annoying alert box on mobile

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -397,14 +397,37 @@
           tocItems[tocItems.length - 1].classList.add("toc-active");
         };
       //scroll to top
-      if(window.scrollY==0) {
+      if(window.pageYOffset === 0) {
         var tocItems = $("#toc a");
         for (let i = 0; i < tocItems.length; i++) {
-          tocItems[i].classList.remove("toc-active")
-          }
+          tocItems[i].classList.remove("toc-active");
+          };
+          tocItems[0].classList.add("toc-active");
         };
-        tocItems[0].classList.add("toc-active");
       })
+  </script>
+
+  <!-- adjust alerts on mobile -->
+  <script type="text/javascript">
+    window.addEventListener("wheel", () => {
+      if (window.innerWidth < 1425) {
+        //adjust alert
+        if(window.pageYOffset > 0) {
+          document.querySelector('#support-alert').style.position = "fixed";
+          document.querySelector('#support-alert').style.bottom = "0px";
+          document.querySelector('#support-alert').style.margin = "5px";
+          document.querySelector('#support-alert').style.zIndex = "9999999";     
+        }
+      }
+   });
+    window.addEventListener('resize', () => {
+      if (window.innerWidth >= 1425) {
+        document.querySelector('#support-alert').style.removeProperty('position');
+        document.querySelector('#support-alert').style.removeProperty('bottom');
+        document.querySelector('#support-alert').style.removeProperty('margin');
+        document.querySelector('#support-alert').style.removeProperty('zIndex');
+      }
+    })
   </script>
 
 </body>


### PR DESCRIPTION
On page scroll, when on mobile, annoying box is kept in view at bottom of page. Preview is broken, this requires a full commerical package build to test.

Preview: http://file.emea.redhat.com/aireilly/files/package/commercial/container-platform/4.4/metering/metering-installing-metering.html#metering-install-cli_installing-metering