### PR TITLE
OSDOCS-3146: Note about AWS us-east-1 region.

### DIFF
--- a/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
+++ b/rosa_getting_started_sts/rosa-sts-aws-prereqs.adoc
@@ -11,6 +11,12 @@ toc::[]
 Ensure that the following AWS prerequisites are met before installing ROSA with STS.
 
 include::modules/rosa-aws-understand.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+When you create a ROSA cluster using AWS STS, an associated AWS OpenID Connect (OIDC) identity provider is created as well. This OIDC provider configuration relies on a public key that is located in the `us-east-1` AWS region. Customers with AWS SCPs must allow the use of the `us-east-1` AWS region, even if these clusters are deployed in a different region.
+====
+
 include::modules/rosa-sts-aws-requirements.adoc[leveloffset=+1]
 include::modules/rosa-requirements-deploying-in-opt-in-regions.adoc[leveloffset=+1]
 include::modules/rosa-setting-the-aws-security-token-version.adoc[leveloffset=+2]


### PR DESCRIPTION
This PR adds a note to the ROSA documentation, alerting users that AWS `us-east-1` is required for OIDC providers.

JIRA: https://issues.redhat.com/browse/OSDOCS-3146

PREVIEW: 

* **STS** - https://deploy-preview-40537--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started_sts/rosa-sts-aws-prereqs.html#rosa-aws-prereqs_rosa-sts-aws-prerequisites 