### PR TITLE
Fix default port to irmc

### DIFF
--- a/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
+++ b/modules/ipi-install-bmc-addressing-for-fujitsu-irmc.adoc
@@ -33,7 +33,7 @@ For Fujitsu hardware, Red Hat supports integrated Remote Management Controller (
 
 .iRMC
 
-Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `623`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
+Fujitsu nodes can use `irmc://<out-of-band-ip>` and defaults to port `443`. The following example demonstrates an iRMC configuration within the `install-config.yaml` file.
 
 [source,yaml]
 ----


### PR DESCRIPTION
Applies to 4.8+

The default port of irmc is 443.

Signed-off-by: Hu Shuai <hus.fnst@fujitsu.com>

Preview: https://deploy-preview-38506--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#bmc-addressing-for-fujitsu-irmc_ipi-install-configuration-files