### PR TITLE
BZ2032023: Updated prerequisite for using HSTS on routes

### DIFF
--- a/modules/nw-disabling-hsts.adoc
+++ b/modules/nw-disabling-hsts.adoc
@@ -8,7 +8,7 @@ To disable HTTP strict transport security (HSTS) per-route, you can set the `max
 
 .Prerequisites
 
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with administrator privileges for the project.
 * You installed the `oc` CLI.
 
 .Procedure

--- a/modules/nw-enabling-hsts-per-route.adoc
+++ b/modules/nw-enabling-hsts-per-route.adoc
@@ -8,7 +8,7 @@ HTTP strict transport security (HSTS) is implemented in the HAProxy template and
 
 .Prerequisites
 
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with administrator privileges for the project.
 * You installed the `oc` CLI.
 
 .Procedure

--- a/modules/nw-enforcing-hsts-per-domain.adoc
+++ b/modules/nw-enforcing-hsts-per-domain.adoc
@@ -25,7 +25,7 @@ HSTS cannot be applied to secure, or non-TLS routes, even if HSTS is requested f
 
 .Prerequisites
 
-* You are logged in to the cluster with a user with `cluster-admin` privileges.
+* You are logged in to the cluster with a user with administrator privileges for the project.
 * You installed the `oc` CLI.
 
 .Procedure


### PR DESCRIPTION
For using HSTS on routes, admin privileges for the project is required instead of `cluster-admin`.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=2032023

OCP Version: **Applicable only to 4.9 and 4.10**

Direct Doc Preview Link: 
https://deploy-preview-40706--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-enabling-hsts-per-route_route-configuration

https://deploy-preview-40706--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-disabling-hsts_route-configuration

https://deploy-preview-40706--osdocs.netlify.app/openshift-enterprise/latest/networking/routes/route-configuration.html#nw-enforcing-hsts-per-domain_route-configuration