### PR TITLE
[RHACS] Fixed all instances of `CENTRAL_ADDRESS` variable

### DIFF
--- a/modules/back-up-central-database.adoc
+++ b/modules/back-up-central-database.adoc
@@ -20,11 +20,11 @@ You can back up the Central database and use that backup for rolling back from a
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" central backup
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central backup
 ----
 ** For {product-title} 3.0.54 and older:
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" central db backup
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central db backup
 ----

--- a/modules/on-demand-backups-roxctl-admin-pass.adoc
+++ b/modules/on-demand-backups-roxctl-admin-pass.adoc
@@ -15,24 +15,24 @@ You can back up the entire database of {product-title} by using your administrat
 
 .Procedure
 
-. Set the `CENTRAL_ADDRESS` environment variable:
+. Set the `ROX_CENTRAL_ADDRESS` environment variable:
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the `backup` command:
 * For {product-title} 3.0.55 or later:
 +
 [source,terminal]
 ----
-$ roxctl -p <admin_password> -e "$CENTRAL_ADDRESS" central backup
+$ roxctl -p <admin_password> -e "$ROX_CENTRAL_ADDRESS" central backup
 ----
 * For {product-title} 3.0.54 or older:
 +
 [source,terminal]
 ----
-$ roxctl -p <admin_password> -e "$CENTRAL_ADDRESS" central db backup
+$ roxctl -p <admin_password> -e "$ROX_CENTRAL_ADDRESS" central db backup
 ----
 
 By default, the `roxctl` CLI saves the backup file in the directory in which you run the command.

--- a/modules/on-demand-backups-roxctl-api.adoc
+++ b/modules/on-demand-backups-roxctl-api.adoc
@@ -17,7 +17,7 @@ You can assign the *Analyst* system role to grant this level of access. The *Ana
 
 .Procedure
 
-. Set the `ROX_API_TOKEN` and the `CENTRAL_ADDRESS` environment variables:
+. Set the `ROX_API_TOKEN` and the `ROX_CENTRAL_ADDRESS` environment variables:
 +
 [source,terminal]
 ----
@@ -26,20 +26,20 @@ $ export ROX_API_TOKEN=<api_token>
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the `backup` command:
 * For {product-title} 3.0.55 or later:
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" central backup
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central backup
 ----
 * For {product-title} 3.0.54 or older:
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" central db backup
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central db backup
 ----
 
 By default, the `roxctl` CLI saves the backup file in the directory in which you run the command.

--- a/modules/restore-acs-roxctl-admin-pass.adoc
+++ b/modules/restore-acs-roxctl-admin-pass.adoc
@@ -15,15 +15,15 @@ You can restore the entire database of {product-title} by using your administrat
 * You must have installed the `roxctl` CLI.
 
 .Procedure
-. Set the `CENTRAL_ADDRESS` environment variable:
+. Set the `ROX_CENTRAL_ADDRESS` environment variable:
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the `restore` command:
 +
 [source,terminal]
 ----
-$ roxctl -p <admin_password> -e "$CENTRAL_ADDRESS" central db restore <backup_file>
+$ roxctl -p <admin_password> -e "$ROX_CENTRAL_ADDRESS" central db restore <backup_file>
 ----

--- a/modules/restore-acs-roxctl-api.adoc
+++ b/modules/restore-acs-roxctl-api.adoc
@@ -15,7 +15,7 @@ You can restore the entire database of {product-title} by using an API token.
 * You must have installed the `roxctl` CLI.
 
 .Procedure
-. Set the `ROX_API_TOKEN` and the `CENTRAL_ADDRESS` environment variables:
+. Set the `ROX_API_TOKEN` and the `ROX_CENTRAL_ADDRESS` environment variables:
 +
 [source,terminal]
 ----
@@ -24,11 +24,11 @@ $ export ROX_API_TOKEN=<api_token>
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the `restore` command:
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" central db restore <backup_file>
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" central db restore <backup_file>
 ----

--- a/modules/upgrade-scanner.adoc
+++ b/modules/upgrade-scanner.adoc
@@ -18,7 +18,7 @@ You can update Scanner to the latest version by using the `roxctl` CLI.
 +
 [source,terminal]
 ----
-$ roxctl -e "$CENTRAL_ADDRESS" scanner generate
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" scanner generate
 ----
 +
 [source,terminal]

--- a/modules/upload-definitions-to-central-admin-pass.adoc
+++ b/modules/upload-definitions-to-central-admin-pass.adoc
@@ -14,11 +14,11 @@ You can upload the vulnerability definitions database that Scanner uses to Centr
 
 .Procedure
 
-. Set the `CENTRAL_ADDRESS` environment variable:
+. Set the `ROX_CENTRAL_ADDRESS` environment variable:
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the following command to upload the definitions file:
 +
@@ -26,6 +26,6 @@ $ export CENTRAL_ADDRESS=<address>:<port_number>
 ----
 $ roxctl scanner upload-db \
   -p <your_administrator_password> \
-  -e "$CENTRAL_ADDRESS" \
+  -e "$ROX_CENTRAL_ADDRESS" \
   --scanner-db-file=<compressed_scanner_definitions.zip>
 ----

--- a/modules/upload-definitions-to-central-api-token.adoc
+++ b/modules/upload-definitions-to-central-api-token.adoc
@@ -14,7 +14,7 @@ You can upload the vulnerability definitions database that Scanner uses to Centr
 
 .Procedure
 
-. Set the `ROX_API_TOKEN` and the `CENTRAL_ADDRESS` environment variables:
+. Set the `ROX_API_TOKEN` and the `ROX_CENTRAL_ADDRESS` environment variables:
 +
 [source,terminal]
 ----
@@ -23,14 +23,14 @@ $ export ROX_API_TOKEN=<api_token>
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the following command to upload the definitions file:
 +
 [source,terminal]
 ----
 $ roxctl scanner upload-db \
-  -e "$CENTRAL_ADDRESS" \
+  -e "$ROX_CENTRAL_ADDRESS" \
   --scanner-db-file=<compressed_scanner_definitions.zip>
 ----
 

--- a/modules/upload-kernel-support-package-to-central.adoc
+++ b/modules/upload-kernel-support-package-to-central.adoc
@@ -14,7 +14,7 @@ You can upload the kernel support packages containing probes for all recent and 
 
 .Procedure
 
-. Set the `ROX_API_TOKEN` and the `CENTRAL_ADDRESS` environment variables:
+. Set the `ROX_API_TOKEN` and the `ROX_CENTRAL_ADDRESS` environment variables:
 +
 [source,terminal]
 ----
@@ -23,7 +23,7 @@ $ export ROX_API_TOKEN=<api_token>
 +
 [source,terminal]
 ----
-$ export CENTRAL_ADDRESS=<address>:<port_number>
+$ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 ----
 . Run the following command to upload the kernel support packages:
 +


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-3002

Changed all instances of the `CENTRAL_ADDRESS` variable to `ROX_CENTRAL_ADDRESS` for correctness and consistency. 