### PR TITLE
CNV13721: Adding CNV Network operator alerts section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3113,6 +3113,8 @@ Topics:
 #  - Name: Collecting OKD Virtualization data for community report
 #    File: virt-collecting-virt-data
 #    Distros: openshift-origin
+  - Name: Virtualization alerts
+    File: virt-virtualization-alerts
 ---
 # OpenShift Serverless
 Name: Serverless

--- a/modules/virt-cnv-network-alerts-cnaodown.adoc
+++ b/modules/virt-cnv-network-alerts-cnaodown.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+
+[id="virt-cnv-network-alerts-cnaodown_{context}"]
+= CnaoDown alert
+
+The cluster-network-addons-operator (CNAO) deploys additional networking components on top of the cluster. This alert occurs when the CNAO operator is down.
+
+If the CNAO is down, changes in the CNV components are not reconciled and might not be properly deployed.
+
+.Procedure
+
+* Diagnose the cause of the CNAO's failure.
+
+** Check CNAO’s operator pod namespace.
++
+[source,terminal]
+----
+export NAMESPACE="$(kubectl get deployment -A | grep cluster-network-addons-operator | awk '{print $1}')"
+----
+
+** Determine if the CNAO’s operator pod is down.
++
+[source,terminal]
+----
+kubectl -n $NAMESPACE get pods -l name=cluster-network-addons-operator
+----
+
+** Check CNAO’s operator pod description and logs.
++
+[source,terminal]
+----
+kubectl -n $NAMESPACE describe pods -l name=cluster-network-addons-operator
+kubectl -n $NAMESPACE logs -l name=cluster-network-addons-operator
+----
+
+* Open an issue and provide the information gathered in the diagnosis process.

--- a/modules/virt-cnv-network-alerts-kubemacpooldown.adoc
+++ b/modules/virt-cnv-network-alerts-kubemacpooldown.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+
+[id="virt-cnv-network-alerts-kubemacpooldown_{context}"]
+= KubeMacPoolDown alert
+
+The KubeMacPool is responsible to allocating MAC Addresses and preventing MAC Address conflicts.
+
+If the KubeMacPool-manager pod is down, `VirtualMachine` objects cannot be created.
+
+.Procedure
+
+* Diagnose the failed component deployment's cause.
+
+** Determine the Kubemacpool-manager’s pod namespace and name.
++
+[source,terminal]
+----
+export KMP_NAMESPACE="$(kubectl get pod -A --no-headers -l control-plane=mac-controller-manager | awk '{print $1}')"
+export KMP_NAME="$(kubectl get pod -A --no-headers -l control-plane=mac-controller-manager | awk '{print $2}')"
+----
+
+** Check the Kubemacpool-manager pod's pod description and logs.
++
+[source,terminal]
+----
+kubectl describe pod -n $KMP_NAMESPACE $KMP_NAME
+kubectl logs -n $KMP_NAMESPACE $KMP_NAME
+----
+
+* Open an issue and provide the information gathered in the diagnosis process.

