### PR TITLE
BZ1903373: Explain the "-2" flag in the Configuring Linuxptp services Section

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -43,7 +43,7 @@ spec:
 <2> Specify an array of one or more `profile` objects.
 <3> Specify the name of a profile object which uniquely identifies a profile object.
 <4> Specify the network interface name to use by the `ptp4l` service, for example `ens787f1`.
-<5> Specify system config options for the `ptp4l` service, for example `-s -2`. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+<5> Specify system config options for the `ptp4l` service, for example `-2` to select the IEEE 802.3 network transport. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
 <6> Specify system config options for the `phc2sys` service, for example `-a -r`. If this field is empty the PTP Operator does not start the `phc2sys` service.
 <7> Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
 <8> Specify an array of one or more `recommend` objects which define rules on how the `profile` should be applied to nodes.


### PR DESCRIPTION
Fixes: [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1903373)
Preview
QA contact: @zhaozhanqi @huiran0826 
OCP version: 4.6, 4.7, 4.8, 4.9, 4.10