### PR TITLE
OSDOCS-2974: Added ap-northest-3 to ROSA/OSD

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -99,6 +99,7 @@ The following AWS regions are supported by Red Hat OpenShift 4 and are supported
 - ap-east-1 (Hong Kong, AWS opt-in required)
 - ap-northeast-1 (Tokyo)
 - ap-northeast-2 (Seoul)
+- ap-northeast-3 (Osaka)
 - ap-south-1 (Mumbai)
 - ap-southeast-1 (Singapore)
 - ap-southeast-2 (Sydney)

--- a/modules/sdpolicy-account-management.adoc
+++ b/modules/sdpolicy-account-management.adoc
@@ -135,6 +135,7 @@ The following AWS regions are supported by {OCP} 4 and are supported for {produc
 * ap-east-1 (Hong Kong, AWS opt-in required)
 * ap-northeast-1 (Tokyo)
 * ap-northeast-2 (Seoul)
+* ap-northeast-3 (Osaka)
 * ap-south-1 (Mumbai)
 * ap-southeast-1 (Singapore)
 * ap-southeast-2 (Sydney)


### PR DESCRIPTION
This PR adds the `ap-northest-3` region to the OSD and ROSA documentation

JIRA: https://issues.redhat.com/browse/OSDOCS-2974

Preview: 

OSD: https://deploy-preview-39458--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#regions-availability-zones_osd-service-definition

ROSA: https://deploy-preview-39458--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition