### PR TITLE
RHDEVDOCS-3566 - Added 4.6 for v1.3.1

### DIFF
--- a/modules/gitops-release-notes-1-3-1.adoc
+++ b/modules/gitops-release-notes-1-3-1.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-1_{context}"]
 = Release notes for {gitops-title} 1.3.1
 
-{gitops-title} 1.3.1 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.3.1 is now available on {product-title} 4.6, 4.7, 4.8, and 4.9.
 
 [id="fixed-issues-1-3-1_{context}"]
 == Fixed issues

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -15,7 +15,12 @@ In the table, features are marked with the following statuses:
 |*OpenShift GitOps* 6+|*Component Versions*|*OpenShift Versions*|*Support status*
 
 |*Version*|*kam*|*Helm*|*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*||
-|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.7-4.9|GA
+|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.6-4.9|GA
 |1.2.0|0.0.38|3.5.0|3.9.4|2.0.5|0.1.0|N/A|4.8|GA
 |1.1.0|0.0.32|3.5.0|3.9.4|2.0.0|N/A|N/A|4.7|GA
 |===
+
+[NOTE]
+====
+To use {gitops-title} v1.3 on {product-title} 4.6, do a fresh installation of {gitops-title}. There is no upgrade path from {gitops-title} 1.0 (TP) on OpenShift 4.6.
+====


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3566
Preview pages: https://deploy-preview-39622--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes
SME+QE review:
Peer-review: