### PR TITLE
BZ:1923869 - Fixing yaml that shows how to disable build strategy

### DIFF
--- a/modules/builds-disabling-build-strategy-globally.adoc
+++ b/modules/builds-disabling-build-strategy-globally.adoc
@@ -60,7 +60,7 @@ $ oc edit clusterrole admin
 $ oc edit clusterrole edit
 ----
 
-. For each role, remove the line that corresponds to the resource of the strategy to disable.
+. For each role, specify the subresources that correspond to the resource of the strategy to disable.
 
 .. Disable the docker Build Strategy for *admin*:
 +
@@ -70,12 +70,23 @@ kind: ClusterRole
 metadata:
   name: admin
 ...
-rules:
-- resources:
-  - builds/custom
-  - builds/docker <1>
+- apiGroups:
+  - ""
+  - build.openshift.io
+  resources:
+  - buildconfigs
+  - buildconfigs/webhooks
+  - builds/custom <1>
   - builds/source
-  ...
+  verbs:
+  - create
+  - delete
+  - deletecollection
+  - get
+  - list
+  - patch
+  - update
+  - watch
 ...
 ----
-<1> Delete this line to disable docker builds globally for users with the *admin* role.
+<1> Add `builds/custom` and `builds/source` to disable docker builds globally for users with the *admin* role.


### PR DESCRIPTION
For Versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1923869

Preview: https://deploy-preview-38612--osdocs.netlify.app/openshift-enterprise/latest/cicd/builds/securing-builds-by-strategy#builds-disabling-build-strategy-globally_securing-builds-by-strategy

Ready for QA: @jitendar-singh 

For Peer reviewers: Labels needed 'enterprise-4.6', 'enterprise-4.7', 'enterprise-4.8', 'enterprise-4.9', 'enterprise-4.10', and 'Peer Review needed'. Thank you!! 