### PR TITLE
[RHACS] Scanner version update for 3.67.2

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -42,7 +42,7 @@ endif::[]
 :ocp: OpenShift Container Platform
 :rhacs-version: 3.67.2
 :ocp-supported-version: 4.5
-:scanner-version: 2.21.1
+:scanner-version: 2.21.3
 :collector-version: 3.5.0-latest
 // Following are used in modules/configure-policy-notifications.adoc
 :toolname: PagerDuty

--- a/release_notes/367-release-notes.adoc
+++ b/release_notes/367-release-notes.adoc
@@ -115,11 +115,11 @@ Also includes `roxctl` for use in continuous integration (CI) systems.
 
 | Scanner
 | Scans images and nodes.
-| registry.redhat.io/rh-acs/scanner:2.21.1
+| registry.redhat.io/rh-acs/scanner:2.21.3
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-| registry.redhat.io/rh-acs/scanner-db:2.21.1
+| registry.redhat.io/rh-acs/scanner-db:2.21.3
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.


### PR DESCRIPTION
Update the Scanner version for the latest release.

Applies to 3.67 only

<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
