### PR TITLE
[enterprise-4.9] Adding OSD and ROSA to the Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ install:
 
 script:
  - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.9 --no-upstream-fetch && python3 makeBuild.py
+ - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
+ - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
 
 after_success:
 - bash ./automerge.sh

--- a/build.py
+++ b/build.py
@@ -957,11 +957,12 @@ def main():
     book_nodes = [node for node in data if check_node_distro_matches(node, args.distro)]
 
     # Make the new source tree
+    build_dir = os.path.join(os.getcwd(), "drupal-build")
     dest_dir = os.path.join(os.getcwd(), "drupal-build", args.distro)
     if not args.no_clean:
         log.info("Cleaning the drupal-build directory")
-        if os.path.exists(dest_dir):
-            shutil.rmtree(dest_dir)
+        if os.path.exists(build_dir):
+            shutil.rmtree(build_dir)
         os.makedirs(dest_dir)
     elif not os.path.exists(dest_dir):
         os.makedirs(dest_dir)


### PR DESCRIPTION
This applies to `enterprise-4.9` only. https://github.com/openshift/openshift-docs/pull/40591 is a separate PR for `main` and `enterprise-4.9`.

This pull request adds the OSD and ROSA collections to the Travis checks. Related PR https://github.com/openshift/openshift-docs/pull/40587 was created to test the checks for the two collections.

The PR also updates the `build.py` script which is called in the `.travis.yml` file. The addition cleans the `drupal-build` directory in the Travis VM that is running the checks, rather than just cleaning the distro subdirectory within the `drupal-build` directory. Without this change, each successive `python build.py...` command in the `travis.yml` file will build all of the distros that have been built so far, because the remnants of the previous run continues to exist in the `drupal-build` directory in the Travis VM.

My understanding is that, in `enterprise-4.9`, the `build.py` script is only called from the `.travis.yml` file. The sync scripts I think use the `build_for_portal.py` file instead. Please let me know if the change in this PR might impact other uses for the `build.py` file that I don't know about. I.e. is there any reason why the previous builds for a different distro might need to remain in the `drupal-build` directory after the `build.py` script has run?

We might also need to determine what constitutes a success if multiple distro builds are being run. Would one successful build cause the auto-merge to take place, or would all of the `build.py` runs need to succeed? How can we test this in Travis?