### PR TITLE
ECOPROJECT-3- Documentation changes for Poison Pill 4.9

### DIFF
--- a/modules/eco-poison-pill-about-watchdog.adoc
+++ b/modules/eco-poison-pill-about-watchdog.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes/eco-poison-pill-operator.adoc
+
+:_content-type: CONCEPT
+[id="about-watchdog-devices_{context}"]
+= About watchdog devices
+
+Watchdog devices can be any of the following:
+
+* Independently powered hardware devices 
+* Hardware devices that share power with the hosts they control
+* Virtual devices implemented in software, or `softdog`
+
+Hardware watchdog and `softdog` devices have electronic or software timers, respectively. These watchdog devices are used to ensure that the machine enters a safe state when an error condition is detected. The cluster is required to repeatedly reset the watchdog timer to prove that it is in a healthy state. This timer might elapse due to fault conditions, such as deadlocks, CPU starvation, and loss of network or disk access. If the timer expires, the watchdog device assumes that a fault has occurred and the device triggers a forced reset of the node.
+
+Hardware watchdog devices are more reliable than `softdog` devices.
+
+[id="understanding-pp-watchdog_{context}"]
+== Understanding Poison Pill Operator behavior with watchdog devices
+
+The Poison Pill Operator determines the remediation strategy based on the watchdog devices that are present.
+
+If a hardware watchdog device is configured and available, the Operator uses it for remediation. If a hardware watchdog device is not configured, the Operator enables and uses a `softdog` device for remediation. 
+
+If neither watchdog devices are supported, either by the system or by the configuration, the Operator remediates nodes by using software reboot. 

--- a/modules/eco-poison-pill-operator-about.adoc
+++ b/modules/eco-poison-pill-operator-about.adoc
@@ -8,10 +8,7 @@
 
 The Poison Pill Operator runs on the cluster nodes and reboots nodes that are identified as unhealthy. The Operator uses the `MachineHealthCheck` controller to detect the health of a node in the cluster. When a node is identified as unhealthy, the `MachineHealthCheck` resource creates the `PoisonPillRemediation` custom resource (CR), which triggers the Poison Pill Operator. 
 
-The Poison Pill Operator provides the following capabilities:
-
-* Minimizes downtime for stateful applications and restores compute capacity if transient failures occur.
-* Independent of any management interface, such as IPMI or an API to provision a node. 
+The Poison Pill Operator minimizes downtime for stateful applications and restores compute capacity if transient failures occur. You can use this Operator regardless of the management interface, such as IPMI or an API to provision a node, and regardless of of the cluster installation type, such as Installer Provisioned Infrastructure (IPI) or User Provisioned Infrastructure (UPI).
 
 [id="understanding-poison-pill-operator-config_{context}"]
 == Understanding the Poison Pill Operator configuration
@@ -32,7 +29,23 @@ metadata:
 spec:
   safeTimeToAssumeNodeRebootedSeconds: 180 <1>
   watchdogFilePath: /test/watchdog1 <2>
+  isSoftwareRebootEnabled: true <3>
+  apiServerTimeout: 15s <4>
+  apiCheckInterval: 5s <5>  
+  maxApiErrorThreshold: 3 <6>
+  peerApiServerTimeout: 5s <7>
+  peerDialTimeout: 5s <8>
+  peerRequestTimeout: 5s <9>
+  peerUpdateInterval: 15m <10>
 ----
 
 <1> Specify the timeout duration for the surviving peer, after which the Operator can assume that an unhealthy node has been rebooted. The Operator automatically calculates the lower limit for this value. However, if different nodes have different watchdog timeouts, you must change this value to a higher value.
 <2> Specify the file path of the watchdog device in the nodes. If a watchdog device is unavailable, the `PoisonPillConfig` CR uses a software reboot.
+<3> Specify if you want to enable software reboot of the unhealthy nodes. By default, the value of `isSoftwareRebootEnabled` is set to `true`. To disable the software reboot, set the parameter value to `false`.
+<4> Specify the timeout duration to check connectivity with each API server. When this duration elapses, the Operator starts remediation. 
+<5> Specify the frequency to check connectivity with each API server.
+<6> Specify a threshold value. After reaching this threshold, the node starts contacting its peers.
+<7> Specify the timeout duration to connect with the peer API server.
+<8> Specify the timeout duration for establishing connection with the peer.
+<9> Specify the timeout duration to get a response from the peer.
+<10> Specify the frequency to update peer information, such as IP address.

--- a/modules/eco-poison-pill-operator-installation-cli.adoc
+++ b/modules/eco-poison-pill-operator-installation-cli.adoc
@@ -8,6 +8,12 @@
 
 You can use the OpenShift CLI (`oc`) to install the Poison Pill Operator.
 
