### PR TITLE
[enterprise-4.10] OSDOCS-2869: Migrating common SD content in Welcome book

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -9,3 +9,26 @@ openshift-enterprise:
     enterprise-4.1:
       name: '4.1'
       dir: container-platform/4.1
+openshift-dedicated:
+  name: OpenShift Dedicated
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-3.11:
+      name: '3'
+      dir: dedicated/3
+    enterprise-4.9:
+      name: ''
+      dir: dedicated/
+openshift-rosa:
+  name: Red Hat OpenShift Service on AWS
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-4.9:
+      name: ''
+      dir: rosa/

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -3,35 +3,42 @@
 = {product-title} {product-version} Documentation
 include::modules/common-attributes.adoc[]
 
-ifndef::openshift-webscale[]
 [.lead]
 Welcome to the official {product-title} {product-version} documentation, where you can learn about {product-title} and start exploring its features.
-endif::openshift-webscale[]
 
-ifdef::openshift-webscale[]
-Use the left navigation bar to browse this limited set of documentation as part of early access.
-endif::openshift-webscale[]
-
-ifndef::openshift-webscale[]
+ifndef::openshift-rosa,openshift-dedicated[]
 To navigate the {product-title} {product-version} documentation, you can use one of the following methods:
 
 * Use the left navigation bar to browse the documentation.
 * Select the task that interests you from the contents of this Welcome page.
+endif::openshift-rosa,openshift-dedicated[]
 
-ifdef::openshift-enterprise,openshift-origin[]
+ifdef::openshift-rosa[]
+To navigate the {product-title} (ROSA) documentation, use the left navigation bar.
+
+For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+endif::[]
+
+ifdef::openshift-dedicated[]
+To navigate the {product-title} documentation, use the left navigation bar.
+
+For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+endif::[]
+
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Start with xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture] and
 xref:../security/container_security/security-understanding.adoc#understanding-security[Security and compliance].
-ifdef::openshift-enterprise[]
+ifdef::openshift-enterprise,openshift-webscale[]
 Then, see the
 xref:../release_notes/ocp-4-10-release-notes.adoc#ocp-4-10-release-notes[release notes].
 endif::[]
 endif::[]
 
-ifdef::openshift-dedicated,openshift-online,openshift-aro[]
+ifdef::openshift-online,openshift-aro[]
 Start with **xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture]**.
 endif::[]
 
-ifdef::openshift-enterprise,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster installer activities
 Explore these {product-title} installation tasks.
 
@@ -42,7 +49,7 @@ You can also deploy a cluster on AWS infrastructure that you provisioned yoursel
 
 - **xref:../installing/installing_azure/installing-azure-account.adoc#installing-azure-account[Install a cluster on Azure]**: You can deploy clusters with xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[default settings], xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[custom Azure settings], or xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[custom networking settings] in Microsoft Azure. You can also provision {product-title} into an xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[Azure Virtual Network] or use xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[Azure Resource Manager Templates] to provision your own infrastructure.
 
-- **xref:../installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc#preparing-to-install-on-azure-stack-hub[Install a cluster on Azure Stack Hub]**: You can install {product-title}on Azure Stack Hub on user-provisioned infrastructure.
+- **xref:../installing/installing_azure_stack_hub/preparing-to-install-on-azure-stack-hub.adoc#preparing-to-install-on-azure-stack-hub[Install a cluster on Azure Stack Hub]**: You can install {product-title} on Azure Stack Hub on user-provisioned infrastructure.
 
 - **xref:../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[Install a cluster on GCP]**: You can deploy clusters with xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[default settings] or xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[custom GCP settings] on Google Cloud Platform (GCP). You can also perform a GCP installation where you provision your own infrastructure.
 
@@ -122,6 +129,7 @@ Internet access is still required to access the cloud APIs and installation medi
 - **xref:../storage/persistent_storage/persistent-storage-ocs.adoc#red-hat-openshift-container-storage[Install Red Hat OpenShift Container Storage]**: You can install Red Hat OpenShift Container Storage as an Operator to provide highly integrated and simplified persistent storage management for containers.
 endif::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 == Developer activities
 Develop and deploy containerized applications with {product-title}. {product-title} is a platform for developing and deploying containerized applications. {product-title} documentation helps you:
 
@@ -144,10 +152,9 @@ The `odo` CLI tool lets developers create single or multi-component applications
 - **xref:../cicd/pipelines/understanding-openshift-pipelines.adoc#op-key-features[Create CI/CD Pipelines]**: Pipelines are serverless, cloud-native, continuous integration and continuous deployment systems that run in isolated containers.
 They use standard Tekton custom resources to automate deployments and are designed for decentralized teams that work on microservice-based architecture.
 
-ifdef::openshift-enterprise,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 - **Deploy Helm charts**:
 xref:../applications/working_with_helm_charts/understanding-helm.adoc#understanding-helm[Helm] is a software package manager that simplifies deployment of applications and services to OpenShift Container Platform clusters. Helm uses a packaging format called charts. A Helm chart is a collection of files that describes the OpenShift Container Platform resources.
