### PR TITLE
Remove breaking xref

### DIFF
--- a/installing/installing-troubleshooting.adoc
+++ b/installing/installing-troubleshooting.adoc
@@ -21,6 +21,3 @@ include::modules/manually-gathering-logs-without-ssh.adoc[leveloffset=+1]
 include::modules/installation-getting-debug-information.adoc[leveloffset=+1]
 
 include::modules/restarting-installation.adoc[leveloffset=+1]
-
-.Additional resources
-* xref:../installing/index.adoc#ocp-installation-overview[Installing an {product-title} cluster]


### PR DESCRIPTION
There is no Jira tracking this; just a quick fix to remove a link to a file that doesn't exist for 4.6.