### PR TITLE
RHDEVDOCS-3571 RN for Pipelines 1.6.1

### DIFF
--- a/modules/op-release-notes-1-6.adoc
+++ b/modules/op-release-notes-1-6.adoc
@@ -245,3 +245,22 @@ time="2021-11-04T13:05:26Z" level=error msg="exit status 127"
 //  (link:https://issues.redhat.com/browse/SRVKP-718[SRVKP-718])
 
 * `When` expression values can now have array parameter references, such as: `values: [$(params.arrayParam[*])]`.
+
+
+
+[id="release-notes-1-6-1_{context}"]
+== Release notes for {pipelines-title} General Availability 1.6.1
+
+The following improvements are made in {pipelines-title} 1.6.1:
+
+* The `SSL_CERT_DIR` environment variable (`/tekton-custom-certs`) set by {pipelines-title} will not override the following default system directories with certificate files:
+** `/etc/pki/tls/certs`
+** `/etc/ssl/certs`
+** `/system/etc/security/cacerts`
+// https://issues.redhat.com/browse/SRVKP-1687
+
+* The Horizontal Pod Autoscaler can manage the replica count of deployments controlled by the {pipelines-title} Operator. From this release onward, if the count is changed by an end user or an on-cluster agent, the {pipelines-title} Operator will not reset the replica count of deployments managed by it. However, the replicas will be reset when you upgrade the {pipelines-title} Operator.
+// https://issues.redhat.com/browse/SRVKP-1783
+
+* The pod serving the `tkn` CLI will now be scheduled on nodes, based on the node selector and toleration limits specified in the `TektonConfig` custom resource.
+// https://issues.redhat.com/browse/SRVKP-1804


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`
- **JIRA issues**: [RHDEVDOCS-3571 RN for Pipelines 1.6.1](https://issues.redhat.com/browse/RHDEVDOCS-3571)
- **Preview pages**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.6.1](https://deploy-preview-39887--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes#release-notes-1-6-1_op-release-notes)
- **SME review**: @concaf    
- **Peer-review**: @Preeticp 