### PR TITLE
BZ2013910: Updating extra note section

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco-cli.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco-cli.adoc
@@ -5,13 +5,11 @@
 [id="troubleshooting-disabling-autoreboot-mco-cli_{context}"]
 = Disabling the Machine Config Operator from automatically rebooting by using the CLI
 
-To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can modify the machine config pool (MCP) using the  OpenShift CLI (oc) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process. 
+To avoid unwanted disruptions from changes made by the Machine Config Operator (MCO), you can modify the machine config pool (MCP) using the OpenShift CLI (oc) to prevent the MCO from making any changes to nodes in that pool. This prevents any reboots that would normally be part of the MCO update process.
 
 [NOTE]
 ====
-Pausing an MCP prevents the MCO from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires, and the MCO attempts to renew the certificate automatically, the new certificate is created but not applied across the nodes in the paused MCP. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only. 
-
-New CA certificates are generated at 292 days from the installation date and removed at 365 days from that date. To determine the next automatic CA certificate rotation, see the link:https://access.redhat.com/articles/5651701[Understand CA cert auto renewal in Red Hat OpenShift 4]. 
+See second `NOTE` in xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling the Machine Config Operator from automatically rebooting].
 ====
 
 .Prerequisites
@@ -21,7 +19,7 @@ New CA certificates are generated at 292 days from the installation date and rem
 
 .Procedure
 
-To pause or unpause automatic MCO update rebooting: 
+To pause or unpause automatic MCO update rebooting:
 
 * Pause the autoreboot process:
 
@@ -70,9 +68,9 @@ The `spec.paused` field is `true` and the MCP is paused.
 +
 .Example output
 ----
-NAME     CONFIG                                             UPDATED   UPDATING   
-master   rendered-master-33cf0a1254318755d7b48002c597bf91   True      False      
-worker   rendered-worker-e405a5bdb0db1295acea08bcca33fa60   False     False    
+NAME     CONFIG                                             UPDATED   UPDATING
+master   rendered-master-33cf0a1254318755d7b48002c597bf91   True      False
+worker   rendered-worker-e405a5bdb0db1295acea08bcca33fa60   False     False
 ----
 +
 If the *UPDATED* column is *False* and *UPDATING* is *False*, there are pending changes. When *UPDATED* is *True* and *UPDATING* is *False*, there are no pending changes. In the previous example, the worker node has pending changes. The control plane node does not have any pending changes.
@@ -82,7 +80,7 @@ If the *UPDATED* column is *False* and *UPDATING* is *False*, there are pending 
 If there are pending changes (where both the *Updated* and *Updating* columns are *False*), it is recommended to schedule a maintenance window for a reboot as early as possible. Use the following steps for unpausing the autoreboot process to apply the changes that were queued since the last reboot.
 ====
 
-* Unpause the autoreboot process: 
+* Unpause the autoreboot process:
 
 . Update the `MachineConfigPool` custom resource to set the `spec.paused` field to `false`.
 +

--- a/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco-console.adoc
@@ -9,9 +9,7 @@ To avoid unwanted disruptions from changes made by the Machine Config Operator (
 
 [NOTE]
 ====
-Pausing an MCP prevents the MCO from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically-rotated certificates from being pushed to the associated nodes, including the automatic rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires, and the MCO attempts to renew the certificate automatically, the new certificate is created but not applied across the nodes in the paused MCP. This causes failure in multiple `oc` commands, including but not limited to `oc debug`, `oc logs`, `oc exec`, and `oc attach`. Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
-
-New CA certificates are generated at 292 days from the installation date and removed at 365 days from that date. To determine the next automatic CA certificate rotation, see the link:https://access.redhat.com/articles/5651701[Understand CA cert auto renewal in Red Hat OpenShift 4].
+See second `NOTE` in xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues[Disabling the Machine Config Operator from automatically rebooting].
 ====
 
 .Prerequisites


### PR DESCRIPTION
For versions 4.9+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2013910

Preview: https://deploy-preview-39642--osdocs.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues#troubleshooting-disabling-autoreboot-mco-console_troubleshooting-operator-issues

Ready for QA: @rioliu-rh 

For peer reviewers: For Peer reviewers: Can you please add the labels: 'enterprise-4.9', 'enterprise-4.10' Thank you!