### PR TITLE
fixing typo in sample azure machineset yaml

### DIFF
--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -118,7 +118,7 @@ endif::infra[]
           subnet: <infrastructure_id>-<role>-subnet <1> <2>
           userDataSecret:
             name: worker-user-data <2>
-          vmSize: qeci-22538-vnet
+          vmSize: Standard_DS4_v2
           vnet: <infrastructure_id>-vnet <1>
 ifndef::infra[]
           zone: "1" <5>


### PR DESCRIPTION
In review of #40732, it came up that there is a typo in the sample azure machineset yaml. That PR fixes it for 4.10+ with the new 4.10 value. This PR fixes it for 4.6-4.9 with the previous default value.

Preview: [Sample YAML for a machine set custom resource on Azure](https://deploy-preview-40776--osdocs.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-yaml-azure_creating-machineset-azure)