### PR TITLE
BZ2014617: Fix links

### DIFF
--- a/storage/persistent_storage/persistent-storage-ocs.adoc
+++ b/storage/persistent_storage/persistent-storage-ocs.adoc
@@ -5,91 +5,91 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-Red Hat OpenShift Container Storage is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, Red Hat OpenShift Container Storage is completely integrated with {product-title} for deployment, management, and monitoring.
+Red Hat OpenShift Data Foundation is a provider of agnostic persistent storage for {product-title} supporting file, block, and object storage, either in-house or in hybrid clouds. As a Red Hat storage solution, Red Hat OpenShift Data Foundation is completely integrated with {product-title} for deployment, management, and monitoring.
 
-Red Hat OpenShift Container Storage provides its own documentation library. The complete set of Red Hat OpenShift Container Storage documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/
+Red Hat OpenShift Data Foundation provides its own documentation library. The complete set of Red Hat OpenShift Data Foundation documentation identified below is available at https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/
 
 [IMPORTANT]
 ====
-OpenShift Container Storage on top of Red Hat Hyperconverged Infrastructure (RHHI) for Virtualization, which uses hyperconverged nodes that host virtual machines installed with {product-title}, is not a supported configuration. For more information about supported platforms, see the link:https://access.redhat.com/articles/4731161[Red Hat OpenShift Container Storage Supportability and Interoperability Guide].
+OpenShift Data Foundation on top of Red Hat Hyperconverged Infrastructure (RHHI) for Virtualization, which uses hyperconverged nodes that host virtual machines installed with {product-title}, is not a supported configuration. For more information about supported platforms, see the link:https://access.redhat.com/articles/4731161[Red Hat OpenShift Data Foundation Supportability and Interoperability Guide].
 ====
 
 [options="header",cols="1,1"]
 |===
 
-|If you are looking for Red Hat OpenShift Container Storage information about...
-|See the following Red Hat OpenShift Container Storage documentation:
+|If you are looking for Red Hat OpenShift Data Foundation information about...
+|See the following Red Hat OpenShift Data Foundation documentation:
 
 2+^| *Planning*
 
 |What's new, known issues, notable bug fixes, and Technology Previews
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/4.7_release_notes/[Red Hat OpenShift Container Storage 4.7 Release Notes]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/4.10_release_notes/[Red Hat OpenShift Data Foundation 4.10 Release Notes]
 
 |Supported workloads, layouts, hardware and software requirements, sizing and scaling recommendations
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/planning_your_deployment/index[Planning your Red Hat OpenShift Container Storage 4.7 deployment]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/planning_your_deployment/index[Planning your Red Hat OpenShift Data Foundation 4.10 deployment]
 
 2+^| *Deploying*
 
 //|Preparing to deploy when your environment is not directly connected to the internet
-//|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/preparing_to_deploy_in_a_disconnected_environment/[Preparing to deploy OpenShift Container Storage 4.7 in a disconnected environment]
+//|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/planning_your_deployment/disconnected-environment_rhocs[Preparing to deploy OpenShift Data Foundation 4.10 in a disconnected environment]
 
-|Deploying Red Hat OpenShift Container Storage using Amazon Web Services for local or cloud storage
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_amazon_web_services/[Deploying OpenShift Container Storage 4.7 using Amazon Web Services]
+|Deploying Red Hat OpenShift Data Foundation using Amazon Web Services for local or cloud storage
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_using_amazon_web_services/index[Deploying OpenShift Data Foundation 4.10 using Amazon Web Services]
 
-|Deploying Red Hat OpenShift Container Storage to local storage on bare metal infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_bare_metal_infrastructure/[Deploying OpenShift Container Storage 4.7 using bare metal infrastructure]
+|Deploying Red Hat OpenShift Data Foundation to local storage on bare metal infrastructure
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_using_bare_metal_infrastructure/[Deploying OpenShift Data Foundation 4.10 using bare metal infrastructure]
 
-|Deploying Red Hat OpenShift Container Storage to use an external Red Hat Ceph Storage cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_in_external_mode/[Deploying OpenShift Container Storage 4.7 in external mode]
+|Deploying Red Hat OpenShift Data Foundation to use an external Red Hat Ceph Storage cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_in_external_mode/[Deploying OpenShift Data Foundation 4.10 in external mode]
 
-|Deploying and managing Red Hat OpenShift Container Storage on existing Google Cloud clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_and_managing_openshift_container_storage_using_google_cloud/[Deploying and managing OpenShift Container Storage 4.7 using Google Cloud]
+|Deploying and managing Red Hat OpenShift Data Foundation on existing Google Cloud clusters
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_and_managing_openshift_container_storage_using_google_cloud/[Deploying and managing OpenShift Data Foundation 4.10 using Google Cloud]
 
-|Deploying Red Hat OpenShift Container Storage to use local storage on IBM Z infrastructure
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_ibm_z_infrastructure/[Deploying OpenShift Container Storage using IBM Z]
+|Deploying Red Hat OpenShift Data Foundation to use local storage on IBM Z infrastructure
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_using_ibm_z_infrastructure/[Deploying OpenShift Data Foundation using IBM Z]
 
