### PR TITLE
BZ2030784: remove ipam from the host-device CNI plug-in configuration

### DIFF
--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -43,11 +43,6 @@ The following object describes the configuration parameters for the host-device 
 |`pciBusID`
 |`string`
 |Optional: The PCI address of the network device, such as `0000:00:1f.6`.
-
-|`ipam`
-|`object`
-|The configuration object for the IPAM CNI plug-in. The plug-in manages IP address assignment for the attachment definition.
-
 |====
 
 [id="nw-multus-hostdev-config-example_{context}"]
@@ -61,9 +56,6 @@ The following example configures an additional network named `hostdev-net`:
   "cniVersion": "0.3.1",
   "name": "work-network",
   "type": "host-device",
-  "device": "eth1",
-  "ipam": {
-    "type": "dhcp"
-  }
+  "device": "eth1"
 }
 ----


### PR DESCRIPTION
For 4.9+

https://bugzilla.redhat.com/show_bug.cgi?id=2030784

[Docs preview](https://deploy-preview-40159--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-host-device-object_configuring-additional-network)

Requires ack from @weliang1 