### PR TITLE
BZ:1865848 - Adding inventory variable to chart and warning label

### DIFF
--- a/install/configuring_inventory_file.adoc
+++ b/install/configuring_inventory_file.adoc
@@ -320,6 +320,9 @@ If you alter this variable, ensure the host name is accessible via your router.
 |This variable is a cluster identifier unique to the AWS Availability Zone. Using this avoids potential issues in Amazon Web Services
 (AWS) with multiple zones or multiple clusters. See xref:../install_config/configuring_aws.adoc#aws-cluster-labeling[Labeling Clusters for AWS] for details.
 
+|`openshift_encryption_config`
+|Use this variable to configure datastore-layer encryption.
+
 |`openshift_image_tag`
 |Use this variable to specify a container image tag to install or configure.
 

--- a/install_config/adding_hosts_to_existing_cluster.adoc
+++ b/install_config/adding_hosts_to_existing_cluster.adoc
@@ -25,6 +25,11 @@ prerequisite
 xref:../install/host_preparation.adoc#install-config-install-host-preparation[host
 preparation] steps.
 
+[WARNING]
+====
+These steps will synchronize the settings in the Ansible inventory with the cluster. Ensure that any local changes are shown in the Ansible inventory.
+====
+
 To add an etcd host to an existing cluster:
 
 . Ensure you have the latest playbooks by updating the *openshift-ansible* package:
@@ -79,6 +84,7 @@ $ ansible-playbook [-i /path/to/file] \
 
 . After the playbook completes successfully,
 xref:../install/running_install.adoc#advanced-verifying-the-installation[verify the installation].
+
 
 [[replacing-existing-masters]]
 == Replacing existing masters with etcd colocated


### PR DESCRIPTION
For enterprise-3.11
Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1865848

Preview configure_invertory_file.adoc: https://deploy-preview-40342--osdocs.netlify.app/openshift-enterprise/latest/install/configuring_inventory_file.html#configuring-cluster-variables
Preview adding_hosts_to_existing_cluster.adoc: https://deploy-preview-40342--osdocs.netlify.app/openshift-enterprise/latest/install_config/adding_hosts_to_existing_cluster.html#adding-etcd-hosts-to-existing-cluster

Ready for QA: @gpei 

For peer reviewers: Labels needed 'enterprise-3.11' Thank you!