### PR TITLE
BZ2029542: FC fully supported for 4.6

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -31,7 +31,7 @@ The following table displays which volume plug-ins support block volumes.
 |Azure Disk | ✅ | ✅ | ✅
 |Azure File | | |
 |Cinder | ✅ | ✅ |
-|Fibre Channel | ✅ | |
+|Fibre Channel | ✅ | |✅
 |GCP | ✅ | ✅ | ✅
 |HostPath | | |
 |iSCSI | ✅ | | ✅


### PR DESCRIPTION
4.6 only

https://bugzilla.redhat.com/show_bug.cgi?id=2029542
Correct Fiber Channel to be fully supported in OCP 4.6 docs

Identical change for 4.7: https://github.com/openshift/openshift-docs/pull/40258

**Preview**: https://deploy-preview-40262--osdocs.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#block-volume-support_understanding-persistent-storage

**PTAL**: @duanwei33, @jsafrane 