### PR TITLE
BZ2020368 Minimum/Preferred cpu reqs on IBM Z

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -40,7 +40,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 
-* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+* xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -44,7 +44,9 @@ include::modules/csr-management.adoc[leveloffset=+2]
 
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
-* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+* See link:https://www.vm.ibm.com/library/presentations/lparperf.pdf[Topics in LPAR performance] for LPAR weight management and entitlements.
+
+* xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -49,7 +49,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 
 .Additional resources
 
-* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+* xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -52,7 +52,9 @@ include::modules/csr-management.adoc[leveloffset=+2]
 
 * See link:http://public.dhe.ibm.com/software/dw/linux390/perf/zvm_hpav00.pdf[Scaling HyperPAV alias devices on Linux guests on z/VM] for performance optimization.
 
-* See xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments].
+* See link:https://www.vm.ibm.com/library/presentations/lparperf.pdf[Topics in LPAR performance] for LPAR weight management and entitlements.
+
+* xref:../../scalability_and_performance/ibm-z-recommended-host-practices.adoc#ibm-z-recommended-host-practices[Recommended host practices for IBM Z & LinuxONE environments]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 

--- a/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
+++ b/modules/installation-requirements-user-infra-ibm-z-kvm.adoc
@@ -73,8 +73,18 @@ You can install {product-title} version {product-version} on the following IBM h
 [discrete]
 === Hardware requirements
 
-* 1 LPAR with 6 IFLs that supports SMT2
-* 1 OSA or RoCE network adapter
+* The equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
+
+[NOTE]
+====
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of IBM Z. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+====
+
+[IMPORTANT]
+====
+Since the overall performance of the cluster can be impacted, the LPARs that are used to setup the {product-title} clusters must provide sufficient compute capacity. In this context, LPAR weight management, entitlements, and CPU shares on the hypervisor level play an important role.
+====
 
 [discrete]
 === Operating system requirements
@@ -134,8 +144,8 @@ Each cluster virtual machine must meet the following minimum requirements:
 [discrete]
 === Hardware requirements
 
-* 3 LPARs with 6 IFLs each that support SMT2
-* 1 or 2 OSA or RoCE network adapters, or both
+* 3 LPARS that each have the equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* Two network connections to connect to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
 
 [discrete]
 === Operating system requirements
@@ -144,9 +154,10 @@ Each cluster virtual machine must meet the following minimum requirements:
 
 On your {op-system-base} KVM host, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines, distributed across the {op-system-base} KVM host machines
-* At least 6 guest virtual machines for {product-title} compute machines, distributed across the {op-system-base} KVM host machines
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
+* 3 guest virtual machines for {product-title} control plane machines, distributed across the {op-system-base} KVM host machines.
+* At least 6 guest virtual machines for {product-title} compute machines, distributed across the {op-system-base} KVM host machines.
+* 1 guest virtual machine for the temporary {product-title} bootstrap machine.
+* To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane by using `cpu_shares`. Do the same for infrastructure nodes, if they exist. See link:https://www.ibm.com/docs/en/linux-on-systems?topic=domain-schedinfo[schedinfo] in IBM Documentation.
 
 [id="preferred-resource-requirements_{context}"]
 == Preferred resource requirements

--- a/modules/installation-requirements-user-infra.adoc
+++ b/modules/installation-requirements-user-infra.adoc
@@ -214,18 +214,28 @@ endif::ibm-z[]
 
 ifdef::ibm-z[]
 [id="minimum-ibm-z-system-requirements_{context}"]
-== Minimum IBM Z system requirements
+== Minimum IBM Z system environment
 
 You can install {product-title} version {product-version} on the following IBM hardware:
 
-* IBM Z, versions 13, 14, or 15
+* IBM z15 (all models), IBM z14 (all models), IBM z13, and IBM z13s
 * LinuxONE, any version
 
 [discrete]
 === Hardware requirements
 
-* 1 LPAR with 6 IFLs that supports SMT2
-* 1 OSA or RoCE network adapter
+* The equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* At least one network connection to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
+
+[NOTE]
+====
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of IBM Z. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+====
+
+[IMPORTANT]
+====
+Since the overall performance of the cluster can be impacted, the LPARs that are used to setup the {product-title} clusters must provide sufficient compute capacity. In this context, LPAR weight management, entitlements, and CPU shares on the hypervisor level play an important role.
+====
 
 [discrete]
 === Operating system requirements
@@ -260,14 +270,14 @@ To install on IBM Z under z/VM, you require a single z/VM virtual NIC in layer 2
 * 16 GB for the temporary {product-title} bootstrap machine
 
 [id="preferred-ibm-z-system-requirements_{context}"]
-== Preferred IBM Z system requirements
+== Preferred IBM Z system environment
 
 [discrete]
 === Hardware requirements
 
-* 3 LPARs with 6 IFLs each that support SMT2
-* 1 or 2 OSA or RoCE network adapters, or both
-* Hipersockets, which are attached to a node either directly as a device or by bridging with one z/VM VSWITCH to be transparent to the z/VM guest. To directly connect Hipersockets to a node, you must set up a gateway to the external network via a {op-system-base} 8 guest to bridge to the Hipersockets network.
+* 3 LPARS that each have the equivalent of 6 IFLs, which are SMT2 enabled, for each cluster.
+* Two network connections to connect to both connect to the `LoadBalancer` service and to serve data for traffic outside the cluster.
+* HiperSockets, which are attached to a node either directly as a device or by bridging with one z/VM VSWITCH to be transparent to the z/VM guest. To directly connect HiperSockets to a node, you must set up a gateway to the external network via a {op-system-base} 8 guest to bridge to the HiperSockets network.
 
 [discrete]
 === Operating system requirements
@@ -276,10 +286,10 @@ To install on IBM Z under z/VM, you require a single z/VM virtual NIC in layer 2
 
 On your z/VM instances, set up:
 
-* 3 guest virtual machines for {product-title} control plane machines, one per z/VM instance
-* At least 6 guest virtual machines for {product-title} compute machines, distributed across the z/VM instances
-* 1 guest virtual machine for the temporary {product-title} bootstrap machine
-* To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane using the CP command `SET SHARE`. Do the same for infrastructure plane machines if they exist. See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-set-share[SET SHARE] in IBM Documentation.
+* 3 guest virtual machines for {product-title} control plane machines, one per z/VM instance.
+* At least 6 guest virtual machines for {product-title} compute machines, distributed across the z/VM instances.
+* 1 guest virtual machine for the temporary {product-title} bootstrap machine.
+* To ensure the availability of integral components in an overcommitted environment, increase the priority of the control plane by using the CP command `SET SHARE`. Do the same for infrastructure nodes, if they exist. See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-set-share[SET SHARE] in IBM Documentation.
 
 [discrete]
 == IBM Z network connectivity requirements


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.6, 4.7, 4.8, 4.9, 4.10

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2020368
 
- Preview 
  - z/VM https://deploy-preview-38677--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#minimum-ibm-z-system-requirements_installing-ibm-z
  - KVM https://deploy-preview-38677--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#preferred-ibm-z-system-requirements_installing-ibm-z-kvm
- QE review: Holger Wolf