### PR TITLE
adds notes for 4.8.23 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2944,3 +2944,19 @@ This update contains changes from Kubernetes 1.21.6. More information can be fou
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-23"]
+=== RHBA-2021:4881 - {product-title} 4.8.23 bug fix update
+
+Issued: 2021-12-07
+
+{product-title} release 4.8.23, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4881[RHBA-2021:4881] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4880[RHBA-2021:4880] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6559931[{product-title} 4.8.23 container image list]
+
+[id="ocp-4-8-23-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Added notes for Dec. 7th 4.8.23 release

- Applies to `enterprise-4.8` only
- [Preview link](https://deploy-preview-39506--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-23)