### PR TITLE
BZ2021867: Extend the IMPORTANT warning

### DIFF
--- a/modules/technology-preview.adoc
+++ b/modules/technology-preview.adoc
@@ -9,6 +9,9 @@ might not be functionally complete. Red Hat does not recommend using them
 in production. These features provide early access to upcoming product
 features, enabling customers to test functionality and provide feedback during
 the development process.
+ifeval::["{context}" == "k8s-nmstate-operator"]
+You must not use {FeatureName} in both {product-title} and {rh-virtualization-first} at the same time. Such configuration is unsupported.
+endif::[]
 
 For more information about the support scope of Red Hat Technology Preview
 features, see https://access.redhat.com/support/offerings/techpreview/.

--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -1,5 +1,6 @@
 [id="k8s-nmstate-about-the-k8s-nmstate-operator"]
 = About the Kubernetes NMState Operator
+include::modules/common-attributes.adoc[]
 :FeatureName: Kubernetes NMState Operator
 :context: k8s-nmstate-operator
 


### PR DESCRIPTION
Extend the IMPORTANT warning
OCP version: 4.9
QA contact: @vvoronkov
preview: [link](https://deploy-preview-38915--osdocs.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html)
Fixes: [BZ2021867](https://bugzilla.redhat.com/show_bug.cgi?id=2021867)