### PR TITLE
BZ1986964: External load balancers for VIP traffic available for RHOSP and baremetal IPI only

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -544,9 +544,11 @@ The assisted installer and installer-provisioned installation for bare metal clu
 If you need the virtual IP (VIP) addresses to run on the control plane nodes in a bare metal installation, you must configure the `apiVIP` and `ingressVIP` VIP addresses to run exclusively on the control plane nodes. By default, {product-title} allows any node in the worker machine configuration pool to host the `apiVIP` and `ingressVIP` VIP addresses. Because many bare metal environments deploy worker nodes in separate subnets from the control plane nodes, configuring the `apiVIP` and `ingressVIP` virtual IP addresses to run exclusively on the control plane nodes prevents issues from arising due to deploying worker nodes in separate subnets. For additional details, see xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configure-network-components-to-run-on-the-control-plane_ipi-install-configuration-files[Configure network components to run on the control plane].
 
 [id="ocp-4-8-networking-external-load-balancer"]
-==== Configuring an external load balancer for apiVIP and ingressVIP traffic
+==== Configuring external load balancers for apiVIP and ingressVIP traffic
 
-In {product-title} 4.8, you can configure an external load balancer to handle `apiVIP` and `ingressVIP` traffic to the control plane of installer-provisioned clusters. External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
+In {product-title} 4.8, you can configure an external load balancer to handle `apiVIP` and `ingressVIP` traffic for {rh-openstack-first} and bare-metal installer-provisioned clusters. External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
+
+Configuring load balancers to handle `apiVIP` and `ingressVIP` traffic is not supported for VMware installer-provisioned clusters.
 
 [id="ocp-4-8-IPsec-support-dual-stack"]
 ==== OVN-Kubernetes IPsec support for dual-stack networking


### PR DESCRIPTION
Change management acks received, notification of change sent. Ready to merge.

Fixes:  
https://bugzilla.redhat.com/show_bug.cgi?id=1986964

Preview link:

https://deploy-preview-40145--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-networking-external-load-balancer

Versions:  4.8 

