### PR TITLE
BZ1945405: Adding port access requirement

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -119,3 +119,8 @@ Configuration must occur before scheduling pods.
 ====
 
 State-driven network configuration requires installing `kubernetes-nmstate`, and also requires Network Manager running on the cluster nodes. See *OpenShift Virtualization > Kubernetes NMState (Tech Preview)* for additional details.
+
+[discrete]
+== Port access for the out-of-band management IP address
+
+The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the `baremetal` node during installation, the out-of-band management IP address address must be granted access to the TCP 6180 port.


### PR DESCRIPTION
Bug link: https://bugzilla.redhat.com/show_bug.cgi?id=1945405

Link to preview (last subsection): https://deploy-preview-39280--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#network-requirements_ipi-install-prerequisites

For releases 4.9, 4.10
4.6: https://github.com/openshift/openshift-docs/pull/39574
4.7: https://github.com/openshift/openshift-docs/pull/39575
4.8: https://github.com/openshift/openshift-docs/pull/39576

SME lgtm via Slack