### PR TITLE
OSDOCS-1768: document mutating .spec.endpointPublishingStrategy (new)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -909,6 +909,9 @@ Topics:
 - Name: Understanding the Ingress Operator
   File: ingress-operator
   Distros: openshift-enterprise,openshift-origin
+- Name: Configuring the Ingress Controller endpoint publishing strategy
+  File: nw-ingress-controller-endpoint-publishing-strategies
+  Distros: openshift-enterprise,openshift-origin
 - Name: Verifying connectivity to an endpoint
   File: verifying-connectivity-endpoint
 - Name: Configuring the node port service range

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -36,13 +36,18 @@ If empty, the default value is `ingress.config.openshift.io/cluster` `.spec.doma
 
 If not set, the default value is based on `infrastructure.config.openshift.io/cluster` `.status.platform`:
 
-* AWS: `LoadBalancerService` (with external scope)
-* Azure: `LoadBalancerService` (with external scope)
-* GCP: `LoadBalancerService` (with external scope)
+* AWS: `LoadBalancerService` (with External scope)
+* Azure: `LoadBalancerService` (with External scope)
+* GCP: `LoadBalancerService` (with External scope)
 * Bare metal: `NodePortService`
 * Other: `HostNetwork`
 
-For most platforms, the `endpointPublishingStrategy` value cannot be updated. However, on GCP, you can configure the `loadbalancer.providerParameters.gcp.clientAccess` subfield.
+For most platforms, the `endpointPublishingStrategy` value can be updated. On GCP, you can configure the the following `endpointPublishingStrategy` fields:
+
+* `loadBalancer.scope`
+* `loadbalancer.providerParameters.gcp.clientAccess`
+* `hostNetwork.protocol`
+* `nodePort.protocol`
 
 |`defaultCertificate`
 |The `defaultCertificate` value is a reference to a secret that contains the default certificate that is served by the Ingress Controller. When Routes do not specify their own certificate, `defaultCertificate` is used.

--- a/modules/nw-ingress-controller-endpoint-publishing-strategies.adoc
+++ b/modules/nw-ingress-controller-endpoint-publishing-strategies.adoc
@@ -3,7 +3,7 @@
 // * ingress/configure-ingress-operator.adoc
 
 [id="nw-ingress-controller-endpoint-publishing-strategies_{context}"]
-= Ingress controller endpoint publishing strategy
+= Ingress Controller endpoint publishing strategy
 
 *`NodePortService` endpoint publishing strategy*
 

--- a/modules/nw-ingress-default-internal.adoc
+++ b/modules/nw-ingress-default-internal.adoc
@@ -16,7 +16,7 @@ If you do not, all of your nodes will lose egress connectivity to the internet.
 
 [IMPORTANT]
 ====
-If you want to change the `scope` for an `IngressController` object, you must delete and then recreate that `IngressController` object. You cannot change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
+If you want to change the `scope` for an `IngressController`, you can change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
 ====
 
 .Prerequisites

--- a/modules/nw-ingress-setting-internal-lb.adoc
+++ b/modules/nw-ingress-setting-internal-lb.adoc
@@ -17,7 +17,7 @@ If you do not, all of your nodes will lose egress connectivity to the internet.
 
 [IMPORTANT]
 ====
-If you want to change the `scope` for an `IngressController` object, you must delete and then recreate that `IngressController` object. You cannot change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
+If you want to change the `scope` for an `IngressController`, you can change the `.spec.endpointPublishingStrategy.loadBalancer.scope` parameter after the custom resource (CR) is created.
 ====
 
 .Diagram of LoadBalancer

--- a/modules/nw-ingresscontroller-change-external.adoc
+++ b/modules/nw-ingresscontroller-change-external.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+[id="nw-ingresscontroller-change-external_{context}"]
+= Configuring the Ingress Controller endpoint publishing scope to External
+
+When a cluster administrator installs a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`.
+
+The Ingress Controller's scope can be configured to be `Internal` during installation or after, and cluster administrators can change an `Internal` Ingress Controller to `External`.
+
+[IMPORTANT]
+====
+On some platforms, it is necessary to delete and recreate the service.
+
+Changing the scope can cause disruption to Ingress traffic, potentially for several minutes. This applies to platforms where it is necessary to delete and recreate the service, because the procedure can cause {product-title} to deprovision the existing service load balancer, provision a new one, and update DNS.
+====
+
+.Prerequisites
+
+* You installed the `oc` CLI.
+
+.Procedure
+
+* To change an `Internal` scoped Ingress Controller to `External`, enter the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/private --type=merge --patch='{"spec":{"endpointPublishingStrategy":{"type":"LoadBalancerService","loadBalancer":{"scope":"External"}}}}'
+----
++
+.Verification
++
+* To check the status of the Ingress Controller, enter the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator get ingresscontrollers/default -o yaml
+----
++
+** The `Progressing` status condition indicates whether you must take further action. For example, the status condition can indicate that you need to delete the service by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress delete services/router-default
+----
++
+If you delete the service, the Ingress Operator recreates it as `External`.

