### PR TITLE
BZ:2022019 - Updating note for RHEL 8 compute node

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -9,7 +9,7 @@ After you update your cluster, you must update the {op-system-base-full} compute
 
 [IMPORTANT]
 ====
-Because only {op-system-base-full} version 7.9 or later is supported for worker (compute) machines, you must not upgrade the {op-system-base} worker machines to version 8.
+{op-system-base-full} version 7.9 and version 8.4 is supported for {op-system-base} worker (compute) machines.
 ====
 
 You can also update your compute machines to another minor version of {product-title} if you are using {op-system-base} as the operating system. You do not need to exclude any RPM packages from {op-system-base} when performing a minor version update.


### PR DESCRIPTION
For Version 4.9
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2022019

Preview: https://deploy-preview-38860--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-rhel-compute#rhel-compute-updating-minor_updating-cluster-rhel-compute

For peer reviewers: labels needed 'enterprise-4.9' Thank you!