### PR TITLE
[RHACS] Added instructions for configuring network baselining duration

### DIFF
--- a/modules/configuring-network-baselining-timeframe.adoc
+++ b/modules/configuring-network-baselining-timeframe.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-network-policies.adoc
+:_module-type: PROCEDURE
+[id="configuring-network-baselining-timeframe_{context}"]
+= Configuring network baselining time frame
+
+You can use the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables to configure the observation period and the network baseline generation duration.
+
+.Procedure
+
+* Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables:
++
+[source,terminal]
+----
+$ oc -n stackrox set env deploy/central \ <1>
+  ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> <2>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
++
+[source,terminal]
+----
+$ oc -n stackrox set env deploy/central \ <1>
+  ROX_BASELINE_GENERATION_DURATION=<value> <2>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.

--- a/operating/manage-network-policies.adoc
+++ b/operating/manage-network-policies.adoc
@@ -42,6 +42,8 @@ include::modules/policy-generation-strategy.adoc[leveloffset=+2]
 
 include::modules/use-network-baselining.adoc[leveloffset=+1]
 
+include::modules/configuring-network-baselining-timeframe.adoc[leveloffset=+2]
+
 include::modules/view-network-baselines.adoc[leveloffset=+2]
 
 include::modules/enable-alert-on-baseline-violations.adoc[leveloffset=+2]


### PR DESCRIPTION
For https://issues.redhat.com/browse/OSDOCS-2742

Applies to:
3.65, 3.66, 3.67, 3.68, 3.69


<hr>

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
