### PR TITLE
adds notes for 4.9.6 release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2115,3 +2115,35 @@ link:https://access.redhat.com/solutions/6465271[{product-title} 4.9.5 container
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.
+
+[id="ocp-4-9-6"]
+=== RHBA-2021:4119 - {product-title} 4.9.6 bug fix and security update
+
+Issued: 2021-11-10
+
+{product-title} release 4.9.6, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4119[RHBA-2021:4119] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4118[RHSA-2021:4118] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6486731[{product-title} 4.9.6 container image list]
+
+[id="ocp-4-9-6-known-issues"]
+==== Known Issues
+
+* The current opt-in obfuscation will not work on clusters with OVN because the `hostsubnets.network.openshift.io` is not currently on OVN clusters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2014633[*BZ#2014633*])
+
+[id="ocp-4-9-6-bug-fixes"]
+==== Bug fixes
+
+* Previously, a bug in the lock implementation for the `nmstate-handler` pod caused multiple nodes to gain control. This update fixes the lock implementation so that only one node is in control of the lock. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954309[*BZ#1954309*])
+
+* Previously, OpenStack flavor validation accepted flavors not meeting the RAM requirements using the wrong unit. With this update, the correct unit is used for comparing minimum RAM against value returned by OpenStack. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2009787[*BZ#2009787*])
+
+* Previously, {product-title} deployments on OpenStack failed for compact clusters with undedicated workers due to control plane nodes missing Ingress security group rules. With this update, an Ingress security group was added to OpenStack when control planes are schedulable. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2016267[*BZ#2016267*])
+
+* Previously, some *cAdvisor* metrics were dropped in order to reduce overall memory consumption but the *Utilization* dashboard in the console did not display any results. With this update, the dashboards display correctly again. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2018455[*BZ#2018455*])
+
+[id="ocp-4-9-6-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes to 4.9.6 release for Nov. 10

- Applies to `enterprise-4.9` only
- [Preview link](https://deploy-preview-38543--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-6)