### PR TITLE
BZ2016892 Remove reboot note on ImageContentSourcePolicy change

### DIFF
--- a/modules/olm-mirroring-catalog-icsp.adoc
+++ b/modules/olm-mirroring-catalog-icsp.adoc
@@ -18,9 +18,4 @@ $ oc create -f <path/to/manifests/dir>/imageContentSourcePolicy.yaml
 +
 where `<path/to/manifests/dir>` is the path to the manifests directory for your mirrored content.
 +
-[NOTE]
-====
-Applying the ICSP causes all worker nodes in the cluster to restart. You must wait for this reboot process to finish cycling through each of your worker nodes before proceeding.
-====
-
 You can now create a `CatalogSource` object to reference your mirrored index image and Operator content.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2016892

Applies to 4.8+

Preview build: https://deploy-preview-39771--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html#olm-mirror-catalog-icsp_post-install-preparing-for-users