### PR TITLE
Delete symlink

### DIFF
--- a/support/index.adoc
+++ b/support/index.adoc
@@ -1,1 +1,0 @@
-getting-support.adoc


### PR DESCRIPTION
Delete symlink added to index.adoc file. 
[Jira issue](https://issues.redhat.com/browse/OSDOCS-2532)
OCP version: 4.6+