### PR TITLE
Updated Travis jobs to include OSD and ROSA builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,43 @@
 language: python
-
 cache: pip
+env:
+  - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
 
-sudo: required
+jobs:
+  include:
+    - stage: build
+      before_install:
+        - gem install asciidoctor
+        - gem install asciidoctor-diagram
+      install:
+        - pip3 install pyyaml
+        - pip3 install aura.tar.gz
+      script:
+        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.10 --no-upstream-fetch && python3 makeBuild.py
+    - # stage name not required, will continue to use `build`
+      if: branch IN (main, enterprise-4.9, enterprise-4.10)
+      before_install:
+        - gem install asciidoctor
+        - gem install asciidoctor-diagram
+      install:
+        - pip3 install pyyaml
+        - pip3 install aura.tar.gz
+      script:
+        - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
+    - # stage name not required, will continue to use `build`
+      if: branch IN (main, enterprise-4.9, enterprise-4.10)
+      before_install:
+        - gem install asciidoctor
+        - gem install asciidoctor-diagram
+      install:
+        - pip3 install pyyaml
+        - pip3 install aura.tar.gz
+      script:
+        - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
+    - stage: automerge
+      if: env(PR_AUTHOR)=openshift-cherrypick-robot
+      script: bash ./automerge.sh
 
-before_install:
- - gem install asciidoctor
- - gem install asciidoctor-diagram
-
-install:
- - pip3 install pyyaml
- - pip3 install aura.tar.gz
-
-script:
- - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.10 --no-upstream-fetch && python3 makeBuild.py
-
-after_success:
-- bash ./automerge.sh
+stages:
+  - build
+  - automerge


### PR DESCRIPTION
Updtaes for the Travis CI build scripts:
- Kicks in 3 stages = 3 different VMs running in parallel
- Checks OCP, OSD, and ROSA builds
- If the PR author is `openshift-cherrypick-robot` runs the Automerge script otherwise skips it.