### PR TITLE
OSDOCS-3000:Changing tab name in web console documentation to match UI

### DIFF
--- a/modules/customizing-project-request-message.adoc
+++ b/modules/customizing-project-request-message.adoc
@@ -31,7 +31,7 @@ To customize the project request message:
 
 ** Using the web console:
 ... Navigate to the *Administration* -> *Cluster Settings* page.
-... Click *Global Configuration* to view all configuration resources.
+... Click *Configuration* to view all configuration resources.
 ... Find the entry for *Project* and click *Edit YAML*.
 
 ** Using the CLI:

--- a/modules/identity-provider-configuring-using-web-console.adoc
+++ b/modules/identity-provider-configuring-using-web-console.adoc
@@ -15,7 +15,7 @@ Configure your identity provider (IDP) through the web console instead of the CL
 .Procedure
 
 . Navigate to *Administration* -> *Cluster Settings*.
-. Under the *Global Configuration* tab, click *OAuth*.
+. Under the *Configuration* tab, click *OAuth*.
 . Under the *Identity Providers* section, select your identity provider from the
 *Add* drop-down menu.
 

--- a/modules/modifying-template-for-new-projects.adoc
+++ b/modules/modifying-template-for-new-projects.adoc
@@ -37,7 +37,7 @@ $ oc create -f template.yaml -n openshift-config
 
 ** Using the web console:
 ... Navigate to the *Administration* -> *Cluster Settings* page.
-... Click *Global Configuration* to view all configuration resources.
+... Click *Configuration* to view all configuration resources.
 ... Find the entry for *Project* and click *Edit YAML*.
 
 ** Using the CLI:

--- a/modules/olm-removing-catalogs.adoc
+++ b/modules/olm-removing-catalogs.adoc
@@ -11,7 +11,7 @@ As a cluster administrator, you can remove custom Operator catalogs that have be
 
 . In the *Administrator* perspective of the web console, navigate to *Administration* -> *Cluster Settings*.
 
-. Click the *Global Configuration* tab, and then click *OperatorHub*.
+. Click the *Configuration* tab, and then click *OperatorHub*.
 
 . Click the *Sources* tab.
 

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -51,7 +51,7 @@ $ oc patch OperatorHub cluster --type json \
 
 [TIP]
 ====
-Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Global Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, delete, disable, and enable individual sources.
+Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, delete, disable, and enable individual sources.
 ====
 
 ifeval::["{context}" == "olm-restricted-networks"]

--- a/modules/quotas-requiring-explicit-quota.adoc
+++ b/modules/quotas-requiring-explicit-quota.adoc
@@ -95,7 +95,7 @@ $ oc edit template <project_request_template> -n openshift-config
 +
 ** By using the web console:
 ... Navigate to the *Administration* -> *Cluster Settings* page.
-... Click *Global Configuration* to view all configuration resources.
+... Click *Configuration* to view all configuration resources.
 ... Find the entry for *Project* and click *Edit YAML*.
 +
 ** By using the CLI:


### PR DESCRIPTION
[OSDOCS-3000](https://issues.redhat.com/browse/OSDOCS-3000)

- Applies to `enterprise-4.9`+
- [Preview link](https://deploy-preview-39180--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/default-network-policy.html#modifying-template-for-new-projects_default-network-policy)