### PR TITLE
OSDOCS-3009:Adding route compression to Ingress

### DIFF
--- a/modules/nw-configuring-router-compression.adoc
+++ b/modules/nw-configuring-router-compression.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * networking/ingress_operator.adoc
+
+[id="nw-configuring-router-compression_{context}"]
+= Using router compression
+
+You configure the HAProxy Ingress Controller to specify router compression globally for specific MIME types. You can use the `mimeTypes` variable to define the formats of MIME types to which compression is applied. The types are: application, image, message, multipart, text, video, or a custom type prefaced by "X-". To see the full notation for MIME types and subtypes, see link:https://datatracker.ietf.org/doc/html/rfc1341#page-7[RFC1341].
+
+[NOTE]
+====
+Memory allocated for compression can affect the max connections. Additionally, compression of large buffers can cause latency, like heavy regex or long lists of regex.
+
+Not all MIME types benefit from compression, but HAProxy still uses resources to try to compress if instructed to.  Generally, text formats, such as html, css, and js, formats benefit from compression, but formats that are already compressed, such as image, audio, and video, benefit little in exchange for the time and resources spent on compression.
+====
+
+.Procedure
+
+. Configure the `httpCompression` field for the Ingress Controller.
+.. Use the following command to edit the `IngressController` resource:
++
+[source,terminal]
+----
+$ oc edit -n openshift-ingress-operator ingresscontrollers/default
+----
++
+.. Under `spec`, set the `httpCompression` policy field to `mimeTypes` and specify a list of MIME types that should have compression applied:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  httpCompression:
+    mimeTypes:
+    - "text/html"
+    - "text/css; charset=utf-8"
+    - "application/json"
+   ...
+----

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -110,7 +110,7 @@ The Ingress Operator converts the TLS `1.0` of an `Old` or `Custom` profile to `
 `clientTLS` has the required subfields, `spec.clientTLS.clientCertificatePolicy` and `spec.clientTLS.ClientCA`.
 
 The `ClientCertificatePolicy` subfield accepts one of the two values: `Required` or `Optional`. The `ClientCA` subfield specifies a config map that is in the openshift-config namespace. The config map should contain a CA certificate bundle.
-The `AllowedSubjectPatterns` is an optional value that specifies a list of regular expressions, which are matched against the distinguished name on a valid client certificate to filter requests.  The regular expressions must use PCRE syntax. At least one pattern must match a client certificate's distinguished name; otherwise, the ingress controller rejects the certificate and denies the connection. If not specified, the ingress controller does not reject certificates based on the distinguished name.
+The `AllowedSubjectPatterns` is an optional value that specifies a list of regular expressions, which are matched against the distinguished name on a valid client certificate to filter requests. The regular expressions must use PCRE syntax. At least one pattern must match a client certificate's distinguished name; otherwise, the ingress controller rejects the certificate and denies the connection. If not specified, the ingress controller does not reject certificates based on the distinguished name.
 
 |`routeAdmission`
 |`routeAdmission` defines a policy for handling new route claims, such as allowing or denying claims across namespaces.
@@ -158,6 +158,11 @@ By setting `headerNameCaseAdjustments`, you can specify case adjustments that ca
 These adjustments are only applied to cleartext, edge-terminated, and re-encrypt routes, and only when using HTTP/1.
 
 For request headers, these adjustments are applied only for routes that have the `haproxy.router.openshift.io/h1-adjust-case=true` annotation. For response headers, these adjustments are applied to all HTTP responses. If this field is empty, no request headers are adjusted.
+
+|`httpCompression`
+|`httpCompression` defines the policy for HTTP traffic compression.
+
+* `mimeTypes` defines a list of MIME types to which compression should be applied. For example, `text/css; charset=utf-8`, `text/html`, `text/*`, `image/svg+xml`, `application/octet-stream`, `X-custom/customsub`, using the format pattern, `type/subtype; [;attribute=value]`. The `types` are: application, image, message, multipart, text, video, or a custom type prefaced by `X-`; e.g. To see the full notation for MIME types and subtypes, see link:https://datatracker.ietf.org/doc/html/rfc1341#page-7[RFC1341]
 
 |`httpErrorCodePages`
 |`httpErrorCodePages` specifies custom HTTP error code response pages. By default, an IngressController uses error pages built into the IngressController image.

--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -72,6 +72,8 @@ include::modules/nw-ingress-configuring-application-domain.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-converting-http-header-case.adoc[leveloffset=+2]
 
+include::modules/nw-configuring-router-compression.adoc[leveloffset=+2]
+
 include::modules/nw-customize-ingress-error-pages.adoc[leveloffset=+2]
 //include::modules/nw-ingress-select-route.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3009

For 4.10

Preview:
Parameters table (httpCompression): https://deploy-preview-39982--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-ingress-controller-configuration-parameters_configuring-ingress

Using router compression: https://deploy-preview-39982--osdocs.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-configuring-router-compression_configuring-ingress