-endif::[]
 
 - **xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understand image builds]**: Choose from different build strategies (Docker, S2I, custom, and pipeline) that can include different kinds of source materials (from places like Git repositories, local binary inputs, and external artifacts). Then, follow examples of build types from basic builds to advanced builds.
 
@@ -160,14 +167,41 @@ endif::[]
 
 - **xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Understand Operators]**: Operators are the preferred method for creating on-cluster applications for {product-title} {product-version}. Learn about the Operator Framework and how to deploy applications using installed Operators into your projects.
 
-ifdef::openshift-enterprise,openshift-origin[]
 - **xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Develop Operators]**: Operators are the preferred method for creating on-cluster applications for {product-title} {product-version}. Learn the workflow for building, testing, and deploying Operators. Then, create your own Operators based on xref:../operators/operator_sdk/ansible/osdk-ansible-support.adoc#osdk-ansible-support[Ansible] or
 xref:../operators/operator_sdk/helm/osdk-helm-support.adoc#osdk-helm-support[Helm], or configure xref:../operators/operator_sdk/osdk-monitoring-prometheus.adoc#osdk-monitoring-prometheus[built-in Prometheus monitoring] using the Operator SDK.
 
 - **xref:../rest_api/index.adoc#api-index[REST API reference]**: Learn about {product-title} application programming interface endpoints.
 endif::[]
+endif::[]
 
-ifdef::openshift-enterprise,openshift-origin[]
+ifdef::openshift-rosa,openshift-dedicated[]
+== Developer activities
+Ultimately, {product-title} is a platform for developing and deploying containerized applications. As an application developer, {product-title} and OpenShift Container Platform documentation helps you:
+
+- *Understand {product-title} development*: Learn the different types of containerized applications, from simple containers to advanced Kubernetes deployments and Operators.
+
+- *Work with projects*: Create projects from the web console or CLI to organize and share the software you develop.
+
+- *Work with applications*: Use the Developer perspective in the {product-title} web console to easily create and deploy applications. Use the Topology view to visually interact with your applications, monitor status, connect and group components, and modify your code base.
+
+- *Use the developer CLI tool (odo)*: The odo CLI tool lets developers create single or multi-component applications easily and automates deployment, build, and service route configurations.
+It abstracts complex Kubernetes and {product-title} concepts, allowing developers to focus on developing their applications.
+
+- *Create CI/CD Pipelines*: Pipelines are serverless, cloud-native, continuous integration and continuous deployment systems that run in isolated containers. They use standard Tekton custom resources to automate deployments and are designed for decentralized teams that work on microservices-based architecture.
+
+- *Understand Operators*: Operators are the preferred method for creating on-cluster applications for {product-title} {product-version}. Learn about the Operator Framework and how to deploy applications using installed Operators into your projects.
+
+- *Understand image builds*: Choose from different build strategies (Docker, S2I, custom, and pipeline) that can include different kinds of source materials (from places like Git repositories, local binary inputs, and external artifacts). Then, follow examples of build types from basic builds to advanced builds.
+
+- *Create container images*: A container image is the most basic building block in {product-title} (and Kubernetes) applications. Defining image streams lets you gather multiple versions of an image in one place as you continue its development. S2I containers let you insert your source code into a base container that is set up to run code of a particular type (such as Ruby, Node.js, or Python).
+
+- *Create deployments*:  Use `Deployment` and `DeploymentConfig` objects to exert fine-grained management over applications.
+Use the Workloads page or `oc` CLI to manage deployments. Learn rolling, recreate, and custom deployment strategies.
+
+- *Create templates*: Use existing templates or create your own templates that describe how an application is built or deployed. A template can combine images with descriptions, parameters, replicas, exposed ports and other content that defines how an application can be run or built.
+endif::[]
+
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 == Cluster administrator activities
 
 Manage machines, provide services to users, and follow monitoring and logging reports. This documentation helps you:
@@ -225,7 +259,7 @@ be reviewed by cluster administrators and xref:../operators/admin/olm-adding-ope
 
 - **xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[Use custom resource definitions (CRDs) to modify the cluster]**: Cluster features implemented with Operators can be modified with CRDs. Learn to xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-creating-custom-resources-definition_crd-extending-api-with-crds[create a CRD] and xref:../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[manage resources from CRDs].
 
-ifdef::openshift-enterprise,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 - **xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set resource quotas]**: Choose from CPU, memory, and other system resources to xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[set quotas].
 endif::[]
 
@@ -254,48 +288,13 @@ After configuring monitoring, use the web console to access xref:../monitoring/r
 - **xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring_about-remote-health-monitoring[Remote health monitoring]**: {product-title} collects anonymized aggregated information about your cluster. Using Telemetry and the Insights Operator, this data is received by Red Hat and used to improve {product-title}. You can view the xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring_showing-data-collected-by-remote-health-monitoring[data collected by remote health monitoring].
 endif::[]
 
