### PR TITLE
Added notes for release 4.7.37

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -2971,3 +2971,19 @@ link:https://access.redhat.com/solutions/6454791[{product-title} 4.7.36 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-37"]
+=== RHBA-2021:4572 - {product-title} 4.7.37 bug fix update
+
+Issued: 2021-11-17
+
+{product-title} release 4.7.37 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4572[RHBA-2021:4572] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4570[RHBA-2021:4570] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6513261[{product-title} 4.7.37 container image list]
+
+[id="ocp-4-7-37-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.7.37.

Applies only to `enterprise-4.7`

Preview: https://deploy-preview-38739--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-37