### PR TITLE
OSDOCS-3154: Adding clarification for choosing the correct OS and architecture

### DIFF
--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -76,7 +76,7 @@ page on the {console-redhat-com} site. If you have a Red Hat account, log in wit
 ifdef::ash[]
 Select *Azure* as the cloud provider if you are installing your cluster on Azure Stack Hub.
 endif::[]
-. Navigate to the page for your installation type, download the installation program for your operating system, and place the file in the directory where you will store the installation configuration files.
+. Navigate to the page for your installation type, download the installation program that corresponds with your host operating system and architecture, and place the file in the directory where you will store the installation configuration files.
 endif::[]
 ifdef::openshift-origin[]
 . Download installer from https://github.com/openshift/okd/releases


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3154
Applies to 4.10+

Preview: https://deploy-preview-40705--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-default.html#installation-obtaining-installer_installing-aws-default