### PR TITLE
BZ: 2036962 - Updating performance addon operator must-gather image info

### DIFF
--- a/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
+++ b/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
@@ -35,11 +35,11 @@ Use the `oc adm must-gather` CLI command to collect information about your clust
 * CPU and NUMA topology
 * Basic PCI device information and NUMA locality.
 
-To collect container-native virtualization data with `must-gather`, you must specify the container-native virtualization image:
+To collect Performance Addon Operator debugging information with `must-gather`, you must specify the Performance Addon Operator `must-gather` image:
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
---image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8.
+--image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version}.
 ----
 
 [id="cnf-about-gathering-data_{context}"]
@@ -61,14 +61,14 @@ To collect the default `must-gather` data in addition to specific feature data, 
 
 . Navigate to the directory where you want to store the `must-gather` data.
 
-. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to container-native virtualization:
+. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to the Performance Addon Operator:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather \
  --image-stream=openshift/must-gather \ <1>
 
- --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8 <2>
+ --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version} <2>
 ----
 +
 <1> The default {product-title} `must-gather` image.


### PR DESCRIPTION
Addressing https://bugzilla.redhat.com/show_bug.cgi?id=2036962 and clarifying this must-gather is for the PAO must-gather image. 
**Preview link**: https://deploy-preview-40552--osdocs.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html#cnf-about-collecting-low-latency-data_cnf-master