### PR TITLE
BZ2020086: Operator catalog mirror using local files has not ready-to-use imageContentSourcePolicy.yaml  sources

### DIFF
--- a/modules/olm-mirroring-catalog-manifests.adoc
+++ b/modules/olm-mirroring-catalog-manifests.adoc
@@ -40,6 +40,20 @@ If you mirrored the content to local files, you must modify your `catalogSource.
 ====
 If your cluster uses an `ImageContentSourcePolicy` object to configure repository mirroring, you can use only global pull secrets for mirrored registries. You cannot add a pull secret to a project.
 ====
+* If you use a local file, modify the generated `imageContentSourcePolicy.yaml` as the following:
++
+[source,yaml]
+----
+spec:
+  repositoryDigestMirrors:
+  - mirrors:
+    - localhost:5000/mirror-from-local/openshift-logging-elasticsearch6-rhel8
+    source: registry.redhat.io/openshift-logging/elasticsearch6-rhel8
+  - mirrors:
+    - localhost:5000/mirror-from-local/openshift4-ose-logging-fluentd
+    source: registry.redhat.io/openshift4/ose-logging-fluentd
+----
+
 * The `mapping.txt` file contains all of the source images and where to map them in the target registry. This file is compatible with the `oc image mirror` command and can be used to further customize the mirroring configuration.
 +
 [IMPORTANT]


### PR DESCRIPTION
Preview
OCP version: 4.8+
[Fixes](https://bugzilla.redhat.com/show_bug.cgi?id=2020086)
QA contact: @jianzhangbjz 