### PR TITLE
Updating 'login' to the verb 'log in' in policy doc

### DIFF
--- a/modules/policy-identity-access-management.adoc
+++ b/modules/policy-identity-access-management.adoc
@@ -13,7 +13,7 @@ For a list of the available subprocessors, see the link:https://access.redhat.co
 
 [id="sre-access-all_{context}"]
 == SRE access to all {product-title} clusters
-SREs access {product-title} clusters through a proxy. The proxy mints a service account in an {product-title} cluster for the SREs when they login. As no identity provider is configured for {product-title} clusters, SREs access the proxy by running a local web console container. SREs do not access the cluster web console directly. SREs must authenticate as individual users to ensure auditability. All authentication attempts are logged to a Security Information and Event Management (SIEM) system.
+SREs access {product-title} clusters through a proxy. The proxy mints a service account in an {product-title} cluster for the SREs when they log in. As no identity provider is configured for {product-title} clusters, SREs access the proxy by running a local web console container. SREs do not access the cluster web console directly. SREs must authenticate as individual users to ensure auditability. All authentication attempts are logged to a Security Information and Event Management (SIEM) system.
 
 [id="privileged-access_{context}"]
 == Privileged access controls in {product-title}


### PR DESCRIPTION
This applies to the `dedicated-4` branch only.

This PR updates one instance of "login" in the OpenShift Dedicated policy docs to the verb "log in".