### PR TITLE
OSSMDOC-387: Document changing the Operator channel.

### DIFF
--- a/distr_tracing/distr_tracing_install/distr-tracing-updating.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-updating.adoc
@@ -7,8 +7,17 @@ toc::[]
 
 Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. The OLM runs by default in {product-title}.
 OLM queries for available Operators as well as upgrades for installed Operators.
-For more information about how {product-title} handles upgrades, refer to the xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager] documentation.
+For more information about how {product-title} handles upgrades, see the xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager] documentation.
 
 During an update, the {DTProductName} Operators upgrade the managed {DTShortName} instances to the version associated with the Operator. Whenever a new version of the {JaegerName} Operator is installed, all the {JaegerShortName} application instances managed by the Operator are upgraded to the Operator's version. For example, after upgrading the Operator from 1.10 installed to 1.11, the Operator scans for running {JaegerShortName} instances and upgrades them to 1.11 as well.
 
-For specific instructions on how to update the OpenShift Elasticsearch Operator, refer to xref:../../logging/cluster-logging-upgrading.adoc#cluster-logging-upgrading_cluster-logging-upgrading[Updating OpenShift Logging].
+For specific instructions on how to update the OpenShift Elasticsearch Operator, see xref:../../logging/cluster-logging-upgrading.adoc#cluster-logging-upgrading_cluster-logging-upgrading[Updating OpenShift Logging].
+
+include::modules/distr-tracing-change-operator-20.adoc[leveloffset=+1]
+
+[IMPORTANT]
+====
+If you have not already updated your OpenShift Elasticsearch Operator as described in xref:../../logging/cluster-logging-upgrading.adoc[Updating OpenShift Logging] complete that update before updating your {JaegerName} Operator.
+====
+
+For instructions on how to update the Operator channel, see xref:../../operators/admin/olm-upgrading-operators.adoc[Upgrading installed Operators].

--- a/modules/distr-tracing-change-operator-20.adoc
+++ b/modules/distr-tracing-change-operator-20.adoc
@@ -1,0 +1,22 @@
+////
+This PROCEDURE module included in the following assemblies:
+- /dist_tracing_install/dist-tracing-updating.adoc
+////
+
+[id="dist-tracing-changing-operator-channel_{context}"]
+= Changing the Operator channel for 2.0
+
+{DTProductName} 2.0.0 made the following changes:
+
+* Renamed the Red Hat OpenShift Jaeger Operator to the {JaegerName} Operator.
+
+* Stopped support for individual release channels. Going forward, the {JaegerName} Operator will only support the *stable* Operator channel. Maintenance channels, for example *1.24-stable*, will no longer be supported by future Operators.
+
+As part of the update to version 2.0, you must update your OpenShift Elasticsearch and {JaegerName} Operator subscriptions.
+
+.Prerequisites
+
+* The {product-title} version is 4.6 or later.
+* You have updated the OpenShift Elasticsearch Operator.
+* You have backed up the Jaeger custom resource file.
+* An account with the `cluster-admin` role. If you use Red Hat OpenShift Dedicated, you must have an account with the `dedicated-admin` role.


### PR DESCRIPTION
Updates the documentation to include information about changing the Operator Channel (part of the rebranding and upgrade to distributed tracing 2.0).

Preview is here -> https://deploy-preview-40733--osdocs.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_install/distr-tracing-updating

Eng review - pavollofay
QE review - iblancasa
Peer review - EricPonvelle