### PR TITLE
[virt] Removing CNV must-gather docs from OKD

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -2788,7 +2788,7 @@ Topics:
   - Name: Extensions
     File: ossm-extensions
   - Name: The 3scale WebAssembly module
-    File: ossm-threescale-webassembly-module    
+    File: ossm-threescale-webassembly-module
   - Name: Using the 3scale Istio adapter
     File: threescale-adapter
   - Name: Troubleshooting Service Mesh
@@ -3157,9 +3157,9 @@ Topics:
   - Name: Collecting OpenShift Virtualization data for Red Hat Support
     File: virt-collecting-virt-data
     Distros: openshift-enterprise
-  - Name: Collecting OKD Virtualization data for community report
-    File: virt-collecting-virt-data
-    Distros: openshift-origin
+#  - Name: Collecting OKD Virtualization data for community report
+#    File: virt-collecting-virt-data
+#    Distros: openshift-origin
 ---
 # OpenShift Serverless
 Name: Serverless


### PR DESCRIPTION
- per discussion with @fabiand, removing CNV must-gather docs from OKD
- commenting out for now in case we want to make the docs OKD-friendly in the future
- CP to 4.9 and 4.10 (not present in 4.8)
- QE not required