### PR TITLE
Hide elements from print preview

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -2639,6 +2639,18 @@ b.conum * {
     padding-bottom: 0 !important;
   }
 
+  #toc {
+    display: none !important;
+  }
+
+  .clipboard-button-container {
+    display: none !important;
+  }
+
+  .open-btn-sm {
+    display: none !important;
+  }
+
   .sect1 {
     padding-bottom: 0 !important;
   }

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -10,7 +10,7 @@
   <meta content="IE=edge" http-equiv="X-UA-Compatible">
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
-  <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>  
+  <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css">
   <link href="https://docs.openshift.com/container-platform/4.1/_stylesheets/search.css" rel="stylesheet" />
@@ -55,7 +55,7 @@
   %>
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
-    <ol class="breadcrumb">
+    <ol class="breadcrumb hide-for-print">
       <% if (version == "4.10" || distro_key == "openshift-webscale") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
@@ -145,7 +145,7 @@
       <% end %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
-      <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas">
+      <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas hide-for-print">
         <div class="row-fluid">
           <div id="btn-close">
             <button id="hc-close-btn" onclick="closeNav()" class="close-btn-sm" aria-label="close"><span class="fa fa-times" /></button>


### PR DESCRIPTION
Fixes print previews for #40166 

While #40166 only talks about fixing issues with print selected text only, the regular print preview doesn't look clean either.
This PR:
- Hides elements from the print preview

What could be better:
- The main element looks cramped up on the right, we should make it full width