### PR TITLE
JIRA-OSDOCS2926: Removed references of deprecated --prefix flag

### DIFF
--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -9,11 +9,6 @@ This section provides details about the account-wide IAM roles and policies that
 
 The account-wide roles and policies are specific to an OpenShift minor release version, for example OpenShift 4.8, and are backward compatible. You can minimize the required STS resources by reusing the account-wide roles and policies for multiple clusters of the same minor version, regardless of their patch version.
 
-[NOTE]
-====
-If your use case requires it, you can deploy multiple sets of account-wide IAM roles and policies for a cluster version by specifying different prefixes for each set.
-====
-
 .ROSA installer role, policy, and policy files
 [cols="1,2",options="header"]
 |===
@@ -27,11 +22,6 @@ If your use case requires it, you can deploy multiple sets of account-wide IAM r
 |An inline IAM policy that provides the ROSA installer with the permissions required to complete cluster installation tasks.
 
 |===
-
-[NOTE]
-====
-The IAM role and policy names include the role prefix that is specified when the STS resources are created. The resource names in the examples in this section include the default prefix `ManagedOpenShift`.
-====
 
 .`sts_installer_trust_policy.json` for all versions
 [%collapsible]
@@ -1032,7 +1022,7 @@ The IAM role and policy names include the role prefix that is specified when the
 |Resource|Description
 
 |`ManagedOpenShift-openshift-ingress-operator-cloud-credentials`
-|A managed IAM policy that provides the ROSA Ingress Operator with the permissions required to manage external access to a cluster. 
+|A managed IAM policy that provides the ROSA Ingress Operator with the permissions required to manage external access to a cluster.
 
 |===
 
@@ -1166,7 +1156,7 @@ The IAM role and policy names include the role prefix that is specified when the
 |Resource|Description
 
 |`ManagedOpenShift-openshift-machine-api-aws-cloud-credentials`
-|A managed IAM policy that provides the ROSA Machine Config Operator with the permissions required to perform core cluster functionality. 
+|A managed IAM policy that provides the ROSA Machine Config Operator with the permissions required to perform core cluster functionality.
 
 |===
 

--- a/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -9,8 +9,8 @@ When you create a {product-title} (ROSA) cluster that uses the AWS Security Toke
 
 There are two `rosa` CLI modes for deploying a cluster with STS:
 
-* `manual` mode. With this mode, the `rosa` CLI generates the `aws` commands needed to create the required AWS Identity and Access Management (IAM) roles and policies, and an OpenID Connect (OIDC) provider. The corresponding policy JSON files are also saved to the current directory. This enables you to review the details before running the `aws` commands manually. 
-* `auto` mode. You can use this mode to immediately create the required AWS Identity and Access Management (IAM) resources using the current AWS account. 
+* `manual` mode. With this mode, the `rosa` CLI generates the `aws` commands needed to create the required AWS Identity and Access Management (IAM) roles and policies, and an OpenID Connect (OIDC) provider. The corresponding policy JSON files are also saved to the current directory. This enables you to review the details before running the `aws` commands manually.
+* `auto` mode. You can use this mode to immediately create the required AWS Identity and Access Management (IAM) resources using the current AWS account.
 
 [IMPORTANT]
 ====
@@ -33,12 +33,6 @@ link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Share
 .Procedure
 
 . Create the required account-wide roles and policies, including the Operator policies:
-+
-[NOTE]
-====
-The account-wide roles and policies are specific to an OpenShift version, for example OpenShift 4.8. If you are using multiple cluster versions in one account, you can optionally specify a version-specific prefix for the ARNs by using `--prefix <prefix_name>`. With the prefix, you can easily identify the roles and policies for each cluster version. If you do not specify a prefix, the `ManagedOpenShift` prefix is implied.
-====
-+
 .. Generate the IAM policy JSON files in the current working directory and output the `aws` CLI commands for review:
 +
 [source,terminal]
@@ -84,12 +78,7 @@ $ aws kms get-key-policy --key-id <key_id_or_arn> --policy-name default --output
 }
 ----
 <1> You must specify the ARN for the account-wide role that will be used when you create the ROSA cluster. The ARNs listed in the section must be comma-separated.
-+
-[NOTE]
-====
-If you specify a prefix when you create the account-wide role, it is included in the role name in place of `ManagedOpenShift`.
-====
-+
+
 .. Apply the changes to your KMS key policy:
 +
 [source,terminal]
@@ -121,14 +110,14 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for 
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
-? External ID (optional): 
+? External ID (optional):
 ? Operator roles prefix: <cluster_name>-<random_string>
 ? Multiple availability zones (optional): No <3>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
 ? Install into an existing VPC (optional): No
 ? Enable Customer Managed key (optional): No <4>
-? Compute nodes instance type (optional): 
+? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
 ? Machine CIDR: 10.0.0.0/16
@@ -153,7 +142,7 @@ I: To watch your cluster installation logs, run 'rosa logs install -c <cluster_n
 +
 [NOTE]
 ====
-As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run `rosa create cluster`. Run `rosa create cluster --help` to view a list of available CLI options. 
+As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run `rosa create cluster`. Run `rosa create cluster --help` to view a list of available CLI options.
 ====
 +
 [IMPORTANT]
@@ -169,12 +158,6 @@ You must complete the following steps to create the Operator IAM roles and the O
 $ rosa create operator-roles --mode manual --cluster <cluster_name|cluster_id> <1>
 ----
 <1> `manual` mode generates the `aws` CLI commands and JSON files needed to create the Operator roles. After review, you must run the commands manually to create the resources.
-+
-[NOTE]
-====
-If you defined a custom prefix when you created the account-wide roles and policies, including the Operator policies, you must reference it by using the `--prefix <prefix_name>` option when you create the Operator roles.
-====
-+
 .. After review, run the `aws` commands manually to create the Operator IAM roles and attach the managed Operator policies to them. Alternatively, you can run the preceding command again using `--mode auto` to run the `aws` commands immediately.
 
 . Create the OpenID Connect (OIDC) provider that the cluster Operators use to authenticate:
@@ -226,7 +209,7 @@ Operator IAM Roles:
  - arn:aws:iam::<aws_account_id>:role/<cluster_name-xxxx-openshift-machine-api-aws-cloud-credentials
  - arn:aws:iam::<aws_account_id>:role/<cluster_name-xxxx-openshift-cloud-credential-operator-cloud-crede
  - arn:aws:iam::<aws_account_id>:role/<cluster_name-xxxx-openshift-image-registry-installer-cloud-creden
-State:                      ready 
+State:                      ready
 Private:                    No
 Created:                    Oct  1 2021 08:12:25 UTC
 Details Page:               https://console.redhat.com/openshift/details/s/<subscription_id>


### PR DESCRIPTION
This PR is to address JIRA: https://issues.redhat.com/browse/OSDOCS-2926
Topics updated: 
#1: https://deploy-preview-38884--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-with-customizations.html
Exact changes: Removed notes mentioning the deprecated --prefix flag from steps 1, 2b, and 4a. 

#2: https://deploy-preview-38884--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-about-iam-resources
Exact changes: Removed the notes 'If your use case requires it, you can deploy multiple sets of account-wide IAM roles and policies for a cluster version by specifying different prefixes for each set.' and 'The IAM role and policy names include the role prefix that is specified when the STS resources are created. The resource names in the examples in this section include the default prefix ManagedOpenShift.'