### PR TITLE
Move additional resouces heading

### DIFF
--- a/machine_management/adding-rhel-compute.adoc
+++ b/machine_management/adding-rhel-compute.adoc
@@ -10,12 +10,13 @@ In {product-title}, you can add Red Hat Enterprise Linux (RHEL) compute, or work
 include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-deleting_nodes-nodes-working[Deleting nodes]
+
+
 include::modules/csr-management.adoc[leveloffset=+2]
-
-[id="additional-resources_adding-rhel-compute"]
-== Additional resources
-
-* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
 
 [id="adding-rhel-compute-preparing-image-cloud"]
 == Preparing an image for your cloud

--- a/machine_management/more-rhel-compute.adoc
+++ b/machine_management/more-rhel-compute.adoc
@@ -10,12 +10,12 @@ If your {product-title} cluster already includes Red Hat Enterprise Linux (RHEL)
 include::modules/rhel-compute-overview.adoc[leveloffset=+1]
 
 include::modules/rhel-compute-requirements.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-deleting_nodes-nodes-working[Deleting nodes]
+
 include::modules/csr-management.adoc[leveloffset=+2]
-
-[id="additional-resources_more-rhel-compute"]
-== Additional resources
-
-* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
 
 [id="more-rhel-compute-preparing-image-cloud"]
 == Preparing an image for your cloud

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -15,13 +15,12 @@ Understand and work with RHEL compute nodes.
 
 include::modules/rhel-compute-overview.adoc[leveloffset=+2]
 include::modules/rhel-compute-requirements.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-deleting_nodes-nodes-working[Deleting nodes]
+
 include::modules/csr-management.adoc[leveloffset=+3]
-
-[id="additional-resources_post-install-node-tasks"]
-== Additional resources
-
-* xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes_nodes-nodes-working[Deleting nodes]
-
 include::modules/rhel-preparing-playbook-machine.adoc[leveloffset=+2]
 include::modules/rhel-preparing-node.adoc[leveloffset=+2]
 include::modules/rhel-adding-node.adoc[leveloffset=+2]


### PR DESCRIPTION
An Additional resources heading seems slightly out of place. Making them module-level headings instead of assembly-level and moving closer to the Note that references it.

Moved the Additional resource to the end of the following sections:
[Adding a RHEL compute machine/System requirements for RHEL compute nodes](https://deploy-preview-40468--osdocs.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-compute-requirements_adding-rhel-compute)
[Adding a RHEL compute machine/System requirements for RHEL compute nodes](https://deploy-preview-40468--osdocs.netlify.app/openshift-enterprise/latest/machine_management/more-rhel-compute.html#rhel-compute-requirements_more-rhel-compute)
[Post-install/Node tasks/System requirements for RHEL compute nodes](https://deploy-preview-40468--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#rhel-compute-requirements_post-install-node-tasks)
