### PR TITLE
Bug 2027332: Fixes for  "Modifying the kubelet as a one-time scenario" section

### DIFF
--- a/modules/modifying-kubelet-as-one-time-scenario.adoc
+++ b/modules/modifying-kubelet-as-one-time-scenario.adoc
@@ -17,8 +17,10 @@ $ oc debug node/<node>
 ----
 $ chroot /host
 ----
++ 
+Alternatively, it is possible to SSH to the node and become root.
 
-. After access is established, check the content:
+. After access is established, check the default log level:
 +
 [source,terminal]
 ----
@@ -28,25 +30,19 @@ $ systemctl cat kubelet
 .Example output
 [source,terminal]
 ----
-# /etc/systemd/system/kubelet.service
-mode: 0644
-path: "/etc/systemd/system/kubelet.service.d/20-logging.conf"
-contents:
-  inline: |
-    [Service]
-    Environment="KUBELET_LOG_LEVEL=2"
+# /etc/systemd/system/kubelet.service.d/20-logging.conf
+[Service]
+Environment="KUBELET_LOG_LEVEL=2"
 ----
 
-. Define the new verbosity required in the `/etc/systemd/system/kubelet.service.d/20-logging.conf` file. In this example, the verbosity is changed from `v=1` to `v=8`:
+. Define the new verbosity required in a new `/etc/systemd/system/kubelet.service.d/30-logging.conf` file, which overrides `/etc/systemd/system/kubelet.service.d/20-logging.conf`. In this example, the verbosity is changed from `2` to `8`:
 +
 [source,terminal]
 ----
-$ vi -i -e 's/--v=1/--v=8/g' /etc/systemd/system/kubelet.service.d/20-logging.conf
+$ echo -e "[Service]\nEnvironment=\"KUBELET_LOG_LEVEL=8\"" > /etc/systemd/system/kubelet.service.d/30-logging.conf
 ----
-+
-Editing the config file or installing a new `logging.conf` file overrides the log level.
 
-. Restart the service:
+. Reload systemd and restart the service:
 +
 [source,terminal]
 ----
@@ -58,9 +54,20 @@ $ systemctl daemon-reload
 $ systemctl restart kubelet
 ----
 
-. Gather the logs, then edit the kubelet log level to revert to the former value to prevent issues, such as this error:
+. Gather the logs, and then revert the log level increase:
 +
 [source,terminal]
 ----
-E0514 12:47:17.998892    2281 daemon.go:1350] content mismatch for file /etc/systemd/system/kubelet.service: [Unit]
+$ rm -f /etc/systemd/system/kubelet.service.d/30-logging.conf
 ----
++
+[source,terminal]
+----
+$ systemctl daemon-reload
+----
++
+[source,terminal]
+----
+$ systemctl restart kubelet
+----
+


### PR DESCRIPTION
- Log level is specified in override file to avoid MCO issues, similar
  to how it is done in persistent version of this procedure.
- Replacement command fixed.
- Minor re-phrasings and improvements.