### PR TITLE
BZ1804551:Updates Multiple zone limitations URL and link text

### DIFF
--- a/install_config/topics/manually_configuring_for_vsphere.adoc
+++ b/install_config/topics/manually_configuring_for_vsphere.adoc
@@ -50,8 +50,7 @@ However, deploying {product-title} in vSphere on different zones can be helpful 
 single-point-of-failures, but creates the need for shared storage across zones.
 If an {product-title} node host goes down in zone "A" and the pods
 should be moved to zone "B".
-See https://kubernetes.io/docs/admin/multiple-zones/#limitations[Multiple zone
-limitations] in the Kubernetes documentation for more information.
+See https://kubernetes.io/docs/setup/best-practices/multiple-zones/[Running in multiple zones] in the Kubernetes documentation for more information.
 
 ** To configure a single vCenter server, use the following format for the
 *_/etc/origin/cloudprovider/vsphere.conf_* file:
@@ -191,4 +190,3 @@ RFC1123 compliant.
 
 [[vsphere-applying-configuration-changes]]
 == Applying Configuration Changes
-


### PR DESCRIPTION
`Multiple zone limitations` URL was broken. Now it has been updated to `Running in multiple zones`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1804551

OCP version: Applicable only to **enterprise-3.11**

Direct Doc Preview Link: https://deploy-preview-40436--osdocs.netlify.app/openshift-enterprise/latest/install_config/configuring_vsphere.html#manually-configuring-master-hosts-for-vsphere

@dav1x @duanwei33 please review and let me know your feedback.