### PR TITLE
[OSDOCS-1451] - Specified Managing Security Context Constraints

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -75,6 +75,13 @@ Topics:
 - Name: Managing administration roles and users
   File: osd-admin-roles
 ---
+Name: Authentication and authorization
+Dir: authentication
+Distros: openshift-dedicated
+Topics:
+- Name: Managing security context constraints
+  File: managing-security-context-constraints
+---
 Name: Upgrading
 Dir: upgrading
 Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -140,6 +140,13 @@ Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
 ---
+Name: Authentication and authorization
+Dir: authentication
+Distros: openshift-rosa
+Topics:
+- Name: Managing security context constraints
+  File: managing-security-context-constraints
+---
 Name: Nodes
 Dir: nodes
 Distros: openshift-rosa

--- a/authentication/managing-security-context-constraints.adoc
+++ b/authentication/managing-security-context-constraints.adoc
@@ -6,15 +6,14 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 include::modules/security-context-constraints-about.adoc[leveloffset=+1]
-
-// I should add a module about installing the OC command line.
-
 include::modules/security-context-constraints-pre-allocated-values.adoc[leveloffset=+1]
-
 include::modules/security-context-constraints-example.adoc[leveloffset=+1]
 
+// This section shouldn't show on OSD
+ifndef::openshift-dedicated[]
 include::modules/security-context-constraints-creating.adoc[leveloffset=+1]
+endif::[]
+// End Exclusion
 
 include::modules/security-context-constraints-rbac.adoc[leveloffset=+1]
-
 include::modules/security-context-constraints-command-reference.adoc[leveloffset=+1]

--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -34,6 +34,7 @@ The cluster contains several default security context constraints (SCCs) as desc
 [IMPORTANT]
 ====
 Do not modify the default SCCs. Customizing the default SCCs can lead to issues when some of the platform pods deploy or {product-title} is upgraded. During upgrades between some versions of {product-title}, the values of the default SCCs are reset to the default values, which discards all customizations to those SCCs.
+
 ifdef::openshift-origin,openshift-enterprise,openshift-webscale[]
 Instead, create new SCCs as needed.
 endif::[]
@@ -47,6 +48,7 @@ endif::[]
 |`anyuid`
 | Provides all features of the `restricted` SCC, but allows users to run with any UID and any GID.
 
+ifndef::openshift-dedicated[]
 |`hostaccess`
 |Allows access to all host namespaces but still requires pods to be run with a UID and SELinux context that are allocated to the namespace.
 
@@ -78,10 +80,12 @@ If additional workloads are run on control plane hosts, use caution when providi
 ====
 This SCC allows host file system access as any UID, including UID 0. Grant with caution.
 ====
+endif::[]
 
 |`nonroot`
 |Provides all features of the `restricted` SCC, but allows users to run with any non-root UID. The user must specify the UID or it must be specified in the manifest of the container runtime.
 
+ifndef::openshift-dedicated[]
 |`privileged`
 |Allows access to all privileged and host features and the ability to run as any user, any group, any FSGroup, and with any SELinux context.
 
@@ -107,6 +111,7 @@ The `privileged` SCC allows:
 ====
 Setting `privileged: true` in the pod specification does not select the `privileged` SCC. Setting `privileged: true` in the pod specification matches on the `allowPrivilegedContainer` field of an SCC.
 ====
+endif::[]
 
 |`restricted`
 |Denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
@@ -119,7 +124,6 @@ The `restricted` SCC:
 * Requires that a pod is run with a pre-allocated MCS label
 * Allows pods to use any FSGroup
 * Allows pods to use any supplemental group
-
 |===
 
 [id="scc-settings_{context}"]
@@ -130,7 +134,6 @@ a pod has access to. These settings fall into three categories:
 
 [cols="1,3",options="header"]
 |===
-
 |Category
 |Description
 
@@ -203,7 +206,7 @@ pre-allocated values. Uses the minimum value of the first range as the default.
 Validates against the first ID in the first range.
 * `RunAsAny` - No default provided. Allows any `fsGroup` ID to be specified.
 
-
+ifndef::openshift-dedicated[]
 [id="authorization-controlling-volumes_{context}"]
 == Controlling volumes
 
@@ -257,6 +260,7 @@ settings in the `volumes` field. For example, if `allowHostDirVolumePlugin`
 is set to false but allowed in the `volumes` field, then the `hostPath`
 value will be removed from `volumes`.
 ====
+endif::[]
 
 
 [id="admission_{context}"]

--- a/modules/security-context-constraints-pre-allocated-values.adoc
+++ b/modules/security-context-constraints-pre-allocated-values.adoc
@@ -2,7 +2,7 @@
 //
 // * authentication/managing-security-context-constraints.adoc
 
-ifdef::openshift-origin,openshift-enterprise[]
+ifdef::openshift-origin,openshift-enterprise,openshift-dedicated,openshift-rosa[]
 [id="security-context-constraints-pre-allocated-values_{context}"]
 = About pre-allocated security context constraints values
 


### PR DESCRIPTION
This PR adds the "Managing security context constraints" to the OSD book and removes sections that are not relevant.

JIRA: https://issues.redhat.com/browse/OSDOCS-1451

Original PR: https://github.com/openshift/openshift-docs/pull/38236. Closed accidentally when changing base branch.

PREVIEW:

OSD: https://deploy-preview-39137--osdocs.netlify.app/openshift-dedicated/latest/authentication/managing-security-context-constraints.html

ROSA: https://deploy-preview-39137--osdocs.netlify.app/openshift-rosa/latest/authentication/managing-security-context-constraints.html