### PR TITLE
OSDOCS-2610: Egress IPs have no assignment guarantees

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -72,6 +72,8 @@ When creating an `EgressIP` object, the following conditions apply to nodes that
 
 When a pod matches the selector for multiple `EgressIP` objects, there is no guarantee which of the egress IP addresses that are specified in the `EgressIP` objects is assigned as the egress IP address for the pod.
 
+Additionally, if an `EgressIP` object specifies multiple egress IP addresses, there is no guarantee which of the egress IP addresses might be assigned to a pod. For example, if a pod matches a selector for an `EgressIP` object with two egress IP addresses, `10.10.20.1` and `10.10.20.2`, either might be assigned to the pod.
+
 [id="nw-egress-ips-node-architecture_{context}"]
 == Architectural diagram of an egress IP address configuration
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-2610

A small clarification about address assignment guarantees.

Preview: [Assignment of egress IPs to nodes](https://deploy-preview-39831--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn#nw-egress-ips-node-assignment_configuring-egress-ips-ovn)