### PR TITLE
OSDOCS-2925: Note about necessary cluster transfer step in OCM

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -11,6 +11,13 @@
 
 You can update the global pull secret for your cluster by either replacing the current pull secret or appending a new pull secret.
 
+[IMPORTANT]
+====
+To transfer your cluster to another owner, you must first initiate the transfer in link:https://console.redhat.com/openshift/[Red Hat OpenShift Cluster Manager], and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in OpenShift Cluster Manager causes the cluster to stop reporting Telemetry metrics in OpenShift Cluster Manager. 
+
+For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2021/html/managing_clusters/assembly-managing-clusters#transferring-cluster-ownership_assembly-managing-clusters[about transferring cluster ownership], see "Transferring cluster ownership" in the Red Hat OpenShift Cluster Manager documentation. 
+====
+
 [WARNING]
 ====
 Cluster resources must adjust to the new pull secret, which can temporarily limit the usability of the cluster.


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2925 (the OCP docs component of [OSSDOCS-18](https://issues.redhat.com/browse/OSSDOCS-18))

Added link to OCM docs for transferring clusters and a note to inform customers they must do part of the transfer process in OCM - this has been tripping up several customers in the last while. The related changes in the OpenShift Cluster Manager docs are here: https://issues.redhat.com/browse/OSSDOCS-18

Separating this out from https://github.com/openshift/openshift-docs/pull/38784 - will deal with editing all the OCM references in a new PR to keep it simpler.

Preview: https://deploy-preview-38921--osdocs.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html#images-update-global-pull-secret_using-image-pull-secrets