### PR TITLE
BZ2020756: Specifying that policyGenerator is a Kustomize plugin

### DIFF
--- a/modules/ztp-generating-ran-policies.adoc
+++ b/modules/ztp-generating-ran-policies.adoc
@@ -8,23 +8,11 @@
 .Prerequisites
 
 * Install Kustomize
-* Install golang
+* Install the link:https://github.com/stolostron/policy-generator-plugin[Kustomize Policy Generator plug-in]
 
 .Procedure
 
-. Build the plug-in using the following commands:
-+
-[source,terminal]
-----
-$ cd ztp/ztp-policy-generator/kustomize/plugin/policyGenerator/v1/policygenerator/
-----
-+
-[source,terminal]
-----
-$ go build -o PolicyGenerator
-----
-+
-The `kustomization.yaml` file has a reference to the `policyGenerator.yaml` file. The following example shows the PolicyGenerator definition:
+. Configure the `kustomization.yaml` file to reference the `policyGenerator.yaml` file. The following example shows the PolicyGenerator definition:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Fixes :  https://bugzilla.redhat.com/show_bug.cgi?id=2020756

It wasn't clear what the plug-in was in this procedure, though it is explained at the beginning of the section.  Added a link to the plugi-n and removed some install instructions, since they are different from the official ones explained in the page of the plug-in.

Preview:

https://deploy-preview-40337--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp-deploying-disconnected.html#ztp-generating-ran-policies_ztp-deploying-disconnected

Releases: 4.10, 4.9