### PR TITLE
BZ2024214: Changed latest versions to stable

### DIFF
--- a/modules/ipi-install-retrieving-the-openshift-installer.adoc
+++ b/modules/ipi-install-retrieving-the-openshift-installer.adoc
@@ -6,11 +6,11 @@
 [id="retrieving-the-openshift-installer_{context}"]
 = Retrieving the {product-title} installer
 
-Use the `latest-4.x` version of the installer to deploy the latest generally
-available version of {product-title}:
+Use the `stable-4.x` version of the installer to deploy the generally
+available stable version of {product-title}:
 
 [source,terminal]
 ----
-$ export VERSION=latest-4.9
+$ export VERSION=stable-4.10
 export RELEASE_IMAGE=$(curl -s https://mirror.openshift.com/pub/openshift-v4/clients/ocp/$VERSION/release.txt | grep 'Pull From: quay.io' | awk -F ' ' '{print $3}')
 ----


### PR DESCRIPTION
BZ link: https://bugzilla.redhat.com/show_bug.cgi?id=2024214

Preview: https://deploy-preview-39362--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#retrieving-the-openshift-installer_ipi-install-installation-workflow

Release(s): 4.10