### PR TITLE
BZ2012651: Push graph data image in restricted network

### DIFF
--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -23,7 +23,7 @@ CMD exec /bin/bash -c "tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinn
 $ podman build -f ./Dockerfile -t registry.example.com/openshift/graph-data:latest
 ----
 
-. Push the graph-data container image created in the above step to a repository that is accessible to the OpenShift Update Service, for example, `registry.example.com/openshift/graph-data:latest`:
+. Push the graph-data container image created in the previous step to a repository that is accessible to the OpenShift Update Service, for example, `registry.example.com/openshift/graph-data:latest`:
 +
 [source,terminal]
 ----
@@ -32,5 +32,5 @@ $ podman push registry.example.com/openshift/graph-data:latest
 +
 [NOTE]
 ====
-For pushing a graph data image to a local registry in a restricted network, copy the graph-data container image created in the previous step to a repository that is accessible to the OpenShift Update Service. You can run `oc image mirror --help` for available options.
+To push a graph data image to a local registry in a restricted network, copy the graph-data container image created in the previous step to a repository that is accessible to the OpenShift Update Service. Run `oc image mirror --help` for available options.
 ====

--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -29,3 +29,8 @@ $ podman build -f ./Dockerfile -t registry.example.com/openshift/graph-data:late
 ----
 $ podman push registry.example.com/openshift/graph-data:latest
 ----
++
+[NOTE]
+====
+For pushing a graph data image to a local registry in a restricted network, copy the graph-data container image created in the previous step to a repository that is accessible to the OpenShift Update Service. You can run `oc image mirror --help` for available options.
+====


### PR DESCRIPTION
Bug: https://bugzilla.redhat.com/show_bug.cgi?id=2012651

Releases: 4.6, 4.7, 4.8, 4.9, 4.10

Preview link: https://deploy-preview-39096--osdocs.netlify.app/openshift-enterprise/latest/updating/installing-update-service.html#update-service-graph-data_update-service

@shellyyang1989 - Kindly help with the QE review.