### PR TITLE
TechPreview for Knative-Kafka-broker docs

### DIFF
--- a/modules/serverless-create-kafka-broker-custom-yaml.adoc
+++ b/modules/serverless-create-kafka-broker-custom-yaml.adoc
@@ -1,0 +1,64 @@
+// Module included in the following assemblies:
+//
+//  * serverless/knative_eventing/serverless-using-brokers.adoc
+
+[id="serverless-create-kafka-broker-custom-yaml_{context}"]
+= Creating a Kafka broker with custom configuration by using YAML
+
+You can create a Kafka broker by using YAML with custom configuration.
+
+:FeatureName: Creating a Kafka broker with custom configuration
+include::../modules/technology-preview.adoc[leveloffset=+0]
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+
+.Procedure
+
+. Create a config map for configuration as a YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-kafka-broker-config
+data:
+  default.topic.partitions: <partitions>
+  default.topic.replication.factor: <replication_factor>
+  bootstrap.servers: <bootstrap_servers>
+----
+
+. Apply the config map YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Create a Kafka broker as a YAML file that points to the preceding configuration:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka
+  name: my-demo-kafka-broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: my-kafka-broker-config
+    namespace: <namespace>
+----
+
+. Apply the broker YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-create-kafka-broker-default-yaml.adoc
+++ b/modules/serverless-create-kafka-broker-default-yaml.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+//  * serverless/knative_eventing/serverless-using-brokers.adoc
+
+[id="serverless-create-kafka-broker-default-yaml_{context}"]
+= Creating a Kafka broker with default configuration by using YAML
+
+You can create a Kafka broker by using YAML with the cluster default configuration, which is stored in the `kafka-broker-config` config map located in the `knative-eventing` namespace.
+
+:FeatureName: Creating a Kafka broker with the cluster default configuration
+include::../modules/technology-preview.adoc[leveloffset=+0]
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+
+.Procedure
+
+. Create a Kafka-based broker as a YAML file:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka
+  name: example-kafka-broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kafka-broker-config
+    namespace: knative-eventing
+----
+
+. Apply the Kafka-based broker YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----

--- a/modules/serverless-kafka-broker-sasl-custom-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-custom-config.adoc
@@ -1,0 +1,82 @@
+// Module is included in the following assemblies:
+//
+// * serverless/knative_eventing/serverless-kafka.adoc
+
+[id="serverless-kafka-broker-sasl-custom-config_{context}"]
+= Configuring SASL authentication for the Kafka broker with custom configuration
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* A username and password for the Kafka cluster.
+* Choose the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+* If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
+
+[NOTE]
+====
+Red Hat recommends enabling TLS in addition to SASL.
+====
+
+.Procedure
+
+. Create the certificate files as secrets in your chosen namespace:
++
+[source,terminal]
+----
+$ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol=SASL_SSL \
+  --from-literal=sasl.mechanism=<sasl_mechanism> \
+  --from-file=ca.crt=caroot.pem \
+  --from-literal=password="SecretPassword" \
+  --from-literal=user="my-sasl-user"
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
+====
+
+. Create a config map as a YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-kafka-broker-config
+data:
+  default.topic.partitions: <partitions>
+  default.topic.replication.factor: <replication_factor>
+  bootstrap.servers: <bootstrap_servers>
+  auth.secret.ref.name: <kafka_auth_secret>
+----
+
+. Apply the config map:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Reference the config map in your Kafka broker configuration:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka
+  name: my-demo-kafka-broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: my-kafka-broker-config
+    namespace: <namespace>
+----
+
+.Additional resources
+
+* See link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[Encryption and authentication] in the Red Hat AMQ Streams documentation.

