### PR TITLE
BZ2032670: Remove CommonName workaround for OCP 4.10 restricted install doc

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -22,12 +22,7 @@ ifdef::openshift-origin[]
 * You have created a pull secret for your mirror repository.
 endif::[]
 
-* If you use self-signed certificates that do not set a Subject Alternative Name, you must precede the `oc` commands in this procedure with `GODEBUG=x509ignoreCN=0`. If you do not set this variable, the `oc` commands will fail with the following error:
-+
-[source,terminal]
-----
-x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0
-----
+* If you use self-signed certificates, you have specified a Subject Alternative Name in the certificates.
 
 .Procedure
 


### PR DESCRIPTION
[Fixes](https://bugzilla.redhat.com/show_bug.cgi?id=2032670)
OCP version: 4.10 
[Preview](https://deploy-preview-40187--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images)
