### PR TITLE
Manual revert for files added in error to PR 39124

### DIFF
--- a/modules/nodes-pods-autoscaling-about.adoc
+++ b/modules/nodes-pods-autoscaling-about.adoc
@@ -99,7 +99,6 @@ status:
   desiredReplicas: 0
 ----
 
-
 . View the new state of the deployment:
 +
 [source,terminal]

--- a/modules/nodes-pods-autoscaling-creating-cpu.adoc
+++ b/modules/nodes-pods-autoscaling-creating-cpu.adoc
@@ -42,9 +42,9 @@ Containers:
     Memory:  45440Ki
 Kind:        PodMetrics
 Metadata:
-  Creation Timestamp:  2019-05-23T18:47:56Z
+  Creation Timestamp:  2021-05-23T18:47:56Z
   Self Link:           /apis/metrics.k8s.io/v1beta1/namespaces/openshift-kube-scheduler/pods/openshift-kube-scheduler-ip-10-0-135-131.ec2.internal
-Timestamp:             2019-05-23T18:47:56Z
+Timestamp:             2021-05-23T18:47:56Z
 Window:                1m0s
 Events:                <none>
 ----

--- a/modules/nodes-pods-autoscaling-creating-memory.adoc
+++ b/modules/nodes-pods-autoscaling-creating-memory.adoc
@@ -45,9 +45,9 @@ Containers:
     Memory:  0
 Kind:        PodMetrics
 Metadata:
-  Creation Timestamp:  2020-02-14T22:21:14Z
+  Creation Timestamp:  2021-02-14T22:21:14Z
   Self Link:           /apis/metrics.k8s.io/v1beta1/namespaces/openshift-kube-scheduler/pods/openshift-kube-scheduler-ip-10-0-129-223.compute.internal
-Timestamp:             2020-02-14T22:21:14Z
+Timestamp:             2021-02-14T22:21:14Z
 Window:                5m0s
 Events:                <none>
 ----

--- a/modules/nodes-pods-autoscaling-creating-web-console.adoc
+++ b/modules/nodes-pods-autoscaling-creating-web-console.adoc
@@ -45,3 +45,4 @@ To remove an HPA in the web console:
 . In the *Topology* view, click the node to reveal the side panel.
 . From the *Actions* drop-down list, select *Remove HorizontalPodAutoscaler*.
 . In the confirmation pop-up window, click *Remove* to remove the HPA.
+


### PR DESCRIPTION
After incorporating the peer review comments for https://github.com/openshift/openshift-docs/pull/39124, these 4 files somehow got into this PR unnoticed. GitHub will not allow me to revert 39124:

`Sorry, this pull request couldn’t be reverted automatically. It may have already been reverted, or the content may have changed since it was merged. `

This PR is an attempt at a manual revert so that I can re-set the PR these file changes belong to,  https://github.com/openshift/openshift-docs/pull/37231