### PR TITLE
BZ1787217:Procedure described in OCP aws installation have repetitive words

### DIFF
--- a/install_config/topics/aws_service_account.adoc
+++ b/install_config/topics/aws_service_account.adoc
@@ -11,9 +11,7 @@ AWS instances require either IAM account with Programmatic Access using an acces
 assigned to instances at creation to be able to request and manage load balancers and storage
 in {product-title}.
 
-The IAM account or IAM role must have the following policy permissions
-xref:../install_config/configuring_aws.adoc#configuring-aws-permissions[permissions]
-to have full cloud provider functionality.
+The IAM account or IAM role must have the following policy permissions to have full cloud provider functionality.
 
 [source,yaml]
 ----


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1787217
Fixed redundant word; removed link to itself.