-|Deploying Red Hat OpenShift Container Storage on IBM Power Systems
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_ibm_power_systems/[Deploying OpenShift Container Storage using IBM Power Systems]
+|Deploying Red Hat OpenShift Data Foundation on IBM Power Systems
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_using_ibm_power_systems/[Deploying OpenShift Data Foundation using IBM Power Systems]
 
-|Deploying Red Hat OpenShift Container Storage on IBM Cloud
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_ibm_cloud/[Deploying OpenShift Container Storage using IBM Cloud]
+|Deploying Red Hat OpenShift Data Foundation on IBM Cloud
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_data_foundation_using_ibm_cloud/[Deploying OpenShift Data Foundation using IBM Cloud]
 
-|Deploying and managing Red Hat OpenShift Container Storage on {rh-openstack-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_and_managing_openshift_container_storage_using_red_hat_openstack_platform/[Deploying and managing OpenShift Container Storage 4.7 using Red Hat OpenStack Platform]
+|Deploying and managing Red Hat OpenShift Data Foundation on {rh-openstack-first}
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_and_managing_openshift_container_storage_using_red_hat_openstack_platform/[Deploying and managing OpenShift Data Foundation 4.10 using Red Hat OpenStack Platform]
 
-|Deploying and managing Red Hat OpenShift Container Storage on {rh-virtualization-first}
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_using_red_hat_virtualization_platform/index[Deploying and managing OpenShift Container Storage 4.7 using Red Hat Virtualization Platform]
+|Deploying and managing Red Hat OpenShift Data Foundation on {rh-virtualization-first}
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_using_red_hat_virtualization_platform/index[Deploying and managing OpenShift Data Foundation 4.10 using Red Hat Virtualization Platform]
 
-|Deploying Red Hat OpenShift Container Storage on VMware vSphere clusters
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/deploying_openshift_container_storage_on_vmware_vsphere/[Deploying OpenShift Container Storage 4.7 on VMware vSphere]
+|Deploying Red Hat OpenShift Data Foundation on VMware vSphere clusters
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/deploying_openshift_container_storage_on_vmware_vsphere/[Deploying OpenShift Data Foundation 4.10 on VMware vSphere]
 
-|Updating Red Hat OpenShift Container Storage to the latest version
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/updating_openshift_container_storage/[Updating OpenShift Container Storage]
+|Updating Red Hat OpenShift Data Foundation to the latest version
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/updating_openshift_container_storage/[Updating OpenShift Data Foundation]
 
 2+^| *Managing*
 
-|Allocating storage to core services and hosted applications in Red Hat OpenShift Container Storage, including snapshot and clone
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/managing_and_allocating_storage_resources/[Managing and allocating resources]
+|Allocating storage to core services and hosted applications in Red Hat OpenShift Data Foundation, including snapshot and clone
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/managing_and_allocating_storage_resources/[Managing and allocating resources]
 
 |Managing storage resources across a hybrid cloud or multicloud environment using the Multicloud Object Gateway (NooBaa)
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/managing_hybrid_and_multicloud_resources/[Managing hybrid and multicloud resources]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/managing_hybrid_and_multicloud_resources/[Managing hybrid and multicloud resources]
 
-|Safely replacing storage devices for Red Hat OpenShift Container Storage
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/replacing_devices/[Replacing devices]
+|Safely replacing storage devices for Red Hat OpenShift Data Foundation
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/replacing_devices/[Replacing devices]
 
-|Safely replacing a node in a Red Hat OpenShift Container Storage cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/replacing_nodes/[Replacing nodes]
+|Safely replacing a node in a Red Hat OpenShift Data Foundation cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/replacing_nodes/[Replacing nodes]
 
-|Scaling operations in Red Hat OpenShift Container Storage
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/scaling_storage/[Scaling storage]
+|Scaling operations in Red Hat OpenShift Data Foundation
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/scaling_storage/[Scaling storage]
 
-|Monitoring a Red Hat OpenShift Container Storage 4.7 cluster
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/monitoring_openshift_container_storage/[Monitoring OpenShift Container Storage 4.7]
+|Monitoring a Red Hat OpenShift Data Foundation 4.10 cluster
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/monitoring_openshift_container_storage/[Monitoring OpenShift Data Foundation 4.10]
 
 |Troubleshooting errors and issues
-|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_container_storage/4.7/html/troubleshooting_openshift_container_storage/[Troubleshooting OpenShift Container Storage 4.7]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/troubleshooting_openshift_container_storage/[Troubleshooting OpenShift Data Foundation 4.10]
 
 |Migrating your {product-title} cluster from version 3 to version 4
-|link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.7/html/migration_toolkit_for_containers/[Migration Toolkit for Containers]
+|link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html/migration_toolkit_for_containers/[Migration Toolkit for Containers]
 
 |===


### PR DESCRIPTION
[Preview](https://deploy-preview-40045--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-ocs.html)
QA contact @duanwei33 
[Fixes](https://bugzilla.redhat.com/show_bug.cgi?id=2014617)
OCP version applies for 4.8 only

I figured out later that this PR should apply to 4.8 only. That's why it's opened from the main branch. Can we backport to 4.8 only?