### PR TITLE
OSDOCS-3186: Adding m6g and c6g ARM instance types to AWS machine type table

### DIFF
--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -13,6 +13,11 @@
 
 The following Amazon Web Services (AWS) instance types are supported with {product-title}.
 
+[IMPORTANT]
+====
+The instance types listed below are supported for AWS x86_64 and ARM instances. However, any size `mg6` or `c6g` instances are only available for AWS on ARM.
+====
+
 .Instance types for machines
 [%collapsible]
 ====
@@ -134,6 +139,46 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |x
 |x
 
+|`m6g.medium`
+|
+|x
+|x
+
+|`m6g.large`
+|
+|
+|x
+
+|`m6g.xlarge`
+|
+|x
+|x
+
+|`m6g.2xlarge`
+|
+|x
+|x
+
+|`m6g.4xlarge`
+|
+|x
+|x
+
+|`m6g.8xlarge`
+|
+|x
+|x
+
+|`m6g.12xlarge`
+|
+|x
+|x
+
+|`m6g.16xlarge`
+|
+|x
+|x
+
 |`c4.2xlarge`
 |
 |x
@@ -216,6 +261,45 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 
 |`c5a.24xlarge`
 |
+|x
+|x
+
+|`c6g.medium`
+|
+|x
+|x
+
+|`c6g.large`
+|
+|
+|x
+
+|`c6g.xlarge`
+|
+|x
+|x
+
+|`c6g.2xlarge`
+|
+|x
+|x
+
+|`c6g.4xlarge`
+|
+|x
+|x
+
+|`c6g.8xlarge`
+|
+|x
+|x
+
+|`c6g.12xlarge`
+|
+|x
+|x
+
+|`c6g.16xlarge`|
 |x
 |x
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3186
For 4.10+ 

Preview: https://deploy-preview-40758--osdocs.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-supported-aws-machine-types_installing-aws-customizations
