### PR TITLE
OSDOCS-3034: Swap the order of ROSA Setting up accounts and clusters sections

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -49,35 +49,6 @@ Topics:
 - Name: Planning your environment
   File: rosa-planning-environment
 ---
-Name: Setting up accounts and clusters
-Dir: rosa_getting_started
-Distros: openshift-rosa
-Topics:
-- Name: Getting started workflow
-  File: rosa-getting-started-workflow
-- Name: AWS prerequisites for ROSA
-  File: rosa-aws-prereqs
-- Name: Required AWS service quotas
-  File: rosa-required-aws-service-quotas
-- Name: Configuring your AWS account
-  File: rosa-config-aws-account
-- Name: Installing ROSA
-  File: rosa-installing-rosa
-- Name: Creating a ROSA cluster
-  File: rosa-creating-cluster
-- Name: Creating an AWS PrivateLink cluster on ROSA
-  File: rosa-aws-privatelink-creating-cluster
-- Name: Accessing a ROSA cluster
-  File: rosa-accessing-cluster
-- Name: Configuring identity providers using the OCM console
-  File: rosa-config-identity-providers
-- Name: Deleting access to a ROSA cluster
-  File: rosa-deleting-access-cluster
-- Name: Deleting a ROSA cluster
-  File: rosa-deleting-cluster
-- Name: Command quick reference for creating clusters and users
-  File: rosa-quickstart
----
 Name: Setting up accounts and clusters using AWS security token service (STS)
 Dir: rosa_getting_started_sts
 Distros: openshift-rosa
@@ -109,6 +80,35 @@ Topics:
   File: rosa-sts-deleting-access-cluster
 - Name: Deleting a ROSA cluster
   File: rosa-sts-deleting-cluster
+---
+Name: Setting up accounts and clusters
+Dir: rosa_getting_started
+Distros: openshift-rosa
+Topics:
+- Name: Getting started workflow
+  File: rosa-getting-started-workflow
+- Name: AWS prerequisites for ROSA
+  File: rosa-aws-prereqs
+- Name: Required AWS service quotas
+  File: rosa-required-aws-service-quotas
+- Name: Configuring your AWS account
+  File: rosa-config-aws-account
+- Name: Installing ROSA
+  File: rosa-installing-rosa
+- Name: Creating a ROSA cluster
+  File: rosa-creating-cluster
+- Name: Creating an AWS PrivateLink cluster on ROSA
+  File: rosa-aws-privatelink-creating-cluster
+- Name: Accessing a ROSA cluster
+  File: rosa-accessing-cluster
+- Name: Configuring identity providers using the OCM console
+  File: rosa-config-identity-providers
+- Name: Deleting access to a ROSA cluster
+  File: rosa-deleting-access-cluster
+- Name: Deleting a ROSA cluster
+  File: rosa-deleting-cluster
+- Name: Command quick reference for creating clusters and users
+  File: rosa-quickstart
 ---
 Name: Upgrading
 Dir: upgrading


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-3034. The pull request reverses the order of Setting up accounts and clusters topic, prioritizing the STS method. 

The preview is [here](https://deploy-preview-39856--osdocs.netlify.app/openshift-rosa/latest/welcome/index.html).
