### PR TITLE
OSDOCS2647: Adding AWS secret-specific installation topic

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -133,6 +133,8 @@ Topics:
     File: installing-aws-private
   - Name: Installing a cluster on AWS into a government region
     File: installing-aws-government-region
+  - Name: Installing a cluster on AWS into a Top Secret Region
+    File: installing-aws-secret-region
   - Name: Installing a cluster on AWS into a China region
     File: installing-aws-china
   - Name: Installing a cluster on AWS using CloudFormation templates

--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -1,16 +1,14 @@
 :_content-type: ASSEMBLY
-[id="installing-aws-government-region"]
-= Installing a cluster on AWS into a government region
+[id="installing-aws-secret-region"]
+= Installing a cluster on AWS into a Top Secret Region
 include::modules/common-attributes.adoc[]
-:context: installing-aws-government-region
+:context: installing-aws-secret-region
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-Amazon Web Services (AWS) into a government region. To configure the
-region, modify parameters in the `install-config.yaml` file before you
-install the cluster.
+In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) into a Commercial Cloud Services (C2S) Top Secret Region. To configure the region, modify parameters in the `install config.yaml` file before you install the cluster.
 
+[id="prerequisites_installing-aws-secret-region"]
 == Prerequisites
 
 * You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
@@ -19,14 +17,14 @@ install the cluster.
 +
 [IMPORTANT]
 ====
-If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multi-factor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
+If you have an AWS profile stored on your computer, it must not use a temporary session token that you generated while using a multifactor authentication device. The cluster continues to use your current AWS credentials to create AWS resources for the entire life of the cluster, so you must use long-lived credentials. To generate appropriate keys, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_credentials_access-keys.html[Managing Access Keys for IAM Users] in the AWS documentation. You can supply the keys when you run the installation program.
 ====
 * If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
 include::modules/installation-aws-about-government-region.adoc[leveloffset=+1]
 
-include::modules/installation-prereq-aws-private-cluster.adoc[leveloffset=+1]
+include::modules/installation-aws-regions-with-no-ami.adoc[leveloffset=+1]
 
 include::modules/private-clusters-default.adoc[leveloffset=+1]
 include::modules/private-clusters-about-aws.adoc[leveloffset=+2]
@@ -35,16 +33,16 @@ include::modules/installation-custom-aws-vpc.adoc[leveloffset=+1]
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
+include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
-include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
-
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
@@ -56,6 +54,7 @@ include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
 include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_installing-aws-secret-region_console"]
 .Additional resources
 
 * See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console.
@@ -63,10 +62,12 @@ include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
+[id="additional-resources_installing-aws-secret-region_telemetry"]
 .Additional resources
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
+[id="next-steps_installing-aws-secret-region"]
 == Next steps
 
 * xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -6,6 +6,7 @@
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -36,6 +36,7 @@
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-china-region.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc

--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 
 ifeval::["{context}" == "installing-aws-government-region"]
 :aws-gov:
@@ -14,7 +15,7 @@ ifdef::aws-gov[]
 = AWS government regions
 endif::aws-gov[]
 ifdef::aws-secret[]
-= AWS secret region
+= AWS Top Secret Region
 endif::aws-secret[]
 
 ifdef::aws-gov[]
@@ -22,11 +23,11 @@ ifdef::aws-gov[]
 endif::aws-gov[]
 
 ifdef::aws-secret[]
-{product-title} supports deploying a cluster to an link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Secret Region].
+{product-title} supports deploying a cluster to an link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Top Secret Region].
 endif::aws-secret[]
 
 ifdef::aws-secret[]
-The C2S Secret Region does not have a published {op-system-first} Amazon Machine Images (AMI) to select, so you
+The C2S Top Secret Region does not have a published {op-system-first} Amazon Machine Images (AMI) to select, so you
 must upload a custom AMI that belongs to that region.
 endif::aws-secret[]
 
@@ -38,7 +39,7 @@ The following AWS GovCloud partitions are supported:
 endif::aws-gov[]
 
 ifdef::aws-secret[]
