### PR TITLE
BZ2022593: Removed limitation of RWNs being only supported on UPI bare metal clusters

### DIFF
--- a/nodes/edge/nodes-edge-remote-workers.adoc
+++ b/nodes/edge/nodes-edge-remote-workers.adoc
@@ -20,8 +20,6 @@ However, having remote worker nodes can introduce higher latency, intermittent l
 
 Note the following limitations when planning a cluster with remote worker nodes:
 
-* Remote worker nodes are supported on only bare metal clusters with user-provisioned infrastructure.
-
 * {product-title} does not support remote worker nodes that use a different cloud provider than the on-premise cluster uses.
 
 * Moving workloads from one Kubernetes zone to a different Kubernetes zone can be problematic due to system and environment issues, such as a specific type of memory not being available in a different zone.


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2022593

Preview: https://deploy-preview-39235--osdocs.netlify.app/openshift-enterprise/latest/nodes/edge/nodes-edge-remote-workers.html

For releases: 4.9, 4.10