### PR TITLE
Remove xrefs to deleted files to fix build

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -160,8 +160,8 @@ Deprecated functionality is still included in OpenShift Logging and continues to
 
 From {product-title} 4.6 to the present, forwarding logs by using the following legacy methods have been deprecated and will be removed in a future release:
 
-* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-legacy-fluentd_cluster-logging-external[Forwarding logs using the legacy Fluentd method]
-* xref:../logging/cluster-logging-external.adoc#cluster-logging-collector-legacy-syslog_cluster-logging-external[Forwarding logs using the legacy syslog method]
+* Forwarding logs using the legacy Fluentd method
+* Forwarding logs using the legacy syslog method
 
 Instead, use the following non-legacy methods:
 


### PR DESCRIPTION
As reported by multiple OCP writers, https://github.com/openshift/openshift-docs/pull/36302 removed to module files that have lingering xrefs in the Logging release notes. For some reason, the build checks passed prior to the PR's merge but now builds are intermittently not passing.

We will attempt to fix this in the main branch and get merged ASAP and then can troubleshoot further to 4.9 and 4.10 separately if necessary.

Preview link: https://deploy-preview-38945--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes#openshift-logging-5-2-0-legacy-forwarding