### PR TITLE
OSDOCS-2406: Updating the OSD internet and telemetry access section

### DIFF
--- a/modules/osd-intro.adoc
+++ b/modules/osd-intro.adoc
@@ -42,17 +42,8 @@ Other enhancements to Kubernetes in {product-title} include improvements in soft
 [id="telemetry_{context}"]
 == Internet and Telemetry access for {product-title}
 
-In {product-title}, you require access to the Internet to install your cluster. The Telemetry service, which runs by default to provide metrics about cluster health and the success of updates, also requires Internet access. If your cluster is connected to the Internet, Telemetry runs automatically, and your cluster is registered to the {console-redhat-com}.
+In {product-title}, you require access to the internet to install and upgrade your cluster.
 
-Once you confirm that your Red Hat OpenShift Cluster Manager inventory is correct, either maintained automatically by Telemetry or manually using OCM, use link:https://access.redhat.com/documentation/en-us/subscription_central/2020-04/html/getting_started_with_subscription_watch/con-how-to-select-datacollection-tool_assembly-requirements-and-your-responsibilities-ctxt#red_hat_openshift[subscription watch] to track your {product-title} subscriptions at the account or multi-cluster level.
+Through the Telemetry service, information is sent to Red Hat from {product-title} clusters to enable subscription management automation, monitor the health of clusters, assist with support, and improve customer experience.
 
-You must have Internet access to:
-
-* Access the {console-redhat-com} page to download the installation program and perform subscription management. If the cluster has Internet access and you do not disable Telemetry, that service automatically entitles your cluster.
-
-* Obtain the packages that are required to perform cluster updates.
-
-[IMPORTANT]
-====
-If your cluster cannot have direct Internet access, you can perform a restricted network installation on some types of infrastructure that you provision. During that process, you download the content that is required and use it to populate a mirror registry with the packages that you need to install a cluster and generate the installation program. With some installation types, the environment that you install your cluster in will not require Internet access. Before you update the cluster, you update the content of the mirror registry.
-====
+The Telemetry service runs automatically and your cluster is registered to the {OCM}. In {product-title}, remote health reporting is always enabled and you cannot opt out. The Red Hat Site Reliability Engineering (SRE) team requires the information to provide effective support for your {product-title} cluster.

--- a/osd_architecture/osd-understanding.adoc
+++ b/osd_architecture/osd-understanding.adoc
@@ -8,3 +8,7 @@ toc::[]
 With its foundation in Kubernetes, {product-title} is a complete {OCP} cluster provided as a cloud service, configured for high availability, and dedicated to a single customer.
 
 include::modules/osd-intro.adoc[leveloffset=+1]
+
+.Additional resources
+
+* For more information about Telemetry and remote health monitoring for {product-title} clusters, see xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-2406. The pull request updates the **Architecture** -> **Introduction to OpenShift Dedicated** -> **Internet and Telemetry access for OpenShift Dedicated** section in the OSD documentation.

The preview is [here](https://deploy-preview-39933--osdocs.netlify.app/openshift-dedicated/latest/osd_architecture/osd-understanding#telemetry_osd-understanding).