### PR TITLE
[BZ2024985] add multi-nic to IBM Z KVM install docs

### DIFF
--- a/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z-kvm.adoc
@@ -82,6 +82,8 @@ include::modules/installation-ibm-z-kvm-user-infra-machines-iso.adoc[leveloffset
 
 include::modules/installation-full-ibm-z-kvm-user-infra-machines-iso.adoc[leveloffset=+2]
 
+include::modules/installation-user-infra-machines-static-network.adoc[leveloffset=+2]
+
 include::modules/installation-installing-bare-metal.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -17,13 +17,13 @@ ifeval::["{context}" == "installing-ibm-z"]
 :ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-ibm-z-kvm"]
-:ibm-z:
+:ibm-z-kvm:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
-:ibm-z:
+:ibm-z-kvm:
 endif::[]
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
@@ -39,7 +39,12 @@ endif::[]
 This section illustrates the networking configuration and other advanced options that allow you to modify the {op-system-first} manual installation process. The following tables describe the kernel arguments and command-line options you can use with the {op-system} live installer and the `coreos-installer` command.
 
 [id="installation-user-infra-machines-routing-bonding_{context}"]
+ifndef::ibm-z-kvm[]
 == Networking and bonding options for ISO installations
+endif::ibm-z-kvm[]
+ifdef::ibm-z-kvm[]
+== Networking options for ISO installations
+endif::ibm-z-kvm[]
 
 If you install {op-system} from an ISO image, you can add kernel arguments manually when you boot the image to configure networking for a node. If no networking arguments are specified, DHCP is activated in the initramfs when {op-system} detects that networking is required to fetch the Ignition config file.
 
@@ -47,7 +52,7 @@ If you install {op-system} from an ISO image, you can add kernel arguments manua
 ====
 When adding networking arguments manually, you must also add the `rd.neednet=1` kernel argument to bring the network up in the initramfs.
 ====
-
+ifndef::ibm-z-kvm[]
 The following table provides examples for configuring networking and bonding on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=`, `nameserver=`, and `bond=` kernel arguments.
 
 [NOTE]
@@ -58,6 +63,19 @@ Ordering is important when adding the kernel arguments: `ip=`, `nameserver=`, an
 The networking options are passed to the `dracut` tool during system boot. For more information about the networking options supported by `dracut`, see the `dracut.cmdline` manual page.
 
 .Networking and bonding options for ISO installations
+endif::ibm-z-kvm[]
+ifdef::ibm-z-kvm[]
+The following table provides examples for configuring networking on your {op-system} nodes for ISO installations. The examples describe how to use the `ip=` and `nameserver=` kernel arguments.
+
+[NOTE]
+====
+Ordering is important when adding the kernel arguments: `ip=` and `nameserver=`.
+====
+
+The networking options are passed to the `dracut` tool during system boot. For more information about the networking options supported by `dracut`, see the `dracut.cmdline` manual page.
+
+.Networking options for ISO installations
+endif::ibm-z-kvm[]
 |===
 |Description |Examples
 
@@ -143,7 +161,7 @@ a|
 nameserver=1.1.1.1
 nameserver=8.8.8.8
 ----
-
+ifndef::ibm-z-kvm[]
 a|Optional: Bonding multiple network interfaces to a single interface is supported
 using the `bond=` option.  In these two examples:
 
@@ -190,9 +208,9 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
-
+endif::ibm-z-kvm[]
 |===
-ifndef::ibm-z,ibm-power[]
+ifndef::ibm-z,ibm-z-kvm,ibm-power[]
 [id="installation-user-infra-machines-coreos-installer-options_{context}"]
 == `coreos-installer` options for ISO installations
 
@@ -395,19 +413,19 @@ a|`ignition.config.url`
 a|Optional: The URL of the Ignition config for the live boot. For example, this can be used to customize how `coreos-installer` is invoked, or to run code before or after the installation. This is different from `coreos.inst.ignition_url`, which is the Ignition config for the installed system.
 |===
 
-endif::ibm-z,ibm-power[]
+endif::ibm-z,ibm-z-kvm,ibm-power[]
 
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-ibm-z-kvm"]
-:!ibm-z:
+:!ibm-z-kvm:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
-:!ibm-z:
+:!ibm-z-kvm:
 endif::[]
 ifeval::["{context}" == "installing-ibm-power"]
 :!ibm-power:


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.9, 4.10

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2024985
 
- Preview: https://deploy-preview-39210--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html#installation-user-infra-machines-static-network_installing-ibm-z-kvm

- QE review: Holger Wolf, Phil Chan

