### PR TITLE
Add info on how the cluster autoscaler works

### DIFF
--- a/modules/cluster-autoscaler-about.adoc
+++ b/modules/cluster-autoscaler-about.adoc
@@ -15,7 +15,11 @@ The cluster autoscaler increases the size of the cluster when there are pods tha
 Ensure that the `maxNodesTotal` value in the `ClusterAutoscaler` resource definition that you create is large enough to account for the total possible number of machines in your cluster. This value must encompass the number of control plane machines and the possible number of compute machines that you might scale to.
 ====
 
-The cluster autoscaler decreases the size of the cluster when some nodes are consistently not needed for a significant period, such as when it has low resource use and all of its important pods can fit on other nodes.
+Every 10 seconds, the cluster autoscaler checks which nodes are unnecessary in the cluster and removes them. The cluster autoscaler considers a node for removal if the following conditions apply:
+
+* The sum of CPU and memory requests of all pods running on the node is less than 50% of the allocated resources on the node.
+* The cluster autoscaler can move all pods running on the node to the other nodes.
+* The cluster autoscaler does not have scale down disabled annotation.
 
 If the following types of pods are present on a node, the cluster autoscaler will not remove the node:
 


### PR DESCRIPTION
Add additional information on how the cluster autoscaler scales down a node.
OCP version: 4.7.z
QA contact: @wabouhamad kindly review
Fixes: [BZ1980722](https://bugzilla.redhat.com/show_bug.cgi?id=1980722)
preview: [link](https://deploy-preview-38894--osdocs.netlify.app/openshift-enterprise/latest/machine_management/applying-autoscaling.html#cluster-autoscaler-about_applying-autoscaling)