### PR TITLE
updating/updating-cluster-within-minor: Replace --force with --clear

### DIFF
--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -18,11 +18,11 @@ Use the web console or `oc adm upgrade channel _<channel>_` to change the update
 See xref:../authentication/using-rbac.adoc[Using RBAC to define and apply permissions].
 * Have a recent xref:../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd backup] in case your upgrade fails and you must xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[restore your cluster to a previous state].
 +
-{product-title} 4.9 requires an upgrade from etcd version 3.4 to 3.5. If the etcd Operator halts the upgrade, an alert is triggered. To clear this alert, ensure that you have a current etcd backup and restart the upgrade using the `--force` flag.
+{product-title} 4.9 requires an upgrade from etcd version 3.4 to 3.5. If the etcd Operator halts the upgrade, an alert is triggered. To clear this alert, cancel the update with the following command:
 +
 [source,terminal]
 ----
-$ oc adm upgrade --force
+$ oc adm upgrade --clear
 ----
 
 * Ensure all Operators previously installed through Operator Lifecycle Manager (OLM) are updated to their latest version in their latest channel. Updating the Operators ensures they have a valid upgrade path when the default OperatorHub catalogs switch from the current minor version to the next during a cluster upgrade. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrading installed Operators] for more information.


### PR DESCRIPTION
The `--force` guidance landed in 7def7f4798 (#36828).  But whenever the cluster-version operator is blocked on a precondition
(like waiting for an etcd snapshot to complete), the admin can use `--clear` to say "actually, never mind, keep running whatever version you are now".  `--force` would be for things like "I don't care that you're failing a precondition, I want you to update anyway", and you'd need to pair it with `--to`, `--to-image`, or `--to-latest`.  This commit pivots us to `--clear`.  Because if we're actually sticking on etcd backups, we want folks to step back, fix the issue, and then try again.  We don't want them forcing their way through without a backup.

Also, while the snapshots were inspired by the one-way 3.4 to 3.5 etcd update, we're still requiring a snapshot before each minor version bump.  Not sure what folks want to do in `main` vs. the current `4.9 requires an upgrade from etcd version 3.4 to 3.5` reference, if anything.

CC @tmalove, @bergerhoffer, and @bobfuru , who were all involved in #36828.