### PR TITLE
[RHACS] Fix typo in the security context section

### DIFF
--- a/modules/violations-view-deployment-tab.adoc
+++ b/modules/violations-view-deployment-tab.adoc
@@ -42,7 +42,7 @@ The container configuration section lists the following information:
 [discrete]
 == Security Context section
 
-Lists whether the container is running as a privilaged container.
+Lists whether the container is running as a privileged container.
 
 * *Privileged*:
 ** `true` if it is *privileged*.


### PR DESCRIPTION
Preview link: https://deploy-preview-39541--osdocs.netlify.app/openshift-acs/latest/operating/respond-to-violations

Fixes #39400 
Urgency: Low

Applies to:
- 3.65
- 3.66
- 3.67

<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
