### PR TITLE
BZ2015255: Updating terminationGracePeriodSeconds values

### DIFF
--- a/modules/virt-adding-vm-to-service-mesh.adoc
+++ b/modules/virt-adding-vm-to-service-mesh.adoc
@@ -17,45 +17,45 @@ To add a virtual machine (VM) workload to a service mesh, enable automatic sidec
 .Example configuration file
 [source,yaml]
 ----
-  apiVersion: kubevirt.io/v1
-  kind: VirtualMachine
-  metadata:
-    labels:
-      kubevirt.io/vm: vm-istio
-    name: vm-istio
-  spec:
-    runStrategy: Always
-    template:
-      metadata:
-        labels:
-          kubevirt.io/vm: vm-istio
-          app: vm-istio <1>
-        annotations:
-          sidecar.istio.io/inject: "true" <2>
-      spec:
-        domain:
-          devices:
-            interfaces:
-            - name: default
-              masquerade: {} <3>
-            disks:
-            - disk:
-                bus: virtio
-              name: containerdisk
-            - disk:
-                bus: virtio
-              name: cloudinitdisk
-          resources:
-            requests:
-              memory: 1024M
-        networks:
-        - name: default
-          pod: {}
-        terminationGracePeriodSeconds: 0
-        volumes:
-        - containerDisk:
-            image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
-          name: containerdisk
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-istio
+  name: vm-istio
+spec:
+  runStrategy: Always
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-istio
+        app: vm-istio <1>
+      annotations:
+        sidecar.istio.io/inject: "true" <2>
+    spec:
+      domain:
+        devices:
+          interfaces:
+          - name: default
+            masquerade: {} <3>
+          disks:
+          - disk:
+              bus: virtio
+            name: containerdisk
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+        resources:
+          requests:
+            memory: 1024M
+      networks:
+      - name: default
+        pod: {}
+      terminationGracePeriodSeconds: 180
+      volumes:
+      - containerDisk:
+          image: registry:5000/kubevirt/fedora-cloud-container-disk-demo:devel
+        name: containerdisk
 ----
 <1> The key/value pair (label) that must be matched to the service selector attribute.
 <2> The annotation to enable automatic sidecar injection.

--- a/modules/virt-configuring-vm-live-migration-cli.adoc
+++ b/modules/virt-configuring-vm-live-migration-cli.adoc
@@ -29,7 +29,7 @@ kind: VirtualMachine
 metadata:
   name: custom-vm
 spec:
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 180
   evictionStrategy: LiveMigrate
   domain:
     resources:

--- a/modules/virt-importing-vm-datavolume.adoc
+++ b/modules/virt-importing-vm-datavolume.adoc
@@ -98,7 +98,7 @@ spec:
         resources:
           requests:
             memory: 1.5Gi
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: fedora-dv

--- a/modules/virt-template-datavolume-vm.adoc
+++ b/modules/virt-template-datavolume-vm.adoc
@@ -48,7 +48,7 @@ spec:
         resources:
           requests:
             memory: 1G
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - dataVolume:
           name: example-dv

--- a/modules/virt-template-vm-probe-config.adoc
+++ b/modules/virt-template-vm-probe-config.adoc
@@ -39,7 +39,7 @@ spec:
         timeoutSeconds: 10
         failureThreshold: 3
         successThreshold: 3
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - name: containerdisk
         containerDisk:

--- a/modules/virt-template-vm-pxe-config.adoc
+++ b/modules/virt-template-vm-pxe-config.adoc
@@ -48,7 +48,7 @@ spec:
       - multus:
           networkName: pxe-net-conf
         name: pxe-net
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 180
       volumes:
       - name: containerdisk
         containerDisk:

--- a/modules/virt-template-windows-vm.adoc
+++ b/modules/virt-template-windows-vm.adoc
@@ -59,7 +59,7 @@ spec:
       networks:
       - name: default
         pod: {}
-      terminationGracePeriodSeconds: 0
+      terminationGracePeriodSeconds: 3600
       volumes:
       - name: pvcdisk
         persistentVolumeClaim:


### PR DESCRIPTION
- https://bugzilla.redhat.com/show_bug.cgi?id=2015255
- Cherrypick to enterprise-4.9 and 4.10 at minimum (might also try 4.8)
- This PR changes the example values for `terminationGracePeriodSeconds` to the defaults for the OS (180 for Linux, 3600 for Windows). I also removed leading indents from one of the YAML examples.
- [Preview build for the file with the most changes](https://deploy-preview-40574--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-connecting-vm-to-service-mesh.html#virt-adding-vm-to-service-mesh_virt-connecting-vm-to-service-mesh)