### PR TITLE
Fix typo in the Web Terminal Operator uninstall instructions

### DIFF
--- a/modules/odc-uninstalling-web-terminal.adoc
+++ b/modules/odc-uninstalling-web-terminal.adoc
@@ -103,7 +103,7 @@ $ oc delete customresourcedefinitions.apiextensions.k8s.io devworkspaceoperatorc
 +
 [source,terminal]
 ----
-$ oc get customresourcedefintions | grep "devfile.io"
+$ oc get customresourcedefinitions.apiextensions.k8s.io | grep "devfile.io"
 ----
 +
 . Remove the `devworkspace-webhook-server` deployment, mutating, and validating webhooks:


### PR DESCRIPTION
Fix typo in uninstall docs for the Web Terminal Operator and use full name:
```diff
- customresourcedefintions
+ customresourcedefinitions.apiextensions.k8s.io
```

Change affects 4.8, 4.9, 4.10 as typo was introduced in https://github.com/openshift/openshift-docs/pull/39532