### PR TITLE
Correcting firewall ports prerequisits

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -177,15 +177,15 @@ Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Ser
 
 |`iam.amazonaws.com`
 |Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
 
 |`route53.amazonaws.com`
 |Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
 
 |`sts.amazonaws.com`
 |Required. Used to install and manage clusters in an AWS environment.
-|443, 80
+|443
 
 |`ec2.<aws_region>.amazonaws.com`
 |Required. Region dependent. Must be added per cluster and per region.
@@ -260,7 +260,7 @@ If you do not use a default Red Hat NTP server, verify the NTP server for your p
 
 |`sftp.access.redhat.com`
 |Recommended. The FTP server used by `must-gather-operator` to upload diagnostic logs to help troubleshoot issues with the cluster.
-|443
+|22
 
 |`.osdsecuritylogs.splunkcloud.com`
 `inputs1.osdsecuritylogs.splunkcloud.com`


### PR DESCRIPTION
- `iam.amazonaws.com`, `route53.amazonaws.com`, `sts.amazonaws.com` are not available on port 80
- `sftp.access.redhat.com` is only available on port 22