### PR TITLE
OSDOCS-2449: IBM VPC Block CSI Operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1201,6 +1201,8 @@ Topics:
     File: persistent-storage-csi-azure-stack-hub
   - Name: GCP PD CSI Driver Operator
     File: persistent-storage-csi-gcp-pd
+  - Name: IBM VPC Block CSI Driver Operator
+    File: persistent-storage-csi-ibm-vpc-block
   - Name: OpenStack Cinder CSI Driver Operator
     File: persistent-storage-csi-cinder
   - Name: OpenStack Manila CSI Driver Operator

--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -17,8 +17,9 @@ The following table describes the CSI drivers that are installed with {product-t
 |CSI driver  |CSI volume snapshots  |CSI cloning  |CSI resize
 
 |AWS EBS | ✅ | - | ✅
-|AWS EFS (Tech Preview) | - | - | -
+|AWS EFS | - | - | -
 |Google Cloud Platform (GCP) persistent disk (PD)| ✅ | - | ✅
+|IBM VPC Block | - | - | ✅
 |Microsoft Azure Disk | ✅ | ✅ | ✅
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅
 |OpenStack Cinder | ✅ | ✅ | ✅

--- a/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-ibm-vpc-block.adoc
@@ -1,0 +1,23 @@
+[id="persistent-storage-csi-ibm-vpc-block"]
+= IBM VPC Block CSI Driver Operator
+include::modules/common-attributes.adoc[]
+:context: persistent-storage-csi-ibm-vpc-block
+
+toc::[]
+
+== Overview
+
+{product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for IBM Virtual Private Cloud (VPC) Block Storage.
+
+Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+
+To create CSI-provisioned PVs that mount to IBM VPC Block storage assets, {product-title} installs the IBM VPC Block CSI Driver Operator and the IBM VPC Block CSI driver by default in the `openshift-cluster-csi-drivers` namespace.
+
+* The _IBM VPC Block CSI Driver Operator_ provides three storage classes named `ibmc-vpc-block-10iops-tier` (default), `ibmc-vpc-block-5iops-tier`, and `ibmc-vpc-block-custom` for different tiers that you can use to create persistent volume claims (PVCs). The IBM VPC Block CSI Driver Operator supports dynamic volume provisioning by allowing storage volumes to be created on demand, eliminating the need for cluster administrators to pre-provision storage.
+
+* The _IBM VPC Block CSI driver_ enables you to create and mount IBM VPC Block PVs.
+
+include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
+
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
4.10+

https://issues.redhat.com/browse/OSDOCS-2449 IBM VPC Block CSI Operator (GA)

**Preview**:
https://deploy-preview-39815--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-ibm-cloud.html
https://deploy-preview-39815--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi

**PTAL**: @dobsonj @chao007 