### PR TITLE
Change copyright from 2021 -> 2022

### DIFF
--- a/404-commercial.html
+++ b/404-commercial.html
@@ -186,7 +186,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2021 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/_templates/_footer_other.html.erb
+++ b/_templates/_footer_other.html.erb
@@ -6,7 +6,7 @@
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2021 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/index-commercial.html
+++ b/index-commercial.html
@@ -352,7 +352,7 @@ height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
             </div>
 
             <div class="col-sm-3">
-                <p class="text-nowrap">Copyright © 2021 Red Hat, Inc.</span></p>
+                <p class="text-nowrap">Copyright © 2022 Red Hat, Inc.</span></p>
             </div>
 
             <div class="col">

--- a/welcome/legal-notice.adoc
+++ b/welcome/legal-notice.adoc
@@ -4,7 +4,7 @@ include::modules/common-attributes.adoc[]
 :context: legal-notice
 
 [.lead]
-Copyright © 2021 Red Hat, Inc.
+Copyright © 2022 Red Hat, Inc.
 
 OpenShift documentation is licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0).
 


### PR DESCRIPTION
These are the files where I am finding 2021 occurrences in the `openshift-docs` repo. Happy New Year! 🎉 

**Preview link (Legal page):** https://deploy-preview-40235--osdocs.netlify.app/openshift-enterprise/latest/welcome/legal-notice.html

Netlify doesn't show the footer but I built locally and it is rendering fine.