### PR TITLE
Adds 4.8.25 release notes

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2936,3 +2936,28 @@ link:https://access.redhat.com/solutions/6585021[{product-title} 4.8.24 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-25"]
+=== RHBA-2021:5209 - {product-title} 4.8.25 bug fix and security update
+
+Issued: 2022-01-05
+
+{product-title} release 4.8.25, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2021:5209[RHBA-2021:5209] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2021:5208[RHSA-2021:5208] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6620441[{product-title} 4.8.25 container image list]
+
+[id="ocp-4-8-25-bug-fixes"]
+==== Bug fixes
+
+* Previously, `ovnkube-node` and `ovnkube-master` pods failed to start when the config file had an unknown field or section. Consequently, OVN-Kubernetes would not update. With this update, OVN-Kubernetes no longer exits if unknown fields are found in the config file. Instead, a warning is logged. As a result, OVN-Kubernetes updates no longer fail if the config file contains an unknown field or section. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2022171[*BZ#2022171*])
+
+* Previously, a vCentre hostname that began with a numeric character was unable to run the `openshift-install` command. Consequently, the installer labeled it as `invalid`. This update adds validation for numeric characters. As a result, it is possible to create a vCenter host with a numeric character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2030465[*BZ#2030465*])
+
+* Previously, 'curl' in the {rh-openstack-first} downloader container did not recognize network CIDRs in the 'noProxy' value of the `install-config.yaml` file. Instead, it only recognized the list of IP addresses separated by commas. With this update, users can include network CIDRs in the 'noProxy' value. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2005805[*BZ#2005805*])
+
+[id="ocp-4-8-25-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To be merged on 05-01.

**Applicable only to enterprise-4.8**

Direct Doc Preview Link: https://deploy-preview-40181--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-25