### PR TITLE
Add subs=attributes for FeatureName in TP&DP modules

### DIFF
--- a/modules/deprecated-feature.adoc
+++ b/modules/deprecated-feature.adoc
@@ -3,6 +3,7 @@
 
 [IMPORTANT]
 ====
+[subs="attributes+"]
 {FeatureName} is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
 For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.

--- a/modules/technology-preview.adoc
+++ b/modules/technology-preview.adoc
@@ -3,6 +3,7 @@
 
 [IMPORTANT]
 ====
+[subs="attributes+"]
 {FeatureName} is a Technology Preview feature only. Technology Preview features
 are not supported with Red Hat production service level agreements (SLAs) and
 might not be functionally complete. Red Hat does not recommend using them


### PR DESCRIPTION
Markup formatting in attribute values aren't passed along to the destination by default, so they end up rending verbatim (e.g., backticks showing up instead of monospace). The Tech Preview and Deprecated Feature modules use the `:FeatureName:` attribute in their respective admonitions, which appear throughout the doc set. Adding `subs=attributes+` to these blocks allow for markup formatting to render correctly.

Typically we've only used this sort of substitution on code blocks, but it apparently works fine on any ol text block. Got the idea from https://docs.asciidoctor.org/asciidoc/latest/attributes/attribute-entry-substitutions/#change-substitutions-when-referencing-an-attribute and then just trimmed it down to only what we needed.

Example spot with it working in preview: https://deploy-preview-40660--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html

Same spot in published docs w/o this substitution in place: https://docs.openshift.com/container-platform/4.9/support/remote_health_monitoring/insights-operator-simple-access.html