### PR TITLE
OSDOCS-2466: Created configuration instructions for cluster-wide proxy.

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -124,6 +124,8 @@ Topics:
   Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
+- Name: Configuring a cluster-wide proxy during installation
+  File: configuring-cluster-wide-proxy
 ---
 Name: Nodes
 Dir: nodes

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -139,6 +139,8 @@ Topics:
   Topics:
   - Name: Enabling multicast for a project
     File: enabling-multicast
+- Name: Configuring a cluster-wide proxy during installation
+  File: configuring-cluster-wide-proxy
 ---
 Name: Authentication and authorization
 Dir: authentication

--- a/modules/cluster-wide-proxy.adoc
+++ b/modules/cluster-wide-proxy.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * networking/configuring-cluster-wide-proxy.adoc
+
+[id="cluster-wide-proxy-config_{context}"]
+= Configuring a cluster-wide proxy
+
+You can add a proxy during cluster installation. Prior to installation, however, you should verify that the proxy is accessible from the intended cluster virtual private cloud (VPC) and its private subnets.
+
+.Prerequsites
+ifdef::openshift-rosa[]
+* You have the `rosa` CLI installed and configured.
+endif::[]
+ifdef::openshift-dedicated[]
+* You have the `ocm` CLI installed and configured.
+endif::[]
+
+.Procedure
+* To create a cluster with a proxy, run the following command:
++
+ifdef::openshift-rosa[]
+[source,terminal]
+----
+$ rosa create cluster \
+ <other_arguments_here> \
+ --additional-trust-bundle-file <path_to_CA_bundle_file> \ <1> <2> <3>
+ --http-proxy http://<username>:<pswd>@<ip>:<port> \ <1> <4>
+ --https-proxy http(s)://<username>:<pswd>@<ip>:<port> <4>
+----
+endif::[]
+ifdef::openshift-dedicated[]
+[source,terminal]
+----
+$ ocm create cluster \
+ <other_arguments_here> \
+ --additional-trust-bundle-file <path_to_CA_bundle_file> \ <1> <2> <3>
+ --http-proxy http://<username>:<pswd>@<ip>:<port> \ <1> <4>
+ --https-proxy http(s)://<username>:<pswd>@<ip>:<port> <4>
+----
+endif::[]
++
+<1> The `http-proxy`, `https-proxy`, and `additional-trust-bundle-file` arguments are all optional.
+<2> If you use the `additional-trust-bundle-file` option without an `http(s)-proxy` argument, the passed additional trust bundle is set on the cluster, but it is not configured to be used with the proxy.
+<3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` field is required unless the proxy's identity certificate is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
+<4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.

--- a/networking/configuring-cluster-wide-proxy.adoc
+++ b/networking/configuring-cluster-wide-proxy.adoc
@@ -1,0 +1,28 @@
+include::modules/common-attributes.adoc[]
+ifdef::openshift-dedicated[]
+include::modules/attributes-openshift-dedicated.adoc[]
+endif::[]
+[id="cluster-wide-proxy-configuration"]
+= Configuring a cluster-wide proxy during installation
+:context: cluster-wide-proxy-configuration
+
+toc::[]
+
+You can configure a cluster-wide proxy during cluster installation.
+
+== Prerequisites
+[id="prerequisites_cluster-wide-proxy-configuration"]
+
+* You are the cluster owner.
+* Your account has sufficient privileges.
+ifdef::openshift-dedicated[]
+* You must have a Customer Cloud Subscription (CCS) cluster with a VPC that the proxy can access.
+
+For more information, see xref:../../osd_quickstart/osd-quickstart.adoc[Quick Start] for a basic cluster installation workflow.
+endif::[]
+
+ifdef::openshift-rosa[]
+For information about standard installation prerequisites, see xref:../../rosa_getting_started/rosa-aws-prereqs.adoc[AWS prerequisites for ROSA]. For information about the prerequisites for installation using AWS Security Token Service (STS), see xref:../../rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc[AWS prerequisites for ROSA with STS].
+endif::[]
+
+include::modules/cluster-wide-proxy.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds cluster-wide proxy information to the OSD and ROSA documentation.

JIRA: https://issues.redhat.com/browse/OSDOCS-2466

PREVIEW: 

1. **OSD**: https://people.redhat.com/eponvell/012722/OSDOCS-2466_ClusterwideProxy/networking/configuring-cluster-wide-proxy.html
2. **ROSA**: https://deploy-preview-39830--osdocs.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html