### PR TITLE
BZ#2014982: adding missing link to how cluster is configured to trust…

### DIFF
--- a/updating/installing-update-service.adoc
+++ b/updating/installing-update-service.adoc
@@ -83,6 +83,11 @@ and must be no more than 63 characters`, try creating the Update Service with a 
 
 include::modules/update-service-configure-cvo.adoc[leveloffset=+2]
 
+[NOTE]
+====
+See xref:../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object[Enabling the cluster-wide proxy] to configure the CA to trust the update server. 
+====
+
 [id="update-service-delete-service"]
 == Deleting an OpenShift Update Service application
 


### PR DESCRIPTION
adding missing link to how cluster is configured to trust the update server hosted by osus

https://bugzilla.redhat.com/show_bug.cgi?id=2014982

Preview: https://deploy-preview-40481--osdocs.netlify.app/openshift-enterprise/latest/updating/installing-update-service.html#update-service-configure-cvo

For 4.6+