### PR TITLE
OSSMDOC-434: Clarify 3scale Nav headings.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2735,9 +2735,9 @@ Topics:
     File: ossm-federation
   - Name: Extensions
     File: ossm-extensions
-  - Name: The 3scale WebAssembly module
+  - Name: 3scale WebAssembly for 2.1
     File: ossm-threescale-webassembly-module
-  - Name: Using the 3scale Istio adapter
+  - Name: 3scale Istio adapter for 2.0
     File: threescale-adapter
   - Name: Troubleshooting Service Mesh
     File: ossm-troubleshooting-istio
@@ -2768,7 +2768,7 @@ Topics:
     File: prepare-to-deploy-applications-ossm
   - Name: Data visualization and observability
     File: ossm-observability
-  - Name: Using the 3scale Istio adapter
+  - Name: 3scale Istio adapter for 1.x
     File: threescale-adapter
   - Name: Removing Service Mesh
     File: removing-ossm

--- a/service_mesh/v2x/ossm-threescale-webassembly-module.adoc
+++ b/service_mesh/v2x/ossm-threescale-webassembly-module.adoc
@@ -1,5 +1,5 @@
 [id="ossm-threescale-webassembly-module"]
-= The 3scale WebAssembly module
+= Using the 3scale WebAssembly module
 include::modules/ossm-document-attributes.adoc[]
 :context: ossm-threescale-webassembly-module
 

--- a/service_mesh/v2x/threescale-adapter.adoc
+++ b/service_mesh/v2x/threescale-adapter.adoc
@@ -10,6 +10,8 @@ It is not required for {ProductName}.
 
 [IMPORTANT]
 ====
+You can only use the 3scale Istio adapter with {ProductName} versions 2.0 and below. The Mixer component was deprecated in release 2.0 and removed in release 2.1. For {ProductName} versions 2.1.0 and later you should use the xref:../../service_mesh/v2x/ossm-threescale-webassembly-module.adoc[3scale WebAssembly module].
+
 If you want to enable 3scale backend cache with the 3scale Istio adapter, you must also enable Mixer policy and Mixer telemetry. See xref:../../service_mesh/v2x/ossm-create-smcp.adoc#ossm-create-smcp[Deploying the Red Hat OpenShift Service Mesh control plane].
 ====
 

--- a/service_mesh/v2x/upgrading-ossm-to-2-1.adoc
+++ b/service_mesh/v2x/upgrading-ossm-to-2-1.adoc
@@ -20,7 +20,7 @@ To upgrade {ProductName}, you must update the version field of the {ProductName}
 
 .Procedure
 
-. Switch to the project that contains your `ServiceMeshControlPlane` resource.  In this example, `istio-system` is the name of the control plane project.
+. Switch to the project that contains your `ServiceMeshControlPlane` resource. In this example, `istio-system` is the name of the control plane project.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Adding some clarification to the navigation as to which 3scale link to use for each version of Service Mesh.

Also adding a note to the 3scale Istio Adapter pointing 2.1 customers towards the new WebAssembly topic.

Preview is here -> https://deploy-preview-39196--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/threescale-adapter



