### PR TITLE
BZ1775456: Add healthz/ready for ingress LB

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -142,6 +142,12 @@ Configure the following ports on both the front and back of the load balancers:
 |X
 |HTTP traffic
 
+|`1936`
+|The worker nodes that run the Ingress Controller pods, by default. You must configure the `/healthz/ready` endpoint for the ingress health check probe.
+|X
+|X
+|HTTP traffic
+
 |===
 
 [NOTE]


### PR DESCRIPTION
Fixes: 1775456
OCP version: 4.8, 4.9, 4.10
[Preview](https://deploy-preview-39833--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-load-balancing-user-infra_installing-vsphere)
QA contact: @jinyunma 