### PR TITLE
BZ2005326: 4.8 updating quay.io to registry.redhat.io

### DIFF
--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -34,7 +34,7 @@ $ oc adm must-gather --image=<PAO_image> --dest-dir=<dir>
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=quay.io/openshift-kni/performance-addon-operator-must-gather:4.8-snapshot --dest-dir=must-gather
+$ oc adm must-gather --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v4.8 --dest-dir=must-gather
 ----
 . Create a compressed file from the `must-gather` directory:
 +

--- a/modules/cnf-how-run-podman-to-create-profile.adoc
+++ b/modules/cnf-how-run-podman-to-create-profile.adoc
@@ -18,7 +18,7 @@ Run `podman` to create the performance profile:
 
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=true --must-gather-dir-path /must-gather > my-performance-profile.yaml
 ----
 
 The created profile is described in the following YAML:

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -34,7 +34,7 @@ readonly IMG_EXISTS_CMD="${CONTAINER_RUNTIME} image exists"
 readonly IMG_PULL_CMD="${CONTAINER_RUNTIME} image pull"
 readonly MUST_GATHER_VOL="/must-gather"
 
-PAO_IMG="quay.io/openshift-kni/performance-addon-operator:4.8-snapshot"
+PAO_IMG="registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8"
 MG_TARBALL=""
 DATA_DIR=""
 
@@ -162,7 +162,7 @@ There two types of arguments:
 * PPC arguments
 ====
 +
-<1> Optional: Specify the Performance Addon Operator image. If not set, the default upstream image is used: `quay.io/openshift-kni/performance-addon-operator:4.8-snapshot`.
+<1> Optional: Specify the Performance Addon Operator image. If not set, the default upstream image is used: `registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8`.
 <2> `-t` is a required wrapper script argument and specifies the path to a `must-gather` tarball.
 
 . Run the performance profile creator tool in discovery mode:
@@ -248,6 +248,12 @@ spec:
 ----
 
 . Apply the generated profile:
++
+[NOTE]
+====
+Install the Performance Addon Operator before applying the profile. For install instructions, see xref:cnf-performance-addon-operator-for-low-latency-nodes.adoc#installing-the-performance-addon-operator_cnf-master[Installing the Performance Addon Operator].
+====
+
 +
 [source,terminal]
 ----

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -32,11 +32,24 @@ master       rendered-master-acd1358917e9f98cbdb599aea622d78b       True      Fa
 worker-cnf   rendered-worker-cnf-1d871ac76e1951d32b2fe92369879826   False     True       False      2              1                   1                     0                      22h
 ----
 
+. Use Podman to authenticate to `registry.redhat.io`:
++
+[source,terminal]
+----
+$ podman login registry.redhat.io
+----
++
+[source,bash]
+----
+Username: myrhusername
+Password: ************
+----
+
 . Optional: Display help for the PPC tool:
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator quay.io/openshift-kni/performance-addon-operator:4.8-snapshot -h
+$ podman run --entrypoint performance-profile-creator registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8 -h
 ----
 +
 .Example output
@@ -77,7 +90,7 @@ Using this information you can set appropriate values for some of the arguments 
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --info log --must-gather-dir-path /must-gather
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8 --info log --must-gather-dir-path /must-gather
 ----
 +
 [NOTE]
@@ -96,7 +109,7 @@ The `info` option requires a value which specifies the output format. Possible v
 +
 [source,terminal]
 ----
-$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z quay.io/openshift-kni/performance-addon-operator:4.8-snapshot --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
+$ podman run --entrypoint performance-profile-creator -v /must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.8 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node --must-gather-dir-path /must-gather  --power-consumption-mode=ultra-low-latency > my-performance-profile.yaml
 ----
 +
 [NOTE]
@@ -144,6 +157,11 @@ spec:
 ----
 
 . Apply the generated profile:
++
+[NOTE]
+====
+Install the Performance Addon Operator before applying the profile. For install instructions, see xref:cnf-performance-addon-operator-for-low-latency-nodes.adoc#installing-the-performance-addon-operator_cnf-master[Installing the Performance Addon Operator].
+====
 
 +
 [source,terminal]


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2005326

Updating quay.io to registry.redhat.io. 
Updating https://docs.openshift.com/container-platform/4.8/scalability_and_performance/cnf-create-performance-profiles.html removing refs to quay.io and replacing with official registry.redhat.io as per https://bugzilla.redhat.com/show_bug.cgi?id=2005326
Preview link: https://deploy-preview-39272--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html