### PR TITLE
BZ2031197: Adds WWIDs parameter in Persistent Volume Object Definition

### DIFF
--- a/modules/persistent-storage-fibre-provisioning.adoc
+++ b/modules/persistent-storage-fibre-provisioning.adoc
@@ -32,11 +32,13 @@ spec:
   accessModes:
     - ReadWriteOnce
   fc:
-    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <1>
-    lun: 2
+    wwids: [scsi-3600508b400105e210000900000490000] <1>
+    targetWWNs: ['500a0981891b8dc5', '500a0981991b8dc5'] <2>
+    lun: 2 <2>
     fsType: ext4
 ----
-<1> Fibre Channel WWNs are identified as
+<1> World wide identifiers (WWIDs). Either FC `*wwids*` or a combination of FC `*targetWWNs*` and `*lun*` must be set, but not both simultaneously. The FC WWID identifier is recommended over the WWNs target because it is guaranteed to be unique for every storage device, and independent of the path that is used to access the device. The WWID identifier can be obtained by issuing a SCSI Inquiry to retrieve the Device Identification Vital Product Data (`*page 0x83*`) or Unit Serial Number (`*page 0x80*`). FC WWIDs are identified as `*/dev/disk/by-id/*` to reference the data on the disk, even if the path to the device changes and even when accessing the device from different systems.
+<2> Fibre Channel WWNs are identified as
 `/dev/disk/by-path/pci-<IDENTIFIER>-fc-0x<WWN>-lun-<LUN#>`,
 but you do not need to provide any part of the path leading up to the `WWN`,
 including the `0x`, and anything after, including the `-` (hyphen).


### PR DESCRIPTION
Added WWIDs parameter in Persistent Volume Object Definition.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2031197

OCP version: 4.6 +

Direct Doc Preview Link: https://deploy-preview-40501--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-fibre.html#provisioning-fibre_persistent-storage-fibre

@duanwei33 please review and let me know your feedback.