### PR TITLE
OSDOCS2950 - Adding release note for Azure Stack Hub IPI support

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -154,6 +154,13 @@ If your cluster is deployed on vSphere, and the preceding components are lower t
 {product-title} {product-version} introduces the ability for installing a cluster on Alibaba Cloud using installer-provisioned infrastructure in Technology Preview. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
 //For more information, see <insert link to help topic>.
 
+[id="ocp-4-10-installation-and-upgrade-ash-ipi"]
+==== Installing a cluster on Microsoft Azure Stack Hub using installer-provisioned infrastructure
+
+{product-title} {product-version} introduces support for installing a cluster on Azure Stack Hub using installer-provisioned infrastructure. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
+
+For more information, see xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[Installing a cluster on Azure Stack Hub with an installer-provisioned infrastructure].
+
 [id="ocp-4-10-conditional-updates"]
 ==== Conditional updates
 


### PR DESCRIPTION
CP to 4.10.

This PR addresses https://issues.redhat.com/browse/OSDOCS-2950. This is 2 of 2[1] PRs for net new support of installing a cluster on Azure Stack Hub using the IPI method. This PR addresses the release note.

Doc preview
[Installing a cluster on Microsoft Azure Stack Hub using installer-provisioned infrastructure](https://deploy-preview-39444--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-and-upgrade-ash-ipi)

Feature doc: https://github.com/openshift/openshift-docs/pull/39366