### PR TITLE
GH22601: Adding link to limits and requests

### DIFF
--- a/applications/deployments/managing-deployment-processes.adoc
+++ b/applications/deployments/managing-deployment-processes.adoc
@@ -19,6 +19,11 @@ include::modules/deployments-viewing-logs.adoc[leveloffset=+2]
 include::modules/deployments-triggers.adoc[leveloffset=+2]
 include::modules/deployments-setting-triggers.adoc[leveloffset=+3]
 include::modules/deployments-setting-resources.adoc[leveloffset=+2]
+
+.Additional resources
+
+* For more information about resource limits and requests, see xref:../../nodes/clusters/nodes-cluster-resource-configure.adoc#nodes-cluster-resource-configure-about_nodes-cluster-resource-configure[Understanding managing application memory].
+
 include::modules/deployments-scaling-manually.adoc[leveloffset=+2]
 include::modules/deployments-accessing-private-repos.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/22601

Added link to section that defines memory requests and limits 
Preview: [Setting deployment resources](https://deploy-preview-40411--osdocs.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes.html#deployments-setting-resources_deployment-operations) 