### PR TITLE
OSDOCS-2831: RN for OVNK and gatewayConfig

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -88,6 +88,21 @@ For more information, see xref:../updating/understanding-upgrade-channels-releas
 [id="ocp-4-10-networking"]
 === Networking
 
+[id="ocp-4-10-networking-ovn-gateway-config"]
+==== OVN-Kubernetes support for gateway configuration
+
+The OVN-Kubernetes CNI network provider adds support for configuring how egress traffic is sent to the node gateway.
+By default, egress traffic is processed in OVN to exit the cluster and traffic is not affected by specialized routes in the kernel routing table.
+
+This enhancement adds a `gatewayConfig.routingViaHost` field.
+The field can be set at runtime as a post-installation activity and when it is set to `true`, egress traffic is sent from pods to the host networking stack.
+This enhancement benefits highly-specialized installations and applications that rely on manually configured routes in the kernel routing table.
+
+This enhancement has an interaction with the Open vSwitch hardware offloading feature.
+When the `gatewayConfig.routingViaHost` field is set to `true`, you do not receive the performance benefits of the offloading because egress traffic is processed by the host networking stack.
+
+For configuration information, see xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration for the OVN-Kubernetes CNI cluster network provider].
+
 [id="ocp-4-10-networking-metrics"]
 ==== Enhancements to networking metrics
 


### PR DESCRIPTION
RN update for https://issues.redhat.com/browse/OSDOCS-2831

Related to #40293.

----

Please review [OVN-Kubernetes support for gateway configuration](https://deploy-preview-40504--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-networking).

FYI: If you follow the link to the configuration information at the end of the release note description, the table does not yet include the `gatewayConfig` or `routingViaHost` fields.  It won't until #40293 is merged.