### PR TITLE
[MULTIARCH-1967] IBM Z remove cio_ignore parm from 4.8 and later docs

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -58,13 +58,18 @@ Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 +
 [source,terminal]
 ----
-rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
-cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
-ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
-rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
-!condev rd.dasd=0.0.3490
+rd.neednet=1 \
+console=ttysclp0 \
+coreos.inst.install_dev=dasda \
+coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign \
+ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \
+rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 \
+zfcp.allow_lun_scan=0 \
+rd.dasd=0.0.3490
 ----
++
+Write all options in the parameter file as a single line and make sure you have no newline characters. 
 
 ** For installations on FCP-type disks, complete the following tasks:
 ... Use `rd.zfcp=<adapter>,<wwpn>,<lun>` to specify the FCP disk where {op-system} is to be installed. For multipathing repeat this step for each additional path.
@@ -91,17 +96,21 @@ The following is an example parameter file `worker-1.parm` for a worker node wit
 +
 [source,terminal]
 ----
-rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=sda
-coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign
-ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
-rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
-!condev
-rd.zfcp=0.0.1987,0x50050763070bc5e3,0x4008400B00000000
-rd.zfcp=0.0.19C7,0x50050763070bc5e3,0x4008400B00000000
-rd.zfcp=0.0.1987,0x50050763071bc5e3,0x4008400B00000000
+rd.neednet=1 \
+console=ttysclp0 \
+coreos.inst.install_dev=sda \
+coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign \
+ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \
+rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 \
+zfcp.allow_lun_scan=0 \
+rd.zfcp=0.0.1987,0x50050763070bc5e3,0x4008400B00000000 \
+rd.zfcp=0.0.19C7,0x50050763070bc5e3,0x4008400B00000000 \
+rd.zfcp=0.0.1987,0x50050763071bc5e3,0x4008400B00000000 \
 rd.zfcp=0.0.19C7,0x50050763071bc5e3,0x4008400B00000000
 ----
++
+Write all options in the parameter file as a single line and make sure you have no newline characters.
 
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to z/VM, for example with FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-installing-zvm-s390[Installing under Z/VM].
 . Punch the files to the virtual reader of the z/VM guest virtual machine that is to become your bootstrap node.


### PR DESCRIPTION
- OCP version for cherry-picking: enterprise-4.8, 4.9, 4.10
- Jira: 
   - https://issues.redhat.com/browse/MULTIARCH/1967
   - https://issues.redhat.com/browse/MULTIARCH-1968
- Bugzilla: Includes change from this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1941302 and stale PR https://github.com/openshift/openshift-docs/pull/31100
- Related PRs 
   - https://github.com/openshift/openshift-docs/pull/39476
   - https://github.com/openshift/openshift-docs/pull/39484

- Preview https://deploy-preview-39314--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z
  
- QE review: Matt Gritter, Nikita Dubrovski