### PR TITLE
CNV-14482: Adding back the VM integration with service mesh assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2986,9 +2986,8 @@ Topics:
       File: virt-configuring-sriov-device-for-vms
     - Name: Configuring certificate rotation
       File: virt-configuring-certificate-rotation
-      # TODO: Add the assembly back for 4.10
-#    - Name: Connecting virtual machines to a service mesh
-#      File: virt-connecting-vm-to-service-mesh
+    - Name: Connecting virtual machines to a service mesh
+      File: virt-connecting-vm-to-service-mesh
     - Name: Defining an SR-IOV network
       File: virt-defining-an-sriov-network
     - Name: Attaching a virtual machine to an SR-IOV network

--- a/modules/virt-adding-vm-to-service-mesh.adoc
+++ b/modules/virt-adding-vm-to-service-mesh.adoc
@@ -7,6 +7,8 @@
 
 To add a virtual machine (VM) workload to a service mesh, enable automatic sidecar injection in the VM configuration file by setting the `sidecar.istio.io/inject` annotation to `true`. Then expose your VM as a service to view your application in the mesh.
 
+.Prerequisites
+* To avoid port conflicts, do not use ports used by the Istio sidecar proxy. These include ports 15000, 15001, 15006, 15008, 15020, 15021, and 15090.
 
 .Procedure
 
@@ -58,11 +60,6 @@ To add a virtual machine (VM) workload to a service mesh, enable automatic sidec
 <1> The key/value pair (label) that must be matched to the service selector attribute.
 <2> The annotation to enable automatic sidecar injection.
 <3> The binding method (masquerade mode) for use with the default pod network.
-+
-[NOTE]
-====
-To avoid port conflicts with sidecars, do not use ports used by Istio proxy for user workloads.
-====
 
 . Apply the VM configuration:
 +


### PR DESCRIPTION
[CNV-14482](https://issues.redhat.com/browse/CNV-14482)

This feature was pushed to 4.10 but the docs work was completed during the 4.9 release. Adding assembly back into the topic map for 4.10. Also added a list of forbidden ports in the associated module.

Preview: https://deploy-preview-40303--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.html