### PR TITLE
OSDOCS2647: Adding AWS GovCloud-specific installation topic

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -120,7 +120,7 @@ Topics:
     File: installing-aws-vpc
   - Name: Installing a private cluster on AWS
     File: installing-aws-private
-  - Name: Installing a cluster on AWS into a government or secret region
+  - Name: Installing a cluster on AWS into a government region
     File: installing-aws-government-region
   - Name: Installing a cluster on AWS into a China region
     File: installing-aws-china

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -1,12 +1,12 @@
 [id="installing-aws-government-region"]
-= Installing a cluster on AWS into a government or secret region
+= Installing a cluster on AWS into a government region
 include::modules/common-attributes.adoc[]
 :context: installing-aws-government-region
 
 toc::[]
 
 In {product-title} version {product-version}, you can install a cluster on
-Amazon Web Services (AWS) into a government or secret region. To configure the
+Amazon Web Services (AWS) into a government region. To configure the
 region, modify parameters in the `install-config.yaml` file before you
 install the cluster.
 
@@ -24,7 +24,7 @@ If you have an AWS profile stored on your computer, it must not use a temporary 
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-aws-about-government-region.adoc[leveloffset=+1]
-include::modules/installation-aws-regions-with-no-ami.adoc[leveloffset=+1]
+include::modules/installation-prereq-aws-private-cluster.adoc[leveloffset=+1]
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
@@ -34,8 +34,6 @@ include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
-
-include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 

--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -2,22 +2,50 @@
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
 
-[id="installation-aws-about-government-region_{context}"]
-= AWS government and secret regions
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws-gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
+endif::[]
 
-{product-title} supports deploying a cluster to
-link:https://aws.amazon.com/govcloud-us[AWS GovCloud (US)] regions and the link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Secret Region]. These regions are specifically designed for US government agencies at the federal, state, and
-local level, as well as contractors, educational institutions, and other US
-customers that must run sensitive workloads in the cloud.
+[id="installation-aws-about-gov-secret-region_{context}"]
+ifdef::aws-gov[]
+= AWS government regions
+endif::aws-gov[]
+ifdef::aws-secret[]
+= AWS secret region
+endif::aws-secret[]
 
-These regions do not have published {op-system-first} Amazon Machine Images (AMI) to select, so you
+ifdef::aws-gov[]
+{product-title} supports deploying a cluster to an link:https://aws.amazon.com/govcloud-us[AWS GovCloud (US)] region.
+endif::aws-gov[]
+
+ifdef::aws-secret[]
+{product-title} supports deploying a cluster to an link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Secret Region].
+endif::aws-secret[]
+
+ifdef::aws-secret[]
+The C2S Secret Region does not have a published {op-system-first} Amazon Machine Images (AMI) to select, so you
 must upload a custom AMI that belongs to that region.
+endif::aws-secret[]
 
+ifdef::aws-gov[]
 The following AWS GovCloud partitions are supported:
 
-* `us-gov-west-1`
 * `us-gov-east-1`
+* `us-gov-west-1`
+endif::aws-gov[]
 
+ifdef::aws-secret[]
 The following AWS Secret Region partition is supported:
 
 * `us-iso-east-1`
+endif::aws-secret[]
+
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws-gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
+endif::[]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -25,6 +25,11 @@ ifeval::["{context}" == "installing-aws-government-region"]
 :private:
 :gov:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:vpc:
+:private:
+:secret:
+endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :vpc:
 :private:
@@ -41,20 +46,20 @@ You can customize the installation configuration file (`install-config.yaml`) to
 your {product-title} cluster's platform or modify the values of the required
 parameters.
 
-ifndef::china,gov[]
+ifndef::china,gov,secret[]
 [IMPORTANT]
 ====
 This sample YAML file is provided for reference only. You must obtain your
 `install-config.yaml` file by using the installation program and modify it.
 ====
-endif::china,gov[]
+endif::china,gov,secret[]
 
-ifdef::china,gov[]
+ifdef::china,gov,secret[]
 [IMPORTANT]
 ====
 This sample YAML file is provided for reference only. Use it as a resource to enter parameter values into the installation configuration file that you created manually.
 ====
-endif::china,gov[]
+endif::china,gov,secret[]
 
 [source,yaml]
 ----
@@ -75,10 +80,14 @@ ifdef::gov[]
       - us-gov-west-1a
       - us-gov-west-1b
 endif::gov[]
-ifndef::gov,china[]
+ifdef::secret[]
+      - us-iso-east-1a
+      - us-iso-east-1b
+endif::secret[]
+ifndef::gov,china,secret[]
       - us-west-2a
       - us-west-2b
