### PR TITLE
BZ-2025586:Documentation update to reflect changes for capabilities getting dropped when using keyword  in the container's securityContext

### DIFF
--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -65,11 +65,11 @@ and ensure that your application meets these requirements before using
 memory-based autoscaling.
 ====
 
-The following example shows autoscaling for the `image-registry` `DeploymentConfig` object. The initial deployment requires 3 pods. The HPA object increased that minimum to 5 and will increase the pods up to 7 if CPU usage on the pods reaches 75%:
+The following example shows autoscaling for the `image-registry` `Deployment` object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods will increase to 7:
 
 [source,terminal]
 ----
-$ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
+$ oc autoscale deployment/image-registry --min=5 --max=7 --cpu-percent=75
 ----
 
 .Example output
@@ -78,7 +78,7 @@ $ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
 horizontalpodautoscaler.autoscaling/image-registry autoscaled
 ----
 
-.Sample HPA for the `image-registry` `DeploymentConfig` object with `minReplicas` set to 3
+.Sample HPA for the `image-registry` `Deployment` object with `minReplicas` set to 3
 [source,yaml]
 ----
 apiVersion: autoscaling/v1
@@ -91,7 +91,7 @@ spec:
   minReplicas: 3
   scaleTargetRef:
     apiVersion: apps.openshift.io/v1
-    kind: DeploymentConfig
+    kind: Deployment
     name: image-registry
   targetCPUUtilizationPercentage: 75
 status:
@@ -99,12 +99,11 @@ status:
   desiredReplicas: 0
 ----
 
-
 . View the new state of the deployment:
 +
 [source,terminal]
 ----
-$ oc get dc image-registry
+$ oc get deployment image-registry
 ----
 +
 There are now 5 pods in the deployment:

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -3,14 +3,19 @@
 // * nodes/nodes-pods-autoscaling-about.adoc
 
 [id="nodes-pods-autoscaling-creating-cpu_{context}"]
-
 = Creating a horizontal pod autoscaler for CPU utilization by using the CLI
 
-You can create a horizontal pod autoscaler (HPA) for an existing `Deployment`, `DeploymentConfig`, `ReplicaSet`, `ReplicationController`, or `StatefulSet` object that automatically scales the pods associated with that object to maintain the CPU usage you specify.
+Using the {product-title} CLI, you can create a horizontal pod autoscaler (HPA) to automatically scale an existing `Deployment`, `DeploymentConfig`, `ReplicaSet`, `ReplicationController`, or `StatefulSet` object. The HPA scales the pods associated with that object to maintain the CPU usage you specify.
+
+[NOTE]
+====
+It is recommended to use a `Deployment` object or `ReplicaSet` object unless you need a specific feature or behavior provided by other objects.
+====
 
 The HPA increases and decreases the number of replicas between the minimum and maximum numbers to maintain the specified CPU utilization across all pods.
 
 When autoscaling for CPU utilization, you can use the `oc autoscale` command and specify the minimum and maximum number of pods you want to run at any given time and the average CPU utilization your pods should target. If you do not specify a minimum, the pods are given default values from the {product-title} server.
+
 To autoscale for a specific CPU value, create a `HorizontalPodAutoscaler` object with the target CPU and pod limits.
 
 .Prerequisites
@@ -70,11 +75,11 @@ $ oc autoscale <object_type>/<name> \// <1>
 <3> Specify the maximum number of replicas when scaling up.
 <4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU. If not specified or negative, a default autoscaling policy is used.
 +
-For example, the following command shows autoscaling for the `image-registry` `DeploymentConfig` object. The initial deployment requires 3 pods. The HPA object increased that minimum to 5 and will increase the pods up to 7 if CPU usage on the pods reaches 75%:
+For example, the following command shows autoscaling for the `image-registry` `Deployment` object. The initial deployment requires 3 pods. The HPA object increases the minimum to 5. If CPU usage on the pods reaches 75%, the pods will increase to 7:
 +
 [source,terminal]
 ----
-$ oc autoscale dc/image-registry --min=5 --max=7 --cpu-percent=75
+$ oc autoscale deployment/image-registry --min=5 --max=7 --cpu-percent=75
 ----
 
 ** To scale for a specific CPU value, create a YAML file similar to the following for an existing object:
@@ -91,7 +96,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: v1 <3>
-    kind: ReplicaSet <4>
+    kind: Deployment <4>
     name: example <5>
   minReplicas: 1 <6>
   maxReplicas: 10 <7>