--- a/modules/virt-cnv-network-alerts-kubemacpoolduplicatemacsfound.adoc
+++ b/modules/virt-cnv-network-alerts-kubemacpoolduplicatemacsfound.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+
+[id="virt-cnv-network-alerts-kubemacpoolduplicatemacsfound_{context}"]
+= KubeMacPoolDuplicateMacsFound alert
+
+The KubeMacPool is responsible for allocating MAC Addresses and preventing MAC Address conflicts. After opening the KubeMacPool, a scan of the cluster for MAC Addresses in virtual machines set on the managed namespaces occurs. This alert occurs if duplicate MAC addresses are found in the scan.
+
+Duplicate MAC Addresses on the same LAN may cause unexpected and various connectability issues in the network.
+
+.Procedure
+
+* Diagnose the failed component deployment's cause.
+
+** Determine the `kubemacpool-mac-controller` pod namespace and name.
++
+[source,terminal]
+----
+kubectl get pod -A -l control-plane=mac-controller-manager --no-headers -o custom-columns=":metadata.namespace,:metadata.name"
+----
+
+** Extract the confliciting Mac Addresses from the kubemacpool-mac-controller pod.
++
+[source,terminal]
+----
+kubectl logs -n <kubemacpool-namespace> <kubemacpool-mac-controller-pod-name> | grep "already allocated"
+----
++
+The extracted output contains the necessary information:
++
+*** The Mac Address which has a conflict
+*** The current entry in the database (VM namespace, name, and interface)
+*** The entry that rejected due to conflict (VM namespace, name, and interface)
++
+An example of a log line is ``"mac address 02:00:ff:ff:ff:ff already allocated to vm/kubemacpool-test/testvm, br1, conflict with: vm/kubemacpool-test/testvm2, br1"`.
+
+** Check the Kubemacpool-manager pod's pod description and logs.
++
+[source,terminal]
+----
+kubectl describe pod -n $KMP_NAMESPACE $KMP_NAME
+kubectl logs -n $KMP_NAMESPACE $KMP_NAME
+----
+
+* Inspect the duplicates.
+* Update the VMs to remove the duplicate MAC Addresses.
+* Once all the conflicts are resolved, restart the `kubemacpool-mac-controller` pod.
++
+[source,terminal]
+----
+kubectl delete pod -n <kubemacpool-namespace> <kubemacpool-mac-controller-pod-name>
+----

--- a/modules/virt-cnv-network-alerts-networkaddonsconfignotready.adoc
+++ b/modules/virt-cnv-network-alerts-networkaddonsconfignotready.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+
+[id="virt-cnv-network-alerts-networkaddonsconfignotready_{context}"]
+= NetworkAddonsConfigNotReady alert
+
+The cluster-network-addons-operator (CNAO) deploys additional networking components on top of the cluster. This alert occurs when the CNAO CR NetworkAddonsConfig is not ready, indicating one of the deployed components is not ready.
+
+If CNAO components are not deployed and ready, some kubevirt networking scenarios cannot be executed.
+
+.Procedure
+
+* Diagnose the failed component deployment's cause.
+
+** Check for messages on the `networkaddonsconfig` CR status.
++
+[source,terminal]
+----
+kubectl get networkaddonsconfig -o custom-columns="":.status.conditions[*].message
+----
+
+** Identify which component is not ready and gather more information from it.
+*** Extract the component deployment or daemonSet and namespace from the message.
++
+For example, if the message is `DaemonSet "cluster-network-addons/macvtap-cni" update is being processed...`, the namespace is `cluster-network-addons` and DaemonSet name is `macvtap-cni`.
+
+*** Check the components’s pod YAML.
++
+[source,terminal]
+----
+kubectl -n <component-namespace> get daemonset <daemonset-name> -o yaml
+----
+
+*** Check the component's pod description and logs.
++
+[source,terminal]
+----
+kubectl -n <component-namespace> logs <pod-name>
+kubectl -n <component-namespace> describe pod <pod-name>
+----
+
+* Open an issue and provide the information gathered in the diagnosis process.

--- a/modules/virt-cnv-network-alerts.adoc
+++ b/modules/virt-cnv-network-alerts.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// * virt/logging_events_monitoring/virt-events.html/virt-virtualization-alerts.adoc
+
+[id="virt-cnv-network-alerts_{context}"]
+= Network Alerts
+
+There are several alerts for the CNV Network operator.

--- a/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
+++ b/virt/logging_events_monitoring/virt-virtualization-alerts.adoc
@@ -1,0 +1,15 @@
+[id="virt-virtualization-alerts"]
+= Virtualization alerts
+include::modules/virt-document-attributes.adoc[]
+include::modules/common-attributes.adoc[]
+:context: virt-virtualization-alerts
+
+toc::[]
+
+Virtualization uses alerts to provide additional information for its metrics.
+
+include::modules/virt-cnv-network-alerts.adoc[leveloffset=+1]
+include::modules/virt-cnv-network-alerts-cnaodown.adoc[leveloffset=+2]
+include::modules/virt-cnv-network-alerts-networkaddonsconfignotready.adoc[leveloffset=+2]
+include::modules/virt-cnv-network-alerts-kubemacpooldown.adoc[leveloffset=+2]
+include::modules/virt-cnv-network-alerts-kubemacpoolduplicatemacsfound.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR addresses JIRA story 

The story asks for adding downstream documentation related to alerts for the CNV Network operator

CP: 4.10

Preview: https://deploy-preview-40008--osdocs.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-virtualization-alerts.html#virt-cnv-network-alerts_virt-virtualization-alerts