### PR TITLE
RN 4.6: Added extra log4j security advisories

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3411,7 +3411,7 @@ Issued: 2021-12-14
 
 {product-title} release 4.6.52, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5010[RHBA-2021:5010] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5009[RHBA-2021:5009] advisory.
 
-This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], which affects the Apache Log4j utility. Fixes for this flaw are provided by the link:https://access.redhat.com/errata/RHSA-2021:5106[RHSA-2021:5106] advisory.
+This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], link:https://access.redhat.com/security/cve/CVE-2021-45046[CVE-2021-45046], link:https://access.redhat.com/security/cve/CVE-2021-4104[CVE-2021-4104], and link:https://access.redhat.com/security/cve/CVE-2021-4125[CVE-2021-4125], all of which concern the Apache Log4j utility. Fixes for these flaws are provided by the link:https://access.redhat.com/errata/RHSA-2021:5106[RHSA-2021:5106], link:https://access.redhat.com/errata/RHSA-2021:5141[RHSA-2021:5141], and link:https://access.redhat.com/errata/RHSA-2021:5186[RHSA-2021:5186] advisories.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
I've added the full suite of CVEs and additional advisories to the Log4j security statement. 

Preview: https://deploy-preview-39996--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-52