### PR TITLE
BZ-2017414: Reworded assembly intro para for clarity

### DIFF
--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -5,9 +5,7 @@ include::modules/virt-document-attributes.adoc[]
 
 toc::[]
 
-You can use the default pod network with {VirtProductName}. To do so, you must use the `masquerade` binding method.
-It is the only recommended binding method for use with the default pod network.
-Do not use `masquerade` mode with non-default networks.
+You can use the default pod network with {VirtProductName}. To do so, you must use the `masquerade` binding method. Do not use `masquerade` mode with non-default networks.
 
 xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#attaching-to-multiple-networks[For secondary networks], use the `bridge` binding method.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2017414

Removed the second sentence from the intro paragraph for clarity. This was one of the issues identified during the Networking docs audit.

Applies to 4.10, 4.9, 4.8

Preview: https://deploy-preview-38920--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt