### PR TITLE
[Updated] Image Registry Operator configuration parameters `disableRe…

### DIFF
--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -61,6 +61,10 @@ for the route.
 |`replicas`
 |Replica count for the registry.
 
+|`disableRedirect`
+| disableRedirect controls whether to route all data through the Registry,
+rather than redirecting to the backend. Defaults to false.
+
 |`spec.storage.managementState`
 
 |The Image Registry Operator sets the `spec.storage.managementState` parameter to `Managed` on new installations or upgrades of clusters using installer-provisioned infrastructure on AWS or Azure.


### PR DESCRIPTION
…direct` is missing

Hello Team,

I have updated the doc for the missing `disableRedirect` parameter in[ Image Registry Operator Configuration
](https://docs.openshift.com/container-platform/4.7/registry/configuring-registry-operator.html#registry-operator-configuration-resource-overview_configuring-registry-operator)

For more info, check the below BZ and slack thread over the BZ.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2026611

CC: @vikram-redhat 