### PR TITLE
BZ#2023799: clarify installation prog role

### DIFF
--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * architecture/architecture_rhcos.adoc
+// * architecture/architecture-rhcos.adoc
 
 [id="rhcos-about_{context}"]
 = About {op-system}
@@ -9,7 +9,7 @@
 
 {op-system} is supported only as a component of {product-title} {product-version} for all {product-title} machines. {op-system} is the only supported operating system for {product-title} control plane, or master, machines. While {op-system} is the default operating system for all cluster machines, you can create compute machines, which are also known as worker machines, that use {op-system-base} as their operating system. There are two general ways {op-system} is deployed in {product-title} {product-version}:
 
-* If you install your cluster on infrastructure that the cluster provisions, {op-system} images are downloaded to the target platform during installation, and suitable Ignition config files, which control the {op-system} configuration, are used to deploy the machines.
+* If you install your cluster on infrastructure that the installation program provisions, {op-system} images are downloaded to the target platform during installation. Suitable Ignition config files, which control the {op-system} configuration, are also downloaded and used to deploy the machines.
 
 * If you install your cluster on infrastructure that you manage, you must follow the installation documentation to obtain the {op-system} images, generate Ignition config files, and use the Ignition config files to provision your machines.
 
@@ -136,3 +136,4 @@ At the end of this process, the machine is ready to join the cluster and does no
 ////
 After Ignition finishes its work on an individual machine, the kernel pivots to the installed system. The initial RAM disk is no longer used and the kernel goes on to run the init service to start up everything on the host from the installed disk. When the last machine under the bootstrap machine's control is completed, and the services on those machines come up, the work of the bootstrap machine is over.
 ////
+


### PR DESCRIPTION
Fixes <https://bugzilla.redhat.com/show_bug.cgi?id=2023799>

Clarify that for IPI, the installation program
downloads the RHCOS images.

----
Preview is at "Red Hat Enterprise Linux CoreOS (RHCOS)" > [About RHCOS](https://deploy-preview-39334--osdocs.netlify.app/openshift-enterprise/latest/architecture/architecture-rhcos.html)