### PR TITLE
OSDOCS-2949 Adding release note for revised IAM role permissions

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -61,8 +61,13 @@ This release adds improvements related to the following components and concepts.
 {op-system-first} Amazon Machine Images (AMIs) are now available for AWS GovCloud regions. The availability of these AMIs improves the installation process because you are no longer required to upload a custom RHCOS AMI to deploy a cluster.
 //For more information on installing to a AWS GovCloud region, <insert link to topic after it merges>
 
+[id="ocp-4-10-installation-and-upgrade-tagrole"]
+==== Using a custom AWS IAM role for instance profiles
+
+Beginning with {product-title} {product-version}, if you configure a cluster with an existing IAM role, the installer no longer adds the `shared` tag to the role when deploying the cluster. This enhancement improves the installation process for organizations that want to use a custom IAM role, but whose security policies prevent the use of the `shared` tag.
+
 [id="ocp-4-10-conditional-updates"]
-=== Conditional updates
+==== Conditional updates
 
 {product-title} 4.10 adds support for consuming conditional update paths provided by the OpenShift Update Service.
 Conditional update paths convey identified risks and the conditions under which those risks apply to clusters.


### PR DESCRIPTION
CP to 4.10

This PR is the release note for [OSDOCS-2949](https://issues.redhat.com/browse/OSDOCS-2949)

Doc preview
[Using a custom AWS IAM role to deploy an installer-provisioned cluster](https://deploy-preview-40407--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes#ocp-4-10-installation-and-upgrade-tagrole)

Note: Update to the OCP help is addressed by https://github.com/openshift/openshift-docs/pull/40398