### PR TITLE
Adds notes for 4.9.13 release

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2394,3 +2394,26 @@ link:https://access.redhat.com/solutions/6606181[{product-title} 4.9.12 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-9-13"]
+=== RHBA-2022:0029 - {product-title} 4.9.13 bug fix update
+
+Issued: 2022-01-10
+
+{product-title} release 4.9.13 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0029[RHBA-2022:0029] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6628731[{product-title} 4.9.13 container image list]
+
+[id="ocp-4-9-13-bug-fixes"]
+==== Bug fixes
+
+* Previously, Windows file paths did not accept the colon character, which blocked mirroring on Windows machines. With this update, the colon is replaced with a dash, which allows mirroring on Windows machines. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1903545[*BZ#1903545*])
+
+* Previously, certificates belonging to the _Custom API Name certificate_ for the cluster had inconsistent file permission of `0644`. With this update, permissions are consistently set to `0600`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1977730[*BZ#1977730*])
+
+[id="ocp-4-9-13-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Adds notes for 4.9.13

- Applies to `enterprise-4.9` only
- [Preview link](https://deploy-preview-40378--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-9-release-notes.html#ocp-4-9-13)