### PR TITLE
BZ1999387: added a ref link

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -12,3 +12,7 @@ include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
 
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
+
+.Additional resources
+
+* See xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Accessing the hosts] for how to create a bastion host to access {product-title} instances and the control plane nodes with SSH.

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -21,6 +21,11 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 * SSH access to control plane hosts.
 * A backup directory containing both the etcd snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
 
+[IMPORTANT]
+====
+For non-recovery control plane nodes, it is not required to establish SSH connectivity or to stop the static pods. You can delete and recreate other non-recovery, control plane machines, one by one.
+====
+
 .Procedure
 
 . Select a control plane host to use as the recovery host. This is the host that you will run the restore operation on.


### PR DESCRIPTION
- Applies to 4.6+ versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1999387)
- [Preview](https://deploy-preview-39687--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state)
 @hasbro17 I have added the ref link in the **Additional resources** section.
@rgangwar@redhat.com please verify.

New update:
Added Caveat
@gangwgr  please check https://deploy-preview-39687--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html