### PR TITLE
OSSMDOC-375: Distinguish between the Envoy and Jaeger sampling

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -43,4 +43,4 @@ endif::[]
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.6
 :mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.1
+:mtc-legacy-version-z: 1.5.3

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -43,4 +43,4 @@ endif::[]
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.6
 :mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.3
+:mtc-legacy-version-z: 1.5.1

--- a/modules/ossm-config-sampling.adoc
+++ b/modules/ossm-config-sampling.adoc
@@ -5,18 +5,23 @@
 [id="ossm-config-sampling_{context}"]
 = Adjusting the sampling rate
 
-The distributed tracing sampling rate is set to sample 100% of traces in your service mesh by default. A high sampling rate consumes cluster resources and performance but is useful when debugging issues. Before you deploy {ProductName} in production, set the value to a smaller proportion of traces.
+A trace is an execution path between services in the service mesh. A trace is comprised of one or more spans. A span is a logical unit of work that has a name, start time, and duration. The sampling rate determines how often a trace is persisted.
 
-A trace is an execution path between services in the service mesh. A trace is comprised of one or more spans. A span is a logical unit of work that has a name, start time, and duration.
+The Envoy proxy sampling rate is set to sample 100% of traces in your service mesh by default. A high sampling rate consumes cluster resources and performance but is useful when debugging issues. Before you deploy {ProductName} in production, set the value to a smaller proportion of traces. For example, set `spec.tracing.sampling` to `100` to sample 1% of traces.
 
-The sampling rate determines how often a trace is generated. Configure sampling as a scaled integer representing 0.01% increments.
+Configure the Envoy proxy sampling rate as a scaled integer representing 0.01% increments.
 
 In a basic installation, `spec.tracing.sampling` is set to `10000`, which samples 100% of traces. For example:
 
 * Setting the value to 10 samples 0.1% of traces.
 * Setting the value to 500 samples 5% of traces.
 
-Setting the value to `10000` is useful for debugging, but can affect performance. For production, set `spec.tracing.sampling` to `100.`
+[NOTE]
+====
+The Envoy proxy sampling rate applies for applications that are available to a Service Mesh, and use the Envoy proxy. This sampling rate determines how much data the Envoy proxy collects and tracks.
+
+The Jaeger remote sampling rate applies to applications that are external to the Service Mesh, and do not use the Envoy proxy, such as a database. This sampling rate determines how much data the distributed tracing system collects and stores. For more information, see xref:../../jaeger/jaeger_install/rhbjaeger-deploying.adoc#jaeger-config-sampling_jaeger-deploying[Configurating Jaeger sampling].
+====
 
 .Procedure
 


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 
- Jira: https://issues.redhat.com/browse/OSSMDOC-375
- Direct link to doc preview: https://deploy-preview-39465--osdocs.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-config-sampling_observability
- SME review: @pavolloffay 
- QE review: @yxun
- Peer review: @JStickler 
- All reviews complete. Please merge now. Cherry pick to 4.6, 4.7, 4.8, 4.9, and 4.10.
