### PR TITLE
[enterprise-4.7] Fixing a level 0 build error

### DIFF
--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -107,6 +107,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service
+
 include::modules/installation-ibm-z-troubleshooting-and-debugging.adoc[leveloffset=+1]
 
 [id="additional-resources_ibmz-kvm-restricted"]


### PR DESCRIPTION
Applies only to enterprise-4.7.

This change fixes a heading structure issue and also eliminates a build error.

Preview: https://deploy-preview-39244--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm