### PR TITLE
[BZ2030713] - Updating TP notice for PTP hardware support in OCP 4.8

### DIFF
--- a/networking/configuring-ptp.adoc
+++ b/networking/configuring-ptp.adoc
@@ -5,24 +5,26 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Precision Time Protocol (PTP) hardware
-include::modules/technology-preview.adoc[leveloffset=+1]
+[NOTE]
+====
+PTP hardware with ordinary clock is generally available and fully supported in {product-title} {product-version}.
+====
 
 [id="about-using-ptp-hardware"]
 == About PTP hardware
 
-{product-title} includes the capability to use Precision Time Protocol (PTP)hardware on your nodes.
+{product-title} includes the capability to use Precision Time Protocol (PTP) hardware on your nodes.
 You can configure linuxptp services on nodes in your cluster that have PTP-capable hardware.
 
 [NOTE]
 ====
-The PTP Operator works with PTP-capable devices on clusters provisioned only on bare metal infrastructure.
+The PTP Operator works with PTP-capable devices on clusters provisioned only on bare-metal infrastructure.
 ====
 
-You can use the {product-title} console to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the linuxptp services. The Operator provides the following features:
+You can use the {product-title} console to install PTP by deploying the PTP Operator. The PTP Operator creates and manages the `linuxptp` services. The Operator provides the following features:
 
 * Discovery of the PTP-capable devices in a cluster.
-* Management of the configuration of linuxptp services.
+* Management of the configuration of `linuxptp` services.
 
 include::modules/nw-ptp-device-discovery.adoc[leveloffset=+1]
 include::modules/nw-ptp-installing-operator.adoc[leveloffset=+1]

--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2063,10 +2063,10 @@ In the table below, features are marked with the following statuses:
 |====
 |Feature |OCP 4.6 |OCP 4.7 |OCP 4.8
 
-|Precision Time Protocol (PTP)
+|Precision Time Protocol (PTP) hardware with ordinary clock
 |TP
 |TP
-|TP
+|GA
 
 |`oc` CLI plug-ins
 |TP


### PR DESCRIPTION
Updating TP notice for PTP hardware. Changes for OCP 4.8: 
* PTP hardware with ordinary clock is GA

**Merge to enterprise-4.8 only**

Previews:

https://deploy-preview-39734--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-technology-preview

https://deploy-preview-39734--osdocs.netlify.app/openshift-enterprise/latest/networking/configuring-ptp.html