### PR TITLE
BZ#2002614 Add vSphere infra requirements to prep doc

### DIFF
--- a/installing/installing_vmc/preparing-to-install-on-vmc.adoc
+++ b/installing/installing_vmc/preparing-to-install-on-vmc.adoc
@@ -54,6 +54,8 @@ User-provisioned infrastructure requires the user to provision all resources req
 
 * **xref:../../installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc#installing-restricted-networks-vmc-user-infra[Installing a cluster on VMC in a restricted network with user-provisioned infrastructure]**: {product-title} can be installed on VMC infrastructure that you provision in a restricted network.
 
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+
 [id="method-to-uninstall-ocp-on-vmc"]
 == Uninstalling an installer-provisioned infrastructure installation of {product-title} on VMC
 

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -53,6 +53,8 @@ User-provisioned infrastructure requires the user to provision all resources req
 
 * **xref:../../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure]**: {product-title} can be installed on VMware vSphere infrastructure that you provision in a restricted network.
 
+include::modules/installation-vsphere-infrastructure.adoc[leveloffset=+1]
+
 == Uninstalling an installer-provisioned infrastructure installation of {product-title} on vSphere
 
 * **xref:../../installing/installing_vsphere/uninstalling-cluster-vsphere-installer-provisioned.adoc#uninstalling-cluster-vsphere-installer-provisioned[Uninstalling a cluster on vSphere that uses installer-provisioned infrastructure]**: You can remove a cluster that you deployed on VMware vSphere infrastructure that used installer-provisioned infrastructure.

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -7,6 +7,7 @@
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
 // * installing/installing_vmc/installing-restricted-networks-vmc.adoc
 // * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -14,6 +15,7 @@
 // * installing/installing_vmc/installing-vmc.adoc
 // * installing/installing_vmc/installing-vmc-customizations.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vmc/preparing-to-install-on-vmc.adoc
 
 ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :vmc:
@@ -34,6 +36,9 @@ ifeval::["{context}" == "installing-vmc-customizations"]
 :vmc:
 endif::[]
 ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "preparing-to-install-on-vmc"]
 :vmc:
 endif::[]
 
@@ -103,5 +108,8 @@ ifeval::["{context}" == "installing-vmc-customizations"]
 :!vmc:
 endif::[]
 ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "preparing-to-install-on-vmc"]
 :!vmc:
 endif::[]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2002614

This adds existing vSphere infra requirements information to the preparing assemblies.

Previews:
- vSphere: https://deploy-preview-38684--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html#installation-vsphere-infrastructure_preparing-to-install-on-vsphere
- VMC: https://deploy-preview-38684--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vmc/preparing-to-install-on-vmc.html#installation-vsphere-infrastructure_preparing-to-install-on-vmc