### PR TITLE
RHDEVDOCS-3490 Pipelines 1.6 RN

### DIFF
--- a/cicd/pipelines/op-release-notes.adoc
+++ b/cicd/pipelines/op-release-notes.adoc
@@ -18,9 +18,13 @@ toc::[]
 
 For an overview of {pipelines-title}, see xref:../../cicd/pipelines/understanding-openshift-pipelines.adoc#understanding-openshift-pipelines[Understanding OpenShift Pipelines].
 
+include::modules/op-tkn-pipelines-compatibility-support-matrix.adoc[leveloffset=+1]
+
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/op-release-notes-1-6.adoc[leveloffset=+1]
+
 include::modules/op-release-notes-1-5.adoc[leveloffset=+1]
 
 include::modules/op-release-notes-1-4.adoc[leveloffset=+1]

--- a/modules/op-release-notes-1-4.adoc
+++ b/modules/op-release-notes-1-4.adoc
@@ -15,15 +15,13 @@ In addition to the stable and preview Operator channels, the {pipelines-title} O
 [id="compatibility-support-matrix-1-4_{context}"]
 == Compatibility and support matrix
 
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
+Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
 
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+In the table, features are marked with the following statuses:
 
-In the table below, features are marked with the following statuses:
-
-- *TP*: _Technology Preview_
-
-- *GA*: _General Availability_
+[horizontal]
+TP:: Technology Preview
+GA:: General Availability
 
 Note the following scope of support on the Red Hat Customer Portal for these features:
 

--- a/modules/op-release-notes-1-5.adoc
+++ b/modules/op-release-notes-1-5.adoc
@@ -10,15 +10,13 @@
 [id="compatibility-support-matrix-1-5_{context}"]
 == Compatibility and support matrix
 
-Some features in this release are currently in Technology Preview. These experimental features are not intended for production use.
-
-link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
 
 In the table, features are marked with the following statuses:
 
-- *TP*: _Technology Preview_
-
-- *GA*: _General Availability_
+[horizontal]
+TP:: Technology Preview
+GA:: General Availability
 
 Note the following scope of support on the Red Hat Customer Portal for these features:
 
