### PR TITLE
[enterprise-4.7] BZ1977793: Fix ICSP steps for mirrored

### DIFF
--- a/modules/olm-mirroring-catalog.adoc
+++ b/modules/olm-mirroring-catalog.adoc
@@ -95,8 +95,8 @@ wrote mirroring manifests to manifests-{index-image}-1614211642 <2>
 +
 [NOTE]
 ====
-Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution article. 
-==== 
+Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution article.
+====
 
 ** *Option B: If your mirror registry is on a disconnected host,* take the following actions.
 
@@ -153,7 +153,25 @@ $ oc adm catalog mirror \
 +
 [NOTE]
 ====
-Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution article. 
+Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution article.
+====
+
+.. Run the `oc adm catalog mirror` command again. Use the newly mirrored index image as the source and the same mirror registry namespace used in the previous step as the target:
++
+[source,terminal]
+----
+$ oc adm catalog mirror \
+    <mirror_registry>:<port>/<index_image> \
+    <mirror_registry>:<port>/<namespace> \
+    --manifests-only \//<1>
+    [-a ${REG_CREDS}] \
+    [--insecure]
+----
+<1> The `--manifests-only` flag is required for this step so that the command does not copy all of the mirrored content again.
++
+[IMPORTANT]
+====
+This step is required because the image mappings in the `imageContentSourcePolicy.yaml` file generated during the previous step must be updated from local paths to valid mirror locations. Failure to do so will cause errors when you create the `ImageContentSourcePolicy` object in a later step.
 ====
 
 . After mirroring the content to your registry, inspect the manifests directory that is generated in your current directory.


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1977793

Preview: https://deploy-preview-40716--osdocs.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-mirror-catalog_olm-restricted-networks

This file moved locations for 4.9 and later, so https://github.com/openshift/openshift-docs/pull/41633 is the PR for `main` that will get cherry-picked to 4.9+.