### PR TITLE
BZ#2016983 Tweak install dir param syntax to avoid syntax issue with tilda

### DIFF
--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -24,7 +24,7 @@ You must configure hybrid networking with OVN-Kubernetes during the installation
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 +
 --

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -27,7 +27,7 @@ you can start the bootstrap sequence that initializes the {product-title} contro
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir=<installation_directory> \ <1>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
     --log-level=info <2>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you

--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -30,7 +30,7 @@ the cluster installation:
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
 stored the installation files in.

--- a/modules/installation-azure-user-infra-completing.adoc
+++ b/modules/installation-azure-user-infra-completing.adoc
@@ -28,7 +28,7 @@ cluster is ready.
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
 ----
 +
 .Example output

--- a/modules/installation-azure-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-azure-user-infra-wait-for-bootstrap.adoc
@@ -36,7 +36,7 @@ following command:
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir=<installation_directory> \ <1>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
     --log-level info <2>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you

--- a/modules/installation-bootstrap-gather.adoc
+++ b/modules/installation-bootstrap-gather.adoc
@@ -32,7 +32,7 @@ the bootstrap and control plane machines:
 +
 [source,terminal]
 ----
-$ ./openshift-install gather bootstrap --dir=<installation_directory> <1>
+$ ./openshift-install gather bootstrap --dir <installation_directory> <1>
 ----
 <1> `installation_directory` is the directory you specified when you ran `./openshift-install create cluster`. This directory contains the {product-title}
 definition files that the installation program creates.
@@ -46,7 +46,7 @@ command:
 +
 [source,terminal]
 ----
-$ ./openshift-install gather bootstrap --dir=<installation_directory> \ <1>
+$ ./openshift-install gather bootstrap --dir <installation_directory> \ <1>
     --bootstrap <bootstrap_address> \ <2>
     --master <master_1_address> \ <3>
     --master <master_2_address> \ <3>

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -101,7 +101,7 @@ Alternatively, the following command notifies you when all of the clusters are a
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
 stored the installation files in.

--- a/modules/installation-gcp-user-infra-completing.adoc
+++ b/modules/installation-gcp-user-infra-completing.adoc
@@ -21,7 +21,7 @@ cluster is ready.
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for install-complete <1>
+$ ./openshift-install --dir <installation_directory> wait-for install-complete <1>
 ----
 +
 .Example output

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -28,7 +28,7 @@ following command:
 +
 [source,terminal]
 ----
-$ ./openshift-install wait-for bootstrap-complete --dir=<installation_directory> \ <1>
+$ ./openshift-install wait-for bootstrap-complete --dir <installation_directory> \ <1>
     --log-level info <2>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -28,7 +28,7 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir=<installation_directory> <1>
+$ ./openshift-install create install-config --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.

--- a/modules/installation-generate-ignition-configs.adoc
+++ b/modules/installation-generate-ignition-configs.adoc
@@ -38,7 +38,7 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create ignition-configs --dir=<installation_directory> <1>
+$ ./openshift-install create ignition-configs --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.

--- a/modules/installation-getting-debug-information.adoc
+++ b/modules/installation-getting-debug-information.adoc
@@ -19,6 +19,6 @@ $ cat ~/<installation_directory>/.openshift_install.log <1>
 +
 [source,terminal]
 ----
-$ ./openshift-install create cluster --dir=<installation_directory> --log-level=debug <1>
+$ ./openshift-install create cluster --dir <installation_directory> --log-level debug <1>
 ----
 <1> For `installation_directory`, specify the same directory you specified when you ran `./openshift-install create cluster`.

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -121,7 +121,7 @@ endif::restricted[]
 ifndef::aws-china,aws-gov,ash[]
 [NOTE]
 ====
