### PR TITLE
OSDOCS3127: Add overview page for migration toolkit for containers

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2154,6 +2154,8 @@ Name: Migration Toolkit for Containers
 Dir: migration_toolkit_for_containers
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: Migration toolkit for containers overview
+  File: index
 - Name: About MTC
   File: about-mtc
 - Name: MTC release notes

--- a/migration_toolkit_for_containers/index.adoc
+++ b/migration_toolkit_for_containers/index.adoc
@@ -1,0 +1,68 @@
+[id="migration-toolkit-for-containers-overview"]
+= Migration toolkit for containers overview
+include::modules/common-attributes.adoc[]
+:context: migration-toolkit-for-containers-overview
+
+toc::[]
+
+You can migrate stateful application workloads between {product-title} 4 clusters at the granularity of a namespace by using the Migration Toolkit for Containers (MTC). To learn more about MTC see xref:../migration_toolkit_for_containers/about-mtc.adoc#about-mtc[understanding MTC].
+
+[NOTE]
+====
+If you are migrating from {product-title} 3, see xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[about migrating from {product-title} 3 to 4] and xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[installing the legacy {mtc-full} Operator on {product-title} 3].
+====
+
+[id="mtc-overview-install-mtc"]
+== Installing MTC
+You must install the Migration Toolkit for Containers Operator that is compatible for your {product-title} version:
+
+* {product-title} 4.6 and later versions: xref:../migration_toolkit_for_containers/installing-mtc.adoc#installing-mtc[Install the Migration Toolkit for Containers Operator by using Operator Lifecycle Manager (OLM)].
+* {product-title} 4.5 and earlier versions: xref:../migration_toolkit_for_containers/installing-mtc.adoc#configuring-replication-repository_installing-mtc[Manually install the legacy Migration Toolkit for Containers Operator].
+
+Then you xref:../migration_toolkit_for_containers/installing-mtc.adoc#configuring-replication-repository_installing-mtc[configure object storage to use as a replication repository].
+
+[id="mtc-overview-upgrade-mtc"]
+== Upgrading MTC
+You can xref:../migration_toolkit_for_containers/upgrading-mtc.adoc#upgrading-mtc[upgrade the MTC] by using OLM.
+
+[id="mtc-overview-mtc-checklists"]
+== Reviewing MTC checklists
+Before you migrate your application workloads with the Migration Toolkit for Containers (MTC), review the xref:../migration_toolkit_for_containers/premigration-checklists-mtc.adoc#premigration-checklists-mtc[premigration checklists].
+
+[id="mtc-overview-migrate-mtc-applications"]
+== Migrating applications
+You can migrate your applications by using the MTC xref:../migration_toolkit_for_containers/migrating-applications-with-mtc.adoc#migrating-applications-mtc-web-console_migrating-applications-with-mtc[web console] or xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migrating-applications-cli_advanced-migration-options-mtc[the command line].
+
+[id="mtc-overview-advanced-migration-options"]
+== Advanced migration options
+You can automate your migrations and modify the `MigPlan` and `MigrationController` custom resources in order to perform large-scale migrations and to improve performance. You can check the following items:
+
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-creating-registry-route-for-dim_advanced-migration-options-mtc[Create a registry route for direct image migration]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-configuring-proxies_advanced-migration-options-mtc[Configuring proxies]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-migrating-applications-api_advanced-migration-options-mtc[Migrating an application by using the MTC API]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-state-migration-cli_advanced-migration-options-mtc[Running a state migration]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-hooks_advanced-migration-options-mtc[Creating migration hooks]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-plan-options_advanced-migration-options-mtc[Editing, excluding, and mapping migrated resources]
+* xref:../migration_toolkit_for_containers/advanced-migration-options-mtc.adoc#migration-controller-options_advanced-migration-options-mtc[Configuring the migration controller for large migrations]
+
+[id="mtc-overview-troubleshooting-mtc"]
+== Troubleshooting migrations
+You can perform the following troubleshooting tasks:
+
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-viewing-migration-plan-resources_troubleshooting-mtc[Viewing plan resources]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-viewing-migration-plan-log_troubleshooting-mtc[Viewing the migration plan aggregated log file]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-using-mig-log-reader_troubleshooting-mtc[Using the migration log reader]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-accessing-performance-metrics_troubleshooting-mtc[Accessing performance metrics]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-using-must-gather_troubleshooting-mtc[Using the `must-gather` tool]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-debugging-velero-resources_troubleshooting-mtc[Using the Velero CLI to debug Backup and Restore CRs]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-partial-failure-velero_troubleshooting-mtc[Debugging a partial migration failure]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-using-mtc-crs-for-troubleshooting_troubleshooting-mtc[Using MTC custom resources for troubleshooting]
+* xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#common-issues-and-concerns_troubleshooting-mtc[Checking common issues and concerns]
+
+[id="mtc-overview-roll-back-mtc"]
+== Rolling back a migration
+You can xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#rolling-back-migration_troubleshooting-mtc[roll back a migration] by using the MTC web console, the CLI or manually.
+
+[id="mtc-overview-uninstall-mtc"]
+== Uninstalling MTC and deleting resources
+You can xref:../migration_toolkit_for_containers/troubleshooting-mtc.adoc#migration-uninstalling-mtc-clean-up_troubleshooting-mtc[uninstall the MTC and delete its resources] to clean up the cluster.


### PR DESCRIPTION
OCP version: 4.6+
[Preview](https://deploy-preview-40034--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/index.html)
QA contact: @XinRedhat 
[Fixes](https://issues.redhat.com/browse/OSDOCS-3127)