@@ -106,9 +111,9 @@ spec:
 <1> Use the `autoscaling/v2beta2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
+* For a `Deployment`, `ReplicaSet`, `Statefulset` object, use `apps/v1`.
 * For a `ReplicationController`, use `v1`.
 * For a `DeploymentConfig`, use `apps.openshift.io/v1`.
-* For a `Deployment`, `ReplicaSet`, `Statefulset` object, use `apps/v1`.
 <4> Specify the type of object. The object must be a `Deployment`, `DeploymentConfig`/`dc`, `ReplicaSet`/`rs`, `ReplicationController`/`rc`, or `StatefulSet`.
 <5> Specify the name of the object to scale. The object must exist.
 <6> Specify the minimum number of replicas when scaling down.
@@ -135,7 +140,7 @@ $ oc get hpa cpu-autoscale
 .Example output
 [source,terminal]
 ----
-NAME            REFERENCE                       TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
-cpu-autoscale   ReplicationController/example   173m/500m       1         10        1          20m
+NAME            REFERENCE            TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
+cpu-autoscale   Deployment/example   173m/500m       1         10        1          20m
 ----
 

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -6,9 +6,15 @@
 
 = Creating a horizontal pod autoscaler object for memory utilization by using the CLI
 
-You can create a horizontal pod autoscaler (HPA) for an existing `DeploymentConfig` object or `ReplicationController` object
-that automatically scales the pods associated with that object to maintain the average memory utilization you specify,
-either a direct value or a percentage of requested memory.
+Using the {product-title} CLI, you can create a horizontal pod autoscaler (HPA) to automatically scale an existing 
+`Deployment`, `DeploymentConfig`, `ReplicaSet`, `ReplicationController`, or `StatefulSet` object. The HPA  
+scales the pods associated with that object to maintain the average memory utilization you specify, either a direct value or a percentage 
+of requested memory.
+
+[NOTE]
+====
+It is recommended to use a `Deployment` object or `ReplicaSet` object unless you need a specific feature or behavior provided by other objects.
+====
 
 The HPA increases and decreases the number of replicas between the minimum and maximum numbers to maintain
 the specified memory utilization across all pods.
@@ -36,13 +42,14 @@ Labels:       <none>
 Annotations:  <none>
 API Version:  metrics.k8s.io/v1beta1
 Containers:
-  Name:  scheduler
+  Name:  wait-for-host-port
   Usage:
-    Cpu:     2m
-    Memory:  41056Ki
-  Name:      wait-for-host-port
-  Usage:
+    Cpu:     0
     Memory:  0
+  Name:      scheduler
+  Usage:
+    Cpu:     8m
+    Memory:  45440Ki
 Kind:        PodMetrics
 Metadata:
   Creation Timestamp:  2020-02-14T22:21:14Z
@@ -58,9 +65,8 @@ To create a horizontal pod autoscaler for memory utilization:
 
 . Create a YAML file for one of the following:
 
-** To scale for a specific memory value, create a `HorizontalPodAutoscaler` object similar to the following for an existing `ReplicationController` object or replication controller:
+** To scale for a specific memory value, create a `HorizontalPodAutoscaler` object similar to the following for an existing object:
 +
-.Example output
 [source,yaml,options="nowrap"]
 ----
 apiVersion: autoscaling/v2beta2 <1>
@@ -71,7 +77,7 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: v1 <3>
-    kind: ReplicationController <4>
+    kind: Deployment <4>
     name: example <5>
   minReplicas: 1 <6>
   maxReplicas: 10 <7>
@@ -97,9 +103,11 @@ spec:
 <1> Use the `autoscaling/v2beta2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
-* For a replication controller, use `v1`,
-* For a `DeploymentConfig` object, use `apps.openshift.io/v1`.
-<4> Specify the kind of object to scale, either `ReplicationController` or `DeploymentConfig`.
+* For a `Deployment`, `ReplicaSet`, or `Statefulset` object, use `apps/v1`.
+* For a `ReplicationController`, use `v1`.
+* For a `DeploymentConfig`, use `apps.openshift.io/v1`.
+<4> Specify the type of object. The object must be a `Deployment`, `DeploymentConfig`, 
+`ReplicaSet`, `ReplicationController`, or `StatefulSet`.
 <5> Specify the name of the object to scale. The object must exist.
 <6> Specify the minimum number of replicas when scaling down.
 <7> Specify the maximum number of replicas when scaling up.
