### PR TITLE
Adds 4.6.53 release notes

### DIFF
--- a/release_notes/ocp-4-6-release-notes.adoc
+++ b/release_notes/ocp-4-6-release-notes.adoc
@@ -3421,3 +3421,25 @@ link:https://access.redhat.com/solutions/6576991[{product-title} 4.6.52 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-6-53"]
+=== RHBA-2022:0025 - {product-title} 4.6.53 bug fix and security update
+
+Issued: 2022-01-12
+
+{product-title} release 4.6.53, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0025[RHBA-2022:0025] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0024[RHSA-2022:0024] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6635841[{product-title} 4.6.53 container image list]
+
+
+[id="ocp-4-6-53-bug-fixes"]
+==== Bug fixes
+
+* Previously, in Unified Extensible Firmware Interface (UEFI) mode, `ironic-python-agent` created a UEFI bootloader entry after downloading the {op-system-first} image. When using a RHCOS image based on {op-system-base-full} 8.4, the image could fail to boot using this entry. Consequently, depending on the ordering of UEFI entries, if the entry installed by `ironic-python-agent` is used when booting the image, the boot could fail and output a BIOS error screen. With this update, `ironic-python-agent` configures the boot entry based on a CSV file located in the image, instead of using a fixed boot entry. As a result the image boots properly without an error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025495[*BZ#2025495*])
+
+[id="ocp-4-6-53-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.6 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

OCP version: **Applicable only to 4.6**

To be merged on 12-01-2022. I will notify when the Erratas are shipped live.

Direct Doc Preview Link: https://deploy-preview-40499--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-6-release-notes#ocp-4-6-53