--- a/modules/serverless-kafka-broker-sasl-default-config.adoc
+++ b/modules/serverless-kafka-broker-sasl-default-config.adoc
@@ -1,0 +1,98 @@
+// Module is included in the following assemblies:
+//
+// * serverless/knative_eventing/serverless-kafka.adoc
+
+[id="serverless-kafka-broker-sasl-default-config_{context}"]
+= Configuring SASL authentication for the Kafka broker with default configuration
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* A username and password for the Kafka cluster.
+* Choose the SASL mechanism to use, for example `PLAIN`, `SCRAM-SHA-256`, or `SCRAM-SHA-512`.
+* If TLS is enabled, you also need the `ca.crt` certificate file for the Kafka cluster.
+
+[NOTE]
+====
+Red Hat recommends to enable TLS in addition to SASL.
+====
+
+.Procedure
+
+. Create the certificate files as secrets in the `knative-eventing` namespace:
++
+[source,terminal]
+----
+$ oc create secret --namespace knative-eventing generic <kafka_auth_secret> \
+  --from-literal=protocol=SASL_SSL \
+  --from-literal=sasl.mechanism=<sasl_mechanism> \
+  --from-file=ca.crt=caroot.pem \
+  --from-literal=password="SecretPassword" \
+  --from-literal=user="my-sasl-user"
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `password`, and `sasl.mechanism`. Do not change them.
+====
+
+. Start editing the `KnativeKafka` custom resource:
++
+[source,terminal]
+----
+$ oc edit knativekafka
+----
+
+. Reference your secret and the namespace of the secret:
++
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  broker:
+    enabled: true
+    defaultConfig:
+      bootstrapServers: <bootstrap_servers>
+      numPartitions: <num_partitions>
+      replicationFactor: <replication_factor>
+      authSecretName: <kafka_auth_secret>
+  channel:
+    enabled: false
+  source:
+    enabled: false
+----
++
+[NOTE]
+====
+Make sure to specify the matching port in the bootstrap server.
+====
++
+For example:
++
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  broker:
+    enabled: true
+    defaultConfig:
+      bootstrapServers: eventing-kafka-bootstrap.kafka.svc:9093
+      authSecretName: scram-user
+  channel:
+    enabled: false
+  source:
+    enabled: false
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kafka-broker-tls-custom-config.adoc
+++ b/modules/serverless-kafka-broker-tls-custom-config.adoc
@@ -1,0 +1,75 @@
+// Module is included in the following assemblies:
+//
+// * serverless/knative_eventing/serverless-kafka.adoc
+
+[id="serverless-kafka-broker-tls-custom-config_{context}"]
+= Configuring TLS authentication for the Kafka broker with custom configuration
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* A Kafka cluster CA certificate as a `.pem` file.
+* A Kafka cluster client certificate and key as `.pem` files.
+
+.Procedure
+
+. Create the certificate files as secrets in your chosen namespace:
++
+[source,terminal]
+----
+$ oc create secret --namespace <namespace> generic <kafka_auth_secret> \
+  --from-literal=protocol=SSL \
+  --from-file=ca.crt=caroot.pem \
+  --from-file=user.crt=certificate.pem \
+  --from-file=user.key=key.pem
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `user.crt`, and `user.key`. Do not change them.
+====
+
+. Create a config map for configuration as a YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: my-kafka-broker-config
+data:
+  default.topic.partitions: <partitions>
+  default.topic.replication.factor: <replication_factor>
+  bootstrap.servers: <bootstrap_servers>
+  auth.secret.ref.name: <kafka_auth_secret>
+----
+
+. Apply the config map YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Reference your the config map on your `Kafka` broker:
++
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka
+  name: my-demo-kafka-broker
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: my-kafka-broker-config
+    namespace: <namespace>
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/modules/serverless-kafka-broker-tls-default-config.adoc
+++ b/modules/serverless-kafka-broker-tls-default-config.adoc
@@ -1,0 +1,91 @@
+// Module is included in the following assemblies:
+//
+// * serverless/knative_eventing/serverless-kafka.adoc
+
+[id="serverless-kafka-broker-tls-default-config_{context}"]
+= Configuring TLS authentication for the Kafka broker with default configuration
+
+.Prerequisites
+
+* The {ServerlessOperatorName}, Knative Eventing, and the `KnativeKafka` custom resource are installed on your {product-title} cluster.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* A Kafka cluster CA certificate as a `.pem` file.
+* A Kafka cluster client certificate and key as `.pem` files.
+
+.Procedure
+
+. Create the certificate files as secrets in the `knative-eventing` namespace:
++
+[source,terminal]
+----
+$ oc create secret --namespace knative-eventing generic <kafka_auth_secret> \
+  --from-literal=protocol=SSL \
+  --from-file=ca.crt=caroot.pem \
+  --from-file=user.crt=certificate.pem \
+  --from-file=user.key=key.pem
+----
++
+[IMPORTANT]
+====
+Use the key names `ca.crt`, `user.crt`, and `user.key`. Do not change them.
+====
+
+. Start editing the `KnativeKafka` custom resource:
++
+[source,terminal]
+----
+$ oc edit knativekafka
+----
+
+. Reference your secret and the namespace of the secret:
++
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  broker:
+    enabled: true
+    defaultConfig:
+      bootstrapServers: <bootstrap_servers>
+      numPartitions: <num_partitions>
+      replicationFactor: <replication_factor>
+      authSecretName: <kafka_auth_secret>
+  channel:
+    enabled: false
+  source:
+    enabled: false
+----
++
+[NOTE]
+====
+Make sure to specify the matching port in the bootstrap server.
+====
++
+For example:
++
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  namespace: knative-eventing
+  name: knative-kafka
+spec:
+  broker:
+    enabled: true
+    defaultConfig:
+      bootstrapServers: eventing-kafka-bootstrap.kafka.svc:9093
+      authSecretName: tls-config
+  channel:
+    enabled: false
+  source:
+    enabled: false
+----
+
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_amq/7.5/html-single/using_amq_streams_on_rhel/index#assembly-kafka-encryption-and-authentication-str[TLS and SASL on Kafka]

