### PR TITLE
OSDOCS-2996 AWS Secret Region rename

### DIFF
--- a/modules/installation-aws-about-government-region.adoc
+++ b/modules/installation-aws-about-government-region.adoc
@@ -6,7 +6,7 @@
 = AWS government and secret regions
 
 {product-title} supports deploying a cluster to
-link:https://aws.amazon.com/govcloud-us[AWS GovCloud (US)] regions and the link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Secret Region]. These regions are specifically designed for US government agencies at the federal, state, and
+link:https://aws.amazon.com/govcloud-us[AWS GovCloud (US)] regions and the link:https://aws.amazon.com/federal/us-intelligence-community/[AWS Commercial Cloud Services (C2S) Top Secret Region]. These regions are specifically designed for US government agencies at the federal, state, and
 local level, as well as contractors, educational institutions, and other US
 customers that must run sensitive workloads in the cloud.
 
@@ -18,6 +18,6 @@ The following AWS GovCloud partitions are supported:
 * `us-gov-west-1`
 * `us-gov-east-1`
 
-The following AWS Secret Region partition is supported:
+The following AWS Top Secret Region partition is supported:
 
 * `us-iso-east-1`

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -345,10 +345,10 @@ endif::openshift-origin[]
 endif::private[]
 ifdef::gov[]
 ifndef::openshift-origin[]
-<14> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+<14> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> The custom CA certificate. This is required when deploying to the AWS C2S Secret Region because the AWS API requires a custom CA trust bundle.
+<13> The custom CA certificate. This is required when deploying to the AWS C2S Top Secret Region because the AWS API requires a custom CA trust bundle.
 endif::openshift-origin[]
 endif::gov[]
 ifdef::restricted[]

--- a/modules/installation-aws-regions-with-no-ami.adoc
+++ b/modules/installation-aws-regions-with-no-ami.adoc
@@ -56,7 +56,7 @@ You cannot use the {product-title} installation program to create the installati
 ifdef::aws-gov[]
 [IMPORTANT]
 ====
-If you are deploying to the C2S Secret Region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
+If you are deploying to the C2S Top Secret Region, you must also define a custom CA certificate in the `additionalTrustBundle` field of the `install-config.yaml` file because the AWS API requires a custom CA trust bundle. To allow the installation program to access the AWS API, the CA certificates must also be defined on the machine that runs the installation program. You must add the CA bundle to the trust store on the machine, use the `AWS_CA_BUNDLE` environment variable, or define the CA bundle in the link:https://docs.aws.amazon.com/credref/latest/refdocs/setting-global-ca_bundle.html[`ca_bundle`] field of the AWS config file.
 ====
 endif::aws-gov[]
 

--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -24,7 +24,7 @@ your cloud.
 ifdef::aws[]
 [NOTE]
 ====
-If you deployed your cluster to the AWS C2S Secret Region, the installation program does not support destroying the cluster; you must manually remove the cluster resources.
+If you deployed your cluster to the AWS C2S Top Secret Region, the installation program does not support destroying the cluster; you must manually remove the cluster resources.
 ====
 endif::aws[]
 

--- a/modules/private-clusters-default.adoc
+++ b/modules/private-clusters-default.adoc
@@ -23,7 +23,7 @@ You can deploy a private {product-title} cluster that does not expose external e
 ifdef::aws-gov[]
 [NOTE]
 ====
-Public zones are not supported in Route 53 in AWS GovCloud or Secret Regions. Therefore, clusters
+Public zones are not supported in Route 53 in AWS GovCloud or Top Secret Regions. Therefore, clusters
 must be private if they are deployed to an AWS government or secret region.
 ====
 endif::aws-gov[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-2996

This will be added separately for `main` and `enterprise-4.10`, since the section is being reorganized for those branches.

Preview: https://deploy-preview-40350--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region