### PR TITLE
Resolving the GitOps compatibility and support matrix title warning

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -2,7 +2,7 @@
 //
 // * gitops/gitops-release-notes.adoc
 
-=== Compatibility and support matrix
+= Compatibility and support matrix
 
 Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
 


### PR DESCRIPTION
This applies to `main`, `enterprise-4.8`, `enterprise-4.9` and `enterprise-4.10`.

This pull request resolves the `section title out of sequence` warnings seen in relation to the GitOps compatibility and support matrix module when running `asciibinder build` against the branches listed above.

The preview is [here](https://deploy-preview-39207--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes).