### PR TITLE
Fix duplicate words RHOSP/RHV

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -20,8 +20,8 @@ If you want to install and manage {product-title} yourself, you can install it o
 * Microsoft Azure
 * Microsoft Azure Stack Hub
 * Google Cloud Platform (GCP)
-* {rh-openstack-first} ({rh-openstack})
-* {rh-virtualization-first} ({rh-virtualization})
+* {rh-openstack-first}
+* {rh-virtualization-first}
 * IBM Z and LinuxONE
 * IBM Z and LinuxONE for {op-system-base-full} KVM
 * IBM Power


### PR DESCRIPTION
In https://docs.openshift.com/container-platform/4.9/installing/installing-preparing.html#installing-preparing-install-manage, duplicate words RHOSP and RHV.
```
Red Hat OpenStack Platform (RHOSP) (RHOSP)
Red Hat Virtualization (RHV) (RHV)
```

The same to https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/installing/installing-preparing