-ifdef::openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
 == Cluster administrator activities
 
-While cluster maintenance and host configuration is performed by the {product-title}
-Operations Team, other ongoing tasks on your {product-title} {product-version}
-cluster can be performed by {product-title} cluster administrators. As a
-{product-title} cluster administrator, this documentation helps you:
+While cluster maintenance and host configuration is performed by the Red Hat Site Reliability Engineering (SRE) team, other ongoing tasks on your {product-title} {product-version} cluster can be performed by {product-title} cluster administrators. As an {product-title} cluster administrator, the documentation helps you:
 
-- **xref:../administering_a_cluster/dedicated-admin-role.adoc#dedicated-administrator-role[Understand the `dedicated-admin` role]**: Learn about the elevated privileges provided to {product-title} cluster administrators.
-
-////
-- **xref:../operators/understanding/olm-what-operators-are.adoc#olm-what-operators-are[Manage Operators]**: Lists of Red Hat, ISV, and community Operators can
-be reviewed by cluster administrators and xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[installed on their clusters]. After you install them, you can xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[run], upgrade, back up or otherwise manage the Operator on your cluster (based on what the Operator is designed to do).
-////
-
-- **xref:../administering_a_cluster/dedicated-admin-role.adoc#dedicated-managing-administrators_dedicated-administrator[Manage RBAC authorizations]**: Grant permissions to users or groups and manage service accounts.
-
-ifdef::openshift-enterprise,openshift-origin[]
-
-- **xref:../applications/quotas/quotas-setting-per-project.adoc#quotas-setting-per-project[Set resource quotas]**: Choose from CPU, memory and other system resources to set quotas.
-
+- *Manage Dedicated Administrators*: Grant or revoke permissions to `dedicated admin` users.
+- *Work with Logging*: Learn about {product-title} Logging and configure the logging add-on services.
+- *Monitor clusters*: Learn to use the Web UI to access monitoring dashboards.
+- *Manage nodes*: Learn to manage nodes, including configuring machine pools and autoscaling.
 endif::[]
-
-////
-- **xref:../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-managing-resources-from-crds[Manage resources from Custom Resource Definition (CRDs)]**: Learn about how {product-title} cluster administrators and project administrators can use CRDs to manage custom resources in non-default namespaces.
-////
-
-
-////
-- **xref:../applications/pruning-objects.adoc#pruning-objects[Prune and reclaim resources]**: You can reclaim spaceby pruning unneeded Operators, groups, deployments, builds, images, registries, and cron jobs.
-
-- **xref:../logging/cluster-logging.adoc#cluster-logging[Work with OpenShift Logging]**:
-Learn about how to deploy and use a cluster to aggregate logs for a range of {product-title}
-services. OpenShift Logging collects, stores, and visualizes logging data from hosts and
-applications, whether coming from multiple containers or even deleted pods.
-
-- **xref:../monitoring/understanding-the-monitoring-stack.adoc#understanding-the-monitoring-stack[Monitor clusters]**: Learn to
-xref:../monitoring/configuring-the-monitoring-stack.adoc#configuring-the-monitoring-stack[configure the monitoring stack].
-Once your monitoring is configured, use the web UI to xref:../monitoring/reviewing-monitoring-dashboards.adoc#reviewing-monitoring-dashboards[monitoring dashboards].
-In addition to infrastructure metrics, you can also scrape and view metrics for your own services.
-
-- **xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring_about-remote-health-monitoring[Remote health monitoring]**: {product-title} collects anonymized aggregated information about your cluster and reports it to Red Hat via Telemetry and the Insights Operator. This information allows Red Hat to improve {product-title} and to react to issues that impact customers more quickly. You can view the xref:../support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc#showing-data-collected-by-remote-health-monitoring_showing-data-collected-by-remote-health-monitoring[data collected by remote health monitoring].
-////
-endif::[]
-endif::openshift-webscale[]


### PR DESCRIPTION
This applies to the `enterprise-4.10` branch only.

This pull request adds the changes that were applied to `main` in https://github.com/openshift/openshift-docs/pull/38919 to `enterprise-4.10`. During the migration we created the 4.9 equivalent PR and merged it. This PR is following up on the same task for 4.10. The `welcome/index.adoc` file that this PR updates to is the same as the one that we updated to `main` during the migration.

The PR also adds OSD and ROSA to the distro map in `enterprise-4.10`.

The previews are as follows:

- [OCP preview](https://deploy-preview-39258--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html)
- [OSD preview](https://deploy-preview-39258--osdocs.netlify.app/openshift-dedicated/latest/welcome/index.html)
- [ROSA preview](https://deploy-preview-39258--osdocs.netlify.app/openshift-rosa/latest/welcome/index.html)