### PR TITLE
BZ1811047: Add RHCOS network teaming example

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -208,6 +208,25 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
+
+a|Optional: Network teaming can be used as an alternative to bonding by using the `team=` parameter. In this example:
+
+* The syntax for configuring a team interface is: `team=name[:network_interfaces]`
++
+_name_ is the team device name (`team0`) and _network_interfaces_ represents a comma-separated list of physical (ethernet) interfaces (`em1, em2`).
+
+[NOTE]
+====
+Teaming is planned to be deprecated when {op-system} switches to an upcoming version of {op-system-base}. For more information, see this https://access.redhat.com/solutions/6509691[Red Hat Knowledgebase Article].
+====
+
+a|
+To configure a network team:
+
+----
+team=team0:em1,em2
+ip=team0:dhcp
+----
 endif::ibm-z-kvm[]
 |===
 ifndef::ibm-z,ibm-z-kvm,ibm-power[]


### PR DESCRIPTION
This PR adds an entry in the table for network teaming configuration. The content closely resembles the content found in the [FCOS docs](https://docs.fedoraproject.org/en-US/fedora-coreos/sysconfig-network-configuration/#_configuring_a_team_dhcp).

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1811047

JIRA (additional info): https://issues.redhat.com/browse/OSDOCS-2247

OCP Version: 4.6+

Current 4.9 docs: https://docs.openshift.com/container-platform/4.9/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-routing-bonding_installing-platform-agnostic

Direct doc preview link: https://deploy-preview-39648--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-user-infra-machines-routing-bonding_installing-platform-agnostic