### PR TITLE
OSDOCS-2972: [OSD] GCP requires new API to be enabled

### DIFF
--- a/modules/ccs-gcp-customer-procedure.adoc
+++ b/modules/ccs-gcp-customer-procedure.adoc
@@ -44,6 +44,9 @@ The project name must be 10 characters or less.
 |link:https://console.cloud.google.com/apis/library/dns.googleapis.com?project=openshift-gce-devel&folder=&organizationId=[Google DNS API]
 |`dns.googleapis.com`
 
+|link:https://console.cloud.google.com/apis/library/networksecurity.googleapis.com?project=openshift-gce-devel&folder=&organizationId=[Network Security API]
+|`networksecurity.googleapis.com`
+
 |link:https://console.cloud.google.com/apis/library/iamcredentials.googleapis.com[IAM Service Account Credentials API]
 |`iamcredentials.googleapis.com`
 


### PR DESCRIPTION
for dedicated-4

https://issues.redhat.com/browse/OSDOCS-2972

Preview: https://deploy-preview-38692--osdocs.netlify.app/openshift-dedicated/latest/osd_planning/gcp-ccs