### PR TITLE
BZ1758448: Fix the oc get svc command

### DIFF
--- a/install_config/registry/securing_and_exposing_registry.adoc
+++ b/install_config/registry/securing_and_exposing_registry.adoc
@@ -43,8 +43,8 @@ use the system hostname or IP address.
 endif::[]
 ----
 $ oc get svc/docker-registry
-NAME              LABELS                                    SELECTOR                  IP(S)            PORT(S)
-docker-registry   docker-registry=default                   docker-registry=default   172.30.124.220   5000/TCP
+NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)    AGE
+docker-registry   ClusterIP   172.30.82.152   <none>        5000/TCP   1d
 ----
 +
 . You can use an existing server certificate, or create a key and server


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1758448

Change the output of the `oc get svc/docker-registry` command to not show `LABELS`

Preview: https://deploy-preview-40530--osdocs.netlify.app/openshift-enterprise/latest/install_config/registry/securing_and_exposing_registry.html#securing-the-registry