### PR TITLE
Updates the network policy namespace selector

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -43,7 +43,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          network.openshift.io/policy-group: ingress
+        policy-group.network.openshift.io/ingress=""
   podSelector: {}
   policyTypes:
   - Ingress


### PR DESCRIPTION
Preview: https://deploy-preview-38542--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html

Continuation of https://github.com/openshift/openshift-docs/pull/38283

For 4.6 only. 

QE ack'd. 