### PR TITLE
[Serverless] Kafka channel wording changed to singular

### DIFF
--- a/serverless/knative_eventing/serverless-kafka.adoc
+++ b/serverless/knative_eventing/serverless-kafka.adoc
@@ -48,7 +48,7 @@ spec:
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+2]
 
 [id="serverless-kafka-channel-link"]
-== Using Kafka channels
+== Using Kafka channel
 
 Create a xref:../../serverless/channels/serverless-creating-channels.adoc#serverless-creating-channels[Kafka channel].
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Looking here: https://docs.openshift.com/container-platform/4.9/serverless/knative_eventing/serverless-kafka.html#serverless-kafka-channel-link
* Using Kafka channels (plural)
* Using Kafka source (singular)

This fix proposes changing the channel to singular too. Later in the docs we also have singular terminology: https://docs.openshift.com/container-platform/4.9/serverless/channels/serverless-creating-channels.html#serverless-create-kafka-channel-yaml_serverless-creating-channels