### PR TITLE
OSDOCS-2999: Updates to Monitoring navagation menu name in OCP docs

### DIFF
--- a/_unused_topics/cluster-logging-kibana-console-launch.adoc
+++ b/_unused_topics/cluster-logging-kibana-console-launch.adoc
@@ -14,7 +14,7 @@ pie charts, heat maps, built-in geospatial support, and other visualizations.
 
 To launch the Kibana interface:
 
-. In the {product-title} console, click *Monitoring* -> *Logging*.
+. In the {product-title} console, click *Observe* -> *Logging*.
 
 . Log in using the same credentials you use to log in to the {product-title} console.
 +

--- a/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
+++ b/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 
-The *Monitoring* view in the *Developer* perspective provides options to monitor your project or application metrics, such as CPU, memory, and bandwidth usage, and network related information.
+The *Observe* view in the *Developer* perspective provides options to monitor your project or application metrics, such as CPU, memory, and bandwidth usage, and network related information.
 
 == Prerequisites
 

--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -87,7 +87,7 @@ The following advisories are available for OpenShift Logging 5.2.x:
 +
 The current release adds namespace metrics to the *Logging* dashboard in the {product-title} console. With these metrics, you can see which namespaces produce logs and how many logs each namespace produces for a given timestamp.
 +
