### PR TITLE
MIG-972: 1.5.3 legacy operator

### DIFF
--- a/migrating_from_ocp_3_to_4/upgrading-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/upgrading-3-4.adoc
@@ -6,13 +6,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can upgrade the {mtc-full} ({mtc-short}) on {product-title} {product-version} by using the Operator Lifecycle Manager.
+You can upgrade the {mtc-full} ({mtc-short}) on {product-title} {product-version} by using Operator Lifecycle Manager.
 
-You can upgrade {mtc-short} on {product-title} versions 3.7 to 3.11 by installing the legacy {mtc-full} Operator.
+You can upgrade {mtc-short} on {product-title} 3 by reinstalling the legacy {mtc-full} Operator.
 
 [IMPORTANT]
 ====
-If you are upgrading from {mtc-short} version 1.3 to {mtc-version}, you must perform an additional procedure to update the `MigPlan` custom resource (CR).
+If you are upgrading from {mtc-short} version 1.3, you must perform an additional procedure to update the `MigPlan` custom resource (CR).
 ====
 
 include::modules/migration-upgrading-mtc-on-ocp-4.adoc[leveloffset=+1]

--- a/migration_toolkit_for_containers/upgrading-mtc.adoc
+++ b/migration_toolkit_for_containers/upgrading-mtc.adoc
@@ -6,13 +6,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-You can upgrade the {mtc-full} ({mtc-short}) on {product-title} {product-version} by using the Operator Lifecycle Manager.
+You can upgrade the {mtc-full} ({mtc-short}) on {product-title} {product-version} by using Operator Lifecycle Manager.
 
-You can upgrade {mtc-short} on {product-title} versions 4.2 to 4.5 by installing the legacy {mtc-full} Operator.
+You can upgrade {mtc-short} on {product-title} 4.5, and earlier versions, by reinstalling the legacy {mtc-full} Operator.
 
 [IMPORTANT]
 ====
-If you are upgrading from {mtc-short} version 1.3 to {mtc-version}, you must perform an additional procedure to update the `MigPlan` custom resource (CR).
+If you are upgrading from {mtc-short} version 1.3, you must perform an additional procedure to update the `MigPlan` custom resource (CR).
 ====
 
 include::modules/migration-upgrading-mtc-on-ocp-4.adoc[leveloffset=+1]

--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -41,10 +41,6 @@ endif::[]
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
-ifndef::openshift-dedicated[]
 :mtc-version: 1.6
-endif::openshift-dedicated[]
-ifdef::openshift-dedicated[]
-:mtc-version: 1.4
-:mtc-version-z: 1.4.1
-endif::openshift-dedicated[]
+:mtc-legacy-version: 1.5
+:mtc-legacy-version-z: 1.5.3

--- a/modules/migration-compatibility-guidelines.adoc
+++ b/modules/migration-compatibility-guidelines.adoc
@@ -10,24 +10,16 @@
 
 You must install the {mtc-full} ({mtc-short}) version that is compatible with your {product-title} version.
 
-You cannot install {mtc-short} 1.6.x on {product-title} versions 3.7 to 4.5 because the custom resource definition API versions are incompatible.
+You cannot install {mtc-short} {mtc-version} on {product-title} 4.5, or earlier versions, because the custom resource definition API versions are incompatible.
 
-You can migrate workloads from a source cluster with {mtc-short} 1.5.1 to a target cluster with {mtc-short} 1.6.x as long as the `MigrationController` custom resource and the {mtc-short} web console are running on the target cluster.
+You can migrate workloads from a source cluster with {mtc-short} {mtc-legacy-version-z} to a target cluster with {mtc-short} {mtc-version} as long as the `MigrationController` custom resource and the {mtc-short} web console are running on the target cluster.
 
-[cols="1,1,2a", options="header"]
+[cols="1,1,2", options="header"]
 .{product-title} and {mtc-short} compatibility
 |===
 |{product-title} version |{mtc-short} version |{mtc-full} Operator
-|3.7 |1.5.1 |Legacy {mtc-full} Operator.
 
-Installed manually with the `operator-3.7.yml` file.
+|4.5 and earlier |{mtc-legacy-version-z} |Legacy {mtc-full} Operator, installed manually with the `operator.yml` file.
 
