### PR TITLE
[virt] removing dedicated section from virt attrib file

### DIFF
--- a/modules/virt-document-attributes.adoc
+++ b/modules/virt-document-attributes.adoc
@@ -12,16 +12,11 @@
 :VirtProductName: OpenShift Virtualization
 :ProductRelease:
 :ProductVersion:
-ifndef::openshift-dedicated[]
+
 :VirtVersion: 4.9
 :KubeVirtVersion: v0.44.2
 :HCOVersion: 4.9.1
-endif::openshift-dedicated[]
-ifdef::openshift-dedicated[]
-:VirtVersion: 2.6
-:KubeVirtVersion: v0.36.2
-:HCOVersion: 2.6.0
-endif::openshift-dedicated[]
+
 // :LastHCOVersion:
 :product-build:
 :DownloadURL: registry.access.redhat.com


### PR DESCRIPTION
* Removing the openshift-dedicated section of the virt attributes file after a discussion with @pneedle-rh.
* CP to 4.9 and 4.10
* No BZ/Jira