### PR TITLE
RHDEVDOCS-3458 - GitOps 1.3.1 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -17,11 +17,13 @@ toc::[]
 
 For an overview of {gitops-title}, see xref:../../cicd/gitops/understanding-openshift-gitops.adoc#understanding-openshift-gitops[Understanding OpenShift GitOps].
 
-include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
-
 include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 
+include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
+
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-3-1.adoc
+++ b/modules/gitops-release-notes-1-3-1.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-3-1_{context}"]
+= Release notes for {gitops-title} 1.3.1
+
+{gitops-title} 1.3.1 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="fixed-issues-1-3-1_{context}"]
+== Fixed issues
+
+* If you upgrade to v1.3.0, the Operator does not return an ordered slice of environment variables. As a result, the reconciler fails causing the frequent recreation of Argo CD pods in {product-title} clusters running behind a proxy. This update fixes the issue so that Argo CD pods are not recreated. link:https://issues.redhat.com/browse/GITOPS-1489[GITOPS-1489]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: [RHDEVDOCS-3458](https://issues.redhat.com/browse/RHDEVDOCS-3458) GitOps 1.3.1 Release Notes, Known Issues and Bug Fixes
https://issues.redhat.com/browse/RHDEVDOCS-3458
Preview pages: https://deploy-preview-38584--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-3-1_gitops-release-notes
SME+QE review: @iam-veeramalla 
Peer-review: @Preeticp 