### PR TITLE
OSDOCS-2917: Azure Ephemeral OS disk support

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -7,16 +7,29 @@ toc::[]
 
 You can create a different machine set to serve a specific purpose in your {product-title} cluster on Microsoft Azure. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
+//[IMPORTANT] admonition for UPI
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
+//Machine API overview
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 
+//Sample YAML for a machine set custom resource on Azure
 include::modules/machineset-yaml-azure.adoc[leveloffset=+1]
 
+//Creating a machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
+//Machine sets that deploy machines as Spot VMs
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 
+//Creating Spot VMs by using machine sets
 include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+1]
 
+//Machine sets that deploy machines on Ephemeral OS disks
+include::modules/machineset-azure-ephemeral-os.adoc[leveloffset=+1]
+
+//Creating machines on Ephemeral OS disks by using machine sets
+include::modules/machineset-creating-azure-ephemeral-os.adoc[leveloffset=+1]
+
+//Enabling customer-managed encryption keys for a machine set
 include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+1]

--- a/modules/machineset-azure-ephemeral-os.adoc
+++ b/modules/machineset-azure-ephemeral-os.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+
+[id="machineset-azure-ephemeral-os_{context}"]
+= Machine sets that deploy machines on Ephemeral OS disks
+
+You can create a machine set running on Azure that deploys machines on Ephemeral OS disks. Ephemeral OS disks use local VM capacity rather than remote Azure Storage. This configuration therefore incurs no additional cost and provides lower latency for reading, writing, and reimaging.
+
+.Additional resources
+
+* For more information, see the Microsoft Azure documentation about link:https://docs.microsoft.com/en-us/azure/virtual-machines/ephemeral-os-disks[Ephemeral OS disks for Azure VMs].

--- a/modules/machineset-creating-azure-ephemeral-os.adoc
+++ b/modules/machineset-creating-azure-ephemeral-os.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+
+[id="machineset-creating-azure-ephemeral-os_{context}"]
+= Creating machines on Ephemeral OS disks by using machine sets
+
+You can launch machines on Ephemeral OS disks on Azure by editing your machine set YAML file.
+
+.Prerequisites
+
+* Have an existing Microsoft Azure cluster.
+
+.Procedure
+
+. Edit the custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit machineset <machine-set-name>
+----
++
+where `<machine-set-name>` is the machine set that you want to provision machines on Ephemeral OS disks.
+
+. Add the following to the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    ...
+    osDisk:
+       ...
+       diskSettings: <1>
+         ephemeralStorageLocation: Local <1>
+       cachingType: ReadOnly <1>
+       managedDisk:
+         storageAccountType: Standard_LRS <2>
+       ...
+----
++
+<1> These lines enable the use of Ephemeral OS disks.
+<2> Ephemeral OS disks are only supported for VMs or scale set instances that use the Standard LRS storage account type.
++
+[IMPORTANT]
+====
+The implementation of Ephemeral OS disk support in {product-title} only supports the `CacheDisk` placement type. Do not change the `placement` configuration setting.
+====
+
+. Create a machine set using the updated configuration:
++
+[source,terminal]
+----
+$ oc create -f <machine-set-config>.yaml
+----
+
+.Verification
+
+* On the Microsoft Azure portal, review the *Overview* page for a machine deployed by the machine set, and verify that the `Ephemeral OS disk` field is set to `OS cache placement`.


### PR DESCRIPTION
For [OSDOCS-2917](https://issues.redhat.com/browse/OSDOCS-2917)

Will also need release notes announcement in the enterprise-4.10 branch.

Preview: new sections in _Creating a machine set on Azure_

- [Machine sets that deploy machines on Ephemeral OS disks](https://deploy-preview-40365--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-ephemeral-os_creating-machineset-azure)
- [Creating machines on Ephemeral OS disks by using machine sets](https://deploy-preview-40365--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-creating-azure-ephemeral-os_creating-machineset-azure)