### PR TITLE
OSDOCS-2949: Removing iam:TagRole as required permission

### DIFF
--- a/modules/installation-aws-permissions.adoc
+++ b/modules/installation-aws-permissions.adoc
@@ -146,7 +146,6 @@ If you use an existing VPC, your account does not require these permissions for 
 * `iam:PutRolePolicy`
 * `iam:RemoveRoleFromInstanceProfile`
 * `iam:SimulatePrincipalPolicy`
-* `iam:TagRole`
 
 [NOTE]
 =====


### PR DESCRIPTION
CP to 4.10

This PR addresses [OSDOCS-2949](https://issues.redhat.com/browse/OSDOCS-2949).

Removed the `iam-TagRole` permission from the list of required IAM permissions installation.

Doc preview
[Required AWS permissions for IAM roles](https://docs.openshift.com/container-platform/4.9/installing/installing_aws/installing-aws-account.html#installation-aws-permissions_installing-aws-account)

Note: The release note for this work is addressed by https://github.com/openshift/openshift-docs/pull/40407