### PR TITLE
OSD and ROSA Travis test

### DIFF
--- a/osd_architecture/osd-understanding.adoc
+++ b/osd_architecture/osd-understanding.adoc
@@ -12,3 +12,5 @@ include::modules/osd-intro.adoc[leveloffset=+1]
 .Additional resources
 
 * For more information about Telemetry and remote health monitoring for {product-title} clusters, see xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
+xref:../nonexistent.adoc#nonexistent_anchor[Broken OSD xref test]

--- a/rosa_architecture/rosa-understanding.adoc
+++ b/rosa_architecture/rosa-understanding.adoc
@@ -8,3 +8,5 @@ Learn about {product-title} (ROSA) access, supported consoles, consumption exper
 
 include::modules/rosa-understanding.adoc[leveloffset=+1]
 include::modules/rosa-using-sts.adoc[leveloffset=+2]
+
+xref:../nonexistent.adoc#nonexistent_anchor[Broken ROSA xref test]


### PR DESCRIPTION
**This is a test PR, do not merge.**

This pull request introduces two broken cross-references, one in a live OSD assembly and one in a live ROSA assembly. The purpose of the PR is to test if Travis checks the OSD and ROSA builds, post-migration.