### PR TITLE
[enterprise-4.6] GH38823: Fixed typo in namespace selector label for OpenShift SDN

### DIFF
--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -43,13 +43,12 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-        policy-group.network.openshift.io/ingress=""
+          policy-group.network.openshift.io/ingress: ""
   podSelector: {}
   policyTypes:
   - Ingress
 EOF
 ----
-
 .. A policy named `allow-from-openshift-monitoring`:
 +
 [source,terminal]


### PR DESCRIPTION
Cherrypicked from `d910d45c01cec9eaace2865cabbf44ab6789b0b4`

See https://github.com/openshift/openshift-docs/pull/38897