### PR TITLE
BZ-2004124: Adding details on configuring descheduler settings in the UI

### DIFF
--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -43,9 +43,9 @@ spec:
   - EvictPodsWithLocalStorage
   - EvictPodsWithPVC
 ----
-<1> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `ns`, `us`, `ms`, `s`, `m`, or `h`. The default pod lifetime is 24 hours.
+<1> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
 <2> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
-<3> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates` because they will conflict with each other.
+<3> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
 +
 You can enable multiple profiles; the order that the profiles are specified in is not important.
 

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -33,7 +33,15 @@ endif::[]
 . Create a descheduler instance.
 .. From the *Operators* -> *Installed Operators* page, click the *Kube Descheduler Operator*.
 .. Select the *Kube Descheduler* tab and click *Create KubeDescheduler*.
-.. Edit the settings as necessary. You can configure the descheduler profiles and customizations now or after it has been created.
+.. Edit the settings as necessary.
+... Expand the *Profiles* section to select one or more profiles to enable. The `AffinityAndTaints` profile is enabled by default. Click *Add Profile* to select additional profiles.
++
+[NOTE]
+====
+Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
+====
+... Optional: Expand the *Profile Customizations* section to set a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
+... Optional: Use the *Descheduling Interval Seconds* field to change the number of seconds between descheduler runs. The default is `3600` seconds.
 .. Click *Create*.
 
-You can now configure the profiles for the descheduler. If you did not adjust the profiles when creating the descheduler instance from the web console, the `AffinityAndTaints` profile is enabled by default.
+You can also configure the profiles and settings for the descheduler later using the OpenShift CLI (`oc`). If you did not adjust the profiles when creating the descheduler instance from the web console, the `AffinityAndTaints` profile is enabled by default.

--- a/modules/nodes-descheduler-profiles.adoc
+++ b/modules/nodes-descheduler-profiles.adoc
@@ -46,7 +46,7 @@ By default, pods that are older than 24 hours are removed. You can customize the
 +
 [NOTE]
 ====
-Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates` because they will conflict with each other.
+Do not enable both `SoftTopologyAndDuplicates` and `TopologyAndDuplicates`. Enabling both results in a conflict.
 ====
 
 `EvictPodsWithLocalStorage`:: This profile allows pods with local storage to be eligible for eviction.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2004124

This PR is for 4.9 and 4.10 only. If we want to cherry pick this back to earlier releases, will have to adjust the content some.

Preview: https://deploy-preview-38813--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler#nodes-descheduler-installing_nodes-descheduler