### PR TITLE
BZ2024198 incorrect STS secret format

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -44,9 +44,11 @@ kind: Secret
 metadata:
   namespace: <target-namespace> <1>
   name: <target-secret-name> <2>
-data:
-  role_name: <operator-role-name> <3>
-  web_identity_token_file: <path-to-token> <4>
+stringData:
+  credentials: |-
+    [default]
+    role_name: <operator-role-name> <3>
+    web_identity_token_file: <path-to-token> <4>
 ----
 <1> The namespace for the component.
 <2> The name of the component secret.


### PR DESCRIPTION
For https://bugzilla.redhat.com/show_bug.cgi?id=2024198

Preview: https://deploy-preview-38880--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts