### PR TITLE
OSDOCS-2682: Add release note for egress IPs public cloud support

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -189,6 +189,22 @@ A new `--node-selector` argument provides a way to identify which nodes you are 
 
 For more information, see xref:../support/gathering-cluster-data.adoc#support-network-trace-methods_gathering-cluster-data[Network trace methods] and xref:../support/gathering-cluster-data.adoc#support-collecting-host-network-trace_gathering-cluster-data[Collecting a host network trace].
 
+[id="ocp-4-10-egress-ip-support-public-clouds"]
+=== Egress IP address support for clusters installed on public clouds
+
+As a cluster administrator, you can associate one or more egress IP addresses with a namespace. An egress IP address ensures that a consistent source IP address is associated with traffic from a particular namespace that is leaving the cluster.
+
+For the OVN-Kubernetes and OpenShift SDN cluster network providers, you can configure an egress IP address on the following public cloud providers:
+
+* Amazon Web Services (AWS)
+* Google Cloud Platform (GCP)
+* Microsoft Azure
+
+To learn more, refer to the respective documentation for your cluster network provider:
+
+* OVN-Kubernetes: xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#configuring-egress-ips-ovn[Configuring an egress IP address]
+* OpenShift SDN: xref:../networking/openshift_sdn/assigning-egress-ips.adoc#egress-ips[Configuring egress IPs for a project]
+
 [id="ocp-4-10-hardware"]
 === Hardware
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2682

Add release note entry for egress IP on public clouds.

Preview: [Egress IP address support for clusters installed on public clouds](https://deploy-preview-39805--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-egress-ip-support-public-clouds)