### PR TITLE
OSDOCS-3158: Removal of upstream vSphere CSI driver

### DIFF
--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// persistent-storage-csi-vsphere.adoc
+//
+
+[id="persistent-storage-csi-vsphere-install-issues_{context}"]
+= Removing an upstream vSphere CSI Operator Driver
+
+If you have installed a non-Red Hat vSphere Container Storage Interface (CSI) Operator Driver, and then try to update your cluster to {product-title} 4.11 or later, {product-title} may prevent the update. This occurs because {product-title} 4.10 has a built-in version of the vSphere CSI Operator Driver, and thus after upgrading to 4.10, your cluster may have updates to the next major versions, such as 4.11 of {product-title} disabled if there is a non-Red Hat provided vSphere CSI driver present in the cluster. (product-title} 4.10 clusters are still fully supported and upgrades to bug fix versions of 4.10 (4.10.z) are not blocked, but you must correct this state before updates to next major version of {product-title} can be enabled.
+
+To correct this issue and update the cluster, you need to uninstall the upstream vSphere CSI Operator Driver. Removing the upstream vSphere CSI driver does not require deletion of associated persistent volume (PV) objects, and no data loss should occur.
+
+[NOTE]
+====
+These instructions may not be complete, so consult the vendor or community provider uninstall guide to ensure removal of the driver and components.
+====
+
+To uninstall the upstream vSphere CSI Operator Driver:
+
+. Delete the upstream vSphere CSI driver (VMware vSphere Container Storage Plug-in) Deployment and Daemonset objects.
+. Delete the configmap and secret objects that were installed previously with the upstream vSphere CSI Operator Driver.
+. Delete the upstream vSphereCSI driver `CSIDriver` object:
++
+[output, terminal]
+----
+~ $ oc delete CSIDriver csi.vsphere.vmware.com
+----
++
+[output, terminal]
+----
+csidriver.storage.k8s.io "csi.vsphere.vmware.com" deleted
+----
+
+After you have completed removal of upstream vSphere CSI driver, the {product-title} update automatically resumes.

--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -4,22 +4,22 @@
 //
 
 [id="persistent-storage-csi-vsphere-install-issues_{context}"]
-= Removing an upstream vSphere CSI Operator Driver
+= Removing a non-Red Hat vSphere CSI Operator Driver
 
-If you have installed a non-Red Hat vSphere Container Storage Interface (CSI) Operator Driver, and then try to update your cluster to {product-title} 4.11 or later, {product-title} may prevent the update. This occurs because {product-title} 4.10 has a built-in version of the vSphere CSI Operator Driver, and thus after upgrading to 4.10, your cluster may have updates to the next major versions, such as 4.11 of {product-title} disabled if there is a non-Red Hat provided vSphere CSI driver present in the cluster. (product-title} 4.10 clusters are still fully supported and upgrades to bug fix versions of 4.10 (4.10.z) are not blocked, but you must correct this state before updates to next major version of {product-title} can be enabled.
+{product-title} 4.10 includes a built-in version of the vSphere CSI Operator Driver that is supported by Red Hat. If you have installed a vSphere Container Storage Interface (CSI) Driver provided by the community or another vendor, updates to the next major version of {product-title}, such as 4.11, might be disabled for your cluster.
 
-To correct this issue and update the cluster, you need to uninstall the upstream vSphere CSI Operator Driver. Removing the upstream vSphere CSI driver does not require deletion of associated persistent volume (PV) objects, and no data loss should occur.
+{product-title} 4.10 clusters are still fully supported, and updates to z-stream releases of 4.10, such as 4.10.z, are not blocked, but you must correct this state by removing the non-Red Hat vSphere CSI Driver before updates to next major version of {product-title} can occur. Removing the non-Red Hat vSphere CSI driver does not require deletion of associated persistent volume (PV) objects, and no data loss should occur.
 
 [NOTE]
 ====
 These instructions may not be complete, so consult the vendor or community provider uninstall guide to ensure removal of the driver and components.
 ====
 
-To uninstall the upstream vSphere CSI Operator Driver:
+To uninstall the non-Red Hat vSphere CSI Driver:
 
-. Delete the upstream vSphere CSI driver (VMware vSphere Container Storage Plug-in) Deployment and Daemonset objects.
-. Delete the configmap and secret objects that were installed previously with the upstream vSphere CSI Operator Driver.
-. Delete the upstream vSphereCSI driver `CSIDriver` object:
+. Delete the non-Red Hat vSphere CSI Driver (VMware vSphere Container Storage Plug-in) Deployment and Daemonset objects.
+. Delete the configmap and secret objects that were installed previously with the non-Red Hat vSphere CSI Driver.
+. Delete the non-Red Hat vSphere CSI driver `CSIDriver` object:
 +
 [output, terminal]
 ----
@@ -31,4 +31,4 @@ To uninstall the upstream vSphere CSI Operator Driver:
 csidriver.storage.k8s.io "csi.vsphere.vmware.com" deleted
 ----
 
-After you have completed removal of upstream vSphere CSI driver, the {product-title} update automatically resumes.
+After you have removed the non-Red Hat vSphere CSI Driver from the {product-title} cluster, installation of Red Hat's vSphere CSI Operator Driver automatically resumes, and any conditions that could block upgrades to {product-title} 4.11, or later, are automatically removed. If you had existing vSphere CSI PV objects, their lifecycle is now managed by Red Hat's vSphere CSI Operator Driver.

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -31,6 +31,10 @@ include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-vsphere-stor-policy.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
+include::modules/persistent-storage-csi-vsphere-install-issues.adoc[leveloffset=+1]
+
+:FeatureName: vSphere
+include::modules/persistent-storage-csi-tp-enable.adoc[leveloffset=+1]
+
 == Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Configuring CSI volumes]


### PR DESCRIPTION
4.10+

[OSDOCS-3185
](https://issues.redhat.com/browse/OSDOCS-3158)

Document removal of an upstream vSphere CSI driver to allow updating to next major versions of OCP.

**NOTE**: This PR just documents this issue. The rest of the 4.10 changes for vSphere are documented in this PR: https://github.com/openshift/openshift-docs/pull/37194.

**Preview**: https://deploy-preview-40571--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere

**PTAL**: @gnufied, @Phaow 