### PR TITLE
BZ2018510: Remove the misleading IMPORTANT note

### DIFF
--- a/install_config/master_node_configuration.adoc
+++ b/install_config/master_node_configuration.adoc
@@ -1182,12 +1182,6 @@ stamp encoded in their filename.
 Defaults to 100MB.
 |===
 
-[IMPORTANT]
-====
-Because the {product-title} master API now runs as static pod, you must define
-the `auditFilePath` location in the *_/var/log/audit/_*, *_/var/log/origin/_* or *_/etc/origin/master/_* directory.
-====
-
 .Example Audit Configuration
 ----
 auditConfig:


### PR DESCRIPTION
Fixes: [BZ2018510](https://bugzilla.redhat.com/show_bug.cgi?id=2018510)
OCP version: 3.11
QE contact: @sunilcio 
[Preview](https://deploy-preview-40672--osdocs.netlify.app/openshift-enterprise/latest/install_config/master_node_configuration.html#master-node-config-audit-config)