### PR TITLE
Update opm mirror site for latest-4.9

### DIFF
--- a/modules/olm-installing-opm.adoc
+++ b/modules/olm-installing-opm.adoc
@@ -15,7 +15,7 @@ You can install the `opm` CLI tool on your Linux, macOS, or Windows workstation.
 
 .Procedure
 
-. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/4.9.0/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
+. Navigate to the link:https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest-{product-version}/[OpenShift mirror site] and download the latest version of the tarball that matches your operating system.
 
 . Unpack the archive.
 


### PR DESCRIPTION
No JIRA/BZ.

The `latest-4.9` dir didn't exist at 4.9 GA on the mirror site, so I couldn't use it like the previous releases and had to use hardcoded `4.9.0` instead. The dir is there now however, so update to match `main` and earlier branches.

The link is broken in the preview because it's using "Branch Build", but it should be fine in the actual 4.9 branch when merged:

https://deploy-preview-40788--osdocs.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-install.html#olm-installing-opm_cli-opm-install

For example, renders fine in 4.8:

https://docs.openshift.com/container-platform/4.8/cli_reference/opm-cli.html#olm-installing-opm_opm-cli

