### PR TITLE
[RHACS] Added a note about proxy configuration for Helm and Operator

### DIFF
--- a/installing/install-ocp-operator.adoc
+++ b/installing/install-ocp-operator.adoc
@@ -36,6 +36,10 @@ include::modules/install-acs-operator.adoc[leveloffset=+1]
 
 include::modules/install-central-operator.adoc[leveloffset=+1]
 
+[role="additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.9/networking/enable-cluster-wide-proxy.html[Configuring the cluster-wide proxy ]
+
 include::modules/verify-central-install-operator.adoc[leveloffset=+1]
 
 include::modules/central-configuration-options-operator.adoc[leveloffset=+1]

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -38,6 +38,22 @@ $ helm install -n stackrox \
   --set imagePullSecrets.allowNone=true
 ----
 
+[IMPORTANT]
+====
+If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter. For example:
+
+[source,yaml]
+----
+env:
+  proxyConfig: |
+    url: http://proxy.name:port
+    username: username
+    password: password
+    excludes:
+    - some.domain
+----
+====
+
 The output of the installation command includes:
 
 * An automatically generated administrator password.

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -31,3 +31,8 @@ When you install {product-title} for the first time, you must first install the 
 . Enter a name for your `Central` custom resource and add any labels you want to apply. Otherwise, accept the default values for the available options.
 //Add a link for customization options
 . Click *Create*.
+
+[NOTE]
+====
+If you are using the cluster-wide proxy, {product-title} uses that proxy configuration to connect to the external services.
+====


### PR DESCRIPTION
For  https://issues.redhat.com/browse/OSDOCS-2749

Preview:
- Operator: https://deploy-preview-38778--osdocs.netlify.app/openshift-acs/latest/installing/install-ocp-operator.html#install-central-operator_install-ocp-operator
- Helm: https://deploy-preview-38778--osdocs.netlify.app/openshift-acs/latest/installing/installing_helm/install-helm-quick.html#installing-quickly_acs-install-helm-quick

Applies to:
- 3.65
- 3.66
- 3.67

<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.

