### PR TITLE
BZ2026308 - Update Note for RT kernel support

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -15,7 +15,7 @@ The cluster administrator can use this performance profile configuration to make
 
 [NOTE]
 ====
-The RT kernel is only supported on worker nodes.
+In most deployments, kernel-rt is supported only on worker nodes when you use a standard cluster with three control plane nodes and three worker nodes. There are exceptions for compact and single nodes on {product-title} deployments. For installations on a single node, kernel-rt is supported on the single control plane node.
 ====
 
 To fully utilize the real-time mode, the containers must run with elevated privileges.


### PR DESCRIPTION
Version 4.9+

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2026308

Current 4.9 doc: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes#performance-addon-operator-known-limitations-for-real-time_cnf-master

Preview: https://deploy-preview-40040--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes

Please QE Ack (lgtm) @mrniranjan 