### PR TITLE
BZ-2017454: Fixed callout description in the code example

### DIFF
--- a/modules/virt-attaching-vm-secondary-network-cli.adoc
+++ b/modules/virt-attaching-vm-secondary-network-cli.adoc
@@ -43,7 +43,7 @@ spec:
 ...
 ----
 <1> The name of the bridge interface.
-<2> The name of the bridge interface. This value must match the `name` value of the corresponding `spec.template.spec.networks` entry.
+<2> The name of the network. This value must match the `name` value of the corresponding `spec.template.spec.domain.devices.interfaces` entry.
 <3> The name of the network attachment definition, prefixed by the namespace where it exists. The namespace must be either the `default` namespace or the same namespace where the VM is to be created.
 
 . Apply the configuration:


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=2017454

Minor correction in the text for callout <2>

Preview: https://deploy-preview-40613--osdocs.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-attaching-vm-secondary-network-cli_virt-attaching-multiple-networks