### PR TITLE
RHDEVDOCS-3476 - Update Configuration tab name in web console instructions for Monitoring

### DIFF
--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -95,7 +95,7 @@ $ oc -n openshift-monitoring create secret generic alertmanager-main --from-file
 
 To change the Alertmanager configuration from the {product-title} web console:
 
-. Navigate to the *Administration* -> *Cluster Settings* -> *Global Configuration* -> *Alertmanager* -> *YAML* page of the web console.
+. Navigate to the *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager* -> *YAML* page of the web console.
 
 . Modify the YAML configuration file.
 

--- a/modules/monitoring-configuring-alert-receivers.adoc
+++ b/modules/monitoring-configuring-alert-receivers.adoc
@@ -14,7 +14,7 @@ You can configure alert receivers to ensure that you learn about important issue
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Administration* -> *Cluster Settings* -> *Global Configuration* -> *Alertmanager*.
+. In the *Administrator* perspective, navigate to *Administration* -> *Cluster Settings* -> *Configuration* -> *Alertmanager*.
 +
 [NOTE]
 ====


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3476
- Direct link to doc preview: https://deploy-preview-38962--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#configuring-alert-receivers_managing-alerts and https://deploy-preview-38962--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#applying-custom-alertmanager-configuration_managing-alerts
- SME review: N/A
- QE review: N/A
- Peer review: @ tbd
- <All reviews complete. Please merge now>

No SME review required for this fix.