### PR TITLE
Bug 2025488: Remove namespace selection

### DIFF
--- a/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
+++ b/modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc
@@ -12,13 +12,11 @@ You must install the Kubernetes NMState Operator from the web console while logg
 
 . Select *Operators* -> *OperatorHub*.
 
-. In the search field below *All Items*, enter `nmstate` and click *Enter*  to search for the Kubernetes NMState Operator.
+. In the search field below *All Items*, enter `nmstate` and click *Enter* to search for the Kubernetes NMState Operator.
 
 . Click on the Kubernetes NMState Operator search result.
 
 . Click on *Install* to open the *Install Operator* window.
-
-. Under *Installed Namespace*, ensure the namespace is `openshift-nmstate`. If `openshift-nmstate` does not exist in the combo box, click on *Create Namespace* and enter `openshift-nmstate` in the *Name* field of the dialog box and press *Create*.
 
 . Click *Install* to install the Operator.
 


### PR DESCRIPTION
Currently the [install docs](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/networking/kubernetes-nmstate#installing-the-kubernetes-nmstate-operator_k8s-nmstate-operator) for the operator suggest the user to select the target namespace:

> 5. Under Installed Namespace, ensure the namespace is openshift-nmstate. If openshift-nmstate does not exist in the combo box, click on Create Namespace and enter openshift-nmstate in the Name field of the dialog box and press Create.

Since https://github.com/openshift/kubernetes-nmstate/pull/215 the suggested namespace is defined and the field autofilled, so this action is not required anymore.
This PR removes this section from the install doc.