### PR TITLE
BZ2024266: Add option for default Seccomp profile

### DIFF
--- a/modules/configuring-default-seccomp-profile.adoc
+++ b/modules/configuring-default-seccomp-profile.adoc
@@ -9,6 +9,7 @@ OpenShift ships with a default seccomp profile that is referenced as `runtime/de
 spec:
   securityContext:
     seccompProfile:
+    - runtime/default  
       type: RuntimeDefault
 ----
 


### PR DESCRIPTION
OCP version: 4.8, 4.9, 4.10
Fixes: [BZ2024266](https://bugzilla.redhat.com/show_bug.cgi?id=2024266)
[Preview](https://deploy-preview-39790--osdocs.netlify.app/openshift-enterprise/latest/security/seccomp-profiles)
QA contact: @xiaojiey @pdhamdhe 