### PR TITLE
Added notes for release 4.9.10

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2334,8 +2334,23 @@ link:https://access.redhat.com/solutions/6542521[{product-title} 4.9.9 container
 
 This update contains changes from Kubernetes 1.22.3. More information can be found in the following changelog: link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.22.md#v1223[1.22.3].
 
-
 [id="ocp-4-9-9-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-9-10"]
+=== RHBA-2021:4889 - {product-title} 4.9.10 bug fix update
+
+Issued: 2021-12-06
+
+{product-title} release 4.9.10 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4889[RHBA-2021:4889] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4888[RHBA-2021:4888] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6562471[{product-title} 4.9.10 container image list]
+
+[id="ocp-4-9-10-upgrading"]
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the notes for release 4.9.10.

For publication on 6 December 2021.

Preview: https://deploy-preview-39519--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-10