### PR TITLE
GH#39470 Add 4.9 to docs.okd.io

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -18,6 +18,9 @@ openshift-origin:
     enterprise-4.8:
       name: '4.8'
       dir: '4.8'
+    enterprise-4.9:
+      name: '4.9'
+      dir: '4.9'
     enterprise-3.6:
       name: '3.6'
       dir: '3.6'

--- a/index-community.html
+++ b/index-community.html
@@ -50,6 +50,7 @@
              <button type="button" class="btn btn-primary dropdown-toggle" data-toggle="dropdown" aria-expanded="false">Select Version<span class="caret"></span></button>
              <ul class="dropdown-menu" role="menu">
                <li><a href="latest/"><i class="fa fa-arrow-circle-o-right"></i> OKD Latest</a></li>
+               <li><a href="4.9/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.9</a></li>
                <li><a href="4.8/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.8</a></li>
                <li><a href="4.7/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.7</a></li>
                <li><a href="4.6/"><i class="fa fa-arrow-circle-o-right"></i> OKD 4.6</a></li>


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/39470

OKD supports 4.9. Add 4.9 to the selector on the main page of docs.okd.io