### PR TITLE
GH38823: Fixed typo in namespace selector label for OpenShift SDN [Fixes #38823]

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -43,7 +43,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          policy-group.network.openshift.io/ingress="" 
+          policy-group.network.openshift.io/ingress: ""
   podSelector: {}
   policyTypes:
   - Ingress
@@ -52,7 +52,7 @@ EOF
 +
 [NOTE]
 ====
-`policy-group.network.openshift.io/ingress=""` is the preferred namespace selector label for OpenShift SDN. You can use the `network.openshift.io/policy-group: ingress` namespace selector label, but this is a legacy label. 
+`policy-group.network.openshift.io/ingress: ""` is the preferred namespace selector label for OpenShift SDN. You can use the `network.openshift.io/policy-group: ingress` namespace selector label, but this is a legacy label.
 ====
 .. A policy named `allow-from-openshift-monitoring`:
 +


### PR DESCRIPTION
Fixes #38823

@jon2100 discovered a problem in a new format for the namespace selector label for OpenShift SDN. Turned out to be a typo. 

This PR fixes the typo.

Applies to versions 4.6 +

QE review: @anuragthehatter Can you take a look?

Preview: https://deploy-preview-38897--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/multitenant-network-policy.html#nw-networkpolicy-multitenant-isolation_multitenant-network-policy

See also: https://github.com/openshift/openshift-docs/pull/38898 https://github.com/openshift/openshift-docs/pull/38283

cc @jboxman 