### PR TITLE
[WIP] OSDOCS3102: Overview page for metering

### DIFF
--- a/modules/metering-overview.adoc
+++ b/modules/metering-overview.adoc
@@ -12,6 +12,50 @@ Metering focuses primarily on in-cluster metric data using Prometheus as a defau
 
 You can install metering on {product-title} 4.x clusters and above.
 
+[discrete]
+[id="metering-overview-install-metering"]
+== Installing metering
+You can install metering using the CLI and the web console on {product-title} 4.x and above. For more information see, [installing metering]
+
+[discrete]
+[id="metering-overview-upgrade-metering"]
+== Upgrading metering
+You can upgrade metering by updating the Metering Operator subscription. Review the following tasks:
+* [Configuring metering]: The MeteringConfig custom resource specifies all the configuration details for your metering installation. When you first install the metering stack, a default MeteringConfig custom resource is generated. Use the examples in the documentation to modify this default file.
+
+* [Generating reports]: A Report custom resource provides a method to manage periodic Extract Transform and Load (ETL) jobs using SQL queries. Reports are composed from other metering resources, such as ReportQuery resources that provide the actual SQL query to run, and ReportDataSource resources that define the data available to the ReportQuery and Report resources.
+
+[discrete]
+[id="metering-overview-use-metering"]
+== Using metering
+You can use metering for writing reports and viewing report results. For more information, see [examples of using metering].
+
+[discrete]
+[id="metering-overview-troubleshoot-metering"]
+== Troubleshooting metering
+You can use the following sections to troubleshoot specific issues with metering.
+
+* Not enough compute resources
+* StorageClass resource not configured
+* Secret not configured correctly
+
+[discrete]
+[id="metering-overview-debug-metering"]
+== Debugging metering
+You can use the following sections to debug specific issues with metering.
+
+* Get reporting operator logs
+* Query Presto using presto-cli
+* Query Hive using beeline
+* Port-forward to the Hive web UI
+* Port-forward to HDFS
+* Metering Ansible Operator
+
+[discrete]
+[id="metering-overview-uninstall-metering"]
+== Uninstalling metering
+You can remove and clean metering resources from your OpenShift Container Platform cluster. For more information see, [how to uninstall metering]
+
 [id="metering-resources_{context}"]
 == Metering resources
 


### PR DESCRIPTION
OCP version 4.6+
The metering feature is deprecated from 4.9 onwards.
[Fixes](https://issues.redhat.com/browse/OSDOCS-3102)
Preview
QE contact: 