### PR TITLE
BZ:1978227 - Adding cookie=strict annotations to table for v3.11

### DIFF
--- a/architecture/networking/routes.adoc
+++ b/architecture/networking/routes.adoc
@@ -597,6 +597,15 @@ and "-". The default is the hashed internal key name for the route. |
 |`*router.openshift.io/haproxy.health.check.interval*`| Sets the interval for the back-end health checks. (TimeUnits) | `ROUTER_BACKEND_CHECK_INTERVAL`
 |`*haproxy.router.openshift.io/ip_whitelist*` | Sets a xref:whitelist[whitelist] for the route. |
 |`*haproxy.router.openshift.io/hsts_header*` | Sets a Strict-Transport-Security header for the edge terminated or re-encrypt route. |
+|`*router.openshift.io/cookie-same-site*` | Sets a value to restrict cookies. The values are:
+
+`Lax`: cookies are transferred between the visited site and third-party sites.
+
+`Strict`: cookies are restricted to the visited site.
+
+`None`: cookies are restricted to the visited site.
+
+This value is applicable to re-encrypt and edge routes only. For more information, see the link:https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite[SameSite cookies documentation].|
 |===
 
 .A Route Setting Custom Timeout


### PR DESCRIPTION
For Version: 3.11 
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1978227

Preview: https://deploy-preview-40055--osdocs.netlify.app/openshift-enterprise/latest/architecture/networking/routes.html#route-specific-annotations

For Peer reviewers: Can you please add the "enterprise-3.11" label, thank you