### PR TITLE
BZ2006232: add cloud.redhat.com to the list

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -63,7 +63,7 @@ CDN hostnames, such as `cdn01.quay.io`, are covered when you add a wildcard entr
 |443, 80
 |Required for Telemetry
 
-|`console.redhat.com/api/ingress`
+|`console.redhat.com/api/ingress`, `cloud.redhat.com/api/ingress`
 |443, 80
 |Required for Telemetry and for `insights-operator`
 |===


### PR DESCRIPTION
Applies to 4.8+

https://bugzilla.redhat.com/show_bug.cgi?=2006232

[Docs preview](https://deploy-preview-39204--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall)

Requires QE ack from @JoaoFula 