### PR TITLE
BZ2032950:removed the note

### DIFF
--- a/modules/nw-proxy-configure-object.adoc
+++ b/modules/nw-proxy-configure-object.adoc
@@ -121,8 +121,3 @@ authority from the RHCOS trust bundle.
 --
 
 . Save the file to apply the changes.
-
-[NOTE]
-====
-The URL scheme must be `http`. The `https` scheme is currently not supported.
-====


### PR DESCRIPTION
- Applies to 4.6+
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2032950)
- [Preview](https://deploy-preview-40068--osdocs.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html)
- @lihongan please verify.