### PR TITLE
TELCODOCS-261: Second round of What's new updates for Redfish HW events

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -114,6 +114,20 @@ For more information, see xref:../updating/understanding-upgrade-channels-releas
 [id="ocp-4-10-networking"]
 === Networking
 
+[id="ocp-4-10-redfish-events"]
+==== Low-latency Redfish hardware event delivery (Technology Preview)
+
+{product-title} now provides a hardware event proxy that enables applications running on bare-metal clusters to respond quickly to Redfish hardware events, such as hardware changes and failures.
+
+The hardware event proxy supports a publish-subscribe service that allows relevant applications to consume hardware events detected by Redfish. The proxy must be running on hardware that supports Redfish v1.8 and higher. An Operator manages the lifecycle of the `hw-event-proxy` container.
+
+You can use a REST API to develop applications to consume and respond to events such as breaches of temperature thresholds, fan failure, disk loss, power outages, and memory failure. Reliable end-to-end messaging without persistent stores is based on the Advanced Message Queuing Protocol (AMQP). The latency of the messaging service is in the 10 millisecond range.
+
+[NOTE]
+====
+This feature is supported for single node OpenShift clusters only.
+====
+
 [id="ocp-4-10-networking-metrics"]
 ==== Enhancements to networking metrics
 
@@ -159,6 +173,9 @@ You can use the enhancement to run packet captures on multiple nodes at the same
 A new `--node-selector` argument provides a way to identify which nodes you are collecting packet captures for.
 
 For more information, see xref:../support/gathering-cluster-data.adoc#support-network-trace-methods_gathering-cluster-data[Network trace methods] and xref:../support/gathering-cluster-data.adoc#support-collecting-host-network-trace_gathering-cluster-data[Collecting a host network trace].
+
+[id="ocp-4-10-hardware"]
+=== Hardware
 
 [id="ocp-4-10-storage"]
 === Storage
@@ -688,6 +705,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 |
+
+| Low-latency Redfish hardware events
+|-
+|-
+|TP
 
 |====
 


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/TELCODOCS-261

For 4.10

https://deploy-preview-39520--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-networking

Note: moved location to Networking after discussion with @jzding .

https://deploy-preview-39520--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-technology-preview