### PR TITLE
BZ1986354:Updates unixs socket command

### DIFF
--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -215,7 +215,7 @@ $ oc rsh -n openshift-etcd etcd-ip-10-0-154-204.ec2.internal
 +
 [source,terminal]
 ----
-sh-4.2# etcdctl endpoint health --cluster
+sh-4.2# etcdctl endpoint health
 ----
 +
 .Example output


### PR DESCRIPTION
From OCP 4.8 onward, unixs socket doesn't print at the `etcdctl endpoint health --cluster` command. Instead, `etcdctl endpoint health ` command works. Doc updated by removing the cluster flag `--cluster`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1986354

OCP Version: **applicable only to 4.8, 4.9, 4.10**

Direct Doc Preview Link: https://deploy-preview-40437--osdocs.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member