### PR TITLE
OSDOCS-2995: Updated a note in ROSA policy documentation

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -49,7 +49,11 @@ Control plane and infrastructure nodes are deployed and managed by Red Hat. Shut
 
 [NOTE]
 ====
-1 vCPU core and 1 GiB of memory are reserved on each worker node to run processes required as part of the managed service. This includes, but is not limited to, audit log aggregation, metrics collection, DNS, image registry, and SDN.
+Approximately one vCPU core and 1 GiB of memory are reserved on each worker node and removed from allocatable resources. This reservation of resources is necessary to run processes required by the underlying platform. These processes include system daemons such as udev, kubelet, and container runtime among others. The reserved resources also account for kernel reservations.
+
+{OCP} core systems such as audit log aggregation, metrics collection, DNS, image registry, SDN, and others might consume additional allocatable resources to maintain the stability and maintainability of the cluster. The additional resources consumed might vary based on usage.
+
+For additional information, see the link:https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/#system-reserved[Kubernetes documentation].
 ====
 
 [id="rosa-sdpolicy-aws-compute-types_{context}"]


### PR DESCRIPTION
This PR updates a note in the ROSA policy documentation to align with OSD.

JIRA: https://issues.redhat.com/browse/OSDOCS-2995

Preview: https://deploy-preview-39393--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition#rosa-sdpolicy-compute_rosa-service-definition