### PR TITLE
OSDOCS-2679: Add missing networking metrics

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -69,6 +69,40 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-10-networking"]
 === Networking
 
+[id="ocp-4-10-networking-metrics"]
+==== Enhancements to networking metrics
+
+The following metrics are now available for clusters.
+The metric names that start with `sdn_controller` are unique to the OpenShift SDN CNI network provider.
+The metric names that start with `ovn` are unique to the OVN-Kubernetes CNI network provider:
+
+* `network_attachment_definition_instances{networks="egress-router"}`
+* `openshift_unidle_events_total`
+* `ovn_controller_bfd_run`
+* `ovn_controller_ct_zone_commit`
+* `ovn_controller_flow_generation`
+* `ovn_controller_flow_installation`
+* `ovn_controller_if_status_mgr`
+* `ovn_controller_if_status_mgr_run`
+* `ovn_controller_if_status_mgr_update`
+* `ovn_controller_integration_bridge_openflow_total`
+* `ovn_controller_ofctrl_seqno_run`
+* `ovn_controller_patch_run`
+* `ovn_controller_pinctrl_run`
+* `ovnkube_master_ipsec_enabled`
+* `ovnkube_master_num_egress_firewall_rules`
+* `ovnkube_master_num_egress_firewalls`
+* `ovnkube_master_num_egress_ips`
+* `ovnkube_master_pod_first_seen_lsp_created_duration_seconds`
+* `ovnkube_master_pod_lsp_created_port_binding_duration_seconds`
+* `ovnkube_master_pod_port_binding_chassis_port_binding_up_duration_seconds`
+* `ovnkube_master_pod_port_binding_port_binding_chassis_duration_seconds`
+* `sdn_controller_num_egress_firewall_rules`
+* `sdn_controller_num_egress_firewalls`
+* `sdn_controller_num_egress_ips`
+
+The `ovnkube_master_resource_update_total` metric is removed for the 4.10 release.
+
 [id="ocp-4-10-storage"]
 === Storage
 
@@ -97,7 +131,7 @@ With this enhancement, the Machine Config Daemon (MCD) now checks nodes for conf
 
 Configuration drift occurs when the on-disk state of a node differs from what is configured in the machine config. The Machine Config Operator (MCO) uses the MCD to check nodes for configuration drift and, if detected, sets that node and machine config pool (MCP) to `degraded`.
 
-For more information on configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection]. 
+For more information on configuration drift, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-drift-detection_post-install-machine-configuration-tasks[Understanding configuration drift detection].
 
 [id="ocp-4-10-nodes"]
 === Nodes


### PR DESCRIPTION
Fixes https://issues.redhat.com/browse/OSDOCS-2679

I populated the list by diffing the metrics that I could
collect from a 4.9 cluster-bot cluster and a 4.10 cluster.

----

Please review https://deploy-preview-40324--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-metrics

----

Dear peer reviewer, I styled the metric names as inline code to match the precedent that I read from [Authentication metrics for Prometheus](https://deploy-preview-40324--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking-metrics).