### PR TITLE
Update contrib guideline for lowercase in ID metadata

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -34,7 +34,7 @@ include::modules/common-attributes.adoc[]                       <3>
 toc::[]                                                         <6>
 ----
 
-<1> A unique (within OpenShift docs) anchor id for this assembly. Example: cli-developer-commands
+<1> A unique (within OpenShift docs) anchor id for this assembly. Use lowercase. Example: cli-developer-commands
 <2> Human readable title (notice the '=' top-level header)
 <3> Includes attributes common to OpenShift docs.
 +
@@ -69,7 +69,7 @@ Every module should be placed in the modules folder and should contain the follo
 ----
 
 <1> List of assemblies in which this module is included.
-<2> A module anchor with {context} that must match the module's file name.
+<2> A module anchor with {context} that must be lowercase and must match the module's file name.
 <3> Human readable title. To ensure consistency in the results of the
 leveloffset values in include statements, you must use a level one heading
 ( = ) for the module title.


### PR DESCRIPTION
While peer reviewers generally advise that anchor IDs should be lowercase, we don't currently spell this out in our OCP contrib guidelines. This PR seeks comment from the team so that we can document this guidance if consensus is reached.