### PR TITLE
BZ2032500: Add link to IBM CEX plug-in

### DIFF
--- a/modules/nodes-pods-plugins-about.adoc
+++ b/modules/nodes-pods-plugins-about.adoc
@@ -53,6 +53,7 @@ service DevicePlugin {
 * link:https://github.com/NVIDIA/k8s-device-plugin[Nvidia official GPU device plug-in]
 * link:https://github.com/vikaschoudhary16/sfc-device-plugin[Solarflare device plug-in]
 * link:https://github.com/kubevirt/kubernetes-device-plugins[KubeVirt device plug-ins: vfio and kvm]
+* link:https://github.com/ibm-s390-cloud/k8s-cex-dev-plugin[Kubernetes device plug-in for IBM Crypto Express (CEX) cards]
 
 
 [NOTE]


### PR DESCRIPTION
-OCP version for cherry-picking: enterprise-4.9, 4.10

- Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=2032500

- Preview https://deploy-preview-39885--osdocs.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-plugins.html

- QE review: Holger Wolf