### PR TITLE
BZ202918: Clarify the rebranding still includes Jaeger components.

### DIFF
--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -11,11 +11,13 @@ Result – If changed, describe the current user experience.
 [id="distr-tracing-rn-new-features_{context}"]
 == New features and enhancements {ProductName} 2.0.0
 
-This release marks the rebranding of Red Hat OpenShift Jaeger to {ProductName}.  This effort includes the following:
+This release marks the rebranding of Red Hat OpenShift Jaeger to {ProductName}. This name change is to reflect that the distributed tracing solution encompasses more than just Jaeger project components, but also Elasticsearch, AMQ Streams, and OpenTelemetry. The rebranding also allows for new technologies and components to be added in the future under the distributed tracing name.
 
-* Updates {ProductShortName} Operator to Jaeger 1.28.  Going forward, {ProductName} will only support the `stable` Operator channel. Channels for individual releases are no longer supported.
+This release includes the following:
 
-* Introduces a new OpenTelemetry Operator based on OpenTelemetry 0.33.  Note that this Operator is a Technology Preview.
+* Updates {ProductShortName} Operator to Jaeger 1.28. Going forward, {ProductName} will only support the `stable` Operator channel. Channels for individual releases are no longer supported.
+
+* Introduces a new OpenTelemetry Operator based on OpenTelemetry 0.33. Note that this Operator is a Technology Preview.
 
 * Adds support for OpenTelemetry protocol (OTLP) to the Query service.
 


### PR DESCRIPTION
Adding a sentence to the New Features topic that I hope addresses the confusion around whether Jaeger is still part of the distributed tracing solution.

BZ2029218 
BZ2029221 

Preview is here -> https://deploy-preview-39611--osdocs.netlify.app/openshift-enterprise/latest/jaeger/distributed-tracing-release-notes#distr-tracing-rn-new-features_distributed-tracing-release-notes