### PR TITLE
BZ2003722: Add bare metal as platform for SR-IOV Network Operator

### DIFF
--- a/modules/nw-sriov-supported-platforms.adoc
+++ b/modules/nw-sriov-supported-platforms.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/about-sriov.adoc
+
+[id="nw-sriov-supported-platforms_{context}"]
+= Supported platforms
+
+The SR-IOV Network Operator is supported on the following platforms:
+
+- Bare metal
+- {rh-openstack-first}

--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -15,7 +15,7 @@ The SR-IOV network device driver for the device determines how the VF is exposed
 * `netdevice` driver: A regular kernel network device in the `netns` of the container
 * `vfio-pci` driver: A character device mounted in the container
 
-You can use SR-IOV network devices with additional networks on your {product-title} cluster for application that require high bandwidth or low latency.
+You can use SR-IOV network devices with additional networks on your {product-title} cluster installed on bare metal or {rh-openstack-first} infrastructure for applications that require high bandwidth or low latency.
 
 [id="components-sr-iov-network-devices"]
 == Components that manage SR-IOV network devices
@@ -54,6 +54,7 @@ A CNI plug-in that attaches InfiniBand (IB) VF interfaces allocated from the SR-
 The SR-IOV Network resources injector and SR-IOV Network Operator webhook are enabled by default and can be disabled by editing the `default` `SriovOperatorConfig` CR.
 ====
 
+include::modules/nw-sriov-supported-platforms.adoc[leveloffset=+2]
 include::modules/nw-sriov-supported-devices.adoc[leveloffset=+2]
 include::modules/nw-sriov-device-discovery.adoc[leveloffset=+2]
 include::modules/nw-sriov-example-vf-function-in-pod.adoc[leveloffset=+2]


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=2003722

@zshi-redhat, is this limited to installer-provisioned or user-provisioned bare metal or does it work with both?

Thanks!