### PR TITLE
osdocs3148: restoring heading in 4.7

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -19,31 +19,34 @@ include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset
 
 include::modules/ipi-install-creating-an-rhcos-images-cache.adoc[leveloffset=+1]
 
-include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+1]
+[id="ipi-install-configuration-files"]
+== Configuration files
+
+include::modules/ipi-install-configuring-the-install-config-file.adoc[leveloffset=+2]
 
 ifeval::[{product-version} <= 4.3]
-include::modules/ipi-install-configuring-the-metal3-config-file.adoc[leveloffset=+1]
+include::modules/ipi-install-configuring-the-metal3-config-file.adoc[leveloffset=+2]
 endif::[]
 
 ifeval::[{product-version} >= 4.4]
-include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+1]
+include::modules/ipi-install-setting-proxy-settings-within-install-config.adoc[leveloffset=+2]
 endif::[]
 
 ifeval::[{product-version} >= 4.6]
-include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+1]
+include::modules/ipi-install-modifying-install-config-for-no-provisioning-network.adoc[leveloffset=+2]
 endif::[]
 
-include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+1]
+include::modules/ipi-install-additional-install-config-parameters.adoc[leveloffset=+2]
 
-include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+1]
+include::modules/ipi-install-bmc-addressing.adoc[leveloffset=+2]
 
-include::modules/ipi-install-bmc-addressing-for-dell.adoc[leveloffset=+1]
+include::modules/ipi-install-bmc-addressing-for-dell.adoc[leveloffset=+2]
 
-include::modules/ipi-install-bmc-addressing-for-hpe.adoc[leveloffset=+1]
+include::modules/ipi-install-bmc-addressing-for-hpe.adoc[leveloffset=+2]
 
-include::modules/ipi-install-root-device-hints.adoc[leveloffset=+1]
+include::modules/ipi-install-root-device-hints.adoc[leveloffset=+2]
 
-include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+1]
+include::modules/ipi-install-creating-the-openshift-manifests.adoc[leveloffset=+2]
 
 
 


### PR DESCRIPTION
Followup to https://github.com/openshift/openshift-docs/pull/40618 - fixing some heading levels.