### PR TITLE
OSDOCS-2988 - Updating the quick ROSA creation procedure

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly.adoc
@@ -46,28 +46,14 @@ When using `auto` mode, you can optionally specify the `-y` argument to bypass t
 +
 [source,terminal]
 ----
-$ rosa create cluster --cluster-name <cluster_name> --sts <1>
+$ rosa create cluster --cluster-name <cluster_name> --sts --mode auto <1>
 ----
 <1> Replace `<cluster_name>` with the name of your cluster.
 +
-[IMPORTANT]
+[NOTE]
 ====
-You must complete the following steps to create the Operator IAM roles and the OpenID Connect (OIDC) provider to move the state of the cluster to `ready`.
+When you specify `--mode auto`, the `rosa create cluster` command creates the cluster-specific Operator IAM roles and the OIDC provider automatically. The Operators use the OIDC provider to authenticate.
 ====
-
-. Create the cluster-specific Operator IAM roles:
-+
-[source,terminal]
-----
-$ rosa create operator-roles --mode auto --cluster <cluster_name|cluster_id>
-----
-
-. Create the OIDC provider that the cluster Operators use to authenticate:
-+
-[source,terminal]
-----
-$ rosa create oidc-provider --mode auto --cluster <cluster_name|cluster_id>
-----
 
 . Check the status of your cluster:
 +


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-2988. The pull request updates the "Creating a ROSA cluster with STS using the default options" procedure to use the `--mode auto` command when creating the cluster. With the latest version of the ROSA CLI, the cluster-specific operator roles and the OIDC provider are created automatically when the cluster is created.

The preview is [here](https://deploy-preview-39604--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly).