### PR TITLE
[enterprise-4.6] BZ1866692 Removed broken MITM transparent proxy information

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -140,10 +140,10 @@ additionalTrustBundle: | <4>
 ...
 ----
 <1> A proxy URL to use for creating HTTP connections outside the cluster. The
-URL scheme must be `http`. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpProxy` value.
-<2> A proxy URL to use for creating HTTPS connections outside the cluster. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must not specify an `httpsProxy` value.
-<3> A comma-separated list of destination domain names, domains, IP addresses, or
-other network CIDRs to exclude proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
+URL scheme must be `http`.
+<2> A proxy URL to use for creating HTTPS connections outside the cluster.
+<3> A comma-separated list of destination domain names, IP addresses, or
+other network CIDRs to exclude from proxying. Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass the proxy for all destinations.
 ifdef::vsphere,vmc[]
 You must include vCenter's IP address and the IP range that you use for its machines.
 endif::vsphere,vmc[]
@@ -154,7 +154,6 @@ Operator then creates a `trusted-ca-bundle` config map that merges the contents 
 with the {op-system} trust bundle. The `additionalTrustBundle` field is required unless
 the proxy's identity certificate is signed by an authority from the {op-system} trust
 bundle.
-If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Cherrypick of https://github.com/openshift/openshift-docs/pull/38550/

Note: language improvements from lines 145-146 are from https://github.com/openshift/openshift-docs/pull/32618.