### PR TITLE
OSDOCS-2173: RN for new network controller support (REPLICA)

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -384,6 +384,16 @@ SR-IOV now supports vhost-net for use with Fast Datapath DPDK applications on In
 
 Single node clusters support SR-IOV hardware and the SR-IOV Network Operator. Be aware that configuring an SR-IOV network device causes the single node to reboot and that you must configure the `disableDrain` field for the Operator. For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator].
 
+[id="ocp-4-9-supported-hardware-sriov"]
+==== Supported hardware for SR-IOV
+
+{product-title} {product-version} adds support for additional Broadcom and Intel hardware.
+
+* Broadcom BCM57414 and BCM57508
+* Intel E810-CQDA2, E810-XXVDA2, and E810-XXVDA4
+
+For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].
+
 [id="ocp-4-9-networking-metallb"]
 ==== MetalLB load balancer
 


### PR DESCRIPTION
Replicates #38632, which was published early and reverted in #38866

Applies only to `enterprise-4.9`

See #38632 for details.

Preview: https://deploy-preview-38879--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-supported-hardware-sriov