### PR TITLE
[enterprise-4.6] Resolve a callout-related warning

### DIFF
--- a/modules/tls-profiles-ingress-configuring.adoc
+++ b/modules/tls-profiles-ingress-configuring.adoc
@@ -68,7 +68,7 @@ spec:
 * `old: {}`
 * `intermediate: {}`
 * `custom:`
-<2> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
+<3> For the `custom` type, specify a list of TLS ciphers and minimum accepted TLS version.
 
 . Save the file to apply the changes.
 


### PR DESCRIPTION
Applies only to enterprise-4.6.

This pull request resolves the callout list item index warning for modules/tls-profiles-ingress-configuring.adoc.

Preview: https://deploy-preview-39236--osdocs.netlify.app/openshift-enterprise/latest/security/tls-security-profiles.html#tls-profiles-ingress-configuring_tls-security-profiles