-The following AWS Secret Region partition is supported:
+The following AWS Top Secret Region partition is supported:
 
 * `us-iso-east-1`
 endif::aws-secret[]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -2,6 +2,7 @@
 //
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
@@ -113,6 +114,7 @@ ifdef::gov[]
 endif::gov[]
 ifdef::secret[]
       - us-iso-east-1a
+      - us-iso-east-1b
 endif::secret[]
 ifndef::gov,china,secret[]
       - us-west-2c
@@ -360,10 +362,10 @@ endif::openshift-origin[]
 endif::private[]
 ifdef::secret[]
 ifndef::openshift-origin[]
-<14> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+<14> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+<13> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 endif::secret[]
 ifdef::restricted[]

--- a/modules/installation-aws-regions-with-no-ami.adoc
+++ b/modules/installation-aws-regions-with-no-ami.adoc
@@ -2,7 +2,7 @@
 //
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
-// * installing/installing_aws/installing-aws-secret.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
@@ -10,9 +10,6 @@ endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
 :aws-secret:
 endif::[]
-// ifeval::["{context}" == "installing-aws-government-region"]
-// :aws-gov:
-// endif::[]
 
 [id="installation-aws-regions-with-no-ami_{context}"]
 ifndef::aws-china,aws-secret[]
@@ -46,7 +43,7 @@ endif::aws-china,aws-secret[]
 
 ifdef::aws-china,aws-secret[]
 ifdef::aws-china[Red Hat does not publish a {op-system-first} Amazon Machine Image (AMI) for the AWS China regions.]
-ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS secret region.]
+ifdef::aws-secret[Red Hat does not publish a {op-system-first} Amzaon Machine Image for the AWS Top Secret Region.]
 
 Before you can install the cluster, you must:
 
@@ -59,7 +56,7 @@ You cannot use the {product-title} installation program to create the installati
 ifdef::aws-secret[]
 [IMPORTANT]
 ====
-If you are deploying to the C2S Secret Region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
+You must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
 ====
 endif::aws-secret[]
 
@@ -71,6 +68,3 @@ endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
 :!aws-secret:
 endif::[]
-// ifeval::["{context}" == "installing-aws-government-region"]
-// :!aws-gov:
-// endif::[]

--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
+// * installing/installing_aws/installing-aws-china.adoc
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
 // * installing/installing_azure/installing-azure-customizations.adoc

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing-aws-customizations.adoc
-// * installing/installing_aws/installing-aws-network-customizations.adoc
-// * installing/installing_aws/installing-aws-private.adoc
-// * installing/installing_aws/installing-aws-vpc.adoc
-// * installing/installing_aws/installing-aws-china.adoc
+// * installing/installing_aws/installing_aws-customizations.adoc
+// * installing/installing_aws/installing_aws-network-customizations.adoc
+// * installing/installing_aws/installing_aws-private.adoc
+// * installing/installing_aws/installing_aws-vpc.adoc
+// * installing/installing_aws/installing_aws-china.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc

--- a/modules/installation-custom-aws-vpc.adoc
+++ b/modules/installation-custom-aws-vpc.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 
@@ -9,6 +10,9 @@ ifeval::["{context}" == "installing-aws-china-region"]
 endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :public:
+endif::[]
+ifeval::["{context}" == "installing-aws-secret-region"]
+:aws-secret:
 endif::[]
 
 :_content-type: CONCEPT
