### PR TITLE
[enterprise-4.7] Removing OSD references from the topic map

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -24,7 +24,7 @@
 ---
 Name: About
 Dir: welcome
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Welcome
   File: index
@@ -46,36 +46,6 @@ Topics:
 - Name: Deprecated features
   File: deprecated-features
 ---
-Name: Getting started
-Dir: getting_started
-Distros: openshift-dedicated
-Topics:
-- Name: Accessing your services
-  File: accessing-your-services
-- Name: Scaling your cluster
-  File: scaling-your-cluster
-- Name: Deleting your cluster
-  File: deleting-your-cluster
-- Name: Networking
-  File: dedicated-networking
----
-Name: Cloud infrastructure access
-Dir: cloud_infrastructure_access
-Distros: openshift-dedicated
-Topics:
-- Name: Understanding cloud infrastructure access
-  File: dedicated-understanding-aws
-- Name: Accessing AWS infrastructure
-  File: dedicated-aws-access
-- Name: Configuring AWS VPC peering
-  File: dedicated-aws-peering
-- Name: Configuring AWS VPN
-  File: dedicated-aws-vpn
-- Name: Configuring AWS Direct Connect
-  File: dedicated-aws-dc
-- Name: Configuring a private cluster
-  File: dedicated-aws-private-cluster
----
 Name: Release notes
 Dir: release_notes
 Distros: openshift-enterprise
@@ -87,7 +57,7 @@ Topics:
 ---
 Name: Architecture
 Dir: architecture
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Product architecture
   File: architecture
@@ -96,7 +66,7 @@ Topics:
   File: architecture-installation
 - Name: The control plane
   File: control-plane
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding OpenShift development
   File: understanding-development
   Distros: openshift-enterprise
@@ -112,15 +82,6 @@ Topics:
 - Name: Admission plug-ins
   File: admission-plug-ins
   Distros: openshift-enterprise,openshift-aro
----
-Name: Administering a cluster
-Dir: administering_a_cluster
-Distros: openshift-dedicated
-Topics:
-- Name: The dedicated-admin role
-  File: dedicated-admin-role
-- Name: The cluster-admin role
-  File: cluster-admin-role
 ---
 Name: Installing
 Dir: installing
@@ -367,7 +328,7 @@ Topics:
   File: installing-troubleshooting
 - Name: Support for FIPS cryptography
   File: installing-fips
-  Distros: openshift-enterprise,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-online
 ---
 Name: Post-installation configuration
 Dir: post_installation_configuration
@@ -420,13 +381,13 @@ Topics:
 ---
 Name: Support
 Dir: support
-Distros: openshift-enterprise,openshift-online,openshift-dedicated,openshift-origin
+Distros: openshift-enterprise,openshift-online,openshift-origin
 Topics:
 - Name: Getting support
   File: getting-support
 - Name: Remote health monitoring with connected clusters
   Dir: remote_health_monitoring
-  Distros: openshift-enterprise,openshift-dedicated,openshift-origin
+  Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: About remote health monitoring
     File: about-remote-health-monitoring
@@ -446,7 +407,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Troubleshooting
   Dir: troubleshooting
-  Distros: openshift-enterprise,openshift-dedicated,openshift-origin
+  Distros: openshift-enterprise,openshift-origin
   Topics:
   - Name: Troubleshooting installations
     File: troubleshooting-installations
@@ -477,7 +438,7 @@ Topics:
 ---
 Name: Web console
 Dir: web_console
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Accessing the web console
   File: web-console
@@ -503,7 +464,7 @@ Topics:
 ---
 Name: CLI tools
 Dir: cli_reference
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: CLI tools overview
   File: index
@@ -526,7 +487,7 @@ Topics:
     File: usage-oc-kubectl
 - Name: Developer CLI (odo)
   Dir: developer_cli_odo
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
   Topics:
   - Name: odo release notes
     File: odo-release-notes
@@ -746,14 +707,11 @@ Topics:
 ---
 Name: Authentication and authorization
 Dir: authentication
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Understanding authentication
   File: understanding-authentication
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
-- Name: Understanding identity provider configuration
-  File: dedicated-understanding-authentication
-  Distros: openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Configuring the internal OAuth server
   File: configuring-internal-oauth
 - Name: Configuring OAuth clients
@@ -815,10 +773,10 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Syncing LDAP groups
   File: ldap-syncing
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Creating and using config maps
   File: configmaps
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Managing cloud provider credentials
   Dir: managing_cloud_provider_credentials
   Topics:
@@ -835,7 +793,7 @@ Topics:
 ---
 Name: Networking
 Dir: networking
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Understanding networking
   File: understanding-networking
@@ -846,7 +804,7 @@ Topics:
   Distros: openshift-enterprise,openshift-origin
 - Name: Understanding the DNS Operator
   File: dns-operator
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
@@ -1055,17 +1013,17 @@ Topics:
 ---
 Name: Storage
 Dir: storage
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Storage overview
   File: index
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding ephemeral storage
   File: understanding-ephemeral-storage
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Understanding persistent storage
   File: understanding-persistent-storage
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
 - Name: Configuring persistent storage
   Dir: persistent_storage
   Distros: openshift-enterprise,openshift-origin
