### PR TITLE
STOR-679: Cinder CSI TP-> GA RN 4.8

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2129,8 +2129,8 @@ In the table below, features are marked with the following statuses:
 
 |CSI OpenStack Cinder Driver Operator
 |-
-|TP
-|TP
+|GA
+|GA
 
 |CSI AWS EBS Driver Operator
 |TP


### PR DESCRIPTION
This is a correction to Rel Notes 4.8 to make Cinder CSI Generally Available.

This PR is part of a larger correction to make Cinder CSI GA for 4.7+.
**RN 4.7**: https://github.com/openshift/openshift-docs/pull/39452
**RN 4.9:** https://github.com/openshift/openshift-docs/pull/39437
**RN 4.10:** https://github.com/openshift/openshift-docs/pull/38258 (future)

https://issues.redhat.com/browse/STOR-679

**Preview**: https://deploy-preview-39450--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-technology-preview

**PTAL**: @jsafrane, @duanwei33