### PR TITLE
OSDOCS-3007: Updating the upgrade channels and releases

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -8,15 +8,42 @@
 [id="understanding-upgrade-channels_{context}"]
 
 = Upgrade channels and release paths
-Cluster administrators can configure the upgrade channel from the web console.
 
+ifndef::openshift-origin[]
+{product-title} {product-version} offers the following upgrade channels:
+
+* `candidate-{product-version}`
+* `fast-{product-version}`
+* `stable-{product-version}`
+* `eus-4.y` (only when running an even-numbered 4.y cluster release, like 4.10)
+
+If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
+
+[WARNING]
+====
+Red Hat recommends upgrading to versions suggested by Openshift Update Service only. For minor version upgrade, versions must be contiguous. Red Hat does not test upgrades to noncontiguous versions and cannot guarantee compatibility with earlier versions.
+====
+
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+{product-title} {product-version} offers the following upgrade channel:
+
+* `stable-4`
+
+endif::openshift-origin[]
 
 [id="candidate-version-channel_{context}"]
 == candidate-{product-version} channel
 
-The `candidate-{product-version}` channel contains candidate builds for a z-stream ({product-version}.z) and previous minor version releases. Release candidates contain all the features of the product but are not supported. Use release candidate versions to test feature acceptance and assist in qualifying the next version of {product-title}. A release candidate is any build that is available in the candidate channel, including ones that do not contain link:https://semver.org/spec/v2.0.0.html#spec-item-9[a pre-release version] such as `-rc` in their names. After a version is available in the candidate channel, it goes through more quality checks. If it meets the quality standard, it is promoted to the `fast-{product-version}` or `stable-{product-version}` channels. Because of this strategy, if a specific release is available in both the `candidate-{product-version}` channel and in the `fast-{product-version}` or `stable-{product-version}` channels, it is a Red Hat-supported version. The `candidate-{product-version}` channel can include release versions from which there are no recommended updates in any channel.
+The `candidate-{product-version}` channel contains pre-release channels with alpha, beta, and release candidate builds and versions. The `candidate` channel contains candidate builds for a z-stream and previous minor version releases.
+
+Release candidates (RC) contain all features of the product, but may not be supported. A release candidate is any build that is available in the candidate channel, including ones that do not contain link:https://semver.org/spec/v2.0.0.html#spec-item-9[a pre-release version] such as `-rc` in their names.
+
+The `candidate-{product-version}` channel can include release versions from which there are no recommended updates in any channel.
 
 You can use the `candidate-{product-version}` channel to upgrade from a previous minor version of {product-title}.
+
+Example channel name: `candidate-{product-version}`.
 
 [NOTE]
 ====
@@ -33,15 +60,25 @@ for more build information.
 [id="fast-version-channel_{context}"]
 == fast-{product-version} channel
 
-The `fast-{product-version}` channel is updated with new and previous minor versions of {product-version} as soon as Red Hat declares the given version as a general availability release. As such, these releases are fully supported, are production quality, and have performed well while available as a release candidate in the `candidate-{product-version}` channel from where they were promoted. Some time after a release appears in the `fast-{product-version}` channel, it is added to the `stable-{product-version}` channel. Releases never appear in the `stable-{product-version}` channel before they appear in the `fast-{product-version}` channel.
+The `fast-{product-version}` channel is updated with new and previous minor versions of {product-version} as soon as Red Hat declares the given version as a general availability (GA) release. The `fast-{product-version}` channel contains releases as soon as their errata are published.
+
+As such, these releases are fully supported and are production quality. The releases in this channel are closely monitored using a Telemetry system. The releases in the `fast-{product-version}` channel are promoted from `candidate-{product-version}` after the builds have performed well. Some time after a release appears in the `fast-{product-version}` channel, it is added to the `stable-{product-version}` channel.
+
+[NOTE]
+====
+Releases never appear in the `stable-{product-version}` channel before they appear in the `fast-{product-version}` channel.
+====
 
 You can use the `fast-{product-version}` channel to upgrade from a previous minor version of {product-title}.
