### PR TITLE
OSDOCS-2889: Adding release notes for syncing group membership for OI…

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -338,6 +338,13 @@ With this additional information, Red Hat improves {product-title} functionality
 [id="ocp-4-10-auth"]
 === Authentication and authorization
 
+[id="ocp-4-10-auth-sync-group-membership"]
+==== Syncing group membership from OpenID Connect identity providers
+
+This release introduces support for synchronizing group membership from an OpenID Connect provider to {product-title} upon user login. You can enable this by configuring the `groups` claim in the {product-title} OpenID Connect identity provider configuration.
+
+For more information, see xref:../authentication/identity_providers/configuring-oidc-identity-provider.adoc#identity-provider-oidc-CR_configuring-oidc-identity-provider[Sample OpenID Connect CRs].
+
 [id="ocp-4-10-oc-commands-obtain-credentials-from-podman-config"]
 ==== oc commands now obtain credentials from Podman configuration locations
 


### PR DESCRIPTION
…DC providers

https://issues.redhat.com/browse/OSDOCS-2889

Preview: https://deploy-preview-40707--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-auth-sync-group-membership