@@ -1120,14 +1078,14 @@ Topics:
     File: persistent-storage-csi-ovirt
 - Name: Expanding persistent volumes
   File: expanding-persistent-volumes
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+  Distros: openshift-enterprise,openshift-origin
 - Name: Dynamic provisioning
   File: dynamic-provisioning
   Distros: openshift-enterprise,openshift-origin
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Overview
   File: architecture-component-imageregistry
@@ -1215,7 +1173,7 @@ Topics:
   Topics:
   - Name: Creating applications from installed Operators
     File: olm-creating-apps-from-installed-operators
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Installing Operators in your namespace
     File: olm-installing-operators-in-namespace
     Distros: openshift-enterprise,openshift-origin
@@ -1224,19 +1182,19 @@ Topics:
   Topics:
   - Name: Adding Operators to a cluster
     File: olm-adding-operators-to-cluster
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Upgrading installed Operators
     File: olm-upgrading-operators
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Deleting Operators from a cluster
     File: olm-deleting-operators-from-cluster
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Configuring proxy support
     File: olm-configuring-proxy-support
     Distros: openshift-enterprise,openshift-origin
   - Name: Viewing Operator status
     File: olm-status
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
   - Name: Managing Operator conditions
     File: olm-managing-operatorconditions
     Distros: openshift-origin,openshift-enterprise
@@ -1314,11 +1272,11 @@ Topics:
 ---
 Name: CI/CD
 Dir: cicd
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Builds
   Dir: builds
-  Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+  Distros: openshift-enterprise,openshift-origin,openshift-online
   Topics:
   - Name: Understanding image builds
     File: understanding-image-builds
@@ -1335,10 +1293,10 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Performing basic builds
     File: basic-build-operations
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+    Distros: openshift-enterprise,openshift-origin,openshift-online
   - Name: Triggering and modifying builds
     File: triggering-builds-build-hooks
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+    Distros: openshift-enterprise,openshift-origin,openshift-online
   - Name: Performing advanced builds
     File: advanced-build-operations
     Distros: openshift-enterprise,openshift-origin
@@ -1356,7 +1314,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Setting up additional trusted certificate authorities for builds
     File: setting-up-trusted-ca
-    Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+    Distros: openshift-enterprise,openshift-origin
 - Name: Pipelines
   Dir: pipelines
   Distros: openshift-enterprise
@@ -1399,7 +1357,7 @@ Topics:
 ---
 Name: Images
 Dir: openshift_images
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated,openshift-online
+Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: Configuring the Cluster Samples Operator
   File: configuring-samples-operator
@@ -1511,7 +1469,7 @@ Topics:
   File: application-health
 - Name: Working with quotas
   File: working-with-quotas
-  Distros: openshift-online,openshift-dedicated
+  Distros: openshift-online
 - Name: Idling applications
   File: idling-applications
   Distros: openshift-origin,openshift-enterprise
@@ -1753,7 +1711,7 @@ Topics:
 ---
 Name: Logging
 Dir: logging
-Distros: openshift-enterprise,openshift-origin,openshift-dedicated
+Distros: openshift-enterprise,openshift-origin
 Topics:
 - Name: Release notes
   File: cluster-logging-release-notes
@@ -1762,9 +1720,6 @@ Topics:
 - Name: Installing Logging
   File: cluster-logging-deploying
   Distros: openshift-enterprise,openshift-origin
-- Name: Installing the Logging and Elasticsearch Operators
-  File: dedicated-cluster-deploying
-  Distros: openshift-dedicated
 - Name: Configuring your Logging deployment
   Dir: config
   Distros: openshift-enterprise,openshift-origin
@@ -1794,10 +1749,6 @@ Topics:
 - Name: Viewing cluster logs in Kibana
   File: cluster-logging-visualizer
   Distros: openshift-enterprise,openshift-origin
-# TODO: This file doesn't exist anymore - update if necessary for dedicated
-# - Name: Viewing cluster logs using Kibana
-#   File: cluster-logging-kibana-interface
-#   Distros: openshift-dedicated
 - Name: Forwarding logs to third party systems
   File: cluster-logging-external
   Distros: openshift-enterprise,openshift-origin
@@ -1811,9 +1762,6 @@ Topics:
 #  Distros: openshift-enterprise,openshift-origin
 - Name: Updating Logging
   File: cluster-logging-upgrading
-- Name: Uninstalling Logging
-  File: cluster-logging-uninstall
-  Distros: openshift-dedicated
 - Name: Viewing cluster dashboards
   File: cluster-logging-dashboards
 - Name: Troubleshooting Logging


### PR DESCRIPTION
Cherry picked from 27ee6ecbc9688a45358ad2d0c960075b731f955f xref: https://github.com/openshift/openshift-docs/pull/38718