### PR TITLE
[Fix] Skip verification because etcd container unexists on non-recovery hosts

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -204,7 +204,7 @@ $ oc adm certificate approve <csr_name>
 3ad41b7908e32       36f86e2eeaaffe662df0d21041eb22b8198e0e58abeeae8c743c3e6e977e8009                                                         About a minute ago   Running             etcd                                          0                   7c05f8af362f0
 ----
 
-.. From the recovery host, verify that the etcd pod is running.
+.. From each control plane host that includes the recovery host, verify that the etcd pod is running.
 +
 [source,terminal]
 ----
@@ -229,8 +229,6 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 ----
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
-
-.. Repeat this step for each lost control plane host that is not the recovery host.
 
 . Delete and recreate other non-recovery, control plane machines, one by one. After these machines are recreated, a new revision is forced and etcd scales up automatically.
 +


### PR DESCRIPTION
i tried to restore etcd.

In the step `Verify that the single member control plane has started successfully`,
etcd container did not exist on the non-recovery host, so it took a long time to determine if it was correct.

i think etcd container exists on only the recovery host in this step, so this PR changes the description to only do the verification by oc command on non-recovery hosts.