### PR TITLE
Consistency with helm repository local naming.

### DIFF
--- a/modules/adding-helm-repository.adoc
+++ b/modules/adding-helm-repository.adoc
@@ -12,7 +12,7 @@
 +
 [source,terminal]
 ----
-$ helm repo add stackrox  https://mirror.openshift.com/pub/rhacs/charts/
+$ helm repo add rhacs https://mirror.openshift.com/pub/rhacs/charts/
 ----
 +
 The Helm repository for {product-title} includes two Helm charts for installing different components.


### PR DESCRIPTION
If the docs are followed explicitly without this change they will not work. This name needs to be consistent throughout the instructions or it will reference incorrect objects.