### PR TITLE
BZ2020708: Updating the agentclusterinstall networking fields

### DIFF
--- a/modules/ztp-creating-siteconfig-custom-resources.adoc
+++ b/modules/ztp-creating-siteconfig-custom-resources.adoc
@@ -149,7 +149,7 @@ spec:
   sshPublicKey: <public-key> <3>
 ----
 +
-<1> `cluster-image-set` is the name of the ClusterImageSet custom resource.
+<1> `cluster-image-set` is the name of the ClusterImageSet custom resource used to install {product-title} on the DU.
 <2> `machine-network-cidr` is the target bare metal machine’s CIDR.
 <3> `public-key` entered as plain text can be used to SSH into the target bare metal machine after the host is installed.
 +

--- a/modules/ztp-du-host-networking-requirements.adoc
+++ b/modules/ztp-du-host-networking-requirements.adoc
@@ -14,9 +14,6 @@ The following tables provide a high level overview of the networking information
 |Field
 |Description
 
-|`imageSetRef`
-| Installer image used to install {product-title} on the DU.
-
 |`clusterNetwork`
 | Used to allocate an IPv4 or IPv6 IP address to each node. Ensure there is no overlap with `serviceNetwork`.
 


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=2020708

Preview links:
Creating custom resources to install a single managed cluster

https://deploy-preview-39275--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-creating-siteconfig-custom-resources_ztp-deploying-disconnected

Distributed unit host networking requirements

https://deploy-preview-39275--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-du-host-networking-requirements_ztp-deploying-disconnected

Releases:  4.9, 4.10
