### PR TITLE
OSDOCS:2475: Adding Dynamic Plugins as Tech Preview in Rel Notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -177,6 +177,20 @@ For more information, see xref:../updating/understanding-upgrade-channels-releas
 [id="ocp-4-10-web-console"]
 === Web console
 
+[id="ocp-4-10-dynamic-plugin-technology-preview"]
+==== Dynamic plug-in (Technology Preview)
+Starting with {product-title} {product-version}, the ability to create OpenShift console dynamic plug-ins is now available as a Technology Preview feature. You can use this feature to customize your interface at runtime in many ways, including:
+
+* Adding custom pages
+* Adding perspectives and updating navigation items
+* Adding tabs and actions to resource pages
+
+For more information on the dynamic plug-in, see xref:../web_console/dynamic-plug-ins.adoc#dynamic-plug-ins_dynamic-plug-ins[Adding a dynamic plug-in to the {product-title} web console].
+
+[id="ocp-4-10-multicluster-console-technology-preview"]
+==== Multi-cluster console (Technology Preview)
+Starting with {product-title} 4.10, the multi-cluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console.
+
 [id="pod-debug-mode-web-console"]
 ==== Running a pod in debug mode
 With this update, you can now view debug terminals in the web console. When a pod has a container that is in a `CrashLoopBackOff` state, a debug pod can be launched. A terminal interface is displayed and can be used to debug the crash looping container.
@@ -1605,7 +1619,6 @@ In the table below, features are marked with the following statuses:
 |TP
 |
 
-
 |Node Health Check Operator
 |-
 |TP
@@ -1621,6 +1634,15 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 
+|Dynamic Plug-ins
+|-
+|-
+|TP
+
+|Multi-cluster console
+|-
+|-
+|TP
 |====
 
 [id="ocp-4-10-known-issues"]


### PR DESCRIPTION
[OSDOCS:2475](https://issues.redhat.com/browse/OSDOCS-2475)
[OSDOCS:2478](https://issues.redhat.com/browse/OSDOCS-2478)

Adds Dynamic Plugins and the Multicluster console to Tech preview table as well as the web console section in Rel Notes.

- Applies to `enterprise-4.10` only
- [Preview link](https://deploy-preview-40759--osdocs.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview)