### PR TITLE
Capitalising Operator references

### DIFF
--- a/modules/ztp-validating-the-generation-of-policy-crs.adoc
+++ b/modules/ztp-validating-the-generation-of-policy-crs.adoc
@@ -108,4 +108,4 @@ status:
 ----
 +
 
-If the Namespace, OperatorGroup, and Subscription policies are compliant but the operator configuration policies are not it is likely that the operators did not install.
+If the Namespace, OperatorGroup, and Subscription policies are compliant but the Operator configuration policies are not it is likely that the Operators did not install.


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This pull request capitalises "Operator" in one file. It is a test PR created to test the recent build format changes in the openshift-docs repo.