### PR TITLE
[enterprise-4.7] Follow-up to PR39260: Add Image Registry Operator configuration parameter `disabledRegistry`

### DIFF
--- a/modules/registry-operator-configuration-resource-overview.adoc
+++ b/modules/registry-operator-configuration-resource-overview.adoc
@@ -52,7 +52,7 @@ instance will handle before queuing additional requests.
 
 |`defaultRoute`
 |Determines whether or not an external route is defined using the default
-hostname. If enabled, the route uses re-encrypt encryption. Defaults to false.
+hostname. If enabled, the route uses re-encrypt encryption. Defaults to `false`.
 
 |`routes`
 |Array of additional routes to create. You provide the hostname and certificate
@@ -62,8 +62,7 @@ for the route.
 |Replica count for the registry.
 
 |`disableRedirect`
-| disableRedirect controls whether to route all data through the Registry,
-rather than redirecting to the backend. Defaults to false.
+| Controls whether to route all data through the registry, rather than redirecting to the back end. Defaults to `false`.
 
 |`spec.storage.managementState`
 


### PR DESCRIPTION
Manual CP from: https://github.com/openshift/openshift-docs/pull/40417