### PR TITLE
Follow-up to PR39260: Add Image Registry Operator configuration parameter `disabledRegistry` 

### DIFF
--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -52,7 +52,7 @@ instance will handle before queuing additional requests.
 
 |`defaultRoute`
 |Determines whether or not an external route is defined using the default
-hostname. If enabled, the route uses re-encrypt encryption. Defaults to false.
+hostname. If enabled, the route uses re-encrypt encryption. Defaults to `false`.
 
 |`routes`
 |Array of additional routes to create. You provide the hostname and certificate
@@ -60,6 +60,9 @@ for the route.
 
 |`replicas`
 |Replica count for the registry.
+
+|`disableRedirect`
+| Controls whether to route all data through the registry, rather than redirecting to the back end. Defaults to `false`.
 
 |`spec.storage.managementState`
 


### PR DESCRIPTION
Follow-up to https://github.com/openshift/openshift-docs/pull/39260. Adds content to the main branch to be cherry picked to 4.7+. 

SME and QE review tracked on https://github.com/openshift/openshift-docs/pull/39260. 

Preview link: https://deploy-preview-40417--osdocs.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html#registry-operator-configuration-resource-overview_configuring-registry-operator