### PR TITLE
BZ-2029667: Updating networking.MachineCIDR to networking.machineNetwork[].cidr first draft

### DIFF
--- a/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
+++ b/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
@@ -18,7 +18,8 @@ baseDomain: <domain>
 metadata:
   name: <cluster_name>
 networking:
-  machineCIDR: <public_cidr>
+  machineNetwork:
+  - cidr: <public-cidr>
   networkType: OVNKubernetes
 compute:
 - name: worker

--- a/modules/installation-osp-restricted-config-yaml.adoc
+++ b/modules/installation-osp-restricted-config-yaml.adoc
@@ -34,7 +34,8 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   serviceNetwork:
   - 172.30.0.0/16
 ifndef::openshift-origin[]

--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -43,7 +43,8 @@ metadata:
 a|
 ----
 networking:
-    machineCIDR:
+    machineNetwork:
+    - cidr:
 ----
 |
 |The public CIDR (Classless Inter-Domain Routing) of the external network. For example, `10.0.0.0/24`

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -18,7 +18,8 @@ baseDomain: <domain>
 metadata:
   name: <cluster-name>
 networking:
-  machineCIDR: <public-cidr>
+  machineNetwork: 
+  - cidr: <public-cidr>
   networkType: OVNKubernetes
 compute:
 - name: worker

--- a/modules/recommended-install-practices.adoc
+++ b/modules/recommended-install-practices.adoc
@@ -15,7 +15,8 @@ networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
-  machineCIDR: 10.0.0.0/16
+  machineNetwork:
+  - cidr: 10.0.0.0/16
   networkType: OpenShiftSDN
   serviceNetwork:
   - 172.30.0.0/16


### PR DESCRIPTION
This applies to 4.10 and needs cherrypicked to 4.9. 
Addressing https://bugzilla.redhat.com/show_bug.cgi?id=2029667. 
Updating networking.MachineCIDR to networking.machineNetwork[].cidr in a number of files

Preview files: 

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-install-practices.html

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/optimizing-networking.html#recommended-install-practices_optimizing-networking

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.html#configuring-the-install-config-file_install-ibm-cloud-installation-workflow

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-installation-workflow.html#additional-install-config-parameters_install-ibm-cloud-installation-workflow

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-restricted.html#installation-osp-restricted-config-yaml_installing-openstack-installer-restricted

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-configuration-files

- https://deploy-preview-39757--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#additional-install-config-parameters_ipi-install-configuration-files
