### PR TITLE
GH39759: Remove SNO assisted installer from OKD

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -5,12 +5,16 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-origin[]
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 include::modules/install-sno-generating-the-discovery-iso-manually.adoc[leveloffset=+1]
 
 include::modules/install-sno-installing-with-usb-media.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 include::modules/install-sno-monitoring-the-installation-with-the-assisted-installer.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffset=+1]


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/39759: OKD doesn't yet support single node clusters using assisted installer. 

Removed SNO Assisted Installer sections from OKD:
_Generating the discovery ISO with the Assisted Installer
Monitoring the installation with the Assisted Installer_

Preview: http://file.rdu.redhat.com/~mburke/GH39759-remove-assisted-installer-okd/installing/installing_sno/install-sno-installing-sno.html