### PR TITLE
BZ1954146: add labels to namespace while using egress with ovn

### DIFF
--- a/modules/nw-egress-ips-assign.adoc
+++ b/modules/nw-egress-ips-assign.adoc
@@ -17,7 +17,7 @@ You can assign one or more egress IP addresses to a namespace or to specific pod
 
 . Create an `EgressIP` object:
 .. Create a `<egressips_name>.yaml` file where `<egressips_name>` is the name of the object.
-.. In the file that you created, define an `EgressIPs` object, as in the following example:
+.. In the file that you created, define an `EgressIP` object, as in the following example:
 +
 [source,yaml]
 ----
@@ -49,3 +49,10 @@ egressips.k8s.ovn.org/<egressips_name> created
 ----
 
 . Optional: Save the `<egressips_name>.yaml` file so that you can make changes later.
+. Add labels to the namespace that requires egress IP addresses. To add a label to the namespace of an `EgressIP` object defined in step 1, run the following command:
++
+[source,terminal]
+----
+$ oc label ns <namespace> env=qa <1>
+----
+<1> Replace `<namespace>` with the namespace that requires egress IP addresses.


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?=1954146

[Docs preview link](https://deploy-preview-38738--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn)

Requires ack from @huiran0826 