### PR TITLE
Updated taints built list

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -125,12 +125,17 @@ The following taints are built into {product-title}:
 
 * `node.kubernetes.io/not-ready`: The node is not ready. This corresponds to the node condition `Ready=False`.
 * `node.kubernetes.io/unreachable`: The node is unreachable from the node controller. This corresponds to the node condition `Ready=Unknown`.
-* `node.kubernetes.io/out-of-disk`: The node has insufficient free space on the node for adding new pods. This corresponds to the node condition `OutOfDisk=True`.
 * `node.kubernetes.io/memory-pressure`: The node has memory pressure issues. This corresponds to the node condition `MemoryPressure=True`.
 * `node.kubernetes.io/disk-pressure`: The node has disk pressure issues. This corresponds to the node condition `DiskPressure=True`.
 * `node.kubernetes.io/network-unavailable`: The node network is unavailable.
 * `node.kubernetes.io/unschedulable`: The node is unschedulable.
 * `node.cloudprovider.kubernetes.io/uninitialized`: When the node controller is started with an external cloud provider, this taint is set on a node to mark it as unusable. After a controller from the cloud-controller-manager initializes this node, the kubelet removes this taint.
+* `node.kubernetes.io/pid-pressure`: The node has pid pressure. This corresponds to the node condition `PIDPressure=True`.
++
+[IMPORTANT]
+====
+{product-title} does not set a default pid.available `evictionHard`.
+====
 
 
 [id="nodes-scheduler-taints-tolerations-about-seconds_{context}"]
@@ -227,7 +232,6 @@ To ensure backward compatibility, the daemon set controller automatically adds t
 
 * node.kubernetes.io/memory-pressure
 * node.kubernetes.io/disk-pressure
-* node.kubernetes.io/out-of-disk (only for critical pods)
 * node.kubernetes.io/unschedulable (1.10 or later)
 * node.kubernetes.io/network-unavailable (host network only)
 


### PR DESCRIPTION
Added `node.kubernetes.io/pid-pressure` and removed `node.kubernetes.io/out-of-disk` from the OCP taint list.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1978533

OCP Version: 4.6+

Direct doc preview link: https://deploy-preview-38837--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations

@rphillips @sunilcio PTAL