### PR TITLE
Fixed the issue in file nw-networkpolicy-project-defaults.adoc steps include misconfiguration. 

### DIFF
--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -46,7 +46,7 @@ objects:
   metadata:
     name: allow-from-same-namespace
   spec:
-    podSelector:
+    podSelector: {}
     ingress:
     - from:
       - podSelector: {}


### PR DESCRIPTION
Hello Team, 
The above pull request will resolve the open issue https://github.com/openshift/openshift-docs/issues/38586 

What's fixed: There was a misconfiguration available in docs of https://docs.openshift.com/container-platform/4.6/post_installation_configuration/network-configuration.html#post-install-nw-networkpolicy-creating-default-networkpolicy-objects-for-a-new-project for v4.6 to v4.10 branches hoping to resolve the same from it.

 Changes: Adding network policies to the new project template steps 2 YAML file. 
 
 @vikram-redhat @Preeticp 