### PR TITLE
Proportional scaling: Difference between Deployment and DeploymentConf is unclear

### DIFF
--- a/modules/deployments-comparing-deploymentconfigs.adoc
+++ b/modules/deployments-comparing-deploymentconfigs.adoc
@@ -60,9 +60,9 @@ The deployment process for `Deployment` objects is driven by a controller loop, 
 [discrete]
 ==== Proportional scaling
 
-Because the deployment controller is the sole source of truth for the sizes of new and old replica sets owned by a deployment, it is able to scale ongoing rollouts. Additional replicas are distributed proportionally based on the size of each replica set.
+Because the deployment controller is the sole source of truth for the sizes of new and old replica sets owned by a `Deployment` object, it is able to scale ongoing rollouts. Additional replicas are distributed proportionally based on the size of each replica set.
 
-Deployments cannot be scaled when a rollout is ongoing because the controller will end up having issues with the deployer process about the size of the new replication controller.
+`DeploymentConfig` objects cannot be scaled when a rollout is ongoing because the controller will end up having issues with the deployer process about the size of the new replication controller.
 
 [discrete]
 ==== Pausing mid-rollout


### PR DESCRIPTION
In section "Proportional scaling" in "Understanding Deployment and
DeploymentConfig objects" the difference between Deployment and
DeploymentConfig is unclear. Both paragraph's talk about deployments.

Explicitly mention Deployment object and DeploymentConfig object to
make the difference clear.

I'm not 100% if this correct, please verify. But the second paragraph talks about a
replication controller so it seems to be related to DeploymentConfig.

It's still confusing that both paragraph's talk about a controller, but this might be another
pull request :-)