### PR TITLE
BZ1888380: include spot VM limits in Azure account limit list

### DIFF
--- a/modules/installation-azure-limits.adoc
+++ b/modules/installation-azure-limits.adoc
@@ -184,6 +184,19 @@ ifndef::ash[]
 endif::ash[]
 |The internal load balancer, each of the three control plane machines, and each
 of the three worker machines each use a private IP address.
+
+ifndef::ash[]
+|Spot VM vCPUs (optional)
+|0
+
+If you configure spot VMs, your cluster must have two spot VM vCPUs for every compute node.
+|20 per region
+|This is an optional component. To use spot VMs, you must increase the Azure default limit to at least twice the number of compute nodes in your cluster.
+[NOTE]
+====
+Using spot VMs for control plane nodes is not recommended.
+====
+endif::ash[]
 |===
 
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]


### PR DESCRIPTION
Applies to 4.6+

https://bugzilla.redhat.com/show_bug.cgi?id=1888380

[Docs preview](https://deploy-preview-39292--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-limits_installing-azure-account)

Requires ack from @MayXuQQ @JoelSpeed 