### PR TITLE
[BZ2030713] - Updating TP notice for PTP hardware support in OCP 4.9 GA

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -6,7 +6,7 @@
 = Configuring linuxptp services as ordinary clock
 
 The PTP Operator adds the `PtpConfig.ptp.openshift.io` custom resource definition (CRD) to {product-title}.
-You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) by creating a `PtpConfig` custom resource (CR) object.
+You can configure the linuxptp services (`ptp4l`, `phc2sys`) by creating a `PtpConfig` custom resource (CR) object.
 
 .Prerequisites
 

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -5,13 +5,13 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Precision Time Protocol (PTP) hardware
+:FeatureName: Precision Time Protocol (PTP) hardware with single NIC configured as boundary clock
 include::modules/technology-preview.adoc[leveloffset=+1]
 
 [id="about-using-ptp-hardware"]
 == About PTP hardware
 
-{product-title} allows you use Precision Time Protocol (PTP) hardware on your nodes. You can configure linuxptp services on nodes that have PTP-capable hardware.
+{product-title} allows you use PTP hardware on your nodes. You can configure linuxptp services on nodes that have PTP-capable hardware.
 
 [NOTE]
 ====
@@ -47,19 +47,24 @@ include::modules/cnf-configuring-fifo-priority-scheduling-for-ptp.adoc[leveloffs
 
 include::modules/cnf-troubleshooting-common-ptp-operator-issues.adoc[leveloffset=+1]
 
-include::modules/cnf-about-ptp-and-clock-synchronization.adoc[leveloffset=+1]
+== PTP hardware fast event notifications framework
 
-include::modules/cnf-about-ptp-fast-event-notifications-framework.adoc[leveloffset=+1]
+:FeatureName: PTP events with ordinary clock
+include::modules/technology-preview.adoc[leveloffset=+2]
 
-include::modules/cnf-installing-amq-interconnect-messaging-bus.adoc[leveloffset=+1]
+include::modules/cnf-about-ptp-and-clock-synchronization.adoc[leveloffset=+2]
 
-include::modules/cnf-configuring-the-ptp-fast-event-publisher.adoc[leveloffset=+1]
+include::modules/cnf-about-ptp-fast-event-notifications-framework.adoc[leveloffset=+2]
 
-include::modules/cnf-fast-event-notifications-api-refererence.adoc[leveloffset=+1]
+include::modules/cnf-installing-amq-interconnect-messaging-bus.adoc[leveloffset=+2]
 
-include::modules/cnf-monitoring-fast-events-metrics-using-cli.adoc[leveloffset=+1]
+include::modules/cnf-configuring-the-ptp-fast-event-publisher.adoc[leveloffset=+2]
 
-include::modules/cnf-ptp-fast-event-metrics-in-prometheus.adoc[leveloffset=+1]
+include::modules/cnf-fast-event-notifications-api-refererence.adoc[leveloffset=+2]
+
+include::modules/cnf-monitoring-fast-events-metrics-using-cli.adoc[leveloffset=+2]
+
+include::modules/cnf-ptp-fast-event-metrics-in-prometheus.adoc[leveloffset=+2]
 
 .Additional resources
 

--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -1683,9 +1683,19 @@ In the table below, features are marked with the following statuses:
 |====
 |Feature |OCP 4.7 |OCP 4.8 |OCP 4.9
 
-|Precision Time Protocol (PTP)
+|Precision Time Protocol (PTP) hardware configured as ordinary clock
 |TP
+|GA
+|GA
+
+|PTP single NIC hardware configured as boundary clock
+|-
+|-
 |TP
+
+|PTP events with ordinary clock
+|-
+|-
 |TP
 
 |`oc` CLI plug-ins


### PR DESCRIPTION
Updating TP notices for PTP hardware. Changes for OCP 4.9:

* Single NIC PTP hardware configured as boundary clock is TP
* PTP events with ordinary clock is TP

**Merge to enterprise-4.9 only**

Previews:

https://deploy-preview-39735--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-technology-preview

https://deploy-preview-39735--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html

https://deploy-preview-39735--osdocs.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#ptp-hardware-fast-event-notifications-framework