-For some platform types, you can alternatively run `./openshift-install create install-config --dir=<installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
+For some platform types, you can alternatively run `./openshift-install create install-config --dir <installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
 ====
 endif::aws-china,aws-gov,ash[]
 ifdef::ash[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -178,7 +178,7 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir=<installation_directory> <1>
+$ ./openshift-install create install-config --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the directory name to store the
 files that the installation program creates.

--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -48,7 +48,7 @@ endif::restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for bootstrap-complete \ <1>
+$ ./openshift-install --dir <installation_directory> wait-for bootstrap-complete \ <1>
     --log-level=info <2>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you stored the installation files in.

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -184,7 +184,7 @@ endif::gcp[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create cluster --dir=<installation_directory> \ <1>
+$ ./openshift-install create cluster --dir <installation_directory> \ <1>
     --log-level=info <2>
 ----
 <1> For `<installation_directory>`, specify the

--- a/modules/installation-osp-kuryr-settings-installing.adoc
+++ b/modules/installation-osp-kuryr-settings-installing.adoc
@@ -18,7 +18,7 @@ During installation, you can configure how Kuryr manages {rh-openstack-first} Ne
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the name of the directory that
 contains the `install-config.yaml` file for your cluster.

--- a/modules/installation-osp-setting-worker-affinity.adoc
+++ b/modules/installation-osp-setting-worker-affinity.adoc
@@ -48,7 +48,7 @@ For more information, see the link:https://access.redhat.com/documentation/en-us
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 +
 where:

--- a/modules/installation-special-config-kargs.adoc
+++ b/modules/installation-special-config-kargs.adoc
@@ -29,7 +29,7 @@ It is best to only add kernel arguments with this procedure if they are needed t
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 
 . Decide if you want to add kernel arguments to worker or control plane nodes.

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -37,14 +37,14 @@ To create it using installer, run:
 +
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir=<installation_directory>
+$ ./openshift-install create install-config --dir <installation_directory>
 ----
 
 . Generate the Kubernetes manifests for the cluster:
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 
 . Decide if you want to add the real-time kernel to worker or control plane nodes.
@@ -74,7 +74,7 @@ Create a separate YAML file to add to both master and worker nodes.
 +
 [source,terminal]
 ----
-$ ./openshift-install create cluster --dir=<installation_directory>
+$ ./openshift-install create cluster --dir <installation_directory>
 ----
 
 . Check the real-time kernel: Once the cluster comes up, log in to the cluster

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -165,7 +165,7 @@ Some methods for configuring static IPs do not affect the initramfs after the fi
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 <1> Replace `<installation_directory>` with the path to the directory that you want to store the installation files in.
 

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -49,7 +49,7 @@ cluster.
 [source,terminal]
 ----
 $ ./openshift-install destroy cluster \
---dir=<installation_directory> --log-level=info <1> <2>
+--dir <installation_directory> --log-level info <1> <2>
 ----
 <1> For `<installation_directory>`, specify the path to the directory that you
 stored the installation files in.

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -146,7 +146,7 @@ endif::restricted,baremetal-restricted[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 +
 .Example output
@@ -396,7 +396,7 @@ endif::ash[]
 +
 [source,terminal]
 ----
-$ ./openshift-install create ignition-configs --dir=<installation_directory> <1>
+$ ./openshift-install create ignition-configs --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the same installation directory.
 +

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -112,7 +112,7 @@ The following procedure sets up a separate `/var` partition by adding a machine 
 +
 [source,terminal]
 ----
-$ openshift-install create manifests --dir=<installation_directory>
+$ openshift-install create manifests --dir <installation_directory>
 ----
 
 . Create a Butane config that configures the additional partition. For example, name the file `$HOME/clusterconfig/98-var-partition.bu`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
@@ -161,7 +161,7 @@ $ butane $HOME/clusterconfig/98-var-partition.bu -o $HOME/clusterconfig/openshif
 +
 [source,terminal]
 ----
-$ openshift-install create ignition-configs --dir=<installation_directory> <1>
+$ openshift-install create ignition-configs --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the same installation directory.
 +

--- a/modules/installing-rhv-example-install-config-yaml.adoc
+++ b/modules/installing-rhv-example-install-config-yaml.adoc
@@ -13,7 +13,7 @@ The following examples are specific to installing {product-title} on {rh-virtual
 `install-config.yaml` is located in `<installation_directory>`, which you specified when you ran the following command.
 [source,terminal]
 ----
-$ ./openshift-install create install-config --dir=<installation_directory>
+$ ./openshift-install create install-config --dir <installation_directory>
 ----
 
 [NOTE]

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -28,7 +28,7 @@ administrator-level credential secret in the cluster `kube-system` namespace.
 +
 [source,terminal]
 ----
-$ openshift-install create install-config --dir=<installation_directory>
+$ openshift-install create install-config --dir <installation_directory>
 ----
 +
 where `<installation_directory>` is the directory in which the installation program creates files.
@@ -52,7 +52,7 @@ compute:
 +
 [source,terminal]
 ----
-$ openshift-install create manifests --dir=<installation_directory>
+$ openshift-install create manifests --dir <installation_directory>
 ----
 
 . From the directory that contains the installation program, obtain details of the {product-title} release image that your `openshift-install` binary is built to use:
@@ -167,7 +167,7 @@ endif::google-cloud-platform[]
 +
 [source,terminal]
 ----
-$ openshift-install create cluster --dir=<installation_directory>
+$ openshift-install create cluster --dir <installation_directory>
 ----
 +
 [IMPORTANT]

--- a/modules/nw-aws-nlb-new-cluster.adoc
+++ b/modules/nw-aws-nlb-new-cluster.adoc
@@ -20,7 +20,7 @@ Create an Ingress Controller backed by an AWS NLB on a new cluster.
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the name of the directory that
 contains the `install-config.yaml` file for your cluster.

--- a/modules/nw-gcp-installing-global-access-configuration.adoc
+++ b/modules/nw-gcp-installing-global-access-configuration.adoc
@@ -19,7 +19,7 @@ Create an Ingress Controller with global access on a new GCP cluster.
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 <1> For `<installation_directory>`, specify the name of the directory that
 contains the `install-config.yaml` file for your cluster.

--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -42,7 +42,7 @@ Customizing your network configuration by modifying the {product-title} manifest
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory> <1>
+$ ./openshift-install create manifests --dir <installation_directory> <1>
 ----
 <1> `<installation_directory>` specifies the name of the directory that contains the `install-config.yaml` file for your cluster.
 

--- a/modules/restarting-installation.adoc
+++ b/modules/restarting-installation.adoc
@@ -14,7 +14,7 @@ For a user-provisioned infrastructure (UPI) installation, you must manually dest
 +
 [source, terminal]
 ----
-$ ./openshift-install destroy cluster --dir=<installation_directory> <1>
+$ ./openshift-install destroy cluster --dir <installation_directory> <1>
 ----
 <1> `installation_directory` is the directory you specified when you ran `./openshift-install create cluster`. This directory contains the {product-title}
 definition files that the installation program creates.

--- a/modules/rhcos-enabling-multipath-day-1-power.adoc
+++ b/modules/rhcos-enabling-multipath-day-1-power.adoc
@@ -16,7 +16,7 @@ During the initial cluster creation, you might want to add kernel arguments to a
 +
 [source,terminal]
 ----
-$ ./openshift-install create manifests --dir=<installation_directory>
+$ ./openshift-install create manifests --dir <installation_directory>
 ----
 
 . Decide if you want to add kernel arguments to worker or master nodes.

--- a/modules/specifying-openshift-installer-log-levels.adoc
+++ b/modules/specifying-openshift-installer-log-levels.adoc
@@ -17,6 +17,6 @@ By default, the {product-title} installer log level is set to `info`. If more de
 +
 [source,terminal]
 ----
-$ ./openshift-install --dir=<installation_directory> wait-for bootstrap-complete --log-level=debug  <1>
+$ ./openshift-install --dir <installation_directory> wait-for bootstrap-complete --log-level debug  <1>
 ----
 <1> Possible log levels include `info`, `warn`, `error,` and `debug`.

--- a/modules/sts-mode-installing-manual-run-installer.adoc
+++ b/modules/sts-mode-installing-manual-run-installer.adoc
@@ -15,7 +15,7 @@
 +
 [source,terminal]
 ----
-$ openshift-install create install-config --dir=<installation_directory>
+$ openshift-install create install-config --dir <installation_directory>
 ----
 +
 where `<installation_directory>` is the directory in which the installation program creates files.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2016983

Fixed across many modules. Example preview can be viewed here: https://deploy-preview-39453--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-initializing_installing-azure-customizations