### PR TITLE
Added notes for 3.11.569 release

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -5381,3 +5381,99 @@ openshift3/ose-template-service-broker:v3.11.542-1.git.f2fd300
 ==== Upgrading
 
 To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.
+
+[[ocp-3-11-569]]
+=== RHSA-2021:4827 - {product-title} 3.11.569 bug fix and security update
+
+Issued: 2021-12-02
+
+{product-title} release 3.11.569, which includes security updates, is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHSA-2021:4827[RHSA-2021:4827] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4828[RHBA-2021:4828] advisory.
+
+[[ocp-3-11-569-images]]
+==== Images
+
+This release updates the Red Hat Container Registry (`registry.redhat.io`) with the following images:
+----
+openshift3/ose-ansible:v3.11.566-1.g490bb2a
+openshift3/ose-cluster-autoscaler:v3.11.566-1.g99b2acf
+openshift3/ose-descheduler:v3.11.566-1.gd435537
+openshift3/ose-metrics-server:v3.11.566-1.gf8bf728
+openshift3/ose-node-problem-detector:v3.11.566-1.gc8f26da
+openshift3/automation-broker-apb:v3.11.566-1
+openshift3/ose-cluster-monitoring-operator:v3.11.566-1.ga9fd527
+openshift3/ose-configmap-reloader:v3.11.566-1.gbb85bd3
+openshift3/csi-attacher:v3.11.566-1
+openshift3/csi-driver-registrar:v3.11.566-1
+openshift3/csi-livenessprobe:v3.11.566-1
+openshift3/csi-provisioner:v3.11.566-1
+openshift3/ose-efs-provisioner:v3.11.566-1.g04aa20d
+openshift3/oauth-proxy:v3.11.566-1.gedebe84
+openshift3/prometheus-alertmanager:v3.11.566-1.g13de638
+openshift3/prometheus-node-exporter:v3.11.566-1.g609cd20
+openshift3/prometheus:v3.11.566-1.g99aae51
+openshift3/grafana:v3.11.566-1.g2ea5517
+openshift3/image-inspector:v3.11.566-1
+openshift3/jenkins-agent-maven-35-rhel7:v3.11.566-1.g93d78c4
+openshift3/jenkins-agent-maven-36-rhel7:v3.11.566-1.g93d78c4
+openshift3/jenkins-agent-nodejs-10-rhel7:v3.11.566-1.g93d78c4
+openshift3/jenkins-agent-nodejs-12-rhel7:v3.11.566-1.g93d78c4
+openshift3/jenkins-slave-base-rhel7:v3.11.566-1.g93d78c4
+openshift3/ose-kube-rbac-proxy:v3.11.566-1.g31106c3
+openshift3/ose-kube-state-metrics:v3.11.566-1.gb7c6d38
+openshift3/kuryr-cni:v3.11.566-1.g0c4bf66
+openshift3/ose-logging-curator5:v3.11.566-1.gc31bbac
+openshift3/ose-logging-elasticsearch5:v3.11.566-1.gc31bbac
+openshift3/ose-logging-eventrouter:v3.11.566-1
+openshift3/logging-fluentd:v3.11.566-1.gc31bbac
+openshift3/ose-logging-kibana5:v3.11.566-1.gc31bbac
+openshift3/metrics-cassandra:v3.11.566-1
+openshift3/metrics-hawkular-metrics:v3.11.566-1
+openshift3/metrics-hawkular-openshift-agent:v3.11.566-1
+openshift3/metrics-heapster:v3.11.566-1
+openshift3/metrics-schema-installer:v3.11.566-1
+openshift3/apb-base:v3.11.566-1.g90cecc3
+openshift3/apb-tools:v3.11.566-1
+openshift3/ose-ansible-service-broker:v3.11.566-1
+openshift3/ose-docker-builder:v3.11.566-1.g0a74536
+openshift3/ose-cli:v3.11.566-1.g0a74536
+openshift3/ose-cluster-capacity:v3.11.566-1.g22be164
+openshift3/ose-console:v3.11.566-1.g34f65c8
+openshift3/ose:v3.11.566-2.g0a74536
+openshift3/ose-deployer:v3.11.566-1.g0a74536
+openshift3/ose-egress-dns-proxy:v3.11.566-1.g0a74536
+openshift3/ose-egress-router:v3.11.566-1.g0a74536
+openshift3/ose-haproxy-router:v3.11.566-1.g0a74536
+openshift3/ose-hyperkube:v3.11.566-1.g0a74536
+openshift3/ose-hypershift:v3.11.566-1.g0a74536
+openshift3/ose-keepalived-ipfailover:v3.11.566-1.g0a74536
+openshift3/mariadb-apb:v3.11.566-1
+openshift3/mediawiki-apb:v3.11.566-1
+openshift3/mediawiki:v3.11.566-1
+openshift3/mysql-apb:v3.11.566-1
+openshift3/node:v3.11.566-1.g0a74536
+openshift3/ose-pod:v3.11.566-1.g0a74536
+openshift3/postgresql-apb:v3.11.566-1
+openshift3/ose-recycler:v3.11.566-1.g0a74536
+openshift3/ose-docker-registry:v3.11.566-1.g3571208
+openshift3/ose-service-catalog:v3.11.566-1.g2e6be86
+openshift3/ose-tests:v3.11.566-1.g0a74536
+openshift3/jenkins-2-rhel7:v3.11.566-3.g93d78c4
+openshift3/local-storage-provisioner:v3.11.566-1
+openshift3/manila-provisioner:v3.11.566-1
+openshift3/ose-operator-lifecycle-manager:v3.11.566-1.g1054881
+openshift3/ose-web-console:v3.11.566-1.gac8eea5
+openshift3/ose-egress-http-proxy:v3.11.566-1.g0a74536
+openshift3/kuryr-controller:v3.11.566-1.g0c4bf66
+openshift3/ose-ovn-kubernetes:v3.11.566-1.g21370b4
+openshift3/ose-prometheus-config-reloader:v3.11.566-1.gd4bae2d
+openshift3/ose-prometheus-operator:v3.11.566-1.gd4bae2d
+openshift3/registry-console:v3.11.566-1
+openshift3/snapshot-controller:v3.11.566-1
+openshift3/snapshot-provisioner:v3.11.566-1
+openshift3/ose-template-service-broker:v3.11.566-1.g0a74536
+----
+
+[[ocp-3-11-569-upgrading]]
+==== Upgrading
+
+To upgrade an existing {product-title} 3.10 or 3.11 cluster to this latest release, see xref:../upgrading/index.adoc#install-config-upgrading-index[Upgrade methods and strategies] for instructions.


### PR DESCRIPTION
Added notes for Dec. 2nd 3.11.569 release

- Applies to `enterprise-3.11` only
- [Preview link](https://deploy-preview-39326--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes.html#ocp-3-11-566)