### PR TITLE
BZ: 2022273 - Add example for scheduling a result server pod on a worker node

### DIFF
--- a/modules/running-compliance-scans-worker-node.adoc
+++ b/modules/running-compliance-scans-worker-node.adoc
@@ -1,0 +1,88 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-scans.adoc
+
+[id="running-compliance-scans-worker-node_{context}"]
+=  Scheduling the result server pod on a worker node
+
+The result server pod mounts the persistent volume (PV) that stores the raw Asset Reporting Format (ARF) scan results. The `nodeSelector` and `tolerations` attributes enable you to configure the location of the result server pod.
+
+This is helpful for those environments where control plane nodes are not permitted to mount persistent volumes.
+
+.Procedure
+* Create a `ScanSetting` custom resource (CR) for the Compliance Operator:
+.. Define the `ScanSetting` CR, and save the YAML file, for example, `rs-workers.yaml`:
++
+[source,yaml]
+----
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSetting
+metadata:
+  name: rs-on-workers
+  namespace: openshift-compliance
+rawResultStorage:
+  nodeSelector:
+    node-role.kubernetes.io/worker: "" <1>
+  pvAccessModes:
+  - ReadWriteOnce 
+  rotation: 3
+  size: 1Gi
+  tolerations:
+  - operator: Exists <2>
+roles:
+- worker
+- master
+scanTolerations:
+  - operator: Exists
+schedule: 0 1 * * *
+----
+<1> The Compliance Operator uses this node to store scan results in ARF format.
+<2> The result server pod tolerates all taints.
+
+.. To create the `ScanSetting` CR, run the following command:
++
+[source,terminal]
+----
+$ oc create -f rs-workers.yaml
+----
+
+.Verification
+
+* To verify that the `ScanSetting` object is created, run the following command:
++
+[source,terminal]
+----
+$ oc get scansettings rs-on-workers -n openshift-compliance -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSetting
+metadata:
+  creationTimestamp: "2021-11-19T19:36:36Z"
+  generation: 1
+  name: rs-on-workers
+  namespace: openshift-compliance
+  resourceVersion: "48305"
+  uid: 43fdfc5f-15a7-445a-8bbc-0e4a160cd46e
+rawResultStorage:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  pvAccessModes:
+  - ReadWriteOnce
+  rotation: 3
+  size: 1Gi
+  tolerations:
+  - operator: Exists
+roles:
+- worker
+- master
+scanTolerations:
+- operator: Exists
+schedule: 0 1 * * *
+strictNodeScan: true
+----
+
+

--- a/security/compliance_operator/compliance-scans.adoc
+++ b/security/compliance_operator/compliance-scans.adoc
@@ -20,3 +20,4 @@ $ oc explain scansettingbindings
 ----
 
 include::modules/running-compliance-scans.adoc[leveloffset=+1]
+include::modules/running-compliance-scans-worker-node.adoc[leveloffset=+1]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2022273

Applies to versions 4.6+

Direct link to new example: 
https://deploy-preview-38680--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-scans.html#running-compliance-scans-worker-node_compliance-operator-scans