### PR TITLE
STOR-679: Cinder CSI TP-> GA RN 4.7

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -1940,7 +1940,7 @@ In the table below, features are marked with the following statuses:
 |CSI OpenStack Cinder Driver Operator
 |-
 |-
-|TP
+|GA
 
 |CSI AWS EBS Driver Operator
 |TP


### PR DESCRIPTION
This is a correction to Rel Notes 4.7 to make Cinder CSI Generally Available.

This PR is part of a larger correction to make Cinder CSI GA for 4.7+.
**RN 4.8**: https://github.com/openshift/openshift-docs/pull/39450
**RN 4.9:** https://github.com/openshift/openshift-docs/pull/39437
**RN 4.10:** https://github.com/openshift/openshift-docs/pull/38258 (future)

https://issues.redhat.com/browse/STOR-679

**Preview**: https://deploy-preview-39452--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-technology-preview

**PTAL**: @jsafrane, @duanwei33