### PR TITLE
 Resolving the upgrading CLI level 0 section errors

### DIFF
--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -43,6 +43,7 @@ include::modules/updating-sno.adoc[leveloffset=+1]
 .Additional resources
 
 For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.html#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+
 include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 
 include::modules/update-changing-update-server-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This pull request resolves the "level 0 sections can only be used when doctype is book" errors seen in relation to the upgrading CLI module when running `asciibinder build` against the branches listed above.

The preview is [here](https://deploy-preview-39208--osdocs.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli#update-upgrading-cli_updating-cluster-cli).