### PR TITLE
[RHACS] Added ScannerDB restart command

### DIFF
--- a/configuration/reissue-internal-certificates.adoc
+++ b/configuration/reissue-internal-certificates.adoc
@@ -21,8 +21,8 @@ include::modules/restart-central-container.adoc[leveloffset=+2]
 //reissue internal certificates for Scanner
 include::modules/reissue-internal-certificates-scanner.adoc[leveloffset=+1]
 
-//Restart Scanner
-include::modules/restart-scanner-container.adoc[leveloffset=+2]
+//Restart Scanner & ScannerDB
+include::modules/restart-scanner-and-scannerdb-containers.adoc[leveloffset=+2]
 
 [id="reissue-internal-certificates-secured-clusters"]
 == Reissuing internal certificates for Sensor, Collector, and Admission Controller

--- a/modules/restart-scanner-and-scannerdb-containers.adoc
+++ b/modules/restart-scanner-and-scannerdb-containers.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * configuration/reissue-internal-certificates.adoc
+
+:_module-type: PROCEDURE
+[id="restart-scanner_{context}"]
+= Restarting the Scanner and ScannerDB containers
+
+[role="_abstract"]
+You can restart the Scanner and ScannerDB container by deleting the pods.
+
+.Procedure
+
+* To delete the Scanner and ScannerDB pods, run the following command:
+** On {ocp}:
++
+[source,terminal]
+----
+$ oc delete pod -n stackrox -l app=scanner; oc -n stackrox delete pod -l app=scanner-db
+----
+** On Kubernetes:
++
+[source,terminal]
+----
+$ kubectl delete pod -n stackrox -l app=scanner; kubectl -n stackrox delete pod -l app=scanner-db
+----


### PR DESCRIPTION
Based on https://github.com/openshift/openshift-docs/pull/39202


Preview: https://deploy-preview-39211--osdocs.netlify.app/openshift-acs/latest/configuration/reissue-internal-certificates#restart-scanner_reissue-internal-certificates

Applies to:
- 3.65
- 3.66
- 3.67

<hr>

NOTE: 
- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.