### PR TITLE
[enterprise-4.7] BZ1970280: Use FQDN for oc adm catalog mirror

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -75,7 +75,7 @@ $ oc adm catalog mirror \
     [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
-<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file. `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
@@ -149,7 +149,7 @@ $ oc adm catalog mirror \
     [--insecure]
 ----
 <1> Specify the `file://` path from the previous command output.
-<2> Specify the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 +
 [NOTE]
 ====

--- a/modules/olm-mirroring-package-manifest-catalog.adoc
+++ b/modules/olm-mirroring-package-manifest-catalog.adoc
@@ -40,18 +40,19 @@ On your workstation with unrestricted network access, run the following command:
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <registry_host_name>:<port>/olm/redhat-operators:v1 \//<1>
-    <registry_host_name>:<port> \
-    [-a ${REG_CREDS}] \//<2>
-    [--insecure] \//<3>
-    [--index-filter-by-os='<platform>/<arch>'] \//<4>
-    [--manifests-only] <5>
+    <registry_host_name>:<port>/olm/redhat-operators:v1 \ <.>
+    <registry_host_name>:<port> \ <.>
+    [-a ${REG_CREDS}] \ <.>
+    [--insecure] \ <.>
+    [--index-filter-by-os='<platform>/<arch>'] \ <.>
+    [--manifests-only] <.>
 ----
-<1> Specify your Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file.
-<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> Optional: Specify which platform and architecture of the catalog image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the catalog image. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
-<5> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
+<.> Specify your Operator catalog image.
+<.> Specify the fully qualified domain name (FQDN) for the target registry.
+<.> Optional: If required, specify the location of your registry credentials file.
+<.> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<.> Optional: Specify which platform and architecture of the catalog image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the catalog image. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<.> Optional: Only generate the manifests required for mirroring and do not actually mirror the image content to a registry.
 +
 .Example output
 [source,terminal]

--- a/modules/olm-updating-operator-catalog-image.adoc
+++ b/modules/olm-updating-operator-catalog-image.adoc
@@ -103,16 +103,17 @@ Pushed sha256:f73d42950021f9240389f99ddc5b0c7f1b533c054ba344654ff1edaf6bf827e3 t
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    <registry_host_name>:<port>/olm/redhat-operators:v2 \//<1>
-    <registry_host_name>:<port> \
-    [-a ${REG_CREDS}] \//<2>
-    [--insecure] \//<3>
-    [--index-filter-by-os='<platform>/<arch>'] <4>
+    <registry_host_name>:<port>/olm/redhat-operators:v2 \ <.>
+    <registry_host_name>:<port> \ <.>
+    [-a ${REG_CREDS}] \ <.>
+    [--insecure] \ <.>
+    [--index-filter-by-os='<platform>/<arch>'] <.>
 ----
-<1> Specify your new Operator catalog image.
-<2> Optional: If required, specify the location of your registry credentials file.
-<3> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
-<4> Optional: Specify which platform and architecture of the catalog image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the catalog image. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
+<.> Specify your new Operator catalog image.
+<.> Specify the fully qualified domain name (FQDN) for the target registry.
+<.> Optional: If required, specify the location of your registry credentials file.
+<.> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
+<.> Optional: Specify which platform and architecture of the catalog image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the catalog image. Valid values are `linux/amd64`, `linux/ppc64le`, and `linux/s390x`.
 
 . Apply the newly generated manifests:
 +


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1970280

Previews:

* https://deploy-preview-39780--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-mirroring-package-manifest-catalog_olm-managing-custom-catalogs
* https://deploy-preview-39780--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks

xref: https://github.com/openshift/openshift-docs/pull/39723