### PR TITLE
OSDOCS-3020 adding release note for thin provisioning support

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -54,6 +54,11 @@ This release adds improvements related to the following components and concepts.
 
 //For more information, see ../installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc#preparing-to-install-on-ibm-cloud[Preparing to install on IBM Cloud].
 
+[id="ocp-4-10-installation-and-upgrade-vsphere-provisioning"]
+==== Thin provisioning support for VMware vSphere cluster installation
+
+{product-title} {product-version} introduces support for thin provisioned disks when you install a cluster using installer-provisioned infrastructure. You can provision disks as `thin`, `thick`, or `eagerZeroedThick`. For more information about disk provisioning modes in VMware vSphere, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations[Installation configuration parameters].
+
 [id="ocp-4-10-installation-and-upgrade-aws-ami"]
 ==== Installing a cluster into an Amazon Web Services GovCloud region
 


### PR DESCRIPTION
CP to 4.10 
This PR addresses the release notes for https://issues.redhat.com/browse/OSDOCS-3020
Doc preview: https://deploy-preview-40703--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-and-upgrade-vsphere-provisioning