@@ -109,9 +117,8 @@ spec:
 <11> Specify `averageValue` and a specific memory value.
 <12> Optional: Specify a scaling policy to control the rate of scaling up or down.
 
-** To scale for a percentage, create a `HorizontalPodAutoscaler` object similar to the following:
+** To scale for a percentage, create a `HorizontalPodAutoscaler` object similar to the following for an existing object:
 +
-.Example output
 [source,yaml,options="nowrap"]
 ----
 apiVersion: autoscaling/v2beta2 <1>
@@ -122,12 +129,12 @@ metadata:
 spec:
   scaleTargetRef:
     apiVersion: apps.openshift.io/v1 <3>
-    kind: DeploymentConfig <4>
+    kind: Deployment <4>
     name: example <5>
   minReplicas: 1 <6>
   maxReplicas: 10 <7>
   metrics: <8>
-  - type: Resource
+  - type: Deployment
     resource:
       name: memory <9>
       target:
@@ -148,9 +155,11 @@ spec:
 <1> Use the `autoscaling/v2beta2` API.
 <2> Specify a name for this horizontal pod autoscaler object.
 <3> Specify the API version of the object to scale:
-* For a replication controller, use `v1`,
-* For a `DeploymentConfig` object, use `apps.openshift.io/v1`.
-<4> Specify the kind of object to scale, either `ReplicationController` or `DeploymentConfig`.
+* For a ReplicationController, use `v1`.
+* For a DeploymentConfig, use `apps.openshift.io/v1`.
+* For a Deployment, ReplicaSet, Statefulset object, use `apps/v1`.
+<4> Specify the type of object. The object must be a `Deployment`, `DeploymentConfig`, 
+`ReplicaSet`, `ReplicationController`, or `StatefulSet`.
 <5> Specify the name of the object to scale. The object must exist.
 <6> Specify the minimum number of replicas when scaling down.
 <7> Specify the maximum number of replicas when scaling up.
@@ -191,8 +200,8 @@ $ oc get hpa hpa-resource-metrics-memory
 .Example output
 [source,terminal]
 ----
-NAME                          REFERENCE                       TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
-hpa-resource-metrics-memory   ReplicationController/example   2441216/500Mi   1         10        1          20m
+NAME                          REFERENCE            TARGETS         MINPODS   MAXPODS   REPLICAS   AGE
+hpa-resource-metrics-memory   Deployment/example   2441216/500Mi   1         10        1          20m
 ----
 +
 [source,terminal]
@@ -208,7 +217,7 @@ Namespace:                   default
 Labels:                      <none>
 Annotations:                 <none>
 CreationTimestamp:           Wed, 04 Mar 2020 16:31:37 +0530
-Reference:                   ReplicationController/example
+Reference:                   Deployment/example
 Metrics:                     ( current / target )
   resource memory on pods:   2441216 / 500Mi
 Min replicas:                1

--- a/modules/nodes-pods-autoscaling-creating-web-console.adoc
+++ b/modules/nodes-pods-autoscaling-creating-web-console.adoc
@@ -5,7 +5,7 @@
 [id="nodes-pods-autoscaling-creating-web-console_{context}"]
 = Creating a horizontal pod autoscaler by using the web console
 
-From the web console, you can create a horizontal pod autoscaler (HPA) that specifies the minimum and maximum number of pods you want to run on a deployment. You can also define the amount of CPU or memory usage that your pods should target..
+From the web console, you can create a horizontal pod autoscaler (HPA) that specifies the minimum and maximum number of pods you want to run on a `Deployment` or `DeploymentConfig` object. You can also define the amount of CPU or memory usage that your pods should target.
 
 [NOTE]
 ====

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -163,7 +163,12 @@ CRI-O has the following default list of capabilities that are allowed for each c
 * `NET_BIND_SERVICE`
 * `KILL`
 
