### PR TITLE
Update helm repo to reference documentation

### DIFF
--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -22,7 +22,7 @@ To install Collector on systems configured with Unified Extensible Firmware Inte
 [source,terminal]
 ----
 $ helm install -n stackrox --create-namespace \
-    stackrox-secured-cluster-services stackrox/secured-cluster-services \
+    stackrox-secured-cluster-services rhacs/secured-cluster-services \
     -f <path_to_cluster_init_bundle.yaml> \ <1>
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <2>

--- a/modules/change-config-options-after-deployment-central-service.adoc
+++ b/modules/change-config-options-after-deployment-central-service.adoc
@@ -15,7 +15,7 @@ You can make changes to any configuration options after you have deployed the `c
 [source,terminal]
 ----
 $ helm upgrade -n stackrox \
-  stackrox-central-services stackrox/central-services \
+  stackrox-central-services rhacs/central-services \
   -f <path_to_values_public.yaml> \
   -f <path_to_values_private.yaml>
 ----

--- a/modules/change-config-options-after-deployment.adoc
+++ b/modules/change-config-options-after-deployment.adoc
@@ -15,7 +15,7 @@ You can make changes to any configuration options after you have deployed the `s
 [source,terminal]
 ----
 $ helm upgrade -n stackrox \
-  stackrox-secured-cluster-services stackrox/secured-cluster-services \
+  stackrox-secured-cluster-services rhacs/secured-cluster-services \
   --reuse-values \ <1>
   -f <path_to_values_public.yaml> \
   -f <path_to_values_private.yaml>

--- a/modules/install-central-services-helm-chart.adoc
+++ b/modules/install-central-services-helm-chart.adoc
@@ -14,7 +14,7 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 [source,terminal]
 ----
 $ helm install -n stackrox --create-namespace \
-  stackrox-central-services stackrox/central-services \
+  stackrox-central-services rhacs/central-services \
   -f <path_to_values_public.yaml> -f <path_to_values_private.yaml> <1>
 ----
 <1> Use the `-f` option to specify the paths for your YAML configuration files.


### PR DESCRIPTION
This PR addresses a consistency issue with the documentation where the older version of the helm repo is referenced. Because we modified how we instruct users to store helm on their local workstation and changed this repo to rhacs we now need to use that reference throughout the documentation. This PR addresses all remaining call outs referencing the old repo.