### PR TITLE
BZ2012715: add information about opm index export command

### DIFF
--- a/modules/opm-cli-ref-index.adoc
+++ b/modules/opm-cli-ref-index.adoc
@@ -21,6 +21,9 @@ $ opm index <subcommand> [<flags>]
 |`add`
 |Add Operator bundles to an index.
 
+|`export`
+|Export an Operator from an index in the `appregistry` format.
+
 |`prune`
 |Prune an index of all but specified packages.
 
@@ -81,6 +84,38 @@ $ opm index add [<flags>]
 |`-t`, `--tag` (string)
 |Custom tag for container image being built.
 
+|===
+
+[id="opm-cli-ref-index-export_{context}"]
+== export
+
+Export an Operator from an index in the `appregistry` format.
+
+.Command syntax
+[source,terminal]
+----
+$ opm index export [<flags>]
+----
+
+.`index export` flags
+[options="header",cols="1,3"]
+|===
+|Flag |Description
+
+|`-i`, `--index` (string)
+|Index to get the packages from.
+
+|`-f`, `--download-folder` (string)
+|Directory where the downloaded Operator bundles are stored. The default directory is `downloaded`.
+
+|`-c`, `--container-tool` (string)
+|Tool to interact with container images, such as for saving and building: `docker` or `podman`.
+
+|`-h`, `--help`
+|Help for the `export` command.
+
+|`-p`, `--package` (string)
+|Comma-separated list of packages to export.
 |===
 
 [id="opm-cli-ref-index-prune_{context}"]
@@ -156,9 +191,6 @@ $ opm index prune-stranded [<flags>]
 |`-d`, `--out-dockerfile` (string)
 |Optional: If generating the Dockerfile, specify a file name.
 
-|`-p`, `--packages` (strings)
-|Comma-separated list of packages to keep.
-
 |`--permissive`
 |Allow registry load errors.
 
@@ -203,9 +235,6 @@ $ opm index rm [<flags>]
 
 |`-d`, `--out-dockerfile` (string)
 |Optional: If generating the Dockerfile, specify a file name.
-
-|`-p`, `--packages` (strings)
-|Comma-separated list of packages to keep.
 
 |`--permissive`
 |Allow registry load errors.


### PR DESCRIPTION
For 4.9
https://bugzilla.redhat.com/show_bug.cgi?id=2012715

[Docs preview](https://deploy-preview-39545--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref#opm-cli-ref-index-export_cli-opm-ref)

Requires ack from @jianzhangbjz 