### PR TITLE
BZ:2039742 - Adding warning about exec probes

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -10,6 +10,11 @@ Many industries and organizations need extremely high performance computing and 
 
 The cluster administrator can use this performance profile configuration to make these changes in a more reliable way. The administrator can specify whether to update the kernel to kernel-rt (real-time), reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolate CPUs for application containers to run the workloads.
 
+[WARNING]
+====
+The usage of execution probes in conjunction with applications that require guaranteed CPUs can cause latency spikes. It is recommended to use other probes, such as a properly configured set of network probes, as an alternative. 
+====
+
 [id="performance-addon-operator-known-limitations-for-real-time_{context}"]
 == Known limitations for real-time
 


### PR DESCRIPTION
**Fixing bug**: https://bugzilla.redhat.com/show_bug.cgi?id=2039742
Adding a warning line to https://docs.openshift.com/container-platform/4.9/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-provisioning-real-time-and-low-latency-workloads_cnf-master
**Preview link**: https://deploy-preview-40549--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-provisioning-real-time-and-low-latency-workloads_cnf-master

This PR is relevant for main and 4.10 and needs to be merged back to 4.9, 4.8, 4.7 and 4.6.