### PR TITLE
BZ#2021461: MetalLB Operator install errors

### DIFF
--- a/modules/nw-metallb-installing-operator-cli.adoc
+++ b/modules/nw-metallb-installing-operator-cli.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
 [id="nw-metallb-installing-operator-cli_{context}"]
 = Installing from OperatorHub using the CLI
 
@@ -22,7 +26,7 @@ $ oc get packagemanifests -n openshift-marketplace metallb-operator
 [source,terminal]
 ----
 NAME               CATALOG                AGE
-metallb-operator   Community Operators    9h
+metallb-operator   Red Hat Operators      9h
 ----
 
 . Create the `metallb-system` namespace:
@@ -67,20 +71,6 @@ NAME               AGE
 metallb-operator   14m
 ----
 
-. Confirm the install plan is in the namespace:
-+
-[source,terminal]
-----
-$ oc get installplan -n metallb-system
-----
-+
-.Example output
-[source,terminal]
-----
-NAME            CSV                                   APPROVAL    APPROVED
-install-wzg94   metallb-operator.4.9.0-nnnnnnnnnnnn   Automatic   true
-----
-
 . Subscribe to the MetalLB Operator.
 
 .. Run the following command to get the {product-title} major and minor version. You use the values to set the `channel` value in the next
@@ -105,9 +95,23 @@ metadata:
 spec:
   channel: "${OC_VERSION}"
   name: metallb-operator
-  source: community-operators
+  source: redhat-operators
   sourceNamespace: openshift-marketplace
 EOF
+----
+
+. Confirm the install plan is in the namespace:
++
+[source,terminal]
+----
+$ oc get installplan -n metallb-system
+----
++
+.Example output
+[source,terminal]
+----
+NAME            CSV                                   APPROVAL    APPROVED
+install-wzg94   metallb-operator.4.9.0-nnnnnnnnnnnn   Automatic   true
 ----
 
 . To verify that the Operator is installed, enter the following command:
@@ -124,3 +128,4 @@ $ oc get clusterserviceversion -n metallb-system \
 Name                                  Phase
 metallb-operator.4.9.0-nnnnnnnnnnnn   Succeeded
 ----
+

--- a/modules/nw-metallb-operator-initial-config.adoc
+++ b/modules/nw-metallb-operator-initial-config.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/metallb-operator-install.adoc
+
 [id="nw-metallb-operator-initial-config_{context}"]
 = Starting MetalLB on your cluster
 
@@ -18,7 +22,7 @@ After you install the Operator, you need to configure a single instance of a Met
 [source,terminal]
 ----
 $ cat << EOF | oc apply -f -
-apiVersion: metallb.io/v1alpha1
+apiVersion: metallb.io/v1beta1
 kind: MetalLB
 metadata:
   name: metallb
@@ -59,3 +63,4 @@ speaker   6         6         6       6            6           kubernetes.io/os=
 ----
 +
 The example output indicates 6 speaker pods. The number of speaker pods in your cluster might differ from the example output. Make sure the output indicates one pod for each node in your cluster.
+


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2021461

----

The updates are in [Installing from the OperatorHub using the CLI](https://deploy-preview-38864--osdocs.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-operator-install#nw-metallb-installing-operator-cli_metallb-operator-install).