### PR TITLE
BZ1982072: non-contiguous upgrades are not supported.

### DIFF
--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -19,6 +19,11 @@ ifndef::openshift-origin[]
 
 If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
 
+[WARNING]
+====
+Red Hat recommends upgrading to versions suggested by Openshift Update Service only. For minor version upgrade, versions must be contiguous. Red Hat does not test upgrades to noncontiguous versions and cannot guarantee compatibility with earlier versions.
+====
+
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 {product-title} {product-version} offers the following upgrade channel:


### PR DESCRIPTION
OCP version: 4.7, 4.8, 4.9, 4.10
QA cntact: @jiajliu - LGTM'd
[Preview](https://deploy-preview-39789--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release)
Fixes: [BZ1982072](https://bugzilla.redhat.com/show_bug.cgi?id=1982072)