### PR TITLE
RHDEVDOCS 3420 - Show Monitoring target info in UI admin perspective

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1998,6 +1998,8 @@ Topics:
   File: enabling-monitoring-for-user-defined-projects
 - Name: Managing metrics
   File: managing-metrics
+- Name: Managing metrics targets
+  File: managing-metrics-targets
 - Name: Managing alerts
   File: managing-alerts
 - Name: Reviewing monitoring dashboards

--- a/modules/monitoring-accessing-the-metrics-targets-page.adoc
+++ b/modules/monitoring-accessing-the-metrics-targets-page.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * monitoring/managing-metrics-targets.adoc
+
+[id="monitoring-accessing-the-metrics-targets-page_{context}"]
+= Accessing the Metrics Targets page in the Administrator perspective
+
+You can view the *Metrics Targets* page in the *Administrator* perspective in the {product-title} web console.
+
+.Prerequisites
+
+* You have access to the cluster as an administrator for the project for which you want to view metrics targets.
+
+.Procedure
+
+* In the *Administrator* perspective, select *Observe* -> *Targets*. 
+The *Metrics Targets* page opens with a list of all service endpoint targets that are being scraped for metrics.
+

--- a/modules/monitoring-getting-detailed-information-about-a-target.adoc
+++ b/modules/monitoring-getting-detailed-information-about-a-target.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * monitoring/managing-metrics-targets.adoc
+
+[id="getting-detailed-information-about-a-target_{context}"]
+= Getting detailed information about a target
+
+On the **Target details** page, you can view detailed information about a metric target.
+
+.Prerequisites
+
+* You have access to the cluster as an administrator for the project for which you want to view metrics targets.
+
+.Procedure
+
+*To view detailed information about a target in the Administrator perspective*:
+
+. Open the {product-title} web console and navigate to *Observe* -> *Targets*.
+
+. Optional: Filter the targets by status and source by selecting filters in the *Filter* list.
+
+. Optional: Search for a target by name or label by using the *Text* or *Label* field next to the search box.
+
+. Optional: Sort the targets by clicking one or more of the *Endpoint*, *Status*, *Namespace*, *Last Scrape*, and *Scrape Duration* column headers.
+
+. Click the URL in the *Endpoint* column for a target to navigate to its *Target details* page. This page provides information about the target, including:
++
+--
+** The endpoint URL being scraped for metrics
+** The current *Up* or *Down* status of the target
+** A link to the namespace
+** A link to the ServiceMonitor details
+** Labels attached to the target
+** The most recent time that the target was scraped for metrics
+--
+

--- a/modules/monitoring-searching-and-filtering-metrics-targets.adoc
+++ b/modules/monitoring-searching-and-filtering-metrics-targets.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * monitoring/managing-metrics-targets.adoc
+
+[id="monitoring-searching-and-filtering-metrics-targets_{context}"]
+= Searching and filtering metrics targets
+
+The list of metrics targets can be long. You can filter and search these targets based on various criteria.
+
+In the *Administrator* perspective, the *Metrics Targets* page provides details about targets for default {product-title} and user-defined projects.
+This page lists the following information for each target:
+
+* the service endpoint URL being scraped
+* the ServiceMonitor component being monitored
+* the up or down status of the target
+* the namespace
+* the last scrape time
+* the duration of the last scrape
+
+You can filter the list of targets by status and source. The following filtering options are available:
+
+* *Status* filters:
+** *Up*. The target is currently up and being actively scraped for metrics.
+** *Down*. The target is currently down and not being scraped for metrics.
+
+* *Source* filters:
+** *Platform*. Platform-level targets relate only to default {product-title} projects. These projects provide core {product-title} functionality.
+** *User*. User targets relate to user-defined projects. These projects are user-created and can be customized. 
+
+You can also use the search box to find a target by target name or label.
+Select *Text* or *Label* from the search box menu to limit your search.

--- a/monitoring/managing-metrics-targets.adoc
+++ b/monitoring/managing-metrics-targets.adoc
@@ -1,0 +1,26 @@
+[id="managing-metrics-targets"]
+= Managing metrics targets
+include::modules/common-attributes.adoc[]
+:context: managing-metrics-targets
+
+toc::[]
+
+{product-title} Monitoring collects metrics from targeted cluster components by scraping data from exposed service endpoints. 
+
+In the *Administrator* perspective in the {product-title} web console, you can use the *Metrics Targets* page to view, search, and filter the endpoints that are currently targeted for scraping, which helps you to identify and troubleshoot problems. 
+For example, you can view the current status of targeted endpoints to see when {product-title} Monitoring is not able to scrape metrics from a targeted component. 
+
+The *Metrics Targets* page shows targets for default {product-title} projects and for user-defined projects. 
+
+// Accessing the Metrics Targets UI in the Administrator perspective
+include::modules/monitoring-accessing-the-metrics-targets-page.adoc[leveloffset=+1]
+
+// Searching and filtering metrics targets
+include::modules/monitoring-searching-and-filtering-metrics-targets.adoc[leveloffset=+1]
+
+// Getting detailed information about metrics targets
+include::modules/monitoring-getting-detailed-information-about-a-target.adoc[leveloffset=+1]
+
+== Next steps
+
+* xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]

--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -33,4 +33,4 @@ include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2
 
 == Next steps
 
-* xref:../monitoring/managing-alerts.adoc#managing-alerts[Managing alerts]
+* xref:../monitoring/managing-metrics-targets.adoc#managing-metrics-targets[Managing metrics targets]


### PR DESCRIPTION
This PR documents the new Targeting UI for Monitoring in the OpenShift web console.
- Aligned team: Dev Tools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3420
- Direct link to doc preview: https://deploy-preview-40359--osdocs.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics-targets.html
- SME review: @simonpasquier @kyoto (approved)
- QE review: @juzhao @lihongyan1 (approved)
- Peer review: @jc-berger (approved)
- All reviews complete. Please merge now