### PR TITLE
BZ:2020128 - Showing that OpenShift 3.11 is on vSphere 7

### DIFF
--- a/install_config/topics/vsphere_prerequisites.adoc
+++ b/install_config/topics/vsphere_prerequisites.adoc
@@ -16,6 +16,11 @@ Standalone ESXi is not supported.
 * vSAN, VMFS and NFS supported.
 ** vSAN support is limited to one cluster in one vCenter.
 
+[NOTE]
+====
+{product-title} 3.11 is supported and deploys on vSphere 7 clusters. If you use the vSphere in-tree storage driver, vSAN, VMFS and NFS storage options are also supported. 
+====
+
 .Prerequisites
 
 You must install the VMware Tools on each Node VM.


### PR DESCRIPTION
For Version 3.11
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2020128

Preview: https://deploy-preview-38561--osdocs.netlify.app/openshift-enterprise/latest/install_config/configuring_vsphere#vsphere-prereqs

Ready for QA: @gpei 

For peer reviewers: Can you please add the 'enterprise-3.11' label, thank you!