### PR TITLE
Fix file name and modify remark on Helm configuration for proxy settings

### DIFF
--- a/modules/configure-proxy-during-installation.adoc
+++ b/modules/configure-proxy-during-installation.adoc
@@ -11,11 +11,11 @@ When you run the installer by using the `roxctl central generate` command, the i
 
 .Procedure
 
-. Open the configuration file `central/proxy-config-secret.yaml` from your deployment bundle directory.
+. Open the configuration file `central/00-proxy-config-secret.yaml` from your deployment bundle directory.
 +
 [NOTE]
 ====
-If you are using Helm the configuration file is at `central/templates/proxy-config-secret.yaml`.
+If you are using the Helm chart, follow the documentation contained in the file `values-private.yaml.example` to configure proxy related settings.
 ====
 . Edit the fields you want to modify in the configuration file:
 +


### PR DESCRIPTION
This fixes a reference to a wrong file contained in a central deployment bundle.
Additionally it improves the wording related to the usage of the Helm chart.
@gaurav-nelson 