### PR TITLE
[enterprise-4.9] Remove BCM57508 abd E810-* as they are unsupported

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -17,11 +17,6 @@
 |14e4
 |16d7
 
-|Broadcom
-|BCM57508
-|14e4
-|1750
-
 |Intel
 |X710
 |8086
@@ -36,21 +31,6 @@
 |XXV710
 |8086
 |158b
-
-|Intel
-|E810-CQDA2
-|8088
-|1592
-
-|Intel
-|E810-XXVDA2
-|8088
-|159b
-
-|Intel
-|E810-XXVDA4
-|8088
-|1593
 
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -387,10 +387,9 @@ Single node clusters support SR-IOV hardware and the SR-IOV Network Operator. Be
 [id="ocp-4-9-supported-hardware-sriov"]
 ==== Supported hardware for SR-IOV
 
-{product-title} {product-version} adds support for additional Broadcom and Intel hardware.
+{product-title} {product-version} adds support for additional Broadcom hardware.
 
-* Broadcom BCM57414 and BCM57508
-* Intel E810-CQDA2, E810-XXVDA2, and E810-XXVDA4
+* Broadcom BCM57414
 
 For more information, see the xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[supported devices].
 


### PR DESCRIPTION
- https://github.com/openshift/openshift-docs/pull/38878