### PR TITLE
BZ2004045: Rescanning creates four additional mc

### DIFF
--- a/modules/compliance-rescan.adoc
+++ b/modules/compliance-rescan.adoc
@@ -11,6 +11,22 @@ Typically you will want to re-run a scan on a defined schedule, like every Monda
 $ oc annotate compliancescans/<scan_name> compliance.openshift.io/rescan=
 ----
 
+A rescan generates four additional `mc` for `rhcos-moderate` profile:
+
+[source,terminal]
+----
+$ oc get mc
+----
+
+.Example output
+[source,terminal]
+----
+75-worker-scan-chronyd-or-ntpd-specify-remote-server
+75-worker-scan-configure-usbguard-auditbackend
+75-worker-scan-service-usbguard-enabled
+75-worker-scan-usbguard-allow-hid-and-hub
+----
+
 [IMPORTANT]
 ====
 When the scan setting `default-auto-apply` label is applied, remediations are applied automatically and outdated remediations automatically update. If there are remediations that were not applied due to dependencies, or remediations that had been outdated, rescanning applies the remediations and might trigger a reboot. Only remediations that use `MachineConfig` objects trigger reboots. If there are no updates or dependencies to be applied, no reboot occurs.

--- a/modules/compliance-review.adoc
+++ b/modules/compliance-review.adoc
@@ -5,7 +5,7 @@
 [id="compliance-review_{context}"]
 = Reviewing a remediation
 
-Review both the `ComplianceRemediation` object and the `ComplianceCheckResult` object that owns the remediation. The `ComplianceCheckResult` object contains human-readable descriptions of what the check does and the hardening trying to prevent, as well as other `metadata` like the severity and the associated security controls. The `ComplianceRemediation` object represents a way to fix the problem described in the `ComplianceCheckResult`.
+Review both the `ComplianceRemediation` object and the `ComplianceCheckResult` object that owns the remediation. The `ComplianceCheckResult` object contains human-readable descriptions of what the check does and the hardening trying to prevent, as well as other `metadata` like the severity and the associated security controls. The `ComplianceRemediation` object represents a way to fix the problem described in the `ComplianceCheckResult`. After first scan, check for remediations with the state `MissingDependencies`.
 
 Below is an example of a check and a remediation called `sysctl-net-ipv4-conf-all-accept-redirects`. This example is redacted to only show `spec` and `status` and omits `metadata`:
 


### PR DESCRIPTION
Rescanning creates four additional mc for profile
xccdf_org.ssgproject.content_profile_moderate

OCP version: 4.6, 4.7, 4.8, 4.9, 4.10
[BZ2004045](https://bugzilla.redhat.com/show_bug.cgi?id=2004045)
[Preview](https://deploy-preview-39673--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-advanced#compliance-rescan_compliance-advanced)
[preview2](https://deploy-preview-39673--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html#compliance-review_compliance-remediation)
QA contact: @sunilcio 