### PR TITLE
SRVOCF-366: Updates to docs on using functions with the default registry

### DIFF
--- a/modules/serverless-functions-using-integrated-registry.adoc
+++ b/modules/serverless-functions-using-integrated-registry.adoc
@@ -9,18 +9,18 @@ When building and deploying functions, the resulting container image is stored i
 
 .Procedure
 
-* Run the `kn func build` command, or the `kn func deploy` command, with the OpenShift Container Registry specified for the `-r` parameter:
+* Run the `kn func build` command, or the `kn func deploy` command, with the OpenShift Container Registry and the namespace specified for the `-r` parameter:
 +
 .Example build command
 [source,terminal]
 ----
-$ kn func build -r $(oc get route -n openshift-image-registry)
+$ kn func build -r $(oc get route -n openshift-image-registry)/my-namespace
 ----
 +
 .Example deploy command
 [source,terminal]
 ----
-$ kn func deploy -r $(oc get route -n openshift-image-registry)
+$ kn func deploy -r $(oc get route -n openshift-image-registry)/my-namespace
 ----
 +
 You can verify that the function deployed successfully by emitting a test event to it.

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -20,6 +20,11 @@ include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-functions-using-integrated-registry.adoc[leveloffset=+1]
+
+== Additional resources
+
+* See xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually].
+
 include::modules/serverless-kn-func-emit.adoc[leveloffset=+1]
 
 [id="next-steps_serverless-functions-getting-started"]


### PR DESCRIPTION
For versions 4.6+
Jira: https://issues.redhat.com/browse/SRVOCF-366
Docs preview: https://deploy-preview-38796--osdocs.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#serverless-functions-using-integrated-registry_serverless-functions-getting-started