### PR TITLE
modules: Update beta.kubernetes.io/os to kubernetes.io/os

### DIFF
--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -50,7 +50,7 @@ metadata:
   resourceVersion: '478704'
   creationTimestamp: '2019-06-10T14:46:08Z'
   labels:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
     failure-domain.beta.kubernetes.io/zone: us-east-1a
     node.openshift.io/os_version: '4.5'
     node-role.kubernetes.io/worker: ''
@@ -76,7 +76,7 @@ metadata:
   resourceVersion: '478704'
   creationTimestamp: '2019-06-10T14:46:08Z'
   labels:
-    beta.kubernetes.io/os: linux
+    kubernetes.io/os: linux
     failure-domain.beta.kubernetes.io/zone: us-east-1a
     node.openshift.io/os_version: '4.5'
     node-role.kubernetes.io/worker: ''

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -193,7 +193,7 @@ spec:
         pod-template-hash: 66d5cf9464
     spec:
       nodeSelector:
-        beta.kubernetes.io/os: linux
+        kubernetes.io/os: linux
         node-role.kubernetes.io/worker: ''
         type: user-node <1>
 ----

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -78,7 +78,7 @@ The `nodePlacement` parameter includes two parts, `nodeSelector` and `toleration
 nodePlacement:
  nodeSelector:
    matchLabels:
-     beta.kubernetes.io/os: linux
+     kubernetes.io/os: linux
  tolerations:
  - effect: NoSchedule
    operator: Exists

--- a/modules/sample-windows-workload-deployment.adoc
+++ b/modules/sample-windows-workload-deployment.adoc
@@ -67,7 +67,7 @@ spec:
           windowsOptions:
             runAsUserName: "ContainerAdministrator"
       nodeSelector:
-        beta.kubernetes.io/os: windows
+        kubernetes.io/os: windows
 ----
 
 [NOTE]


### PR DESCRIPTION
Seen in a 4.9.7 cluster:

```console
$ oc apply -n openshift-insights -f gather-job.yaml
W1118 20:24:47.058068    9468 warnings.go:70] spec.template.spec.nodeSelector[beta.kubernetes.io/os]: deprecated since v1.14; use "kubernetes.io/os" instead
job.batch/insights-operator-job created
```

Docs on their deprecation [here][1].

Generated with:

```console
$ sed -i 's|beta.kubernetes.io/os|kubernetes.io/os|g' $(git grep -l beta.kubernetes.io/os)
```

[1]: https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.14.md#deprecations