### PR TITLE
OSDOCS-3040: Check for config drift regularly RN

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -84,6 +84,15 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-10-machine-api"]
 === Machine API
 
+[id="ocp-4-10-mco-config-drift"]
+==== Enhanced configuration drift detection
+
+With this enhancement, the Machine Config Daemon (MCD) now checks nodes for configuration drift if a filesystem write event occurs for any of the files specified in the machine config and before a new machine config is applied, in addition to node bootup. Previously, the MCD checked for configuration drift only at node bootup. This change was made because node reboots do not occur frequently enough to avoid the problems caused by configuration drift until an administrator can correct the issue.
+
+Configuration drift occurs when the on-disk state of a node differs from what is configured in the machine config. The Machine Config Operator (MCO) uses the MCD to check nodes for configuration drift and, if detected, sets that node and machine config pool (MCP) to `degraded`.
+
+For more information on configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection]. 
+
 [id="ocp-4-10-nodes"]
 === Nodes
 


### PR DESCRIPTION
Release note for https://issues.redhat.com/browse/OSDOCS-3040

Preview: https://deploy-preview-40144--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-mco-config-drift