### PR TITLE
BZ2032088: The indent of name should be same as namespace 

### DIFF
--- a/modules/compliance-profiles.adoc
+++ b/modules/compliance-profiles.adoc
@@ -55,7 +55,7 @@ metadata:
     generation: 1
   labels:
     compliance.openshift.io/profile-bundle: rhcos4
-    name: rhcos4-e8
+  name: rhcos4-e8
   namespace: openshift-compliance
 rules:
 - rhcos4-accounts-no-uid-except-zero


### PR DESCRIPTION
OCP version: 4.9, 4.10
[Preview](https://deploy-preview-39835--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-understanding#compliance_profiles_understanding-compliance)
QA contact: @lihongyan1 
Fixes: [BZ](https://bugzilla.redhat.com/show_bug.cgi?id=2032088)