### PR TITLE
BZ2018902: Adds removal of Prometheus UI link in 4.9 release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -813,6 +813,9 @@ Red Hat does not guarantee backward compatibility for metrics, recording rules, 
 * You can exclude individual user-defined projects from the `openshift-user-workload-monitoring` project by adding the `openshift.io/user-monitoring: "false"` label to them.
 * You can configure an `enforcedTargetLimit` parameter for the `openshift-user-workload-monitoring` project to set an overall limit on the number of targets scraped.
 
+==== Removed Prometheus UI link
+The link to the third-party Prometheus UI is removed from the *Observe → Metrics* page in the {product-title} web console. You can still access the route to the Prometheus UI in the web console in the *Administrator* perspective by navigating to the *Networking → Routes* page in the `openshift-monitoring` project.
+
 ==== Grafana
 
 Because running the default Grafana dashboard can take resources from user workloads, you can disable the Grafana dashboard deployment.


### PR DESCRIPTION
Added removal of Prometheus UI link section in 4.9 release notes.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2018902

OCP version: **applicable only to 4.9**

Doc preview: https://deploy-preview-39672--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#removed-prometheus-ui-link