### PR TITLE
BZ2021367: Change 'than' to 'that'

### DIFF
--- a/modules/nw-customize-ingress-error-pages.adoc
+++ b/modules/nw-customize-ingress-error-pages.adoc
@@ -16,7 +16,7 @@ By default, the HAProxy router serves only a 503 error page when the application
 
 [NOTE]
 ====
-If you use the {product-title} default 503 error code page as a template for your customizations, the headers in the file require an editor than can use CRLF line endings.
+If you use the {product-title} default 503 error code page as a template for your customizations, the headers in the file require an editor that can use CRLF line endings.
 ====
 
 .Procedure


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2021367

OCP version: 4.9

Current 4.9 doc: https://docs.openshift.com/container-platform/4.9/networking/ingress-operator.html#nw-customize-ingress-error-pages_configuring-ingress

Direct doc preview link: https://deploy-preview-39372--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-customize-ingress-error-pages_configuring-ingress