### PR TITLE
Adds 4.8.24 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2918,3 +2918,19 @@ link:https://access.redhat.com/solutions/6559931[{product-title} 4.8.23 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-24"]
+=== RHBA-2021:4999 - {product-title} 4.8.24 bug fix update
+
+Issued: 2021-12-14
+
+{product-title} release 4.8.24 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:4999[RHBA-2021:4999] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4998[RHBA-2021:4998] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6585021[{product-title} 4.8.24 container image list]
+
+[id="ocp-4-8-24-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged on 12-14.

OCP version: Applicable only to **enterprise 4.8**

Doc preview link: https://deploy-preview-39809--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-24