### PR TITLE
BZ2022560: adding m6i instance type in 4.6

### DIFF
--- a/modules/installation-aws-user-infra-requirements.adoc
+++ b/modules/installation-aws-user-infra-requirements.adoc
@@ -128,14 +128,9 @@ If `m4` instance types are not available in your region, such as with `eu-west-3
 |x
 |x
 
-| `c4.large`
-|
+|`m6i.xlarge`
 |
 |x
-
-| `c4.xlarge`
-|
-|
 |x
 
 | `c4.2xlarge`

--- a/modules/installation-creating-aws-control-plane.adoc
+++ b/modules/installation-creating-aws-control-plane.adoc
@@ -162,6 +162,7 @@ the CloudFormation template for the security group and roles.
 * `m5.8xlarge`
 * `m5.10xlarge`
 * `m5.16xlarge`
+* `m6i.xlarge`
 * `c4.2xlarge`
 * `c4.4xlarge`
 * `c4.8xlarge`

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -119,8 +119,7 @@ the CloudFormation template for the security group and roles.
 * `m5.8xlarge`
 * `m5.10xlarge`
 * `m5.16xlarge`
-* `c4.large`
-* `c4.xlarge`
+* `m6i.xlarge`
 * `c4.2xlarge`
 * `c4.4xlarge`
 * `c4.8xlarge`


### PR DESCRIPTION
[BZ link](https://bugzilla.redhat.com/show_bug.cgi?id=2022560)

Applies to `enterprise-4.6` only

[PR for `main` and `enterprise-4.7`+](https://github.com/openshift/openshift-docs/pull/38872)

- [Preview link 1](https://deploy-preview-40007--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-aws-user-infra-cluster-machines_installing-aws-user-infra)
- [Preview link 2](https://deploy-preview-40007--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-control-plane_installing-aws-user-infra)  22
- [Preview link 3](https://deploy-preview-40007--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra) 16

