### PR TITLE
[enterprise-4.10] SRVCOM-1574: Serverless 1.19.0 release notes

### DIFF
--- a/modules/serverless-rn-1-19-0.adoc
+++ b/modules/serverless-rn-1-19-0.adoc
@@ -1,0 +1,60 @@
+[id="serverless-rn-1-19-0_{context}"]
+= Release Notes for Red Hat {ServerlessProductName} 1.19.0
+
+[id="new-features-1-19-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.25.
+* {ServerlessProductName} now uses Knative Eventing 0.25.
+* {ServerlessProductName} now uses Kourier 0.25.
+* {ServerlessProductName} now uses Knative `kn` CLI 0.25.
+* {ServerlessProductName} now uses Knative Kafka 0.25.
+* The `kn func` CLI plug-in now uses `func` 0.19.
+
+* The `KafkaBinding` API is deprecated in {ServerlessProductName} 1.19.0 and will be removed in a future release.
+
+* HTTPS redirection is now supported and can be configured either globally for a cluster or per each Knative service.
+
+[id="fixed-issues-1-19-0_{context}"]
+== Fixed issues
+
+* In previous releases, the Kafka channel dispatcher waited only for the local commit to succeed before responding, which might have caused lost events in the case of an Apache Kafka node failure. The Kafka channel dispatcher now waits for all in-sync replicas to commit before responding.
+
+[id="known-issues-1-19-0_{context}"]
+== Known issues
+
+* In `func` version 0.19, some runtimes might be unable to build a function by using podman. You might see an error message similar to the following:
++
+[source,terminal]
+----
+ERROR: failed to image: error during connect: Get "http://%2Fvar%2Frun%2Fdocker.sock/v1.40/info": EOF
+----
++
+** The following workaround exists for this issue:
+
+.. Update the podman service by adding `--time=0` to the service `ExecStart` definition:
++
+.Example service configuration
+[source,terminal]
+----
+ExecStart=/usr/bin/podman $LOGGING system service --time=0
+----
+.. Restart the podman service by running the following commands:
++
+[source,terminal]
+----
+$ systemctl --user daemon-reload
+----
++
+[source,terminal]
+----
+$ systemctl restart --user podman.socket
+----
+
+** Alternatively, you can expose the podman API by using TCP:
++
+[source,terminal]
+----
+$ podman system service --time=0 tcp:127.0.0.1:5534 &
+export DOCKER_HOST=tcp://127.0.0.1:5534
+----

--- a/serverless/admin_guide/knative-serving-CR-config.adoc
+++ b/serverless/admin_guide/knative-serving-CR-config.adoc
@@ -13,8 +13,7 @@ include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
 include::modules/serverless-config-emptydir.adoc[leveloffset=+1]
 
 // global https redirect
-// include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
-// uncomment at 1.19.0 release
+include::modules/serverless-https-redirect-global.adoc[leveloffset=+1]
 
 [id="additional-resources_knative-serving-CR-config"]
 == Additional resources

--- a/serverless/knative_serving/serverless-applications.adoc
+++ b/serverless/knative_serving/serverless-applications.adoc
@@ -46,8 +46,7 @@ include::modules/interacting-serverless-apps-http2-gRPC.adoc[leveloffset=+1]
 include::modules/serverless-services-network-policies.adoc[leveloffset=+1]
 
 // HTTPS redirection
-// include::modules/serverless-https-redirect-service.adoc[leveloffset=+1]
-// uncomment at 1.19.0 release
+include::modules/serverless-https-redirect-service.adoc[leveloffset=+1]
 
 [id="serverless-applications-kn-offline-mode"]
 == Using kn CLI in offline mode

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -18,6 +18,7 @@ For details about the latest Knative component releases, see the link:https://kn
 include::modules/serverless-api-versions.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/serverless-rn-1-19-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-18-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-17-0.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-16-0.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherrypicked from https://github.com/openshift/openshift-docs/pull/38150/commits/6f86c384681cd1427c9eb43f78a980173afbeffc xref: https://github.com/openshift/openshift-docs/pull/38150