### PR TITLE
BZ2020709: Clarified that DU required fields are not only networking fields

### DIFF
--- a/modules/ztp-du-host-requirements.adoc
+++ b/modules/ztp-du-host-requirements.adoc
@@ -3,12 +3,12 @@
 //
 // scalability_and_performance/ztp-deploying-disconnected.adoc
 
-[id="ztp-du-host-networking-requirements_{context}"]
-= Distributed unit host networking requirements
+[id="ztp-du-host-requirements_{context}"]
+= Distributed unit host requirements
 
 The following tables provide a high level overview of the networking information and custom resources required by {rh-rhacm-first} to provision a DU bare-metal host:
 
-.Required `AgentClusterInstall` networking fields
+.Required `AgentClusterInstall` fields
 [cols="2,4", width="90%", options="header"]
 |====
 |Field
@@ -29,7 +29,7 @@ The following tables provide a high level overview of the networking information
 Do not specify API and Ingress VIP addresses for DU single node clusters. Instead, when the host is provisioned by the assisted installer service, the `machineNetwork` field in the `AgentClusterInstall` CR is used to determine the API and Ingress VIP addresses.
 ====
 
-.Required `ClusterDeployment` networking fields
+.Required `ClusterDeployment` fields
 [cols="2,4", width="90%", options="header"]
 |====
 |Field
@@ -45,7 +45,7 @@ Do not specify API and Ingress VIP addresses for DU single node clusters. Instea
 |Pull secret for secure installation on the DU host.
 |====
 
-.Required `BareMetalHost` networking fields
+.Required `BareMetalHost` fields
 [cols="2,4", width="90%", options="header"]
 |====
 |Field
@@ -71,7 +71,7 @@ Do not specify API and Ingress VIP addresses for DU single node clusters. Instea
 
 |====
 
-.Required `InfraEnv` networking fields
+.Required `InfraEnv` fields
 [cols="2,4", width="90%", options="header"]
 |====
 |Field
@@ -85,7 +85,7 @@ Do not specify API and Ingress VIP addresses for DU single node clusters. Instea
 
 |====
 
-.Required `NMStateConfig` networking fields
+.Required `NMStateConfig` fields
 [cols="2,4", width="90%", options="header"]
 |====
 |Field

--- a/scalability_and_performance/ztp-deploying-disconnected.adoc
+++ b/scalability_and_performance/ztp-deploying-disconnected.adoc
@@ -27,7 +27,7 @@ include::modules/ztp-low-latency-for-distributed-units-dus.adoc[leveloffset=+1]
 
 include::modules/ztp-du-host-bios-requirements.adoc[leveloffset=+1]
 
-include::modules/ztp-du-host-networking-requirements.adoc[leveloffset=+1]
+include::modules/ztp-du-host-requirements.adoc[leveloffset=+1]
 
 include::modules/ztp-acm-preparing-to-install-disconnected-acm.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Removes "networking" from the DU required field tables, since only the AgentClusterInstall fields were networking ones.  It also renames a file, changes its ID to take "networking" out of it, and updates an assembly.

Fixes: 

https://bugzilla.redhat.com/show_bug.cgi?id=2020709

Preview: 

Distributed unit host requirements

https://deploy-preview-39294--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-du-host-requirements_ztp-deploying-disconnected

Releases: 4.9, 4.10