### PR TITLE
CNV-13829: CNV 4.10 Release Notes Shell - first draft

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2808,7 +2808,7 @@ Topics:
   File: virt-learn-more-about-openshift-virtualization
   Distros: openshift-origin
 - Name: OpenShift Virtualization release notes
-  File: virt-4-9-release-notes
+  File: virt-4-10-release-notes
   Distros: openshift-enterprise
 #- Name: OKD Virtualization release notes
 #  File: virt-4-9-release-notes

--- a/virt/virt-4-10-release-notes.adoc
+++ b/virt/virt-4-10-release-notes.adoc
@@ -1,0 +1,203 @@
+[id="virt-4-10-release-notes"]
+= {RN_BookName}
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-release-notes
+
+toc::[]
+
+== About Red Hat {VirtProductName}
+
+Red Hat {VirtProductName} enables you to bring traditional virtual machines (VMs) into {product-title} where they run alongside containers, and are managed as native Kubernetes objects.
+
+{VirtProductName} is represented by the image:Operator_Icon-OpenShift_Virtualization-5.png[{VirtProductName},40,40] logo.
+
+You can use {VirtProductName} with either the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] or the xref:../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShiftSDN] default Container Network Interface (CNI) network provider.
+
+Learn more about xref:../virt/about-virt.adoc#about-virt[what you can do with {VirtProductName}].
+
+include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
+
+[id="virt-guest-os"]
+=== Supported guest operating systems
+{VirtProductName} guests can use the following operating systems:
+
+* Red Hat Enterprise Linux 6, 7, and 8.
+* Red Hat Enterprise Linux 9 Alpha (Technology Preview).
+* Microsoft Windows Server 2012 R2, 2016, and 2019.
+* Microsoft Windows 10.
+
+Other operating system templates shipped with {VirtProductName} are not supported.
+
+//CNV-8167  Supported guest operating systems
+//CNV-13793 Supported guest OS
+
+[id="virt-4-10-inclusive-language"]
+== Making open source more inclusive
+
+Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
+
+[id="virt-4-10-new"]
+== New and changed features
+
+* OpenShift Virtualization is certified in Microsoft’s Windows Server Virtualization Validation Program (SVVP) to run Windows Server workloads.
++
+The SVVP Certification applies to:
++
+** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS__.
+** Intel and AMD CPUs.
+
+//CNV-13851 SVVP for 4.10: Ensure platform passes Windows Server Virtualization Validation Program - with RHCOS workers
+
+//CNV-13807 Release readiness and closure
+
+[id="virt-4-10-quick-starts"]
+=== Quick starts
+
+* Quick start tours are available for several {VirtProductName} features. To view the tours, click the *Help* icon *?* in the menu bar on the header of the {VirtProductName} console and then select *Quick Starts*. You can filter the available tours by entering the `virtualization` keyword in the *Filter* field.
+
+[id="virt-4-10-installation-new"]
+=== Installation
+
+//CNV-14192 Update launchers using live-migration - default/opt out
+
+//CNV-14910 HyperConverged Operator technical debt
+
+[id="virt-4-10-networking-new"]
+=== Networking
+
+//CNV-11201 Rollout of NodeNetworkConfigurationPolicy
+
+//CNV-13660 Inherit static IP from a NIC attached to the bridge
+
+//CNV-13679 SR-IOV live-migration without privilege escalation
+
+//CNV-13680 Primary and secondary networks over a shared NIC on OVN clusters
+
+//CNV-8577 CNV-14481 Service Mesh for VMs on the primary network with IPv4 (Done in CNV-8577 for 4.9 then reverted in CNV-14481)
+
+[id="virt-4-10-storage-new"]
+=== Storage
+
+[id="virt-4-10-web-new"]
+=== Web console
+
+// NOTE: no deprecated features in 4.10; commenting out these sections to retain for future use
+//[id="virt-4-10-deprecated-removed"]
+//== Deprecated and removed features
+
+//[id="virt-4-10-deprecated"]
+//=== Deprecated features
+
+//Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
+
+// NOTE: when uncommenting deprecated features list, change the header level below to ===
+
+//[id="virt-4-10-removed"]
+//=== Removed features
+
+//Removed features are not supported in the current release.
+
+// NOTE: no notable technical changes in 4.9, commenting out to retain
+//[id="virt-4-10-changes"]
+//== Notable technical changes
+
+[id="virt-4-10-technology-preview"]
+== Technology Preview features
+
+Some features in this release are currently in Technology Preview. These experimental features are not intended for production use. Note the following scope of support on the Red Hat Customer Portal for these features:
+
+link:https://access.redhat.com/support/offerings/techpreview[Technology Preview Features Support Scope]
+
+* You can now xref:../virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.adoc#virt-hot-plugging-virtual-disks[hot-plug and hot-unplug virtual disks] when you want to add or remove them from your virtual machine without stopping the virtual machine instance.
+
+* You can now use the Red Hat Enterprise Linux 9 Alpha template to create virtual machines.
+
+* You can now link:https://access.redhat.com/articles/6409731[deploy {VirtProductName} on AWS bare metal nodes].
+
+[id="virt-4-10-bug-fixes"]
+== Bug fixes
+
+[id="virt-4-10-known-issues"]
+== Known issues
+
+//Known issues at time of 4.9 release
+//BZ-2007397
+* If you hot-plug a virtual disk and then force delete the `virt-launcher` pod, you might lose data. This is due to a race condition that can cause the VM disk's contents to be wiped from the persistent volume. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2007397[*BZ#2007397*])
+
+// Review this for permanent doc home in 4.10
+* Editing a virtual machine fails if the VM references a deleted template that was provided by {VirtProductName} before version 4.8. In {VirtProductName} 4.8 and later, deleted {VirtProductName}-provided templates are automatically recreated by the {VirtProductName} Operator.
+
+* If a cloning operation is initiated before the source is available to be cloned, the operation stalls indefinitely. This is because the clone authorization expires before the cloning operation starts. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1855182[*BZ#1855182*])
++
+** As a workaround, delete the `DataVolume` object that is requesting the clone. When the source is available, recreate the `DataVolume` object that you deleted so that the cloning operation can complete successfully.
+
+* If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding to the default interface of a host because of a change in the host network topology of OVN-Kubernetes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1885605[*BZ#1885605*])
+
+** As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider.
+
+// Review this for permanent doc home in 4.10
+* Running virtual machines that cannot be live migrated might block an {product-title} cluster upgrade. This includes virtual machines that use hostpath provisioner storage or SR-IOV network interfaces.
+
+** As a workaround, you can reconfigure the virtual machines so that they can be powered off during a cluster upgrade. In the `spec` section of the virtual machine configuration file:
++
+. Remove the `evictionStrategy: LiveMigrate` field. See xref:../virt/live_migration/virt-configuring-vmi-eviction-strategy.adoc#virt-configuring-vmi-eviction-strategy[Configuring virtual machine eviction strategy] for more information on how to configure eviction strategy.
+. Set the `runStrategy` field to `Always`.
+
+** As a workaround, set the default CPU model by running the following command:
++
+[NOTE]
+====
+You must make this change before starting the virtual machines that support live migration.
+====
++
+[source,terminal]
+----
+$ oc annotate --overwrite -n openshift-cnv hyperconverged kubevirt-hyperconverged kubevirt.kubevirt.io/jsonpatch='[
+  {
+      "op": "add",
+      "path": "/spec/configuration/cpuModel",
+      "value": "<cpu_model>" <1>
+  }
+]'
+----
+<1> Replace `<cpu_model>` with the actual CPU model value. You can determine this value by running `oc describe node <node>` for all nodes and looking at the `cpu-model-<name>` labels. Select the CPU model that is present on all of your nodes.
+
+* If you enter the wrong credentials for the RHV Manager while importing a RHV VM, the Manager might lock the admin user account because the `vm-import-operator` tries repeatedly to connect to the RHV API. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1887140[*BZ#1887140*])
++
+** To unlock the account, log in to the Manager and enter the following command:
++
+[source,terminal]
+----
+$ ovirt-aaa-jdbc-tool user unlock admin
+----
+
+* If you run {VirtProductName} 2.6.5 with {product-title} 4.8 or later, various issues occur. You can avoid these issues by upgrading {VirtProductName} to version 4.8 or later.
++
+** In the web console, if you navigate to the *Virtualization* page and select *Create* -> *With YAML* the following error message is displayed:
++
+[source,text]
+----
+The server doesn't have a resource type "kind: VirtualMachine, apiVersion: kubevirt.io/v1"
+----
++
+*** As a workaround, edit the `VirtualMachine` manifest so the `apiVersion` is `kubevirt.io/v1alpha3`. For example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachine
+metadata:
+  annotations:
+...
+----
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1979114[*BZ#1979114*])
++
+** When connecting to the VNC console by using the {VirtProductName} web console, the VNC console always fails to respond.
++
+*** As a workaround, create the virtual machine from the CLI or upgrade to {VirtProductName} 4.8.
++
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1977037[*BZ#1977037*])
+
+//Known issues discovered after 4.9 release


### PR DESCRIPTION
Replaced by PR https://github.com/openshift/openshift-docs/pull/39857

Jira: https://issues.redhat.com/browse/CNV-13829

First draft of the shell for of the CNV 4.10 release notes. Dummy shell file PR to be staged shortly. Contains updated section IDs and New and Changed Feature markers as of 12/8/21.

**Note: I have not yet deleted the 4.9 release notes file from this build. Wasn't sure if I do this now or later.**

_Question: Do I update the {VirtVersion} variable?_

Tagging @ousleyp @sjhala-ccs for peer review before merge and pick.

Direct doc preview link: https://deploy-preview-39645--osdocs.netlify.app/openshift-enterprise/latest/virt/virt-4-10-release-notes.html