### PR TITLE
Fixing typo in a link

### DIFF
--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -57,7 +57,7 @@ include::modules/updating-sno.adoc[leveloffset=+1]
 
 .Additional resources
 
-* For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.aodc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
+* For information on which machine configuration changes require a reboot, see the note in xref:../architecture/control-plane.adoc#understanding-machine-config-operator_control-plane[Understanding the Machine Config Operator].
 
 include::modules/update-upgrading-web.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Applies to 4.9 only.
Typo fix.
QE/SME not required.