+You can install the Poison Pill Operator in your own namespace or in the `openshift-operators` namespace.
+
+To install the Operator in your own namespace, follow the steps in the procedure.
+
+To install the Operator in the `openshift-operators` namespace, skip to step 3 of the procedure because the steps to create a new `Namespace` custom resource (CR) and an `OperatorGroup` CR are not required.
+
 .Prerequisites
 
 * Install the OpenShift CLI (`oc`).
@@ -42,9 +48,6 @@ kind: OperatorGroup
 metadata:
   name: poison-pill-manager
   namespace: poison-pill
-spec:
-  targetNamespaces:
-  - poison-pill
 ----
 .. To create the `OperatorGroup` CR, run the following command:
 +
@@ -62,14 +65,18 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
     name: poison-pill-manager
-    namespace: poison-pill
+    namespace: poison-pill <1>
 spec:
-    channel: alpha
+    channel: stable
+    installPlanApproval: Manual <2>
     name: poison-pill-manager
     source: redhat-operators
     sourceNamespace: openshift-marketplace
     package: poison-pill-manager
 ----
+<1> Specify the `Namespace` where you want to install the Poison Pill Operator. To install the Poison Pill Operator in the `openshift-operators` namespace, specify `openshift-operators` in the `Subscription` CR.
+<2> Set the approval strategy to Manual in case your specified version is superseded by a later version in the catalog. This plan prevents an automatic upgrade to a later version and requires manual approval before the starting CSV can complete the installation.
+
 .. To create the `Subscription` CR, run the following command:
 +
 [source,terminal]
@@ -90,7 +97,7 @@ $ oc get csv -n poison-pill
 [source,terminal]
 ----
 NAME                   DISPLAY                 VERSION   REPLACES    PHASE
-poison-pill.v0.1.4     Poison Pill Operator    0.1.4                 Succeeded
+poison-pill.v.0.2.0     Poison Pill Operator    0.2.0                 Succeeded
 ----
 
 . Verify that the Poison Pill Operator is up and running:

--- a/modules/eco-poison-pill-operator-installation-web-console.adoc
+++ b/modules/eco-poison-pill-operator-installation-web-console.adoc
@@ -16,7 +16,7 @@ You can use the {product-title} web console to install the Poison Pill Operator.
 
 . In the {product-title} web console, navigate to *Operators* -> *OperatorHub*.
 . Search for the Poison Pill Operator from the list of available Operators, and then click *Install*.
-. Keep the default selection of *Installation mode* and *namespace* to ensure that the Operator is installed to the `poison-pill` namespace.
+. Keep the default selection of *Installation mode* and *namespace* to ensure that the Operator is installed to the `openshift-operators` namespace.
 . Click *Install*.
 
 .Verification
@@ -24,7 +24,7 @@ You can use the {product-title} web console to install the Poison Pill Operator.
 To confirm that the installation is successful:
 
 . Navigate to the *Operators* -> *Installed Operators* page.
-. Check that the Operator is installed in the `poison-pill` namespace and its status is `Succeeded`.
+. Check that the Operator is installed in the `openshift-operators` namespace and its status is `Succeeded`.
 
 If the Operator is not installed successfully:
 

--- a/nodes/nodes/eco-poison-pill-operator.adoc
+++ b/nodes/nodes/eco-poison-pill-operator.adoc
@@ -10,6 +10,11 @@ You can use the Poison Pill Operator to automatically reboot unhealthy nodes. Th
 
 include::modules/eco-poison-pill-operator-about.adoc[leveloffset=+1]
 
+include::modules/eco-poison-pill-about-watchdog.adoc[leveloffset=+2]
+
+.Additional resources
+xref:../../virt/virtual_machines/advanced_vm_management/virt-configuring-a-watchdog.adoc#virt-configuring-a-watchdog[Configuring a watchdog]
+
 include::modules/eco-poison-pill-operator-installation-web-console.adoc[leveloffset=+1]
 
 include::modules/eco-poison-pill-operator-installation-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-343](https://issues.redhat.com/browse/TELCODOCS-343): Documentation for the Poison Pill Operator 4.9

Applies to OpenShift version: 4.9+ (4.9, 4.10, and main)

Preview: 
New module:  [About watchdog devices](https://deploy-preview-40380--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-poison-pill-operator.html#about-watchdog-devices_poison-pill-operator-remediate-nodes)

Updated module with new config parameters for 4.9+:  [Understanding the Poison Pill Operator configuration](https://deploy-preview-40380--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/eco-poison-pill-operator.html#understanding-poison-pill-operator-config_poison-pill-operator-remediate-nodes)