### PR TITLE
OSDOCS-2407 - Adding etcd encryption section

### DIFF
--- a/modules/rosa-sdpolicy-security.adoc
+++ b/modules/rosa-sdpolicy-security.adoc
@@ -6,7 +6,6 @@
 [id="rosa-sdpolicy-security_{context}"]
 = Security
 
-
 This section provides information about the service definition for {product-title} security.
 
 [id="rosa-sdpolicy-auth-provider_{context}"]
@@ -58,3 +57,23 @@ See Understanding process and security for ROSA for the latest compliance inform
 [id="rosa-sdpolicy-network-security_{context}"]
 == Network security
 With {product-title}, AWS provides a standard DDoS protection on all load balancers, called AWS Shield. This provides 95% protection against most commonly used level 3 and 4 attacks on all the public facing load balancers used for {product-title}. A 10-second timeout is added for HTTP requests coming to the `haproxy` router to receive a response or the connection is closed to provide additional protection.
+
+[id="rosa-sdpolicy-etcd-encryption_{context}"]
+== etcd encryption
+
+In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
+
+You can also enable etcd encryption, which encrypts the key values in etcd state, but not the keys. If you enable etcd encryption, the following Kubernetes API server and OpenShift API server resources are encrypted:
+
+* Secrets
+* Config maps
+* Routes
+* OAuth access tokens
+* OAuth authorize tokens 
+
+The etcd encryption feature is not enabled by default and it can be enabled only at cluster installation time.
+
+[IMPORTANT]
+====
+By enabling etcd encryption for the key values in etcd state, you might incur a performance overhead of approximately 20%. Red Hat only recommends that you enable etcd encryption in addition to the default storage-level encryption if you specifically require this for your use case.
+====

--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -6,6 +6,8 @@
 [id="sdpolicy-security_{context}"]
 = Security
 
+This section provides information about the service definition for {product-title} security.
+
 [id="auth-provider_{context}"]
 == Authentication provider
 Authentication for the cluster is configured as part of the {OCM} cluster creation process. OpenShift is not an identity provider, and all access to the cluster must be managed by the customer as part of their integrated solution. Provisioning multiple identity providers provisioned at the same time is supported. The following identity providers are supported:
@@ -58,3 +60,23 @@ See link:https://www.openshift.com/products/dedicated/process-and-security#compl
 [id="network-security_{context}"]
 == Network security
 With {product-title} on AWS, AWS provides a standard DDoS protection on all Load Balancers, called AWS Shield. This provides 95% protection against most commonly used level 3 and 4 attacks on all the public facing Load Balancers used for {product-title}. A 10-second timeout is added for HTTP requests coming to the haproxy router to receive a response or the connection is closed to provide additional protection.
+
+[id="etcd-encryption_{context}"]
+== etcd encryption
+
+In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. This storage-level encryption is provided through the storage layer of the cloud provider.
+
+You can also enable etcd encryption, which encrypts the key values in etcd state, but not the keys. If you enable etcd encryption, the following Kubernetes API server and OpenShift API server resources are encrypted:
+
+* Secrets
+* Config maps
+* Routes
+* OAuth access tokens
+* OAuth authorize tokens 
+
+The etcd encryption feature is not enabled by default and it can be enabled only at cluster installation time.
+
+[IMPORTANT]
+====
+By enabling etcd encryption for the key values in etcd state, you might incur a performance overhead of approximately 20%. Red Hat only recommends that you enable etcd encryption in addition to the default storage-level encryption if you specifically require this for your use case.
+====


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This relates to https://issues.redhat.com/browse/OSDOCS-2407 and https://issues.redhat.com/browse/OSDOCS-1737. The PR adds an "etcd encryption" section in the service definition pages for OSD and ROSA.

The previews are as follows:

- [OSD](https://deploy-preview-39955--osdocs.netlify.app/openshift-dedicated/latest/osd_policy/osd-service-definition.html#etcd-encryption_osd-service-definition)
- [ROSA](https://deploy-preview-39955--osdocs.netlify.app/openshift-rosa/latest/rosa_policy/rosa-service-definition.html#rosa-sdpolicy-etcd-encryption_rosa-service-definition)