### PR TITLE
OSDOCS-2647: Adding release note for RHOCS AMI for AWS GovCloud

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 
 {product-title} {product-version} clusters are available at https://cloud.redhat.com/openshift. The {cloud-redhat-com} application for {product-title} allows you to deploy OpenShift clusters to either on-premise or cloud environments.
 
-// Double check OP system versions 
+// Double check OP system versions
 {product-title} {product-version} is supported on {op-system-base-full} 7.9 and 8.4, as well as on {op-system-first} 4.9.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base-full} 7.9 or 8.4 for compute machines.
@@ -47,6 +47,12 @@ This release adds improvements related to the following components and concepts.
 
 [id="ocp-4-10-installation-and-upgrade"]
 === Installation and upgrade
+
+[id="ocp-4-10-installation-and-upgrade-aws-ami"]
+==== Installing a cluster into an Amazon Web Services GovCloud region
+
+{op-system-first} Amazon Machine Images (AMIs) are now available for AWS GovCloud regions. The availability of these AMIs improves the installation process because you are no longer required to upload a custom RHCOS AMI to deploy a cluster.
+//For more information on installing to a AWS GovCloud region, <insert link to topic after it merges>
 
 [id="ocp-4-10-web-console"]
 === Web console
@@ -229,7 +235,7 @@ In the table, features are marked with the following statuses:
 |vSphere 6.7 Update 2 or earlier and virtual hardware version 13
 |GA
 |DEP
-| 
+|
 
 |====
 


### PR DESCRIPTION
CP to 4.10

This PR is the release note for https://issues.redhat.com/browse/OSDOCS-2647.

Doc preview

[Installing a cluster into an Amazon Web Services GovCloud region](https://deploy-preview-40352--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-installation-and-upgrade-aws-ami)