@@ -61,13 +65,13 @@ The installation program modifies your subnets to add the `kubernetes.io/cluster
 +
 If you prefer to use your own Route 53 hosted private zone, you must associate the existing hosted zone with your VPC prior to installing a cluster. You can define your hosted zone using the `platform.aws.hostedZone` field in the `install-config.yaml` file.
 
-ifndef::aws-china[]
+ifndef::aws-china,aws-secret[]
 If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:
 
 * `ec2.<region>.amazonaws.com`
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
-endif::aws-china[]
+endif::aws-china,aws-secret[]
 
 ifdef::aws-china[]
 If you are working in a disconnected environment, you are unable to reach the public IP addresses for EC2 and ELB endpoints. To resolve this, you must create a VPC endpoint and attach it to the subnet that the clusters are using. The endpoints should be named as follows:
@@ -76,6 +80,13 @@ If you are working in a disconnected environment, you are unable to reach the pu
 * `elasticloadbalancing.<region>.amazonaws.com`
 * `s3.<region>.amazonaws.com`
 endif::aws-china[]
+
+ifdef::aws-secret[]
+* A cluster in a Top Secret Region is unable to reach the public IP addresses for the EC2 and ELB endpoints. You must create a VPC endpoint and attach it to the subnet that the clusters are using. Name the endpoints as follows:
+** `elasticloadbalancing.<region>.c2s.ic.gov`
+** `ec2.<region>.c2s.ic.gov`
+** `s3.<region>.c2s.ic.gov`
+endif::aws-secret[]
 
 .Required VPC components
 
@@ -178,6 +189,7 @@ If you deploy {product-title} to an existing network, the isolation of cluster s
 //You can restrict ingress to the control plane and compute security groups by either adding the security groups to an SSH bastion instance or altering rules to allow the bastion.
 * Control plane TCP 6443 ingress (Kubernetes API) is allowed to the entire network.
 * Control plane TCP 22623 ingress (MCS) is allowed to the entire network.
+//This should be restricted to the control plane and compute security groups, instead of the current by-VPC-CIDR logic to avoid leaking sensitive Ignition configs to non-cluster entities sharing the VPC.
 
 ifeval::["{context}" == "installing-aws-china-region"]
 :!aws-china:
@@ -185,4 +197,6 @@ endif::[]
 ifeval::["{context}" == "installing-aws-vpc"]
 :!public:
 endif::[]
-//This should be restricted to the control plane and compute security groups, instead of the current by-VPC-CIDR logic to avoid leaking sensitive Ignition configs to non-cluster entities sharing the VPC.
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!aws-secret:
+endif::[]

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-private.adoc

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
 // * installing/installing_azure/installing-azure-customizations.adoc

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-aws-private.adoc

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // *installing/installing_aws/installing-aws-china.adoc.
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // *installing/validating-an-installation.adoc
 // *installing/installing_aws/installing-aws-user-infra.adoc
 // *installing/installing_aws/installing-restricted-networks-aws.adoc

--- a/modules/private-clusters-about-aws.adoc
+++ b/modules/private-clusters-about-aws.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * post_installation_configuration/node-tasks.adoc
 

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -3,6 +3,7 @@
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_gcp/installing-gcp-private.adoc
 // * installing/installing_azure/installing-azure-government-region.adoc
 // * installing/installing_azure/installing-azure-private.adoc
@@ -35,8 +36,8 @@ endif::aws-gov[]
 ifdef::aws-secret[]
 [NOTE]
 ====
-Public zones are not supported in Route 53 in an AWS Secret Region. Therefore, clusters
-must be private if they are deployed to an AWS Secret Region.
+Public zones are not supported in Route 53 in an AWS Top Secret Region. Therefore, clusters
+must be private if they are deployed to an AWS Top Secret Region.
 ====
 endif::aws-secret[]
 

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
+// * installing/installing_aws/installing-aws-secret-region.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-private.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc


### PR DESCRIPTION
CP to 4.10

This PR addresses [OSDOCS-2647](https://issues.redhat.com/browse/OSDOCS-2647). This is 1 of 2 PRs[1] for this feature work. With the addition of a published RHCOS AMI for the AWS GovCloud regions, the existing AWS Government and Secret [topic](https://docs.openshift.com/container-platform/4.9/installing/installing_aws/installing-aws-government-region.html) has to be separated into two distinct topics; one for GovCould regions and one for Secret regions. This PR is for the stand-alone secret topic.

**Material changes**
A majority of this topic remains unchanged from the previous version of the combined topic. This new topic:

1. Removes content/guidance that to is specific to configuring a cluster on an AWS gov region.
2. Updates the installation configuration sample yaml section with a secret-specific region.

**Doc preview**
[Installing a cluster on AWS into a secret region](https://deploy-preview-39769--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region#:~:text=Installing%20a%20cluster%20on%20AWS%20into%20a%20secret%20region)

[1] New topic that is specific to installing to an AWS gov region is covered [PR 39614](https://github.com/openshift/openshift-docs/pull/39614).