+
+Example channel name: `fast-{product-version}`.
 
 ifndef::openshift-origin[]
 
 [id="stable-version-channel_{context}"]
 == stable-{product-version} channel
-While the `fast-{product-version}` channel contains releases as soon as their errata are published, releases are added to the `stable-{product-version}` channel after a delay. During this delay, data is collected from Red Hat SRE teams, Red Hat support services, and pre-production and production environments that participate in connected customer program about the stability of the release.
+
+The `stable{product-version}` channel contains general availability releases that have a proven track record of upgrade success. The builds were originally a part of the `fast-{product-version}` channel where data was collected by Red Hat to ensure the stability of the release. These builds are supported by Red Hat.
 
 You can use the `stable-{product-version}` channel to upgrade from a previous minor version of {product-title}.
 endif::openshift-origin[]

--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -5,31 +5,11 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} 4.1, Red Hat introduced the concept of channels for recommending the appropriate release versions for cluster upgrades. By controlling the pace of upgrades, these upgrade channels allow you to choose an upgrade strategy. Upgrade channels are tied to a minor version of {product-title}. For instance, {product-title} 4.9 upgrade channels recommend upgrades to 4.9 and upgrades within 4.9. They also recommend upgrades within 4.8 and from 4.8 to 4.9, to allow clusters on 4.8 to eventually upgrade to 4.9. They do not recommend upgrades to 4.10 or later releases. This strategy ensures that administrators explicitly decide to upgrade to the next minor version of {product-title}.
+Upgrade channels enable cluster administrators to choose an upgrade strategy. {product-title} 4 releases are sequential. Updates are decoupled from releases which enables you to create dynamic upgrade paths.
+
+{product-title}introduced upgrade channels as a way to recommend appropriate release versions for cluster upgrades. The upgrade channels establish a controlled pace for upgrades between minor versions. You can select an upgrade strategy that is best suited for your needs. Channels are tied to a minor version, for example, 4.7. Each channel has an independently-maintained update graph.
 
 Upgrade channels control only release selection and do not impact the version of the cluster that you install; the `openshift-install` binary file for a specific version of {product-title} always installs that version.
 
-ifndef::openshift-origin[]
-{product-title} {product-version} offers the following upgrade channels:
-
-* `candidate-{product-version}`
-* `fast-{product-version}`
-* `stable-{product-version}`
-* `eus-4.y` (only when running an even-numbered 4.y cluster release, like 4.10)
-
-If you do not want the Cluster Version Operator to fetch available updates from the upgrade recommendation service, you can use the `oc adm upgrade channel` command in the OpenShift CLI to configure an empty channel. This configuration can be helpful if, for example, a cluster has restricted network access and there is no local, reachable upgrade recommendation service.
-
-[WARNING]
-====
-Red Hat recommends upgrading to versions suggested by Openshift Update Service only. For minor version upgrade, versions must be contiguous. Red Hat does not test upgrades to noncontiguous versions and cannot guarantee compatibility with earlier versions.
-====
-
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-{product-title} {product-version} offers the following upgrade channel:
-
-* `stable-4`
-
-endif::openshift-origin[]
 
 include::modules/understanding-upgrade-channels.adoc[leveloffset=+1]


### PR DESCRIPTION
Applies to 4.6+
JIRA Link:https://issues.redhat.com/browse/OSDOCS-3007
Requires SME/QE ack.
Preview links for updated sections: 

- [Understanding upgrade channels and releases](https://deploy-preview-40268--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html)
- [Upgrade channels and release paths](https://deploy-preview-40268--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#understanding-upgrade-channels_understanding-upgrade-channels-releases)
- [candidate-4.10 channel](https://deploy-preview-40268--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#candidate-version-channel_understanding-upgrade-channels-releases)
- [fast-4.10 channel](https://deploy-preview-40268--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#fast-version-channel_understanding-upgrade-channels-releases)
- [stable-4.10 channel](https://deploy-preview-40268--osdocs.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#stable-version-channel_understanding-upgrade-channels-releases)