### PR TITLE
SRVKS-824: Add HTTPS redirect docs

### DIFF
--- a/modules/serverless-https-redirect-global.adoc
+++ b/modules/serverless-https-redirect-global.adoc
@@ -1,0 +1,21 @@
+// Module is included in the following assemblies:
+//
+// * serverless/admin_guide/knative-serving-CR-config.adoc
+
+[id="serverless-https-redirect-global_{context}"]
+= HTTPS redirection global settings
+
+You can enable HTTPS redirection for all services on the cluster by configuring the `httpProtocol` spec for the `KnativeServing` custom resource, as shown in the following example:
+
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1alpha1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+spec:
+  config:
+    network:
+      httpProtocol: "redirected"
+...
+----

--- a/modules/serverless-https-redirect-service.adoc
+++ b/modules/serverless-https-redirect-service.adoc
@@ -1,0 +1,21 @@
+// Module is included in the following assemblies:
+//
+// * serverless/knative_serving/serverless-applications.adoc
+
+[id="serverless-https-redirect-service_{context}"]
+= HTTPS redirection per service
+
+You can enable or disable HTTPS redirection for a service by configuring the `networking.knative.dev/httpOption` annotation, as shown in the following example:
+
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: example
+  namespace: default
+  annotations:
+    networking.knative.dev/httpOption: "redirected"
+spec:
+  ...
+----

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -12,6 +12,10 @@ This guide describes how cluster administrators can manage settings for develope
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
 include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
 
+// global https redirect
+// include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
+// uncomment at 1.19.0 release
+
 [id="additional-resources_knative-serving-CR-config"]
 == Additional resources
 

--- a/serverless/knative_serving/serverless-applications.adoc
+++ b/serverless/knative_serving/serverless-applications.adoc
@@ -38,6 +38,10 @@ include::modules/interacting-serverless-apps-http2-gRPC.adoc[leveloffset=+1]
 // Using Knative services w/ restrictive NetworkPolicies
 include::modules/serverless-services-network-policies.adoc[leveloffset=+1]
 
+// HTTPS redirection
+// include::modules/serverless-https-redirect-service.adoc[leveloffset=+1]
+// uncomment at 1.19.0 release
+
 [id="serverless-applications-kn-offline-mode"]
 == Using kn CLI in offline mode
 


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKS-824

Applies for OCP 4.6+

Direct preview links:
- https://deploy-preview-38916--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_serving/serverless-applications.html#serverless-https-redirect-service_serverless-applications
- https://deploy-preview-38916--osdocs.netlify.app/openshift-enterprise/latest/serverless/admin_guide/knative-serving-cr-config#serverless-https-redirect-global_knative-serving-CR-config