### PR TITLE
OSSMDOC-408: Delete trace verbosity level from Configuration Options

### DIFF
--- a/modules/distr-tracing-config-jaeger-collector.adoc
+++ b/modules/distr-tracing-config-jaeger-collector.adoc
@@ -62,5 +62,5 @@ The Collectors are stateless and thus many instances of Jaeger Collector can be 
 |options:
   log-level:
 |Logging level for the Collector.
-|`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |===

--- a/modules/distr-tracing-config-query.adoc
+++ b/modules/distr-tracing-config-query.adoc
@@ -40,7 +40,7 @@ Query is a service that retrieves traces from storage and hosts the user interfa
 |options:
   log-level:
 |Logging level for Query.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |
 
 |options:

--- a/modules/jaeger-config-ingester.adoc
+++ b/modules/jaeger-config-ingester.adoc
@@ -42,7 +42,7 @@ The deadlock interval is disabled by default (set to 0), to avoid the Ingester b
 |options:
   log-level:
 |Logging level for the Ingester.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |===
 
 .Streaming Collector and Ingester example


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 
- Jira: https://issues.redhat.com/browse/OSSMDO-408
- Direct link to doc preview: https://deploy-preview-40730--osdocs.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_install/distr-tracing-deploying.html#distr-tracing-config-jaeger-collector_deploying-distributed-tracing
- SME review: @ tbd
- QE review: @@iblancasa
- Peer review: @JStickler 
- Cherry pick to 4.6, 4.7, 4.8, 4.9, 4.10
