### PR TITLE
NE-743: include upstream resolvers in the DNS Opertaor CRD

### DIFF
--- a/modules/nw-dns-forward.adoc
+++ b/modules/nw-dns-forward.adoc
@@ -5,7 +5,16 @@
 [id="nw-dns-forward_{context}"]
 = Using DNS forwarding
 
-You can use DNS forwarding to override the forwarding configuration identified in `/etc/resolv.conf` on a per-zone basis by specifying which name server should be used for a given zone. If the forwarded zone is the Ingress domain managed by {product-title}, then the upstream name server must be authorized for the domain.
+You can use DNS forwarding to override the default forwarding configuration in the `/etc/resolv.conf` file in the following ways:
+
+* Specify name servers for every zone. If the forwarded zone is the Ingress domain managed by {product-title}, then the upstream name server must be authorized for the domain.
+* Provide a list of upstream DNS servers.
+* Change the default forwarding policy.
+
+[NOTE]
+=====
+A DNS forwarding configuration for the default domain can have both the default servers specified in the `/etc/resolv.conf` file and the upstream DNS servers.
+=====
 
 .Procedure
 
@@ -16,7 +25,7 @@ You can use DNS forwarding to override the forwarding configuration identified i
 $ oc edit dns.operator/default
 ----
 +
-This allows the Operator to create and update the ConfigMap named `dns-default` with additional server configuration blocks based on `Server`. If none of the servers has a zone that matches the query, then name resolution falls back to the name servers that are specified in `/etc/resolv.conf`.
+This allows the Operator to create and update the ConfigMap named `dns-default` with additional server configuration blocks based on `Server`. If none of the servers has a zone that matches the query, then name resolution falls back to the upstream DNS servers.
 +
 .Sample DNS
 [source,yaml]
@@ -42,10 +51,24 @@ spec:
       upstreams:
         - 3.3.3.3
         - 4.4.4.4:5454
+  upstreamResolvers: <4>
+    policy: Random <5>
+    upstreams: <6>
+    - type: SystemResolvConf <7>
+    - type: Network
+      address: 1.2.3.4 <8>
+      port: 53 <9>
 ----
-<1> `name` must comply with the `rfc6335` service name syntax.
-<2> `zones` must conform to the definition of a `subdomain` in `rfc1123`. The cluster domain, `cluster.local`, is an invalid `subdomain` for `zones`.
+<1> Must comply with the `rfc6335` service name syntax.
+<2> Must conform to the definition of a `subdomain` in `rfc1123`. The cluster domain, `cluster.local`, is an invalid `subdomain` for `zones`.
 <3> A maximum of 15 `upstreams` is allowed per `forwardPlugin`.
+<4> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
+<5> Determines the order in which upstream servers are selected for querying. You can specify one of these values: `Random`, `RoundRobin`, and `Sequential`. The default value is `Sequential`.
+<6> Optional. You can use it to provide upstream resolvers.
+<7> You can specify two types of `upstreams` - `SystemResolvConf` and `Network`. `SystemResolvConf` is for configuring the upstream to use `/etc/resolv.conf` and `Network` is for defining a `Networkresolver`. You can specify one or both.
+<8> If the specified type is `Network`, you must provide an IP address. `address` must be a valid IPv4 or IPv6 address.
+<9> If the specified type is `Network`, you can optionally provide a port. `port` must be between 1 and 65535.
+
 +
 [NOTE]
 ====
@@ -80,8 +103,8 @@ data:
             fallthrough in-addr.arpa ip6.arpa
         }
         prometheus :9153
-        forward . /etc/resolv.conf {
-            policy sequential
+        forward . /etc/resolv.conf 1.2.3.4:53 {
+            policy Random
         }
         cache 30
         reload


### PR DESCRIPTION
**********
This PR was merged prematurely. Changes were reverted in the following PRs:

* `main` https://github.com/openshift/openshift-docs/pull/40546
* `enterprise-4.10` https://github.com/openshift/openshift-docs/pull/40548
* `enterprise-4.9` https://github.com/openshift/openshift-docs/pull/40547
**********


For 4.9+

https://issues.redhat.com/browse/NE-743

[Docs preview](https://deploy-preview-39661--osdocs.netlify.app/openshift-enterprise/latest/networking/dns-operator#nw-dns-forward_dns-operator)

Requires ack from @sherine-k @ShudiLi 