### PR TITLE
BZ1669050: Use oc exec instead of oc rsh in Customized HAProxy Router steps

### DIFF
--- a/install_config/router/customized_haproxy_router.adoc
+++ b/install_config/router/customized_haproxy_router.adoc
@@ -70,8 +70,8 @@ router by running this on master, referencing the router pod:
 # oc get po
 NAME                       READY     STATUS    RESTARTS   AGE
 router-2-40fc3             1/1       Running   0          11d
-# oc rsh router-2-40fc3 cat haproxy-config.template > haproxy-config.template
-# oc rsh router-2-40fc3 cat haproxy.config > haproxy.config
+# oc exec router-2-40fc3 cat haproxy-config.template > haproxy-config.template
+# oc exec router-2-40fc3 cat haproxy.config > haproxy.config
 ----
 
 Alternatively, you can log onto the node that is running the router:
@@ -656,11 +656,11 @@ on a running router. Make a work directory and copy the files from the router:
 # oc get po
 NAME                       READY     STATUS    RESTARTS   AGE
 router-2-40fc3             1/1       Running   0          11d
-# oc rsh router-2-40fc3 cat haproxy-config.template > conf/haproxy-config.template
-# oc rsh router-2-40fc3 cat error-page-503.http > conf/error-page-503.http
-# oc rsh router-2-40fc3 cat default_pub_keys.pem > conf/default_pub_keys.pem
-# oc rsh router-2-40fc3 cat ../Dockerfile > Dockerfile
-# oc rsh router-2-40fc3 cat ../reload-haproxy > reload-haproxy
+# oc exec router-2-40fc3 cat haproxy-config.template > conf/haproxy-config.template
+# oc exec router-2-40fc3 cat error-page-503.http > conf/error-page-503.http
+# oc exec router-2-40fc3 cat default_pub_keys.pem > conf/default_pub_keys.pem
+# oc exec router-2-40fc3 cat ../Dockerfile > Dockerfile
+# oc exec router-2-40fc3 cat ../reload-haproxy > reload-haproxy
 ----
 
 You can edit or replace any of these files. However, *_conf/haproxy-config.template_*


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1669050

Use "oc exec" instead of 'ocrsh" which does not modify the content when piping out to file.
