### PR TITLE
Add the cluster-monitoring namespace label to CO and FIO cli instructions

### DIFF
--- a/modules/compliance-operator-cli-installation.adoc
+++ b/modules/compliance-operator-cli-installation.adoc
@@ -24,6 +24,8 @@ $ oc create -f <file-name>.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-compliance
 ----
 

--- a/modules/file-integrity-operator-installing-cli.adoc
+++ b/modules/file-integrity-operator-installing-cli.adoc
@@ -24,6 +24,8 @@ $ oc create -f <file-name>.yaml
 apiVersion: v1
 kind: Namespace
 metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
   name: openshift-file-integrity
 ----
 


### PR DESCRIPTION
This label is needed to have monitoring work out-of-box and is handled automatically during the console install. In the case of a CLI install, however, when creating the namespace manually, the label is needed.

@kmccarron-rh This should apply for 4.6+
@rhmdnd @Vincent056 