### PR TITLE
BZ2021390: replace Stable with stable for the channel

### DIFF
--- a/modules/op-installing-pipelines-operator-in-web-console.adoc
+++ b/modules/op-installing-pipelines-operator-in-web-console.adoc
@@ -40,8 +40,8 @@ The supported profiles are:
 
 .. Select an *Update Channel*.
 
-*** The *Stable* channel enables installation of the latest stable and supported release of the {pipelines-title} Operator.
-*** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the *Stable* channel and is not supported.
+*** The *stable* channel enables installation of the latest stable and supported release of the {pipelines-title} Operator.
+*** The *preview* channel enables installation of the latest preview version of the {pipelines-title} Operator, which may contain features that are not yet available from the *stable* channel and is not supported.
 
 . Click *Install*. You will see the Operator listed on the *Installed Operators* page.
 +


### PR DESCRIPTION
- Applies to 4.7+ versions as CI/CD is not there in 4.6.
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2021390)
- [Preview](https://deploy-preview-39277--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/installing-pipelines#op-installing-pipelines-operator-in-web-console_installing-pipelines)
- @yapei please verify.