### PR TITLE
BZ: 2021245 - Updated title of release notes with correct version of …

### DIFF
--- a/sandboxed_containers/sandboxed-containers-4.9-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4.9-release-notes.adoc
@@ -1,18 +1,18 @@
 [id="sandboxed-containers-4-9-release-notes"]
-= {sandboxed-containers-first} {product-version} release notes
+= {sandboxed-containers-first} 1.1 release notes
 include::modules/common-attributes.adoc[]
 :context: sandboxed-containers-release-notes
 
 toc::[]
 
-[id="ocp-4-9-about-this-release"]
+[id="sandboxed-containers-1-1-about-this-release"]
 == About this release
 
-These release notes track the development of {sandboxed-containers-first} in Red Hat {product-title}.
+These release notes track the development of {sandboxed-containers-first} 1.1 alongside Red Hat {product-title} {product-version}.
 
 This product is currently in Technology Preview. {sandboxed-containers-first} is not intended for production use. For more information, see the Red Hat Customer Portal link:https://access.redhat.com/support/offerings/techpreview[support scope] for features in Technology Preview.
 
-[id="sandboxed-containers-4-9-new-features-and-enhancements"]
+[id="sandboxed-containers-1-1-new-features-and-enhancements"]
 == New features and enhancements
 
 [id="fips-compatability-rn"]
@@ -30,7 +30,7 @@ The {sandboxed-containers-operator} now includes a must-gather image, allowing y
 
 You can now install the {sandboxed-containers-operator} in a disconnected environment. For more information, see the xref:../sandboxed_containers/deploying-sandboxed-container-workloads.adoc#deploying-sandboxed-containers-workloads_additional-resources[Additional resources for Deploying {sandboxed-containers-first} workloads].
 
-[id="sandboxed-containers-4-9-bug-fixes"]
+[id="sandboxed-containers-1-1-bug-fixes"]
 == Bug fixes
 
 * Previously, when running Fedora on {sandboxed-containers-first}, some packages required file access permission changes that {product-title} did not grant to containers by default. With this release, these permissions are granted by default. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1915377[*BZ#1915377*])
@@ -43,12 +43,12 @@ You can now install the {sandboxed-containers-operator} in a disconnected enviro
 
 * Previously, there were instances where the Operator Hub in the {product-title} web console did not display icons for an Operator. With this release, icons are always displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019380[*BZ#9019380*])
 
-[id="sandboxed-containers-4-9-known-issues"]
+[id="sandboxed-containers-1-1-known-issues"]
 == Known issues
 
 * If you are using {sandboxed-containers-first}, you cannot use the `hostPath` volume in a {product-title} cluster to mount a file or directory from the host node’s file system into your pod. As an alternative, you can use local persistent volumes. See xref:../storage/persistent_storage/persistent-storage-local.adoc[Persistent storage using local volumes] for more information. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
 
-[id="sandboxed-containers-4-9-asynchronous-errata-updates"]
+[id="sandboxed-containers-1-1-asynchronous-errata-updates"]
 == Asynchronous errata updates
 
 Security, bug fix, and enhancement updates for {sandboxed-containers-first} {product-version} are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.


### PR DESCRIPTION
Bugzilla [2021245](https://bugzilla.redhat.com/show_bug.cgi?id=2021245) update to Sandboxed containers release notes in 4.9.

Preview link: https://deploy-preview-38553--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-4.9-release-notes

Reviewed and approved.