### PR TITLE
OCP 3.11 Day Two Operations Guide -> Docker tasks Guides section BUG

### DIFF
--- a/day_two_guide/topics/increasing_docker_storage.adoc
+++ b/day_two_guide/topics/increasing_docker_storage.adoc
@@ -256,7 +256,7 @@ following solution for more information:
 +
 ** https://access.redhat.com/solutions/199573
 
-. Verify that the *_/etc/sysconfig/container-storage-setup_* file is correctly
+. Verify that the *_/etc/sysconfig/docker-storage-setup_* file is correctly
 configured for the new disk by checking the device name, size, etc.
 
 . Run `docker-storage-setup` to reconfigure the new disk:


### PR DESCRIPTION
This PR will resolve Buzilla[https://bugzilla.redhat.com/show_bug.cgi?id=2040627], The more information can be found on BZ itself I have followed the second approach since docker-storage-setup already has been used in many KCS articles so removed the issue part[container-storage-setup] 

Let me know if there is any confusion.