### PR TITLE
Added guidance to avoid nested assemblies

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -257,6 +257,8 @@ The following examples include IDs that are unique to the "Configuring alert not
 == Writing assemblies
 An _assembly_ is a collection of modules that describes how to accomplish a user story.
 
+Avoid link:https://redhat-documentation.github.io/modular-docs/#nesting-assemblies[nesting assemblies] in other assembly files. You can create more complicated document structures by modifying the link:https://github.com/openshift/openshift-docs/tree/main/_topic_maps[topic maps].
+
 For more information about forming assemblies, see the
 link:https://redhat-documentation.github.io/modular-docs/#forming-assemblies[Red Hat modular docs reference guide] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_ASSEMBLY_a-collection-of-modules.adoc[assembly template].
 


### PR DESCRIPTION
Added guidance about nested assemblies in OpenShift documentation.

Avoiding nested assemblies is a _de facto_ rule in our doc set, probably because we put much of the structural work into the _topic_map.yml file.

But for outside contributors, or anyone else looking to the [Modular Documentation Reference Guide](https://redhat-documentation.github.io/modular-docs/#nesting-assemblies) for guidance, this is not clear.

Preview: https://github.com/ctauchen/openshift-docs/blob/no-nested-assemblies/contributing_to_docs/doc_guidelines.adoc#writing-assemblies