### PR TITLE
Rns 4.7.40 log4j

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3025,11 +3025,13 @@ link:https://access.redhat.com/solutions/6564591[{product-title} 4.7.39 containe
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-7-40"]
-=== RHBA-2021:5088 - {product-title} 4.7.40 bug fix update
+=== RHBA-2021:5088 - {product-title} 4.7.40 bug fix and security update
 
 Issued: 2021-12-16
 
-{product-title} release 4.7.40 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5088[RHBA-2021:5088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5087[RHBA-2021:5087] advisory.
+{product-title} release 4.7.40, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5088[RHBA-2021:5088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5087[RHBA-2021:5087] advisory.
+
+This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], which affects the Apache Log4j utility. Fixes for this flaw are provided by the link:https://access.redhat.com/errata/RHSA-2021:5184[RHSA-2021:5184] advisory.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
Added line for extra security advisory.
See: https://github.com/openshift/openshift-docs/pull/39866
 [Preview link](https://deploy-preview-39972--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-40)