### PR TITLE
BZ1871254: Add section for RAID storage

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -32,6 +32,7 @@ include::modules/installation-special-config-encrypt-disk.adoc[leveloffset=+1]
 include::modules/installation-special-config-encrypt-disk-tpm2.adoc[leveloffset=+2]
 include::modules/installation-special-config-encrypt-disk-tang.adoc[leveloffset=+2]
 include::modules/installation-special-config-mirrored-disk.adoc[leveloffset=+1]
+include::modules/installation-special-config-raid.adoc[leveloffset=+2]
 include::modules/installation-special-config-chrony.adoc[leveloffset=+1]
 
 ifndef::openshift-origin[]

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * installing/install_config/installing-customizing.adoc
+
+[id="installation-special-config-raid_{context}"]
+= Configuring a RAID-enabled data volume
+
+You can enable software RAID partitioning to provide an external data volume.
+
+.Procedure
+
+. Create a machine config that configures a data volume by using software RAID in the `<installation_directory>/openshift` directory. In this example, it is called `raid1-alt-storage.yaml`:
++
+.Sample RAID 1 on secondary disks configuration file
+[source, yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: raid1-alt-storage
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      disks:
+      - device: /dev/sdc
+        partitions:
+        - label: data-1
+        wipeTable: true
+      - device: /dev/sdd
+        partitions:
+        - label: data-2
+        wipeTable: true
+      filesystems:
+      - device: /dev/md/md-data
+        format: xfs
+        path: /var/lib/containers
+        wipeFilesystem: true
+      raid:
+      - devices:
+        - /dev/disk/by-partlabel/data-1
+        - /dev/disk/by-partlabel/data-2
+        level: raid1
+        name: md-data
+    systemd:
+      units:
+      - contents: |-
+          [Unit]
+          Before=local-fs.target
+          Requires=systemd-fsck@dev-md-md\x2ddata.service
+          After=systemd-fsck@dev-md-md\x2ddata.service
+
+          [Mount]
+          Where=/var/lib/containers
+          What=/dev/md/md-data
+          Type=xfs
+
+          [Install]
+          RequiredBy=local-fs.target
+        enabled: true
+        name: var-lib-containers.mount <1>
+----
++
+<1> If you choose a different mount point, you must update the unit name to correspond to your mount point. Otherwise the unit will not activate. You can generate a matching unit name with `echo $(systemd-escape -p $mountpoint).mount` where `$mountpoint` is your chosen mount point.
++
+. Apply the config to your cluster by running the following command:
++
+[source, terminal]
+----
+$ oc create -f raid1-alt-storage.yaml
+----


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1871254

OCP Version: 4.7

Current 4.7 doc: https://docs.openshift.com/container-platform/4.7/installing/install_config/installing-customizing.html#installation-special-config-mirrored-disk_installing-customizing

Direct doc preview link: https://deploy-preview-39515--osdocs.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing#configuring-a-raid-enabled-data-volume