### PR TITLE
GH#40104 Hide AWS-specific configs for installer proxy information

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -1,10 +1,10 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing_aws-customizations.adoc
-// * installing/installing_aws/installing_aws-network-customizations.adoc
-// * installing/installing_aws/installing_aws-private.adoc
-// * installing/installing_aws/installing_aws-vpc.adoc
-// * installing/installing_aws/installing_aws-china.adoc
+// * installing/installing_aws/installing-aws-customizations.adoc
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-vpc.adoc
+// * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -53,7 +53,32 @@
 // * installing/installing-rhv-restricted-network.adoc
 
 ifeval::["{context}" == "installing-aws-china-region"]
+:aws:
 :aws-china:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:aws:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
@@ -152,12 +177,13 @@ The `Proxy` object `status.noProxy` field is populated with the values of the `n
 
 For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
-ifndef::aws-china[]
-* If your cluster is on AWS, you added the `ec2.<region>.amazonaws.com`,  `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
-endif::aws-china[]
-ifdef::aws-china[]
-* You have added the `ec2.<region>.amazonaws.com.cn`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
-endif::aws-china[]
+
+ifdef::aws[]
+* You have added the
+ifdef::aws-china[`ec2.<region>.amazonaws.com.cn`, ]
+ifndef::aws-china[`ec2.<region>.amazonaws.com`, ]
+`elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+endif::aws[]
 // TODO: xref installation-aws-user-infra-requirements.adoc#installation-aws-user-infra-other-infrastructure_{context} as a relative link
 
 .Procedure
@@ -213,7 +239,32 @@ proxies can be created.
 ====
 
 ifeval::["{context}" == "installing-aws-china-region"]
+:!aws:
 :!aws-china:
+endif::[]
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!aws:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!bare-metal:


### PR DESCRIPTION
Resolves #40104

Previews:
- [AWS China](https://deploy-preview-40236--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-china.html#installation-configure-proxy_installing-aws-china-region)
- [Non-AWS China](https://deploy-preview-40236--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configure-proxy_installing-aws-customizations)
- [Azure](https://deploy-preview-40236--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-configure-proxy_installing-azure-customizations)