### PR TITLE
OSDOCS-2869 - Removing an OSD xref comment

### DIFF
--- a/upgrading/osd-upgrades.adoc
+++ b/upgrading/osd-upgrades.adoc
@@ -13,7 +13,3 @@ include::modules/upgrade.adoc[leveloffset=+1]
 include::modules/upgrade-auto.adoc[leveloffset=+1]
 
 include::modules/upgrade-manual.adoc[leveloffset=+1]
-
-// Per Will Gordon: Right now, the OCM CLI isn't productized, so I'm not sure if we should be referring to it in documentation just yet, but I absolutely think it will be useful eventually!
-
-//include::modules/upgrade-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This pull request removes an comment related to OSD that includes an `xref`. The comment is being removed in this PR to resolve a build issue.