### PR TITLE
JIRA-OSDOCS2850: Added procedure to revoke access to ROSA clusters using OCM console

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -76,7 +76,7 @@ Topics:
   File: rosa-sts-accessing-cluster
 - Name: Configuring identity providers using the OCM console
   File: rosa-sts-config-identity-providers
-- Name: Deleting access to a ROSA cluster
+- Name: Revoking access to a ROSA cluster
   File: rosa-sts-deleting-access-cluster
 - Name: Deleting a ROSA cluster
   File: rosa-sts-deleting-cluster

--- a/modules/rosa-delete-cluster-admins.adoc
+++ b/modules/rosa-delete-cluster-admins.adoc
@@ -5,7 +5,7 @@
 
 
 [id="rosa-delete-cluster-admins"]
-= Revoking `cluster-admin` access
+= Revoking `cluster-admin` access using the `rosa` CLI
 Only the user who created the cluster can revoke access for `cluster-admin` users.
 
 .Prerequisites
@@ -16,16 +16,16 @@ Only the user who created the cluster can revoke access for `cluster-admin` user
 
 .Procedure
 
-. Revoke the user `cluster-admin` privileges:
+. Enter the following command to revoke the `cluster-admin` access of a user:
 +
 [source,terminal]
 ----
-$ rosa revoke user --cluster=<cluster_name> --cluster-admins=<idp_user_name>
+$ rosa revoke user cluster-admins --user=myusername --cluster=mycluster
 ----
 +
-. Verify your user is no longer listed as a `cluster-admin`:
+. Enter the following command to verify that the user no longer has `cluster-admin` access. The output does not list the revoked user.
 +
 [source,terminal]
 ----
-$ rosa list users --cluster=<cluster_name>
+$ oc get groups cluster-admins
 ----

--- a/modules/rosa-delete-dedicated-admins.adoc
+++ b/modules/rosa-delete-dedicated-admins.adoc
@@ -5,8 +5,8 @@
 
 
 [id="rosa-delete-dedicated-admins"]
-= Revoking `dedicated-admin` access
-Only the user who created the cluster can revoke access for a `dedicated-admin` users.
+= Revoking `dedicated-admin` access using the `rosa` CLI
+You can revoke access for a `dedicated-admin` user if you are the user who created the cluster, the organization administrator user, or the super administrator user.
 
 .Prerequisites
 
@@ -16,21 +16,16 @@ Only the user who created the cluster can revoke access for a `dedicated-admin` 
 
 .Procedure
 
-. Enter the following command to revoke access for a `dedicated-admin`:
+. Enter the following command to revoke the `dedicated-admin` access of a user:
 +
 [source,terminal]
 ----
 $ rosa revoke user dedicated-admin --user=<idp_user_name> --cluster=<cluster_name>
 ----
 +
-. Enter the following command to verify that your user no longer has `dedicated-admin` access. The user will not be listed in the output.
+. Enter the following command to verify that your user no longer has `dedicated-admin` access. The output does not list the revoked user.
 +
 [source,terminal]
 ----
 $ oc get groups dedicated-admins
 ----
-+
-[NOTE]
-====
-A `Forbidden` error displays if user without `dedicated-admin` privileges runs this command.
-====

--- a/modules/rosa-delete-users.adoc
+++ b/modules/rosa-delete-users.adoc
@@ -1,0 +1,21 @@
+
+// Module included in the following assemblies:
+//
+// getting_started_rosa/rosa-creating-cluster.adoc
+
+
+[id="rosa-delete-users"]
+= Revoking administrator access using the OCM console
+You can revoke the `dedicated-admin` or `cluster-admin` access of users through the OpenShift Cluster Manager (OCM) console. Users will be able to access the cluster without administrator privileges.
+
+.Prerequisites
+
+* You have added an Identity Provider (IDP) to your cluster.
+* You have the IDP user name for the user whose privileges you are revoking.
+* You are logged in to the OCM console using the OCM account that you used to create the cluster, the organization administrator user, or the super administrator user.
+
+.Procedure
+
+. On the *Clusters* tab of the OCM console, select the name of your cluster to view the cluster details.
+. Select *Access control* > *Cluster Roles and Access*.
+. For the user that you want to remove, click the *Options* menu {kebab} to the right of the user and group combination and click *Delete*.

--- a/rosa_getting_started_sts/rosa-sts-deleting-access-cluster.adoc
+++ b/rosa_getting_started_sts/rosa-sts-deleting-access-cluster.adoc
@@ -1,12 +1,18 @@
 include::modules/attributes-openshift-dedicated.adoc[]
 [id="rosa-sts-deleting-access-cluster"]
-= Deleting access to a ROSA cluster
+= Revoking access to a ROSA cluster
 :context: rosa-sts-deleting-access-cluster
 
 toc::[]
 
-Delete access to a {product-title} (ROSA) cluster using the `rosa` command-line.
+An identity provider (IDP) controls access to a {product-title} (ROSA) cluster. To revoke access of a user to a cluster, you must configure that within the IDP that was set up for authentication.
 
-include::modules/rosa-delete-dedicated-admins.adoc[leveloffset=+1]
+[id="rosa-revoke-admin-access"]
+== Revoking administrator access using the `rosa` CLI
+You can revoke the administrator access of users so that they can access the cluster without administrator privileges. To remove the administrator access for a user, you must revoke the `dedicated-admin` or `cluster-admin` privileges. You can revoke the administrator privileges using the `rosa` command-line utility or using the OpenShift Cluster Manager (OCM) console.
 
-include::modules/rosa-delete-cluster-admins.adoc[leveloffset=+1]
+include::modules/rosa-delete-dedicated-admins.adoc[leveloffset=+2]
+
+include::modules/rosa-delete-cluster-admins.adoc[leveloffset=+2]
+
+include::modules/rosa-delete-users.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR is to address JIRA issue: https://issues.redhat.com/browse/OSDOCS-2850

Topic updated: https://deploy-preview-39993--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-deleting-access-cluster.html

The exact changes are as follows: 
-  Section "Deleting access to a ROSA cluster" > Modified the introduction to include info. about revoking admin access and removing users through the OCM console.
- Section "Revoking dedicated-admin access" > Fixed a few grammatical errors + incorporated tech. review feedback.
- Section "Revoking cluster-admin access" > Fixed a few grammatical errors + incorporated tech. review feedback.
- Section "Removing a user through the OCM console" > Added this section. 

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10