### PR TITLE
OSDOCS-2658: added CNI note

### DIFF
--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -36,3 +36,10 @@ only select pods in the project that the NetworkPolicy object is defined.
 <3> A selector matching the pods that the policy object allows ingress traffic
 from. The selector will match pods in any project.
 <4> A list of one or more destination ports to accept traffic on.
+
+[NOTE]
+====
+If you log in as a user with the `cluster-admin` role and access the policy
+through the web console, your Container Network Interface (CNI) type determines
+the available fields.
+====


### PR DESCRIPTION
For version 4.10

Jira: https://issues.redhat.com/browse/OSDOCS-2658

Direct link to doc preview (all three locations reuse the same content):
- [Creating a network policy](https://deploy-preview-40318--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/creating-network-policy.html#nw-networkpolicy-object_creating-network-policy)
- [Viewing network policies](https://deploy-preview-40318--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/viewing-network-policy.html#nw-networkpolicy-object_viewing-network-policy)
- [Editing a network policy](https://deploy-preview-40318--osdocs.netlify.app/openshift-enterprise/latest/networking/network_policy/editing-network-policy.html#nw-networkpolicy-object_editing-network-policy)


Ready for Dev, QE, SME review:
- @jotak 
- @stlee
- @memodi 
- @jechen0648 