### PR TITLE
BZ1970280: Use FQDN for oc adm catalog mirror

### DIFF
--- a/modules/connected-to-disconnected-mirror-images.adoc
+++ b/modules/connected-to-disconnected-mirror-images.adoc
@@ -7,7 +7,7 @@
 
 After the cluster is properly configured, you can mirror the images from your external repositories to the mirror repository.
 
-.Procedure 
+.Procedure
 
 . Mirror the Operator Lifecycle Manager (OLM) images:
 // copied from olm-mirroring-catalog.adoc
@@ -21,7 +21,7 @@ $ oc adm catalog mirror registry.redhat.io/redhat/redhat-operator-index:v{produc
 where:
 
 `product-version`:: Specifies the tag that corresponds to the version of {product-title} to install, such as `4.8`.
-`mirror_registry`:: Specifies the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry.
+`mirror_registry`:: Specifies the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry.
 `reg_creds`:: Specifies the location of your modified `.dockerconfigjson` file.
 --
 +
@@ -42,8 +42,8 @@ $ oc adm catalog mirror <index_image> <mirror_registry>:<port>/<namespace> -a <r
 --
 where:
 
-`index_image`:: Specifies the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`. 
-`mirror_registry`:: Specifies the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry.
+`index_image`:: Specifies the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+`mirror_registry`:: Specifies the FQDN for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry.
 `reg_creds`:: Optional: Specifies the location of your registry credentials file, if required.
 --
 +

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -72,7 +72,7 @@ $ oc adm catalog mirror \
     --index-filter-by-os='<platform>/<arch>' <.>
 ----
 <.> Specify the `file://` path from the previous command output.
-<.> Specify the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<.> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <.> Optional: If required, specify the location of your registry credentials file.
 <.> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <.> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -38,7 +38,7 @@ $ oc adm catalog mirror \
     [--manifests-only] <.>
 ----
 <1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<2> Specify the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1970280

Edits for `main`, 4.10, and 4.9 branches.

Preview:

* https://deploy-preview-39723--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#olm-mirror-catalog-colocated_installing-mirroring-installation-images
* https://deploy-preview-39723--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#olm-mirror-catalog-airgapped_installing-mirroring-installation-images
* https://deploy-preview-39723--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/connected-to-disconnected.html#connected-to-disconnected-mirror-images_connected-to-disconnected

Changes for 4.8 branch: https://github.com/openshift/openshift-docs/pull/39724
Changes for 4.7 branch: https://github.com/openshift/openshift-docs/pull/39780
Changes for 4.6 branch: https://github.com/openshift/openshift-docs/pull/39781