-|3.9 to 4.5 |1.5.1 |Legacy {mtc-full} Operator.
-
-Installed manually with the `operator.yml` file.
-
-|4.6 and later |1.6.x^[1]^ |{mtc-full} Operator.
-
-Installed with the Operator Lifecycle Manager.
+|4.6 and later |Latest {mtc-version}.x z-stream release |{mtc-full} Operator, installed with Operator Lifecycle Manager.
 |===
-^1^ Latest z-stream release.

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -40,41 +40,20 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-ifdef::installing-3-4,installing-restricted-3-4[]
-. Download the `operator.yml` file for your {product-title} version:
-
-* {product-title} version 3.7:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator-3.7.yml ./
-----
-
-* {product-title} version 3.9 to 3.11:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator.yml ./
-----
-endif::[]
-ifdef::installing-mtc,installing-mtc-restricted[]
 . Download the `operator.yml` file:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
 ----
-endif::[]
 
 . Download the `controller.yml` file:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/controller.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
 ----
 
 ifdef::installing-restricted-3-4,installing-mtc-restricted[]

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -5,9 +5,9 @@
 
 [id="migration-upgrading-mtc-with-legacy-operator_{context}"]
 ifdef::upgrading-3-4[]
-= Upgrading the {mtc-full} on {product-title} 3.7 to 3.11
+= Upgrading the {mtc-full} on {product-title} 3
 
-You can upgrade {mtc-full} ({mtc-short}) on {product-title} versions 3.7 to 3.11 by manually installing the legacy {mtc-full} Operator.
+You can upgrade {mtc-full} ({mtc-short}) on {product-title} 3 by manually installing the legacy {mtc-full} Operator.
 endif::[]
 ifdef::upgrading-mtc[]
 = Upgrading the {mtc-full} on {product-title} versions 4.2 to 4.5
@@ -30,39 +30,12 @@ endif::[]
 $ sudo podman login registry.redhat.io
 ----
 
-ifdef::upgrading-3-4[]
-. Download the `operator.yml` file for your {product-title} 3 version:
-
-* {product-title} version 3.7:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator-3.7.yml ./
-----
-
-* {product-title} version 3.9 to 3.11:
-+
-[source,terminal,subs="attributes+"]
-----
-$ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator.yml ./
-----
-
-. Replace the {mtc-full} Operator:
-+
-[source,terminal]
-----
-$ oc replace --force -f <operator.yml>
-----
-endif::[]
-ifdef::upgrading-mtc[]
 . Download the `operator.yml` file:
 +
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/operator.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/operator.yml ./
 ----
 
 . Replace the {mtc-full} Operator:
@@ -71,7 +44,6 @@ $ sudo podman cp $(sudo podman create \
 ----
 $ oc replace --force -f operator.yml
 ----
-endif::[]
 
 . Scale the `migration-operator` deployment to `0` to stop the deployment:
 +
@@ -99,7 +71,7 @@ $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep ima
 [source,terminal,subs="attributes+"]
 ----
 $ sudo podman cp $(sudo podman create \
-  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v1.5.1):/controller.yml ./
+  registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-legacy-version-z}):/controller.yml ./
 ----
 
 . Create the `migration-controller` object:
@@ -110,13 +82,6 @@ $ oc create -f controller.yml
 ----
 
 ifdef::upgrading-3-4[]
-. For {product-title} versions 3.9 and 3.10, set the security context constraint of the `migration-controller` service account to `anyuid` to enable direct image migration and direct volume migration:
-+
-[source,terminal]
-----
-$ oc adm policy add-scc-to-user anyuid -z migration-controller -n openshift-migration
-----
-
 . If you have previously added the {product-title} 3 cluster to the {mtc-short} web console, you must update the service account token in the web console because the upgrade process deletes and restores the `openshift-migration` namespace:
 
 .. Obtain the service account token:


### PR DESCRIPTION
https://issues.redhat.com/browse/MIG-972

Update legacy operator verson for 1.5.3. (1.5.2 is broken).

Previews:

https://deploy-preview-39538--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-compatibility-guidelines_installing-3-4

https://deploy-preview-39538--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-installing-legacy-operator_installing-3-4

https://deploy-preview-39538--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/upgrading-3-4.html#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4

Urgent need for peer review because GA is Dec. 9.