### PR TITLE
OSDOCS-2831: OVNK and gatewayConfig

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -1,21 +1,22 @@
 // Module included in the following assemblies:
 //
-// * networking/cluster-network-operator.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_gcp/installing-gcp-network-customizations.adoc
-// * post_installation_configuration/network-configuration.adoc
-// * installing/installing_ibm_z/installing-ibm-z.adoc
-// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
-// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
-// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+// * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-ibm-z.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+// * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+// * installing/installing_vmc/installing-vmc-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * networking/cluster-network-operator.adoc
+// * networking/network_policy/logging-network-policy.adoc
+// * post_installation_configuration/network-configuration.adoc
 
 // Installation assemblies need different details than the CNO operator does
 ifeval::["{context}" == "cluster-network-operator"]
@@ -282,6 +283,10 @@ endif::ibm-z[]
 |`object`
 |Specify a configuration object for customizing network policy audit logging. If unset, the defaults audit log settings are used.
 
+|`gatewayConfig`
+|`object`
+|Optional: Specify a configuration object for customizing how egress traffic is sent to the node gateway.
+
 |====
 
 // tag::policy-audit[]
@@ -315,8 +320,25 @@ One of the following additional audit log targets:
 |====
 // end::policy-audit[]
 
+.`gatewayConfig` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`routingViaHost`
+|`boolean`
+|Set this field to `true` to send egress traffic from pods to the host networking stack.
+For highly-specialized installations and applications that rely on manually configured routes in the kernel routing table, you might want to route egress traffic to the host networking stack.
+By default, egress traffic is processed in OVN to exit the cluster and is not affected by specialized routes in the kernel routing table.
+The default value is `false`.
+
+This field has an interaction with the Open vSwitch hardware offloading feature.
+If you set this field to `true`, you do not receive the performance benefits of the offloading because egress traffic is processed by the host networking stack.
+
+|====
+
 ifdef::operator[]
-NOTE: You can only change the configuration for your cluster network provider during cluster installation.
+NOTE: You can only change the configuration for your cluster network provider during cluster installation, except for the `gatewayConfig` field that can be changed at runtime as a post-installation activity.
 endif::operator[]
 
 .Example OVN-Kubernetes configuration


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSDOCS-2831

* Enable customers to route egress traffic
to the host network (and kernel routing table)
for highly-specialized installations and applications.

----

There's a new row in Table 4 for `gatewayConfig` in the [Configuration for OVN-K CNI provider](https://deploy-preview-40293--osdocs.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator.html#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator).

Scroll down to Table 6 for the description of `routingViaHost`.