### PR TITLE
[enterprise-4.6] GH#40104 Hide AWS-specific configs for installer proxy information

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_aws/installing_aws-customizations.adoc
-// * installing/installing_aws/installing_aws-network-customizations.adoc
-// * installing/installing_aws/installing_aws-private.adoc
-// * installing/installing_aws/installing_aws-vpc.adoc
+// * installing/installing_aws/installing-aws-customizations.adoc
+// * installing/installing_aws/installing-aws-network-customizations.adoc
+// * installing/installing_aws/installing-aws-private.adoc
+// * installing/installing_aws/installing-aws-vpc.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
 // * installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -46,6 +46,30 @@
 // * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
 // * networking/configuring-a-custom-pki.adoc
 
+ifeval::["{context}" == "installing-aws-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:aws:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
 endif::[]
@@ -118,7 +142,9 @@ The `Proxy` object `status.noProxy` field is populated with the values of the `n
 
 For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
 ====
-* If your cluster is on AWS, you added the `ec2.<region>.amazonaws.com`,  `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+ifdef::aws[]
+* If your cluster is on AWS, you added the `ec2.<region>.amazonaws.com`, `elasticloadbalancing.<region>.amazonaws.com`, and `s3.<region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works on the container level, not the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not sufficient.
+endif::aws[]
 // TODO: xref installation-aws-user-infra-requirements.adoc#installation-aws-user-infra-other-infrastructure_{context} as a relative link
 
 .Procedure
@@ -173,6 +199,30 @@ Only the `Proxy` object named `cluster` is supported, and no additional
 proxies can be created.
 ====
 
+ifeval::["{context}" == "installing-aws-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-network-customizations"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-vpc"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-aws-government-region"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws-installer-provisioned"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-aws"]
+:!aws:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :!bare-metal:
 endif::[]


### PR DESCRIPTION
Manual cherrypick of #40236