### PR TITLE
OSDOCS-2466: Created documentation for Clusterwide proxies.

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -117,6 +117,8 @@ Topics:
   Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
+- Name: Configuring your cluster-wide proxy
+  File: cluster-wide-proxy
 ---
 Name: Nodes
 Dir: nodes

--- a/modules/nw-configuring-proxy.adoc
+++ b/modules/nw-configuring-proxy.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * networking/cluster-wide-proxy.adoc
+
+[id="nw-configuring-proxy_{context}"]
+= Configuring the proxy
+
+//canary for rebasing

--- a/networking/cluster-wide-proxy.adoc
+++ b/networking/cluster-wide-proxy.adoc
@@ -1,0 +1,20 @@
+[id="configuring-cluster-wide-proxy"]
+= Cluster-wide proxy
+include::modules/common-attributes.adoc[]
+:context: configuring-cluster-wide-proxy
+
+toc::[]
+
+
+[id="configuring-cluster-wide-proxy-prereqs"]
+== Prerequisites
+
+- You have an AWS account.
+- You have a configured virtual private cloud.
+
+See link:https://docs.openshift.com/container-platform/4.9/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your VPC] for more information.
+
+include::modules/nw-configuring-proxy.adoc[leveloffset=+1]
+
+[id="configuring-cluster-wide-proxy-additional-resources"]
+== Additional resources


### PR DESCRIPTION
This PR addresses [OSDOCS-2466](https://issues.redhat.com/browse/OSDOCS-2466), which asks for clear instructions for setting up a cluster-wide proxy.

JIRA: https://issues.redhat.com/browse/OSDOCS-2466

Preview: https://deploy-preview-39001--osdocs.netlify.app/openshift-dedicated/latest/networking/cluster-wide-proxy.html