### PR TITLE
BZ2012763: Fix file storing credentials multiple registries JSON

### DIFF
--- a/modules/olm-accessing-images-private-registries.adoc
+++ b/modules/olm-accessing-images-private-registries.adoc
@@ -50,26 +50,23 @@ A registry credentials file can, by default, store details for more than one reg
 [source,json]
 ----
 {
-        "auths": {
-                "registry.redhat.io": {
-                        "auth": "FrNHNydQXdzclNqdg=="
-                },
-                "quay.io": {
-                        "auth": "fegdsRib21iMQ=="
-                }
-                },
-                "https://quay.io/my-namespace/my-user/my-image": {
-                        "auth": "eWfjwsDdfsa221=="
-                }
-                },
-                "https://quay.io/my-namespace/my-user": {
-                        "auth": "feFweDdscw34rR=="
-                }
-                },
-                "https://quay.io/my-namespace": {
-                        "auth": "frwEews4fescyq=="
-                }
+    "auths": {
+        "registry.redhat.io": {
+            "auth": "FrNHNydQXdzclNqdg=="
+        },
+        "quay.io": {
+            "auth": "fegdsRib21iMQ=="
+        },
+        "https://quay.io/my-namespace/my-user/my-image": {
+            "auth": "eWfjwsDdfsa221=="
+        },
+        "https://quay.io/my-namespace/my-user": {
+            "auth": "feFweDdscw34rR=="
+        },
+        "https://quay.io/my-namespace": {
+            "auth": "frwEews4fescyq=="
         }
+    }
 }
 ----
 +


### PR DESCRIPTION
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2012763

OCP Version: 4.9, 4.10

Current 4.9 doc: https://docs.openshift.com/container-platform/4.9/operators/admin/olm-managing-custom-catalogs.html#olm-accessing-images-private-registries_olm-managing-custom-catalogs

Direct doc preview link: https://deploy-preview-39904--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-accessing-images-private-registries_olm-managing-custom-catalogs