### PR TITLE
CNV-11202: Documenting rollout of node network configuration policy

### DIFF
--- a/modules/virt-creating-interface-on-nodes.adoc
+++ b/modules/virt-creating-interface-on-nodes.adoc
@@ -10,6 +10,8 @@ Create an interface on nodes in the cluster by applying a `NodeNetworkConfigurat
 
 By default, the manifest applies to all nodes in the cluster. To add the interface to specific nodes, add the `spec: nodeSelector` parameter and the appropriate `<key>:<value>` for your node selector.
 
+You can configure multiple nmstate-enabled nodes concurrently. The configuration applies to 50% of the nodes in parallel. This strategy prevents the entire cluster from being unavailable if the network connection fails. To apply the policy configuration in parallel to a specific portion of the cluster, use the `maxUnavailable` field.
+
 .Procedure
 
 . Create the `NodeNetworkConfigurationPolicy` manifest. The following example configures a Linux bridge on all worker nodes:
@@ -19,14 +21,15 @@ By default, the manifest applies to all nodes in the cluster. To add the interfa
 apiVersion: nmstate.io/v1
 kind: NodeNetworkConfigurationPolicy
 metadata:
-  name: <br1-eth1-policy> <1>
+  name: br1-eth1-policy <1>
 spec:
   nodeSelector: <2>
     node-role.kubernetes.io/worker: "" <3>
+  maxUnavailable: 3 <4>
   desiredState:
     interfaces:
       - name: br1
-        description: Linux bridge with eth1 as a port <4>
+        description: Linux bridge with eth1 as a port <5>
         type: linux-bridge
         state: up
         ipv4:
@@ -42,12 +45,25 @@ spec:
 <1> Name of the policy.
 <2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
 <3> This example uses the `node-role.kubernetes.io/worker: ""` node selector to select all worker nodes in the cluster.
-<4> Optional: Human-readable description for the interface.
+<4> Optional: Specifies the maximum number of nmstate-enabled nodes that the policy configuration can be applied to concurrently. This parameter can be set to either a percentage value (string), for example, `"10%"`, or an absolute value (number), such as `3`.
+<5> Optional: Human-readable description for the interface.
 
 . Create the node network policy:
 +
 [source,terminal]
 ----
-$ oc apply -f <br1-eth1-policy.yaml> <1>
+$ oc apply -f br1-eth1_policy.yaml <1>
 ----
 <1> File name of the node network configuration policy manifest.
++
+.Example output
+[source,terminal]
+----
+NAME                     STATUS
+node01.br1-eth1-policy   Pending
+node02.br1-eth1-policy   Progressing
+node03.br1-eth1-policy   Available
+node04.br1-eth1-policy   Progressing
+node05.br1-eth1-policy   Progressing
+node06.br1-eth1-policy   Pending
+----


### PR DESCRIPTION
[CNV-11202](https://issues.redhat.com/browse/CNV-11202)

Updated the `Creating an interface on nodes` module to include content about how to apply the policy manifest in parallel by using the `maxUnavailable` field.

Preview: https://deploy-preview-38619--osdocs.netlify.app/openshift-enterprise/latest/virt/node_network/virt-updating-node-network-config.html#virt-creating-interface-on-nodes_virt-updating-node-network-config