### PR TITLE
BZ2023197: correct CSI version for 4.10+

### DIFF
--- a/modules/persistent-storage-csi-snapshots-overview.adoc
+++ b/modules/persistent-storage-csi-snapshots-overview.adoc
@@ -29,4 +29,3 @@ Be aware of the following when using volume snapshots:
 * {product-title} only ships with select CSI drivers. For CSI drivers that are not provided by an {product-title} Driver Operator, it is recommended to use the CSI drivers provided by
 link:https://kubernetes-csi.github.io/docs/drivers.html[community or storage vendors]. Follow the installation instructions provided by the CSI driver.
 * CSI drivers may or may not have implemented the volume snapshot functionality. CSI drivers that have provided support for volume snapshots will likely use the `csi-external-snapshotter` sidecar. See documentation provided by the CSI driver for details.
-* {product-title} {product-version} supports version 1.1.0 of the link:https://github.com/container-storage-interface/spec[CSI specification].

--- a/storage/container_storage_interface/persistent-storage-csi.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi.adoc
@@ -10,6 +10,11 @@ storage from storage back ends that implement the
 link:https://github.com/container-storage-interface/spec[CSI interface]
 as persistent storage.
 
+[NOTE]
+====
+{product-title} {product-version} supports version 1.5.0 of the link:https://github.com/container-storage-interface/spec[CSI specification].
+====
+
 include::modules/persistent-storage-csi-architecture.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-external-controllers.adoc[leveloffset=+2]


### PR DESCRIPTION
4.10+

[BZ2023197](https://bugzilla.redhat.com/show_bug.cgi?id=2023197) This BZ fixed 4.6-4.9. This PR fixes 4.10+.

**Preview**: https://deploy-preview-40653--osdocs.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html

**PTAL**: @duanwei33, @jsafrane 