### PR TITLE
4.7 RN: Added extra log47 security advisories

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3025,11 +3025,13 @@ link:https://access.redhat.com/solutions/6564591[{product-title} 4.7.39 containe
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-7-40"]
-=== RHBA-2021:5088 - {product-title} 4.7.40 bug fix update
+=== RHBA-2021:5088 - {product-title} 4.7.40 bug fix and security update
 
 Issued: 2021-12-16
 
-{product-title} release 4.7.40 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5088[RHBA-2021:5088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5087[RHBA-2021:5087] advisory.
+{product-title} release 4.7.40, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5088[RHBA-2021:5088] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:5087[RHBA-2021:5087] advisory.
+
+This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], link:https://access.redhat.com/security/cve/CVE-2021-45046[CVE-2021-45046], link:https://access.redhat.com/security/cve/CVE-2021-4104[CVE-2021-4104], and link:https://access.redhat.com/security/cve/CVE-2021-4125[CVE-2021-4125], all of which concern the Apache Log4j utility. Fixes for these flaws are provided by the link:https://access.redhat.com/errata/RHSA-2021:5107[RHSA-2021:5107] and link:https://access.redhat.com/errata/RHSA-2021:5184[RHSA-2021:5184] advisories.
 
 Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
 


### PR DESCRIPTION
I've added the full suite of CVEs and additional advisories to the Log4j security statement. 

Preview: https://deploy-preview-39997--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes#ocp-4-7-40