### PR TITLE
CNV-13464: Updated HCO version for 2.6.8

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -14,7 +14,7 @@
 :ProductVersion:
 :VirtVersion: 2.6
 :KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.7
+:HCOVersion: 2.6.8
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
[CNV-13464](https://issues.redhat.com/browse/CNV-13464)

New PR to update the HCO version variable for 2.6.8 after the original PR https://github.com/openshift/openshift-docs/pull/38513 was mistakenly merged and then reverted.

SME and peer review approvals from the original PR will apply to this one as well.