### PR TITLE
Removing OSD references from the topic map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -24,7 +24,7 @@
 ---
 Name: About
 Dir: welcome
-Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-webscale,openshift-origin,openshift-online
 Topics:
 - Name: Welcome
   File: index
@@ -36,7 +36,7 @@ Topics:
   Distros: openshift-enterprise
 - Name: Legal notice
   File: legal-notice
-  Distros: openshift-enterprise,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-online
 ---
 Name: What's new?
 Dir: whats_new
@@ -46,36 +46,6 @@ Topics:
   File: new-features
 - Name: Deprecated features
   File: deprecated-features
----
-Name: Getting started
-Dir: getting_started
-Distros: openshift-dedicated
-Topics:
-- Name: Accessing your services
-  File: accessing-your-services
-- Name: Scaling your cluster
-  File: scaling-your-cluster
-- Name: Deleting your cluster
-  File: deleting-your-cluster
-- Name: Networking
-  File: dedicated-networking
----
-Name: Cloud infrastructure access
-Dir: cloud_infrastructure_access
-Distros: openshift-dedicated
-Topics:
-- Name: Understanding cloud infrastructure access
-  File: dedicated-understanding-aws
-- Name: Accessing AWS infrastructure
-  File: dedicated-aws-access
-- Name: Configuring AWS VPC peering
-  File: dedicated-aws-peering
-- Name: Configuring AWS VPN
-  File: dedicated-aws-vpn
-- Name: Configuring AWS Direct Connect
-  File: dedicated-aws-dc
-- Name: Configuring a private cluster
-  File: dedicated-aws-private-cluster
 ---
 Name: Release notes
 Dir: release_notes
@@ -88,7 +58,7 @@ Topics:
 ---
 Name: Architecture
 Dir: architecture
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Product architecture
   File: architecture
@@ -97,7 +67,7 @@ Topics:
   File: architecture-installation
 - Name: The control plane
   File: control-plane
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding OpenShift development
   File: understanding-development
   Distros: openshift-enterprise
@@ -113,15 +83,6 @@ Topics:
 - Name: Admission plug-ins
   File: admission-plug-ins
   Distros: openshift-enterprise,openshift-aro
----
-Name: Administering a cluster
-Dir: administering_a_cluster
-Distros: openshift-dedicated
-Topics:
-- Name: The dedicated-admin role
-  File: dedicated-admin-role
-- Name: The cluster-admin role
-  File: cluster-admin-role
 ---
 Name: Installing
 Dir: installing
@@ -436,7 +397,7 @@ Topics:
   Distros: openshift-origin,openshift-enterprise
 - Name: Support for FIPS cryptography
   File: installing-fips
-  Distros: openshift-enterprise,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-online
 ---
 Name: Post-installation configuration
 Dir: post_installation_configuration
@@ -493,14 +454,14 @@ Topics:
 ---
 Name: Support
 Dir: support
-Distros: openshift-enterprise,openshift-online,openshift-dedicated,openshift-origin
+Distros: openshift-enterprise,openshift-online,openshift-origin
 Topics:
 - Name: Getting support
   File: getting-support
-  Distros: openshift-enterprise,openshift-dedicated
+  Distros: openshift-enterprise
 - Name: Remote health monitoring with connected clusters
   Dir: remote_health_monitoring
-  Distros: openshift-enterprise,openshift-dedicated,openshift-origin
+  Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: About remote health monitoring
     File: about-remote-health-monitoring
@@ -522,7 +483,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Troubleshooting
   Dir: troubleshooting
-  Distros: openshift-enterprise,openshift-dedicated,openshift-origin
+  Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: Troubleshooting installations
     File: troubleshooting-installations
@@ -553,7 +514,7 @@ Topics:
 ---
 Name: Web console
 Dir: web_console
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Accessing the web console
   File: web-console
@@ -581,7 +542,7 @@ Topics:
 ---
 Name: CLI tools
 Dir: cli_reference
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: CLI tools overview
   File: index
@@ -604,7 +565,7 @@ Topics:
     File: usage-oc-kubectl
 - Name: Developer CLI (odo)
   Dir: developer_cli_odo
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
   Topics:
   - Name: odo release notes
     File: odo-release-notes
@@ -833,14 +794,11 @@ Topics:
 ---
 Name: Authentication and authorization
 Dir: authentication
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Understanding authentication
   File: understanding-authentication
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
-- Name: Understanding identity provider configuration
-  File: dedicated-understanding-authentication
-  Distros: openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Configuring the internal OAuth server
   File: configuring-internal-oauth
 - Name: Configuring OAuth clients
@@ -902,7 +860,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Syncing LDAP groups
   File: ldap-syncing
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Managing cloud provider credentials
   Dir: managing_cloud_provider_credentials
   Topics:
@@ -919,7 +877,7 @@ Topics:
 ---
 Name: Networking
 Dir: networking
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Understanding networking
   File: understanding-networking
