### PR TITLE
OSDOCS3102: Metering Overview

### DIFF
--- a/modules/metering-overview.adoc
+++ b/modules/metering-overview.adoc
@@ -12,6 +12,45 @@ Metering focuses primarily on in-cluster metric data using Prometheus as a defau
 
 You can install metering on {product-title} 4.x clusters and above.
 
+[id="metering-overview-install-metering"]
+== Installing metering
+You can install metering using the CLI and the web console on {product-title} 4.x and above. To learn more, see xref:../metering/metering-installing-metering.adoc#metering-install-prerequisites_installing-metering[installing metering].
+
+[id="metering-overview-upgrade-metering"]
+== Upgrading metering
+You can upgrade metering by updating the Metering Operator subscription. Review the following tasks:
+
+* The `MeteringConfig` custom resource specifies all xref:../metering/configuring_metering/metering-about-configuring.adoc#metering-about-configuring[the configuration details for your metering installation]. When you first install the metering stack, a default `MeteringConfig` custom resource is generated. Use the examples in the documentation to modify this default file.
+
+* xref:../metering/reports/metering-about-reports.adoc#metering-about-reports[A report custom resource] provides a method to manage periodic Extract Transform and Load (ETL) jobs using SQL queries. Reports are composed from other metering resources, such as `ReportQuery` resources that provide the actual SQL query to run, and `ReportDataSource` resources that define the data available to the `ReportQuery` and `Report` resources.
+
+[id="metering-overview-use-metering"]
+== Using metering
+You can use metering for writing reports and viewing report results. To learn more, see xref:../metering/metering-usage-examples.adoc#metering-usage-examples[examples of using metering].
+
+[id="metering-overview-troubleshoot-metering"]
+== Troubleshooting metering
+You can use the following sections to xref:../metering/metering-troubleshooting-debugging.adoc#metering-troubleshooting_metering-troubleshooting-debugging[troubleshoot specific issues with metering].
+
+* Not enough compute resources
+* `StorageClass` resource not configured
+* Secret not configured correctly
+
+[id="metering-overview-debug-metering"]
+== Debugging metering
+You can use the following sections to xref:../metering/metering-troubleshooting-debugging.adoc#metering-debugging_metering-troubleshooting-debugging[debug specific issues with metering].
+
+* Get reporting Operator logs
+* Query Presto using presto-cli
+* Query Hive using beeline
+* Port-forward to the Hive web UI
+* Port-forward to HDFS
+* Metering Ansible Operator
+
+[id="metering-overview-uninstall-metering"]
+== Uninstalling metering
+You can remove and clean metering resources from your OpenShift Container Platform cluster. To learn more, see xref:../metering/metering-uninstall.adoc#metering-uninstall[uninstalling metering].
+
 [id="metering-resources_{context}"]
 == Metering resources
 


### PR DESCRIPTION
OCP version 4.6+
The metering feature is deprecated from 4.9 onwards. So this overview would be valid for 4.6, 4.7 and 4.8 only.
Can we cherry-pick to 4.6 and 4.7 from this PR?
[Fixes](https://issues.redhat.com/browse/OSDOCS-3102)
[Preview](https://deploy-preview-40490--osdocs.netlify.app/openshift-enterprise/latest/metering/metering-about-metering#metering-overview_about-metering)
QE contact: @juzhao 