### PR TITLE
OSDOCS-3166: Create Release Notes for FIO

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -12,6 +12,17 @@ These release notes track the development of the File Integrity Operator in the 
 
 For an overview of the File Integrity Operator, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[Understanding the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-0-1-22"]
+== OpenShift File Integrity Operator 0.1.22
+
+The following advisory is available for the OpenShift File Integrity Operator 0.1.22:
+
+* link:https://access.redhat.com/errata/RHBA-2022:0142[RHBA-2022:0142 OpenShift File Integrity Operator Bug Fix]
+
+[id="openshift-file-integrity-operator-0-1-22-bug-fixes"]
+=== Bug fixes
+* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file.  This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
+
 [id="file-integrity-operator-release-notes-0-1-21"]
 == OpenShift File Integrity Operator 0.1.21
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3166
Applies to 4.6+
File Preview for the FIO release notes is [here](https://deploy-preview-40615--osdocs.netlify.app/openshift-enterprise/latest/security/file_integrity_operator/file-integrity-operator-release-notes.html).

Final Errata link will not be active until the Errata goes live.