### PR TITLE
BZ2028880: Clarify that MTC installation is for OCP4

### DIFF
--- a/migration_toolkit_for_containers/about-mtc.adoc
+++ b/migration_toolkit_for_containers/about-mtc.adoc
@@ -7,6 +7,11 @@ toc::[]
 
 The {mtc-full} ({mtc-short}) enables you to migrate stateful application workloads between {product-title} 4 clusters at the granularity of a namespace.
 
+[NOTE]
+====
+If you are migrating from {product-title} 3, see xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[About migrating from {product-title} 3 to 4] and xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
+====
+
 You can migrate applications within the same cluster by using state migration.
 
 {mtc-short} provides a web console and an API, based on Kubernetes custom resources, to help you control the migration and minimize application downtime.

--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -19,6 +19,11 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 * {product-title} 4.6 or later: Install the {mtc-full} Operator by using Operator Lifecycle Manager.
 * {product-title} 4.2 to 4.5: Install the legacy {mtc-full} Operator from the command line interface.
++
+[NOTE]
+====
+To install {mtc-short} on {product-title} 3, see xref:../migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc#migration-installing-legacy-operator_installing-restricted-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
+====
 
 . Configure object storage to use as a replication repository.
 

--- a/migration_toolkit_for_containers/installing-mtc.adoc
+++ b/migration_toolkit_for_containers/installing-mtc.adoc
@@ -8,7 +8,10 @@ toc::[]
 
 You can install the {mtc-full} ({mtc-short}) on {product-title} 4.
 
-After you manually install the legacy {mtc-full} Operator on the {product-title} 4 source cluster, you install the {mtc-full} Operator on the {product-title} {product-version} target cluster by using the Operator Lifecycle Manager.
+[NOTE]
+====
+To install {mtc-short} on {product-title} 3, see xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
+====
 
 By default, the {mtc-short} web console and the `Migration Controller` pod run on the target cluster. You can configure the `Migration Controller` custom resource manifest to run the {mtc-short} web console and the `Migration Controller` pod on a link:https://access.redhat.com/articles/5064151[remote cluster].
 

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -8,7 +8,7 @@
 [id="migration-compatibility-guidelines_{context}"]
 = Compatibility guidelines
 
-You must install the {mtc-full} ({mtc-short}) version that is compatible with your {product-title} version.
+You must install the {mtc-full} ({mtc-short}) Operator that is compatible with your {product-title} version.
 
 You cannot install {mtc-short} {mtc-version} on {product-title} 4.5, or earlier versions, because the custom resource definition API versions are incompatible.
 


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2028880

Add notes with link to installation on OCP 3.

Previews:

https://deploy-preview-39537--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html

https://deploy-preview-39537--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html

https://deploy-preview-39537--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html#migration-compatibility-guidelines_installing-mtc

https://deploy-preview-39537--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc-restricted.html (note in step 3)

Changes approved. No QE required. Ready for peer review.
