### PR TITLE
OSDOCS-3189: CMP: Fix Steps 1-3 in Installing the CO using the CLI

### DIFF
--- a/modules/compliance-operator-cli-installation.adoc
+++ b/modules/compliance-operator-cli-installation.adoc
@@ -11,14 +11,9 @@
 
 .Procedure
 
-. Create a `Namespace` object YAML file by running:
+. Define a `Namespace` object:
 +
-[source,terminal]
-----
-$ oc create -f <file-name>.yaml
-----
-+
-.Example output
+.Example `namespace-object.yaml`
 [source,yaml]
 ----
 apiVersion: v1
@@ -28,15 +23,16 @@ metadata:
     openshift.io/cluster-monitoring: "true"
   name: openshift-compliance
 ----
-
-. Create the `OperatorGroup` object YAML file by running:
+. Create the `Namespace` object:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f namespace-object.yaml
 ----
+
+. Define an `OperatorGroup` object:
 +
-.Example output
+.Example `operator-group-object.yaml`
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -49,14 +45,16 @@ spec:
   - openshift-compliance
 ----
 
-. Create the `Subscription` object YAML file by running:
+. Create the `OperatorGroup` object:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f operator-group-object.yaml
 ----
+
+. Define a `Subscription` object:
 +
-.Example output
+.Example `subscription-object.yaml`
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -70,6 +68,12 @@ spec:
   name: compliance-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
+----
+. Create the `Subscription` object:
++
+[source,terminal]
+----
+$ oc create -f subscription-object.yaml
 ----
 
 [NOTE]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-3189
Affects 4.6+

Best way to view this change is the direct preview [here](https://deploy-preview-40778--osdocs.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-cli_compliance-operator-installation).