### PR TITLE
[enterprise-4.8] BZ1970280: Use FQDN for oc adm catalog mirror

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -75,7 +75,7 @@ $ oc adm catalog mirror \
     [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file. `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, and `.*`
@@ -151,7 +151,7 @@ $ oc adm catalog mirror \
     [--index-filter-by-os='<platform>/<arch>']
 ----
 <1> Specify the `file://` path from the previous command output.
-<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 +
 [NOTE]
 ====


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1970280

Preview: https://deploy-preview-39724--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks

xref: https://github.com/openshift/openshift-docs/pull/39723