### PR TITLE
BZ1999387: redefine steps to recover from one healthy master control plane

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -25,68 +25,13 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 . Select a control plane host to use as the recovery host. This is the host that you will run the restore operation on.
 
-. Establish SSH connectivity to each of the control plane nodes, including the recovery host.
+. Establish SSH connectivity to the recovery control plane host. Note that non-recovery control plane hosts cannot be accessed through SSH.
 +
-The Kubernetes API server becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to each control plane host in a separate terminal.
-+
-[IMPORTANT]
-====
-If you do not complete this step, you will not be able to access the control plane hosts to complete the restore procedure, and you will be unable to recover your cluster from this state.
-====
+The Kubernetes API server becomes inaccessible after the restore process starts, so you cannot access the control plane nodes. For this reason, it is recommended to establish SSH connectivity to the recovery control plane host in a separate terminal.
 
 . Copy the etcd backup directory to the recovery control plane host.
 +
 This procedure assumes that you copied the `backup` directory containing the etcd snapshot and the resources for the static pods to the `/home/core/` directory of your recovery control plane host.
-
-. Stop the static pods on any other control plane nodes.
-+
-[NOTE]
-====
-It is not required to manually stop the pods on the recovery host. The recovery script will stop the pods on the recovery host.
-====
-
-.. Access a control plane host that is not the recovery host.
-
-.. Move the existing etcd pod file out of the kubelet manifest directory:
-+
-[source,terminal]
-----
-[core@ip-10-0-154-194 ~]$ sudo mv /etc/kubernetes/manifests/etcd-pod.yaml /tmp
-----
-
-.. Verify that the etcd pods are stopped.
-+
-[source,terminal]
-----
-[core@ip-10-0-154-194 ~]$ sudo crictl ps | grep etcd | grep -v operator
-----
-+
-The output of this command should be empty. If it is not empty, wait a few minutes and check again.
-
-.. Move the existing Kubernetes API server pod file out of the kubelet manifest directory:
-+
-[source,terminal]
-----
-[core@ip-10-0-154-194 ~]$ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
-----
-
-.. Verify that the Kubernetes API server pods are stopped.
-+
-[source,terminal]
-----
-[core@ip-10-0-154-194 ~]$ sudo crictl ps | grep kube-apiserver | grep -v operator
-----
-+
-The output of this command should be empty. If it is not empty, wait a few minutes and check again.
-
-.. Move the etcd data directory to a different location:
-+
-[source,terminal]
-----
-[core@ip-10-0-154-194 ~]$ sudo mv /var/lib/etcd/ /tmp
-----
-
-.. Repeat this step on each of the other control plane hosts that is not the recovery host.
 
 . Access the recovery control plane host.
 


### PR DESCRIPTION
- Applies to 4.6+ versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1999387)
- [Preview](https://deploy-preview-39092--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html)
- @hasbro17 please review the changes .