### PR TITLE
[RHACS] Fixes to OAuth server docs

### DIFF
--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -8,26 +8,18 @@ toc::[]
 [role="_abstract"]
 {ocp} includes a built-in OAuth server that you can use as an authentication provider for {product-title} ({product-title-short}).
 
-[CAUTION]
-====
-The {ocp} OAuth server integration only works when you install {product-title} by using the `roxctl` CLI on {ocp}. It does not work when you install {product-title-short} by using Helm or the {product-title-short} Operator.
-====
+include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
 
 [IMPORTANT]
 ====
-* To disable the {ocp} OAuth server integration, set the `ROX_ENABLE_OPENSHIFT_AUTH` environment variable to `false` in Central:
+* If you use a custom TLS certificate for {ocp} OAuth server, you must add the certificate as a trusted root CA, if it is not already trusted. Otherwise, Central will not establish a TLS connection with the {ocp} OAuth server.
+* To enable the {ocp} OAuth server integration when installing {product-title} using roxctl, set the `ROX_ENABLE_OPENSHIFT_AUTH` environment variable to `true` in Central:
 +
 [source,terminal]
 ----
-$ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=false
+$ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 ----
-+
-When you disable the {ocp} OAuth server integration, all the previously configured {ocp} OAuth providers stop working and they are not listed as a login option. The UI still shows the option to configure {ocp} OAuth server, but the integration will not work.
-* Integration with {ocp} OAuth server is only available for {ocp} 4.1 and newer.
-* If you use a custom TLS certificate for {ocp} OAuth server, you must add the certificate as a trusted root CA or as a Kubernetes secret `/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt`. Otherwise, Central will not establish a TLS connection with the {ocp} OAuth server.
 ====
-
-include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -21,8 +21,6 @@ $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 ----
 ====
 
-include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider ]

--- a/operating/manage-user-access/configure-ocp-oauth.adoc
+++ b/operating/manage-user-access/configure-ocp-oauth.adoc
@@ -21,6 +21,8 @@ $ oc -n stackrox set env deploy/central ROX_ENABLE_OPENSHIFT_AUTH=true
 ----
 ====
 
+include::modules/configure-ocp-oauth-identity-provider.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 * link:https://docs.openshift.com/container-platform/4.9/authentication/identity_providers/configuring-ldap-identity-provider.html[Configuring an LDAP identity provider ]


### PR DESCRIPTION
A comment of mine was taken a bit out of context but luckily this is an easy fix. Correcting this documentation. Everything is fully supported using the operator and helm. The environment variable will only be set with roxctl install workflows.