### PR TITLE
[enterprise-4.8] CNV-4971: Replace kubevirt api version with v1 version

### DIFF
--- a/modules/virt-about-runstrategies-vms.adoc
+++ b/modules/virt-about-runstrategies-vms.adoc
@@ -54,7 +54,7 @@ In {VirtProductName} clusters installed using installer-provisioned infrastructu
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
   RunStrategy: Always <1>

--- a/modules/virt-configuring-masquerade-mode-dual-stack.adoc
+++ b/modules/virt-configuring-masquerade-mode-dual-stack.adoc
@@ -21,7 +21,7 @@ When the virtual machine is running, incoming and outgoing traffic for the virtu
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: example-vm-ipv6

--- a/modules/virt-configuring-vm-live-migration-cli.adoc
+++ b/modules/virt-configuring-vm-live-migration-cli.adoc
@@ -24,7 +24,7 @@ $ oc edit vm <custom-vm> -n <my-namespace>
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: custom-vm

--- a/modules/virt-creating-a-service-from-a-virtual-machine.adoc
+++ b/modules/virt-creating-a-service-from-a-virtual-machine.adoc
@@ -44,7 +44,7 @@ This procedure presents an example of how to create, connect to, and expose a `S
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: vm-ephemeral
@@ -171,7 +171,7 @@ vmservice   ClusterIP   172.30.3.149   <none>        27017/TCP   2m
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: vm-connect

--- a/modules/virt-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
+++ b/modules/virt-creating-new-vm-from-cloned-pvc-using-datavolumetemplate.adoc
@@ -39,7 +39,7 @@ For example:
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/modules/virt-example-vm-node-placement-node-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-node-affinity.adoc
@@ -14,7 +14,7 @@ If possible, the scheduler avoids nodes that have the label `example-node-label-
 ----
 metadata:
   name: example-vm-node-affinity
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
   affinity:

--- a/modules/virt-example-vm-node-placement-node-selector.adoc
+++ b/modules/virt-example-vm-node-placement-node-selector.adoc
@@ -17,7 +17,7 @@ If there are no nodes that fit this description, the virtual machine is not sche
 ----
 metadata:
   name: example-vm-node-selector
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
   nodeSelector:

--- a/modules/virt-example-vm-node-placement-pod-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-pod-affinity.adoc
@@ -14,7 +14,7 @@ If possible, the VM is not scheduled on a node that has any pod with the label `
 ----
 metadata:
   name: example-vm-pod-affinity
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
   affinity:

--- a/modules/virt-example-vm-node-placement-tolerations.adoc
+++ b/modules/virt-example-vm-node-placement-tolerations.adoc
@@ -17,7 +17,7 @@ A virtual machine that tolerates a taint is not required to schedule onto a node
 ----
 metadata:
   name: example-vm-tolerations
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
   tolerations:

--- a/modules/virt-importing-vm-datavolume.adoc
+++ b/modules/virt-importing-vm-datavolume.adoc
@@ -54,7 +54,7 @@ the virtual machine image you want to import. In this example, a Fedora image is
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   creationTimestamp: null

--- a/modules/virt-initiating-vm-migration-cli.adoc
+++ b/modules/virt-initiating-vm-migration-cli.adoc
@@ -13,7 +13,7 @@ Initiate a live migration of a running virtual machine instance by creating a `V
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstanceMigration
 metadata:
   name: migration-job

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -63,7 +63,7 @@ generation: 5
 name: my-vmrestore
 namespace: default
 ownerReferences:
-- apiVersion: kubevirt.io/v1alpha3
+- apiVersion: kubevirt.io/v1
   blockOwnerDeletion: true
   controller: true
   kind: VirtualMachine

--- a/modules/virt-schedule-supported-cpu-model-vms.adoc
+++ b/modules/virt-schedule-supported-cpu-model-vms.adoc
@@ -13,7 +13,7 @@ You can configure a CPU model for a virtual machine (VM) or a virtual machine in
 +
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   name: myvmi

--- a/modules/virt-template-datavolume-vm.adoc
+++ b/modules/virt-template-datavolume-vm.adoc
@@ -9,7 +9,7 @@
 *example-dv-vm.yaml*
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   labels:

--- a/modules/virt-template-vm-config.adoc
+++ b/modules/virt-template-vm-config.adoc
@@ -7,7 +7,7 @@
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 metadata:
   name: example-vm

--- a/modules/virt-template-vmi-probe-config.adoc
+++ b/modules/virt-template-vmi-probe-config.adoc
@@ -7,7 +7,7 @@
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:

--- a/modules/virt-template-vmi-pxe-config.adoc
+++ b/modules/virt-template-vmi-pxe-config.adoc
@@ -7,7 +7,7 @@
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   creationTimestamp: null

--- a/modules/virt-template-windows-vmi.adoc
+++ b/modules/virt-template-windows-vmi.adoc
@@ -7,7 +7,7 @@
 
 [source,yaml]
 ----
-apiVersion: kubevirt.io/v1alpha3
+apiVersion: kubevirt.io/v1
 kind: VirtualMachineInstance
 metadata:
   labels:


### PR DESCRIPTION
Cherrypicked from 0cecf93a991547b9dbc7cc17a52b1173a86454bc xref: https://github.com/openshift/openshift-docs/pull/39339