### PR TITLE
[enterprise-4.10] OSSMDOC-408: Delete trace verbosity level from Configuration Options

### DIFF
--- a/modules/distr-tracing-config-ingester.adoc
+++ b/modules/distr-tracing-config-ingester.adoc
@@ -42,7 +42,7 @@ The deadlock interval is disabled by default (set to `0`), to avoid terminating 
 |options:
   log-level:
 |Logging level for the Ingester.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |===
 
 .Streaming Collector and Ingester example

--- a/modules/distr-tracing-config-jaeger-collector.adoc
+++ b/modules/distr-tracing-config-jaeger-collector.adoc
@@ -62,5 +62,5 @@ The Collectors are stateless and thus many instances of Jaeger Collector can be 
 |options:
   log-level:
 |Logging level for the Collector.
-|`trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |===

--- a/modules/distr-tracing-config-query.adoc
+++ b/modules/distr-tracing-config-query.adoc
@@ -40,7 +40,7 @@ Query is a service that retrieves traces from storage and hosts the user interfa
 |options:
   log-level:
 |Logging level for Query.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 |
 
 |options:

--- a/modules/jaeger-config-ingester.adoc
+++ b/modules/jaeger-config-ingester.adoc
@@ -46,7 +46,7 @@ The deadlock interval is disabled by default (set to 0), to avoid the Ingester b
 
 |log-level:
 |Logging level for the Ingester.
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
+|Possible values: `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
 
 |maxReplicas:
 |Specifies the maximum number of replicas to create when autoscaling the Ingester.


### PR DESCRIPTION
Cherry picked from 5689aa4d1ba0bdaa47deb42677ba90c66da0a5b5 xref:#40730.

Also, I realized that we updated the Jaeger file instead of the distributed tracing file, so I added the change to that file too.