### PR TITLE
JIRA-OSDOCS2844: Added Limited Support status section to ROSA service definition

### DIFF
--- a/modules/rosa-sdpolicy-account-management.adoc
+++ b/modules/rosa-sdpolicy-account-management.adoc
@@ -130,6 +130,15 @@ The region and the choice of single or multiple availability zone cannot be chan
 == Service Level Agreement (SLA)
 Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20210503.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].
 
+
+[id="rosa-limited-support_{context}"]
+== Limited support status
+
+You must not remove or replace any native {product-title} components or any other component that is installed and managed by Red Hat. If using cluster administration rights, Red Hat is not responsible for any actions taken by you or any of your authorized users, including actions that might affect infrastructure services, service availability, and data loss.
+
+If any actions that affect infrastructure services, service availability, or data loss are detected, Red Hat will notify the customer of such and request either that the action be reverted or to create a support case to work with Red Hat to remedy any issues.
+
+
 [id="rosa-sdpolicy-support_{context}"]
 == Support
 {product-title} includes Red Hat Premium Support, which can be accessed by using the link:https://access.redhat.com/support?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Red Hat Customer Portal].


### PR DESCRIPTION
This PR is to address JIRA: https://issues.redhat.com/browse/OSDOCS-2844
Topic updated: https://deploy-preview-39620--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition#rosa-limited-support_rosa-service-definition
Exact change: Added the section 'Limited support status' similar to that in OpenShift Dedicated service definition. 
Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10