-endif::gov,china[]
+endif::gov,china,secret[]
       rootVolume:
         iops: 4000
         size: 500
@@ -102,9 +111,12 @@ endif::china[]
 ifdef::gov[]
       - us-gov-west-1c
 endif::gov[]
-ifndef::gov,china[]
+ifdef::secret[]
+      - us-iso-east-1a
+endif::secret[]
+ifndef::gov,china,secret[]
       - us-west-2c
-endif::gov,china[]
+endif::gov,china,secret[]
   replicas: 3
 metadata:
   name: test-cluster <1>
@@ -129,15 +141,18 @@ endif::openshift-origin[]
   - 172.30.0.0/16
 platform:
   aws:
-ifndef::gov,china[]
+ifndef::gov,china,secret[]
     region: us-west-2 <1>
-endif::gov,china[]
+endif::gov,china,secret[]
 ifdef::china[]
     region: cn-north-1 <1>
 endif::china[]
 ifdef::gov[]
     region: us-gov-west-1 <1>
 endif::gov[]
+ifdef::secret[]
+    region: us-iso-east-1 <1>
+endif::secret[]
     userTags:
       adminContact: jdoe
       costCenter: 7536
@@ -146,12 +161,12 @@ ifdef::vpc,restricted[]
     - subnet-1
     - subnet-2
     - subnet-3
-ifndef::gov,china[]
+ifndef::secret,china[]
     amiID: ami-96c6f8f7 <8>
-endif::gov,china[]
-ifdef::gov,china[]
+endif::secret,china[]
+ifdef::secret,china[]
     amiID: ami-96c6f8f7 <1> <8>
-endif::gov,china[]
+endif::secret,china[]
     serviceEndpoints: <9>
       - name: ec2
 ifndef::china[]
@@ -202,27 +217,27 @@ ifdef::openshift-origin[]
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
 endif::openshift-origin[]
 endif::restricted[]
-ifdef::gov[]
+ifdef::secret[]
 ifndef::openshift-origin[]
 additionalTrustBundle: | <14>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
 endif::openshift-origin[]
-endif::gov[]
+endif::secret[]
 ifdef::private[]
 ifdef::openshift-origin[]
 publish: Internal <12>
 endif::openshift-origin[]
 endif::private[]
-ifdef::gov[]
+ifdef::secret[]
 ifdef::openshift-origin[]
 additionalTrustBundle: | <13>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
 endif::openshift-origin[]