--- a/serverless/knative_eventing/serverless-kafka.adoc
+++ b/serverless/knative_eventing/serverless-kafka.adoc
@@ -39,13 +39,34 @@ spec:
         bootstrapServers: <bootstrap_servers> <2>
     source:
         enabled: true <3>
+    broker:
+        enabled: true <4>
+        defaultConfig:
+            bootstrapServers: <bootstrap_servers> <5>
+            numPartitions: <num_partitions> <6>
+            replicationFactor: <replication_factor> <7>
 ----
 <1> Enables developers to use the `KafkaChannel` channel type in the cluster.
 <2> A comma-separated list of bootstrap servers from your AMQ Streams cluster.
 <3> Enables developers to use the `KafkaSource` event source type in the cluster.
+<4> Enables developers to use the Knative Kafka broker implementation in the cluster.
+<5> A comma-separated list of bootstrap servers from your Red Hat AMQ Streams cluster.
+<6> Defines the number of partitions of the Kafka topics, backed by the `Broker` objects. The default is `10`.
+<7> Defines the replication factor of the Kafka topics, backed by the `Broker` objects. The default is `3`. 
+
+[NOTE]
+====
+The `replicationFactor` value must match the number of nodes of your Red Hat AMQ Streams cluster.
+====
+
 
 // Install Kafka
 include::modules/serverless-install-kafka-odc.adoc[leveloffset=+2]
+
+[id="serverless-kafka-broker-link"]
+== Using a Kafka broker
+
+Create a xref:../../serverless/knative_eventing/serverless-using-brokers.adoc#serverless-using-brokers-creating-kafka-brokers[Kafka broker].
 
 [id="serverless-kafka-channel-link"]
 == Using Kafka channel

--- a/serverless/knative_eventing/serverless-using-brokers.adoc
+++ b/serverless/knative_eventing/serverless-using-brokers.adoc
@@ -24,6 +24,18 @@ include::modules/serverless-creating-broker-annotation.adoc[leveloffset=+2]
 include::modules/serverless-creating-broker-labeling.adoc[leveloffset=+2]
 include::modules/serverless-deleting-broker-injection.adoc[leveloffset=+2]
 
+[id="serverless-using-brokers-creating-kafka-brokers"]
+== Creating a Kafka broker
+
+{ServerlessProductName} provides an alternative Kafka-based implementation of the Knative broker APIs.
+
+include::modules/serverless-create-kafka-broker-custom-yaml.adoc[leveloffset=+2]
+include::modules/serverless-kafka-broker-sasl-custom-config.adoc[leveloffset=+2]
+include::modules/serverless-kafka-broker-tls-custom-config.adoc[leveloffset=+2]
+include::modules/serverless-create-kafka-broker-default-yaml.adoc[leveloffset=+2]
+include::modules/serverless-kafka-broker-sasl-default-config.adoc[leveloffset=+2]
+include::modules/serverless-kafka-broker-tls-default-config.adoc[leveloffset=+2]
+
 [id="serverless-using-brokers-managing-brokers"]
 == Managing brokers
 


### PR DESCRIPTION
Signed-off-by: Matthias Wessendorf <mwessend@redhat.com>

Jira: https://issues.redhat.com/browse/SRVKE-747

Docs for the Knative Kafka broker becoming Tech-Preview

Direct preview link: https://deploy-preview-39408--osdocs.netlify.app/openshift-enterprise/latest/serverless/knative_eventing/serverless-using-brokers#serverless-using-brokers-creating-kafka-brokers