### PR TITLE
BZ#2027477: IPVLAN not support DHCP

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -31,7 +31,7 @@ plug-in:
 
 |`ipam`
 |`object`
-|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
 
 |`ipMasq`
 |`boolean`
@@ -51,7 +51,7 @@ plug-in:
 
 |`hairpinMode`
 |`boolean`
-|Set to `true` to allow the virtual bridge to send an ethernet frame back through the virtual port it was received on. This mode is also known as _reflective relay_. The default value is `false`.
+|Set to `true` to allow the virtual bridge to send an Ethernet frame back through the virtual port it was received on. This mode is also known as _reflective relay_. The default value is `false`.
 
 |`promiscMode`
 |`boolean`

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -46,7 +46,7 @@ The following object describes the configuration parameters for the host-device 
 
 |`ipam`
 |`object`
-|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
 
 |====
 

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -34,7 +34,7 @@ plug-in:
 
 |`master`
 |`string`
-|The ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
+|The Ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
 
 |`mtu`
 |`integer`
@@ -42,7 +42,9 @@ plug-in:
 
 |`ipam`
 |`object`
-|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+
+Do not specify `dhcp`. Configuring IPVLAN with DHCP is not supported because IPVLAN interfaces share the MAC address with the host interface.
 
 |====
 
@@ -64,3 +66,4 @@ The following example configures an additional network named `ipvlan-net`:
     }
 }
 ----
+

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -31,7 +31,7 @@ plug-in:
 
 |`master`
 |`string`
-|The ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary ethernet interface is used.
+|The Ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary Ethernet interface is used.
 
 |`mtu`
 |`string`
@@ -39,7 +39,7 @@ plug-in:
 
 |`ipam`
 |`object`
-|The configuration object for the ipam CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
+|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
 
 |====
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2027477

----

See the row for `ipam` in the table for the [Configuration for an IPVLAN additional network](https://deploy-preview-39718--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-object_configuring-additional-network) procedure.