### PR TITLE
Add missing closing XML tag for store

### DIFF
--- a/modules/cluster-logging-collector-legacy-fluentd.adoc
+++ b/modules/cluster-logging-collector-legacy-fluentd.adoc
@@ -88,6 +88,7 @@ To configure {product-title} to forward logs using the legacy Fluentd method:
     name
     host
   </server>
+</store>
 ----
 <1> Enter the shared key between nodes.
 <2> Specify `tls` to enable TLS validation.


### PR DESCRIPTION
Fix typo in sample Fluentd config.

This fix was branched from enterprise-4.8.

This applies to: 4.6, 4.7, 4.8