### PR TITLE
RHDEVDOCS-3365 - Add cluster logging supported versions table.

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -10,47 +10,21 @@ toc::[]
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
 
-[id="openshift-logging-about-this-release-5-1"]
-
-== Red Hat OpenShift Logging 5.1
-
-.Supported versions
-
-OpenShift Logging 5.1 runs on {product-title} 4.7 and 4.8.
-
-.Advisories
-
-The following advisories are available for OpenShift Logging 5.1.x:
-
-* link:https://access.redhat.com/errata/RHBA-2021:3545[RHBA-2021:3545 - Bug Fix Advisory. Openshift Logging Bug Fix Release 5.1.2]
-* link:https://access.redhat.com/errata/RHBA-2021:2885[RHBA-2021:2885 - Bug Fix Advisory. Openshift Logging Bug Fix Release 5.1.1]
-* link:https://access.redhat.com/errata/RHBA-2021:2112[RHBA-2021:2112 - Bug Fix Advisory. OpenShift Logging Bug Fix Release 5.1.0]
+[id="openshift-supported-versions-table"]
+== Supported Versions
+.{product-title} version support for Red Hat OpenShift Logging (RHOL)
+[options="header"]
+|====
+|OpenShift       |4.7          |4.8          |4.9
+|RHOL 5.0|X            |X            |
+|RHOL 5.1|X            |X            |
+|RHOL 5.2|X            |X            |X
+|RHOL 5.3|             |             |X
+|====
 
 // Release Notes by version
+
 include::modules/cluster-logging-release-notes-5.1.0.adoc[leveloffset=+2]
-
-[id="cluster-logging-release-notes-5-0"]
-== Red Hat OpenShift Logging 5.0
-
-.Supported versions
-
-OpenShift Logging 5.0 runs on {product-title} 4.7.
-
-.Advisories
-
-The following advisories are available for OpenShift Logging 5.0.x:
-
-* link:https://access.redhat.com/errata/RHBA-2021:3705[RHBA-2021:3705 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.9)]
-* link:https://access.redhat.com/errata/RHBA-2021:3526[RHBA-2021:3526 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.8)]
-* link:https://access.redhat.com/errata/RHBA-2021:2884[RHBA-2021:2884 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.7)]
-* link:https://access.redhat.com/errata/RHBA-2021:2655[RHBA-2021:2655 - Bug Fix Advisory. Openshift Logging Bug Fix Release (5.0.6)]
-* link:https://access.redhat.com/errata/RHSA-2021:2374[RHSA-2021:2374 - Security Advisory. Moderate: Openshift Logging Bug Fix Release (5.0.5)]
-* link:https://access.redhat.com/errata/RHSA-2021:2136[RHSA-2021:2136 - Security Advisory. Moderate: Openshift Logging security and bugs update (5.0.4)]
-* link:https://access.redhat.com/errata/RHSA-2021:1515[RHSA-2021:1515 - Security Advisory. Important OpenShift Logging Bug Fix Release (5.0.3)]
-* link:https://access.redhat.com/errata/RHBA-2021:1167[RHBA-2021:1167 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.2)]
-* link:https://access.redhat.com/errata/RHBA-2021:0963[RHBA-2021:0963 - Bug Fix Advisory. OpenShift Logging Bug Fix Release (5.0.1)]
-* link:https://access.redhat.com/errata/RHBA-2021:0652[RHBA-2021:0652 - Bug Fix Advisory. Errata Advisory for Openshift Logging 5.0.0]
-
 include::modules/cluster-logging-release-notes-5.0.9.adoc[leveloffset=+2]
 include::modules/cluster-logging-release-notes-5.0.8.adoc[leveloffset=+2]
 include::modules/cluster-logging-release-notes-5.0.7.adoc[leveloffset=+2]


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: enterprise-4.7, 4.8
- https://issues.redhat.com/browse/RHDEVDOCS-3365
- Direct link to doc preview: : https://deploy-preview-38824--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes
- SME review: @alanconway 
- QE review: @anpingli 
- Peer review: @Srivaralakshmi 
- Please merge