### PR TITLE
Remove instances of *.beta.kubernetes.io/

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1038,7 +1038,7 @@ EOF
 ----
 Name:               node1.example.com
 Roles:              worker
-Labels:             beta.kubernetes.io/arch=amd64
+Labels:             kubernetes.io/arch=amd64
 ...
 Annotations:        cluster.k8s.io/machine: openshift-machine-api/ahardin-worker-us-east-2a-q5dzc
 ...

--- a/modules/dedicated-exposing-TCP-services.adoc
+++ b/modules/dedicated-exposing-TCP-services.adoc
@@ -92,7 +92,7 @@ metadata:
     # Specifies whether access logs are enabled for the load balancer
     service.beta.kubernetes.io/aws-load-balancer-attributes: "true"
     # The interval for publishing the access logs. You can specify an interval of either 5 or 60 (minutes).
-    service.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
+    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
     # The name of the Amazon S3 bucket where the access logs are stored
     service.beta.kubernetes.io/aws-load-balancer-attributes: "my-bucket"
     # The logical hierarchy you created for your Amazon S3 bucket, for example `my-bucket-prefix/prod`

--- a/modules/dedicated-exposing-TCP-services.adoc
+++ b/modules/dedicated-exposing-TCP-services.adoc
@@ -63,7 +63,7 @@ only through AWS VPC Peering or a VPN connection.
 
 [source,terminal]
 ----
-$ oc expose dc httpd-example --type=LoadBalancer --name=internal-lb --dry-run -o yaml | awk '1;/metadata:/{ print "  annotations:\n    service.beta.kubernetes.io/aws-load-balancer-internal: \"true\"" }' | oc create -f -
+$ oc expose dc httpd-example --type=LoadBalancer --name=internal-lb --dry-run -o yaml | awk '1;/metadata:/{ print "  annotations:\n    service.beta.kubernetes.io/aws-load-balancer-scheme: \"true\"" }' | oc create -f -
 ----
 
 .Example output
@@ -90,14 +90,14 @@ metadata:
   name: my-service
   annotations:
     # Specifies whether access logs are enabled for the load balancer
-    service.beta.kubernetes.io/aws-load-balancer-access-log-enabled: "true"
+    service.beta.kubernetes.io/aws-load-balancer-attributes: "true"
     # The interval for publishing the access logs. You can specify an interval of either 5 or 60 (minutes).
-    service.beta.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
+    service.kubernetes.io/aws-load-balancer-access-log-emit-interval: "60"
     # The name of the Amazon S3 bucket where the access logs are stored
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name: "my-bucket"
+    service.beta.kubernetes.io/aws-load-balancer-attributes: "my-bucket"
     # The logical hierarchy you created for your Amazon S3 bucket, for example `my-bucket-prefix/prod`
     # This must match the prefix specified in the S3 policy
-    service.beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix: "my-bucket-prefix/prod"
+    service.beta.kubernetes.io/aws-load-balancer-attributes: "my-bucket-prefix/prod"
 ----
 
 === Creating the LoadBalancer service

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -105,11 +105,11 @@ $ oc describe node node1.example.com
 ----
 Name:               node1.example.com <1>
 Roles:              worker <2>
-Labels:             beta.kubernetes.io/arch=amd64   <3>
-                    beta.kubernetes.io/instance-type=m4.large
+Labels:             kubernetes.io/arch=amd64   <3>
+                    node.kubernetes.io/instance-type=m4.large
                     kubernetes.io/os=linux
-                    failure-domain.beta.kubernetes.io/region=us-east-2
-                    failure-domain.beta.kubernetes.io/zone=us-east-2a
+                    topology.beta.kubernetes.io/region=us-east-2
+                    topology.beta.kubernetes.io/zone=us-east-2a
                     kubernetes.io/hostname=ip-10-0-140-16
                     node-role.kubernetes.io/worker=
 Annotations:        cluster.k8s.io/machine: openshift-machine-api/ahardin-worker-us-east-2a-q5dzc  <4>

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -51,14 +51,14 @@ metadata:
   creationTimestamp: '2019-06-10T14:46:08Z'
   labels:
     kubernetes.io/os: linux
-    failure-domain.beta.kubernetes.io/zone: us-east-1a
+    topology.beta.kubernetes.io/zone: us-east-1a
     node.openshift.io/os_version: '4.5'
     node-role.kubernetes.io/worker: ''
-    failure-domain.beta.kubernetes.io/region: us-east-1
+    topology.beta.kubernetes.io/region: us-east-1
     node.openshift.io/os_id: rhcos
-    beta.kubernetes.io/instance-type: m4.large
+    node.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
-    beta.kubernetes.io/arch: amd64
+    kubernetes.io/arch: amd64
     region: east <1>
 ----
 <1> Label to match the pod node selector.
@@ -77,14 +77,14 @@ metadata:
   creationTimestamp: '2019-06-10T14:46:08Z'
   labels:
     kubernetes.io/os: linux
-    failure-domain.beta.kubernetes.io/zone: us-east-1a
+    topology.beta.kubernetes.io/zone: us-east-1a
     node.openshift.io/os_version: '4.5'
     node-role.kubernetes.io/worker: ''
-    failure-domain.beta.kubernetes.io/region: us-east-1
+    topology.beta.kubernetes.io/region: us-east-1
     node.openshift.io/os_id: fedora
-    beta.kubernetes.io/instance-type: m4.large
+    node.kubernetes.io/instance-type: m4.large
     kubernetes.io/hostname: ip-10-0-131-14
-    beta.kubernetes.io/arch: amd64
+    kubernetes.io/arch: amd64
     region: east <1>
 ----
 <1> Label to match the pod node selector.

--- a/modules/nodes-scheduler-pod-affinity-about.adoc
+++ b/modules/nodes-scheduler-pod-affinity-about.adoc
@@ -47,7 +47,7 @@ spec:
             operator: In <4>
             values:
             - S1 <3>
-        topologyKey: failure-domain.beta.kubernetes.io/zone
+        topologyKey: topology.beta.kubernetes.io/zone
   containers:
   - name: with-pod-affinity
     image: docker.io/ocpqe/hello-pod

--- a/modules/nodes-scheduler-pod-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-affinity-configuring.adoc
@@ -42,7 +42,7 @@ spec:
             operator: In
             values:
             - S1
-        topologyKey: failure-domain.beta.kubernetes.io/zone
+        topologyKey: topology.beta.kubernetes.io/zone
 ----
 +
 .. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.


### PR DESCRIPTION
Per [slack conversation](https://coreos.slack.com/archives/C025XCRRH28/p1637342991145900): 

      4 beta.kubernetes.io/arch
      1 beta.kubernetes.io/aws-load-balancer-access-log-emit-interval
      1 beta.kubernetes.io/aws-load-balancer-access-log-enabled
      1 beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-name
      1 beta.kubernetes.io/aws-load-balancer-access-log-s3-bucket-prefix
      1 beta.kubernetes.io/aws-load-balancer-internal
      1 beta.kubernetes.io/aws-load-balancer-type
      3 beta.kubernetes.io/instance-type
      1 beta.kubernetes.io/is-default-class
      1 beta.kubernetes.io/load-balancer-source-ranges
      3 beta.kubernetes.io/region
      2 beta.kubernetes.io/storage-provisioner
      5 beta.kubernetes.io/zone