### PR TITLE
Adds notes for 4.8.27 release

### DIFF
--- a/release_notes/ocp-4-8-release-notes.adoc
+++ b/release_notes/ocp-4-8-release-notes.adoc
@@ -2977,3 +2977,19 @@ link:https://access.redhat.com/solutions/6631251[{product-title} 4.8.26 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-8-27"]
+=== RHBA-2022:0113 - {product-title} 4.8.27 bug fix update
+
+Issued: 2022-01-18
+
+{product-title} release 4.8.27 is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0113[RHBA-2022:0113] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0111[RHBA-2022:0111] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6643691[{product-title} 4.8.27 container image list]
+
+[id="ocp-4-8-27-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.8 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Added notes for 4.8.27 release Tuesday 1/18

- Applies to `enterprise-4.8` only
- [Preview link](https://deploy-preview-40610--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-8-release-notes#ocp-4-8-27)