### PR TITLE
BZ-1952538: Update virtctl command options

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -6,15 +6,30 @@
 = Virtctl client commands
 
 The `virtctl` client is a command-line utility for managing {VirtProductName}
-resources. The following table contains the `virtctl` commands used throughout
-the {VirtProductName} documentation.
+resources.
 
-To view a list of options that you can use with a command, run it with the `-h` or `--help` flag. For example:
+To view a list of `virtctl` commands, run the following command:
+
+[source,terminal]
+----
+$ virtctl help
+----
+
+To view a list of options that you can use with a specific command, run it with the `-h` or `--help` flag. For example:
 
 [source,terminal]
 ----
 $ virtctl image-upload -h
 ----
+
+To view a list of global command options that you can use with any `virtctl` command, run the following command:
+
+[source,terminal]
+----
+$ virtctl options
+----
+
+The following table contains the `virtctl` commands used throughout the {VirtProductName} documentation.
 
 .`virtctl` client commands
 


### PR DESCRIPTION
This PR is associated with https://bugzilla.redhat.com/show_bug.cgi?id=1952583.
The updated content applies to CNV releases 4.8 and 4.9.

This is the topic that was updated with new content:
https://deploy-preview-38498--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-using-the-cli-tools.html#virt-virtctl-commands_virt-using-the-cli-tools