### PR TITLE
JIRA-OSDOCS2693: Updated the PrivateLink firewall ports for Splunk operator

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -262,8 +262,15 @@ If you do not use a default Red Hat NTP server, verify the NTP server for your p
 |Recommended. The FTP server used by `must-gather-operator` to upload diagnostic logs to help troubleshoot issues with the cluster.
 |443
 
-|`.osdsecuritylogs.splunkcloud.com`
-`inputs1.osdsecuritylogs.splunkcloud.com`
+|`*.osdsecuritylogs.splunkcloud.com`
+|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+|443 and 9997
+
+|`http-inputs-osdsecuritylogs.splunkcloud.com`
+|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+|443
+
+|`inputs1.osdsecuritylogs.splunkcloud.com`
 `inputs2.osdsecuritylogs.splunkcloud.com`
 `inputs4.osdsecuritylogs.splunkcloud.com`
 `inputs5.osdsecuritylogs.splunkcloud.com`
@@ -277,10 +284,8 @@ If you do not use a default Red Hat NTP server, verify the NTP server for your p
 `inputs13.osdsecuritylogs.splunkcloud.com`
 `inputs14.osdsecuritylogs.splunkcloud.com`
 `inputs15.osdsecuritylogs.splunkcloud.com`
-
-`http-inputs-osdsecuritylogs.splunkcloud.com`
-|Required. Used by the `splunk-forwarder-operator` as a logging forwarding endpoint to be used by Red Hat SRE for log-based alerting.
-|443
+|Required. Used by the `splunk-forwarder-operator` as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
+|9997
 
 |`observatorium.api.openshift.com`
 |Required. Used for Managed OpenShift-specific telemetry.


### PR DESCRIPTION
This PR is to address JIRA issue: https://issues.redhat.com/browse/OSDOCS-2693

Topic: https://deploy-preview-40643--osdocs.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites

Exact change: Section "AWS PrivateLink firewall prerequisites" > Procedure > Step 7 table > Rows 4, 5, and 6 > Updated the PrivateLink firewall ports for Splunk operator.

Repo: Request cherrypick to enterprise-4.9 and enterprise-4.10