### PR TITLE
OCPRHV-609 Storage domain and thin/preallocated support

### DIFF
--- a/modules/machineset-yaml-rhv.adoc
+++ b/modules/machineset-yaml-rhv.adoc
@@ -52,16 +52,17 @@ spec:
           guaranteed_memory_mb:  <memory_size> <14>
           os_disk: <15>
             size_gb: <disk_size> <16>
-          network_interfaces: <17>
-            vnic_profile_id:  <vnic_profile_id> <18>
+            storage_domain_id: <storage_domain_UUID> <17>
+          network_interfaces: <18>
+            vnic_profile_id:  <vnic_profile_id> <19>
           credentialsSecret:
-            name: ovirt-credentials <19>
+            name: ovirt-credentials <20>
           kind: OvirtMachineProviderSpec
-          type: <workload_type> <20>
-          auto_pinning_policy: <auto_pinning_policy> <21>
-          hugepages: <hugepages> <22>
+          type: <workload_type> <21>
+          auto_pinning_policy: <auto_pinning_policy> <22>
+          hugepages: <hugepages> <23>
           affinityGroupsNames:
-            - compute <23>
+            - compute <24>
           userDataSecret:
             name: worker-user-data
 ----
@@ -113,16 +114,18 @@ If you are using a version earlier than {rh-virtualization} 4.4.8, see link:http
 
 <16> Optional: Specify the size of the bootable disk in GiB.
 
-<17> Optional: List of the network interfaces of the VM. If you include this parameter, {product-title} discards all network interfaces from the template and creates new ones.
+<17> Optional: Specify the UUID of the storage domain for the compute node's disks. If none is provided, the compute node is created on the same storage domain as the control nodes. (default)
 
-<18> Optional: Specify the vNIC profile ID.
+<18> Optional: List of the network interfaces of the VM. If you include this parameter, {product-title} discards all network interfaces from the template and creates new ones.
 
-<19> Specify the name of the secret that holds the {rh-virtualization} credentials.
+<19> Optional: Specify the vNIC profile ID.
 
-<20> Optional: Specify the workload type for which the instance is optimized. This value affects the `{rh-virtualization} VM` parameter. Supported values: `desktop`, `server` (default), `high_performance`. `high_performance` improves performance on the VM, but there are limitations. For example, you cannot access the VM with a graphical console. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
-<21> Optional: AutoPinningPolicy defines the policy that automatically sets CPU and NUMA settings, including pinning to the host for this instance. Supported values: `none`, `resize_and_pin`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Setting_NUMA_Nodes[Setting NUMA Nodes] in the _Virtual Machine Management Guide_.
-<22> Optional: Hugepages is the size in KiB for defining hugepages in a VM. Supported values: `2048` or `1048576`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_Huge_Pages[Configuring Huge Pages] in the _Virtual Machine Management Guide_.
-<23> Optional: A list of affinity group names that should be applied to the VMs. The affinity groups must exist in oVirt.
+<20> Specify the name of the secret that holds the {rh-virtualization} credentials.
+
+<21> Optional: Specify the workload type for which the instance is optimized. This value affects the `{rh-virtualization} VM` parameter. Supported values: `desktop`, `server` (default), `high_performance`. `high_performance` improves performance on the VM, but there are limitations. For example, you cannot access the VM with a graphical console. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_High_Performance_Virtual_Machines_Templates_and_Pools[Configuring High Performance Virtual Machines, Templates, and Pools] in the _Virtual Machine Management Guide_.
+<22> Optional: AutoPinningPolicy defines the policy that automatically sets CPU and NUMA settings, including pinning to the host for this instance. Supported values: `none`, `resize_and_pin`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Setting_NUMA_Nodes[Setting NUMA Nodes] in the _Virtual Machine Management Guide_.
+<23> Optional: Hugepages is the size in KiB for defining hugepages in a VM. Supported values: `2048` or `1048576`. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_virtualization/4.4/html-single/virtual_machine_management_guide/index#Configuring_Huge_Pages[Configuring Huge Pages] in the _Virtual Machine Management Guide_.
+<24> Optional: A list of affinity group names that should be applied to the VMs. The affinity groups must exist in oVirt.
 
 [NOTE]
 ====


### PR DESCRIPTION
RFE

This PR addresses [OCPRHV-609](https://issues.redhat.com/browse/OCPRHV-609).

This applies to:
enterprise-4.10

Preview:
https://deploy-preview-39171--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-rhv.html

Added two new parameters in the following topic:
modules/machineset-yaml-rhv.adoc