### PR TITLE
TELCODOCS-365-main: Using pod-level bonding

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -981,6 +981,8 @@ Topics:
     File: using-sriov-multicast
   - Name: Using DPDK and RDMA
     File: using-dpdk-and-rdma
+  - Name: Using pod-level bonding for secondary networks
+    File: using-pod-level-bonding
 - Name: OpenShift SDN default CNI network provider
   Dir: openshift_sdn
   Topics:

--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-operator.adoc
+:_content-type: PROCEDURE
+[id="nw-sriov-cfg-bond-interface-with-virtual-functions_{context}"]
+= Configuring a bond interface from two SR-IOV interfaces
+
+Bonding enables multiple network interfaces to be aggregated into a single logical "bonded" interface. Bond-CNI brings bond capability into containers.
+
+Bond-CNI can be created using SR-IOV virtual functions and placing them in the container network namespace.
+
+{product-title} only supports Bond-CNI using SR-IOV virtual functions. Physical interfaces are not supported.
+
+.Prerequisites
+
+* The SR-IOV operator must be installed and configured to obtain virtual functions in a container.
+* To configure SR-IOV interfaces, an SR-IOV network and policy must be created for each interface.
+* The SR-IOV operator creates a network attachment definition for each SR-IOV interface, based on the SR-IOV network and policy defined.
+
+[id="nw-sriov-cfg-creating-bond-network-attachment-definition_{context}"]
+== Creating a bond network attachment definition
+
+Now that the SR-IOV virtual functions are available, you can create a bond network attachment definition.
+
+[source,yaml]
+----
+apiVersion: "k8s.cni.cncf.io/v1"
+    kind: NetworkAttachmentDefinition
+    metadata:
+      name: bond-net1
+      namespace: demo
+    spec:
+      config: '{
+      "type": "bond", <1>
+      "cniVersion": "0.3.1",
+      "name": "bond-net1",
+      "ifname: "bond0" <2>
+      "mode": "active-backup",
+      "failOverMac": 1, <3>
+      "linksInContainer": true, <4>
+      "miimon": "100",
+      "mtu": 1500,
+      "links": [ <5>
+            {"name": "net1"},
+            {"name": "net2"}
+        ],
+      "ipam": {
+            "type": "host-local"
+            "subnet": "10.56.217.0/24"
+            "routes": [{
+            "dst": "0.0.0.0/0"
+            }],
+            "gateway": "10.56.217.1"
+        }
+      }'
+----
+<1> The type is `bond`.
+<2> The `ifname` attribute specifies the name of the bond interface.
+<3> The `failover` attribute is mandatory for active-backup mode.
+<4> The `linksInContainer=true` flag tells the Bond CNI that the interfaces required are to be found inside the container. By default Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV/Multus.
+<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+
+[id="nw-sriov-cfg-creating-pod-using-interface_{context}"]
+== Creating a pod using a bond interface
+
+You can now test the setup by creating a pod using a bond interface.
+
+[source,yaml]
+----
+apiVersion: v1
+    kind: Pod
+    metadata:
+      name: bondpod1
+      namespace: demo
+      annotations:
+        k8s.v1.cni.cncf.io/networks: demo/sriovnet1, demo/sriovnet2, demo/bond-net1 <1>
+    spec:
+      containers:
+      - name: podexample
+        image: quay.io/openshift/origin-network-interface-bond-cni:4.9.0
+        command: ["/bin/bash", "-c", "sleep INF"]
+----
+<1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bond slaves.
+
+You can inspect the pod interfaces with the following command:
+[source,yaml]
+----
+$ oc rsh -n demo bondpod1
+sh-4.4#
+sh-4.4# ip a
+1: lo: <LOOPBACK,UP,LOWER_UP> mtu 65536 qdisc noqueue state UNKNOWN qlen 1000
+link/loopback 00:00:00:00:00:00 brd 00:00:00:00:00:00
+inet 127.0.0.1/8 scope host lo
+valid_lft forever preferred_lft forever
+3: eth0@if150: <BROADCAST,MULTICAST,UP,LOWER_UP,M-DOWN> mtu 1450 qdisc noqueue state UP
+link/ether 62:b1:b5:c8:fb:7a brd ff:ff:ff:ff:ff:ff
+inet 10.244.1.122/24 brd 10.244.1.255 scope global eth0
+valid_lft forever preferred_lft forever
+4: bond0: <BROADCAST,MULTICAST,UP,LOWER_UP400> mtu 1500 qdisc noqueue state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff
+inet 10.56.217.66/24 scope global bond0
+valid_lft forever preferred_lft forever
+43: net1: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <1>
+44: net2: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <2>
+----
+<1> The `net1` interface is based on an SR-IOV virtual function.
+<2> The `net2` interface is based on an SR-IOV virtual function.

--- a/networking/hardware_networks/using-pod-level-bonding.adoc
+++ b/networking/hardware_networks/using-pod-level-bonding.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="using-pod-level-bonding"]
+= Using pod-level bonding
+include::modules/common-attributes.adoc[]
+:context: using-pod-level-bonding
+
+toc::[]
+
+
+:FeatureName: Bond Container Network Interface (CNI)
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+Bonding at the pod level is vital to enable workloads inside pods that require high availability and more throughput. With pod-level bonding, you can create a bond interface from multiple single root I/O virtualization (SR-IOV) virtual function interfaces in a kernel mode interface. The SR-IOV virtual functions are passed into the pod and attached to a kernel driver.
+
+One scenario where pod level bonding is required is creating a bond interface from multiple SR-IOV virtual functions on different physical functions. Creating a bond interface from two different physical functions on the host can be used to achieve high availability and throughput at pod level.
+
+[NOTE]
+====
+The current functionality of Bond CNI is available only in active-backup mode - for further details, see link:https://bugzilla.redhat.com/show_bug.cgi?id=2037214[*BZ#2037214*].
+====
+
+For guidance on tasks such as creating a SR-IOV network, network policies, network attachment definitions and pods, see  xref:../../networking/hardware_networks/configuring-sriov-device.adoc#configuring-sriov-device[Configuring an SR-IOV network device].
+
+include::modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc[leveloffset=+1]


### PR DESCRIPTION
Jira ticket: https://issues.redhat.com/browse/TELCODOCS-365

Versions: for 4.10 and further releases.

Preview: https://deploy-preview-39555--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-pod-level-bonding