### PR TITLE
BZ2037414: deprecate flex volumes

### DIFF
--- a/storage/persistent_storage/persistent-storage-flexvolume.adoc
+++ b/storage/persistent_storage/persistent-storage-flexvolume.adoc
@@ -5,6 +5,15 @@ include::modules/common-attributes.adoc[]
 
 toc::[]
 
+[IMPORTANT]
+====
+FlexVolume is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
+
+Out-of-tree Container Storage Interface (CSI) driver is the recommended way to write volume drivers in {product-title}. Maintainers of FlexVolume drivers should implement a CSI driver and move users of FlexVolume to CSI. Users of FlexVolume should move their workloads to CSI driver.
+
+For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
+====
+
 {product-title} supports FlexVolume, an out-of-tree plug-in that uses an executable model to interface with drivers.
 
 To use storage from a back-end that does not have a built-in plug-in, you can extend {product-title} through FlexVolume drivers and provide persistent storage to applications.


### PR DESCRIPTION
4.10+

[BZ2037414](https://bugzilla.redhat.com/show_bug.cgi?id=2037414) FlexVolumes are deprecated for 4.10

Rel Notes deprecated changes are here: https://github.com/openshift/openshift-docs/pull/38258

**Preview**: https://deploy-preview-40731--osdocs.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-flexvolume.html

**PTAL**: @jsafrane, @duanwei33 