### PR TITLE
BZ2014055: tang rekey verification procedure update

### DIFF
--- a/modules/nbde-rekeying-all-nbde-nodes.adoc
+++ b/modules/nbde-rekeying-all-nbde-nodes.adoc
@@ -16,7 +16,7 @@ If a node loses power during the rekeying, it is possible that it might become u
 .Prerequisites
 
 * `cluster-admin` access to all clusters with Network-Bound Disk Encryption (NBDE) nodes.
-* All Tang servers, not just the server being rotated, must be accessible to every NBDE node undergoing rekeying.
+* All Tang servers must be accessible to every NBDE node undergoing rekeying, even if the keys of a Tang server have not changed.
 * Obtain the Tang server URL and key thumbprint for every Tang server.
 
 .Procedure

--- a/modules/nbde-troubleshooting-permanent-error-conditions.adoc
+++ b/modules/nbde-troubleshooting-permanent-error-conditions.adoc
@@ -71,11 +71,26 @@ When replacing, removing, or adding a Tang server from a configuration, the reke
 
 .Verification
 
-* Check the logs from each pod in the daemon set to determine whether the rekeying completed successfully. If the rekeying is not successful, the logs might indicate the failure condition. The following log is from a completed successful rekeying operation:
+Check the logs from each pod in the daemon set to determine whether the rekeying completed successfully. If the rekeying is not successful, the logs might indicate the failure condition.
+
+. Locate the name of the container that was created by the daemon set:
 +
 [source,terminal]
 ----
-$ oc logs rekey-tang-kp4q2
+$ oc get pods -A | grep tang-rekey
+----
++
+.Example output
+[source,terminal]
+----
+openshift-machine-config-operator  tang-rekey-7ks6h  1/1  Running   20 (8m39s ago)  89m
+----
+
+. Print the logs from the container. The following log is from a completed successful rekeying operation:
++
+[source,terminal]
+----
+$ oc logs tang-rekey-7ks6h
 ----
 +
 .Example output


### PR DESCRIPTION
Applies to 4.9+

https://bugzilla.redhat.com/show_bug.cgi?id=2014055

See Verification steps for "Troubleshooting permanent rekeying errors for Tang servers"

Preview: https://deploy-preview-39791--osdocs.netlify.app/openshift-enterprise/latest/security/network_bound_disk_encryption/nbde-managing-encryption-keys

Requires Ack from @obochan-rh and @lack 