### PR TITLE
CCXDEV-4810 Add the Insights Operator to the "Red Hat Operators" 

### DIFF
--- a/modules/insights-operator.adoc
+++ b/modules/insights-operator.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * operators/operator-reference.adoc
+
+[id="insights-operator_{context}"]
+= Insights Operator
+
+[discrete]
+== Purpose
+
+The Insights Operator gathers {product-title} configuration data and sends it to Red Hat. The data is used to produce proactive insights recommendations about potential issues that a cluster might be exposed to. These insights are communicated to cluster administrators through Insights Advisor on link:https://console.redhat.com/[console.redhat.com].
+
+[discrete]
+== Project
+
+link:https://github.com/openshift/insights-operator[insights-operator]
+
+[discrete]
+== Configuration
+
+No configuration is required.
+
+[discrete]
+== Notes
+
+Insights Operator compliments {product-title} Telemetry.

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -28,6 +28,11 @@ include::modules/console-operator.adoc[leveloffset=+1]
 include::modules/cluster-dns-operator.adoc[leveloffset=+1]
 include::modules/etcd-operator.adoc[leveloffset=+1]
 include::modules/ingress-operator.adoc[leveloffset=+1]
+include::modules/insights-operator.adoc[leveloffset=+1]
+.Additional resources
+
+* See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc[About remote health monitoring] for details about Insights Operator and Telemetry.
+
 include::modules/kube-apiserver-operator.adoc[leveloffset=+1]
 include::modules/kube-controller-manager-operator.adoc[leveloffset=+1]
 include::modules/cluster-kube-scheduler-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds the Insights Operator to the list of official Red Hat operators. 

Versions: `enterprise-4.7`, `enterprise-4.8`, `enterprise-4.9`, `enterprise-4.10` +

Jira: https://issues.redhat.com/browse/CCXDEV-4810

Preview: https://deploy-preview-38484--osdocs.netlify.app/openshift-enterprise/latest/operators/operator-reference#insights-operator_red-hat-operators

Reviewers:
SMEs: radekvokal, tremes  
QE: quarckster 

