### PR TITLE
[RHACS]: OCDOCS-2857 - RHACS 3.64 collector version

### DIFF
--- a/release_notes/364-release-notes.adoc
+++ b/release_notes/364-release-notes.adoc
@@ -72,5 +72,5 @@ Also includes `roxctl` for use in continuous integration (CI) systems.
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-| registry.redhat.io/rh-acs/collector:3.3.2-latest
+| registry.redhat.io/rh-acs/collector:3.3.1-latest
 |===


### PR DESCRIPTION
Preview link: https://deploy-preview-39592--osdocs.netlify.app/openshift-acs/latest/release_notes/364-release-notes.html

Original JIRA: [OSDOCS-2857](https://issues.redhat.com/browse/OSDOCS-2857)
Urgency: Low

Applies to:
- 3.65
- 3.66
- 3.67

<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
