### PR TITLE
Adds a small note that talks about master and node versions matching

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -11,6 +11,32 @@
 The cluster also contains the definition for the bootstrap role. Because the bootstrap machine is used only during cluster installation, its function is explained in the cluster installation documentation.
 ====
 
+== Control plane and node host compatibility
+
+The {product-title} version must match between control plane host and node host. For example, in a 4.9 cluster, all control plane hosts must be 4.9 and all nodes must be 4.9.
+
+Temporary mismatches during cluster upgrades are acceptable. For example, when upgrading from {product-title} 4.8 to 4.9, some nodes will upgrade to 4.9 before others. Prolonged skewing of control plane hosts and node hosts might expose older compute machines to bugs and missing features. Users should resolve skewed control plane hosts and node hosts as soon as possible.
+
+The `kubelet` service must not be newer than `kube-apiserver`, and can be up to two minor versions older depending on whether your {product-title} version is odd or even. The table below shows the appropriate version compatibility:
+
+[cols="2",options="header"]
+|===
+| {product-title} version
+| Supported `kubelet` skew
+
+
+| Odd {product-title} minor versions ^[1]^
+| Up to one version older
+
+| Even {product-title} minor versions ^[2]^
+| Up to two versions older
+|===
+[.small]
+--
+1. For example, {product-title} 4.5, 4.7, 4.9.
+2. For example, {product-title} 4.6, 4.8, 4.10.
+--
+
 [id="defining-workers_{context}"]
 == Cluster workers
 


### PR DESCRIPTION
No BZ. Follow up to https://github.com/openshift/openshift-docs/pull/39184

Preview: https://deploy-preview-39647--osdocs.netlify.app/openshift-enterprise/latest/architecture/control-plane#control-plane-and-node-host-compatibility

SME ack'd in private slack message: 

W. Trevor King  4:03 PM
Both of those hit all the points I'm interested in 

Please check for formatting.