### PR TITLE
BZ1949994: Added Tech Preview to Assigning an SR-IOV network to a VRF module

### DIFF
--- a/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
+++ b/modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc
@@ -5,6 +5,13 @@
 [id="cnf-assigning-a-sriov-network-to-a-vrf_{context}"]
 = Assigning an SR-IOV network to a VRF
 
+[IMPORTANT]
+====
+CNI VRF plug-in is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see https://access.redhat.com/support/offerings/techpreview/.
+====
+
 As a cluster administrator, you can assign an SR-IOV network interface to your VRF domain by using the CNI VRF plug-in.
 
 To do this, add the VRF configuration to the optional `metaPlugins` parameter of the `SriovNetwork` resource.

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -16,9 +16,6 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-troubleshooting.adoc[leveloffset=+1]
 
-:FeatureName: CNI VRF plug-in
-include::modules/technology-preview.adoc[leveloffset=+1]
-
 include::modules/cnf-assigning-a-sriov-network-to-a-vrf.adoc[leveloffset=+1]
 
 [id="configuring-sriov-device-next-steps"]


### PR DESCRIPTION
Removed Tech Preview from `Configuring SR-IOV network devices` module and moved it under `Assigning an SR-IOV network to a VRF`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1949994

OCP version: **Applicable only to 4.8 and 4.7**

Direct Doc Preview Link: https://deploy-preview-40631--osdocs.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#cnf-assigning-a-sriov-network-to-a-vrf_configuring-sriov-device