### PR TITLE
BZ1873575: add a section called reinstalling the OCP cluster

### DIFF
--- a/installing/installing-troubleshooting.adoc
+++ b/installing/installing-troubleshooting.adoc
@@ -19,3 +19,8 @@ include::modules/manually-gathering-logs-with-ssh.adoc[leveloffset=+1]
 include::modules/manually-gathering-logs-without-ssh.adoc[leveloffset=+1]
 
 include::modules/installation-getting-debug-information.adoc[leveloffset=+1]
+
+include::modules/restarting-installation.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../installing/index.adoc#ocp-installation-overview[Installing an {product-title} cluster]

--- a/modules/restarting-installation.adoc
+++ b/modules/restarting-installation.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// installing/installing-troubleshooting.adoc
+
+[id="restarting-installation_{context}"]
+= Reinstalling the {product-title} cluster
+
+If you are unable to debug and resolve issues in the failed {product-title} installation, consider installing a new {product-title} cluster. Before starting the installation process again, you must complete thorough cleanup.
+For a user-provisioned infrastructure (UPI) installation, you must manually destroy the cluster and delete all associated resources. The following procedure is for an installer-provisioned infrastructure (IPI) installation.
+
+.Procedure
+
+. Destroy the cluster and remove all the resources associated with the cluster, including the hidden installer state files in the installation directory:
++
+[source, terminal]
+----
+$ ./openshift-install destroy cluster --dir=<installation_directory> <1>
+----
+<1> `installation_directory` is the directory you specified when you ran `./openshift-install create cluster`. This directory contains the {product-title}
+definition files that the installation program creates.
+
+. Before reinstalling the cluster, delete the installation directory:
++
+[source, terminal]
+----
+$ rm -rf <installation_directory>
+----
+
+. Follow the procedure for installing a new {product-title} cluster.


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1873575

[Docs preview link](https://deploy-preview-38587--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-troubleshooting.html#restarting-installation_installing-troubleshooting)

Requires ack from @gpei 