### PR TITLE
BZ:1965420 - Adding note section to show why we do not have guidance on support limits 

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -66,3 +66,7 @@ Tested Cloud Platforms for {product-title} 4.x: Amazon Web Services, Microsoft A
 5. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
 6. Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
 --
+[NOTE]
+====
+Red Hat does not provide direct guidance on sizing your {product-title} cluster. This is because determining whether your cluster is within the supported bounds of {product-title} requires careful consideration of all the multidimensional factors that limit the cluster scale. 
+====


### PR DESCRIPTION
For versions 4.6+
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1965420

Ready for QA: @mffiedler 

Preview: https://deploy-preview-40139--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits

For peer reviewers: Please add the labels 'enterprise-4.7', 'enterprise-4.8' enterprise-4.9' 'enterprise-4.10' and 'Peer Review needed'. Thank you!!