### PR TITLE
RHDEVDOCS-3123 - removed gitops openshift service from support matrix tables

### DIFF
--- a/modules/gitops-release-notes-1-1.adoc
+++ b/modules/gitops-release-notes-1-1.adoc
@@ -32,8 +32,6 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | TP
 | {gitops-title} Application Manager (kam)
 | TP
-| {gitops-title} Service
-| TP
 |===
 
 [id="new-features-1-1_{context}"]

--- a/modules/gitops-release-notes-1-2-1.adoc
+++ b/modules/gitops-release-notes-1-2-1.adoc
@@ -32,8 +32,6 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | TP
 | {gitops-title} Application Manager (kam)
 | TP
-| {gitops-title} Service
-| TP
 |===
 
 [id="fixed-issues-1-2-1_{context}"]

--- a/modules/gitops-release-notes-1-2.adoc
+++ b/modules/gitops-release-notes-1-2.adoc
@@ -32,8 +32,6 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | TP
 | {gitops-title} Application Manager (kam)
 | TP
-| {gitops-title} Service
-| TP
 |===
 
 [id="new-features-1-2_{context}"]


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: Enterprise-4.7, enterprise-4.8, enterprise-4.9
JIRA issues: [RHDEVDOCS-3123](https://issues.redhat.com/browse/RHDEVDOCS-3123) - Please remove "Red Hat OpenShift GitOps Service " from GitOps docs
https://issues.redhat.com/browse/RHDEVDOCS-3123
Preview pages: https://deploy-preview-38585--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes
SME+QE review: 
Peer-review: @Preeticp