### PR TITLE
CCXDEV-6549: enabling remote health monitoring

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -469,6 +469,8 @@ Topics:
     File: showing-data-collected-by-remote-health-monitoring
   - Name: Opting out of remote health reporting
     File: opting-out-of-remote-health-reporting
+  - Name: Enabling remote health reporting
+    File: enabling-remote-health-reporting
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using remote health reporting in a restricted network

--- a/modules/insights-operator-new-pull-secret-enable.adoc
+++ b/modules/insights-operator-new-pull-secret-enable.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * support/insights-operator/enabling-remote-health-reporting.adoc
+
+[id="insights-operator-new-pull-secret-enable_{context}"]
+= Modifying your global cluster pull secret to enable remote health reporting
+
+You can modify your existing global cluster pull secret to enable remote health reporting. If you have previously disabled remote health monitoring, you must first download a new pull secret with your `cloud.openshift.com` access token from Red Hat OpenShift Cluster Manager. 
+
+.Prerequisites
+
+* Access to the cluster as a user with the `cluster-admin` role.
+* Access to Red Hat OpenShift Cluster Manager.
+
+.Procedure
+
+. Navigate to link:https://console.redhat.com/openshift/downloads[https://console.redhat.com/openshift/downloads].
+. From *Tokens* -> *Pull Secret*, click *Download*. 
++
+The file `pull-secret.txt` containing your `cloud.openshift.com` access token in JSON format downloads:
++
+[source,json,subs="+quotes"]
+----
+{    
+  "auths": {        
+    "cloud.openshift.com": {            
+      "auth": "_<your_token>_",
+      "email": "_<email_address>_"
+    }
+}
+----
+
+. Download the global cluster pull secret to your local file system.
++
+[source,terminal]
+----
+$ oc get secret/pull-secret -n openshift-config --template='{{index .data ".dockerconfigjson" | base64decode}}' > pull-secret
+----
+. Make a backup copy of your pull secret. 
++
+[source,terminal]
+----
+$ cp pull-secret pull-secret-backup
+----
+. Open the `pull-secret` file in a text editor.
+. Append the `cloud.openshift.com` JSON entry from `pull-secret.txt` into `auths`.
+. Save the file.
+. Update the secret in your cluster.
++
+[source,terminal]
+----
+oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=pull-secret
+----
+
+It may take several minutes for the secret to update and your cluster to begin reporting. 
+
+.Verification 
+
+. Navigate to the {product-title} Web Console Overview page.
+. *Insights* in the *Status* tile reports the number of issues found. 

--- a/support/remote_health_monitoring/enabling-remote-health-reporting.adoc
+++ b/support/remote_health_monitoring/enabling-remote-health-reporting.adoc
@@ -1,0 +1,19 @@
+[id="enabling-remote-health-reporting"]
+= Enabling remote health reporting
+include::modules/common-attributes.adoc[]
+
+:context: enabling-remote-health-reporting
+
+toc::[]
+
+
+If you or your organization have disabled remote health reporting, you can enable this feature again. You can see that remote health reporting is disabled from the message "Insights not available" in the *Status* tile on the {product-title} Web Console Overview page. 
+
+To enable remote health reporting, you must xref:../../support/remote_health_monitoring/enabling-remote-health-reporting.adoc#insights-operator-new-pull-secret-enable_enabling-remote-health-reporting[Modify the global cluster pull secret] with a new authorization token.
+
+[NOTE]
+====
+Enabling remote health reporting enables both Insights Operator and Telemetry.
+====
+
+include::modules/insights-operator-new-pull-secret-enable.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR Applies to **4.10+**

**Preview**: https://deploy-preview-39518--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/enabling-remote-health-reporting

**Jira** : https://issues.redhat.com/browse/CCXDEV-6549

**SME**: Tremes, radekvokal, tdosek  
**QE**: JoaoFula 