### PR TITLE
Default SCC clarifications

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -9,7 +9,8 @@ Similar to the way that RBAC resources control user access, administrators can u
 
 Security context constraints allow an administrator to control:
 
-* Whether a pod can run privileged containers
+* Whether a pod can run privileged containers (allowPrivilegedContainer)
+* Whether a pod is constrained by with no_new_privs (allowPrivilegeEscalation)
 * The capabilities that a container can request
 * The use of host directories as volumes
 * The SELinux context of the container
@@ -105,11 +106,11 @@ The `privileged` SCC allows:
 
 [NOTE]
 ====
-Setting `privileged: true` in the pod specification does not select the `privileged` SCC. Setting `privileged: true` in the pod specification matches on the `allowPrivilegedContainer` field of an SCC.
+Setting `privileged: true` in the pod specification does not select the `privileged` SCC. However, setting `privileged: true` in the pod specification causes only those SCCs that have a match on their `allowPrivilegedContainer` field to be considered, of which the privileged SCC is one.
 ====
 
 |`restricted`
-|Denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
+|Denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive default SCC and it is used by default for authenticated users.
 
 The `restricted` SCC:
 
@@ -119,6 +120,16 @@ The `restricted` SCC:
 * Requires that a pod is run with a pre-allocated MCS label
 * Allows pods to use any FSGroup
 * Allows pods to use any supplemental group
+
+[NOTE]
+====
+The `restricted` SCC still configures `allowPrivilegeEscalation: true`, which disables the "no_new_privs" protection.  If you wish to prevent this in your cluster you may create a custom SCC with the flag disabled and configure appropriate users to only have access to this new SCC in place of `restricted`.
+
+See https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html for more details on the flag.
+
+====
+
+
 
 |===
 

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -52,7 +52,7 @@ endif::[]
 
 [WARNING]
 ====
-This SCC allows host access to namespaces, file systems, and PIDS. It should only be used by trusted pods. Grant with caution.
+This SCC allows host access to namespaces, file systems, and PIDs. It should only be used by trusted pods. Grant with caution.
 ====
 
 |`hostmount-anyuid`


### PR DESCRIPTION
This PR contains two suggested improvements:

1/ A simple typo fix (PIDS to PIDs)

2/ A clarification on the fact that "restricted" is not the most restrictive SCC that can exist, and it still contains "allowPrivilegeEscalation".  This is easily confused with "allowPrivilegedContainer" so the additional text may help with understanding how each option differs.

