### PR TITLE
Update UPI TP support statements for WMCO 3.1+ to GA

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -21,19 +21,19 @@ The following information details the supported platform versions, Windows Serve
 |4.6+
 |WMCO 1.0+
 |GA
-|Tech Preview
+|GA
 
 |Microsoft Azure
 |4.6+
 |WMCO 1.0+
 |GA
-|Tech Preview
+|GA
 
 |VMware vSphere
 |4.7+
 |WMCO 2.0+
 |GA
-|Tech Preview
+|GA
 |===
 
 == Supported platforms for Bring-Your-Own-Host (BYOH) instances based on {product-title} and WMCO versions
@@ -50,30 +50,26 @@ The following information details the supported platform versions, Windows Serve
 |4.8+
 |WMCO 3.1+
 |GA
-|Tech Preview
+|GA
 
 |Microsoft Azure
 |4.8+
 |WMCO 3.1+
 |GA
-|Tech Preview
+|GA
 
 |VMware vSphere
 |4.8+
 |WMCO 3.1+
 |GA
-|GA^[1]^
+|GA
 
 |bare metal
 |4.8+
 |WMCO 3.1+
 |
-|GA^[1]^
+|GA
 |===
-[.small]
---
-1. This installation type is only supported when the `platform: none` field is set in the `install-config.yaml` file during cluster installation.
---
 
 == Supported Windows Server versions
 


### PR DESCRIPTION
After additional testing post-release, the UPI related Tech Preview statements for WINC have been requested for upgrade to GA.

Preview: https://deploy-preview-39754--osdocs.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-4-x.html#supported-platforms-based-on-openshift-container-platform-and-wmco-versions