### PR TITLE
BZ2030713 - Removing TP notice for PTP hardware

### DIFF
--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -5,9 +5,6 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Precision Time Protocol (PTP) hardware
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 [id="about-using-ptp-hardware"]
 == About PTP hardware
 


### PR DESCRIPTION
Removing tech preview notice for PTP. Merge to main, Cherry pick to enterprise-4.9, enterprise-4.10. Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2030713