### PR TITLE
BZ1902748: Split the ELB and ELBv2 permissions

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -86,33 +86,44 @@ If you use an existing VPC, your account does not require these permissions for 
 =====
 ====
 
-.Required Elastic Load Balancing permissions for installation
+.Required Elastic Load Balancing permissions (ELB) for installation
 [%collapsible]
 ====
 * `elasticloadbalancing:AddTags`
 * `elasticloadbalancing:ApplySecurityGroupsToLoadBalancer`
 * `elasticloadbalancing:AttachLoadBalancerToSubnets`
 * `elasticloadbalancing:ConfigureHealthCheck`
-* `elasticloadbalancing:CreateListener`
 * `elasticloadbalancing:CreateLoadBalancer`
 * `elasticloadbalancing:CreateLoadBalancerListeners`
-* `elasticloadbalancing:CreateTargetGroup`
 * `elasticloadbalancing:DeleteLoadBalancer`
 * `elasticloadbalancing:DeregisterInstancesFromLoadBalancer`
-* `elasticloadbalancing:DeregisterTargets`
 * `elasticloadbalancing:DescribeInstanceHealth`
-* `elasticloadbalancing:DescribeListeners`
 * `elasticloadbalancing:DescribeLoadBalancerAttributes`
 * `elasticloadbalancing:DescribeLoadBalancers`
 * `elasticloadbalancing:DescribeTags`
+* `elasticloadbalancing:ModifyLoadBalancerAttributes`
+* `elasticloadbalancing:RegisterInstancesWithLoadBalancer`
+* `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
+====
+
+.Required Elastic Load Balancing permissions (ELBv2) for installation
+[%collapsible]
+====
+* `elasticloadbalancing:AddTags`
+* `elasticloadbalancing:CreateListener`
+* `elasticloadbalancing:CreateLoadBalancer`
+* `elasticloadbalancing:CreateTargetGroup`
+* `elasticloadbalancing:DeleteLoadBalancer`
+* `elasticloadbalancing:DeregisterTargets`
+* `elasticloadbalancing:DescribeListeners`
+* `elasticloadbalancing:DescribeLoadBalancerAttributes`
+* `elasticloadbalancing:DescribeLoadBalancers`
 * `elasticloadbalancing:DescribeTargetGroupAttributes`
 * `elasticloadbalancing:DescribeTargetHealth`
 * `elasticloadbalancing:ModifyLoadBalancerAttributes`
 * `elasticloadbalancing:ModifyTargetGroup`
 * `elasticloadbalancing:ModifyTargetGroupAttributes`
-* `elasticloadbalancing:RegisterInstancesWithLoadBalancer`
 * `elasticloadbalancing:RegisterTargets`
-* `elasticloadbalancing:SetLoadBalancerPoliciesOfListener`
 ====
 
 .Required IAM permissions for installation


### PR DESCRIPTION
Split the ELB and ELBv2 permissions
Fixes: [BZ1902748](https://bugzilla.redhat.com/show_bug.cgi?id=1902748)
OCP version: 4.6, 4.7, 4.8, 4.9, 4.10
QA contact: @yunjiang29 kindly review
Preview: [link](https://deploy-preview-38902--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account)