### PR TITLE
BZ: 2023822 - Updated typo in yaml file

### DIFF
--- a/modules/sandboxed-containers-selecting-nodes.adoc
+++ b/modules/sandboxed-containers-selecting-nodes.adoc
@@ -42,7 +42,7 @@ $ oc edit kataconfig
   spec:
     kataConfigPoolSelector:
       matchLabels:
-         custom-kata-machine-pool: true
+         custom-kata-machine-pool: 'true'
 ----
 
 .Verification


### PR DESCRIPTION
Update to 4.8, 4.9, and main for [BZ 2023822](https://bugzilla.redhat.com/show_bug.cgi?id=2023822).

Preview link: https://deploy-preview-38899--osdocs.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-selecting-nodes_deploying-sandboxed-containers