### PR TITLE
BZ2013756: correct machine config metrics in 4.9

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -41,12 +41,7 @@ ifdef::openshift-origin[]
 |
 endif::openshift-origin[]
 
-|`ssh_accessed`
-|`counter`
-|Shows the number of successful SSH authentications into the node.
-|The non-zero value shows that someone might have made manual changes to the node. Such changes might cause irreconcilable errors due to the differences between the state on the disk and the state defined in the machine configuration.
-
-|`mcd_drain*`
+|`mcd_drain_err*`
 |`{"drain_time", "err"}`
 |Logs errors received during failed drain. *
 |While drains might need multiple tries to succeed, terminal failed drains prevent updates from proceeding. The `drain_time` metric, which shows how much time the drain took, might help with troubleshooting.
@@ -56,7 +51,7 @@ For further investigation, see the logs by running:
 `$ oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon`
 
 |`mcd_pivot_err*`
-|`[]string{"pivot_target", "err"}`
+|`[]string{"err", "node", "pivot_target"}`
 |Logs errors encountered during pivot. *
 |Pivot errors might prevent OS upgrades from proceeding.
 
@@ -85,7 +80,7 @@ For further investigation, run this command to access the node and see all its l
 `$ oc debug node/<node> -- chroot /host journalctl -u kubelet`
 
 |`mcd_reboot_err*`
-|`[]string{"message", "err"}`
+|`[]string{"message", "err", "node"}`
 |Logs the failed reboots and the corresponding errors. *
 |This is expected to be empty, which indicates a successful reboot.
 


### PR DESCRIPTION
For 4.9+
https://bugzilla.redhat.com/show_bug.cgi?id=2013756

[Docs preview](https://deploy-preview-39553--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics)

Requires ack from @sergiordlr 