### PR TITLE
BZ2024738-Added Azure Stack Hub as supported platform for UPI install

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -32,6 +32,7 @@ In {product-title} {product-version}, you can install a cluster that uses user-p
 
 * AWS
 * Azure
+* Azure Stack Hub
 * GCP
 * {rh-openstack}
 * {rh-virtualization}


### PR DESCRIPTION
CP to 4.9 and 4.10

https://bugzilla.redhat.com/show_bug.cgi?id=2024738

Does not require SME or QE. As of 4.9, we support Azure Stack Hub for a UPI install. As part of that effort, a list specifying  the supported platforms for UPI was not updated. Corrected the oversight.

Preview
https://deploy-preview-39313--osdocs.netlify.app/openshift-enterprise/latest/installing/index.html#supported-platforms-for-openshift-clusters_ocp-installation-overview