### PR TITLE
[BZ1886092]: Resume all workloads after disaster recovery

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -554,6 +554,8 @@ etcd-ip-10-0-154-194.ec2.internal                2/2     Running     0          
 etcd-ip-10-0-173-171.ec2.internal                2/2     Running     0          9h
 ----
 
+To ensure that all workloads return to normal operation following a recovery procedure, restart each pod that stores Kubernetes API information. This includes {product-title} components such as routers, Operators, and third-party components.
+
 Note that it might take several minutes after completing this procedure for all services to be restored. For example, authentication by using `oc login` might not immediately work until the OAuth server pods are restarted.
 
 [id="dr-scenario-cluster-state-issues_{context}"]


### PR DESCRIPTION
Preview link: https://deploy-preview-39046--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html

Bug: https://bugzilla.redhat.com/show_bug.cgi?id=1886092
Urgency: Low
Versions: 4.6 +