### PR TITLE
RHDEVDOCS-3304 Document disabling the default pipelines SA

### DIFF
--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -47,7 +47,7 @@ include::modules/op-disabling-automatic-creation-of-rbac-resources.adoc[leveloff
 
 * You can learn more about installing Operators on {product-title} in the xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[adding Operators to a cluster] section.
 
-* For more information on using pipelines in a restricted environment see:
+* For more information on using pipelines in a restricted environment, see:
 
 ** xref:../../cicd/pipelines/creating-applications-with-cicd-pipelines.html#op-mirroring-images-to-run-pipelines-in-restricted-environment_creating-applications-with-cicd-pipelines[Mirroring images to run pipelines in a restricted environment]
 

--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+[role="_abstract"]
 This guide walks cluster administrators through the process of installing the {pipelines-title} Operator to an {product-title} cluster.
 
 // Prerequisites for installing OpenShift Operator

--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -36,7 +36,7 @@ include::modules/op-installing-pipelines-operator-using-the-cli.adoc[leveloffset
 
 include::modules/op-pipelines-operator-in-restricted-environment.adoc[leveloffset=+1]
 
-// Disabling the default `pipeline` service account 
+// Disabling automatic creation of RBAC resources 
 
 include::modules/op-disabling-automatic-creation-of-rbac-resources.adoc[leveloffset=+1]
 

--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -36,6 +36,10 @@ include::modules/op-installing-pipelines-operator-using-the-cli.adoc[leveloffset
 
 include::modules/op-pipelines-operator-in-restricted-environment.adoc[leveloffset=+1]
 
+// Disabling the default `pipeline` service account 
+
+include::modules/op-disabling-automatic-creation-of-rbac-resources.adoc[leveloffset=+1]
+
 
 [role="_additional-resources"]
 == Additional resources

--- a/modules/3304-delete-later.adoc
+++ b/modules/3304-delete-later.adoc
@@ -1,1 +1,0 @@
-lorem ipsum

--- a/modules/3304-delete-later.adoc
+++ b/modules/3304-delete-later.adoc
@@ -1,0 +1,1 @@
+lorem ipsum

--- a/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
+++ b/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
@@ -4,7 +4,7 @@
 [id="op-disabling-automatic-creation-of-rbac-resources_{context}"]
 = Disabling the automatic creation of RBAC resources
 
-After default installation, the {pipelines-title} Operator creates multiple Role Based Access Control (RBAC) resources for all namespaces in the cluster. Among them, the `pipelines-scc-rolebinding` SCC role binding resource is a potential security issue, because the associated `pipelines-scc` Security Context Constraint has `RunAsAny` privilege. 
+The default installation of the {pipelines-title} Operator creates multiple Role Based Access Control (RBAC) resources for all namespaces in the cluster, except the namespaces matching the `^(openshift|kube)-*` regular expression pattern. Among these RBAC resources, the `pipelines-scc-rolebinding` SCC role binding resource is a potential security issue, because the associated `pipelines-scc` Security Context Constraint has `RunAsAny` privilege. 
 
 To disable the automatic creation of cluster-wide RBAC resources after the {pipelines-title} Operator is installed, cluster administrators can set the `createRbacResource` parameter to `false` in the cluster level `TektonConfig` custom resource.
 

--- a/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
+++ b/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
@@ -6,7 +6,7 @@
 = Disabling the automatic creation of RBAC resources
 
 [role="_abstract"]
-The default installation of the {pipelines-title} Operator creates multiple Role Based Access Control (RBAC) resources for all namespaces in the cluster, except the namespaces matching the `^(openshift|kube)-*` regular expression pattern. Among these RBAC resources, the `pipelines-scc-rolebinding` SCC role binding resource is a potential security issue, because the associated `pipelines-scc` Security Context Constraint has `RunAsAny` privilege. 
+The default installation of the {pipelines-title} Operator creates multiple role-based access control (RBAC) resources for all namespaces in the cluster, except the namespaces matching the `^(openshift|kube)-*` regular expression pattern. Among these RBAC resources, the `pipelines-scc-rolebinding` security context constraint (SCC) role binding resource is a potential security issue, because the associated `pipelines-scc` SCC has the `RunAsAny` privilege. 
 
 To disable the automatic creation of cluster-wide RBAC resources after the {pipelines-title} Operator is installed, cluster administrators can set the `createRbacResource` parameter to `false` in the cluster-level `TektonConfig` custom resource (CR).
 

--- a/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
+++ b/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// */openshift_pipelines/installing-pipelines.adoc
+[id="op-disabling-automatic-creation-of-rbac-resources_{context}"]
+= Disabling the automatic creation of RBAC resources
+
+After default installation, the {pipelines-title} Operator creates multiple Role Based Access Control (RBAC) resources for all namespaces in the cluster. Among them, the `pipelines-scc-rolebinding` SCC role binding resource is a potential security issue, because the associated `pipelines-scc` Security Context Constraint has `RunAsAny` privilege. 
+
+To disable the automatic creation of cluster-wide RBAC resources after the {pipelines-title} Operator is installed, cluster administrators can set the `createRbacResource` parameter to `false` in the cluster level `TektonConfig` custom resource.
+
+.Example `TektonConfig` custom resource
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  params:
+  - name: createRbacResource
+    value: "false"
+  profile: all
+  targetNamespace: openshift-pipelines
+  addon:
+    params:
+    - name: clusterTasks
+      value: "true"
+    - name: pipelineTemplates
+      value: "true"
+...
+----
+
+[WARNING]
+====
+When you disable automatic creation of the RBAC resources on all namespaces, the default `ClusterTask` resource does not work. For the `ClusterTask` resource to function, cluster administrators or users with appropriate privileges must create the RBAC resources manually for each intended namespace.
+====
+

--- a/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
+++ b/modules/op-disabling-automatic-creation-of-rbac-resources.adoc
@@ -1,14 +1,16 @@
 // Module included in the following assemblies:
 //
 // */openshift_pipelines/installing-pipelines.adoc
+:_content-type: CONCEPT
 [id="op-disabling-automatic-creation-of-rbac-resources_{context}"]
 = Disabling the automatic creation of RBAC resources
 
+[role="_abstract"]
 The default installation of the {pipelines-title} Operator creates multiple Role Based Access Control (RBAC) resources for all namespaces in the cluster, except the namespaces matching the `^(openshift|kube)-*` regular expression pattern. Among these RBAC resources, the `pipelines-scc-rolebinding` SCC role binding resource is a potential security issue, because the associated `pipelines-scc` Security Context Constraint has `RunAsAny` privilege. 
 
-To disable the automatic creation of cluster-wide RBAC resources after the {pipelines-title} Operator is installed, cluster administrators can set the `createRbacResource` parameter to `false` in the cluster level `TektonConfig` custom resource.
+To disable the automatic creation of cluster-wide RBAC resources after the {pipelines-title} Operator is installed, cluster administrators can set the `createRbacResource` parameter to `false` in the cluster-level `TektonConfig` custom resource (CR).
 
-.Example `TektonConfig` custom resource
+.Example `TektonConfig` CR
 [source,yaml]
 ----
 apiVersion: operator.tekton.dev/v1alpha1
@@ -32,6 +34,6 @@ spec:
 
 [WARNING]
 ====
-When you disable automatic creation of the RBAC resources on all namespaces, the default `ClusterTask` resource does not work. For the `ClusterTask` resource to function, cluster administrators or users with appropriate privileges must create the RBAC resources manually for each intended namespace.
+As a cluster administrator or an user with appropriate privileges, when you disable the automatic creation of RBAC resources for all namespaces, the default `ClusterTask` resource does not work. For the `ClusterTask` resource to function, you must create the RBAC resources manually for each intended namespace.
 ====
 


### PR DESCRIPTION
- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: `enterprise-4.9`, `enterprise-4.10`, `enterprise-4.11`
- **JIRA issues**: [RHDEVDOCS-3304 Document default pipelines SA](https://issues.redhat.com/browse/RHDEVDOCS-3304)
- **Preview pages**: [Disabling the automatic creation of RBAC resources](https://deploy-preview-40749--osdocs.netlify.app/openshift-enterprise/latest/cicd/pipelines/installing-pipelines.html#op-disabling-automatic-creation-of-rbac-resources_installing-pipelines)
- **SME review**: @savitaashture ([TEP](https://github.com/openshift-pipelines/enhancements/blob/main/enhancements/option-to-disable-default-injection-of-serviceaccount-rbac.md), [RBAC module](https://github.com/tektoncd/operator/blob/main/pkg/reconciler/openshift/tektonconfig/rbac.go))    
- **Peer-review**: @Srivaralakshmi  