### PR TITLE
BZ2020573: Fix typo in pipelines release notes

### DIFF
--- a/modules/op-release-notes-1-5.adoc
+++ b/modules/op-release-notes-1-5.adoc
@@ -53,7 +53,7 @@ pruner:
 ...
 ----
 
-* In {product-title}, you can customize the installation of the Tekton Add-ons component by modifying the values of the new parameters `clusterTasks` and `pipelinesTemplates` in the `TektonConig` custom resource:
+* In {product-title}, you can customize the installation of the Tekton Add-ons component by modifying the values of the new parameters `clusterTasks` and `pipelinesTemplates` in the `TektonConfig` custom resource:
 +
 [source,yaml,subs="attributes+"]
 ----


### PR DESCRIPTION
Typo fixed per https://bugzilla.redhat.com/show_bug.cgi?id=2020573

Change applies to 4.8+

No QE required.

Preview build: https://deploy-preview-39719--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes#new-features-1-5_op-release-notes