### PR TITLE
Update version number of legacy MTC operator for 1.5.3

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -43,4 +43,4 @@ endif::[]
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.6
 :mtc-legacy-version: 1.5
-:mtc-legacy-version-z: 1.5.1
+:mtc-legacy-version-z: 1.5.3


### PR DESCRIPTION
No Jira. No QE required. Peer review done - xref:https://github.com/openshift/openshift-docs/pull/39538

4.6+