### PR TITLE
[MULTIARCH-1965] IBM Z remove cio_ignore parm from 4.6 docs

### DIFF
--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -54,18 +54,23 @@ The rootfs image is the same for FCP and DASD.
 Example parameter file, `bootstrap-0.parm`, for the bootstrap machine:
 +
 ----
-rd.neednet=1 console=ttysclp0 coreos.inst.install_dev=dasda coreos.live.rootfs_url=http://
-cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img
-coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign
-ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1
-rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 zfcp.allow_lun_scan=0 cio_ignore=all,
-!condev rd.dasd=0.0.3490
+rd.neednet=1 \
+console=ttysclp0 \
+coreos.inst.install_dev=dasda \
+coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
+coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/bootstrap.ign \
+ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \
+rd.znet=qeth,0.0.bdf0,0.0.bdf1,0.0.bdf2,layer2=1,portno=0 \
+zfcp.allow_lun_scan=0 \
+rd.dasd=0.0.3490
 ----
++ 
+Write all options in the parameter file as a single line and make sure you have no newline characters.
 
 . Transfer the initramfs, kernel, parameter files, and {op-system} images to z/VM, for example with FTP. For details about how to transfer the files with FTP and boot from the virtual reader, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/installation_guide/sect-installing-zvm-s390[Installing under Z/VM].
 . Punch the files to the virtual reader of the z/VM guest virtual machine that is to become your bootstrap node.
 +
-See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.dmsb4/pun.htm[PUNCH] in the IBM Knowledge Center.
+See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-punch[PUNCH] in IBM Documentation.
 +
 [TIP]
 ====
@@ -79,6 +84,6 @@ You can use the CP PUNCH command or, if you use Linux, the **vmur** command to t
 $ ipl c
 ----
 +
-See link:https://www.ibm.com/support/knowledgecenter/en/SSB27U_7.1.0/com.ibm.zvm.v710.hcpb7/iplcommd.htm[IPL] in the IBM Knowledge Center.
+See link:https://www.ibm.com/docs/en/zvm/7.1?topic=commands-ipl[IPL] in IBM Documentation.
 +
 . Repeat this procedure for the other machines in the cluster.


### PR DESCRIPTION
-OCP version for cherry-picking: enterprise-4.6

- Jira: https://issues.redhat.com/browse/MULTIARCH-1965

- Bugzilla: Includes change from this BZ https://bugzilla.redhat.com/show_bug.cgi?id=1941302 and stale PR s390x: add notes to prevent usage of 'newlines' in zVM's parmfiles #31100
- Related PRs 
   - https://github.com/openshift/openshift-docs/pull/39314
   - https://github.com/openshift/openshift-docs/pull/39476

- Preview https://deploy-preview-39476--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-iso-ibm-z_installing-ibm-z

- QE review: Matt Gritter, Nikita Dubrovski