### PR TITLE
RHDEVDOCS-3605 GitOps Release Notes, Known Issues and Bug Fixes for 1.4

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -22,6 +22,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-4-0.adoc
+++ b/modules/gitops-release-notes-1-4-0.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-0_{context}"]
+= Release notes for {gitops-title} 1.4.0
+
+{gitops-title} 1.4.0 is now available on {product-title} 4.7, 4.8, and 4.9.
+
+[id="new-features-1-4-0_{context}"]
+== New features
+
+The current release adds the following improvements.
+
+* This enhancement upgrades {gitops-title} Application Manager (kam) to version *0.0.41*. link:https://issues.redhat.com/browse/GITOPS-1669[GITOPS-1669]
+
+* This enhancement upgrades Argo CD to version *2.2.2*. link:https://issues.redhat.com/browse/GITOPS-1532[GITOPS-1532]
+
+* This enhancement upgrades Helm to version *3.7.1*. link:https://issues.redhat.com/browse/GITOPS-1530[GITOPS-1530]
+
+* This enhancement adds the health status of the `DeploymentConfig`, `Route`, and `OLM Operator` items to the Argo CD Dashboard and {product-title} web console. This information helps you monitor the overall health status of your application. link:https://issues.redhat.com/browse/GITOPS-655[GITOPS-655], link:https://issues.redhat.com/browse/GITOPS-915[GITOPS-915], link:https://issues.redhat.com/browse/GITOPS-916[GITOPS-916], link:https://issues.redhat.com/browse/GITOPS-1110[GITOPS-1110]
+
+* With this update, you can to specify the number of desired replicas for the `argocd-server` and `argocd-repo-server` components by setting the `.spec.server.replicas` and `.spec.repo.replicas` attributes in the Argo CD custom resource, respectively. If you configure the horizontal pod autoscaler (HPA) for the `argocd-server` components, it takes precedence over the Argo CD custom resource attributes. link:https://issues.redhat.com/browse/GITOPS-1245[GITOPS-1245]
+
+* As an administrative user, when you give Argo CD access to a namespace by using the `argocd.argoproj.io/managed-by` label, it assumes namespace-admin privileges. These privileges are an issue for administrators who provide namespaces to non-administrators, such as development teams, because the privileges enable non-administrators to modify objects such as network policies.
++
+With this update, administrators can configure a common cluster role for all the managed namespaces. In role bindings for the Argo CD application controller, the Operator refers to the `CONTROLLER_CLUSTER_ROLE` environment variable. In role bindings for the Argo CD server, the Operator refers to the `SERVER_CLUSTER_ROLE` environment variable. If these environment variables contain custom roles, the Operator doesn't create the default admin role. Instead, it uses the existing custom role for all managed namespaces. link:https://issues.redhat.com/browse/GITOPS-1290[GITOPS-1290]
+
+* With this update, the Environment page in the {product-title} Developer Console displays a broken heart icon to indicate degraded resources, excluding ones whose status is Progressing, Missing, and Unknown. The console displays a yellow yield sign icon to indicate out-of-sync resources. link:https://issues.redhat.com/browse/GITOPS-1307[GITOPS-1307]
+
+[id="fixed-issues-1-4-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, when the Route to the {gitops-title} Application Manager (kam) was accessed without specifying a path in the URL, a default page without any helpful information was displayed to the user. This update fixes the issue so that the default page displays download links for kam. link:https://issues.redhat.com/browse/GITOPS-923[GITOPS-923]
+
+* Before this update, setting a resource quota in the namespace of the Argo CD custom resource might cause the setup of the Red Hat SSO (RH SSO) instance to fail. This update fixes this issue by setting a minimum resource request for the RH SSO deployment pods. link:https://issues.redhat.com/browse/GITOPS-1297[GITOPS-1297]
+
+* Before this update, if you changed the log level for the `argocd-repo-server` workload, the Operator didn't reconcile this setting. The workaround was to delete the deployment resource so that the Operator recreated it with the new log level. With this update, the log level is correctly reconciled for existing `argocd-repo-server` workloads. link:https://issues.redhat.com/browse/GITOPS-1387[GITOPS-1387]
+
+* Before this update, if the Operator managed an Argo CD instance that lacked the `.data` field in the `argocd-secret` Secret, the Operator on that instance crashed. This update fixes the issue so that the Operator doesn't crash when the `.data` field is missing. Instead, the secret regenerates and the `gitops-operator-controller-manager` resource is redeployed. link:https://issues.redhat.com/browse/GITOPS-1402[GITOPS-1402]
+
+* Before this update, the `gitopsservice` service was annotated as an internal object. This update removes the annotation so you can update or delete the default Argo CD instance and run GitOps workloads on infrastructure nodes by using the UI. link:https://issues.redhat.com/browse/GITOPS-1429[GITOPS-1429]
+
+[id="known-issues-1-4-0_{context}"]
+== Known issues
+
+These are the known issues in the current release:
+
+* If you migrate from the Dex authentication provider to the Keycloak provider, you might experience login issues with Keycloak.
++
+To prevent this issue, when migrating, uninstall Dex by removing the `.spec.dex` section from the Argo CD custom resource. Allow a few minutes for Dex to uninstall completely. Then, install Keycloak by adding `.spec.sso.provider: keycloak` to the Argo CD custom resource.
++
+As a workaround, uninstall Keycloak by removing `.spec.sso.provider: keycloak`. Then, re-install it. link:https://issues.redhat.com/browse/GITOPS-1450[GITOPS-1450], link:https://issues.redhat.com/browse/GITOPS-1331[GITOPS-1331]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -12,15 +12,17 @@ In the table, features are marked with the following statuses:
 * *GA*: _General Availability_
 
 |===
-|*OpenShift GitOps* 6+|*Component Versions*|*OpenShift Versions*|*Support status*
+|*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
-|*Version*|*kam*|*Helm*|*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*||
-|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.6-4.9|GA
-|1.2.0|0.0.38|3.5.0|3.9.4|2.0.5|0.1.0|N/A|4.8|GA
-|1.1.0|0.0.32|3.5.0|3.9.4|2.0.0|N/A|N/A|4.7|GA
+|*Version*|*kam*    |*Helm*  |*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*     |*RH SSO* |
+|1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP        |2.30.0 GA |7.4.0 GA |4.7-4.9
+|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP        |2.28.0 GA |7.4.0 GA |4.6-4.9
+|1.2.0    |0.0.38 TP|3.5.0 GA|3.9.4 GA   |2.0.5 GA |0.1.0 TP        |N/A  |7.4.0 GA |4.8
+|1.1.0    |0.0.32 TP|3.5.0 GA|3.9.4 GA   |2.0.0 GA |N/A             |N/A      |N/A      |4.7
 |===
 
-[NOTE]
-====
-To use {gitops-title} v1.3 on {product-title} 4.6, do a fresh installation of {gitops-title}. There is no upgrade path from {gitops-title} 1.0 (TP) on OpenShift 4.6.
-====
+* "kam" is an abbreviation for {gitops-title} Application Manager (kam).
+* "RH SSO" is an abbreviation for Red Hat SSO.
+* The *Environments* page in the *Developer* perspective of the {product-title} web console is also in Technology Preview.
+
+// Writer, to update this support matrix, refer to https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix


### PR DESCRIPTION
- Aligned team: Dev Tools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3605
- Direct link to doc preview: https://deploy-preview-40738--osdocs.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes
- PO: @siamaksade 
- SME review: @wtam2018 
- QE review: @bluengo
- Peer review: @jc-berger 
- All reviews complete. Please merge for GitOps 1.4 GA, which is currently scheduled for Tuesday, January 25th.