### PR TITLE
BZ2014246: Correcting command to upgrade clusterversion channel

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -121,7 +121,7 @@ A channel can be switched from the web console or through the `adm upgrade chann
 
 [source,terminal]
 ----
-$ oc adm upgrade channel clusterversion version --type json -p '[{"op": "add", "path": "/spec/channel", "value": "<channel>”}]'
+$ oc adm upgrade channel <channel>
 ----
 
 The web console will display an alert if you switch to a channel that does not include the current release. The web console does not recommend any updates while on a channel without the current release. You can return to the original channel at any point, however.


### PR DESCRIPTION
[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2014246)

- Applies to `main` and `enterprise-4.9`+
- [Preview link](https://deploy-preview-38686--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release#switching-between-channels_understanding-upgrade-channels-releases) (Switching between channels section)