### PR TITLE
[MULTIARCH-1494] Ipsec support on IBM Z for 4.10

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -25,18 +25,6 @@ endif::[]
 ifeval::["{context}" == "post-install-network-configuration"]
 :post-install-network-configuration:
 endif::[]
-ifeval::["{context}" == "installing-ibm-z"]
-:ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-ibm-z-kvm"]
-:ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
-:ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
-:ibm-z:
-endif::[]
 
 [id="nw-operator-cr_{context}"]
 = Cluster Network Operator configuration
@@ -266,7 +254,6 @@ ifdef::operator[]
 The UDP port for the Geneve overlay network.
 endif::operator[]
 
-ifndef::ibm-z[]
 |`ipsecConfig`
 |`object`
 |
@@ -276,7 +263,6 @@ endif::operator[]
 ifdef::operator[]
 If the field is present, IPsec is enabled for the cluster.
 endif::operator[]
-endif::ibm-z[]
 
 |`policyAuditConfig`
 |`object`
@@ -327,9 +313,7 @@ defaultNetwork:
   ovnKubernetesConfig:
     mtu: 1400
     genevePort: 6081
-ifndef::ibm-z[]
     ipsecConfig: {}
-endif::ibm-z[]
 ----
 
 [discrete]
@@ -408,16 +392,4 @@ endif::[]
 
 ifdef::post-install-network-configuration[]
 :!post-install-network-configuration:
-endif::[]
-ifeval::["{context}" == "installing-ibm-z"]
-:!ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-ibm-z-kvm"]
-:!ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
-:!ibm-z:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
-:!ibm-z:
 endif::[]


### PR DESCRIPTION
OCP version for cherry-picking: enterprise-4.10 and later

Jira: https://issues.redhat.com/browse/MULTIARCH-1494

Preview https://deploy-preview-40584--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#nw-operator-cr-cno-object_installing-ibm-z

QE review: Tom Dale