@@ -298,8 +296,7 @@ For {pipelines-title} installed by the Operator, if you do not clone the `git-cl
 
 * On IBM Power Systems, IBM Z, and LinuxONE, the `s2i-dotnet` cluster task and the `tkn hub` command are unsupported.
 
-* When you run Maven and Jib-Maven cluster tasks on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters, set the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
-
+* When you run Maven and Jib-Maven cluster tasks, the default container image is supported only on Intel (x86) architecture. Therefore, tasks will fail on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters. As a workaround, you can specify a custom image by setting the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
 
 [id="fixed-issues-1-5_{context}"]
 == Fixed issues

--- a/modules/op-release-notes-1-6.adoc
+++ b/modules/op-release-notes-1-6.adoc
@@ -1,0 +1,247 @@
+// Module included in the following assembly:
+//
+// * cicd/pipelines/op-release-notes.adoc
+
+[id="op-release-notes-1-6_{context}"]
+= Release notes for {pipelines-title} General Availability 1.6
+
+With this update, {pipelines-title} General Availability (GA) 1.6 is available on {product-title} 4.9.
+
+[id="new-features-1-6_{context}"]
+== New features
+
+In addition to the fixes and stability improvements, the following sections highlight what is new in {pipelines-title} 1.6.
+
+//[id="new-features-cli-0-21-0-release-1-6_{context}"]
+//=== CLI
+
+* With this update, you can configure a pipeline or task `start` command to return a YAML or JSON-formatted string by using the `--output <string>`, where `<string>` is `yaml` or `json`. Otherwise, without the `--output` option, the `start` command returns a human-friendly message that is hard for other programs to parse. Returning a YAML or JSON-formatted string is useful for continuous integration (CI) environments. For example, after a resource is created, you can use `yq` or `jq` to parse the YAML or JSON-formatted message about the resource and wait until that resource is terminated without using the `showlog` option.
+// (link:https://github.com/tektoncd/cli/pull/1326[#1326])
+
+* With this update, you can authenticate to a registry using the `auth.json` authentication file of Podman. For example, you can use `tkn bundle push` to push to a remote registry using Podman instead of Docker CLI.
+// (link:https://github.com/tektoncd/cli/pull/1430[#1430])
+
+* With this update, if you use the `tkn [taskrun | pipelinerun] delete --all` command, you can preserve runs that are younger than a specified number of minutes by using the new `--keep-since <minutes>` option. For example, to keep runs that are less than five minutes old, you enter `tkn [taskrun | pipelinerun] delete -all --keep-since 5`. 
+// (link:https://github.com/tektoncd/cli/pull/1435[#1435])
+
+* With this update, when you delete task runs or pipeline runs, you can use the `--parent-resource` and `--keep-since` options together. For example, the `tkn pipelinerun delete --pipeline pipelinename --keep-since 5` command preserves pipeline runs whose parent resource is named `pipelinename` and whose age is five minutes or less. The `tkn tr delete -t <taskname> --keep-since 5` and `tkn tr delete --clustertask <taskname> --keep-since 5` commands work similarly for task runs.
+// (link:https://github.com/tektoncd/cli/pull/1443[#1443])
+
+* This update adds support for the triggers resources to work with `v1beta1` resources.
+
+// (link:https://github.com/tektoncd/cli/pull/1446[#1446], link:https://github.com/tektoncd/cli/pull/1449[#1449], link:https://github.com/tektoncd/cli/pull/1450[#1450], link:https://github.com/tektoncd/cli/pull/1454[#1454], link:https://github.com/tektoncd/cli/pull/1455[#1455])
+
+* This update adds an `ignore-running` option to the `tkn pipelinerun delete` and `tkn taskrun delete` commands.
+// (link:https://github.com/tektoncd/cli/pull/1445[#1445])
+
+* This update adds a `create` subcommand to the `tkn task` and `tkn clustertask` commands.
+// (link:https://github.com/tektoncd/cli/pull/1359[#1359])
+
+* With this update, when you use the `tkn pipelinerun delete --all` command, you can use the new `--label <string>` option to filter the pipeline runs by label. Optionally, you can use the `--label` option with `=` and `==` as equality operators, or `!=` as an inequality operator. For example, the `tkn pipelinerun delete --all --label asdf` and  `tkn pipelinerun delete --all --label==asdf` commands both delete all the pipeline runs that have the `asdf` label.
+// (link:https://github.com/tektoncd/cli/pull/1402[#1402])
+
+* With this update, you can fetch the version of installed Tekton components from the config map or, if the config map is not present, from the deployment controller.
+//  (link:https://github.com/tektoncd/cli/pull/1393[#1393])
+
+//[id="new-features-tekton-triggers-0-16-0-release-1-6_{context}"]
+//=== Tekton Triggers
+
+* With this update, triggers support the `feature-flags` and `config-defaults` config map to configure feature flags and to set default values respectively.
+//  (link:https://github.com/tektoncd/triggers/pull/1182[#1182], link:https://github.com/tektoncd/triggers/pull/1110[#1110])
+
+* This update adds a new metric, `eventlistener_event_count`, that you can use to count events received by the `EventListener` resource.
+//  (link:https://github.com/tektoncd/triggers/pull/1160[#1160])
+
+* This update adds `v1beta1` Go API types. With this update, triggers now support the `v1beta1` API version.
++
+With the current release, the `v1alpha1` features are now deprecated and will be removed in a future release. Begin using the `v1beta1` features instead.
+//  (link:https://github.com/tektoncd/triggers/pull/1103[#1103])
+
+//[id="new-features-pipelines-operator-1-6_{context}"]
+//=== {pipelines-title} Operator
+
+* In the current release, auto-prunning of resources is enabled by default. In addition, you can configure auto-prunning of task run and pipeline run for each namespace separately, by using the following new annotations:
+
+** `operator.tekton.dev/prune.schedule`: If the value of this annotation is different from the value specified at the `TektonConfig` custom resource definition, a new cron job in that namespace is created.
+** `operator.tekton.dev/prune.skip`: When set to `true`, the namespace for which it is configured will not be prunned.
+** `operator.tekton.dev/prune.resources`: This annotation accepts a comma-separated list of resources. To prune a single resource such as a pipeline run, set this annotation to `"pipelinerun"`. To prune multiple resources, such as task run and pipeline run, set this annotation to `"taskrun, pipelinerun"`.
+** `operator.tekton.dev/prune.keep`: Use this annotation to retain a resource without prunning.
+** `operator.tekton.dev/prune.keep-since`: Use this annotation to retain resources based on their age. The value for this annotation must be equal to the age of the resource in minutes. For example, to retain resources which were created not more than five days ago, set `keep-since` to `7200`.
++
+[NOTE]
+====
+The `keep` and `keep-since` annotations are mutually exclusive. For any resource, you must configure only one of them.
+====
++
+** `operator.tekton.dev/prune.strategy`: Set the value of this annotation to either `keep` or `keep-since`.
+
+* Administrators can disable the creation of the `pipeline` service account for the entire cluster, and prevent privilege escalation by misusing the associated SCC, which is very similar to `anyuid`.
+
+* You can now configure feature flags and components by using the `TektonConfig` custom resource, and the custom resources for individual components, such as `TektonPipeline` and `TektonTriggers`. This level of granularity is useful for customization and testing of alpha features such as the Tekton OCI bundle for individual components.
+
+* You can now configure optional `Timeouts` field for the `PipelineRun` resource. For example, you can configure timeouts separately for a pipeline run, each task run, and the `finally` tasks.
+
+* The pods generated by the `TaskRun` resource now sets the `activeDeadlineSeconds` field of the pods. This enables OpenShift to consider them as terminating, and allows you to use specifically scoped `ResourceQuota` object for the pods.
+
+* You can use configmaps to eliminate metrics tags or labels type on a task run, pipeline run, task, and pipeline. In addition, you can configure different types of metrics for measuring duration, such as a histogram, gauge, or last value.
+
+* You can define requests and limits on a pod coherently, as Tekton now fully supports the `LimitRange` object by considering the `Min`, `Max`, `Default`, and `DefaultRequest` fields.
+
+* The following alpha features are introduced:
+
+** A pipeline run can now stop after running the `finally` tasks, rather than the previous behavior of stopping the execution of all task run directly. This update adds the following `spec.status` values:
+
+*** `StoppedRunFinally` will stop the currently running tasks after they are completed, and then run the `finally` tasks.
+*** `CancelledRunFinally` will immediately cancel the running tasks, and then run the `finally` tasks.
+*** `Cancelled` will retain the previous behavior provided by the `PipelineRunCancelled` status.
++
+[NOTE]
+====
+The `Cancelled` status replaces the deprecated `PipelineRunCancelled` status, which will be removed in the `v1` version.
+====
++
+
+** You can now use the `oc debug` command to put a task run into debug mode, which pauses the execution and allows you to inspect specific steps in a pod.
+
+** When you set the `onError` field of a step to `continue`, the exit code for the step is recorded and passed on to subsequent steps. However, the task run does not fail and the execution of the rest of the steps in the task continues. To retain the existing behavior, you can set the value of the `onError` field to `stopAndFail`.
+
+** Tasks can now accept more parameters than are actually used. When the alpha feature flag is enabled, the parameters can implicitly propagate to inlined specs. For example, an inlined task can access parameters of its parent pipeline run, without explicitly defining each parameter for the task.
+
+** If you enable the flag for the alpha features, the conditions under `When` expressions will only apply to the task with which it is directly associated, and not the dependents of the task. To apply the `When` expressions to the associated task and its dependents, you must associate the expression with each dependent task separately. Note that, going forward, this will be the default behavior of the `When` expressions in any new API versions of Tekton. The existing default behavior will be deprecated in favor of this update.
+
+* The current release enables you to configure node selection by specifying the `nodeSelector` and `tolerations` values in the `TektonConfig` custom resource (CR). The Operator adds these values to all the deployments that it creates.
+
+** To configure node selection for the Operator's controller and webhook deployment, you edit the `config.nodeSelector` and `config.tolerations` fields in the specification for the `Subscription` CR, after installing the Operator.
+
+** To deploy the rest of the control plane pods of OpenShift Pipelines on an infrastructure node, update the `TektonConfig` CR with the `nodeSelector` and `tolerations` fields. The modifications are then applied to all the pods created by Operator.
+
+
+[id="deprecated-features-1-6_{context}"]
+== Deprecated features
+
+//[id="deprecated-cli-0-21-0-release-1-6_{context}"]
+//=== CLI
+
+* In CLI 0.21.0, support for all `v1alpha1` resources for `clustertask`, `task`, `taskrun`, `pipeline`, and `pipelinerun` commands are deprecated. These resources are now deprecated and will be removed in a future release.
+
+//[id="deprecated-tekton-0-16-0-1-6_{context}"]
+//=== Tekton Triggers
+
+* In Tekton Triggers v0.16.0, the redundant `status` label is removed from the metrics for the `EventListener` resource.
+//  (link:https://github.com/tektoncd/triggers/pull/1166[#1166])
++
+[IMPORTANT]
+====
+Breaking change: The `status` label has been removed from the `eventlistener_http_duration_seconds_*` metric.
+Remove queries that are based on the `status` label.
+====
+
+* With the current release, the `v1alpha1` features are now deprecated and will be removed in a future release. With this update, you can begin using the `v1beta1` Go API types instead. Triggers now supports the `v1beta1` API version.
+//  (link:https://github.com/tektoncd/triggers/pull/1103[#1103])
+
+* With the current release, the `EventListener` resource sends a response before the triggers finish processing.
+//  (link:https://github.com/tektoncd/triggers/pull/1132[#1132])
++
+[IMPORTANT]
+====
+Breaking change: With this change, the `EventListener` resource stops responding with a `201 Created` status code when it creates resources. Instead, it responds with a `202 Accepted` response code.
+====
+
+* The current release removes the `podTemplate` field from the `EventListener` resource.
+//  (link:https://github.com/tektoncd/triggers/pull/1118[#1118])
++
+[IMPORTANT]
+====
+Breaking change: The `podTemplate` field, which was deprecated as part of link:https://github.com/tektoncd/triggers/pull/1100[#1100], has been removed.
+====
+
+* The current release removes the deprecated `replicas` field from the specification for the `EventListener` resource.
+//  (link:https://github.com/tektoncd/triggers/pull/1113[#1113])
++
+[IMPORTANT]
+====
+Breaking change: The deprecated `replicas` field has been removed.
+====
+
+//[id="deprecated-features-pipelines-operator-1-6_{context}"]
+//=== {pipelines-title} Operator
+
+* In {pipelines-title} 1.6, the values of `HOME="/tekton/home"` and `workingDir="/workspace"` are removed from the specification of the `Step` objects.
++
+Instead, {pipelines-title} sets `HOME` and `workingDir` to the values defined by the containers running the `Step` objects. You can override these values in the specification of your `Step` objects.
++
+To use the older behavior, you can change the `disable-working-directory-overwrite` and `disable-home-env-overwrite` fields in the `TektonConfig` CR to `false`:
++
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+  kind: TektonConfig
+  metadata:
+    name: config
+  spec:
+    pipeline:
+      disable-working-directory-overwrite: false
+      disable-home-env-overwrite: false
+  ...
+----
++
+[IMPORTANT]
+====
+The `disable-working-directory-overwrite` and `disable-home-env-overwrite` fields in the `TektonConfig` CR are now deprecated and will be removed in a future release.
+====
+// (link:https://issues.redhat.com/browse/SRVKP-1465[SRVKP-1465])
+
+[id="known-issues-1-6_{context}"]
+== Known issues
+
+* When you run Maven and Jib-Maven cluster tasks, the default container image is supported only on Intel (x86) architecture. Therefore, tasks will fail on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) clusters. As a workaround, you can specify a custom image by setting the `MAVEN_IMAGE` parameter value to `maven:3.6.3-adoptopenjdk-11`.
+// issue # is unknown.
+
+* On IBM Power Systems, IBM Z, and LinuxONE, the `s2i-dotnet` cluster task is unsupported.
+// issue # is unknown.
+
+* Before you install tasks based on the Tekton Catalog on IBM Power Systems (ppc64le), IBM Z, and LinuxONE (s390x) using `tkn hub`, verify if the task can be executed on these platforms. To check if `ppc64le` and `s390x` are listed in the "Platforms" section of the task information, you can run the following command: `tkn hub info task <name>`
+// issue # is unknown.
+
+* You cannot use the `nodejs:14-ubi8-minimal` image stream because doing so generates the following errors:
++
+[source,terminal]
+----
+STEP 7: RUN /usr/libexec/s2i/assemble
+/bin/sh: /usr/libexec/s2i/assemble: No such file or directory
+subprocess exited with status 127
+subprocess exited with status 127
+error building at STEP "RUN /usr/libexec/s2i/assemble": exit status 127
+time="2021-11-04T13:05:26Z" level=error msg="exit status 127"
+----
+// https://issues.redhat.com/browse/SRVKP-1782
+
+
+[id="fixed-issues-1-6_{context}"]
+== Fixed issues
+
+* The `tkn hub` command is now supported on IBM Power Systems, IBM Z, and LinuxONE.
+// issue # is unknown.
+
+//[id="fixed-cli-0-21-0-1-6_{context}"]
+//=== CLI
+
+* Before this update, the terminal was not available after the user ran a `tkn` command, and the pipeline run was done, even if `retries` were specified. Specifying a timeout in the task run or pipeline run had no effect. This update fixes the issue so that the terminal is available after running the command.
+//  (link:https://github.com/tektoncd/cli/issues/1459[#1459])
+
+* Before this update, running `tkn pipelinerun delete --all` would delete all resources. This update prevents the resources in the running state from getting deleted.
+//  https://issues.redhat.com/browse/SRVKP-1638
+
+* Before this update, using the `tkn version --component=<component>` command did not return the component version. This update fixes the issue so that this command returns the component version.
+//  (https://github.com/tektoncd/cli/pull/1408[#1408])
+
+* Before this update, when you used the `tkn pr logs` command, it displayed the pipelines output logs in the wrong task order. This update resolves the issue so that logs of completed `PipelineRuns` are listed in the appropriate `TaskRun` execution order.
+//  (link:https://github.com/tektoncd/cli/pull/1385[#1385])
+
+//[id="fixed-pipelines-operator-1-6_{context}"]
+//=== {pipelines-title} Operator
+
+* Before this update, editing the specification of a running pipeline might prevent the pipeline run from stopping when it was complete. This update fixes the issue by fetching the definition only once and then using the specification stored in the status for verification. This change reduces the probability of a race condition when a `PipelineRun` or a `TaskRun` refers to a `Pipeline` or `Task` that changes while it is running.
+//  (link:https://issues.redhat.com/browse/SRVKP-718[SRVKP-718])
+
+* `When` expression values can now have array parameter references, such as: `values: [$(params.arrayParam[*])]`.

--- a/modules/op-tkn-pipeline-run.adoc
+++ b/modules/op-tkn-pipeline-run.adoc
@@ -40,6 +40,17 @@ $ tkn pipelinerun delete -n myspace --keep 5 <1>
 ----
 <1> Replace `5` with the number of most recently executed pipeline runs you want to retain.
 
+.Example: Delete all pipelines
+[source,terminal]
+----
+$ tkn pipelinerun delete --all
+----
+
+[NOTE]
+====
+Starting with {pipelines-title} 1.6, the `tkn pipelinerun delete --all` command does not delete any resources that are in the running state.
+====
+
 == pipelinerun describe
 Describe a pipeline run.
 

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -1,0 +1,31 @@
+[id="compatibility-support-matrix_{context}"]
+= Compatibility and support matrix
+
+Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
+
+In the table, features are marked with the following statuses:
+
+[horizontal]
+TP:: Technology Preview
+GA:: General Availability
+
+.Compatibility and support matrix
+[options="header"]
+|===
+
+| {pipelines-title} Version 4+| Component Version | OpenShift Version | Support Status
+
+|Operator | Pipelines | Triggers | CLI | Catalog | |
+
+|1.6 | 0.28.x | 0.16.x      | 0.21.x | 0.28 | 4.9 | GA
+|1.5 | 0.24.x | 0.14.x      | 0.19.x | 0.24 | 4.8 | GA
+|1.4 | 0.22.x | 0.12.x      | 0.17.x | 0.22 | 4.7 | GA
+
+|===
+
+[NOTE]
+====
+In {pipelines-title} 1.6, Triggers 0.16.x transitioned to GA status. In earlier versions, Triggers was available as a technology preview feature. 
+====
+
+For questions and feedback, you can send an email to the product team at pipelines-interest@redhat.com.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [RHDEVDOCS-3490 Release Notes, Known Issues, and Bug Fixes for Pipelines GA 1.6](https://issues.redhat.com/browse/RHDEVDOCS-3490)
- **Preview pages**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.6](https://deploy-preview-39389--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes)
- **SME review**: @vdemeester, @VeereshAradhya, @concaf, @ppitonak    
- **Peer-review**: @rolfe, @Preeticp 

> **NOTE**: This PR is a successor to https://github.com/openshift/openshift-docs/pull/38489.