### PR TITLE
BZ1825250: Managing cluster resources

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -457,6 +457,8 @@ Distros: openshift-enterprise,openshift-online,openshift-origin
 Topics:
 - Name: Support overview
   File: index
+- Name: Managing your cluster resources
+  File: managing-cluster-resources
 - Name: Getting support
   File: getting-support
   Distros: openshift-enterprise

--- a/modules/cluster-resources.adoc
+++ b/modules/cluster-resources.adoc
@@ -1,0 +1,39 @@
+[id="support-cluster-resources_{context}"]
+= Interacting with your cluster resources
+
+You can interact with cluster resources by using the OpenShift CLI (`oc`) tool in {product-title}. The cluster resources that you see after running the `oc api-resources` command can be edited.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the web console or you have installed the `oc` CLI tool.
+
+.Procedure
+
+. To see which configuration Operators have been applied, run the following command:
++
+[source,terminal]
+----
+$ oc api-resources -o name | grep config.openshift.io
+----
+
+. To see what cluster resources you can configure, run the following command:
++
+[source,terminal]
+----
+$ oc explain ${resource_name}.config.openshift.io
+----
+
+. To see the configuration of custom resource definition (CRD) objects in the cluster, run the following command:
++
+[source,terminal]
+----
+$ oc get ${resource_name}.config -o yaml
+----
+
+. To edit the cluster resource configuration, run the following command:
++
+[source,terminal]
+----
+$ oc edit ${resource_name}.config -o yaml
+----

--- a/support/managing-cluster-resources.adoc
+++ b/support/managing-cluster-resources.adoc
@@ -1,0 +1,13 @@
+[id="managing-cluster-resources"]
+= Managing your cluster resources
+include::modules/common-attributes.adoc[]
+ifdef::openshift-dedicated[]
+include::modules/attributes-openshift-dedicated.adoc[]
+endif::[]
+:context: managing-cluster-resources
+
+toc::[]
+
+You can apply global configuration options in {product-title}. Operators apply these configuration settings across the cluster.
+
+include::modules/cluster-resources.adoc[leveloffset=+1]


### PR DESCRIPTION
OCP version: 4.6+
[Preview](https://deploy-preview-39793--osdocs.netlify.app/openshift-enterprise/latest/support/managing-cluster-resources)
Fixes: [BZ1925250](https://bugzilla.redhat.com/show_bug.cgi?id=1825250)
QA contact: @zhouying7780