### PR TITLE
OSDOCS-2809_Rev2: remove hardened SRE support pod info

### DIFF
--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -15,7 +15,7 @@ For a list of the available subprocessors, see the link:https://access.redhat.co
 == SRE access to all {product-title} clusters
 SREs access {product-title} clusters through the web console or command-line tools. Authentication requires multi-factor authentication (MFA) with industry-standard requirements for password complexity and account lockouts. SREs must authenticate as individuals to ensure auditability. All authentication attempts are logged to a Security Information and Event Management (SIEM) system.
 
-SREs access private clusters using an encrypted tunnel through a hardened SRE support pod running in the cluster. Connections to the SRE support pod are permitted only from a secured Red Hat network using an IP allow-list. In addition to the cluster authentication controls described above, authentication to the SRE support pod is controlled by using SSH keys. SSH key authorization is limited to SRE staff and automatically synchronized with Red Hat corporate directory data. Corporate directory data is secured and controlled by HR systems, including management review, approval, and audits.
+SREs access private clusters using an encrypted HTTP connection. Connections are permitted only from a secured Red Hat network using either an IP allowlist or a private cloud provider link.
 
 [id="rosa-policy-privileged-access-control_{context}"]
 == Privileged access controls in {product-title}


### PR DESCRIPTION
4.9+ 

Fixes the following issue for ROSA: https://issues.redhat.com/browse/OSDOCS-2809
**NOTE**: The OSD content has been removed by some other PR.

This is a redo of PR: https://github.com/openshift/openshift-docs/pull/38388 to point it to the "main" rather than "dedicated-4" branch.

**Preview**:
**ROSA**: https://deploy-preview-39950--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-policy-process-security.html#rosa-policy-sre-access_rosa-policy-process-security

**PTAL**: @xueli181114, @yuwang-RH, @okashi18