### PR TITLE
TELCODOCS-368: [CLONED] Deploying an OCP cluster manually without Assisted Installer (regardless of use case)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -213,9 +213,9 @@ Topics:
   Dir: installing_sno
   Distros: openshift-origin,openshift-enterprise
   Topics:
-  - Name: Preparing to install on a single node
+  - Name: Preparing to install OpenShift on a single node
     File: install-sno-preparing-to-install-sno
-  - Name: Installing on a single node
+  - Name: Installing OpenShift on a single node
     File: install-sno-installing-sno
 - Name: Deploying installer-provisioned clusters on bare metal
   Dir: installing_bare_metal_ipi

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -1,10 +1,16 @@
-[id="installing-sno"]
-= Installing on a single node
-:context: install-sno-installing-sno
+[id="install-sno-installing-sno"]
+= Installing OpenShift on a single node
+:context: install-sno-installing-sno-with-the-assisted-installer
 include::modules/common-attributes.adoc[]
 
 toc::[]
 
-include::modules/install-sno-generate-the-discovery-iso.adoc[leveloffset=+1]
+include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+1]
+
+include::modules/install-sno-generating-the-discovery-iso-manually.adoc[leveloffset=+1]
 
 include::modules/install-sno-installing-with-usb-media.adoc[leveloffset=+1]
+
+include::modules/install-sno-monitoring-the-installation-with-the-assisted-installer.adoc[leveloffset=+1]
+
+include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffset=+1]

