### PR TITLE
BZ2020144: Add an option to opm index add command

### DIFF
--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -36,11 +36,13 @@ endif::[]
 $ opm index add \
     --bundles <registry>/<namespace>/<new_bundle_image>@sha256:<digest> \//<1>
     --from-index <registry>/<namespace>/<existing_index_image>:<tag> \//<2>
-    --tag <registry>/<namespace>/<existing_index_image>:<tag> <3>
+    --tag <registry>/<namespace>/<existing_index_image>:<tag> \//<3>
+    --pull-tool podman <4>
 ----
 <1> A comma-separated list of additional bundle images to add to the index.
 <2> The existing index that was previously pushed.
 <3> The image tag that you want the updated index image to have.
+<4> A tool that pulls images for `opm index add`.
 
 . Push the updated index image:
 +


### PR DESCRIPTION
Fixes: [BZ2020144](https://bugzilla.redhat.com/show_bug.cgi?id=2020144)
OCP version: 4.8, 4.9, 4.10
QA contact: @Xia-Zhao-rh 
[Preview](https://deploy-preview-39660--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-updating-index-image_olm-restricted-networks)