### PR TITLE
[Enterprise-4.10] OSDOCS-2869: Removed outdated ifdefs for OpenShift-Dedicated

### DIFF
--- a/modules/applications-create-using-cli-source-code.adoc
+++ b/modules/applications-create-using-cli-source-code.adoc
@@ -82,7 +82,7 @@ If you use the source build strategy, `new-app` attempts to determine the langua
 |===
 
 |Language |Files
-ifdef::openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-aro,openshift-online[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-aro,openshift-online[]
 |`dotnet`
 |`project.json`, `pass:[*.csproj]`
 endif::[]

--- a/modules/architecture-platform-benefits.adoc
+++ b/modules/architecture-platform-benefits.adoc
@@ -17,9 +17,6 @@ of technology areas.
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 * Hybrid cloud deployments. You can deploy {product-title} clusters to a variety of public cloud platforms or in your data center.
 endif::[]
-ifdef::openshift-dedicated[]
-* {product-title} clusters are deployed on AWS environments and can be used as part of a hybrid approach for application management.
-endif::[]
 * Integrated Red Hat technology. Major components in {product-title} come from {op-system-base-full} and related Red Hat technologies. {product-title} benefits from the intense testing and certification initiatives for Red Hat's enterprise quality software.
 * Open source development model. Development is completed in the open, and the source code is available from public software repositories. This open collaboration fosters rapid innovation and development.
 

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -13,9 +13,6 @@ Cluster administrators can delete installed Operators from a selected namespace 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 - `oc` command installed on workstation.
 
 .Procedure

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -13,9 +13,6 @@ Cluster administrators can delete installed Operators from a selected namespace 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 
 .Procedure
 

--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -13,9 +13,6 @@ When a cluster administrator adds a custom CA certificate to a cluster using a c
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 - Custom CA certificate added to the cluster using a config map.
 - Desired Operator installed and running on OLM.
 

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -23,9 +23,6 @@ ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 endif::[]
 
 ifdef::olm-user[]

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -40,9 +40,6 @@ ifdef::olm-admin[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 endif::[]
 
 ifdef::olm-user[]
@@ -72,9 +69,6 @@ ifdef::olm-admin[]
 .. Select one of the following:
 *** *All namespaces on the cluster (default)* installs the Operator in the default `openshift-operators` namespace to watch and be made available to all namespaces in the cluster. This option is not always available.
 *** *A specific namespace on the cluster* allows you to choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.
-ifdef::openshift-dedicated[]
-If you are installing the Red Hat OpenShift Logging Operator, choose this option to select the `openshift-logging` namespace.
-endif::[]
 endif::[]
 ifdef::olm-user[]
 .. Choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -21,16 +21,6 @@ As a cluster administrator, you can install an Operator from OperatorHub using t
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
 endif::[]
-ifdef::openshift-dedicated[]
-web console. You can then subscribe the Operator to the default `openshift-operators` namespace to make it available for developers on your cluster. When you subscribe the Operator to all namespaces, the Operator is installed in the `openshift-operators` namespace; this installation method is not supported by all Operators.
-
-In {product-title} clusters, a curated list of Operators is made available for installation from OperatorHub. Administrators can only install Operators to the default `openshift-operators` namespace, except for the Logging Operator, which requires the `openshift-logging` namespace.
-
-[NOTE]
-====
-Privileged and custom Operators cannot be installed.
-====
-endif::[]
 endif::[]
 
 ifdef::olm-user[]
@@ -42,9 +32,6 @@ During installation, you must determine the following initial settings for the O
 ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Installation Mode:: Choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces or choose individual namespaces, if available, to only install the Operator on selected namespaces. This example chooses *All namespaces...* to make the Operator available to all users and projects.
-endif::[]
-ifdef::openshift-dedicated[]
-Installation Mode:: In {product-title} clusters, you can choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces. This makes the Operator available to all users and projects.
 endif::[]
 endif::[]
 ifdef::olm-user[]

--- a/modules/olm-installing-specific-version-cli.adoc
+++ b/modules/olm-installing-specific-version-cli.adoc
@@ -19,9 +19,6 @@ ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions
-endif::[]
 endif::[]
 
 ifdef::olm-user[]

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -18,9 +18,6 @@ Operators must handle setting environment variables for proxy settings in the po
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-ifdef::openshift-dedicated[]
-`dedicated-admins-cluster` permissions.
-endif::[]
 
 .Procedure
 

--- a/modules/rbac-adding-roles.adoc
+++ b/modules/rbac-adding-roles.adoc
@@ -8,11 +8,6 @@
 
 You can use  the `oc adm` administrator CLI to manage the roles and bindings.
 
-ifdef::openshift-dedicated[]
-Dedicated administrators cannot manage cluster roles. They can manage
-cluster role bindings and local roles and bindings.
-endif::[]
-
 Binding, or adding, a role to users or groups gives the user or group the access
 that is granted by the role. You can add and remove roles to and from users and
 groups using `oc adm policy` commands.

--- a/modules/rbac-overview.adoc
+++ b/modules/rbac-overview.adoc
@@ -12,9 +12,6 @@ perform a given action within a project.
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Cluster
 endif::[]
-ifdef::openshift-dedicated[]
-Dedicated
-endif::[]
 administrators can use the cluster roles and
 bindings to control who has various access levels to the {product-title}
 platform itself and all projects.
@@ -39,7 +36,7 @@ to multiple roles.
 |Bindings |Associations between users and/or groups with a role.
 |===
 
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+ifdef::openshift-origin,openshift-enterprise[]
 There are two levels of RBAC roles and bindings that control authorization:
 
 [cols="1,4",options="header"]
@@ -110,11 +107,6 @@ power to view or modify roles or bindings.
 |`view` |A user who cannot make any modifications, but can see most objects in a
 project. They cannot view or modify roles or bindings.
 
-ifdef::openshift-dedicated[]
-|`dedicated-readers` |A user who cannot make any modifications, but can see most objects in a
-project. They cannot view or modify roles or bindings. Similar to the `view` role.  All dedicated administrators are also granted these permissions.
-endif::[]
-
 |===
 endif::[]
 
@@ -176,7 +168,7 @@ apply to the user or their groups.
 . If no matching rule is found, the action is then denied by default.
 
 
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+ifdef::openshift-origin,openshift-enterprise[]
 
 [TIP]
 ====
@@ -185,16 +177,13 @@ roles at the same time.
 ====
 
 Project administrators can use the CLI to
-endif::openshift-origin,openshift-enterprise,openshift-dedicated[]
+endif::openshift-origin,openshift-enterprise[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 view local roles and bindings,
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
-ifdef::openshift-dedicated[]
-view local bindings,
-endif::openshift-dedicated[]
 including a matrix of the verbs and resources each are associated with.
 
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+ifdef::openshift-origin,openshift-enterprise[]
 [IMPORTANT]
 ====
 The cluster role bound to the project administrator is limited in a project
@@ -205,7 +194,7 @@ It is not bound cluster-wide like the cluster roles granted to the
 Cluster roles are roles defined at the cluster level but can be bound either at
 the cluster level or at the project level.
 ====
-endif::openshift-origin,openshift-enterprise,openshift-dedicated[]
+endif::openshift-origin,openshift-enterprise[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 [id="cluster-role-aggregations_{context}"]

--- a/modules/rbac-viewing-cluster-roles.adoc
+++ b/modules/rbac-viewing-cluster-roles.adoc
@@ -13,9 +13,6 @@ You can use the `oc` CLI to view cluster roles and bindings by using the
 
 * Install the `oc` CLI.
 * Obtain permission to view the cluster roles and bindings.
-ifdef::openshift-dedicated[]
-Users with the `dedicated-admins-cluster` role can view cluster roles and bindings.
-endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Users with the `cluster-admin` default cluster role bound cluster-wide can
@@ -222,12 +219,6 @@ Resources  Non-Resource URLs  Resource Names  Verbs
 ...
 ----
 endif::[]
-ifdef::openshift-dedicated[]
-[source,terminal]
-----
-$ oc describe clusterrole.rbac
-----
-endif::[]
 
 . To view the current set of cluster role bindings, which shows the users and
 groups that are bound to various roles:
@@ -314,11 +305,5 @@ Subjects:
   ServiceAccount  default  openshift-machine-api
 
 ...
-----
-endif::[]
-ifdef::openshift-dedicated[]
-[source,terminal]
-----
-$ oc describe clusterrolebinding.rbac
 ----
 endif::[]

--- a/modules/rbac-viewing-local-roles.adoc
+++ b/modules/rbac-viewing-local-roles.adoc
@@ -14,10 +14,6 @@ You can use the `oc` CLI to view local roles and bindings by using the
 * Install the `oc` CLI.
 * Obtain permission to view the local roles and bindings:
 
-ifdef::openshift-dedicated[]
-** Users with the `dedicated-admins-cluster` role can view and manage local roles and bindings.
-endif::[]
-
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 ** Users with the `cluster-admin` default cluster role bound cluster-wide can
 perform any action on any resource, including viewing local roles and bindings.

--- a/modules/security-context-constraints-command-reference.adoc
+++ b/modules/security-context-constraints-command-reference.adoc
@@ -15,12 +15,6 @@ You must have `cluster-admin` privileges to manage SCCs.
 
 endif::openshift-enterprise,openshift-webscale,openshift-origin[]
 
-ifdef::openshift-dedicated[]
-As a cluster administrator, you can list and view details for
-SCCs, but cannot edit or delete the default SCCs.
-endif::openshift-dedicated[]
-
-
 [id="listing-security-context-constraints_{context}"]
 == Listing security context constraints
 

--- a/modules/security-context-constraints-pre-allocated-values.adoc
+++ b/modules/security-context-constraints-pre-allocated-values.adoc
@@ -2,7 +2,7 @@
 //
 // * authentication/managing-security-context-constraints.adoc
 
-ifdef::openshift-origin,openshift-enterprise,openshift-dedicated[]
+ifdef::openshift-origin,openshift-enterprise[]
 [id="security-context-constraints-pre-allocated-values_{context}"]
 = About pre-allocated security context constraints values
 

--- a/modules/service-accounts-overview.adoc
+++ b/modules/service-accounts-overview.adoc
@@ -13,7 +13,7 @@ access without sharing a regular user's credentials.
 When you use the {product-title} CLI or web console, your API token
 authenticates you to the API. You can associate a component with a service account
 so that they can access the API without using a regular user's credentials.
-ifdef::openshift-online,openshift-origin,openshift-dedicated,openshift-enterprise,openshift-webscale[]
+ifdef::openshift-online,openshift-origin,openshift-enterprise,openshift-webscale[]
 For example, service accounts can allow:
 
 * Replication controllers to make API calls to create or delete pods.

--- a/networking/openshift_sdn/about-openshift-sdn.adoc
+++ b/networking/openshift_sdn/about-openshift-sdn.adoc
@@ -21,11 +21,5 @@ ifdef::openshift-origin[]
 endif::openshift-origin[]
 endif::[]
 
-ifdef::openshift-dedicated[]
-OpenShift SDN supports only the _network policy_ mode, which allows project
-administrators to configure their own isolation policies by using
-xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[NetworkPolicy objects].
-endif::[]
-
 // flipped table for OpenShift SDN
 include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -10,10 +10,6 @@ Use the following sections for instructions on accessing the registry, including
 viewing logs and metrics, as well as securing and exposing the registry.
 endif::[]
 
-ifdef::openshift-dedicated[]
-Use the following section for instructions on accessing the registry.
-endif::[]
-
 You can access the registry directly to invoke `podman` commands. This allows
 you to push images to or pull them from the integrated registry directly using
 operations like `podman push` or `podman pull`. To do so, you must be logged in


### PR DESCRIPTION
The PR is only for the `enterprise-4.10` branch.

With the migration of OSD and ROSA documentation to the `main` branch, all references to `openshift-dedicated` are being removed.

See https://github.com/openshift/openshift-docs/pull/39080 for edits to `enterprise-4.9`.
See https://github.com/openshift/openshift-docs/pull/39048 for edits to `main.`