### PR TITLE
BZ2020750: Changed Api to lowercase

### DIFF
--- a/modules/ztp-creating-siteconfig-custom-resources.adoc
+++ b/modules/ztp-creating-siteconfig-custom-resources.adoc
@@ -21,7 +21,7 @@ Example of the hub’s API and `{asterisk}.app` hostname:
 [source,terminal]
 ----
 console-openshift-console.apps.hub-cluster.internal.domain.com
-Api.hub-cluster.internal.domain.com
+api.hub-cluster.internal.domain.com
 ----
 
 ** The hub must be able to resolve and reach the API and `{asterisk}.app` hostname of the managed cluster.
@@ -30,7 +30,7 @@ Here is an example of the managed cluster’s API and `{asterisk}.app` hostname:
 [source,terminal]
 ----
 console-openshift-console.apps.sno-managed-cluster-1.internal.domain.com
-Api.sno-managed-cluster-1.internal.domain.com
+api.sno-managed-cluster-1.internal.domain.com
 ----
 
 ** A DNS Server that is IP reachable from the target bare metal machine.


### PR DESCRIPTION
Corrected a possible typo in a URL, from capital "Api" to "api".

* Fixes: 
https://bugzilla.redhat.com/show_bug.cgi?id=2020750

* Preview:
https://deploy-preview-39217--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-siteconfig-custom-resources_ztp-deploying-disconnected

* For release(s): 4.9, 4.10