### PR TITLE
BZ-1892611: adding first commit for BZ-1892611

### DIFF
--- a/modules/ipi-install-creating-a-disconnected-registry.adoc
+++ b/modules/ipi-install-creating-a-disconnected-registry.adoc
@@ -185,6 +185,38 @@ $ jq ".auths += $AUTHSTRING" < pull-secret.txt > pull-secret-update.txt
 $ sudo scp kni@provisioner:/usr/local/bin/oc /usr/local/bin
 ----
 
+. Set the required environment variables.
+
+.. Set the release version:
++
+[source,terminal]
+----
+$ VERSION=<release_version>
+----
++
+For `<release_version>`, specify the tag that corresponds to the version of {product-title} to install, such as `{product-version}`.
+
+.. Set the local registry name and host port:
++
+[source,terminal]
+----
+$ LOCAL_REG='<local_registry_host_name>:<local_registry_host_port>'
+----
++
+For `<local_registry_host_name>`, specify the registry domain name for your mirror
+repository, and for `<local_registry_host_port>`, specify the port that it
+serves content on.
+
+.. Set the local repository name:
++
+[source,terminal]
+----
+$ LOCAL_REPO='<local_repository_name>'
+----
++
+For `<local_repository_name>`, specify the name of the repository to create in your
+registry, such as `ocp4/openshift4`.
+
 . Mirror the remote install images to the local repository.
 +
 [source,terminal]


### PR DESCRIPTION
**Addressing**: https://bugzilla.redhat.com/show_bug.cgi?id=1892611

**Preview**: https://deploy-preview-40046--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#mirroring-the-repository-optional

This change needs to be brought back to v4.6. So change is relevant for 4.6, 4.7, 4.8, 4.9 and 4.10 and main.


