### PR TITLE
[BZ2004651] Additional day 2 steps for external load balancers with Octavia  

### DIFF
--- a/modules/nw-osp-configure-octavia-load-balancing-services.adoc
+++ b/modules/nw-osp-configure-octavia-load-balancing-services.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/network-configuration.adoc
+
+[id="nw-osp-configure-octavia-load-balancing-services_{context}"]
+= Enabling {rh-openstack} Octavia for load balancer services
+
+You can create load balancer service types and ingress controllers that have load balancers as back ends by using Octavia on {rh-openstack-first}. 
+
+[NOTE]
+====
+Services and controllers that rely on Octavia have the following limitations:
+
+* Only TCP traffic is supported.
+* Active Octavia load balancers and the floating IP addresses that are attached to them are not deleted during a cluster delete operation. You must delete these items prior performing the operation.
+* The `manage-security-groups` property in the cloud provider configuration only applies to {rh-openstack} tenants that have administrative privileges. 
+* The `loadBalancerSourceRanges` property for load balancer services is not supported.
+* The `loadBalancerIP` property for load balancer services is not supported.
+====
+
+.Prerequisites
+
+* You have an active cluster.
+* You installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. From a command line, open the cloud provider configuration for editing:
++
+[source,terminal]
+----
+$ oc edit configmap -n openshift-config cloud-provider-config
+----
+
+. Edit the configuration for your driver type:
+
+** If you are using the Amphora driver, add the following section to your cloud provider configuration:
++
+[source,yaml]
+----
+[LoadBalancer]
+use-octavia = true
+lb-provider = amphora
+----
+
+** If you are using the OVN driver, add the following section to your cloud provider configuration:
++
+[source,yaml]
+----
+[LoadBalancer]
+use-octavia = true
+lb-provider = ovn
+lb-method = SOURCE_IP_PORT
+----
++
+[NOTE]
+====
+If you are using the OVN driver for Octavia, you must also modify the TCP ingress security group rules for the primary and worker security groups to allow IPv4 traffic to ports 30000 through 32767 from 0.0.0.0/0.
+====
+
+. If you have multiple external networks, set the value of the `floating-network-id` parameter in your cloud provider configuration to the UUID of the external network in which floating IP addresses are created. For example:
++
+[source,yaml]
+----
+[LoadBalancer]
+use-octavia = true
+lb-provider = amphora
+floating-network-id = <network_UUID>
+----
+
+. Save the changes to your configuration.

--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -106,3 +106,4 @@ You can configure some aspects of a {product-title} on {rh-openstack-first} clus
 include::modules/installation-osp-configuring-api-floating-ip.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-port-pools.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-settings-active.adoc[leveloffset=+2]
+include::modules/nw-osp-configure-octavia-load-balancing-services.adoc[leveloffset=+2]


### PR DESCRIPTION
Context: https://bugzilla.redhat.com/show_bug.cgi?id=2004651

Preview: https://deploy-preview-40581--osdocs.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration.html#nw-osp-configure-octavia-load-balancing-services_post-install-network-configuration