### PR TITLE
OSDOCS-3161 Add Compliance benchmark column to Supported profiles table

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -8,60 +8,72 @@
 The Compliance Operator provides the following compliance profiles:
 
 .Supported compliance profiles
-[cols="40%,50%,10%", options="header"]
+[cols="10%,40%,10%,40%", options="header"]
 
 |===
-|Profile name
+|Profile
 |Profile title
 |Compliance Operator version 
+|Industry compliance benchmark
 
 |ocp4-cis
-|link:https://www.cisecurity.org/cis-benchmarks/[CIS Red Hat OpenShift Container Platform 4 Benchmark]
+|CIS Red Hat OpenShift Container Platform 4 Benchmark
 |0.1.39+
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[To locate the CIS RedHat OpenShift Container Platform v4 Benchmark, go to  link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks] and type `Kubernetes` in the search box. Click on *Kubernetes* and then *Download Latest CIS Benchmark*, where you can then register to download the benchmark.]
 
 |ocp4-cis-node
-|link:https://www.cisecurity.org/cis-benchmarks/[CIS Red Hat OpenShift Container Platform 4 Benchmark]
+|CIS Red Hat OpenShift Container Platform 4 Benchmark
 |0.1.39+
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[]
 
 |ocp4-e8
-|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[Australian Cyber Security Centre (ACSC) Essential Eight]
+|Australian Cyber Security Centre (ACSC) Essential Eight
 |0.1.39+
+|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 
 |ocp4-moderate
-|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level]
+|NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level
 |0.1.39+
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 
 |ocp4-moderate-node
-|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level]
+|NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
 |0.1.44+
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 
 |ocp4-nerc-cip
-|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
 |0.1.44+
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 
 |ocp4-nerc-cip-node
-|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
 |0.1.44+
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 
 |ocp4-pci-dss
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4]
+|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
 |0.1.47+
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 
 |ocp4-pci-dss-node
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4]
+|PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
 |0.1.47+
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 
 |rhcos4-e8
-|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[Australian Cyber Security Centre (ACSC) Essential Eight]
+|Australian Cyber Security Centre (ACSC) Essential Eight
 |0.1.39+
+|link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 
 |rhcos4-moderate
-|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS]
+|NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS
 |0.1.39+
+|link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 
 |rhcos4-nerc-cip
-|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[North American Electric Reliability Corporation (NERC)]
+|North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for Red Hat Enterprise Linux CoreOS
 |0.1.44+
-
+|link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 |===
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3161
Applies to 4.6+

Direct link to the Supported profiles table [here](https://deploy-preview-40531--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-supported-profiles.html)
