### PR TITLE
make toc selectable for easy copy/paste action

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -524,7 +524,6 @@ h2:hover>a.anchor, h2>a.anchor:hover, h3:hover>a.anchor, h3>a.anchor:hover, h4:h
   }
 
   #toc {
-    user-select: none;
     float: right;
     padding-top: 0.1em !important;
     font-size: 0.8em;


### PR DESCRIPTION
Merge to main, enterprise-4.1

Preview broken in netlify, view output here: http://file.emea.redhat.com/aireilly/files/fixed-toc-copy/updating/installing-update-service.html

The change is that the right hand toc can now be copy/selected.