-The containers use the capabilities from this default list, but pod manifest authors can alter it by requesting additional capabilities or removing some of the default behaviors. Use the `allowedCapabilities`, `defaultAddCapabilities`, and `requiredDropCapabilities` parameters to control such requests from the pods and to dictate which capabilities can be requested, which ones must be added to each container, and which ones must be forbidden.
+The containers use the capabilities from this default list, but pod manifest authors can alter the list by requesting additional capabilities or removing some of the default behaviors. Use the `allowedCapabilities`, `defaultAddCapabilities`, and `requiredDropCapabilities` parameters to control such requests from the pods and to specify which capabilities can be requested, which ones must be added to each container, and which ones must be forbidden, or dropped, from each container.
+
+[NOTE]
+====
+You can drop all capabilites from containers by setting the `requiredDropCapabilities` parameter to `ALL`. 
+====
 
 [id="authorization-SCC-strategies_{context}"]
 == Security context constraints strategies

--- a/modules/security-context-constraints-creating.adoc
+++ b/modules/security-context-constraints-creating.adoc
@@ -38,10 +38,10 @@ groups:
 - my-admin-group
 ----
 +
-Optionally, you can specify drop capabilities for an SCC by setting the
+Optionally, you can drop specific capabilities for an SCC by setting the
 `requiredDropCapabilities` field with the desired values. Any specified
-capabilities are dropped from the container. For example, to create an SCC
-with the `KILL`, `MKNOD`, and `SYS_CHROOT` required drop capabilities, add
+capabilities are dropped from the container. To drop all capabilities, specify `ALL`. For example, to create an SCC
+that drops the `KILL`, `MKNOD`, and `SYS_CHROOT` capabilities, add
 the following to the SCC object:
 +
 [source,yaml]
@@ -51,6 +51,12 @@ requiredDropCapabilities:
 - MKNOD
 - SYS_CHROOT
 ----
++
+[NOTE]
++
+====
+You cannot list a capability in both `allowedCapabilities` and `requiredDropCapabilities`.
+====
 +
 CRI-O supports the same list of capability values that are found in the link:https://docs.docker.com/engine/reference/run/#runtime-privilege-and-linux-capabilities[Docker documentation].
 

--- a/modules/security-context-constraints-example.adoc
+++ b/modules/security-context-constraints-example.adoc
@@ -37,7 +37,11 @@ metadata:
   name: privileged
 priority: null
 readOnlyRootFilesystem: false
-requiredDropCapabilities: [] <5>
+requiredDropCapabilities: <5>
+- KILL
+- MKNOD
+- SETUID
+- SETGID
 runAsUser: <6>
   type: RunAsAny
 seLinuxContext: <7>
@@ -61,7 +65,7 @@ allows any capabilities.
 <3> The `FSGroup` strategy, which dictates the allowable values for the
 security context.
 <4> The groups that can access this SCC.
-<5> A list of capabilities that are be dropped from a pod.
+<5> A list of capabilities to drop from a pod. Or, specify `ALL` 
 <6> The `runAsUser` strategy type, which dictates the allowable values for the
 Security Context.
 //could use the available strategies

--- a/nodes/pods/nodes-pods-autoscaling.adoc
+++ b/nodes/pods/nodes-pods-autoscaling.adoc
@@ -9,8 +9,14 @@ As a developer, you can use a horizontal pod autoscaler (HPA) to
 specify how {product-title} should automatically increase or decrease the scale of
 a replication controller or deployment configuration, based on metrics collected
 from the pods that belong to that replication controller or deployment
-configuration.
+configuration. You can create an HPA for any `Deployment`, `DeploymentConfig`, 
+`ReplicaSet`, `ReplicationController`, or `StatefulSet` object.
 
+[NOTE]
+====
+It is recommended to use a `Deployment` object or `ReplicaSet` object unless you need a specific feature or behavior provided by other objects. For more information on
+these objects, see xref:../../applications/deployments/what-deployments-are.adoc#what-deployments-are[Understanding Deployment and DeploymentConfig objects].
+====
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2025586

Add `ALL` to the `requiredDropCapabilities` and few other small edits.

**DO NOT MERGE TO 4.6 AND 4.7 UNTIL https://github.com/cri-o/cri-o/pull/5466 MERGES**

Previews
[Security context constraints settings](https://deploy-preview-39124--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints#scc-settings_configuring-internal-oauth) -- Last paragraph in section and note.
[Example security context constraints](https://deploy-preview-39124--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints#security-context-constraints-example_configuring-internal-oauth) -- Expanded callout 5.
[Creating security context constraints](https://deploy-preview-39124--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints#security-context-constraints-creating_configuring-internal-oauth) -- Text changes and note in step 1.
