### PR TITLE
Adding 'update' to the glossary

### DIFF
--- a/contributing_to_docs/term_glossary.adoc
+++ b/contributing_to_docs/term_glossary.adoc
@@ -683,6 +683,14 @@ See link:https://kubernetes.io/docs/concepts/storage/storage-classes/[Storage Cl
 == U
 
 ''''
+=== update
+
+Usage: update
+
+Use "update" when referring to updating the cluster to a new version. Although "upgrade" is sometimes used interchangeably, "update" is the preferred term to use, for consistency.
+
+
+''''
 === user-provisioned infrastructure
 
 Usage: user-provisioned infrastructure


### PR DESCRIPTION
Adding "update" as the preferred term over "upgrade". We've casually made this decree, but have never documented it.

Preview: https://github.com/openshift/openshift-docs/blob/a68b6073254a76d1369185875f7ffcb317c459f8/contributing_to_docs/term_glossary.adoc#update