### PR TITLE
CNV-12277: Removed mention of sriovLiveMigration feature gate

### DIFF
--- a/modules/virt-about-live-migration.adoc
+++ b/modules/virt-about-live-migration.adoc
@@ -16,4 +16,4 @@ You can use live migration if the following conditions are met:
 
 * Ports `49152` and `49153` must be available in the `virt-launcher` pod. If these ports are specified in the `masquerade` interface, live migration does not function.
 
-* Live migration is supported for virtual machines that are attached to an SR-IOV network interface only if the `sriovLiveMigration` feature gate is enabled in the `HyperConverged` custom resource (CR). When the `spec.featureGates.sriovLiveMigration` field is set to `true`, the `virt-launcher` pod runs with the `SYS_RESOURCE` capability. This might degrade its security.
+* Live migration is supported for virtual machines that are attached to an SR-IOV network interface.

--- a/modules/virt-about-upgrading-virt.adoc
+++ b/modules/virt-about-upgrading-virt.adoc
@@ -24,8 +24,7 @@ connection. Most automatic updates complete within fifteen minutes.
 
 [IMPORTANT]
 ====
-If you have virtual machines running that cannot be live migrated, they might block an {product-title} cluster upgrade.
-This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces that have the `sriovLiveMigration` feature gate disabled.
+If you have virtual machines running that use hostpath provisioner storage, they cannot be live migrated and might block an {product-title} cluster upgrade. 
 
 As a workaround, you can reconfigure the virtual machines so that they can be powered off automatically during a cluster upgrade. Remove the `evictionStrategy: LiveMigrate` field and set the `runStrategy` field to `Always`.
 ====

--- a/modules/virt-features-for-storage-matrix.adoc
+++ b/modules/virt-features-for-storage-matrix.adoc
@@ -51,7 +51,7 @@
 You cannot live migrate virtual machines that use:
 
 * A storage class with ReadWriteOnce (RWO) access mode
-* Passthrough features such as GPUs or SR-IOV network interfaces that have the `sriovLiveMigration` feature gate disabled
+* Passthrough features such as GPUs 
 
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====

--- a/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
+++ b/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.adoc
@@ -8,11 +8,7 @@ toc::[]
 You can configure a Single Root I/O Virtualization (SR-IOV) device for virtual machines in your cluster.
 This process is similar but not identical to configuring an SR-IOV device for {product-title}.
 
-[NOTE]
-====
-Live migration is supported for virtual machines that are attached to an SR-IOV network interface only if the `sriovLiveMigration` feature gate is enabled in the HyperConverged Cluster custom resource (CR). When the `spec.featureGates.sriovLiveMigration` field is set to `true`, the `virt-launcher` pod runs with the `SYS_RESOURCE` capability. This might degrade its security.
-====
-
+[id="prerequisites_configuring-sriov-device-for-vms"]
 == Prerequisites
 * You must have xref:../../../networking/hardware_networks/installing-sriov-operator.adoc#installing-sriov-operator[installed the SR-IOV Operator.]
 
@@ -21,6 +17,7 @@ Live migration is supported for virtual machines that are attached to an SR-IOV 
 include::modules/nw-sriov-device-discovery.adoc[leveloffset=+1]
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
+[id="next-steps_configuring-sriov-device-for-vms"]
 == Next steps
 
 * xref:../../../virt/virtual_machines/vm_networking/virt-defining-an-sriov-network.adoc#virt-defining-an-sriov-network[Configuring an SR-IOV network attachment for virtual machines]


### PR DESCRIPTION
[CNV-12277](https://issues.redhat.com/browse/CNV-12277)

The `sriovLiveMigration` will be enabled by default starting in 4.10. Removed note stating that live migration is only supported if the feature gate is enabled for VMs attached to an SR-IOV network interface.

Applies to 4.10

Preview builds:

[About upgrading OpenShift Virtualization](https://deploy-preview-38918--osdocs.netlify.app/openshift-enterprise/latest/virt/upgrading-virt.html#virt-about-upgrading-virt_upgrading-virt)

[About live migration](https://deploy-preview-38918--osdocs.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration.html#virt-about-live-migration_virt-live-migration)

[Configuring an SR-IOV network device for virtual machines](https://deploy-preview-38918--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-configuring-sriov-device-for-vms.html)

[Storage matrix
](https://deploy-preview-38918--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-features-for-storage.html#virt-features-for-storage-matrix_virt-features-for-storage)