### PR TITLE
BZ2005023: Updates MaxCSIVolumeCount namespace

### DIFF
--- a/modules/nodes-scheduler-default-predicates.adoc
+++ b/modules/nodes-scheduler-default-predicates.adoc
@@ -87,11 +87,11 @@ The `MaxGCEPDVolumeCount` predicate checks the maximum number of Google Compute 
 {"name" : "MaxGCEPDVolumeCount"}
 ----
 
-The `MaxCSIVolumeCount` predicate determines how many Container Storage Interface (CSI) volumes should be attached to a node and whether that number exceeds a configured limit.
+The `MaxCSIVolumeCountPred` predicate determines how many Container Storage Interface (CSI) volumes should be attached to a node and whether that number exceeds a configured limit.
 
 [source,yaml]
 ----
-{"name" : "MaxCSIVolumeCount"}
+{"name" : "MaxCSIVolumeCountPred"}
 ----
 
 The `MatchInterPodAffinity` predicate checks if the pod affinity/anti-affinity rules permit the pod.


### PR DESCRIPTION
Updated `MaxCSIVolumeCount` to `MaxCSIVolumeCountPred`

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2005023

OCP version: Applicable to 4.6 +

DocPreview link: https://deploy-preview-40076--osdocs.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-default.html#default-predicates_nodes-scheduler-default

@sunilcio Please review and let me know your feedback.