### PR TITLE
log4j CVE info for 3.11 rel notes

### DIFF
--- a/release_notes/ocp_3_11_release_notes.adoc
+++ b/release_notes/ocp_3_11_release_notes.adoc
@@ -5485,6 +5485,8 @@ Issued: 2021-12-08
 
 {product-title} release 3.11.570 is now available. The list of packages and bug fixes included in the update are documented in the link:https://access.redhat.com/errata/RHBA-2021:4929[RHBA-2021:4929] advisory. The container images included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2021:4930[RHBA-2021:4930] advisory.
 
+This release includes critical security updates for link:https://access.redhat.com/security/cve/CVE-2021-44228[CVE-2021-44228], which concerns the Apache Log4j utility. Fixes for this flaw are provided by the link:https://access.redhat.com/errata/RHSA-2021:5094[RHSA-2021:5094] advisory.
+
 [[ocp-3-11-570-images]]
 ==== Images
 


### PR DESCRIPTION
Adds information and links related to log4j advisory in 3.11.

Preview: https://deploy-preview-40143--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp_3_11_release_notes.html#ocp-3-11-570