### PR TITLE
BZ1683050: Fix oc logs command

### DIFF
--- a/dev_guide/dev_tutorials/ruby_on_rails.adoc
+++ b/dev_guide/dev_tutorials/ruby_on_rails.adoc
@@ -341,7 +341,7 @@ env": [
 To check the build process:
 
 ----
-$ oc logs -f build rails-app-1
+$ oc logs -f build/rails-app-1
 ----
 
 Once the build is complete, you can look at the running pods in {product-title}.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1683050

Check the build process:
$ oc logs -f build rails-app-1

The cmd should be '$ oc logs -f build/rails-app-1'

Preview: [Creating the Frontend Service](https://deploy-preview-40527--osdocs.netlify.app/openshift-enterprise/latest/dev_guide/dev_tutorials/ruby_on_rails.html#creating-the-frontend-service)