### PR TITLE
OSDOCS-2888: Adding list of supported OIDC providers

### DIFF
--- a/authentication/identity_providers/configuring-oidc-identity-provider.adoc
+++ b/authentication/identity_providers/configuring-oidc-identity-provider.adoc
@@ -85,6 +85,10 @@ ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 include::modules/identity-provider-overview.adoc[leveloffset=+1]
 endif::openshift-origin,openshift-enterprise,openshift-webscale[]
 
+ifdef::openshift-enterprise[]
+include::modules/identity-provider-oidc-supported.adoc[leveloffset=+1]
+endif::openshift-enterprise[]
+
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 include::modules/identity-provider-secret.adoc[leveloffset=+1]
 

--- a/modules/identity-provider-oidc-supported.adoc
+++ b/modules/identity-provider-oidc-supported.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+//
+// * authentication/identity_providers/configuring-oidc-identity-provider.adoc
+
+[id="identity-provider-oidc-supported_{context}"]
+= Supported OIDC providers
+
+The following OpenID Connect (OIDC) providers are tested and supported with {product-title}:
+
+* GitLab
+* Google
+* Keycloak
+* Okta
+* Ping Identity
+* Red Hat Single Sign-On


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2888

Preview: https://deploy-preview-38743--osdocs.netlify.app/openshift-enterprise/latest/authentication/identity_providers/configuring-oidc-identity-provider#identity-provider-oidc-supported_configuring-oidc-identity-provider