### PR TITLE
STOR-679: Cinder CSI TP-> GA RN 4.9

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1741,9 +1741,9 @@ In the table below, features are marked with the following statuses:
 |GA
 
 |CSI OpenStack Cinder Driver Operator
-|TP
-|TP
-|TP
+|GA
+|GA
+|GA
 
 |CSI AWS EBS Driver Operator
 |TP


### PR DESCRIPTION
This is a correction to Rel Notes 4.9 to make Cinder CSI Generally Available. 

This PR is part of a larger correction to make Cinder CSI GA for 4.7+.
**RN 4.7**: https://github.com/openshift/openshift-docs/pull/39452
**RN 4.8:** https://github.com/openshift/openshift-docs/pull/39450
**RN 4.10:** https://github.com/openshift/openshift-docs/pull/38258 (future)

https://issues.redhat.com/browse/STOR-679

**Preview**: https://deploy-preview-39437--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-technology-preview

**PTAL**: @jsafrane, @duanwei33 