### PR TITLE
BZ2022560: Adds m6i AWS EC2 instance

### DIFF
--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -129,6 +129,11 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
+|`m6i.xlarge`
+|
+|x
+|x
+
 |`c4.2xlarge`
 |
 |x


### PR DESCRIPTION
[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2022560)

- Applies to versions `enterprise-4.6`+
- [Preview link](https://deploy-preview-38872--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations)