### PR TITLE
OSDOCS-2758: Add release note about OpenShift SDN egress netpol

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -205,6 +205,13 @@ To learn more, refer to the respective documentation for your cluster network pr
 * OVN-Kubernetes: xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
 * OpenShift SDN: xref:../networking/openshift_sdn/assigning-egress-ips.adoc#egress-ips[Configuring egress IPs for a project]
 
+[id="ocp-4-10-openshift-sdn-netpol-egress-policies"]
+==== OpenShift SDN cluster network provider network policy support for egress policies and ipBlock except
+
+If you use the OpenShift SDN cluster network provider, you can now use egress rules in network policy with `ipBlock` and `ipBlock.except`. You define egress policies in the `egress` array of the `NetworkPolicy` object.
+
+For more information, refer to xref:../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2758

Preview: [OpenShift SDN cluster network provider network policy support for egress policies](https://deploy-preview-39799--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-openshift-sdn-netpol-egress-policies)