### PR TITLE
BZ2015103 Fixed broken URL

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -97,7 +97,7 @@ For more information, see xref:../updating/updating-cluster-prepare.adoc#updatin
 [id="ocp-4-9-openshift-on-openstack-pci-passthrough-support"]
 ==== Support for installation on {rh-openstack} deployments that use PCI passthrough
 
-{product-title} {product-version} introduces support for installation on {rh-openstack-first} deployments that rely on link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/configuring-pci-passthrough[PCI passthrough].
+{product-title} {product-version} introduces support for installation on {rh-openstack-first} deployments that rely on link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/configuring_the_compute_service_for_instance_creation/assembly_configuring-pci-passthrough_pci-passthrough[PCI passthrough].
 
 [id="ocp-4-9-upgrading-etcd-backup"]
 ==== Upgrading etcd version 3.4 to 3.5


### PR DESCRIPTION
Fixed PCI passthrough URL.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2015103

OCP version: **Applicable only to 4.9**

Doc Preview Link: https://deploy-preview-39416--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-openshift-on-openstack-pci-passthrough-support