### PR TITLE
Adding missing OSD and ROSA distro references

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -84,6 +84,7 @@ Topics:
 ---
 Name: Upgrading
 Dir: upgrading
+Distros: openshift-dedicated
 Topics:
 - Name: Upgrading OpenShift Dedicated
   File: osd-upgrades

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -112,6 +112,7 @@ Topics:
 ---
 Name: Upgrading
 Dir: upgrading
+Distros: openshift-rosa
 Topics:
 - Name: Upgrading ROSA
   File: rosa-upgrading


### PR DESCRIPTION
This applies to `main`, `enterprise-4.9` and `enterprise-4.10`.

This pull request adds missing distribution references to the OSD and ROSA topic maps. The references relate to the Upgrading book for each collection.