### PR TITLE
fix issue in file networking/using-ptp.adoc #39115

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -29,7 +29,7 @@ spec:
   profile: <2>
   - name: "profile1" <3>
     interface: "" <4>
-    ptp4lOpts: "-s -2" <5>
+    ptp4lOpts: "-2" <5>
     ptp4lConf: | <6>
       [ens1f0] <7>
       masterOnly 0
@@ -148,7 +148,7 @@ spec:
 <2> Specify an array of one or more `profile` objects.
 <3> Specify the name of a profile object which uniquely identifies a profile object.
 <4> This field should remain empty for boundary clock.
-<5> Specify system config options for the `ptp4l` service, for example `-s -2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+<5> Specify system config options for the `ptp4l` service, for example `-2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
 <6> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
 <7> The interface name to synchronize from.
 <8> The interface to synchronize devices connected to the interface.
@@ -202,7 +202,7 @@ I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
 I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
 I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
 I1115 09:41:17.117616 4143292 daemon.go:102] Interface:
-I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -s -2
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2
 I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r
 I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
 ----


### PR DESCRIPTION
-s should not be there in boundary clock configuration.

Refs https://github.com/openshift/openshift-docs/pull/39183 && https://github.com/openshift/openshift-docs/pull/39636.

Refs https://github.com/openshift/openshift-docs/pull/39834.