### PR TITLE
JIRA-OSDOCS3005: Removed one reference of deprecated --prefix flag

### DIFF
--- a/modules/rosa-upgrading-preparing-4-7-to-4-8.adoc
+++ b/modules/rosa-upgrading-preparing-4-7-to-4-8.adoc
@@ -29,7 +29,8 @@ $ rosa create account-roles --mode auto
 +
 [IMPORTANT]
 ====
-If you created the roles and policies for version 4.7 with a custom prefix, you must include the `--prefix` option and specify the same prefix name. Specifying the prefix name ensures that the existing roles and policies used by the cluster are updated.
+If you created the roles and policies with a custom prefix, you must include the `--prefix` option and specify the same prefix name. Specifying the prefix name ensures that the existing roles and policies used by the cluster are updated. If you did not define a custom prefix, do not use the +
+`--prefix` option.
 ====
 
 . As a cluster administrator, update the value of the `cloudcredential.openshift.io/upgradeable-to` annotation in the `CloudCredential` custom resource to `v4.8`:


### PR DESCRIPTION
This PR is to address JIRA: https://issues.redhat.com/browse/OSDOCS-3005

Topic updated: https://deploy-preview-39342--osdocs.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading-sts

Exact change: In the section 'Preparing an upgrade from 4.7 to 4.8' section > procedure step 1, updated the note about the --prefix flag with these changes: 

- Removed the reference to 4.7
- Added info. that 'if users did not define a custom prefix, they do not need to use the flag'.

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10