### PR TITLE
BZ2023838: Adds better explanation of SCCs

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -10,7 +10,8 @@ Similar to the way that RBAC resources control user access, administrators can u
 
 Security context constraints allow an administrator to control:
 
-* Whether a pod can run privileged containers
+* Whether a pod can run privileged containers with the `allowPrivilegedContainer` flag.
+* Whether a pod is constrained with the `allowPrivilegeEscalation` flag.
 * The capabilities that a container can request
 * The use of host directories as volumes
 * The SELinux context of the container
@@ -55,7 +56,7 @@ ifndef::openshift-dedicated[]
 
 [WARNING]
 ====
-This SCC allows host access to namespaces, file systems, and PIDS. It should only be used by trusted pods. Grant with caution.
+This SCC allows host access to namespaces, file systems, and PIDs. It should only be used by trusted pods. Grant with caution.
 ====
 
 |`hostmount-anyuid`
@@ -110,12 +111,12 @@ The `privileged` SCC allows:
 
 [NOTE]
 ====
-Setting `privileged: true` in the pod specification does not select the `privileged` SCC. Setting `privileged: true` in the pod specification matches on the `allowPrivilegedContainer` field of an SCC.
+Setting `privileged: true` in the pod specification does not necessarily select the `privileged` SCC. The SCC that has `allowPrivilegedContainer: true` and has the highest prioritization will be chosen if the user has the permissions to use it.
 ====
 endif::[]
 
 |`restricted`
-|Denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace.  This is the most restrictive SCC and it is used by default for authenticated users.
+|Denies access to all host features and requires pods to be run with a UID, and SELinux context that are allocated to the namespace. This is the most restrictive SCC provided by a new installation and will be used by default for authenticated users.
 
 The `restricted` SCC:
 
@@ -125,6 +126,12 @@ The `restricted` SCC:
 * Requires that a pod is run with a pre-allocated MCS label
 * Allows pods to use any FSGroup
 * Allows pods to use any supplemental group
+
+[NOTE]
+====
+The restricted SCC is the most restrictive of the SCCs that ship by default with the system. However, you can create a custom SCC that is even more restrictive. For example, you can create an SCC that restricts `readOnlyRootFS` to `true` and `allowPrivilegeEscalation` to `false`.
+====
+
 |===
 
 [id="scc-settings_{context}"]
@@ -171,7 +178,7 @@ The containers use the capabilities from this default list, but pod manifest aut
 
 [NOTE]
 ====
-You can drop all capabilites from containers by setting the `requiredDropCapabilities` parameter to `ALL`. 
+You can drop all capabilites from containers by setting the `requiredDropCapabilities` parameter to `ALL`.
 ====
 
 [id="authorization-SCC-strategies_{context}"]


### PR DESCRIPTION
This PR is taken over from #38803. I have improvised the content to meet our writing standards.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2023838

OCE version: 4.6 +

Doc Preview link: https://deploy-preview-39717--osdocs.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-about_configuring-internal-oauth

@dbaker-rh and @xingxingxia PTAL and let me know if you have any comments.