### PR TITLE
OSDOCS-3138: Release notes for scheduler policy removal

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -442,7 +442,7 @@ In the table, features are marked with the following statuses:
 |Scheduler policy
 |DEP
 |DEP
-|
+|REM
 
 |`ImageChangesInProgress` condition for Cluster Samples Operator
 |DEP
@@ -539,6 +539,11 @@ The following OpenShift CLI (`oc`) commands were removed with this release:
 * `oc adm completion`
 * `oc adm config`
 * `oc adm options`
+
+[id="ocp-4-10-removed-scheduler-policy"]
+==== Scheduler policy removed
+
+Support for configuring a scheduler policy has been removed with this release. Use a xref:../nodes/scheduling/nodes-scheduler-profiles.adoc#nodes-scheduler-profiles[scheduler profile] instead to control how pods are scheduled onto nodes.
 
 [id="ocp-4-10-removed-feature-rhel-7-support"]
 ==== {op-system-base} 7 support for compute machines removed


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3138

Preview: https://deploy-preview-40237--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-removed-scheduler-policy