### PR TITLE
OSDOCS-2098: Add release note for IPsec encryption

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -382,7 +382,13 @@ SR-IOV support is now available for xref:../networking/hardware_networks/about-s
 
 [id="ocp-4-11-cidr-ranges-for-network"]
 ==== {product-title} CIDR Ranges for Networks
+
 Be aware that CIDR ranges for networks are not adjustable after cluster installation. Red Hat does not provide direct guidance on determining the range because it requires careful consideration of the number of pods created.
+
+[id="ocp-4-11-ovn-kubernetes-ipsec-enable"]
+==== OVN-Kubernetes network provider: Enable IPsec at runtime
+
+If you are using the OVN-Kubernetes cluster network provider, you can now enable IPsec encryption after cluster installation. For more information about how to enable IPsec, see xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption].
 
 [id="ocp-4-11-hardware"]
 === Hardware


### PR DESCRIPTION
Add release note for IPsec:

- https://issues.redhat.com/browse/OSDOCS-2098

Preview: http://shell.lab.bos.redhat.com/~jboxman/rn-[OSDOCS-2098](https://issues.redhat.com//browse/OSDOCS-2098)/release_notes/ocp-4-11-release-notes.html#ocp-4-11-ovn-kubernetes-ipsec-enable (keep getting eaten by GitHub)

Fun. I apparently cannot include a preview link without GitHub destroying it.

```
http://shell.lab.bos.redhat.com/~jboxman/rn-OSDOCS-2098/release_notes/ocp-4-11-release-notes.html#ocp-4-11-ovn-kubernetes-ipsec-enable
```

Sorry for the unlinked URL