### PR TITLE
BZ1995934: add the IPv6 prereq for converting to dual stack

### DIFF
--- a/modules/nw-dual-stack-convert.adoc
+++ b/modules/nw-dual-stack-convert.adoc
@@ -13,6 +13,7 @@ After converting to dual-stack networking only newly created pods are assigned I
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 * Your cluster uses the OVN-Kubernetes cluster network provider.
+* The cluster nodes have IPv6 addresses.
 
 .Procedure
 


### PR DESCRIPTION
For 4.8+

https://bugzilla.redhat.com/show_bug.cgi?id=1995934

[Doc preview](https://deploy-preview-40175--osdocs.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html)

Requires ack from @zhaozhanqi 