### PR TITLE
CCXDEV-7025 Update the SCA configuration docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -480,7 +480,7 @@ Topics:
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network
-  - Name: Configuring RHEL Simple Content Access
+  - Name: Importing simple content access certificates with Insights Operator
     File: insights-operator-simple-access
 - Name: Gathering data about your cluster
   File: gathering-cluster-data

--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -4,9 +4,9 @@
 
 
 [id="insights-operator-configuring-sca_{context}"]
-= Configuring Simple Content Access import interval
+= Configuring simple content access import interval
 
-You can configure how often the Insights Operator imports the RHEL Simple Content Access (SCA) certificates using the `support` secret in the `openshift-config` namespace. The certificate import normally occurs every 8 hours, but you may want to shorten this interval if you update your SCA configuration in Red Hat Subscription Management.
+You can configure how often the Insights Operator imports the simple content access certificates using the `support` secret in the `openshift-config` namespace. The certificate import normally occurs every 8 hours, but you can shorten this interval if you update your simple content access configuration in Red Hat Subscription Management.
 
 This procedure describes how to update the import interval to one hour. 
 
@@ -21,14 +21,9 @@ This procedure describes how to update the import interval to one hour.
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
-. Create a key named `ocmInterval` with a value of `1h`, and click *Save*.
+. Create a key named `scaInterval` with a value of `1h`, and click *Save*.
 +
 [NOTE]
 ====
 The interval `1h` can also be entered as `60m` for 60 minutes. 
 ====
-+
-. Navigate to *Workloads* -> *Pods*
-. Select the `openshift-insights` project.
-. Find the `insights-operator` pod.
-. To restart the `insights-operator` pod, click the *Options* menu {kebab}, and then click *Delete Pod*.

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -4,9 +4,9 @@
 
 
 [id="insights-operator-disabling-sca_{context}"]
-= Disabling Simple Content Access import
+= Disabling simple content access import
 
-You can disable the import of RHEL Simple Content Access certificates using the `support` secret in the `openshift-config` namespace.
+You can disable the import of simple content access certificates using the `support` secret in the `openshift-config` namespace.
 
 .Prerequisites
 
@@ -19,8 +19,11 @@ You can disable the import of RHEL Simple Content Access certificates using the 
 . Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
-. Create a key named `ocmPullDisabled` with a value of `true`, and click *Save*.
-. Navigate to *Workloads* -> *Pods*
-. Select the `openshift-insights` project.
-. Find the `insights-operator` pod.
-. To restart the `insights-operator` pod, click the *Options* menu {kebab}, and then click *Delete Pod*.
+. Create a key named `scaPullDisabled` with a value of `true`, and click *Save*.
++
+The simple content access certificate import is now disabled. 
++
+[NOTE]
+====
+To enable the simple content access import again, edit the `support` secret and delete the `scaPullDisabled` key.
+====

--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -1,20 +1,19 @@
 [id="insights-operator-simple-access"]
-= Importing RHEL Simple Content Access certificates with Insights Operator
+= Importing simple content access certificates with Insights Operator
 include::modules/common-attributes.adoc[]
 :context: remote-health-reporting-from-restricted-network
 :FeatureName: `InsightsOperatorPullingSCA`
 
 toc::[]
 
-Insights Operator can import your RHEL Simple Content Access (SCA) certificates from {console-redhat-com}. SCA is a capability in Red Hat’s subscription tools which simplifies the behavior of the entitlement tooling. It is easier to consume the content provided by your Red Hat subscriptions without the complexity of configuring subscription tooling. After importing the certificates, they are stored in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace. 
+Insights Operator periodically imports your simple content access certificates from {console-redhat-com} and stores them in the `etc-pki-entitlement` secret in the `openshift-config-managed` namespace. Simple content access is a capability in Red Hat subscription tools which simplifies the behavior of the entitlement tooling. This feature makes it easier to consume the content provided by your Red Hat subscriptions without the complexity of configuring subscription tooling.
 
-Insights Operator imports SCA certificates every 8 hours by default, but can be configured or disabled using the `support` secret in the `openshift-config` namespace.
+Insights Operator imports simple content access certificates every 8 hours by default, but can be configured or disabled using the `support` secret in the `openshift-config` namespace.
 
-In {product-title} 4.9, this feature is in Technology Preview and must be enabled using the `TechPreviewNoUpgrade` Feature Set. See xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc[_Enabling OpenShift Container Platform features using FeatureGates_] for more information.
+For more information about simple content access, see link:https://access.redhat.com/documentation/en-us/subscription_central/2021/html-single/getting_started_with_simple_content_access/index#assembly-about-simplecontent[_About simple content access_] in the Red Hat Subscription Central documentation.
 
-For more information about Simple Content Access certificates see the link:https://access.redhat.com/articles/simple-content-access[_Simple Content Access_] article in the Red Hat Knowledgebase.
-
-include::modules/technology-preview.adoc[leveloffset=+1]
+// This is a placeholder for when the Build Entitlements doc is updated to reference simple content access certificates
+// For information on using simple content access certificates in {product-title} see (xref to entitlements doc)
 
 include::modules/insights-operator-configuring-sca.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Update to the SCA docs to prepare for 4.10 GA

https://issues.redhat.com/browse/CCXDEV-7025

Versions: enterprise-4.10 + 

Preview:
https://deploy-preview-40689--osdocs.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access.html


SME: tremes 
QE: JoaoFula 
