### PR TITLE
[RHACS]: Update Circle CI commands and correct spelling error

### DIFF
--- a/modules/integrate-circle-ci.adoc
+++ b/modules/integrate-circle-ci.adoc
@@ -7,7 +7,7 @@
 
 You can integrate {product-title} with CircleCI.
 
-.Prerequisetes
+.Prerequisites
 * You have a token with `read` and `write` permissions for the `Image` resource.
 * You have a username and password for your Docker Hub account.
 
@@ -36,18 +36,24 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Create output directory for checks results
+          command: |
+              mkdir junit
+      - run:
           name: Install roxctl
           command: |
               curl -H "Authorization: Bearer $ROX_API_TOKEN" https://$STACKROX_CENTRAL_HOST:443/api/cli/download/roxctl-linux -o roxctl && chmod +x ./roxctl
       - run:
           name: Scan images for policy deviations and vulnerabilities
           command: |
-              ./roxctl image check --endpoint "$STACKROX_CENTRAL_HOST:443" --image "<your_registry/repo/image_name>" <1>
+              ./roxctl image check --endpoint "$STACKROX_CENTRAL_HOST:443" --image "<your_registry/repo/image_name>" -o junit > junit/image.xml <1>
       - run:
           name: Scan deployment files for policy deviations
           command: |
-              ./roxctl image check --endpoint "$STACKROX_CENTRAL_HOST:443" --image "<your_deployment_file>" <2>
+              ./roxctl deployment check --endpoint "$STACKROX_CENTRAL_HOST:443" --file "<your_deployment_file>" -o junit > junit/deployment.xml <2>
               # Important note: This step assumes the YAML file you'd like to test is located in the project.
+      - store_test_results:
+          path: junit
 workflows:
   version: 2
   build_and_test:


### PR DESCRIPTION
Preview link: https://deploy-preview-40345--osdocs.netlify.app/openshift-acs/latest/integration/integrate-with-ci-systems

Fixes: [OSDOCS-3070](https://issues.redhat.com/browse/OSDOCS-3070)
Urgency: Low
Applies to: 3.65 +

NOTE:
- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.