### PR TITLE
OSDOCS-2661: Add console customization types for bundles in 4.10

### DIFF
--- a/modules/olm-bundle-format.adoc
+++ b/modules/olm-bundle-format.adoc
@@ -50,9 +50,13 @@ etcd
 The following object types can also be optionally included in the `/manifests` directory of a bundle:
 
 .Supported optional object types
+[.small]
 * `ClusterRole`
 * `ClusterRoleBinding`
 * `ConfigMap`
+* `ConsoleCLIDownload`
+* `ConsoleLink`
+* `ConsoleQuickStart`
 * `ConsoleYamlSample`
 * `PodDisruptionBudget`
 * `PriorityClass`


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2661

Preview: https://deploy-preview-40308--osdocs.netlify.app/openshift-enterprise/latest/operators/understanding/olm-packaging-format.html#olm-bundle-format-manifests-optional_olm-packaging-format