### PR TITLE
BZ1866692: Removed broken MITM transparent proxy information

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -179,8 +179,8 @@ additionalTrustBundle: | <4>
 ...
 ----
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
-URL scheme must be `http`. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpProxy` value.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpsProxy` value.
+URL scheme must be `http`.
+<2> A proxy URL to use for creating HTTPS connections outside the cluster.
 <3> A comma-separated list of destination domain names, IP addresses, or
 other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
 ifdef::vsphere,vmc[]
@@ -193,7 +193,6 @@ Operator then creates a `trusted-ca-bundle` config map that merges the contents 
 with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless
 the proxy's identity certificate is signed by an authority from the {op-system} trust
 bundle.
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
 +
 [NOTE]
 ====


### PR DESCRIPTION
This PR removes information about configuring MITM transparent proxies during installation, which isn't currently possible.  

See https://bugzilla.redhat.com/show_bug.cgi?id=1866692

Applies to 4.6+

Representative preview: https://deploy-preview-38550--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#installation-configure-proxy_installing-aws-network-customizations

See also:

// RFE to allow MITM transparent proxy configuration during installation
https://issues.redhat.com/browse/RFE-2181

// Docs issue to add day-2 transparent proxy configuration procedure
https://issues.redhat.com/browse/OSDOCS-2945


