### PR TITLE
OSDOCS-2173: RN for new network controller support

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -379,6 +379,16 @@ The containerized Data Plane Development Kit (DPDK) is now GA in {product-title}
 
 SR-IOV now supports vhost-net for use with Fast Datapath DPDK applications on Intel and Mellanox NICs. You can enable this feature by configuring the `SriovNetworkNodePolicy` resource. For more information, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-networknodepolicy-object_configuring-sriov-device[SR-IOV network node configuration object].
 
+[id="ocp-4-9-supported-hardware-sriov"]
+==== Supported hardware for SR-IOV
+
+{product-title} {product-version} adds support for additional Broadcom and Intel hardware.
+
+* Broadcom BCM57414 and BCM57508
+* Intel E810-CQDA2
+
+For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].
+
 [id="ocp-4-9-networking-metallb"]
 ==== MetalLB load balancer
 


### PR DESCRIPTION
[**UPDATE 2021-11-17**] This PR was merged early, reverted, and recreated in a new PR: https://github.com/openshift/openshift-docs/pull/38879

RN for #38380

Applies only to `enterprise-4.9`

Preview: https://deploy-preview-38632--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes#ocp-4-9-supported-hardware-sriov