### PR TITLE
OSDOCS-3075: Update Release Notes for Compliance Operator

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -43,6 +43,14 @@ The Compliance Operator provides the following compliance profiles:
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
 |0.1.44+
 
+|ocp4-pci-dss
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4]
+|0.1.47+
+
+|ocp4-pci-dss-node
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4]
+|0.1.47+
+
 |rhcos4-e8
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[Australian Cyber Security Centre (ACSC) Essential Eight]
 |0.1.39+

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -12,12 +12,40 @@ These release notes track the development of the Compliance Operator in the {pro
 
 For an overview of the Compliance Operator, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#understanding-compliance-operator[Understanding the Compliance Operator].
 
+[id="compliance-operator-release-notes-0-1-47"]
+== OpenShift Compliance Operator 0.1.47
+
+The following advisory is available for the OpenShift Compliance Operator 0.1.47:
+
+* link:https://access.redhat.com/errata/RHBA-2022:0014[RHBA-2022:0014 - OpenShift Compliance Operator bug fix and enhancement update]
+
+[id="compliance-operator-0-1-47-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The Compliance Operator now supports the following compliance benchmarks for the Payment Card Industry Data Security Standard (PCI DSS):
++
+** ocp4-pci-dss
+** ocp4-pci-dss-node
+
+* Additional rules and remediations for FedRAMP moderate impact level are added to the OCP4-moderate, OCP4-moderate-node, and rhcos4-moderate profiles.
+
+* Remediations for KubeletConfig are now available in node-level profiles.
+
+[id="openshift-compliance-operator-0-1-47-bug-fixes"]
+=== Bug fixes
+
+* Previously, if your cluster was running {product-title} 4.6 or earlier, remediations for USBGuard-related rules would fail for the moderate profile. This is because the remediations created by the Compliance Operator were based on an older version of USBGuard that did not support drop-in directories. Now, invalid remediations for USBGuard-related rules are not created for clusters running {product-title} 4.6. If your cluster is using {product-title} 4.6, you must manually create remediations for USBGuard-related rules.
++
+Additionally, remediations are created only for rules that satisfy minimum version requirements. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1965511[*BZ#1965511*])
+
+* Previously, when rendering remediations, the compliance operator would check that the remediation was well-formed by using a regular expression that was too strict. As a result, some remediations, such as those that render `sshd_config`, would not pass the regular expression check and therefore, were not created. The regular expression was found to be unnecessary and removed. Remediations now render correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033009[*BZ#2033009*])
+
 [id="compliance-operator-release-notes-0-1-44"]
 == OpenShift Compliance Operator 0.1.44
 
 The following advisory is available for the OpenShift Compliance Operator 0.1.44:
 
-* link:https://access.redhat.com/errata/RHBA-2021:4530[RHBA-2021:4530 OpenShift Compliance Operator Bug Fix and Enhancement Update]
+* link:https://access.redhat.com/errata/RHBA-2021:4530[RHBA-2021:4530 - OpenShift Compliance Operator bug fix and enhancement update]
 
 [id="compliance-operator-0-1-44-new-features-and-enhancements"]
 === New features and enhancements
@@ -44,6 +72,7 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.44
 +
 * In this release, the Compliance Operator supports the NIST 800-53 Moderate-Impact Baseline for the Red Hat OpenShift - Node level, ocp4-moderate-node, security profile.
 
+[id="openshift-compliance-operator-0-1-44-templating"]
 === Templating and variable use
 
 * In this release, the remediation template now allows multi-value variables.
@@ -59,7 +88,7 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.44
 +
 * The RBAC Role and Role Binding used for Prometheus metrics are changed to 'ClusterRole' and 'ClusterRoleBinding' to ensure that monitoring works without customization.
 +
-* Previously, if an error occurred while parsing a profile, rules or variables objects were removed and deleted from the profile. Now, if an error occurs during parsing, the `profileparser` annotates the object with a temporary annotation that prevents the object from being deleted until after parsing completes. link:https://bugzilla.redhat.com/show_bug.cgi?id=1988259[(BZ#1988259)].
+* Previously, if an error occurred while parsing a profile, rules or variables objects were removed and deleted from the profile. Now, if an error occurs during parsing, the `profileparser` annotates the object with a temporary annotation that prevents the object from being deleted until after parsing completes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1988259[*BZ#1988259*])
 +
 * Previously, an error occurred if titles or descriptions were missing from a tailored profile. Because the XCCDF standard requires titles and descriptions for tailored profiles, titles and descriptions are now required to be set in `TailoredProfile` CRs.
 +
@@ -69,7 +98,7 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.44
 == Release Notes for Compliance Operator 0.1.39
 The following advisory is available for the OpenShift Compliance Operator 0.1.39:
 
-* link:https://access.redhat.com/errata/RHBA-2021:3214[RHBA-2021:3214 OpenShift Compliance Operator Bug Fix and Enhancement Update]
+* link:https://access.redhat.com/errata/RHBA-2021:3214[RHBA-2021:3214 - OpenShift Compliance Operator bug fix and enhancement update]
 
 [id="compliance-operator-0-1-39-new-features-and-enhancements"]
 === New features and enhancements


### PR DESCRIPTION
Affects Version 4.6+
[OSDOCS-3075](https://issues.redhat.com/browse/OSDOCS-3075)

Release Notes for Compliance Operator 0.1.47:
Preview: https://deploy-preview-39989--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-release-notes.html
Supported Profiles:
https://deploy-preview-39989--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-supported-profiles.html