### PR TITLE
Move uninstall module to installation assemblies

### DIFF
--- a/migrating_from_ocp_3_to_4/installing-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-3-4.adoc
@@ -14,6 +14,8 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+To uninstall {mtc-short}, see xref:../migrating_from_ocp_3_to_4/installing-3-4.adoc#migration-uninstalling-mtc-clean-up_installing-3-4[Uninstalling {mtc-short} and deleting resources].
+
 include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-legacy-operator.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
@@ -53,4 +55,6 @@ include::modules/migration-configuring-azure.adoc[leveloffset=+2]
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-understanding-data-copy-methods_about-mtc-3-4[About data copy methods]
 * xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#migration-adding-replication-repository-to-cam_migrating-applications-3-4[Adding a replication repository to the {mtc-short} web console]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
 :installing-3-4!:

--- a/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc
@@ -18,6 +18,8 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 . Install the _legacy_ {mtc-full} Operator on the {product-title} 3 source cluster from the command line interface.
 . Configure object storage to use as a replication repository.
 
+To uninstall {mtc-short}, see xref:../migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc#migration-uninstalling-mtc-clean-up_installing-restricted-3-4[Uninstalling {mtc-short} and deleting resources].
+
 include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
 include::modules/migration-installing-legacy-operator.adoc[leveloffset=+1]
@@ -47,4 +49,6 @@ include::modules/migration-configuring-mcg.adoc[leveloffset=+2]
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-mtc-workflow_about-mtc-3-4[{mtc-short} workflow]
 * xref:../migrating_from_ocp_3_to_4/about-mtc-3-4.adoc#migration-understanding-data-copy-methods_about-mtc-3-4[About data copy methods]
 * xref:../migrating_from_ocp_3_to_4/migrating-applications-3-4.adoc#migration-adding-replication-repository-to-cam_migrating-applications-3-4[Adding a replication repository to the {mtc-short} web console]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
 :installing-restricted-3-4!:

--- a/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
@@ -53,8 +53,6 @@ include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-manually.adoc[leveloffset=+2]
 
-include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
-
 [id="additional-resources-uninstalling_{context}"]
 [discrete]
 === Additional resources for uninstalling {mtc-short}

--- a/migration_toolkit_for_containers/installing-mtc-restricted.adoc
+++ b/migration_toolkit_for_containers/installing-mtc-restricted.adoc
@@ -19,13 +19,14 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 * {product-title} 4.6 or later: Install the {mtc-full} Operator by using Operator Lifecycle Manager.
 * {product-title} 4.2 to 4.5: Install the legacy {mtc-full} Operator from the command line interface.
-+
+
+. Configure object storage to use as a replication repository.
+
 [NOTE]
 ====
 To install {mtc-short} on {product-title} 3, see xref:../migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc#migration-installing-legacy-operator_installing-restricted-3-4[Installing the legacy {mtc-full} Operator on {product-title} 3].
 ====
-
-. Configure object storage to use as a replication repository.
+To uninstall {mtc-short}, see xref:../migration_toolkit_for_containers/installing-mtc-restricted.adoc#migration-uninstalling-mtc-clean-up_installing-mtc-restricted[Uninstalling {mtc-short} and deleting resources].
 
 include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
@@ -56,4 +57,7 @@ include::modules/migration-configuring-mcg.adoc[leveloffset=+2]
 * xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
 * xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-understanding-data-copy-methods_about-mtc[About data copy methods]
 * xref:../migration_toolkit_for_containers/migrating-applications-with-mtc.adoc#migration-adding-replication-repository-to-cam_migrating-applications-with-mtc[Adding a replication repository to the {mtc-short} web console]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
+
 :installing-mtc-restricted!:

--- a/migration_toolkit_for_containers/installing-mtc.adoc
+++ b/migration_toolkit_for_containers/installing-mtc.adoc
@@ -17,6 +17,8 @@ By default, the {mtc-short} web console and the `Migration Controller` pod run o
 
 After you have installed {mtc-short}, you must configure an object storage to use as a replication repository.
 
+To uninstall {mtc-short}, see xref:../migration_toolkit_for_containers/installing-mtc.adoc#migration-uninstalling-mtc-clean-up_installing-mtc[Uninstalling {mtc-short} and deleting resources].
+
 include::modules/migration-compatibility-guidelines.adoc[leveloffset=+1]
 include::modules/migration-installing-legacy-operator.adoc[leveloffset=+1]
 include::modules/migration-installing-mtc-on-ocp-4.adoc[leveloffset=+1]
@@ -56,5 +58,7 @@ include::modules/migration-configuring-azure.adoc[leveloffset=+2]
 * xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-mtc-workflow_about-mtc[{mtc-short} workflow]
 * xref:../migration_toolkit_for_containers/about-mtc.adoc#migration-understanding-data-copy-methods_about-mtc[About data copy methods]
 * xref:../migration_toolkit_for_containers/migrating-applications-with-mtc.adoc#migration-adding-replication-repository-to-cam_migrating-applications-with-mtc[Adding a replication repository to the {mtc-short} web console]
+
+include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
 
 :installing-mtc!:

--- a/migration_toolkit_for_containers/troubleshooting-mtc.adoc
+++ b/migration_toolkit_for_containers/troubleshooting-mtc.adoc
@@ -51,8 +51,6 @@ include::modules/migration-rolling-back-migration-web-console.adoc[leveloffset=+
 include::modules/migration-rolling-back-migration-cli.adoc[leveloffset=+2]
 include::modules/migration-rolling-back-migration-manually.adoc[leveloffset=+2]
 
-include::modules/migration-uninstalling-mtc-clean-up.adoc[leveloffset=+1]
-
 [id="additional-resources-uninstalling_{context}"]
 [discrete]
 === Additional resources for uninstalling {mtc-short}

--- a/modules/migration-uninstalling-mtc-clean-up.adoc
+++ b/modules/migration-uninstalling-mtc-clean-up.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
 // * migrating_from_ocp_3_to_4/troubleshooting-3-4.adoc
-// * migration_toolkit_for_containers/troubleshooting-mtc
+// * migration_toolkit_for_containers/installing-mtc.adoc
+// * migration_toolkit_for_containers/installing-mtc-restricted.adoc
 
 [id="migration-uninstalling-mtc-clean-up_{context}"]
 = Uninstalling {mtc-short} and deleting resources


### PR DESCRIPTION
No Jira or BZ.

Moved MTC uninstall from Troubleshooting to installation assemblies.

Previews: 

https://deploy-preview-40633--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html

https://deploy-preview-40633--osdocs.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-restricted-3-4.html

https://deploy-preview-40633--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html

https://deploy-preview-40633--osdocs.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc-restricted.html

No QE required. Ready for peer review.