### PR TITLE
OSDOCS-2173: Added new NICs for 4.9/4.10 (REPLICA)

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -10,7 +10,17 @@
 .Supported network interface controllers
 [cols="1,2,1,1"]
 |===
-|Manufacturer |Model |Vendor ID | Device ID 
+|Manufacturer |Model |Vendor ID | Device ID
+
+|Broadcom
+|BCM57414
+|14e4
+|16d7
+
+|Broadcom
+|BCM57508
+|14e4
+|1750
 
 |Intel
 |X710
@@ -26,6 +36,21 @@
 |XXV710
 |8086
 |158b
+
+|Intel
+|E810-CQDA2
+|8088
+|1592
+
+|Intel
+|E810-XXVDA2
+|8088
+|159b
+
+|Intel
+|E810-XXVDA4
+|8088
+|1593
 
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]


### PR DESCRIPTION
Replicates #38380, which was published early and reverted in #38865.

https://issues.redhat.com/browse/OSDOCS-2173

Applies to `enterprise-4.9` and `enterprise-4.10`

See #38380 for acks

Preview: https://deploy-preview-38878--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html#supported-devices_about-sriov