### PR TITLE
OSDOCS-2758: OpenShift SDN supports netpol egress and except clause

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -9,14 +9,6 @@
 In a cluster using a Kubernetes Container Network Interface (CNI) plug-in that supports Kubernetes network policy, network isolation is controlled entirely by `NetworkPolicy` objects.
 In {product-title} {product-version}, OpenShift SDN supports using network policy in its default network isolation mode.
 
-[NOTE]
-====
-When using the OpenShift SDN cluster network provider, the following limitations apply regarding network policies:
-
-* Egress network policy as specified by the `egress` field is not supported.
-* IPBlock is supported by network policy, but without support for `except` clauses. If you create a policy with an IPBlock section that includes an `except` clause, the SDN pods log warnings and the entire IPBlock section of that policy is ignored.
-====
-
 [WARNING]
 ====
 Network policy does not apply to the host network namespace. Pods with host networking enabled are unaffected by network policy rules.


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2758

This PR removes the warning notice about OpenShift SDN not supporting netpol egress or except clause.

Preview: [About network policy](https://deploy-preview-39803--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html#nw-networkpolicy-about_about-network-policy)