### PR TITLE
Removed three NICs from SR-IOV support table.

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -37,21 +37,6 @@
 |8086
 |158b
 
-|Intel
-|E810-CQDA2
-|8088
-|1592
-
-|Intel
-|E810-XXVDA2
-|8088
-|159b
-
-|Intel
-|E810-XXVDA4
-|8088
-|1593
-
 |Mellanox
 |MT27700 Family [ConnectX&#8209;4]
 |15b3


### PR DESCRIPTION
Removing Intel E810 network interface controllers from the SR-IOV support table.

Preview: https://deploy-preview-39606--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov#supported-devices_about-sriov