### PR TITLE
[enterprise-4.6] Manual CP and content port for BZ1859736: adding pod…

### DIFF
--- a/modules/registry-authentication.adoc
+++ b/modules/registry-authentication.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * registry/registry-options.adoc
+
+[id="authentication_{context}"]
+= Authentication
+{product-title} can communicate with registries to access private image
+repositories using credentials supplied by the user. This allows {product-title}
+to push and pull images to and from private repositories.
+
+[id="registry-authentication_{context}"]
+== Registry authentication with Podman
+Some container image registries require access authorization. Podman is an open source tool for managing containers and container images and interacting with image registries. You can use Podman to authenticate your credentials, pull the registry image, and store local images in a local file-system. The following is a generic example of authenticating the registry with Podman. You can use the link:https://catalog.redhat.com/software/containers/explore[Red Hat Ecosystem Catalog] to search for specific container images from the Red Hat Repository. Select the image you need. Then click the *Get this image* tab to find the `podman` command for your container image.
+
+
+. Login using the `podman login` command and your username and password authentication to the registry:
++
+[source,terminal]
+----
+$ podman login registry.redhat.io
+ Username:<your_registry_account_username>
+ Password:<your_registry_account_password>
+----
+
+. Download the image and save it locally using the `podman pull` command:
++
+[source,terminal]
+----
+$ podman pull registry.redhat.io/<repository_name>
+----

--- a/modules/registry-third-party-registries.adoc
+++ b/modules/registry-third-party-registries.adoc
@@ -14,9 +14,3 @@ creation.
 Refreshing the fetched tags is as simple as running `oc import-image
 <stream>`. When new images are detected, the previously described build and
 deployment reactions occur.
-
-[id="authentication_{context}"]
-== Authentication
-{product-title} can communicate with registries to access private image
-repositories using credentials supplied by the user. This allows {product-title}
-to push and pull images to and from private repositories.

--- a/registry/index.adoc
+++ b/registry/index.adoc
@@ -15,6 +15,8 @@ include::modules/registry-integrated-openshift-registry.adoc[leveloffset=+1]
 
 include::modules/registry-third-party-registries.adoc[leveloffset=+1]
 
+include::modules/registry-authentication.adoc[leveloffset=+2]
+
 include::modules/registry-quay-overview.adoc[leveloffset=+1]
 
 .Additional resources


### PR DESCRIPTION
…man registry authentication procedure and additional info

Manual CP from https://github.com/openshift/openshift-docs/pull/38163. This PR was merged right before we brought the dedicated-4 branch to main, but the original CP (https://github.com/openshift/openshift-docs/pull/39074) did not merge.  Because of the major changes to the main branch, I pulled the content directly as it would have gone in the original CP and am treating this PR as a CP. 

Preview: https://deploy-preview-40575--osdocs.netlify.app/openshift-enterprise/latest/registry/index.html#authentication_registry-overview