### PR TITLE
BZ2028380: Removed Important block 

### DIFF
--- a/installing/installing-mirroring-installation-images.adoc
+++ b/installing/installing-mirroring-installation-images.adoc
@@ -27,11 +27,6 @@ can move across network boundaries with.
 ** link:https://www.sonatype.com/products/repository-oss?topnav=true[Sonatype Nexus Repository]
 ** link:https://goharbor.io/[Harbor]
 --
-+
-[IMPORTANT]
-====
-The internal registry of the {product-title} cluster cannot be used as the target registry because it does not support pushing without a tag, which is required during the mirroring process.
-====
 
 If you have an entitlement to Red Hat Quay, see the documentation on deploying Red Hat Quay link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_for_proof-of-concept_non-production_purposes/[for proof-of-concept purposes] or link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.5/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/[by using the Quay Operator]. If you need additional assistance selecting and installing a registry, contact your sales representative or Red Hat support.
 


### PR DESCRIPTION
Removed Important block from prerequisites section of `Mirroring images for a disconnected installation`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2028380

OCP version: **Applicable to 4.6+**

Direct Doc Preview Link: https://deploy-preview-40679--osdocs.netlify.app/openshift-enterprise/latest/installing/installing-mirroring-installation-images.html#prerequisites_installing-mirroring-installation-images