### PR TITLE
Updated Networking Requirements for Vsphere IPI

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -307,7 +307,6 @@ While provisioning more than one OCP cluster in same multicast domain with insta
 ----
 $ podman run quay.io/openshift/origin-baremetal-runtimecfg:TAG vr-ids cnf10
 APIVirtualRouterID: 147
-DNSVirtualRouterID: 158
 IngressVirtualRouterID: 2
 ----
 
@@ -316,7 +315,6 @@ Where TAG is the release you are going to install, e.g., 4.8. Let's see another 
 ----
 $ podman run quay.io/openshift/origin-baremetal-runtimecfg:TAG vr-ids cnf11
 APIVirtualRouterID: 228
-DNSVirtualRouterID: 239
 IngressVirtualRouterID: 147
 ----
 

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -299,3 +299,26 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :!restricted:
 endif::[]
+
+[IMPORTANT]
+====
+While provisioning more than one OCP cluster in same multicast domain with installer-provisioned vSphere installation,  make sure that the VRRP router IDs should not be conflicting.
+
+----
+$ podman run quay.io/openshift/origin-baremetal-runtimecfg:TAG vr-ids cnf10
+APIVirtualRouterID: 147
+DNSVirtualRouterID: 158
+IngressVirtualRouterID: 2
+----
+
+Where TAG is the release you are going to install, e.g., 4.8. Let's see another example:
+
+----
+$ podman run quay.io/openshift/origin-baremetal-runtimecfg:TAG vr-ids cnf11
+APIVirtualRouterID: 228
+DNSVirtualRouterID: 239
+IngressVirtualRouterID: 147
+----
+
+In the example output above two clusters in the same multicast domain with names cnf10 and cnf11 would lead to a conflict.
+====


### PR DESCRIPTION
Hello Team,

I have updated the Networking Requirement section of the Vsphere Installation.

For more info, please check the relevant BZ[1]  and Doc[2].  The above PR is for OCP 4.8+

[1]  https://bugzilla.redhat.com/show_bug.cgi?id=1821667
[2] https://github.com/openshift/installer/blob/master/docs/user/metal/install_ipi.md