### PR TITLE
OKD replacing oVirt install docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -317,6 +317,18 @@ Topics:
     File: installing-rhv-restricted-network
   - Name: Uninstalling a cluster on RHV
     File: uninstalling-cluster-rhv
+- Name: Installing on oVirt
+  Dir: installing_rhv
+  Distros: openshift-origin
+  Topics:
+  - Name: Installing a cluster quickly on oVirt
+    File: installing-rhv-default
+  - Name: Installing a cluster on oVirt with customizations
+    File: installing-rhv-customizations
+  - Name: Installing a cluster on oVirt with user-provisioned infrastructure
+    File: installing-rhv-user-infra
+  - Name: Uninstalling a cluster on oVirt
+    File: uninstalling-cluster-rhv
 - Name: Installing on vSphere
   Dir: installing_vsphere
   Distros: openshift-origin,openshift-enterprise


### PR DESCRIPTION
The OKD-only section in the topic map for [installing on oVirt instead of RHV](https://github.com/openshift/openshift-docs/pull/27649) is not in 4.9. Not sure why. This replaces the section.