### PR TITLE
Resolving the release notes title warning

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -973,6 +973,7 @@ Operator Lifecycle Manager (OLM) now compresses Operator bundles with large amou
 
 Operator Lifecycle Management (OLM) catalog pods are now more efficient and use less RAM.
 
+[discrete]
 [id="ocp-4-9-olm-stable-channel"]
 ==== Default update channel for Operators from "Extras" advisories
 


### PR DESCRIPTION
Applies only to `enterprise-4.9`.

This pull request resolves the `section title out of sequence` warning seen in relation to the "Notable technical changes" section when running asciibinder build against `enterprise-4.9` branch.

Preview link [here](https://deploy-preview-39233--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-notable-technical-changes).