### PR TITLE
Added notes for release 4.6.51

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3387,3 +3387,19 @@ link:https://access.redhat.com/solutions/6474711[{product-title} 4.6.49 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-51"]
+=== RHBA-2021:4800 - {product-title} 4.6.51 bug fix and security update
+
+Issued: 2021-12-02
+
+{product-title} release 4.6.51, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4800[RHBA-2021:4800] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:4799[RHSA-2021:4799] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6547401[{product-title} 4.6.51 container image list]
+
+[id="ocp-4-6-51-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.6.51. 

Applies only to `enterprise-4.6`

Preview: https://deploy-preview-39370--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-51