### PR TITLE
Updated cdi-insecure-registries configmap namespace

### DIFF
--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -13,11 +13,11 @@ You can disable TLS (transport layer security) for a container registry by addin
 
 .Procedure
 
-* Add the registry to the `cdi-insecure-registries` config map in the `cdi` namespace.
+* Add the registry to the `cdi-insecure-registries` config map in the `openshift-cnv` namespace.
 +
 [source,terminal]
 ----
-$ oc patch configmap cdi-insecure-registries -n cdi \
+$ oc patch configmap cdi-insecure-registries -n openshift-cnv \
   --type merge -p '{"data":{"mykey": "<insecure-registry-host>:5000"}}' <1>
 ----
 <1> Replace `<insecure-registry-host>` with the registry hostname.


### PR DESCRIPTION
`cdi` namespace is invalid. Updated namespace to `openshift-cnv`

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1903721

OCP applicable versions: 4.7 and 4.6

Doc peview: https://deploy-preview-38508--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms

@yanpzhan PTAL for QA