### PR TITLE
Added notes for release 4.8.26

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2961,3 +2961,19 @@ link:https://access.redhat.com/solutions/6620441[{product-title} 4.8.25 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-26"]
+=== RHBA-2022:0021 - {product-title} 4.8.26 bug fix update
+
+Issued: 2022-01-11
+
+{product-title} release 4.8.26 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0021[RHBA-2022:0021] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0020[RHBA-2022:0020] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6631251[{product-title} 4.8.26 container image list]
+
+[id="ocp-4-8-26-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
These are the note for release 4.8.26.

Scheduled to be published on 11 January 2022

Applies only to `enterprise-4.8`

Preview: https://deploy-preview-40376--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes.html#ocp-4-8-26