### PR TITLE
BZ1999786: added a KCS ref link for system reserved values

### DIFF
--- a/modules/nodes-nodes-resources-configuring-setting.adoc
+++ b/modules/nodes-nodes-resources-configuring-setting.adoc
@@ -26,41 +26,7 @@ For example, to access the resources from `cluster.node22` node, you can enter:
 $ oc get --raw /api/v1/nodes/cluster.node22/proxy/stats/summary
 ----
 +
-.Example output
-[source,json]
-----
-{
-    "node": {
-        "nodeName": "cluster.node22",
-        "systemContainers": [
-            {
-                "cpu": {
-                    "usageCoreNanoSeconds": 929684480915,
-                    "usageNanoCores": 190998084
-                },
-                "memory": {
-                    "rssBytes": 176726016,
-                    "usageBytes": 1397895168,
-                    "workingSetBytes": 1050509312
-                },
-                "name": "kubelet"
-            },
-            {
-                "cpu": {
-                    "usageCoreNanoSeconds": 128521955903,
-                    "usageNanoCores": 5928600
-                },
-                "memory": {
-                    "rssBytes": 35958784,
-                    "usageBytes": 129671168,
-                    "workingSetBytes": 102416384
-                },
-                "name": "runtime"
-            }
-        ]
-    }
-}
-----
+For more details, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
 
 . Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure.
 Perform one of the following steps:


### PR DESCRIPTION
- Applies to 4.7 (cherry pick to 4.6)
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=1999786)
- [Preview](https://deploy-preview-40207--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring)