### PR TITLE
Adds 4.7.41 release notes

### DIFF
--- a/release_notes/ocp-4-7-release-notes.adoc
+++ b/release_notes/ocp-4-7-release-notes.adoc
@@ -3041,3 +3041,19 @@ link:https://access.redhat.com/solutions/6590181[{product-title} 4.7.40 containe
 ==== Upgrading
 
 To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-7-41"]
+=== RHBA-2022:0117 - {product-title} 4.7.41 bug fix and security update
+
+Issued: 2022-01-19
+
+{product-title} release 4.7.41, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2022:0117[RHBA-2022:0117] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2022:0114[RHSA-2022:0114] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory. See the following article for notes on the container images in this release:
+
+link:https://access.redhat.com/solutions/6650941[{product-title} 4.7.41 container image list]
+
+[id="ocp-4-7-41-upgrading"]
+==== Upgrading
+
+To upgrade an existing {product-title} 4.7 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
No BZ.

To  be merged on 01-19. I will send a reminder when the errata are shipped live.

OCP version: **Applicable only to 4.7**

Direct Doc Preview Link: https://deploy-preview-40745--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-7-release-notes.html#ocp-4-7-41