### PR TITLE
[RHACS] Release notes for 3.67.1

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -40,7 +40,7 @@ endif::[]
 :mtc-version: 1.4
 :mtc-version-z: 1.4.2
 :ocp: OpenShift Container Platform
-:rhacs-version: 3.67.0
+:rhacs-version: 3.67.1
 :ocp-supported-version: 4.5
 :scanner-version: 2.21.0
 :collector-version: 3.5.0-latest

--- a/release_notes/367-release-notes.adoc
+++ b/release_notes/367-release-notes.adoc
@@ -5,7 +5,7 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} (RHACS) 3.67 includes feature enhancements, bug fixes, scale improvements, and other changes.
+{product-title} ({product-title-short}) 3.67 includes feature enhancements, bug fixes, scale improvements, and other changes.
 
 *Release date:* December 1, 2021
 
@@ -26,13 +26,20 @@ Red Hat has improved the usability of {product-title} CI integrations. CI output
 
 [id="new-runtimeclass-policy-criteria"]
 === Runtime Class policy criteria
-Users can now use RHACS to define the container runtime configuration that may be used to run a pod's containers using the *Runtime Class* policy criteria.
+Users can now use {product-title-short} to define the container runtime configuration. This configuration can be used to run a pod's containers using the *Runtime Class* policy criteria.
 
 [id="important-bug-fixes"]
 == Important bug fixes
 
-* *ROX-7815*: Previously, when using RHACS with the Compliance Operator integration, RHACS did not respect or populate Compliance Operator `TailoredProfiles`. This has been fixed.
+* *ROX-7815*: Previously, when using {product-title-short} with the Compliance Operator integration, {product-title-short} did not respect or populate Compliance Operator `TailoredProfiles`. This issue has been fixed.
 * *ROX-7254*: Previously, the *Alpine Linux package manager (APK) in Image* policy looked for the presence of `apk` package in the image rather than the `apk-tools` package. This issue has been fixed.
+
+[id="resolved-in-version-3671"]
+=== Resolved in version 3.67.1
+
+Release date: December 6, 2021
+
+* *ROX-8698*: In {product-title-short} 3.67.0, the TLS verification would fail when you integrated {product-title-short} with {ocp} OAuth server for {ocp} 4.8 and later. This issue has been fixed.
 
 [id="important-system-changes"]
 == Important system changes
@@ -83,7 +90,7 @@ Red Hat recommends that you only use the `ROX_NETWORK_ACCESS_LOG` environment va
 | Main
 | Includes Central, Sensor, Admission Controller, and Compliance.
 Also includes `roxctl` for use in continuous integration (CI) systems.
-| registry.redhat.io/rh-acs/main:3.67.0
+| registry.redhat.io/rh-acs/main:3.67.1
 
 | Scanner
 | Scans images and nodes.


### PR DESCRIPTION
- [x] Updated release notes for 3.67.1
- ~~Version updates for Scanner, Scanner DB, Collector in release notes and common attributes file.~~ No updates to Scanner, Scanner DB, and Collector for 3.67.1 patch release.
> We are only releasing new artifacts for central, so those versions will not be updated by the patch and should stay the same as they were in 3.67.0 

Preview: https://deploy-preview-39540--osdocs.netlify.app/openshift-acs/latest/release_notes/367-release-notes.html#resolved-in-version-3671