### PR TITLE
BZ-2017416-2017418: Fixed port list description in the masquerade bin…

### DIFF
--- a/modules/virt-configuring-masquerade-mode-cli.adoc
+++ b/modules/virt-configuring-masquerade-mode-cli.adoc
@@ -31,14 +31,19 @@ spec:
       interfaces:
         - name: red
           masquerade: {} <1>
-          ports:
-            - port: 80 <2>
+          ports: <2>
+            - port: 80
   networks:
   - name: red
     pod: {}
 ----
 <1> Connect using masquerade mode
-<2> Allow incoming traffic on port 80
+<2> Optional: List the ports that you want to expose from the virtual machine, each specified by the `port` field. The `port` value must be a number between 0 and 65536. When the `ports` array is not used, all ports in the valid range are open to incoming traffic. In this example, incoming traffic is allowed on port 80.
++
+[NOTE]
+====
+Ports 49152 and 49153 are reserved for use by the libvirt platform and all other incoming traffic to these ports is dropped.
+====
 
 . Create the virtual machine:
 +


### PR DESCRIPTION
…ding example

This PR addresses both https://bugzilla.redhat.com/show_bug.cgi?id=2017416 and https://bugzilla.redhat.com/show_bug.cgi?id=2017418

Applies to 4.8, 4.9, and 4.10

Preview: https://deploy-preview-40572--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-configuring-masquerade-mode-cli_virt-using-the-default-pod-network-with-virt