### PR TITLE
TELCODOCS: 357 - moving sandboxed containers to dedicated release not…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1804,6 +1804,8 @@ Name: Sandboxed Containers Support for OpenShift
 Dir: sandboxed_containers
 Distros: openshift-enterprise
 Topics:
+- Name: OpenShift sanboxed containers release notes
+  File: sandboxed-containers-4-8-release-notes
 - Name: Understanding OpenShift sandboxed containers
   File: understanding-sandboxed-containers
 - Name: Deploying OpenShift sandboxed containers workloads

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -1080,11 +1080,7 @@ For more information, see xref:../authentication/managing_cloud_provider_credent
 [id="ocp-4.8-sandboxed-containers-tp"]
 ==== {sandboxed-containers-first} support on {product-title} (Technology Preview)
 
-{sandboxed-containers-first} 1.0.0 Technology Preview release introduces built-in support for running Kata Containers as an additional runtime. {sandboxed-containers-first} enables users to choose Kata Containers as an additional runtime to provide additional isolation for their workloads. The {sandboxed-containers-operator} automates the tasks of installing, removing, and updating Kata Containers. It allows for tracking the state of those tasks by describing the `KataConfig` custom resource.
-
-{sandboxed-containers-first} are only supported on bare metal. {op-system-first} is the only supported operating system for {sandboxed-containers-first} 1.0.0. Disconnected environments are not supported in {product-title} {product-version}.
-
-For more information, see xref:../sandboxed_containers/understanding-sandboxed-containers.adoc#understanding-sandboxed-containers[Understanding OpenShift sandboxed containers]
+To review {sandboxed-containers-first} new features, bug fixes, known issues, and asynchronous errata updates, see xref:../sandboxed_containers/sandboxed-containers-4-8-release-notes.adoc#sandboxed-containers-release-notes[{sandboxed-containers-first} 1.0 release notes].
 
 [id="ocp-4-8-notable-technical-changes"]
 == Notable technical changes
