### PR TITLE
BZ2026814: Added support for NIC Mellanox ConnectX Lx 15b3:101f

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -76,4 +76,9 @@
 |MT28908 Family [ConnectX&#8209;6]
 |15b3
 |101b
+
+|Mellanox
+|MT28908 Family [ConnectX&#8209;6{nbsp}Lx]
+|15b3
+|101f
 |===


### PR DESCRIPTION
Added new NIC device to SR-IOV support table. 

4.9: https://bugzilla.redhat.com/show_bug.cgi?id=2026814
4.10: https://bugzilla.redhat.com/show_bug.cgi?id=2026813

Preview: https://deploy-preview-39607--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov#supported-devices_about-sriov


