### PR TITLE
Updating URL to latest OCP welcome page

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -16,13 +16,13 @@ endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-rosa[]
 To navigate the {product-title} (ROSA) documentation, use the left navigation bar.
 
-For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/4.7/welcome/index.html[OpenShift Container Platform documentation].
+For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifdef::openshift-dedicated[]
 To navigate the {product-title} documentation, use the left navigation bar.
 
-For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/4.7/welcome/index.html[OpenShift Container Platform documentation].
+For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]


### PR DESCRIPTION
This applies to `main` and `enterprise-4.9`.

The pull request updates a link in the OSD and ROSA welcome page to point at the latest version of the OCP welcome page, instead of to 4.7. Given that there is only one version of the OSD and ROSA docs collections for OpenShift 4, it makes sense for the URL to point to the latest OCP 4 minor release version of the docs.

This is resolved in `enterprise-4.10` as part of https://github.com/openshift/openshift-docs/pull/39258.

The previews are as follows:

- [OSD preview](https://deploy-preview-39263--osdocs.netlify.app/openshift-dedicated/latest/welcome/index.html)
- [ROSA preview](https://deploy-preview-39263--osdocs.netlify.app/openshift-rosa/latest/welcome/index.html)