### PR TITLE
[RHACS]: Update the button label for generating an init bundle

### DIFF
--- a/modules/portal-generate-init-bundle.adoc
+++ b/modules/portal-generate-init-bundle.adoc
@@ -34,7 +34,7 @@ $ oc port-forward svc/central 18443:443 -n stackrox
 ... Navigate to `\https://localhost:18443/`.
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
 . Under the *Authentication Tokens* section, click on *Cluster Init Bundle*.
-. Click *New Integration*.
+. Click *Generate bundle*.
 . Enter a name for the cluster init bundle and click *Generate*.
 ifdef::topic-helm[]
 . Click *Download Helm Values File* to download the generated bundle.


### PR DESCRIPTION
Preview Link: https://deploy-preview-40301--osdocs.netlify.app/openshift-acs/latest/installing/install-ocp-operator.html#portal-generate-init-bundle_install-ocp-operator

Applies to: 3.67.1 +

Urgency: Low

Fixes: [OSDOCS-3055](https://issues.redhat.com/browse/OSDOCS-3055)

NOTE:

- This PR is for RHACS docs.
- It does not require any special labels or milestones.