-endif::gov[]
+endif::secret[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
 additionalTrustBundle: | <14>
@@ -254,13 +269,13 @@ endif::restricted[]
 
 
 ----
-ifndef::gov,china[]
+ifndef::gov,secret,china[]
 <1> Required. The installation program prompts you for this value.
-endif::gov,china[]
-ifdef::gov,china[]
+endif::gov,secret,china[]
+ifdef::gov,secret,china[]
 <1> Required.
-endif::gov,china[]
-<2> Optional: Add this parameter to force the Cloud Credential Operator (CCO) to use the specified mode, instead of having the CCO dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the _Cloud Credential Operator_ entry in the _Platform Operators reference_ content.
+endif::gov,secret,china[]
+<2> Optional: Add this parameter to force the Cloud Credential Operator (CCO) to use the specified mode, instead of having the CCO dynamically try to determine the capabilities of the credentials. For details about CCO modes, see the _Cloud Credential Operator_ entry in the _Red Hat Operators reference_ content.
 <3> If you do not provide these parameters and values, the installation program
 provides the default value.
 <4> The `controlPlane` section is a single mapping, but the compute section is a
@@ -343,14 +358,14 @@ ifdef::openshift-origin[]
 <12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 endif::private[]
-ifdef::gov[]
+ifdef::secret[]
 ifndef::openshift-origin[]
 <14> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 <13> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
-endif::gov[]
+endif::secret[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
 <13> For `<local_registry>`, specify the registry domain name, and optionally the
@@ -387,6 +402,11 @@ ifeval::["{context}" == "installing-aws-government-region"]
 :!vpc:
 :!private:
 :!gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!vpc:
+:!private:
+:!secret:
 endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :!vpc:

--- a/modules/installation-aws-regions-with-no-ami.adoc
+++ b/modules/installation-aws-regions-with-no-ami.adoc
@@ -1,26 +1,29 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-china.adoc
-// * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
+// * installing/installing_aws/installing-aws-secret.adoc
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
 endif::[]
-ifeval::["{context}" == "installing-aws-government-region"]
-:aws-gov:
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
 endif::[]
+// ifeval::["{context}" == "installing-aws-government-region"]
+// :aws-gov:
+// endif::[]
 
 [id="installation-aws-regions-with-no-ami_{context}"]
-ifndef::aws-china,aws-gov[]
+ifndef::aws-china,aws-secret[]
 = AWS regions without a published {op-system} AMI
-endif::aws-china,aws-gov[]
+endif::aws-china,aws-secret[]
 
-ifdef::aws-china,aws-gov[]
-= Installation requirments
-endif::aws-china,aws-gov[]
+ifdef::aws-china,aws-secret[]
+= Installation requirements
+endif::aws-china,aws-secret[]
 
-ifndef::aws-china,aws-gov[]
+ifndef::aws-china,aws-secret[]
 You can deploy an {product-title} cluster to Amazon Web Services (AWS) regions
 without native support for a {op-system-first} Amazon Machine Image (AMI) or the
 AWS software development kit (SDK). If a
@@ -39,11 +42,11 @@ A region without native support for an {op-system} AMI is not available to
 select from the terminal during cluster creation because it is not published.
 However, you can install to this region by configuring the custom AMI in the
 `install-config.yaml` file.
-endif::aws-china,aws-gov[]
+endif::aws-china,aws-secret[]
 
-ifdef::aws-china,aws-gov[]
+ifdef::aws-china,aws-secret[]
 ifdef::aws-china[Red Hat does not publish a {op-system-first} Amazon Machine Image (AMI) for the AWS China regions.]
-ifdef::aws-gov[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS government or secret regions.]
+ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS secret region.]
 
 Before you can install the cluster, you must:
 
@@ -53,18 +56,21 @@ Before you can install the cluster, you must:
 
 You cannot use the {product-title} installation program to create the installation configuration file. The installer does not list an AWS region without native support for an {op-system} AMI.
 
-ifdef::aws-gov[]
+ifdef::aws-secret[]
 [IMPORTANT]
 ====
 If you are deploying to the C2S Secret Region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
 ====
-endif::aws-gov[]
+endif::aws-secret[]
 
-endif::aws-china,aws-gov[]
+endif::aws-china,aws-secret[]
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :!aws-china:
 endif::[]
-ifeval::["{context}" == "installing-aws-government-region"]
-:!aws-gov:
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
 endif::[]
+// ifeval::["{context}" == "installing-aws-government-region"]
+// :!aws-gov:
+// endif::[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -48,6 +48,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
 :aws:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :aws:
 endif::[]
@@ -1280,6 +1283,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
 :!aws:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws:
+endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :!aws:
 endif::[]
@@ -1392,4 +1398,3 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
 endif::[]
-

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -59,9 +59,6 @@ The installation program modifies your subnets to add the `kubernetes.io/cluster
 * You must enable the `enableDnsSupport` and `enableDnsHostnames` attributes in your VPC, so that the cluster can use the Route 53 zones that are attached to the VPC to resolve cluster's internal DNS records. See link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-support[DNS Support in Your VPC] in the AWS documentation.
 +
 If you prefer to use your own Route 53 hosted private zone, you must associate the existing hosted zone with your VPC prior to installing a cluster. You can define your hosted zone using the `platform.aws.hostedZone` field in the `install-config.yaml` file.
-ifndef::public[]
-* If you use a cluster with public access, you must create a public and a private subnet for each availability zone that your cluster uses. Each availability zone can contain no more than one public and one private subnet.
-endif::public[]
 
 ifndef::aws-china[]
 If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -38,6 +38,9 @@ endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
 :aws-gov:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
+endif::[]
 ifeval::["{context}" == "installing-aws-private"]
 :aws-private:
 endif::[]
@@ -51,14 +54,13 @@ endif::[]
 [id="installation-initializing-manual_{context}"]
 = Manually creating the installation configuration file
 
-ifndef::aws-china,aws-gov,azure-gov,ash,aws-private,azure-private,gcp-private[]
+ifndef::aws-china,aws-gov,aws-secret,ash,aws-private,azure-private,gcp-private[]
 For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
-endif::aws-china,aws-gov,azure-gov,ash,aws-private,azure-private,gcp-private[]
-ifdef::aws-china,aws-gov[]
-When installing {product-title} on Amazon Web Services (AWS) into a region
-requiring a custom {op-system-first} AMI, you must manually generate your
-installation configuration file.
-endif::aws-china,aws-gov[]
+endif::aws-china,aws-gov,aws-secret,ash,aws-private,azure-private,gcp-private[]
+ifdef::aws-china,aws-secret,aws-gov[]
+Installing the cluster requires that you manually generate the installation configuration file.
+//Made this update as part of feedback in PR3961. tl;dr Simply state you have to create the config file, instead of creating a number of conditions to explain why.
+endif::aws-china,aws-secret,aws-gov[]
 ifdef::azure-gov[]
 When installing {product-title} on Microsoft Azure into a government region, you
 must manually generate your installation configuration file.
@@ -69,9 +71,9 @@ endif::aws-private,azure-private,gcp-private[]
 
 .Prerequisites
 
-ifdef::aws-china,aws-gov[]
+ifdef::aws-china,aws-secret[]
 * You have uploaded a custom RHCOS AMI.
-endif::aws-china,aws-gov[]
+endif::aws-china,aws-secret[]
 * You have an SSH public key on your local machine to provide to the installation program. The key will be used for SSH authentication onto your cluster nodes for debugging and disaster recovery.
 * You have obtained the {product-title} installation program and the pull secret for your
 cluster.
@@ -118,12 +120,12 @@ mirror the repository.
 endif::restricted[]
 +
 
-ifndef::aws-china,aws-gov,ash[]
+ifndef::aws-china,aws-gov,aws-secret,ash,azure-gov[]
 [NOTE]
 ====
 For some platform types, you can alternatively run `./openshift-install create install-config --dir <installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
 ====
-endif::aws-china,aws-gov,ash[]
+endif::aws-china,aws-gov,aws-secret,ash,azure-gov[]
 ifdef::ash[]
 +
 Make the following modifications for Azure Stack Hub:
@@ -188,6 +190,9 @@ ifeval::["{context}" == "installing-aws-china-region"]
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
 :!aws-gov:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
 endif::[]
 ifeval::["{context}" == "installing-aws-private"]
 :!aws-private:

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -45,6 +45,10 @@ ifeval::["{context}" == "installing-aws-government-region"]
 :custom-config:
 :aws:
 endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:custom-config:
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :custom-config:
 :aws:
@@ -436,6 +440,10 @@ ifeval::["{context}" == "installing-aws-china-region"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
+:!custom-config:
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
 :!custom-config:
 :!aws:
 endif::[]

--- a/modules/installation-prereq-aws-private-cluster.adoc
+++ b/modules/installation-prereq-aws-private-cluster.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-government-region.adoc
+
+[id="installation-prereq-aws-private-cluster_{context}"]
+= Installation requirements
+
+Before you can install the cluster, you must:
+
+* Provide an existing private AWS VPC and subnets to host the cluster.
++
+Public zones are not supported in Route 53 in AWS GovCloud. As a result, clusters must be private when you deploy to an AWS government region.
+* Manually create the installation configuration file (`install-config.yaml`).

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -18,15 +18,27 @@ ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
 endif::[]
 
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
+endif::[]
+
 You can deploy a private {product-title} cluster that does not expose external endpoints. Private clusters are accessible from only an internal network and are not visible to the internet.
 
 ifdef::aws-gov[]
 [NOTE]
 ====
-Public zones are not supported in Route 53 in AWS GovCloud or Secret Regions. Therefore, clusters
-must be private if they are deployed to an AWS government or secret region.
+Public zones are not supported in Route 53 in an AWS GovCloud Region. Therefore, clusters
+must be private if they are deployed to an AWS GovCloud Region.
 ====
 endif::aws-gov[]
+
+ifdef::aws-secret[]
+[NOTE]
+====
+Public zones are not supported in Route 53 in an AWS Secret Region. Therefore, clusters
+must be private if they are deployed to an AWS Secret Region.
+====
+endif::aws-secret[]
 
 By default, {product-title} is provisioned to use publicly-accessible DNS and endpoints. A private cluster sets the DNS, Ingress Controller, and API server to private when you deploy your cluster. This means that the cluster resources are only accessible from your internal network and are not visible to the internet.
 
@@ -60,4 +72,8 @@ endif::[]
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :!aws-china:
+endif::[]
+
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
 endif::[]


### PR DESCRIPTION
CP to 4.10

This PR addresses [OSDOCS-2647](https://issues.redhat.com/browse/OSDOCS-2647). This is 1 of 2 PRs [1] for this feature work. With the addition of a published RHCOS AMI for the AWS GovCloud regions, the existing AWS Government and Secret [topic](https://docs.openshift.com/container-platform/4.9/installing/installing_aws/installing-aws-government-region.html) has to be separated into two distinct topics; one for GovCould regions and one for Secret regions. This PR is for the stand-alone gov topic.

**Material changes**
A majority of this topic remains unchanged from the previous version of the combined topic. This new topic:

1. Removes the requirement of uploading a custom RHOCS AWS AMI
2. Removes content/guidance that to is specific to configuring a cluster on an AWS secret region. 

Doc preview
[Installing a cluster on AWS into a government region](https://deploy-preview-39614--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region.html).

[1] New topic that is specific to installing to an AWS secret region is covererd by [PR 39769](https://github.com/openshift/openshift-docs/pull/39769)

