### PR TITLE
Update ref title based on 4.8 re-arch

### DIFF
--- a/modules/installation-infrastructure-user-infra.adoc
+++ b/modules/installation-infrastructure-user-infra.adoc
@@ -57,7 +57,7 @@ ifndef::ibm-z[]
 +
 [NOTE]
 ====
-If you are not using a DHCP service, you must provide the IP networking configuration and the address of the DNS server to the nodes at {op-system} install time. These can be passed as boot arguments if you are installing from an ISO image. See the _Creating Red Hat Enterprise Linux CoreOS (RHCOS) machines_ section for more information about static IP provisioning and advanced networking options.
+If you are not using a DHCP service, you must provide the IP networking configuration and the address of the DNS server to the nodes at {op-system} install time. These can be passed as boot arguments if you are installing from an ISO image. See the _Installing {op-system} and starting the {product-title} bootstrap process_ section for more information about static IP provisioning and advanced networking options.
 ====
 +
 .. Define the hostnames of your cluster nodes in your DHCP server configuration. See the _Setting the cluster node hostnames through DHCP_ section for details about hostname considerations.
@@ -68,7 +68,7 @@ If you are not using a DHCP service, the cluster nodes obtain their hostname thr
 ====
 endif::ibm-z[]
 ifdef::ibm-z-kvm[]
-. Choose to perform either a fast track installation of {op-system-first} or a full installation of {op-system-first}. For the full installation you must set up an HTTP or HTTPS server to provide Ignition files and install images to the cluster nodes. For the fast track installation an HTTP or HTTPS server is not required, however, a DHCP server is required. See sections “Fast-track installation: Creating {op-system-first} machines" and “Full installation: Creating {op-system-first} machines".
+. Choose to perform either a fast track installation of {op-system-first} or a full installation of {op-system-first}. For the full installation, you must set up an HTTP or HTTPS server to provide Ignition files and install images to the cluster nodes. For the fast track installation an HTTP or HTTPS server is not required, however, a DHCP server is required. See sections “Fast-track installation: Creating {op-system-first} machines" and “Full installation: Creating {op-system-first} machines".
 endif::ibm-z-kvm[]
 
 . Ensure that your network infrastructure provides the required network connectivity between the cluster components. See the _Networking requirements for user-provisioned infrastructure_ section for details about the requirements.

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -97,7 +97,7 @@ It is recommended to use a DHCP server for long-term management of the cluster m
 
 [NOTE]
 ====
-If a DHCP service is not available for your user-provisioned infrastructure, you can instead provide the IP networking configuration and the address of the DNS server to the nodes at {op-system} install time. These can be passed as boot arguments if you are installing from an ISO image. See the _Creating Red Hat Enterprise Linux CoreOS (RHCOS) machines_ section for more information about static IP provisioning and advanced networking options.
+If a DHCP service is not available for your user-provisioned infrastructure, you can instead provide the IP networking configuration and the address of the DNS server to the nodes at {op-system} install time. These can be passed as boot arguments if you are installing from an ISO image. See the _Installing {op-system} and starting the {product-title} bootstrap process_ section for more information about static IP provisioning and advanced networking options.
 ====
 endif::ibm-z[]
 


### PR DESCRIPTION
Through OCP 4.7, we had this title: https://docs.openshift.com/container-platform/4.7/installing/installing_bare_metal/installing-bare-metal.html#creating-machines-bare-metal
Starting in OCP 4.8, these docs were updated to https://docs.openshift.com/container-platform/4.8/installing/installing_bare_metal/installing-bare-metal.html#creating-machines-bare-metal

There are a couple of references to the old title that this PR updates. No technical changes, so no QE should be required.

**Preview link:** https://deploy-preview-38933--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-infrastructure-user-infra_installing-bare-metal