### PR TITLE
JIRA-OSDOCS2848: Improved a phrase in ROSA architecture concepts

### DIFF
--- a/modules/rosa-kubernetes-concept.adoc
+++ b/modules/rosa-kubernetes-concept.adoc
@@ -7,7 +7,7 @@
 [id="rosa-kubernetes-concept_{context}"]
 = Kubernetes
 
-{product-title} (ROSA) uses the Red Hat enterprise Kubernetes platform. Kubernetes is an open source platform for managing containerized workloads and services across multiple hosts, and offers management tools for deploying, automating, monitoring, and scaling containerized apps with minimal to no manual intervention. For complete information about Kubernetes, see the link:https://kubernetes.io/docs/home/?path=users&persona=app-developer&level=foundational[Kubernetes documentation].
+{product-title} (ROSA) uses Red Hat OpenShift, which is an enterprise Kubernetes platform. Kubernetes is an open source platform for managing containerized workloads and services across multiple hosts, and offers management tools for deploying, automating, monitoring, and scaling containerized apps with minimal to no manual intervention. For complete information about Kubernetes, see the link:https://kubernetes.io/docs/home/?path=users&persona=app-developer&level=foundational[Kubernetes documentation].
 
 Cluster, compute pool, and compute node:: A Kubernetes cluster consists of a control plane and one or more compute nodes. Compute nodes are organized into compute pools of the type or profile of CPU, memory, operating system, attached disks, and other properties. The compute nodes correspond to the Kubernetes `Node` resource, and are managed by a Kubernetes control plane that centrally controls and monitors all Kubernetes resources in the cluster.
 +


### PR DESCRIPTION
This PR is to address JIRA: https://issues.redhat.com/browse/OSDOCS-2848
Topic updated: https://deploy-preview-39464--osdocs.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-basic-architecture-concepts.html
Exact change: Section Kubernetes > Changed sentence "Red Hat OpenShift Service on AWS (ROSA) uses the Red Hat enterprise Kubernetes platform." to "Red Hat OpenShift Service on AWS (ROSA) uses Red Hat OpenShift, which is an enterprise Kubernetes platform." for clarity.
Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10