@@ -930,7 +888,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Understanding the DNS Operator
   File: dns-operator
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
@@ -1161,17 +1119,17 @@ Topics:
 ---
 Name: Storage
 Dir: storage
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Storage overview
   File: index
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding ephemeral storage
   File: understanding-ephemeral-storage
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding persistent storage
   File: understanding-persistent-storage
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Configuring persistent storage
   Dir: persistent_storage
   Distros: openshift-enterprise,openshift-origin
@@ -1236,14 +1194,14 @@ Topics:
     File: persistent-storage-csi-vsphere
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Dynamic provisioning
   File: dynamic-provisioning
   Distros: openshift-enterprise,openshift-origin
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Overview
   File: architecture-component-imageregistry
@@ -1333,7 +1291,7 @@ Topics:
   Topics:
   - Name: Creating applications from installed Operators
     File: olm-creating-apps-from-installed-operators
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Installing Operators in your namespace
     File: olm-installing-operators-in-namespace
     Distros: openshift-enterprise,openshift-origin
@@ -1342,19 +1300,19 @@ Topics:
   Topics:
   - Name: Adding Operators to a cluster
     File: olm-adding-operators-to-cluster
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Upgrading installed Operators
     File: olm-upgrading-operators
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Deleting Operators from a cluster
     File: olm-deleting-operators-from-cluster
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Configuring proxy support
     File: olm-configuring-proxy-support
     Distros: openshift-enterprise,openshift-origin
   - Name: Viewing Operator status
     File: olm-status
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Managing Operator conditions
     File: olm-managing-operatorconditions
     Distros: openshift-origin,openshift-enterprise
@@ -1438,11 +1396,11 @@ Topics:
 ---
 Name: CI/CD
 Dir: cicd
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Builds
   Dir: builds
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
   Topics:
   - Name: Understanding image builds
     File: understanding-image-builds
@@ -1459,10 +1417,10 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Performing and configuring basic builds
     File: basic-build-operations
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+    Distros: openshift-enterprise,openshift-origin,openshift-online
   - Name: Triggering and modifying builds
     File: triggering-builds-build-hooks
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+    Distros: openshift-enterprise,openshift-origin,openshift-online
   - Name: Performing advanced builds
     File: advanced-build-operations
     Distros: openshift-enterprise,openshift-origin
@@ -1480,7 +1438,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
 - Name: Migrating from Jenkins to Tekton
   Dir: jenkins-tekton
   Distros: openshift-enterprise
@@ -1535,7 +1493,7 @@ Topics:
 ---
 Name: Images
 Dir: openshift_images
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Configuring the Cluster Samples Operator
   File: configuring-samples-operator
@@ -1673,7 +1631,7 @@ Topics:
   File: odc-editing-applications
 - Name: Working with quotas
   File: working-with-quotas
-  Distros: openshift-online,openshift-dedicated
+  Distros: openshift-online
 - Name: Pruning objects to reclaim resources
   File: pruning-objects
   Distros: openshift-origin,openshift-enterprise
@@ -1945,7 +1903,7 @@ Topics:
 ---
 Name: Logging
 Dir: logging
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Release notes
   File: cluster-logging-release-notes
@@ -1954,9 +1912,6 @@ Topics:
 - Name: Installing Logging
   File: cluster-logging-deploying
   Distros: openshift-enterprise,openshift-origin
-- Name: Installing the Logging and Elasticsearch Operators
-  File: dedicated-cluster-deploying
-  Distros: openshift-dedicated
 - Name: Configuring your Logging deployment
   Dir: config
   Distros: openshift-enterprise,openshift-origin
@@ -1986,10 +1941,6 @@ Topics:
 - Name: Viewing cluster logs in Kibana
   File: cluster-logging-visualizer
   Distros: openshift-enterprise,openshift-origin
-# TODO: This file doesn't exist anymore - update if necessary for dedicated
-# - Name: Viewing cluster logs using Kibana
-#   File: cluster-logging-kibana-interface
-#   Distros: openshift-dedicated
 - Name: Forwarding logs to third party systems
   File: cluster-logging-external
   Distros: openshift-enterprise,openshift-origin
@@ -2003,9 +1954,6 @@ Topics:
 #  Distros: openshift-enterprise,openshift-origin
 - Name: Updating Logging
   File: cluster-logging-upgrading
-- Name: Uninstalling Logging
-  File: cluster-logging-uninstall
-  Distros: openshift-dedicated
 - Name: Viewing cluster dashboards
   File: cluster-logging-dashboards
 - Name: Troubleshooting Logging


### PR DESCRIPTION
This applies to `main`, `enterprise-4.6`, `enterprise-4.7`, `enterprise-4.8`, `enterprise-4.9` and `enterprise-4.10`.

This pull request removes references to OpenShift Dedicated from the mainstream topic map. OpenShift Dedicated documentation content is not currently published from the mainstream branches. Instead, it uses the `dedicated-4` branch, which has its own topic map.

This PR is part of the migration preparation for the SD books.

The preview is [here](https://deploy-preview-38718--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html).