### PR TITLE
GH38690: Update link to kubernetes config options

### DIFF
--- a/modules/nodes-nodes-managing-about.adoc
+++ b/modules/nodes-nodes-managing-about.adoc
@@ -84,7 +84,7 @@ For example:
 $ oc create -f master-kube-config.yaml
 ----
 
-Most https://github.com/kubernetes/kubelet/blob/master/config/v1beta1/types.go[KubeletConfig Options] can be set by the user. The following options are not allowed to be overwritten:
+Most https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/[Kubelet Configuration options] can be set by the user. The following options are not allowed to be overwritten:
 
 * CgroupDriver
 * ClusterDNS


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/issues/38690

Update a link to the upstream KubeletConfig options at HEAD, which probably don't correspond to the current version of OpenShift and are hard to read. We could at least link to the API docs.

Preview: Link at the end of [Modifying nodes](https://deploy-preview-40475--osdocs.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-managing-about_nodes-nodes-jobs)