### PR TITLE
BZ#2027477: ipvlan does not support dhcp

### DIFF
--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -62,8 +62,13 @@ The following example configures an additional network named `ipvlan-net`:
   "master": "eth1",
   "mode": "l3",
   "ipam": {
-    "type": "dhcp"
-    }
+    "type": "static",
+    "addresses": [
+       {
+         "address": "192.168.10.10"
+       }
+    ]
+  }
 }
 ----
 


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=2027477

This is a do-over for #39718.

Update the ipvlan example to show the
static IPAM plugin in use rather than
the DHCP plugin.

-----

Please review [ipvlan configuration example](https://deploy-preview-40269--osdocs.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-ipvlan-config-example_configuring-additional-network).