### PR TITLE
Remove errant + in table 12

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -107,11 +107,11 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:enp1s0:none
 ip=10.10.10.3::10.10.10.254:255.255.255.0:core0.example.com:enp2s0:none
 ----
 
-a|Optional: You can configure routes to additional networks by setting an `rd.route=` value. 
+a|Optional: You can configure routes to additional networks by setting an `rd.route=` value.
 
 If the additional network gateway is different from the primary network gateway, the default gateway must be the primary network gateway.
 a|
-To configure the default gateway: 
+To configure the default gateway:
 
 ----
 ip=::10.10.10.254::::
@@ -121,7 +121,7 @@ To configure the route for the additional network:
 
 ----
 rd.route=20.20.20.0/24:20.20.20.254:enp2s0
----- 
+----
 
 a|Disable DHCP on a single interface, such as when there are two or more network interfaces and only one interface is being used. In the example, the `enp1s0` interface has a static networking configuration and DHCP is disabled for `enp2s0`, which is not used.
 a|
@@ -277,7 +277,7 @@ a|Delete a default kernel argument from the installed system.
 
 a|`-n`, `--copy-network`
 a|Copy the network configuration from the install environment.
-+
+
 [IMPORTANT]
 ====
 The `--copy-network` option only copies networking configuration found under `/etc/NetworkManager/system-connections`. In particular, it does not copy the system hostname.


### PR DESCRIPTION
There is a floating `+` that doesn't belong in the table. This applies to OCP 4.6+. No QE required.