### PR TITLE
OSDOCS-2164: Adding release note for Alibaba Cloud IPI

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -117,6 +117,12 @@ To install a CSI driver on a cluster running on vSphere, you must have the follo
 
 These components are still supported, but are deprecated; support for them will be removed in a future version of {product-title}.
 
+[id="ocp-4-10-installation-and-upgrade-alibaba-ipi"]
+==== Installing a cluster on Alibaba Cloud using installer-provisioned infrastructure
+
+{product-title} {product-version} introduces the ability for installing a cluster on Alibaba Cloud using installer-provisioned infrastructure in Technology Preview. This type of installation lets you use the installation program to deploy a cluster on infrastructure that the installation program provisions and the cluster maintains.
+//For more information, see <insert link to help topic>.
+
 [id="ocp-4-10-conditional-updates"]
 ==== Conditional updates
 


### PR DESCRIPTION
CP to 4.10

This PR is the release note for [OSDOCS-2164](https://issues.redhat.com/browse/OSDOCS-2164)

Doc preview

[Installing a cluster on Alibaba Cloud using installer-provisioned infrastructure](https://deploy-preview-40349--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-installation-and-upgrade-alibaba-ipi)