### PR TITLE
SDN-1340: remove warning about OVN-Kubernetes and HostNetwork

### DIFF
--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -33,11 +33,6 @@ configured for your cluster. The default template name is `project-request`.
 +
 In the following example, the `objects` parameter collection includes several `NetworkPolicy` objects.
 +
-[IMPORTANT]
-====
-For the OVN-Kubernetes network provider plug-in, when the Ingress Controller is configured to use the `HostNetwork` endpoint publishing strategy, there is no supported way to apply network policy so that ingress traffic is allowed and all other traffic is denied.
-====
-+
 [source,yaml]
 ----
 objects:


### PR DESCRIPTION
According to https://issues.redhat.com/browse/SDN-1340 this is fixed
with OCP version 4.8.

I was able to verify this on site with a customer cluster. Ingress
policy seems to work even with `endpointPublishingStrategy` set to
`HostNetwork`.