### PR TITLE
BZ-2008984: Clarifying that 0 priority is the highest

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -322,15 +322,15 @@ pod to fail.
 == Security context constraints prioritization
 
 Security context constraints (SCCs) have a priority field that affects the ordering when attempting to
-validate a request by the admission controller. A higher priority
-SCC is moved to the front of the set when sorting. When the complete set
-of available SCCs are determined they are ordered by:
+validate a request by the admission controller. A priority value of `0` is the highest possible priority. Higher priority
+SCCs are moved to the front of the set when sorting. When the complete set
+of available SCCs is determined, the SCCs are ordered in the following manner:
 
-. Highest priority first, nil is considered a 0 priority
-. If priorities are equal, the SCCs will be sorted from most restrictive to least restrictive
-. If both priorities and restrictions are equal the SCCs will be sorted by name
+. The highest priority SCCs are ordered first. A nil priority is considered a `0`, or highest, priority.
+. If the priorities are equal, the SCCs are sorted from most restrictive to least restrictive.
+. If both the priorities and restrictions are equal, the SCCs are sorted by name.
 
 By default, the `anyuid` SCC granted to cluster administrators is given priority
 in their SCC set. This allows cluster administrators to run pods as any
 user by without specifying a `RunAsUser` on the pod's `SecurityContext`. The
-administrator may still specify a `RunAsUser` if they wish.
+administrator can still specify a `RunAsUser` if they want.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2008984

Preview: https://deploy-preview-39177--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints#scc-prioritization_configuring-internal-oauth