### PR TITLE
OSDOCS-2975: Add supported profiles table

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -727,6 +727,8 @@ Topics:
   Topics:
   - Name: Compliance Operator release notes
     File: compliance-operator-release-notes
+  - Name: Supported compliance profiles
+    File: compliance-operator-supported-profiles
   - Name: Installing the Compliance Operator
     File: compliance-operator-installation
   - Name: Compliance Operator scans

--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/
+
+[id="compliance-supported-profiles_{context}"]
+= Compliance profiles
+
+The Compliance Operator provides the following compliance profiles:
+
+.Supported compliance profiles
+[cols="40%,50%,10%", options="header"]
+
+|===
+|Profile name
+|Profile title
+|Compliance Operator version 
+
+|ocp4-cis
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Red Hat OpenShift Container Platform 4 Benchmark]
+|0.1.39+
+
+|ocp4-cis-node
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Red Hat OpenShift Container Platform 4 Benchmark]
+|0.1.39+
+
+|ocp4-e8
+|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[Australian Cyber Security Centre (ACSC) Essential Eight]
+|0.1.39+
+
+|ocp4-moderate
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level]
+|0.1.39+
+
+|ocp4-moderate-node
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level]
+|0.1.44+
+
+|ocp4-nerc-cip
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|0.1.44+
+
+|ocp4-nerc-cip-node
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|0.1.44+
+
+|rhcos4-e8
+|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[Australian Cyber Security Centre (ACSC) Essential Eight]
+|0.1.39+
+
+|rhcos4-moderate
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS]
+|0.1.39+
+
+|rhcos4-nerc-cip
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|0.1.44+
+
+|===
+

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -12,11 +12,6 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
-[id="compliance-operator-inclusive-language"]
-== Making open source more inclusive
-
-Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[Red Hat CTO Chris Wright's message].
-
 [id="compliance-operator-release-notes-0-1-44"]
 == OpenShift Compliance Operator 0.1.44
 
@@ -40,13 +35,20 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.44
 * This enhancement removes the requirement that you have to extend an existing profile in order to create a tailored profile. This means the `extends` field in the `TailoredProfile` CRD is no longer mandatory. You can now select a list of rule objects to create a tailored profile.  Note that you must select whether your profile applies to nodes or the platform by setting the `compliance.openshift.io/product-type:` annotation or by setting the `-node` suffix for the `TailoredProfile` CR.
 +
 * In this release, the Compliance Operator is now able to schedule scans on all nodes irrespective of their taints. Previously, the scan pods would only tolerated the `node-role.kubernetes.io/master taint`, meaning that they would either ran on nodes with no taints or only on nodes with the `node-role.kubernetes.io/master` taint. In deployments that use custom taints for their nodes, this resulted in the scans not being scheduled on those nodes. Now, the scan pods tolerate all node taints.
++
+* In this release, the Compliance Operator supports the following North American Electric Reliability Corporation (NERC) security profiles:
++
+** ocp4-nerc-cip
+** ocp4-nerc-cip-node
+** rhcos4-nerc-cip
++
+* In this release, the Compliance Operator supports the NIST 800-53 Moderate-Impact Baseline for the Red Hat OpenShift - Node level, ocp4-moderate-node, security profile.
 
 === Templating and variable use
 
 * In this release, the remediation template now allows multi-value variables.
 +
-* With this update, the Compliance Operator can change remediations based on variables that are set in the compliance profile. This is useful for remediations that include deployment-specific values such as time outs, NTP server host names, or similar. Additionally, the `ComplianceCheckResult` objects now use the label `compliance.openshift.io/check-has-value` that lists the variables a check can use.
-
+* With this update, the Compliance Operator can change remediations based on variables that are set in the compliance profile. This is useful for remediations that include deployment-specific values such as time outs, NTP server host names, or similar. Additionally, the `ComplianceCheckResult` objects now use the label `compliance.openshift.io/check-has-value` that lists the variables a check has used.
 
 [id="openshift-compliance-operator-0-1-44-bug-fixes"]
 === Bug fixes

--- a/security/compliance_operator/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/compliance-operator-supported-profiles.adoc
@@ -1,0 +1,13 @@
+[id="compliance-operator-supported-profiles"]
+= Supported compliance profiles
+include::modules/common-attributes.adoc[]
+:context: compliance-operator-supported-profiles
+
+There are several profiles available as part of the Compliance Operator (CO) installation. 
+
+include::modules/compliance-supported-profiles.adoc[leveloffset=+1]
+
+[id="additional-resources-compliance-operator-"]
+== Additional resources
+
+* For more information about viewing the compliance profiles available in your system, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profiles_understanding-compliance[Compliance Operator profiles] in Understanding the Compliance Operator.


### PR DESCRIPTION
Applies to 4.6+.
Jira Card: https://issues.redhat.com/browse/OSDOCS-2975

Compliance Operator release notes are updated to include the profiles that were added in release 0.1.44 (see the last 2 bullets in this section):
https://deploy-preview-39324--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-0-1-44-new-features-and-enhancements

A table listing the supported profiles is added here:
https://deploy-preview-39324--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-supported-profiles.html#compliance-supported-profiles_compliance-operator-supported-profiles