### PR TITLE
Update Web Terminal Operator uninstall docs

### DIFF
--- a/modules/odc-uninstalling-web-terminal.adoc
+++ b/modules/odc-uninstalling-web-terminal.adoc
@@ -31,7 +31,7 @@ Prior to {product-title} 4.8, the Web Terminal Operator used different CRDs to p
 .. Click the Options menu {kebab} for the Web Terminal Operator, and then select *Uninstall Operator*.
 .. In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.
 +
-. Run the following commands to ensure that all `DevWorkspace` CRs created for the Web Terminals are removed.
+. Remove the CRDs used by the Operator.
 +
 [source,terminal]
 ----
@@ -55,7 +55,7 @@ The DevWorkspace Operator functions as a standalone Operator and may be required
 ====
 
 .Procedure
-. Run the following commands to ensure that all `DevWorkspace` CRs are removed along with their related Kubernetes objects, such as deployments.
+. Remove the `DevWorkspace` custom resources used by the Operator, along with any related Kubernetes objects, such as deployments.
 +
 [source,terminal]
 ----
@@ -72,7 +72,12 @@ $ oc delete devworkspaceroutings.controller.devfile.io --all-namespaces --all --
 If this step is not complete, finalizers make it difficult to fully uninstall the Operator easily.
 ====
 +
-. Run the following commands to remove the CRDs:
+. Remove the CRDs used by the Operator:
++
+[WARNING]
+====
+The DevWorkspace Operator provides custom resource definitions (CRDs) that use conversion webhooks. Failing to remove these CRDs can cause issues on the cluster.
+====
 +
 [source,terminal]
 ----
@@ -84,7 +89,24 @@ $ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaceroutings.
 $ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaces.workspace.devfile.io
 ----
 +
-. Remove the `DevWorkspace-Webhook-Server` deployment, mutating, and validating webhooks:
+[source,terminal]
+----
+$ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspacetemplates.workspace.devfile.io
+----
++
+[source,terminal]
+----
+$ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaceoperatorconfigs.controller.devfile.io
+----
++
+. Verify that all involved custom resource definitions are removed. The following command should not display any result.
++
+[source,terminal]
+----
+$ oc get customresourcedefintions | grep "devfile.io"
+----
++
+. Remove the `devworkspace-webhook-server` deployment, mutating, and validating webhooks:
 +
 [source,terminal]
 ----
@@ -103,14 +125,14 @@ $ oc delete validatingwebhookconfigurations controller.devfile.io
 +
 [NOTE]
 ====
-If you remove the `devworkspace-webhook-server` deployment without removing the mutating and validating webhooks, you will not be able use `oc exec` commands to run commands in a container on the cluster. After you remove the webhooks you will be able to use the `oc exec` commands again.
+If you remove the `devworkspace-webhook-server` deployment without removing the mutating and validating webhooks, you will not be able to use `oc exec` commands to run commands in a container on the cluster. After you remove the webhooks you will be able to use the `oc exec` commands again.
 ====
 +
-. Run the following commands to remove any lingering services, secrets, and config maps:
+. Remove any remaining services, secrets, and config maps. Depending on the installation, some resources included in the following command may not exist on the cluster.
 +
 [source,terminal]
 ----
-$ oc delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server
+$ oc delete all --selector app.kubernetes.io/part-of=devworkspace-operator,app.kubernetes.io/name=devworkspace-webhook-server -n openshift-operators
 ----
 +
 [source,terminal]


### PR DESCRIPTION
Update the Web Terminal Operator uninstall process doc to clarify a few things
* Update the list of CRDs to remove from the cluster to include all CRDs used by the Operator
* Clarify that depending on the installation, some optional resources may not be present (and the failure to delete them is not an issue)
* Verify and highlight removal of CRDs, as we've found that failing to fully remove CRDs before uninstalling the Operator can cause cluster-wide issues due to the use of conversion webhooks: https://issues.redhat.com/browse/OLM-2336