### PR TITLE
Adds notes for 4.7.40 release

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3023,3 +3023,19 @@ link:https://access.redhat.com/solutions/6564591[{product-title} 4.7.39 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-40"]
+=== RHBA-2021:5088 - {product-title} 4.7.40 bug fix update
+
+Issued: 2021-12-16
+
+{product-title} release 4.7.40 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5088[RHBA-2021:5088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5087[RHBA-2021:5087] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6590181[{product-title} 4.7.40 container image list]
+
+[id="ocp-4-7-40-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for Thursdays 4.7.40 release

- Applies to `enterprise-4..7` only
- [Preview link](https://deploy-preview-39866--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-40)