### PR TITLE
[enterprise-4.1] Hide elements from print

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -2639,6 +2639,18 @@ b.conum * {
     padding-bottom: 0 !important;
   }
 
+  #toc {
+    display: none !important;
+  }
+
+  .clipboard-button-container {
+    display: none !important;
+  }
+
+  .open-btn-sm {
+    display: none !important;
+  }
+
   .sect1 {
     padding-bottom: 0 !important;
   }


### PR DESCRIPTION
Manual commit because of git conflict https://github.com/openshift/openshift-docs/pull/40242#issuecomment-1012664067

Reason for conflict: 
`_templates/_page_openshift.html.erb` is different in the `main` branch and the `enterprise-4.1` branch.