### PR TITLE
[enterprise-4.6] RHDEVDOCS-3428 - Replaced instances of 8Gi req mem with 16Gi.

### DIFF
--- a/modules/cluster-logging-about-crd.adoc
+++ b/modules/cluster-logging-about-crd.adoc
@@ -40,8 +40,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       resources:
-        request:
-          memory: 8G
+        limits:
+          memory: "16Gi"
+        requests:
+          memory: "16Gi"
       proxy:
         resources:
           limits:

--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -305,9 +305,10 @@ spec:
       redundancyPolicy: "SingleRedundancy"
       nodeSelector:
         node-role.kubernetes.io/worker: ""
-      resources:
-        request:
-          memory: 8G
+        limits:
+          memory: "16Gi"
+        requests:
+          memory: "16Gi"
   visualization:
     type: "kibana"
     kibana:
@@ -354,8 +355,10 @@ spec:
         storageClassName: "<storage-class-name>" <6>
         size: 200G
       resources: <7>
+        limits:
+          memory: "16Gi"
         requests:
-          memory: "8Gi"
+          memory: "16Gi"
       proxy: <8>
         resources:
           limits:
@@ -382,8 +385,8 @@ However, an unmanaged deployment does not receive updates until cluster logging 
 <3> Settings for configuring Elasticsearch. Using the custom resource (CR), you can configure shard replication policy and persistent storage.
 <4> Specify the length of time that Elasticsearch should retain each log source. Enter an integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s). For example, `7d` for seven days. Logs older than the `maxAge` are deleted. You must specify a retention policy for each log source or the Elasticsearch indices will not be created for that source.
 <5> Specify the number of Elasticsearch nodes. See the note that follows this list.
-<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys cluster logging with ephemeral storage only.
-<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are  `16G` for the memory request and `1` for the CPU request.
+<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys OpenShift Logging with ephemeral storage only.
+<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that are sufficient for most deployments. The default values are `16Gi` for the memory request and `1` for the CPU request.
 <8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are  `256Mi` for the memory request and `100m` for the CPU request.
 <9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana pods. For more information, see *Configuring the log visualizer*.
 <10> Settings for configuring the Curator schedule. Curator is used to remove data that is in the Elasticsearch index format prior to {product-title} 4.5 and will be removed in a later release.

--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -154,8 +154,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       resources:
+        limits:
+          memory: "16Gi"
         request:
-          memory: 8G
+          memory: "16Gi"
   visualization:
     type: "kibana"
     kibana:
@@ -202,14 +204,16 @@ spec:
         storageClassName: "<storage-class-name>" <6>
         size: 200G
       resources: <7>
-        requests:
-          memory: "8Gi"
+          limits:
+            memory: "16Gi"
+          requests:
+            memory: "16Gi"
       proxy: <8>
         resources:
           limits:
             memory: 256Mi
           requests:
-             memory: 256Mi
+            memory: 256Mi
       redundancyPolicy: "SingleRedundancy"
   visualization:
     type: "kibana"  <9>
@@ -230,8 +234,8 @@ However, an unmanaged deployment does not receive updates until the cluster logg
 <3> Settings for configuring Elasticsearch. Using the CR, you can configure shard replication policy and persistent storage.
 <4> Specify the length of time that Elasticsearch should retain each log source. Enter an integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s). For example, `7d` for seven days. Logs older than the `maxAge` are deleted. You must specify a retention policy for each log source or the Elasticsearch indices will not be created for that source.
 <5> Specify the number of Elasticsearch nodes. See the note that follows this list.
-<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys cluster logging with ephemeral storage only.
-<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `16G` for the memory request and `1` for the CPU request.
+<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, OpenShift Logging uses ephemeral storage.
+<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `16Gi` for the memory request and `1` for the CPU request.
 <8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are `256Mi` for the memory request and `100m` for the CPU request.
 <9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana nodes. For more information, see *Configuring the log visualizer*.
 <10> Settings for configuring the Curator schedule. Curator is used to remove data that is in the Elasticsearch index format prior to {product-title} 4.5 and will be removed in a later release.

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -23,7 +23,7 @@ Your OpenShift Dedicated cluster includes 600 GiB of persistent storage that is
 exclusively available for deploying Elasticsearch for cluster logging.
 
 Elasticsearch is a memory-intensive application. Each Elasticsearch node needs
-8G of memory for both memory requests and limits. Each Elasticsearch node can
+16Gi of memory for both memory requests and limits. Each Elasticsearch node can
 operate with a lower memory setting, though this is not recommended for
 production deployments.
 
@@ -97,8 +97,10 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/worker: ""
       resources:
+        limits:
+          memory: "16Gi"
         requests:
-          memory: 8G
+          memory: "16Gi"
   visualization:
     type: "kibana"
     kibana:

--- a/modules/images-create-metadata-define.adoc
+++ b/modules/images-create-metadata-define.adoc
@@ -75,7 +75,7 @@ exceed their user quota. The values must be compatible with
 Kubernetes quantity.
 
 ----
-LABEL io.openshift.min-memory 8Gi
+LABEL io.openshift.min-memory 16Gi
 LABEL io.openshift.min-cpu     4
 ----
 

--- a/modules/images-create-metadata.adoc
+++ b/modules/images-create-metadata.adoc
@@ -56,7 +56,7 @@ LABEL io.openshift.non-scalable     true
 |This label suggests how much resources the container image needs to work properly. The UI can warn the user that deploying this container image may exceed their user quota. The values must be compatible with Kubernetes quantity.
 
 ----
-LABEL io.openshift.min-memory 8Gi
+LABEL io.openshift.min-memory 16Gi
 LABEL io.openshift.min-cpu     4
 ----
 


### PR DESCRIPTION
Cherry picked from fd53b69a53d2ea96d35a71d36da6c5de54ecbdf7 xref: https://github.com/openshift/openshift-docs/pull/38211