--- a/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
+++ b/installing/installing_sno/install-sno-preparing-to-install-sno.adoc
@@ -5,6 +5,12 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[id="preparing-to-install-sno_{context}"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You have read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+
 include::modules/install-sno-about-installing-on-a-single-node.adoc[leveloffset=+1]
 
 include::modules/install-sno-requirements-for-installing-on-a-single-node.adoc[leveloffset=+1]

--- a/modules/install-sno-about-installing-on-a-single-node.adoc
+++ b/modules/install-sno-about-installing-on-a-single-node.adoc
@@ -3,8 +3,6 @@
 // installing_sno/install-sno-preparing-to-install-sno.adoc
 
 [id="install-sno-about-installing-on-a-single-node_{context}"]
-= About installing on a single node
+= About OpenShift on a single node
 
-An installation of {product-title} on a single node is a specialized installation. The primary use case is for edge computing workloads, including small physical footprints, intermittent connectivity, portable clouds, and 5G radio access networks (RAN) close to a base station. An installation on a single node supports autonomous workloads.
-
-The major trade off with an installation on a single node is the lack of high availability.
+You can create a single node cluster with standard installation methods. {product-title} on a single node is a specialized installation that requires the creation of a special ignition configuration ISO. The primary use case is for edge computing workloads, including intermittent connectivity, portable clouds, and 5G radio access networks (RAN) close to a base station. The major tradeoff with an installation on a single node is the lack of high availability.

--- a/modules/install-sno-generating-the-discovery-iso-manually.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-manually.adoc
@@ -1,0 +1,153 @@
+// This is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+[id="generating-the-discovery-iso-manually_{context}"]
+= Generating the discovery ISO manually
+
+Installing {product-title} on a single node requires a discovery ISO, which you can generate with the following procedure.
+
+.Procedure
+
+. Download the {product-title} client (`oc`) and make it available for use by entering the following command:
++
+[source,terminal]
+----
+$ curl -k https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest/openshift-client-linux.tar.gz > oc.tar.gz
+----
++
+[source,terminal]
+----
+$ tar zxf oc.tar.gz
+----
++
+[source,terminal]
+----
+$ chmod +x oc
+----
+
+. Set the {product-title} version:
++
+[source,terminal]
+----
+$ OCP_VERSION=<ocp_version> <1>
+----
++
+<1> Replace `<ocp_version>` with the current version. For example. `latest-{product-version}`
+
+. Download the {product-title} installer and make it available for use by entering the following commands:
++
+[source,terminal]
+----
+$ curl -k https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$OCP_VERSION/openshift-install-linux.tar.gz > openshift-install-linux.tar.gz
+----
++
+[source,terminal]
+----
+$ tar zxvf openshift-install-linux.tar.gz
+----
++
+[source,terminal]
+----
+$ chmod +x openshift-install
+----
+
+. Retrieve the {op-system} ISO URL:
++
+[source,terminal]
+----
+$ ISO_URL=$(./openshift-install coreos print-stream-json | grep location | grep x86_64 | grep iso | cut -d\" -f4)
+----
+
+. Download the {op-system} ISO:
++
+[source,terminal]
+----
+$ curl $ISO_URL > rhcos-live.x86_64.iso
+----
+
+. Prepare the `install-config.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: <domain> <1>
+compute:
+- name: worker
+  replicas: 0 <2>
+controlPlane:
+  name: master
+  replicas: 1 <3>
+metadata:
+  name: <name> <4>
+networking:
+  networkType: OVNKubernetes
+  clusterNetwork:
+  - cidr: <IP_address>/<prefix> <5>
+    hostPrefix: <prefix> <6>
+  serviceNetwork:
+  - <IP_address>/<prefix> <7>
+platform:
+  none: {}
+BootstrapInPlace:
+  InstallationDisk: <path_to_install_drive> <8>
+pullSecret: '<pull_secret>' <9>
+sshKey: |
+  <ssh_key> <10>
+----
++
+<1> Add the cluster domain name.
++
+<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
++
+<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures the cluster runs on a single node.
++
+<4> Set the `metadata` name to the cluster name.
++
+<5> Set the `clusterNetwork` CIDR.
++
+<6> Set the `clusterNetwork` host prefix. Pods receive their IP addresses from this pool.
++
+<7> Set the `serviceNetwork` CIDR. Services receive their IP addresses from this pool.
++
+<8> Set the path to the installation disk drive.
++
+<9> Copy the pull secret from link:https://console.redhat.com/openshift/install/pull-secret[Red Hat Hybrid Cloud Console]. In step 1, click *Download pull secret* and add the contents to this configuration setting.
++
+<10> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+
+. Generate {product-title} assets:
++
+[source,terminal]
+----
+$ mkdir ocp
+----
++
+[source,terminal]
+----
+$ cp install-config.yaml ocp
+----
++
+[source,terminal]
+----
+$ ./openshift-install --dir=ocp create single-node-ignition-config
+----
+
+. Embed the ignition data into the {op-system} ISO:
++
+[source,terminal]
+----
+$ alias coreos-installer='podman run --privileged --rm \
+        -v /dev:/dev -v /run/udev:/run/udev -v $PWD:/data \
+        -w /data quay.io/coreos/coreos-installer:release'
+----
++
+[source,terminal]
+----
+$ cp ocp/bootstrap-in-place-for-live-iso.ign iso.ign
+----
++
+[source,terminal]
+----
+$ coreos-installer iso ignition embed -fi iso.ign rhcos-live.x86_64.iso
+----

--- a/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
+++ b/modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc
@@ -2,21 +2,20 @@
 //
 // installing_sno/install-sno-installing-sno.adoc
 
-[id="generate-the-discovery-iso_{context}"]
+[id="install-sno-generating-the-discovery-iso-with-the-assisted-installer_{context}"]
+= Generating the discovery ISO with the Assisted Installer
 
-= Generate the discovery ISO
-
-Installing {product-title} on a single node requires a discovery ISO, which the Assisted Installer (AI) generates with the cluster name, base domain, Secure Shell (SSH) public key, and pull secret.
+Installing {product-title} on a single node requires a discovery ISO, which the Assisted Installer (AI) can generate with the cluster name, base domain, Secure Shell (SSH) public key, and pull secret.
 
 .Procedure
 
 . On the administration node, open a browser and navigate to link:https://console.redhat.com/openshift/assisted-installer/clusters[Install OpenShift with the Assisted Installer].
 
-. Click *Create New Cluster* to create a new cluster.
+. Click *Create Cluster* to create a new cluster.
 
-. In the *Cluster Name* field, enter a name for the cluster.
+. In the *Cluster name* field, enter a name for the cluster.
 
-. In the *Base Domain* field, enter a base domain. For example:
+. In the *Base domain* field, enter a base domain. For example:
 +
 ----
 example.com
@@ -28,21 +27,21 @@ All DNS records must be subdomains of this base domain and include the cluster n
 <cluster-name>.example.com
 ----
 
-. Select *"I want to install single node OpenShift (SNO)"*.
+. Select *Install single node OpenShift (SNO)*.
 
 . Read the limitations for installing {product-title} on a single node.
 
-. Select *"I understand, accept, and agree to the limitations associated with using Single Node OpenShift"*.
-
 . Select the {product-title} version.
+
+. Optional: Edit the pull secret.
 
 . Click *Next*.
 
 . Click *Generate Discovery ISO*.
 
-. Select *Full ISO* to boot with a USB drive or PXE. Select *Minimal ISO* to boot with virtual media.
+. Select *Full image file* to boot with a USB drive or PXE. Select *Minimal image file* to boot with virtual media.
 
-. Add the Secure Shell public key of the administration node to the *Public key* field.
+. Add SSH public key of the administration node to the *Public key* field.
 
 . Click *Generate Discovery ISO*.
 

--- a/modules/install-sno-installing-with-usb-media.adoc
+++ b/modules/install-sno-installing-with-usb-media.adoc
@@ -34,19 +34,3 @@ After the ISO is copied to the USB drive, you can use the USB drive to install {
 . Change boot drive order to make the USB drive boot first.
 
 . Save and exit the BIOS settings. The server will boot with the discovery image.
-
-. On the administration node, return to the browser and refresh the page. If necessary, reload the link:https://console.redhat.com/openshift/assisted-installer/clusters[Install OpenShift with the Assisted Installer] page and select the cluster name.
-
-. Click *Next* until you reach step 3.
-
-. Select a subnet from the available subnets.
-
-. Keep *Use the same host discovery SSH key* checked. You can change the SSH public key, if necessary.
-
-. Click *Next* to step 4.
-
-. Click *Install cluster*.
-
-. Monitor the installation's progress. Watch the cluster events. After the installation process finishes writing the discovery image to the server's drive, the server will reboot. Remove the USB drive and reset the BIOS to boot to the server's local media rather than the USB drive.
-
-The server will reboot several times, deploying a control plane followed by a worker.

--- a/modules/install-sno-monitoring-the-installation-manually.adoc
+++ b/modules/install-sno-monitoring-the-installation-manually.adoc
@@ -1,0 +1,36 @@
+// This is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+[id="install-sno-monitoring-the-installation-manually_{context}"]
+= Monitoring the installation manually
+
+If you created the ISO manually, use this procedure to monitor the installation.
+
+.Procedure
+
+. Monitor the installation:
++
+[source,terminal]
+----
+$ ./openshift-install --dir=ocp wait-for install-complete
+----
++
+The server will restart several times while deploying the control plane.
+
+. Optional: After the installation is complete, check the environment:
++
+[source,terminal]
+----
+$ export KUBECONFIG=ocp/auth/kubeconfig
+----
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+[source,terminal]
+----
+$ oc get clusterversion
+----

--- a/modules/install-sno-monitoring-the-installation-with-the-assisted-installer.adoc
+++ b/modules/install-sno-monitoring-the-installation-with-the-assisted-installer.adoc
@@ -1,0 +1,26 @@
+// This is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+[id="install-sno-monitoring-the-installation-with-the-assisted-installer_{context}"]
+= Monitoring the installation with the Assisted Installer
+
+If you created the ISO using the Assisted Installer, use this procedure to monitor the installation.
+
+.Procedure
+
+. On the administration host, return to the browser and refresh the page. If necessary, reload the link:https://console.redhat.com/openshift/assisted-installer/clusters[*Install OpenShift with the Assisted Installer*] page and select the cluster name.
+
+. Click *Next* until you reach step 3, *Networking*.
+
+. Select a subnet from the available subnets.
+
+. Keep *Use the same host discovery SSH key* checked. You can change the SSH public key, if necessary.
+
+. Click *Next* to proceed to the *Review and Create* step.
+
+. Click *Install cluster*.
+
+. Monitor the installation's progress. Watch the cluster events. After the installation process finishes writing the discovery image to the server's drive, the server will restart. Remove the USB drive and reset the BIOS to boot to the server's local media rather than the USB drive.
+
+The server will restart several times, deploying the control plane.

--- a/modules/installing-sno-requirements-for-installing-single-node-openshift.adoc
+++ b/modules/installing-sno-requirements-for-installing-single-node-openshift.adoc
@@ -2,10 +2,10 @@
 //
 // installing_sno/install-sno-preparing-to-install-sno.adoc
 
-[id="install-sno-requirements-for-installing-on-a-single-node_{context}"]
+[id="installing-sno-requirements-for-installing-single-node-openshift_{context}"]
 = Requirements for installing OpenShift on a single node
 
-Installing {product-title} on a single node alleviates some of the requirements for high availability and large scale clusters. However, you must address the following requirements:
+Installing {product-title} on a single node alleviates some of the requirements of high availability and large scale clusters. However, you must address the following requirements:
 
 * *Administration host:* You must have a computer to prepare the ISO, to create the USB boot drive, and to monitor the installation.
 


### PR DESCRIPTION
This PR is a clone of https://github.com/openshift/openshift-docs/pull/38068

Adds modules for generating the ISO manually and monitoring the installation manually. It also renames the doc back to Single Node OpenShift (SNO), which was originally removed because it was not present in a spreadsheet that peer reviewers used to verify names.

Fixes: [TELCODOCS-368](https://issues.redhat.com/browse/TELCODOCS-368)

See https://issues.redhat.com/browse/TELCODOCS-368 for additional details.

Preview URL: https://deploy-preview-39205--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html

For release(s): 4.9, 4.10
Signed-off-by: John Wilkins jowilkin@redhat.com