### PR TITLE
TELCODOCS: 358 - added xref in 4.9 OCP release notes, in the Sandboxe…

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -887,6 +887,11 @@ With this release, installations on Microsoft Azure Stack Hub can be performed b
 
 For more information, see xref:../authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc[Using manual mode].
 
+[id="ocp-4-9-sandboxed-containers-tp"]
+=== {sandboxed-containers-first} support on {product-title} (Technology Preview)
+
+To review {sandboxed-containers-first} new features, bug fixes, known issues, and asynchronous errata updates, see xref:../sandboxed_containers/sandboxed-containers-4.9-release-notes.adoc#sandboxed-containers-release-notes[{sandboxed-containers-first} 1.1 release notes].
+
 [id="ocp-4-9-notable-technical-changes"]
 == Notable technical changes
 


### PR DESCRIPTION
Update for 4.9 - Sandboxed containers now have their own dedicated release notes page. I added a link to these new release notes into the OCP release notes, under a Sandboxed containers section.

Preview: https://deploy-preview-38555--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-sandboxed-containers-tp