### PR TITLE
OSDOCS-3053: Removing a KubeletConfig remediation

### DIFF
--- a/modules/compliance-removing-kubeletconfig.adoc
+++ b/modules/compliance-removing-kubeletconfig.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-remediation.adoc
+
+[id="compliance-removing-kubeletconfig_{context}"]
+= Removing a KubeletConfig remediation
+`KubeletConfig` remediations are included in node-level profiles. In order to remove a KubeletConfig remediation, you must manually remove it from the `KubeletConfig` objects. This example demonstrates how to remove the compliance check for the `one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available` remediation.
+
+.Procedure
+
+. Locate the `scan-name` and compliance check for the `one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available` remediation: 
++
+[source,terminal]
+----
+$ oc get remediation one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ComplianceRemediation
+metadata:
+  annotations:
+    compliance.openshift.io/xccdf-value-used: var-kubelet-evictionhard-imagefs-available
+  creationTimestamp: "2022-01-05T19:52:27Z"
+  generation: 1
+  labels:
+    compliance.openshift.io/scan-name: one-rule-tp-node-master <1>
+    compliance.openshift.io/suite: one-rule-ssb-node
+  name: one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available
+  namespace: openshift-compliance
+  ownerReferences:
+  - apiVersion: compliance.openshift.io/v1alpha1
+    blockOwnerDeletion: true
+    controller: true
+    kind: ComplianceCheckResult
+    name: one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available 
+    uid: fe8e1577-9060-4c59-95b2-3e2c51709adc
+  resourceVersion: "84820"
+  uid: 5339d21a-24d7-40cb-84d2-7a2ebb015355
+spec:
+  apply: true
+  current:
+    object:
+      apiVersion: machineconfiguration.openshift.io/v1
+      kind: KubeletConfig
+      spec:
+        kubeletConfig:
+          evictionHard:
+            imagefs.available: 10% <2>
+  outdated: {}
+  type: Configuration
+status:
+  applicationState: Applied
+----
+<1> The scan name of the remediation.
+<2> The remediation that was added to the `KubeletConfig` objects.
++  
+. Remove the remediation:
+
+.. Set `apply` to false for the remediation object:
++
+[source,terminal]
+----
+$ oc patch complianceremediations/one-rule-tp-node-master-kubelet-eviction-thresholds-set-hard-imagefs-available -p '{"spec":{"apply":false}}' --type=merge
+----
++
+.. Using the `scan-name`, find the `KubeletConfig` object that the remediation was applied to: 
++
+[source,terminal]
+----
+$ oc get kubeletconfig --selector compliance.openshift.io/scan-name=one-rule-tp-node-master
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                 AGE
+compliance-operator-kubelet-master   2m34s
+----
+.. Manually remove the remediation, `imagefs.available: 10%`, from the `KubeletConfig` object:
++
+[source,terminal]
+----
+$ oc edit KubeletConfig compliance-operator-kubelet-master
+----
++
+[IMPORTANT]
+====
+All affected nodes with the remediation will be rebooted.
+====
+
+[NOTE]
+====
+You must also exclude the rule from any scheduled scans in your tailored profiles that auto-applies the remediation, otherwise, the remediation will be re-applied during the next scheduled scan.
+====
+

--- a/security/compliance_operator/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/compliance-operator-remediation.adoc
@@ -17,6 +17,12 @@ include::modules/compliance-updating.adoc[leveloffset=+1]
 
 include::modules/compliance-unapplying.adoc[leveloffset=+1]
 
+include::modules/compliance-removing-kubeletconfig.adoc[leveloffset=+1]
+
 include::modules/compliance-inconsistent.adoc[leveloffset=+1]
 
 include::modules/compliance-filtering-failed-results.adoc[leveloffset=+1]
+
+== Additional resources
+
+*  For more information about `KubeletConfig` objects, see xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Modifying nodes].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3053
Applies to 4.6+

Preview available [here](https://deploy-preview-40343--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html#compliance-removing-kubeletconfig_compliance-remediation)