### PR TITLE
BZ2031163: change the storage location for Tang server keys

### DIFF
--- a/modules/nbde-backing-up-server-keys.adoc
+++ b/modules/nbde-backing-up-server-keys.adoc
@@ -5,7 +5,7 @@
 [id="nbde-backing-up-server-keys_{context}"]
 = Backing up keys for a Tang server
 
-The Tang server, by default, stores its keys in the `/usr/libexec/tangd-keygen` directory. Back up the contents of this directory to enable recovery in the event of the loss of the Tang server. The keys are sensitive and since they are able to perform the boot disk decryption of all hosts that have used them, the keys must be protected accordingly.
+The Tang server uses `/usr/libexec/tangd-keygen` to generate new keys and stores them in the `/var/db/tang` directory by default. To recover the Tang server in the event of a failure, back up this directory. The keys are sensitive and because they are able to perform the boot disk decryption of all hosts that have used them, the keys must be protected accordingly.
 
 .Procedure
 


### PR DESCRIPTION
For 4.9+

https://bugzilla.redhat.com/show_bug.cgi?id=2031163

[Docs preview](https://deploy-preview-40160--osdocs.netlify.app/openshift-enterprise/latest/security/network_bound_disk_encryption/nbde-managing-encryption-keys.html#nbde-backing-up-server-keys_nbde-implementation)

Requires ack from @pdhamdhe 