### PR TITLE
Add links to Helm welcome page and SBO topics with minor edits

### DIFF
--- a/applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
+++ b/applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
@@ -31,3 +31,4 @@ include::modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-databa
 * xref:../../applications/connecting_applications_to_services/installing-sbo.adoc#installing-sbo[Installing Service Binding Operator].
 * xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating applications using the Developer perspective].
 * xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc[Managing resources from custom resource definitions].
+* link:https://github.com/redhat-developer/service-binding-operator#known-bindable-operators[Known bindable Operators]. 

--- a/applications/connecting_applications_to_services/odc-connecting-an-application-to-a-service-using-the-developer-perspective.adoc
+++ b/applications/connecting_applications_to_services/odc-connecting-an-application-to-a-service-using-the-developer-perspective.adoc
@@ -88,3 +88,4 @@ image::odc_context_operator.png[]
 
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/getting-started-with-service-binding.adoc#getting-started-with-service-binding[Getting started with service binding].
+* link:https://github.com/redhat-developer/service-binding-operator#known-bindable-operators[Known bindable Operators].

--- a/applications/connecting_applications_to_services/projecting-binding-data.adoc
+++ b/applications/connecting_applications_to_services/projecting-binding-data.adoc
@@ -19,3 +19,4 @@ include::modules/sbo-projecting-the-binding-data.adoc[leveloffset=+1]
 
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/exposing-binding-data-from-a-service.adoc#exposing-binding-data-from-a-service[Exposing binding data from a service].
+* link:https://redhat-developer.github.io/service-binding-operator/userguide/using-projected-bindings/using-projected-bindings.html[Using the projected binding data in the source code of the application].

--- a/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
+++ b/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
@@ -31,6 +31,7 @@ spec:
       group: apps
       version: v1
       resource: deployments
+EOD
 ----
 <1> Specifies a list of service resources.
 <2> The CR of the database.

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -153,7 +153,7 @@ The `odo` CLI tool lets developers create single or multi-component applications
 They use standard Tekton custom resources to automate deployments and are designed for decentralized teams that work on microservice-based architecture.
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
-- **Deploy Helm charts**:
+- **xref:../applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.html#installing-a-helm-chart-on-an-openshift-cluster_configuring-custom-helm-chart-repositories[Deploy Helm charts]**:
 xref:../applications/working_with_helm_charts/understanding-helm.adoc#understanding-helm[Helm] is a software package manager that simplifies deployment of applications and services to OpenShift Container Platform clusters. Helm uses a packaging format called charts. A Helm chart is a collection of files that describes the OpenShift Container Platform resources.
 
 - **xref:../cicd/builds/understanding-image-builds.adoc#understanding-image-builds[Understand image builds]**: Choose from different build strategies (Docker, S2I, custom, and pipeline) that can include different kinds of source materials (from places like Git repositories, local binary inputs, and external artifacts). Then, follow examples of build types from basic builds to advanced builds.


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.9`
- **JIRA issues**: [RHDEVDOCS-3528 - Add EOD to the end of the block in step 1; it is missing now](https://issues.redhat.com/browse/RHDEVDOCS-3528), [RHDEVDOCS-3563 - Add links under the additional resources section](https://issues.redhat.com/browse/RHDEVDOCS-3563), [RHDEVDOCS-3511 - Add a link to the `Deploy Helm charts` topic in the welcome page of OCP documentation](https://issues.redhat.com/browse/RHDEVDOCS-3511)
- **Preview pages**: [Developer activities](https://deploy-preview-39623--osdocs.netlify.app/openshift-enterprise/latest/welcome/index.html#developer-activities), [Additional Resources in the ODC Service Binding section](https://deploy-preview-39623--osdocs.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/odc-connecting-an-application-to-a-service-using-the-developer-perspective.html#additional-resources), [Additional Resources in the Getting started section](https://deploy-preview-39623--osdocs.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding.html#additional-resources), [Step 1 command snippet in the Connecting sample app to DB service procedure](https://deploy-preview-39623--osdocs.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding.html#connecting-the-spring-petclinic-sample-application-to-the-postgresql-database-service)
- **SME Review**: Approved by @zonggen 
- **QE review**: Approved by @pmacik
- **Peer-review**: Approved by @sounix000 