### PR TITLE
 RHDEVDOCS-3360 - How to run OpenShift GitOps control plane on infra nodes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1490,6 +1490,8 @@ Topics:
     File: configuring-sso-on-argo-cd-using-dex
   - Name: Configuring SSO for Argo CD using Keycloak
     File: configuring-sso-for-argo-cd-using-keycloak
+  - Name: Running Control Plane Workloads on Infra Nodes 
+    File: run-gitops-control-plane-workload-on-infra-nodes
 ---
 Name: Images
 Dir: openshift_images

--- a/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.adoc
+++ b/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.adoc
@@ -1,0 +1,14 @@
+include::modules/gitops-document-attributes.adoc[]
+[id="run-gitops-control-plane-workload-on-infra-nodes"]
+= Running GitOps control plane workloads on infrastructure nodes
+:context: run-gitops-control-plane-workload-on-infra-nodes
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+You can use infrastructure nodes to isolate infrastructure workloads for two primary purposes:
+
+* Prevent incurring billing costs against subscription counts.
+* Separate maintenance and management.
+
+include::modules/go-add-infra-nodes.adoc[leveloffset=+1]

--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assembly:
+//
+// * gitops/run-gitops-control-plane-workload-on-infra-node.adoc
+
+[id="add-infra-nodes_{context}"]
+= Adding infrastructure nodes
+
+.Procedure
+
+. Label existing nodes as infrastructure by running the following command:
++
+[source,terminal]
+----
+$ oc label node <node-name> node-role.kubernetes.io/infra
+----
+. Edit the `GitOpsService` Custom Resource (CR) to add the infrastructure node selector:
++
+[source,terminal]
+----
+$ oc edit gitopsservice -n openshift-gitops
+----
+. In the `GitOpsService` CR file, add `runOnInfra` toggle to the `spec` section and set it to `true`:
++
+[source,yaml]
+----
+apiVersion: pipelines.openshift.io/v1alpha1
+kind: GitopsService
+metadata:
+  name: cluster
+spec:
+  runOnInfra: true
+----
+. Optional: Apply taints and isolate the workloads on infrastructure nodes and prevent other workloads from scheduling on these nodes. 
++
+[source,terminal]
+----
+$ oc adm taint nodes -l node-role.kubernetes.io/infra 
+infra=reserved:NoSchedule infra=reserved:NoExecute
+----
++
+. Optional: If you apply taints to the nodes, you can add tolerations in the `GitOpsService` CR:
++
+[source,yaml]
+----
+spec:
+  runOnInfra: true
+  tolerations:
+  - effect: NoSchedule
+    key: infra
+    value: reserved
+  - effect: NoExecute
+    key: infra
+    value: reserved 
+----
+
+To verify that the workloads are scheduled on infrastructure nodes in the {gitops-title} namespace, click any of the pod names and ensure that the *Node selector* and *Tolerations* have been added.
+
+[NOTE]
+====
+Any manually added *Node selectors* and *Tolerations* in the default Argo CD CR will be overwritten by the toggle and the tolerations in the `GitOpsService` CR.
+====


### PR DESCRIPTION
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.8, enterprise-4.9
JIRA issues: https://issues.redhat.com/browse/RHDEVDOCS-3360
Preview pages: https://deploy-preview-40180--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html
SME+QE review:
Peer-review: