### PR TITLE
BZ2022643: Add note that oVirt CSI driver doesn't support snapshots.

### DIFF
--- a/storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ovirt.adoc
@@ -18,6 +18,10 @@ To create CSI-provisioned PVs that mount to {rh-virtualization} storage assets, 
 * The _oVirt CSI driver_ enables you to create and mount oVirt PVs.
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+[NOTE]
+====
+The oVirt CSI driver does not support snapshots.
+====
 include::modules/ovirt-csi-driver-storage-class.adoc[leveloffset=+1]
 include::modules/persistent-storage-rhv.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR addresses https://bugzilla.redhat.com/show_bug.cgi?id=2022643.

This applies to:
enterprise-4.10
enterprise-4.9
enterprise-4.8
enterprise-4.7

Preview:
https://deploy-preview-38895--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ovirt.html#csi-about_persistent-storage-csi-ovirt

Added a note in the following topic:
modules/persistent-storage-csi-about.adoc