--- a/modules/nw-ingresscontroller-change-internal.adoc
+++ b/modules/nw-ingresscontroller-change-internal.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress-operator.adoc
+
+[id="nw-ingresscontroller-change-internal_{context}"]
+= Configuring the Ingress Controller endpoint publishing scope to Internal
+
+When a cluster administrator installs a new cluster without specifying that the cluster is private, the default Ingress Controller is created with a `scope` set to `External`. Cluster administrators can change an `External` scoped Ingress Controller to `Internal`.
+
+.Prerequisites
+
+* You installed the `oc` CLI.
+
+.Procedure
+
+* To change an `External` scoped Ingress Controller to `Internal`, enter the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator patch ingresscontrollers/default --type=merge --patch='{"spec":{"endpointPublishingStrategy":{"type":"LoadBalancerService","loadBalancer":{"scope":"Internal"}}}}'
+----
++
+.Verification
++
+* To check the status of the Ingress Controller, enter the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress-operator get ingresscontrollers/default -o yaml
+----
++
+** The `Progressing` status condition indicates whether you must take further action. For example, the status condition can indicate that you need to delete the service by entering the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-ingress delete services/router-default
+----
++
+If you delete the service, the Ingress Operator recreates it as `Internal`.

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -24,8 +24,6 @@ include::modules/tls-profiles-ingress-configuring.adoc[leveloffset=+3]
 
 include::modules/nw-mutual-tls-auth.adoc[leveloffset=+3]
 
-include::modules/nw-ingress-controller-endpoint-publishing-strategies.adoc[leveloffset=+2]
-
 include::modules/nw-ingress-view.adoc[leveloffset=+1]
 
 include::modules/nw-ingress-operator-status.adoc[leveloffset=+1]

--- a/networking/nw-ingress-controller-endpoint-publishing-strategies.adoc
+++ b/networking/nw-ingress-controller-endpoint-publishing-strategies.adoc
@@ -1,0 +1,18 @@
+[id="nw-ingress-controller-endpoint-publishing-strategies"]
+= Configuring the Ingress Controller endpoint publishing strategy
+include::modules/common-attributes.adoc[]
+:context: nw-ingress-controller-endpoint-publishing-strategies
+
+toc::[]
+
+include::modules/nw-ingress-controller-endpoint-publishing-strategies.adoc[leveloffset=+1]
+
+include::modules/nw-ingresscontroller-change-internal.adoc[leveloffset=+2]
+
+include::modules/nw-ingresscontroller-change-external.adoc[leveloffset=+2]
+
+
+[id="additional-resources_nw-ingress-controller-endpoint-publishing-strategies"]
+== Additional resources
+
+* For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-controller-configuration-parameters_configuring-ingress[Ingress Controller configuration parameters].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-1768

Original PR: https://github.com/openshift/openshift-docs/pull/28903

Previews:
Ingress Controller configuration parameters: https://deploy-preview-39451--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-ingress-controller-configuration-parameters_configuring-ingress
Configuring the Ingress Controller endpoint publishing strategy: https://deploy-preview-39451--osdocs.netlify.app/openshift-enterprise/latest/networking/nw-ingress-controller-endpoint-publishing-strategies.html