@@ -2315,59 +2311,6 @@ You can attempt to resolve the issue with the steps in this link:https://kb.vmwa
 * An Open Virtual Network (OVN) bug causes persistent connectivity issues with Octavia load balancers. When Octavia load balancers are created, OVN might not plug them into some Neutron subnets. These load balancers might be unreachable for some of the Neutron subnets. This problem affects Neutron subnets, which are created for each OpenShift namespace, at random when Kuryr is configured. As a result, when this problem occurs the load balancer that implements OpenShift `Service` objects will be unreachable from OpenShift namespaces affected by the issue. Because of this bug, {product-title} 4.8 deployments that use Kuryr SDN are not recommended on {rh-openstack-first} 16.1 with OVN and OVN Octavia configured until the bug is fixed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1937392[*BZ#1937392*])
 
 * The Console Operator does not properly update the `Ingress` resource with the `componentRoutes` conditions for either of the console's routes (`console` or `downloads`). (link:https://bugzilla.redhat.com/show_bug.cgi?id=1954148[*BZ#1954148*])
-
-* If you are using {sandboxed-containers-first}, you cannot use the `hostPath` volume in a {product-title} cluster to mount a file or directory from the host node’s file system into your pod. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
-
-* If you are running Fedora on {sandboxed-containers-first}, you need a workaround to install some packages. Some packages, like `iputils`, require file access permission changes that {product-title} does not grant to containers by default. To run containers that require such special permissions, it is necessary to add an annotation to the YAML file describing the workload, which tells `virtiofsd` to accept such file permissions for that workload. The required annotations are:
-+
-[source,yaml]
-----
-io.katacontainers.config.hypervisor.virtio_fs_extra_args: [ "-o", "modcaps=+sys_admin", "-o", "xattr" ]
-----
-+
-(link:https://bugzilla.redhat.com/show_bug.cgi?id=1915377[*BZ#1915377*])
-
-* In the 4.8 release, adding a value to `kataConfgPoolSelector` by using the {product-title} web console causes `scheduling.nodeSelector` to be populated with an empty value. Pods that use `RuntimeClass` with the value of `kata` might be scheduled to nodes that do not have the Kata Containers runtime installed.
-+
-To work around this issue, specify the `nodeSelector` value manually in the `RuntimeClass` `kata` by running the following command:
-+
-[source,terminal]
-----
-$ oc edit runtimeclass kata
-----
-+
-The following is an example of a `RuntimeClass` with the correct `nodeSelector` statement.
-+
-[source,yaml]
-----
-apiVersion: node.k8s.io/v1
-handler: kata
-kind: RuntimeClass
-metadata:
-  creationTimestamp: "2021-06-14T12:54:19Z"
-  name: kata
-overhead:
-  podFixed:
-    cpu: 250m
-    memory: 350Mi
-scheduling:
-  nodeSelector:
-    custom-kata-pool: "true"
-----
-+
-(link:https://issues.redhat.com/browse/KATA-764[*KATA-764*])
-
-* The {sandboxed-containers-operator} details page on Operator Hub contains a few missing fields. The missing fields do not prevent you from installing the {sandboxed-containers-operator} in 4.8.
-+
-(link:https://issues.redhat.com/browse/KATA-826[*KATA-826*])
-
-* Creating multiple `KataConfig` custom resources results in a silent failure. The {product-title} web console does not provide a prompt to notify the user that creating more than one custom resource has failed.
-+
-(link:https://issues.redhat.com/browse/KATA-725[*KATA-725*])
-
-* Sometimes the Operator Hub in the {product-title} web console does not display icons for an Operator.
-+
-(link:https://issues.redhat.com/browse/KATA-804[*KATA-804*])
 
 * The OVN-Kubernetes network provider does not support the `externalTrafficPolicy` feature for `NodePort`- and `LoadBalancer`-type services.  The `service.spec.externalTrafficPolicy` field determines whether traffic for a service is routed to node-local or cluster-wide endpoints. Currently, such traffic is routed by default to cluster-wide endpoints, and there is no way to limit traffic to node-local endpoints. This will be resolved in a future release. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903408[*BZ#1903408*])
 

--- a/sandboxed_containers/sandboxed-containers-4-8-release-notes.adoc
+++ b/sandboxed_containers/sandboxed-containers-4-8-release-notes.adoc
@@ -1,0 +1,128 @@
+[id="sandboxed-containers-4-8-release-notes"]
+= {sandboxed-containers-first} 1.0 release notes
+include::modules/common-attributes.adoc[]
+:context: sandboxed-containers-release-notes
+
+toc::[]
+
+[id="ocp-1-0-about-this-release"]
+== About this release
+
+These release notes track the development of {sandboxed-containers-first} in Red Hat {product-title}.
+
+This product is currently in Technology Preview. {sandboxed-containers-first} is not intended for production use. For more information, see the Red Hat Customer Portal link:https://access.redhat.com/support/offerings/techpreview[support scope] for features in Technology Preview.
+
+[id="sandboxed-containers-1-0-new-features-and-enhancements"]
+== New features and enhancements
+
+[id="sandboxed-containers-support-in-tech-preview"]
+=== {sandboxed-containers-first} support on {product-title} (Technology Preview)
+
+{sandboxed-containers-first} 1.0.0 Technology Preview release introduces built-in support for running Kata Containers as an additional runtime. {sandboxed-containers-first} enables users to choose Kata Containers as an additional runtime to provide additional isolation for their workloads. The {sandboxed-containers-operator} automates the tasks of installing, removing, and updating Kata Containers. It allows for tracking the state of those tasks by describing the `KataConfig` custom resource.
+
+{sandboxed-containers-first} are only supported on bare metal. {op-system-first} is the only supported operating system for {sandboxed-containers-first} 1.0.0. Disconnected environments are not supported in {product-title} {product-version}.
+
+For more information, see xref:../sandboxed_containers/understanding-sandboxed-containers.adoc#understanding-sandboxed-containers[Understanding OpenShift sandboxed containers]
+
+[id="sandboxed-containers-1-0-known-issues"]
+== Known issues
+
+* If you are using {sandboxed-containers-first}, you cannot use the `hostPath` volume in a {product-title} cluster to mount a file or directory from the host node’s file system into your pod. As an alternative, you can use local persistent volumes. See xref:../storage/persistent_storage/persistent-storage-local.adoc[Persistent storage using local volumes] for more information. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1904609[*BZ#1904609*])
+
+* If you are running Fedora on {sandboxed-containers-first}, you need a workaround to install some packages. Some packages, like `iputils`, require file access permission changes that {product-title} does not grant to containers by default. To run containers that require such special permissions, it is necessary to add an annotation to the YAML file describing the workload, which tells `virtiofsd` to accept such file permissions for that workload. The required annotations are:
++
+[source,yaml]
+----
+io.katacontainers.config.hypervisor.virtio_fs_extra_args: |
+  [ "-o", "modcaps=+sys_admin", "-o", "xattr" ]
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1915377[*BZ#1915377*])
+
+* In the 4.8 release, adding a value to `kataConfgPoolSelector` by using the {product-title} web console causes `scheduling.nodeSelector` to be populated with an empty value. Pods that use `RuntimeClass` with the value of `kata` might be scheduled to nodes that do not have the Kata Containers runtime installed.
++
+To work around this issue, specify the `nodeSelector` value manually in the `RuntimeClass` `kata` by running the following command:
++
+[source,terminal]
+----
+$ oc edit runtimeclass kata
+----
++
+The following is an example of a `RuntimeClass` with the correct `nodeSelector` statement.
++
+[source,yaml]
+----
+apiVersion: node.k8s.io/v1
+handler: kata
+kind: RuntimeClass
+metadata:
+  creationTimestamp: "2021-06-14T12:54:19Z"
+  name: kata
+overhead:
+  podFixed:
+    cpu: 250m
+    memory: 350Mi
+scheduling:
+  nodeSelector:
+    custom-kata-pool: "true"
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=2019384[*BZ#2019384*])
+
+* The {sandboxed-containers-operator} details page on Operator Hub contains a few missing fields. The missing fields do not prevent you from installing the {sandboxed-containers-operator} in 4.8. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019383[*BZ#2019383*])
+
+* Creating multiple `KataConfig` custom resources results in a silent failure. The {product-title} web console does not provide a prompt to notify the user that creating more than one custom resource has failed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019381[*BZ#2019381*])
+
+* Sometimes the Operator Hub in the {product-title} web console does not display icons for an Operator. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019380[*BZ#2019380*])
+
+[id="sandboxed-containers-1-0-asynchronous-errata-updates"]
+== Asynchronous errata updates
+
+Security, bug fix, and enhancement updates for {sandboxed-containers-first} 1.0 are released as asynchronous errata through the Red Hat Network. All {product-title} {product-version} errata is https://access.redhat.com/downloads/content/290/[available on the Red Hat Customer Portal]. See the https://access.redhat.com/support/policy/updates/openshift[{product-title} Life Cycle] for more information about asynchronous errata.
+
+Red Hat Customer Portal users can enable errata notifications in the account settings for Red Hat Subscription Management (RHSM). When errata notifications are enabled, users are notified via email whenever new errata relevant to their registered systems are released.
+
+[NOTE]
+====
+Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
+====
+
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {sandboxed-containers-first} 1.0.0.
+
+[id="sandboxed-containers-1-0-2"]
+=== RHBA-2021:3751 - {sandboxed-containers-first} 1.0.2 bug fix advisory
+
+Issued: 2021-10-07
+
+{sandboxed-containers-first} release 1.0.2 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+
+The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/product/290/ver=4.8/rhel---8/x86_64/RHBA-2021:3751[RHBA-2021:3751] advisory.
+
+[id="sandboxed-containers-1-0-1"]
+=== RHBA-2021:3552 - {sandboxed-containers-first} 1.0.1 bug fix advisory
+
+Issued: 2021-09-16
+
+{sandboxed-containers-first} release 1.0.1 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+
+The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/product/290/ver=4.8/rhel---8/x86_64/RHBA-2021:3552[RHBA-2021:3552] advisory.
+
+[id="sandboxed-containers-1-0-0"]
+=== RHEA-2021:2546 - {sandboxed-containers-first} 1.0.0 image release, bug fix, and enhancement advisory
+
+Issued: 2021-07-29
+
+The components for {sandboxed-containers-first} release 1.0.0 support for {product-title} {product-version} are now available as a technology preview.
+
+The list of bug fixes included in the update is documented in the link:https://access.redhat.com/errata/product/290/ver=4.8/rhel---8/x86_64/RHEA-2021:2546[RHEA-2021:3941] advisory.
+//
+//#link:https://access.redhat.com/errata/product/290/ver=4.9/rhel---8/x86_64/RHEA-2021:3941[]
+//
+//[id="sandboxed-containers-1-0-2"]
+//=== RHBA-2021:3751 - {sandboxed-containers-first} 1.0.2 bug fix advisory
+//
+//Issued: 2021-10-07
+//
+//{sandboxed-containers-first} release 1.0.2 is now available. This advisory contains an update for {sandboxed-containers-first} with bug fixes.
+//
+//The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/product/290/ver=4.8/rhel---8/x86_64/RHBA-2021:3751[RHBA-2021:3751] advisory.


### PR DESCRIPTION
[JIRA](https://issues.redhat.com/browse/TELCODOCS-363): Update for enterprise-4.8. Moved release notes for sandboxed containers to their own dedicated document.

Most content was previously located in the core OCP release notes. It was only moved, and the content was removed from the OCP notes, linking to the new doc instead. In addition, errata were added to the notes.

Preview link: https://deploy-preview-38896--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/sandboxed-containers-4-8-release-notes.html

These changes were approved by the PM, dev, and QE, and have gone through peer review by @skrthomas . The change notice email went out on Wednesday.