### PR TITLE
OSDOCS-3122: Migrating from version 3 to 4 overview

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2158,6 +2158,8 @@ Name: Migrating from version 3 to 4
 Dir: migrating_from_ocp_3_to_4
 Distros: openshift-enterprise,openshift-origin
 Topics:
+- Name: Migrating from version 3 to 4 overview
+  File: index
 - Name: About migrating from OpenShift Container Platform 3 to 4
   File: about-migrating-from-3-to-4
   Distros: openshift-enterprise

--- a/migrating_from_ocp_3_to_4/index.adoc
+++ b/migrating_from_ocp_3_to_4/index.adoc
@@ -1,0 +1,82 @@
+:_content-type: ASSEMBLY
+[id="migration-from-version-3-to-4-overview"]
+= Migration from OpenShift Container Platform 3 to 4 overview
+include::modules/common-attributes.adoc[]
+:context: migration-from-version-3-to-4-overview
+
+toc::[]
+
+{product-title} 4 clusters are different from {product-title} 3 clusters. {product-title} 4 clusters contain new technologies and functionality that result in a cluster that is self-managing, flexible, and automated. To learn more about migrating from {product-title} 3 to 4 see xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[About migrating from OpenShift Container Platform 3 to 4].
+
+[id="mtc-3-to-4-overview-differences-mtc"]
+== Differences between {product-title} 3 and 4
+Before migrating from {product-title} 3 to 4, you can check xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[differences between {product-title} 3 and 4]. Review the following information:
+
+* xref:../architecture/architecture.adoc#architecture[Architecture]
+* xref:../architecture/architecture-installation.adoc#architecture-installation[Installation and update]
+* xref:../storage/index.adoc#index[Storage], xref:../networking/understanding-networking.adoc#understanding-networking[network], xref:../logging/cluster-logging.adoc#cluster-logging[logging], xref:../security/index.adoc#index[security], and xref:../monitoring/monitoring-overview.adoc#monitoring-overview[monitoring considerations]
+
+[id="mtc-3-to-4-overview-planning-network-considerations-mtc"]
+== Planning network considerations
+Before migrating from {product-title} 3 to 4, review the xref:../migrating_from_ocp_3_to_4/planning-migration-3-4.adoc#planning-migration-3-4[differences between {product-title} 3 and 4] for information about the following areas:
+
+* xref:../migrating_from_ocp_3_to_4/planning-considerations-3-4.adoc#dns-considerations_planning-considerations-3-4[DNS considerations]
+** xref:../migrating_from_ocp_3_to_4/planning-considerations-3-4.adoc#migration-isolating-dns-domain-of-target-cluster-from-clients_planning-considerations-3-4[Isolating the DNS domain of the target cluster from the clients].
+** xref:../migrating_from_ocp_3_to_4/planning-considerations-3-4.adoc#migration-setting-up-target-cluster-to-accept-source-dns-domain_planning-considerations-3-4[Setting up the target cluster to accept the source DNS domain].
+
+You can migrate stateful application workloads from {product-title} 3 to 4 at the granularity of a namespace. To learn more about MTC see xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#about-mtc-3-4[Understanding MTC].
+
+[NOTE]
+====
+If you are migrating from {product-title} 3, see xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to-4.adoc#about-migrating-from-3-to-4[About migrating from {product-title} 3 to 4] and xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
+====
+
+[id="mtc-overview-install-mtc"]
+== Installing MTC
+Review the following tasks to install the MTC:
+
+. xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-mtc-on-ocp-4_installing-3-4[Install the {mtc-full} Operator on target cluster by using Operator Lifecycle Manager (OLM)].
+. xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-installing-legacy-operator_installing-3-4[Install the legacy {mtc-full} Operator on the source cluster manually].
+. xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#configuring-replication-repository_installing-3-4[Configure object storage to use as a replication repository].
+
+[id="mtc-overview-upgrade-mtc"]
+== Upgrading MTC
+You xref:../migrating_from_ocp_3_to_4/upgrading-3-4.adoc#upgrading-3-4[upgrade the {mtc-full} ({mtc-short})] on {product-title} {product-version} by using OLM. You upgrade {mtc-short} on {product-title} 3 by reinstalling the legacy {mtc-full} Operator.
+
+[id="mtc-overview-mtc-checklists"]
+== Reviewing premigration checklists
+Before you migrate your application workloads with the Migration Toolkit for Containers (MTC), review the xref:../migrating_from_ocp_3_to_4/premigration-checklists-3-4.adoc#premigration-checklists-3-4[premigration checklists].
+
+[id="mtc-overview-migrate-mtc-applications"]
+== Migrating applications
+You can migrate your applications by using the MTC xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#migrating-applications-mtc-web-console_migrating-applications-3-4[web console] or xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migrating-applications-cli_advanced-migration-options-3-4[the command line].
+
+[id="mtc-overview-advanced-migration-options"]
+== Advanced migration options
+You can automate your migrations and modify MTC custom resources to improve the performance of large-scale migrations by using the following options:
+
+* xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-state-migration-cli_advanced-migration-options-3-4[Running a state migration]
+* xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-hooks_advanced-migration-options-3-4[Creating migration hooks]
+* xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-plan-options_advanced-migration-options-3-4[Editing, excluding, and mapping migrated resources]
+* xref:../migrating_from_ocp_3_to_4/advanced-migration-options-3-4.adoc#migration-controller-options_advanced-migration-options-3-4[Configuring the migration controller for large migrations]
+
+[id="mtc-overview-troubleshooting-mtc"]
+== Troubleshooting migrations
+You can perform the following troubleshooting tasks:
+
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-viewing-migration-plan-resources_troubleshooting-3-4[Viewing migration plan resources by using the MTC web console]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-viewing-migration-plan-log_troubleshooting-3-4[Viewing the migration plan aggregated log file]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-using-mig-log-reader_troubleshooting-3-4[Using the migration log reader]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-accessing-performance-metrics_troubleshooting-3-4[Accessing performance metrics]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-using-must-gather_troubleshooting-3-4[Using the `must-gather` tool]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-debugging-velero-resources_troubleshooting-3-4[Using the Velero CLI to debug `Backup` and `Restore` CRs]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#migration-using-mtc-crs-for-troubleshooting_troubleshooting-3-4[Using MTC custom resources for troubleshooting]
+* xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#common-issues-and-concerns_troubleshooting-3-4[Checking common issues and concerns]
+
+[id="mtc-overview-roll-back-mtc"]
+== Rolling back a migration
+You can xref:../migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc#rolling-back-migration_troubleshooting-3-4[roll back a migration] by using the MTC web console, by using the CLI, or manually.
+
+[id="mtc-overview-uninstall-mtc"]
+== Uninstalling MTC and deleting resources
+You can xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-uninstalling-mtc-clean-up_installing-3-4[uninstall the MTC and delete its resources] to clean up the cluster.


### PR DESCRIPTION
[Preview](https://deploy-preview-40171--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/index.html)
Fixes: [OCSOSD3122](https://issues.redhat.com/browse/OSDOCS-3092)
QE contact: @XinRedhat 
OCP version: 4.6+