-To see these metrics, open the *Administrator* perspective in the {product-title} web console, and navigate to *Monitoring* -> *Dashboards* -> *Logging/Elasticsearch*. (link:https://issues.redhat.com/browse/LOG-1680[LOG-1680])
+To see these metrics, open the *Administrator* perspective in the {product-title} web console, and navigate to *Observe* -> *Dashboards* -> *Logging/Elasticsearch*. (link:https://issues.redhat.com/browse/LOG-1680[LOG-1680])
 
 * The current release, OpenShift Logging 5.2, enables two new metrics: For a given timestamp or duration, you can see the total logs produced or logged by individual containers, and the total logs collected by the collector. These metrics are labeled by namespace, pod, and container name so that you can see how many logs each namespace and pod collects and produces. (link:https://issues.redhat.com/browse/LOG-1213[LOG-1213])
 

--- a/modules/checking-cluster-resource-availability-and-utilization.adoc
+++ b/modules/checking-cluster-resource-availability-and-utilization.adoc
@@ -28,7 +28,7 @@ image::monitoring-dashboard-compute-resources.png[]
 
 .Procedure
 
-. In the *Administrator* perspective in the {product-title} web console, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective in the {product-title} web console, navigate to *Observe* -> *Dashboards*.
 
 . Choose a dashboard in the *Dashboard* list. Some dashboards, such as the *etcd* dashboard, produce additional sub-menus when selected.
 

--- a/modules/cluster-logging-collector-alerts-viewing.adoc
+++ b/modules/cluster-logging-collector-alerts-viewing.adoc
@@ -6,7 +6,7 @@
 = Viewing logging collector alerts
 
 Alerts are shown in the {product-title} web console, on the *Alerts* tab of the Alerting UI. Alerts are in one of the following states:
- 
+
 * *Firing*. The alert condition is true for the duration of the timeout. Click the *Options* menu at the end of the firing alert to view more information or silence the alert.
 * *Pending* The alert condition is currently true, but the timeout has not been reached.
 * *Not Firing*. The alert is not currently triggered.
@@ -15,7 +15,6 @@ Alerts are shown in the {product-title} web console, on the *Alerts* tab of the 
 
 To view OpenShift Logging and other {product-title} alerts:
 
-. In the {product-title} console, click *Monitoring* → *Alerting*.
+. In the {product-title} console, click *Observe* → *Alerting*.
 
 . Click the *Alerts* tab. The alerts are listed, based on the filters selected.
-

--- a/modules/cluster-logging-dashboards-access.adoc
+++ b/modules/cluster-logging-dashboards-access.adoc
@@ -2,7 +2,7 @@
 // * logging/cluster-logging-dashboards.adoc
 
 [id="cluster-logging-dashboards-access_{context}"]
-= Accessing the Elastisearch and Openshift Logging dashboards
+= Accessing the Elasticsearch and Openshift Logging dashboards
 
 
 You can view the *Logging/Elasticsearch Nodes* and *Openshift Logging* dashboards in the {product-title} web console.
@@ -11,7 +11,7 @@ You can view the *Logging/Elasticsearch Nodes* and *Openshift Logging* dashboard
 
 To launch the dashboards:
 
-. In the {product-title} web console, click *Monitoring* -> *Dashboards*.
+. In the {product-title} web console, click *Observe* -> *Dashboards*.
 
 . On the *Dashboards* page, select *Logging/Elasticsearch Nodes* or *Openshift Logging* from the *Dashboard* menu.
 +

--- a/modules/dedicated-cluster-install-deploy.adoc
+++ b/modules/dedicated-cluster-install-deploy.adoc
@@ -139,5 +139,5 @@ You should see several pods for OpenShift Logging, Elasticsearch, Fluentd, and K
 * fluentd-zqgqx
 * kibana-7fb4fd4cc9-bvt4p
 
-. Access the OpenShift Logging interface, *Kibana*, from the *Monitoring* →
+. Access the OpenShift Logging interface, *Kibana*, from the *Observe* →
 *Logging* page of the {product-title} web console.

--- a/modules/listing-alerts-that-are-firing.adoc
+++ b/modules/listing-alerts-that-are-firing.adoc
@@ -13,7 +13,7 @@ Alerts provide notifications when a set of defined conditions are true in an {pr
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to the *Monitoring* -> *Alerting* -> *Alerts* page.
+. In the *Administrator* perspective, navigate to the *Observe* -> *Alerting* -> *Alerts* page.
 
 . Review the alerts that are firing, including their *Severity*, *State*, and *Source*.
 

--- a/modules/migration-accessing-performance-metrics.adoc
+++ b/modules/migration-accessing-performance-metrics.adoc
@@ -12,7 +12,7 @@ You can access the performance metrics and run queries by using the {product-tit
 
 .Procedure
 
-. In the {product-title} web console, click *Monitoring* -> *Metrics*.
+. In the {product-title} web console, click *Observe* -> *Metrics*.
 . Enter a PromQL query, select a time window to display, and click *Run Queries*.
 +
 If your web browser does not display all the results, use the Prometheus console.

--- a/modules/monitoring-contents-of-the-metrics-ui.adoc
+++ b/modules/monitoring-contents-of-the-metrics-ui.adoc
@@ -7,7 +7,7 @@
 
 This section shows and explains the contents of the Metrics UI, a web interface to Prometheus.
 
-The *Metrics* page is accessible by clicking *Monitoring* -> *Metrics* in the {product-title} web console.
+The *Metrics* page is accessible by clicking *Observe* -> *Metrics* in the {product-title} web console.
 
 image::monitoring-metrics-screen.png[]
 

--- a/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
+++ b/modules/monitoring-listing-alerting-rules-for-all-projects-in-a-single-view.adoc
@@ -14,7 +14,7 @@ As a cluster administrator, you can list alerting rules for core {product-title}
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Alerting* -> *Alerting Rules*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Alerting* -> *Alerting Rules*.
 
 . Select the *Platform* and *User* sources in the *Filter* drop-down menu.
 +

--- a/modules/monitoring-running-metrics-queries.adoc
+++ b/modules/monitoring-running-metrics-queries.adoc
@@ -9,7 +9,7 @@ You begin working with metrics by entering one or several Prometheus Query Langu
 
 .Procedure
 
-. Open the {product-title} web console and navigate to the *Monitoring* -> *Metrics* page.
+. Open the {product-title} web console and navigate to the *Observe* -> *Metrics* page.
 
 . In the query field, enter your PromQL query.
 * To show all available metrics and PromQL functions, click *Insert Metric at Cursor*.

--- a/modules/odc-monitoring-health-checks.adoc
+++ b/modules/odc-monitoring-health-checks.adoc
@@ -14,5 +14,5 @@ In case an application health check fails, you can use the *Topology* view to mo
 
 .Procedure
 . In the *Topology* view, click on the application node to see the side panel.
-. Click the *Monitoring* tab to see the health check failures in the *Events (Warning)* section.
+. Click the *Observe* tab to see the health check failures in the *Events (Warning)* section.
 . Click the down arrow adjoining *Events (Warning)* to see the details of the health check failure.

--- a/modules/odc-monitoring-your-application-metrics.adoc
+++ b/modules/odc-monitoring-your-application-metrics.adoc
@@ -11,7 +11,7 @@ After you create applications in your project and deploy them, you can use the *
 To see the alerts for your workload:
 
 . In the *Topology* view, click the workload to see the workload details in the right panel.
-. Click the *Monitoring* tab to see the critical and warning alerts for the application; graphs for metrics, such as CPU, memory, and bandwidth usage; and all the events for the application.
+. Click the *Observe* tab to see the critical and warning alerts for the application; graphs for metrics, such as CPU, memory, and bandwidth usage; and all the events for the application.
 +
 [NOTE]
 ====

--- a/modules/odc-monitoring-your-project-metrics.adoc
+++ b/modules/odc-monitoring-your-project-metrics.adoc
@@ -9,7 +9,7 @@ After you create applications in your project and deploy them, you can use the *
 
 .Procedure
 
-. On the left navigation panel of the *Developer* perspective, click *Monitoring* to see the *Dashboard*, *Metrics*, *Alerts*, and *Events* for your project.
+. On the left navigation panel of the *Developer* perspective, click *Observe* to see the *Dashboard*, *Metrics*, *Alerts*, and *Events* for your project.
 
 * Use the *Dashboard* tab to see graphs depicting the CPU, memory, and bandwidth consumption and network related information, such as the rate of transmitted and received packets and the rate of dropped packets.
 +

--- a/modules/osd-monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/osd-monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -18,7 +18,7 @@ Only dedicated administrators have access to the third-party UIs provided with {
 
 .Procedure
 
-. From the *Administrator* perspective in the OpenShift web console, select *Monitoring* -> *Metrics*.
+. From the *Administrator* perspective in the OpenShift web console, select *Observe* -> *Metrics*.
 
 . Select *Insert Metric at Cursor* to view a list of predefined queries.
 

--- a/modules/osd-monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
+++ b/modules/osd-monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc
@@ -24,7 +24,7 @@ Developers can only use the *Developer* perspective and not the *Administrator* 
 .Procedure
 
 // TODO: The previous procedure said the "OpenShift web console" and this says the "OpenShift Dedicated web console". I assume it should be the same between the two?
-. From the *Developer* perspective in the {product-title} web console, select *Monitoring* -> *Metrics*.
+. From the *Developer* perspective in the {product-title} web console, select *Observe* -> *Metrics*.
 
 . Select the project that you want to view metrics for in the *Project:* list.
 

--- a/modules/osd-monitoring-reviewing-monitoring-dashboards-developer.adoc
+++ b/modules/osd-monitoring-reviewing-monitoring-dashboards-developer.adoc
@@ -13,7 +13,7 @@ In the *Developer* perspective, you can view dashboards relating to a selected p
 
 .Procedure
 
-. In the *Developer* perspective in the {product-title} web console, navigate to *Monitoring* -> *Dashboard*.
+. In the *Developer* perspective in the {product-title} web console, navigate to *Observe* -> *Dashboard*.
 
 . Choose a project in the *Project:* list.
 

--- a/modules/osd-monitoring-troubleshooting-issues.adoc
+++ b/modules/osd-monitoring-troubleshooting-issues.adoc
@@ -11,7 +11,7 @@ If metrics are not displaying when monitoring user-defined projects, follow thes
 .Procedure
 
 . Query the metric name and verify that the project is correct:
-.. From the *Developer* perspective in the OpenShift Container Platform web console, select *Monitoring* -> *Metrics*.
+.. From the *Developer* perspective in the OpenShift Container Platform web console, select *Observe* -> *Metrics*.
 .. Select the project that you want to view metrics for in the *Project:* list.
 .. Choose a query from the *Select Query* list, or run a custom PromQL query by selecting *Show PromQL*.
 +

--- a/modules/ref_cluster-logging-elasticsearch-cluster-status.adoc
+++ b/modules/ref_cluster-logging-elasticsearch-cluster-status.adoc
@@ -1,12 +1,12 @@
 :_module-type: REFERENCE
 
 [id="ref_cluster-logging-elasticsearch-cluster-status_{context}"]
-= Elasticsearch cluster status  
+= Elasticsearch cluster status
 
 [role="_abstract"]
-The Grafana dashboard in the *Monitoring* section of the {product-title} web console displays the status of the Elasticsearch cluster.
+The Grafana dashboard in the *Observe* section of the {product-title} web console displays the status of the Elasticsearch cluster.
 
-To get the status of the OpenShift Elasticsearch cluster, visit the Grafana dashboard in the *Monitoring* section of the {product-title} web console at
+To get the status of the OpenShift Elasticsearch cluster, visit the Grafana dashboard in the *Observe* section of the {product-title} web console at
 `<cluster_url>/monitoring/dashboards/grafana-dashboard-cluster-logging`.
 
 .Elasticsearch status fields

--- a/modules/reviewing-cluster-status-from-the-openshift-cluster-manager.adoc
+++ b/modules/reviewing-cluster-status-from-the-openshift-cluster-manager.adoc
@@ -36,7 +36,7 @@ Alternatively, you can navigate to the link:https://console.redhat.com/openshift
 +
 * A cluster history
 
-. Navigate to the *Monitoring* page to review the following information:
+. Navigate to the *Observe* page to review the following information:
 * A list of any issues that have been detected
 +
 * A list of alerts that are firing

--- a/modules/serverless-admin-monitoring-eventing-broker-trigger.adoc
+++ b/modules/serverless-admin-monitoring-eventing-broker-trigger.adoc
@@ -15,7 +15,7 @@ You can use the {product-title} monitoring dashboards to view metrics for broker
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Eventing - Broker/Trigger* dashboard in the *Dashboard* drop-down list.
 . You can now view the following metrics:
 .. For brokers:

--- a/modules/serverless-admin-monitoring-eventing-channel.adoc
+++ b/modules/serverless-admin-monitoring-eventing-channel.adoc
@@ -11,7 +11,7 @@ You can use the {product-title} monitoring dashboards to view metrics for channe
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Eventing - Channel* dashboard in the *Dashboard* drop-down list.
 . You can now view the following metrics:
 .. For in-memory channels:

--- a/modules/serverless-admin-monitoring-eventing-cpu-memory.adoc
+++ b/modules/serverless-admin-monitoring-eventing-cpu-memory.adoc
@@ -15,7 +15,7 @@ You can use the {product-title} monitoring dashboards to view source CPU and mem
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Eventing - Source CPU and Memory Usage* dashboard in the *Dashboard* drop-down list to view the following metrics:
 ** Total CPU Usage (rate per minute)
 ** Total Memory Usage (bytes)

--- a/modules/serverless-admin-monitoring-eventing-sources.adoc
+++ b/modules/serverless-admin-monitoring-eventing-sources.adoc
@@ -15,7 +15,7 @@ You can use the {product-title} monitoring dashboards to view metrics for event 
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Eventing - Sources* dashboard in the *Dashboard* drop-down list.
 . You can now view the following metrics:
 .. For API server sources:

--- a/modules/serverless-admin-monitoring-health-status.adoc
+++ b/modules/serverless-admin-monitoring-health-status.adoc
@@ -15,7 +15,7 @@ You can use the {product-title} monitoring dashboards to view the overall health
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Health Status* dashboard in the *Dashboard* drop-down to view the overall health status of Knative. If your Knative deployment is running as expected, the dashboard shows a status of *Ready*.
 +
 image::knative-admin-health-status-dash.png[Knative Health Status dashboard]

--- a/modules/serverless-admin-monitoring-serving-cpu-memory.adoc
+++ b/modules/serverless-admin-monitoring-serving-cpu-memory.adoc
@@ -15,7 +15,7 @@ You can use the {product-title} monitoring dashboards to view revision CPU and m
 
 .Procedure
 
-. In the *Administrator* perspective, navigate to *Monitoring* -> *Dashboards*.
+. In the *Administrator* perspective, navigate to *Observe* -> *Dashboards*.
 . Select the *Knative Serving - Source CPU and Memory Usage* dashboard in the *Dashboard* drop-down list to view the following metrics:
 ** Total CPU Usage (rate per minute)
 ** Total Memory Usage (bytes)

--- a/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
+++ b/modules/serverless-monitoring-services-examining-metrics-dashboard.adoc
@@ -5,7 +5,7 @@ You can examine the metrics using a dedicated dashboard that aggregates queue pr
 
 .Procedure
 
-. In the web console, navigate to the *Monitoring* -> *Metrics* interface.
+. In the web console, navigate to the *Observe* -> *Metrics* interface.
 
 . Select the `Knative User Services (Queue Proxy metrics)` dashboard.
 

--- a/modules/serverless-monitoring-services-examining-metrics.adoc
+++ b/modules/serverless-monitoring-services-examining-metrics.adoc
@@ -19,7 +19,7 @@ $ hello_route=$(oc get ksvc helloworld-go -n ns1 -o jsonpath='{.status.url}') &&
 Hello Go Sample v1!
 ----
 
-. In the web console, navigate to the *Monitoring* -> *Metrics* interface.
+. In the web console, navigate to the *Observe* -> *Metrics* interface.
 
 . In the input field, enter the query for the metric you want to observe, for example:
 +


### PR DESCRIPTION
[OSDOCS-2999 ](https://issues.redhat.com/browse/OSDOCS-2999)

- Applies to `enterprise-4.9`+
- [Preview link](https://deploy-preview-39336--osdocs.netlify.app/openshift-enterprise/latest/logging/cluster-logging-deploying.html#cluster-logging-deploy-console_cluster-logging-deploying)